### PR TITLE
Shortened external pages URL

### DIFF
--- a/mod/externalpages/start.php
+++ b/mod/externalpages/start.php
@@ -8,9 +8,9 @@ register_elgg_event_handler('init', 'system', 'expages_init');
 function expages_init() {
 
 	// Register a page handler, so we can have nice URLs
-	elgg_register_page_handler('about', 'about_page_handler');
-        elgg_register_page_handler('terms', 'terms_page_handler');
-        elgg_register_page_handler('privacy', 'privacy_page_handler');
+	elgg_register_page_handler('about', 'expages_page_handler');
+        elgg_register_page_handler('terms', 'expages_page_handler');
+        elgg_register_page_handler('privacy', 'expages_page_handler');
 	elgg_register_page_handler('expages', 'expages_page_handler');
 	
 	
@@ -33,7 +33,7 @@ function expages_setup_footer_menu() {
     	$pages = array('about', 'terms', 'privacy');
     	foreach ($pages as $page) {
 	
-        	$url = "expages/read/$page";
+        	$url = "$page";
         	$item = new ElggMenuItem($page, elgg_echo("expages:$page"), $url);
 		$item->setSection('alt');
         	elgg_register_menu_item('footer', $item);
@@ -47,58 +47,34 @@ function expages_setup_footer_menu() {
  * 
  */
 
-function expages_page_handler($page) {
-	if (!empty($page) && ($page[1] == 'about' || $page[1] == 'terms' || $page[1] == 'privacy')){
-			expages_url_forwarder($page[1]);	
-	}
-
-	else{
-		$type = strtolower($page);
-	
-		$title = elgg_echo("expages:$type");
-		$content = elgg_view_title($title);
-
-		$object = elgg_get_entities(array(
-			'type' => 'object',
-			'subtype' => $type,
-			'limit' => 1,
-		));
-		if ($object) {
-		$content .= elgg_view('output/longtext', array('value' => $object[0]->description));
-		} else {
-			$content .= elgg_echo("expages:notset");
+function expages_page_handler($page, $handler) {
+        if($handler == 'expages'){
+		if($page[0] == 'read'){
+			expages_url_forwarder($page[1]);
 		}
-
-		$body = elgg_view_layout("one_sidebar", array('content' => $content));
-		echo elgg_view_page($title, $body);
-		return 0;
+		expages_url_forwarder($page[0]);
 	}
-		
+
+	$type = strtolower($handler);
 	
+	$title = elgg_echo("expages:$type");
+	$content = elgg_view_title($title);
+
+	$object = elgg_get_entities(array(
+		'type' => 'object',
+		'subtype' => $type,
+		'limit' => 1,
+	));
+	if ($object) {
+	$content .= elgg_view('output/longtext', array('value' => $object[0]->description));
+	} else {
+		$content .= elgg_echo("expages:notset");
+	}
+
+	$body = elgg_view_layout("one_sidebar", array('content' => $content));
+	echo elgg_view_page($title, $body);
+
 }
-
-/**
- * About page handler
- */
-
-function about_page_handler(){
-	expages_page_handler('about');
-}
-
-/**
- * Terms page handler
- */
-function terms_page_handler(){
-	expages_page_handler('terms');
-}
-
-/**
- * Privacy page handler
- */
-function privacy_page_handler(){
-	expages_page_handler('privacy');
-}
-
 /**
  * Forward to the new style of URLs
  *

--- a/mod/externalpages/start.php
+++ b/mod/externalpages/start.php
@@ -8,7 +8,9 @@ register_elgg_event_handler('init', 'system', 'expages_init');
 function expages_init() {
 
 	// Register a page handler, so we can have nice URLs
-	elgg_register_page_handler('expages', 'expages_page_handler');
+	elgg_register_page_handler('about', 'expages_page_handler');
+        elgg_register_page_handler('terms', 'expages_page_handler');
+        elgg_register_page_handler('privacy', 'expages_page_handler');
 
 	// add a menu item for the admin edit page
 	elgg_register_admin_menu_item('configure', 'expages', 'site');
@@ -27,7 +29,7 @@ function expages_init() {
 function expages_setup_footer_menu() {
     $pages = array('about', 'terms', 'privacy');
     foreach ($pages as $page) {
-        $url = "expages/read/$page";
+        $url = "$page";
         $item = new ElggMenuItem($page, elgg_echo("expages:$page"), $url);
 		$item->setSection('alt');
         elgg_register_menu_item('footer', $item);

--- a/mod/externalpages/start.php
+++ b/mod/externalpages/start.php
@@ -14,14 +14,14 @@ function expages_init() {
 	elgg_register_page_handler('expages', 'expages_page_handler');
 	
 	// add a menu item for the admin edit page
-	elgg_register_admin_menu_item('configure', 'expages', 'appearance');
+	elgg_register_admin_menu_item('configure', 'expages', 'site');
 
 	
 	// add footer links
 	expages_setup_footer_menu();
 
 	// register action
-	$actions_base = elgg_get_plugins_path() . 'externalpages/about/actions';
+	$actions_base = elgg_get_plugins_path() . 'externalpages/actions';
 	elgg_register_action("expages/edit", "$actions_base/edit.php", 'admin');
 }
 

--- a/mod/externalpages/start.php
+++ b/mod/externalpages/start.php
@@ -8,9 +8,9 @@ register_elgg_event_handler('init', 'system', 'expages_init');
 function expages_init() {
 
 	// Register a page handler, so we can have nice URLs
-	elgg_register_page_handler('about', 'expages_page_handler');
-        elgg_register_page_handler('terms', 'expages_page_handler');
-        elgg_register_page_handler('privacy', 'expages_page_handler');
+	elgg_register_page_handler('about', 'about_page_handler');
+        elgg_register_page_handler('terms', 'terms_page_handler');
+        elgg_register_page_handler('privacy', 'privacy_page_handler');
 
 	// add a menu item for the admin edit page
 	elgg_register_admin_menu_item('configure', 'expages', 'site');
@@ -39,11 +39,11 @@ function expages_setup_footer_menu() {
 /**
  * External pages page handler
  *
- * @param array $page
+ * 
  */
-function expages_page_handler($page) {
-	$type = strtolower($page[1]);
-
+function about_page_handler() {
+	$type = 'about';
+	
 	$title = elgg_echo("expages:$type");
 	$content = elgg_view_title($title);
 
@@ -55,6 +55,49 @@ function expages_page_handler($page) {
 	if ($object) {
 		$content .= elgg_view('output/longtext', array('value' => $object[0]->description));
 	} else {
+		$content .= elgg_echo("expages:notset");
+	}
+
+	$body = elgg_view_layout("one_sidebar", array('content' => $content));
+	echo elgg_view_page($title, $body);
+}
+
+function terms_page_handler() {
+	$type = 'terms';
+	
+	$title = elgg_echo("expages:$type");
+	$content = elgg_view_title($title);
+
+	$object = elgg_get_entities(array(
+		'type' => 'object',
+		'subtype' => $type,
+		'limit' => 1,
+	));
+	if ($object) {
+		$content .= elgg_view('output/longtext', array('value' => $object[0]->description));
+	} else {
+		$content .= elgg_echo("expages:notset");
+	}
+
+	$body = elgg_view_layout("one_sidebar", array('content' => $content));
+	echo elgg_view_page($title, $body);
+}
+
+function privacy_page_handler() {
+	$type = 'privacy';
+	
+	$title = elgg_echo("expages:$type");
+	$content = elgg_view_title($title);
+
+	$object = elgg_get_entities(array(
+		'type' => 'object',
+		'subtype' => $type,
+		'limit' => 1,
+	));
+	if ($object) {
+		$content .= elgg_view('output/longtext', array('value' => $object[0]->description));
+	} else {
+
 		$content .= elgg_echo("expages:notset");
 	}
 

--- a/mod/externalpages/start.php
+++ b/mod/externalpages/start.php
@@ -13,11 +13,9 @@ function expages_init() {
         elgg_register_page_handler('privacy', 'expages_page_handler');
 	elgg_register_page_handler('expages', 'expages_page_handler');
 	
-	
 	// add a menu item for the admin edit page
 	elgg_register_admin_menu_item('configure', 'expages', 'site');
 
-	
 	// add footer links
 	expages_setup_footer_menu();
 
@@ -30,31 +28,29 @@ function expages_init() {
  * Setup the links to site pages
  */
 function expages_setup_footer_menu() {
-    	$pages = array('about', 'terms', 'privacy');
-    	foreach ($pages as $page) {
-	
-        	$url = "$page";
-        	$item = new ElggMenuItem($page, elgg_echo("expages:$page"), $url);
+    $pages = array('about', 'terms', 'privacy');
+    foreach ($pages as $page) {
+        $url = "$page";
+        $item = new ElggMenuItem($page, elgg_echo("expages:$page"), $url);
 		$item->setSection('alt');
-        	elgg_register_menu_item('footer', $item);
-	
-    	}
+        elgg_register_menu_item('footer', $item);
+    }
 }
 
 /**
  * External pages page handler
  *
- * 
+ * @param array $page
+ * @param string $handler
  */
 
 function expages_page_handler($page, $handler) {
-        if($handler == 'expages'){
-		if($page[0] == 'read'){
+        if ($handler == 'expages') {
+		if ($page[0] == 'read') {
 			expages_url_forwarder($page[1]);
 		}
 		expages_url_forwarder($page[0]);
 	}
-
 	$type = strtolower($handler);
 	
 	$title = elgg_echo("expages:$type");
@@ -66,15 +62,15 @@ function expages_page_handler($page, $handler) {
 		'limit' => 1,
 	));
 	if ($object) {
-	$content .= elgg_view('output/longtext', array('value' => $object[0]->description));
+		$content .= elgg_view('output/longtext', array('value' => $object[0]->description));
 	} else {
 		$content .= elgg_echo("expages:notset");
 	}
 
 	$body = elgg_view_layout("one_sidebar", array('content' => $content));
 	echo elgg_view_page($title, $body);
-
 }
+
 /**
  * Forward to the new style of URLs
  *

--- a/mod/externalpages/start.php
+++ b/mod/externalpages/start.php
@@ -8,18 +8,20 @@ register_elgg_event_handler('init', 'system', 'expages_init');
 function expages_init() {
 
 	// Register a page handler, so we can have nice URLs
-	elgg_register_page_handler('about', 'about_page_handler');
-        elgg_register_page_handler('terms', 'terms_page_handler');
-        elgg_register_page_handler('privacy', 'privacy_page_handler');
-
+	elgg_register_page_handler('about', 'expages_page_handler');
+        elgg_register_page_handler('terms', 'expages_page_handler');
+        elgg_register_page_handler('privacy', 'expages_page_handler');
+	elgg_register_page_handler('expages', 'expages_page_handler');
+	
 	// add a menu item for the admin edit page
-	elgg_register_admin_menu_item('configure', 'expages', 'site');
+	elgg_register_admin_menu_item('configure', 'expages', 'appearance');
 
+	
 	// add footer links
 	expages_setup_footer_menu();
 
 	// register action
-	$actions_base = elgg_get_plugins_path() . 'externalpages/actions';
+	$actions_base = elgg_get_plugins_path() . 'externalpages/about/actions';
 	elgg_register_action("expages/edit", "$actions_base/edit.php", 'admin');
 }
 
@@ -29,10 +31,12 @@ function expages_init() {
 function expages_setup_footer_menu() {
     $pages = array('about', 'terms', 'privacy');
     foreach ($pages as $page) {
+	
         $url = "$page";
         $item = new ElggMenuItem($page, elgg_echo("expages:$page"), $url);
 		$item->setSection('alt');
         elgg_register_menu_item('footer', $item);
+	
     }
 }
 
@@ -41,8 +45,16 @@ function expages_setup_footer_menu() {
  *
  * 
  */
-function about_page_handler() {
-	$type = 'about';
+
+function expages_page_handler() {
+	$page = preg_split('/\//', $_SERVER["REQUEST_URI"]);
+
+	if ($page[2] == 'expages') {
+		expages_url_forwarder($page);
+		return 0;
+	}
+	
+	$type = strtolower($page[2]);
 	
 	$title = elgg_echo("expages:$type");
 	$content = elgg_view_title($title);
@@ -58,49 +70,24 @@ function about_page_handler() {
 		$content .= elgg_echo("expages:notset");
 	}
 
+	
 	$body = elgg_view_layout("one_sidebar", array('content' => $content));
 	echo elgg_view_page($title, $body);
+
 }
 
-function terms_page_handler() {
-	$type = 'terms';
-	
-	$title = elgg_echo("expages:$type");
-	$content = elgg_view_title($title);
-
-	$object = elgg_get_entities(array(
-		'type' => 'object',
-		'subtype' => $type,
-		'limit' => 1,
-	));
-	if ($object) {
-		$content .= elgg_view('output/longtext', array('value' => $object[0]->description));
-	} else {
-		$content .= elgg_echo("expages:notset");
+/**
+ * Forward to the new style of URLs
+ *
+ * @param string $page
+ */
+function expages_url_forwarder($page) {
+	global $CONFIG;
+	if ($page[3] == 'read') {
+		$url = "{$CONFIG->wwwroot}{$page[4]}";
 	}
-
-	$body = elgg_view_layout("one_sidebar", array('content' => $content));
-	echo elgg_view_page($title, $body);
-}
-
-function privacy_page_handler() {
-	$type = 'privacy';
-	
-	$title = elgg_echo("expages:$type");
-	$content = elgg_view_title($title);
-
-	$object = elgg_get_entities(array(
-		'type' => 'object',
-		'subtype' => $type,
-		'limit' => 1,
-	));
-	if ($object) {
-		$content .= elgg_view('output/longtext', array('value' => $object[0]->description));
-	} else {
-
-		$content .= elgg_echo("expages:notset");
-	}
-
-	$body = elgg_view_layout("one_sidebar", array('content' => $content));
-	echo elgg_view_page($title, $body);
+	else {
+		$url = "{$CONFIG->wwwroot}{$page[3]}";
+	}	
+	forward($url);
 }


### PR DESCRIPTION
I edited the start file of externalpages plugin to register page handler for 'about', 'terms', 'privacy' pages. Also in the expages_setup_footer_menu() function i put the shortened url for each footer menu item. In my localhost the shortened url were directed to the respective pages succesfully (eg : http://127.0.0.1/elgg-1.8/about).
