### PR TITLE
Re: Ticket #2922 userpicker JS needs to send the term as well

### DIFF
--- a/js/lib/userpicker.js
+++ b/js/lib/userpicker.js
@@ -75,9 +75,9 @@ elgg.userpicker.removeUser = function(link, guid) {
 
 elgg.userpicker.getSearchParams = function(e) {
 	if ($(e).closest('.elgg-user-picker').find('[name=match_on]').attr('checked')) {
-		return {'match_on[]': 'friends'};
+		return {'match_on[]': 'friends', 'term' : e.term};
 	} else {
-		return {'match_on[]': 'users'};
+		return {'match_on[]': 'users', 'term' : e.term};
 	}
 }
 


### PR DESCRIPTION
Since 'pg/livesearch' has been updated to work with the 'term' paramater, I thought the userpicker js should actually send the term along. (The getSearchParams function was only sending 'match_on' without the term)
