### PR TITLE
#2046: Fix malformed offsets causing query errors.

### DIFF
--- a/engine/lib/database.php
+++ b/engine/lib/database.php
@@ -680,22 +680,31 @@ function sanitize_string($string) {
  * Sanitises an integer for database use.
  *
  * @param int $int Integer
- *
+ * @param bool[optional] $unsigned Whether negative values should be forbidden (true)
  * @return int Sanitised integer
  */
-function sanitise_int($int) {
+function sanitise_int($int, $unsigned = false) {
+	$int = (int) $int;
+
+	if ($unsigned === true) {
+		if ($int < 0) {
+			$int = 0;
+		}
+	}
+
 	return (int) $int;
 }
 
 /**
- * Wrapper function for alternate English spelling
+ * Sanitises an integer for database use.
+ * Wrapper function for alternate English spelling (@see sanitise_int)
  *
  * @param int $int Integer
- *
+ * @param bool[optional] $unsigned Whether negative values should be forbidden (true)
  * @return int Sanitised integer
  */
-function sanitize_int($int) {
-	return (int) $int;
+function sanitize_int($int, $unsigned = false) {
+	return sanitise_int($int, $unsigned);
 }
 
 /**

--- a/engine/lib/database.php
+++ b/engine/lib/database.php
@@ -680,13 +680,13 @@ function sanitize_string($string) {
  * Sanitises an integer for database use.
  *
  * @param int $int Integer
- * @param bool[optional] $unsigned Whether negative values should be forbidden (true)
+ * @param bool[optional] $signed Whether negative values should be allowed (true)
  * @return int Sanitised integer
  */
-function sanitise_int($int, $unsigned = false) {
+function sanitise_int($int, $signed = true) {
 	$int = (int) $int;
 
-	if ($unsigned === true) {
+	if ($signed === false) {
 		if ($int < 0) {
 			$int = 0;
 		}
@@ -700,11 +700,11 @@ function sanitise_int($int, $unsigned = false) {
  * Wrapper function for alternate English spelling (@see sanitise_int)
  *
  * @param int $int Integer
- * @param bool[optional] $unsigned Whether negative values should be forbidden (true)
+ * @param bool[optional] $signed Whether negative values should be allowed (true)
  * @return int Sanitised integer
  */
-function sanitize_int($int, $unsigned = false) {
-	return sanitise_int($int, $unsigned);
+function sanitize_int($int, $signed = true) {
+	return sanitise_int($int, $signed);
 }
 
 /**

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -922,7 +922,7 @@ function elgg_get_entities(array $options = array()) {
 
 		if ($options['limit']) {
 			$limit = sanitise_int($options['limit']);
-			$offset = sanitise_int($options['offset'], true);
+			$offset = sanitise_int($options['offset'], false);
 			$query .= " LIMIT $offset, $limit";
 		}
 

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -922,7 +922,7 @@ function elgg_get_entities(array $options = array()) {
 
 		if ($options['limit']) {
 			$limit = sanitise_int($options['limit']);
-			$offset = sanitise_int($options['offset']);
+			$offset = sanitise_int($options['offset'], true);
 			$query .= " LIMIT $offset, $limit";
 		}
 

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -319,7 +319,7 @@ function elgg_get_metastring_based_objects($options) {
 		'metastring_owner_guid', 'metastring_id',
 		'select', 'where', 'join'
 	);
-	
+
 	$options = elgg_normalise_plural_options_array($options, $singulars);
 
 	if (!$options) {
@@ -446,7 +446,7 @@ function elgg_get_metastring_based_objects($options) {
 
 		if ($options['limit']) {
 			$limit = sanitise_int($options['limit']);
-			$offset = sanitise_int($options['offset']);
+			$offset = sanitise_int($options['offset'], true);
 			$query .= " LIMIT $offset, $limit";
 		}
 

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -446,7 +446,7 @@ function elgg_get_metastring_based_objects($options) {
 
 		if ($options['limit']) {
 			$limit = sanitise_int($options['limit']);
-			$offset = sanitise_int($options['offset'], true);
+			$offset = sanitise_int($options['offset'], false);
 			$query .= " LIMIT $offset, $limit";
 		}
 

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -302,7 +302,7 @@ function elgg_get_river(array $options = array()) {
 
 		if ($options['limit']) {
 			$limit = sanitise_int($options['limit']);
-			$offset = sanitise_int($options['offset'], true);
+			$offset = sanitise_int($options['offset'], false);
 			$query .= " LIMIT $offset, $limit";
 		}
 

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -302,7 +302,7 @@ function elgg_get_river(array $options = array()) {
 
 		if ($options['limit']) {
 			$limit = sanitise_int($options['limit']);
-			$offset = sanitise_int($options['offset']);
+			$offset = sanitise_int($options['offset'], true);
 			$query .= " LIMIT $offset, $limit";
 		}
 
@@ -375,7 +375,7 @@ function elgg_row_to_elgg_river_item($row) {
 function elgg_river_get_access_sql() {
 	// rewrite default access where clause to work with river table
 	return str_replace("and enabled='yes'", '',
-		str_replace('owner_guid', 'rv.subject_guid', 
+		str_replace('owner_guid', 'rv.subject_guid',
 		str_replace('access_id', 'rv.access_id', get_access_sql_suffix())));
 }
 


### PR DESCRIPTION
There you go. This should be the better solution than https://github.com/Elgg/Elgg/pull/17/.

What is left?
I haven't checked yet, but maybe the same thing needs to be applied to limits? Also, there seems to be the same issue in the search plugin (in the search_comments_hook() function in search_hooks.php) - which might even lead to SQL injection (not sure yet, I need to verify that).
