### PR TITLE
Better handling of options in ElggMenuItem

### DIFF
--- a/engine/classes/ElggMenuItem.php
+++ b/engine/classes/ElggMenuItem.php
@@ -10,10 +10,41 @@
  * @since 1.8.0
  */
 class ElggMenuItem {
+
 	/**
-	 * @var string Identifier of the menu
+	 * @var array Non-rendered data about the menu item
 	 */
-	protected $name;
+	protected $data = array(
+		// string Identifier of the menu
+		'name' => '',
+
+		// array Page contexts this menu item should appear on
+		'contexts' => array('all'),
+
+		// string Menu section identifier
+		'section' => 'default',
+
+		// int Smaller priorities float to the top
+		'priority' => 100,
+
+		// bool Is this the currently selected menu item
+		'selected' => false,
+
+		// string Identifier of this item's parent
+		'parent_name' => '',
+
+		// ElggMenuItem The parent object or null
+		'parent' => null,
+
+		// array Array of children objects or empty array
+		'children' => array(),
+
+		// array Classes to apply to the li tag
+		'itemClass' => array(),
+
+		// array Classes to apply to the anchor tag
+		'linkClass' => array(),
+	);
 
 	/**
 	 * @var string The menu display string
@@ -26,59 +57,15 @@ class ElggMenuItem {
 	protected $href = null;
 
 	/**
-	 * @var string The string to display if link is clicked
-	 */
-	protected $confirm = '';
-
-	/**
-	 * @var array Classes to apply to the anchor tag.
-	 */
-	protected $linkClass = array();
-
-	/**
-	 * @var array Classes to apply to the li tag.
-	 */
-	protected $itemClass = array();
-
-	/**
-	 * @var array Page context array
-	 */
-	protected $contexts = array('all');
-
-	/**
-	 * @var string Menu section identifier
-	 */
-	protected $section = 'default';
-
-	/**
 	 * @var string Tooltip
 	 */
 	protected $title = '';
 
 	/**
-	 * @var int Menu priority - smaller prioritys float to the top
+	 * @var string The string to display if link is clicked
 	 */
-	protected $priority = 100;
+	protected $confirm = '';
 
-	/**
-	 * @var bool Is this the currently selected menu item
-	 */
-	protected $selected = false;
-
-	/**
-	 * @var string Identifier of this item's parent
-	 */
-	protected $parent_name = '';
-
-	/**
-	 * @var ElggMenuItem The parent object or null
-	 */
-	protected $parent = null;
-
-	/**
-	 * @var array Array of children objects or empty array
-	 */
-	protected $children = array();
 
 	/**
 	 * ElggMenuItem constructor
@@ -88,13 +75,15 @@ class ElggMenuItem {
 	 * @param string $href  URL of the menu item (false if not a link)
 	 */
 	public function __construct($name, $text, $href) {
-		$this->name = $name;
+		//$this->name = $name;
 		$this->text = $text;
 		if ($href) {
 			$this->href = elgg_normalize_url($href);
 		} else {
 			$this->href = $href;
 		}
+
+		$this->data['name'] = $name;
 	}
 
 	/**
@@ -122,6 +111,12 @@ class ElggMenuItem {
 			$options['contexts'] = $options['context'];
 			unset($options['context']);
 		}
+		
+		// make sure contexts is set correctly
+		if (isset($options['contexts'])) {
+			$item->setContext($options['contexts']);
+			unset($options['contexts']);
+		}
 
 		if (isset($options['link_class'])) {
 			$item->setLinkClass($options['link_class']);
@@ -133,16 +128,62 @@ class ElggMenuItem {
 			unset($options['item_class']);
 		}
 
-		foreach ($options as $key => $value) {
-			$item->$key = $value;
+		if (isset($options['data']) && is_array($options['data'])) {
+			$item->setData($options['data']);
+			unset($options['data']);
 		}
-
-		// make sure contexts is set correctly
-		if (isset($options['contexts'])) {
-			$item->setContext($options['contexts']);
+		
+		foreach ($options as $key => $value) {
+			if (isset($item->data[$key])) {
+				$item->data[$key] = $value;
+			} else {
+				$item->$key = $value;
+			}
 		}
 
 		return $item;
+	}
+
+	/**
+	 * Set a data key/value pair or a set of key/value pairs
+	 *
+	 * This method allows storage of arbitrary data with this menu item. The
+	 * data can be used for sorting, custom rendering, or any other use.
+	 *
+	 * @param mixed $key   String key or an associative array of key/value pairs
+	 * @param mixed $value The value if $key is a string
+	 * @return void
+	 */
+	public function setData($key, $value = null) {
+		if (is_array($key)) {
+			$this->data += $key;
+		} else {
+			$this->data[$key] = $value;
+		}
+	}
+
+	/**
+	 * Get stored data
+	 *
+	 * @param string $key The key for the requested key/value pair
+	 * @return mixed
+	 */
+	public function getData($key) {
+		if (isset($this->data[$key])) {
+			return $this->data[$key];
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Set the identifier of the menu item
+	 *
+	 * @param string Unique identifier
+	 * @return void
+	 */
+	public function setName($name) {
+		$this->data['name'] = $name;
 	}
 
 	/**
@@ -151,14 +192,13 @@ class ElggMenuItem {
 	 * @return string
 	 */
 	public function getName() {
-		return $this->name;
+		return $this->data['name'];
 	}
-	
+
 	/**
 	 * Set the display text of the menu item
 	 * 
 	 * @param string $text The display text
-	 * 
 	 * @return void
 	 */
 	public function setText($text) {
@@ -177,6 +217,7 @@ class ElggMenuItem {
 	/**
 	 * Set the URL of the menu item
 	 *
+	 * @param string $href URL or false if not a link
 	 * @return void
 	 */
 	public function setHref($href) {
@@ -196,14 +237,13 @@ class ElggMenuItem {
 	 * Set the contexts that this menu item is available for
 	 *
 	 * @param array $contexts An array of context strings
-	 *
 	 * @return void
 	 */
 	public function setContext($contexts) {
 		if (is_string($contexts)) {
 			$contexts = array($contexts);
 		}
-		$this->contexts = $contexts;
+		$this->data['contexts'] = $contexts;
 	}
 
 	/**
@@ -212,27 +252,26 @@ class ElggMenuItem {
 	 * @return array
 	 */
 	public function getContext() {
-		return $this->contexts;
+		return $this->data['contexts'];
 	}
 
 	/**
 	 * Should this menu item be used given the current context
 	 *
 	 * @param string $context A context string (default is empty string for
-	 *                        current context stack.
-	 *
+	 *                        current context stack).
 	 * @return bool
 	 */
 	public function inContext($context = '') {
 		if ($context) {
-			return in_array($context, $this->contexts);
+			return in_array($context, $this->data['contexts']);
 		}
 
-		if (in_array('all', $this->contexts)) {
+		if (in_array('all', $this->data['contexts'])) {
 			return true;
 		}
 
-		foreach ($this->contexts as $context) {
+		foreach ($this->data['contexts'] as $context) {
 			if (elgg_in_context($context)) {
 				return true;
 			}
@@ -244,11 +283,10 @@ class ElggMenuItem {
 	 * Set the selected flag
 	 *
 	 * @param bool $state Selected state (default is true)
-	 *
 	 * @return void
 	 */
 	public function setSelected($state = true) {
-		$this->selected = $state;
+		$this->data['selected'] = $state;
 	}
 
 	/**
@@ -257,14 +295,13 @@ class ElggMenuItem {
 	 * @return bool
 	 */
 	public function getSelected() {
-		return $this->selected;
+		return $this->data['selected'];
 	}
 
 	/**
 	 * Set the tool tip text
 	 *
 	 * @param string $text The text of the tool tip
-	 *
 	 * @return void
 	 */
 	public function setTooltip($text) {
@@ -284,7 +321,6 @@ class ElggMenuItem {
 	 * Set the confirm text shown when link is clicked
 	 *
 	 * @param string $text The text to show
-	 *
 	 * @return void
 	 */
 	public function setConfirmText($text) {
@@ -304,14 +340,13 @@ class ElggMenuItem {
 	 * Set the anchor class
 	 *
 	 * @param mixed $class An array of class names, or a single string class name.
-	 *
 	 * @return void
 	 */
 	public function setLinkClass($class) {
 		if (!is_array($class)) {
-			$this->linkClass[] = $class;
+			$this->data['linkClass'] = array($class);
 		} else {
-			$this->linkClass = $class;
+			$this->data['linkClass'] = $class;
 		}
 	}
 
@@ -321,21 +356,34 @@ class ElggMenuItem {
 	 * @return string
 	 */
 	public function getLinkClass() {
-		return implode(' ', $this->linkClass);
+		return implode(' ', $this->data['linkClass']);
+	}
+
+	/**
+	 * Add a link class
+	 *
+	 * @param mixed $class An array of class names, or a single string class name.
+	 * @return void
+	 */
+	public function addLinkClass($class) {
+		if (!is_array($class)) {
+			$this->data['linkClass'][] = $class;
+		} else {
+			$this->data['linkClass'] += $class;
+		}
 	}
 
 	/**
 	 * Set the li classes
 	 *
 	 * @param mixed $class An array of class names, or a single string class name.
-	 *
 	 * @return void
 	 */
 	public function setItemClass($class) {
 		if (!is_array($class)) {
-			$this->itemClass[] = $class;
+			$this->data['itemClass'] = array($class);
 		} else {
-			$this->itemClass = $class;
+			$this->data['itemClass'] = $class;
 		}
 	}
 
@@ -345,11 +393,11 @@ class ElggMenuItem {
 	 * @return string
 	 */
 	public function getItemClass() {
-		//allow people to specify name with underscores and colons
+		// allow people to specify name with underscores and colons
 		$name = str_replace('_', '-', $this->getName());
 		$name = str_replace(':', '-', $name);
 
-		$class = implode(' ', $this->itemClass);
+		$class = implode(' ', $this->data['itemClass']);
 		if ($class) {
 			return "elgg-menu-item-$name $class";
 		} else {
@@ -361,11 +409,10 @@ class ElggMenuItem {
 	 * Set the priority of the menu item
 	 *
 	 * @param int $priority The smaller numbers mean higher priority (1 before 100)
-	 *
 	 * @return void
 	 */
 	public function setWeight($priority) {
-		$this->priority = $priority;
+		$this->data['priority'] = $priority;
 	}
 
 	/**
@@ -374,18 +421,17 @@ class ElggMenuItem {
 	 * @return int
 	 */
 	public function getWeight() {
-		return $this->priority;
+		return $this->data['priority'];
 	}
 
 	/**
 	 * Set the section identifier
 	 *
 	 * @param string $section The identifier of the section
-	 *
 	 * @return void
 	 */
 	public function setSection($section) {
-		$this->section = $section;
+		$this->data['section'] = $section;
 	}
 
 	/**
@@ -394,18 +440,17 @@ class ElggMenuItem {
 	 * @return string
 	 */
 	public function getSection() {
-		return $this->section;
+		return $this->data['section'];
 	}
 
 	/**
 	 * Set the parent identifier
 	 *
-	 * @param string $parent_name The identifier of the parent ElggMenuItem
-	 *
+	 * @param string $name The identifier of the parent ElggMenuItem
 	 * @return void
 	 */
-	public function setParentName($parent_name) {
-		$this->parent_name = $parent_name;
+	public function setParentName($name) {
+		$this->data['parent_name'] = $name;
 	}
 
 	/**
@@ -414,18 +459,17 @@ class ElggMenuItem {
 	 * @return string
 	 */
 	public function getParentName() {
-		return $this->parent_name;
+		return $this->data['parent_name'];
 	}
 
 	/**
 	 * Set the parent menu item
 	 *
 	 * @param ElggMenuItem $parent
-	 *
 	 * @return void
 	 */
 	public function setParent($parent) {
-		$this->parent = $parent;
+		$this->data['parent'] = $parent;
 	}
 
 	/**
@@ -434,29 +478,27 @@ class ElggMenuItem {
 	 * @return ElggMenuItem or null
 	 */
 	public function getParent() {
-		return $this->parent;
+		return $this->data['parent'];
 	}
 
 	/**
 	 * Add a child menu item
 	 *
 	 * @param ElggMenuItem $item
-	 *
 	 * @return void
 	 */
 	public function addChild($item) {
-		$this->children[] = $item;
+		$this->data['children'][] = $item;
 	}
 
 	/**
 	 * Set the menu item's children
 	 *
 	 * @param array $children Array of ElggMenuItems
-	 *
 	 * @return void
 	 */
 	public function setChildren($children) {
-		$this->children = $children;
+		$this->data['children'] = $children;
 	}
 
 	/**
@@ -465,25 +507,23 @@ class ElggMenuItem {
 	 * @return array
 	 */
 	public function getChildren() {
-		return $this->children;
+		return $this->data['children'];
 	}
 
 	/**
 	 * Sort the children
 	 *
-	 * @param string $sort_function
-	 *
+	 * @param string $sortFunction A function that is passed to usort()
 	 * @return void
 	 */
-	public function sortChildren($sort_function) {
-		usort($this->children, $sort_function);
+	public function sortChildren($sortFunction) {
+		usort($this->data['children'], $sortFunction);
 	}
 
 	/**
 	 * Get the menu item content (usually a link)
 	 *
 	 * @params array $vars Options to pass to output/url if a link
-	 *
 	 * @return string
 	 *
 	 * @todo View code in a model.  How do we feel about that?
@@ -494,30 +534,17 @@ class ElggMenuItem {
 			return $this->text;
 		}
 
-		$vars['text'] = $this->text;
+		$defaults = get_object_vars($this);
+		unset($defaults['data']);
 
-		if ($this->href) {
-			$vars['href'] = $this->href;
-		}
+		$vars += $defaults;
 
-		if ($this->linkClass) {
-			$vars['class'] = $this->getLinkClass();
-		}
-
-		if ($this->link_rel) {
-			$vars['rel'] = $this->link_rel;
-		}
-
-		if ($this->rel) {
-			$vars['rel'] = $this->rel;
-		}
-
-		if ($this->title) {
-			$vars['title'] = $this->title;
-		}
-
-		if ($this->is_action) {
-			$vars['is_action'] = $this->is_action;
+		if ($this->data['linkClass']) {
+			if (isset($vars['class'])) {
+				$vars['class'] += $this->getLinkClass();
+			} else {
+				$vars['class'] = $this->getLinkClass();
+			}
 		}
 
 		if ($this->confirm) {

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -276,7 +276,7 @@ function elgg_river_menu_setup($hook, $type, $return, $params) {
 					'href' => "#comments-add-$object->guid",
 					'text' => elgg_view_icon('speech-bubble'),
 					'title' => elgg_echo('comment:this'),
-					'link_rel' => 'toggle',
+					'rel' => 'toggle',
 					'priority' => 50,
 				);
 				$return[] = ElggMenuItem::factory($options);

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -776,7 +776,7 @@ function discussion_add_to_river_menu($hook, $type, $return, $params) {
 						'href' => "#groups-reply-$object->guid",
 						'text' => elgg_view_icon('speech-bubble'),
 						'title' => elgg_echo('reply:this'),
-						'link_rel' => 'toggle',
+						'rel' => 'toggle',
 						'priority' => 50,
 					);
 					$return[] = ElggMenuItem::factory($options);


### PR DESCRIPTION
- Only options defined as not renderable are **not** passed to output/url view. This includes options like priority, section, and contexts. (opposite of previous implementation). This means passing 'rel' => 'whatever' will show up on the anchor tag without special code in the ElggMenuItem class to recognize it.
- Added a data array in the class for storage of arbitrary data. Think jQuery's .data() method
- You can now pass 'class' and have it end up on the anchor tag.
- backward compatible (unless someone was already adding arbitrary data to a menu item. It will now show up in the anchor tag)
