### PR TITLE
#3310: Rewrite of plugin activation handlers (using specific files instead of functions)

### DIFF
--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -639,24 +639,16 @@ class ElggPlugin extends ElggObject {
 
 			// if there are any on_enable functions, start the plugin now and run them
 			// Note: this will not run re-run the init hooks!
-			$functions = $this->manifest->getOnActivate();
-			if ($return && $functions) {
-				$flags = ELGG_PLUGIN_INCLUDE_START | ELGG_PLUGIN_REGISTER_CLASSES
-						| ELGG_PLUGIN_REGISTER_LANGUAGES | ELGG_PLUGIN_REGISTER_VIEWS;
+			if ($return)
+			{
+				if ($this->canIncludeFile('activate.php'))
+				{
+					$flags = ELGG_PLUGIN_INCLUDE_START | ELGG_PLUGIN_REGISTER_CLASSES
+							| ELGG_PLUGIN_REGISTER_LANGUAGES | ELGG_PLUGIN_REGISTER_VIEWS;
 
-				$this->start($flags);
-				foreach ($functions as $function) {
-					if (!is_callable($function)) {
-						$return = false;
-					} else {
-						$result = call_user_func($function);
-						// allow null to mean "I don't care" like other subsystems
-						$return = ($result === false) ? false: true;
-					}
+					$this->start($flags);
 
-					if ($return === false) {
-						break;
-					}
+					$return = $this->includeFile('activate.php');
 				}
 			}
 
@@ -690,28 +682,9 @@ class ElggPlugin extends ElggObject {
 
 		$return = elgg_trigger_event('deactivate', 'plugin', $params);
 
-		// run any deactivate functions
-		// check for the manifest in case we haven't fully loaded the plugin.
-		if ($this->manifest) {
-			$functions = $this->manifest->getOnDeactivate();
-		} else {
-			$functions = array();
-		}
+		// run any deactivate code
+		if ($return) {
 
-		if ($return && $functions) {
-			foreach ($functions as $function) {
-				if (!is_callable($function)) {
-					$return = false;
-				} else {
-					$result = call_user_func($function);
-					// allow null to mean "I don't care" like other subsystems
-					$return = ($result === false) ? false : true;
-				}
-
-				if ($return === false) {
-					break;
-				}
-			}
 		}
 
 		if ($return === false) {
@@ -736,7 +709,7 @@ class ElggPlugin extends ElggObject {
 
 		// include start file
 		if ($flags & ELGG_PLUGIN_INCLUDE_START) {
-			$this->includeStart();
+			$this->includeFile('start.php');
 		}
 
 		// include views
@@ -761,24 +734,33 @@ class ElggPlugin extends ElggObject {
 	// start helpers
 
 	/**
-	 * Includes the plugin's start file
+	 * Includes one of the plugins files
+	 *
+	 * @param string $filename The name of the file
 	 *
 	 * @throws PluginException
-	 * @return true
+	 * @return mixed The return value of the included file (or 1 if there is none)
 	 */
-	protected function includeStart() {
+	protected function includeFile($filename) {
 		// This needs to be here to be backwards compatible for 1.0-1.7.
 		// They expect the global config object to be available in start.php.
-		global $CONFIG;
+		if ($filename == 'start.php')
+			global $CONFIG;
 
-		$start = "$this->path/start.php";
-		if (!include($start)) {
-			$msg = elgg_echo('ElggPlugin:Exception:CannotIncludeStart',
-							array($this->getID(), $this->guid, $this->path));
+		// TODO: Validate $name???
+		$filepath = "$this->path/$filename";
+
+		if (!$this->canIncludeFile($filename)) {
+			$msg = elgg_echo('ElggPlugin:Exception:CannotIncludeFile',
+							array($filename, $this->getID(), $this->guid, $this->path));
 			throw new PluginException($msg);
 		}
 
-		return true;
+		return include $filepath;
+	}
+
+	protected function canIncludeFile($filename) {
+		return file_exists($this->path.'/'.$filename);
 	}
 
 	/**

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -684,7 +684,9 @@ class ElggPlugin extends ElggObject {
 
 		// run any deactivate code
 		if ($return) {
-
+			if ($this->canIncludeFile('deactivate.php')) {
+				$return = $this->includeFile('deactivate.php');
+			}
 		}
 
 		if ($return === false) {

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -639,10 +639,8 @@ class ElggPlugin extends ElggObject {
 
 			// if there are any on_enable functions, start the plugin now and run them
 			// Note: this will not run re-run the init hooks!
-			if ($return)
-			{
-				if ($this->canIncludeFile('activate.php'))
-				{
+			if ($return) {
+				if ($this->canIncludeFile('activate.php')) {
 					$flags = ELGG_PLUGIN_INCLUDE_START | ELGG_PLUGIN_REGISTER_CLASSES
 							| ELGG_PLUGIN_REGISTER_LANGUAGES | ELGG_PLUGIN_REGISTER_VIEWS;
 
@@ -746,10 +744,10 @@ class ElggPlugin extends ElggObject {
 	protected function includeFile($filename) {
 		// This needs to be here to be backwards compatible for 1.0-1.7.
 		// They expect the global config object to be available in start.php.
-		if ($filename == 'start.php')
+		if ($filename == 'start.php') {
 			global $CONFIG;
+		}
 
-		// TODO: Validate $name???
 		$filepath = "$this->path/$filename";
 
 		if (!$this->canIncludeFile($filename)) {
@@ -761,6 +759,12 @@ class ElggPlugin extends ElggObject {
 		return include $filepath;
 	}
 
+	/**
+	 * Checks whether a plugin file with the given name exists
+	 *
+	 * @param string $filename The name of the file
+	 * @return bool
+	 */
 	protected function canIncludeFile($filename) {
 		return file_exists($this->path.'/'.$filename);
 	}

--- a/engine/classes/ElggPluginManifest.php
+++ b/engine/classes/ElggPluginManifest.php
@@ -577,36 +577,6 @@ class ElggPluginManifest {
 	}
 
 	/**
-	 * Returns the functions to run upon activation
-	 *
-	 *  @return array
-	 */
-	public function getOnActivate() {
-		$functions = $this->parser->getAttribute('on_activate');
-
-		if (!$functions) {
-			$functions = array();
-		}
-
-		return $functions;
-	}
-
-	/**
-	 * Returns the functions to run upon deactivation
-	 *
-	 *  @return array
-	 */
-	public function getOnDeactivate() {
-		$functions = $this->parser->getAttribute('on_deactivate');
-
-		if (!$functions) {
-			$functions = array();
-		}
-
-		return $functions;
-	}
-
-	/**
 	 * Returns the admin interface to use.
 	 *
 	 *  @return string simple or advanced

--- a/engine/classes/ElggPluginManifestParser18.php
+++ b/engine/classes/ElggPluginManifestParser18.php
@@ -15,8 +15,8 @@ class ElggPluginManifestParser18 extends ElggPluginManifestParser {
 	protected $validAttributes = array(
 		'name', 'author', 'version', 'blurb', 'description',
 		'website', 'copyright', 'license', 'requires', 'suggests',
-		'screenshot', 'category', 'conflicts', 'provides', 'on_activate',
-		'on_deactivate', 'admin_interface', 'activate_on_install'
+		'screenshot', 'category', 'conflicts', 'provides',
+		'admin_interface', 'activate_on_install'
 	);
 
 	/**
@@ -52,8 +52,6 @@ class ElggPluginManifestParser18 extends ElggPluginManifestParser {
 					break;
 
 				// arrays
-				case 'on_activate':
-				case 'on_deactivate':
 				case 'category':
 					$parsed[$element->name][] = $element->content;
 					break;

--- a/languages/en.php
+++ b/languages/en.php
@@ -78,7 +78,7 @@ $english = array(
 	'ElggPluginPackage:InvalidPlugin:InvalidProvides' => 'Invalid provides type "%s"',
 	'ElggPluginPackage:InvalidPlugin:CircularDep' => 'Invalid %s dependency "%s" in plugin %s.  Plugins cannot conflict with or require something they provide!',
 
-	'ElggPlugin:Exception:CannotIncludeStart' => 'Cannot include start.php for plugin %s (guid: %s) at %s.  Check permissions!',
+	'ElggPlugin:Exception:CannotIncludeFile' => 'Cannot include %s for plugin %s (guid: %s) at %s.  Check permissions!',
 	'ElggPlugin:Exception:CannotRegisterViews' => 'Cannot open views dir for plugin %s (guid: %s) at %s.  Check permissions!',
 	'ElggPlugin:Exception:CannotRegisterLanguages' => 'Cannot register languages for plugin %s (guid: %s) at %s.  Check permissions!',
 	'ElggPlugin:Exception:CannotRegisterClasses' => 'Cannot register classes for plugin %s (guid: %s) at %s.  Check permissions!',
@@ -579,7 +579,7 @@ $english = array(
 'This page is the Admin Dashboard and provides a quick overview of your system. '
 . "You can <a class=\"elgg-toggler\" href=\"#widgets-add-panel\">add</a>"
 . " and rearrange widgets to show the information you care about.  The menu to the right is oranganized into"
-. " three areas: 
+. " three areas:
 	<ul>
 		<li>Administer - Everyday tasks like monitoring reported content, checking online users, and viewing logs.</li>
 		<li>Configure - Configuration settings likes the site name, the active plugins, and plugin settings.</li>
@@ -597,7 +597,7 @@ $english = array(
 . " <a href=\"http://docs.elgg.org/wiki/Category:Administration_FAQ\">FAQs</a>, <a href=\"http://docs.elgg.org/wiki/Administration_Manual\">"
 . "manuals</a>, <a href=\"http://blog.elgg.org/\">Elgg news</a>, and <a href=\"http://community.elgg.org/pg/groups/world/\">support forums</a>"
 . " at the <a href=\"http://community.elgg.org/\">Elgg Community</a>.",
-	
+
 	'admin:widget:admin_welcome:outro' => 'Thank you for using Elgg!',
 
 	'admin:footer:faq' => 'Administration FAQ',

--- a/mod/blog/activate.php
+++ b/mod/blog/activate.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Blogs
+ *
+ * Activation file - runs when blog plugin is activated.
+ *
+ * @package Blog
+ */
+
+add_subtype('object', 'blog', 'ElggBlog');

--- a/mod/blog/manifest.xml
+++ b/mod/blog/manifest.xml
@@ -16,5 +16,4 @@
 	</requires>
 	<admin_interface>simple</admin_interface>
 	<activate_on_install>true</activate_on_install>
-	<on_activate>blog_on_activate</on_activate>
 </plugin_manifest>

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -18,7 +18,7 @@ elgg_register_event_handler('init', 'system', 'blog_init');
  * Init blog plugin.
  */
 function blog_init() {
-	
+
 	elgg_register_library('elgg:blog', elgg_get_plugins_path() . 'blog/lib/blog.php');
 
 	// add a site navigation item
@@ -101,14 +101,14 @@ function blog_page_handler($page) {
 	// @todo remove the forwarder in 1.9
 	// forward to correct URL for bookmarks pre-1.7.5
 	blog_url_forwarder($page);
-	
+
 	// push all blogs breadcrumb
 	elgg_push_breadcrumb(elgg_echo('blog:blogs'), "blog/all");
 
 	if (!isset($page[0])) {
 		$page[0] = 'all';
 	}
-	
+
 	$page_type = $page[0];
 	switch ($page_type) {
 		case 'owner':
@@ -143,7 +143,7 @@ function blog_page_handler($page) {
 			$params = blog_get_page_content_list();
 			break;
 	}
-	
+
 	$params['sidebar'] .= elgg_view('blog/sidebar', array('page' => $page_type));
 
 	$body = elgg_view_layout('content', $params);
@@ -222,13 +222,6 @@ function blog_ecml_views_hook($hook, $entity_type, $return_value, $params) {
 	$return_value['object/blog'] = elgg_echo('blog:blogs');
 
 	return $return_value;
-}
-
-/**
- * Runs when blog plugin is activated. See manifest file.
- */
-function blog_on_activate() {
-	add_subtype('object', 'blog', 'ElggBlog');
 }
 
 /**

--- a/mod/categories/activate.php
+++ b/mod/categories/activate.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Elgg categories plugin
+ *
+ * Activation file - runs when categories plugin is activated.
+ *
+ * @package ElggCategories
+ */
+
+/**
+ * Add a reminder to set default categories.
+ */
+$site = elgg_get_site_entity();
+
+if (!$site->categories) {
+	$url = elgg_normalize_url('admin/plugin_settings/categories');
+	$message = elgg_echo('categories:on_enable_reminder', array($url));
+	elgg_add_admin_notice('categories_admin_notice_no_categories', $message);
+}

--- a/mod/categories/deactivate.php
+++ b/mod/categories/deactivate.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Elgg categories plugin
+ *
+ * Deactivation file - runs when categories plugin is deactivated.
+ *
+ * @package ElggCategories
+ */
+
+/**
+ * Clean up admin notices
+ */
+elgg_delete_admin_notice('categories_admin_notice_no_categories');

--- a/mod/categories/manifest.xml
+++ b/mod/categories/manifest.xml
@@ -14,6 +14,4 @@
 		<version>2010030101</version>
 	</requires>
 	<admin_interface>advanced</admin_interface>
-	<on_activate>categories_on_activate</on_activate>
-	<on_deactivate>categories_on_deactivate</on_deactivate>
 </plugin_manifest>

--- a/mod/categories/start.php
+++ b/mod/categories/start.php
@@ -54,24 +54,3 @@ function categories_save($event, $object_type, $object) {
 	}
 	return TRUE;
 }
-
-/**
- * Add a reminder to set default categories.
- */
-function categories_on_activate() {
-	$site = elgg_get_site_entity();
-	
-	if (!$site->categories) {
-		$url = elgg_normalize_url('admin/plugin_settings/categories');
-		$message = elgg_echo('categories:on_enable_reminder', array($url));
-		elgg_add_admin_notice('categories_admin_notice_no_categories', $message);
-	}
-	return TRUE;
-}
-
-/**
- * Clean up admin notices on disable.
- */
-function categories_on_deactivate() {
-	elgg_delete_admin_notice('categories_admin_notice_no_categories');
-}


### PR DESCRIPTION
http://trac.elgg.org/ticket/3310

This is my first proposal for an implementation providing the possibility for plugins to include an activate.php file (and/or deactivate.php) with code that should be run during activation/deactivation of the plugin.

There are a few things that can be done differently and a few questions I would still like to ask, but I would first like to receive some feedback.

You should also note that I successfully converted the two plugins that needed it (blog and categories) to the new system.
(And I suppose I will also have to change the documentation in the process of including this.)
