### PR TITLE
Updated river view and language string for user icon update entry

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -404,7 +404,7 @@ $english = array(
  */
 	'river' => "River",
 	'river:friend:user:default' => "%s is now a friend with %s",
-	'profile:river:iconupdate' => 'updated their profile icon',
+	'river:update:user:default' => '%s updated their profile icon',
 	'river:noaccess' => 'You do not have permission to view this item.',
 	'river:posted:generic' => '%s posted',
 	'riveritem:single:user' => 'a user',

--- a/views/default/river/user/default/profileiconupdate.php
+++ b/views/default/river/user/default/profileiconupdate.php
@@ -2,12 +2,7 @@
 /**
  * Update avatar river view
  */
-$subject = $vars['item']->getSubjectEntity();
 
-$subject_icon = elgg_view_entity_icon($subject, 'tiny');
-
-echo elgg_echo("profile:river:iconupdate");
-
-echo '<div class="elgg-river-content clearfix">';
-echo $subject_icon;
-echo '</div>';
+echo elgg_view('river/item', array(
+	'item' => $vars['item'],
+));


### PR DESCRIPTION
Looks like the avatar update view was missed in the river revamp, I've addressed that with this commit. 
