### PR TITLE
group invitations, filters (#3720) and site-wide categories (#3746) bug-fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ engine/settings.php
 /.buildpath
 /.settings
 /.project
+.DS_Store
+

--- a/mod/categories/start.php
+++ b/mod/categories/start.php
@@ -16,7 +16,7 @@ function categories_init() {
 	elgg_extend_view('css/elgg', 'categories/css');
 
 	$action_base = elgg_get_plugins_path() . 'categories/actions';
-	elgg_register_action('settings/categories/save', "$action_base/save.php", 'admin');
+	elgg_register_action('categories/settings/save', "$action_base/save.php", 'admin');
 
 	elgg_register_page_handler('categories', 'categories_page_handler');
 

--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -198,7 +198,7 @@ function groups_handle_invitations_page() {
 	elgg_push_breadcrumb($title);
 
 	// @todo temporary workaround for exts #287.
-	$invitations = groups_get_invited_groups($user->getGUID());
+	$invitations = groups_get_invited_groups(elgg_get_logged_in_user_guid());
 	$content = elgg_view('groups/invitationrequests', array('invitations' => $invitations));
 
 	$params = array(

--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -25,7 +25,7 @@ function groups_handle_all_page() {
 				'full_view' => false,
 			));
 			break;
-		case 'active':
+		case 'discussion':
 			$content = elgg_list_entities(array(
 				'type' => 'object',
 				'subtype' => 'groupforumtopic',

--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -17,7 +17,7 @@ function groups_handle_all_page() {
 	$selected_tab = get_input('filter', 'newest');
 
 	switch ($selected_tab) {
-		case 'pop':
+		case 'popular':
 			$content = elgg_list_entities_from_relationship_count(array(
 				'type' => 'group',
 				'relationship' => 'member',


### PR DESCRIPTION
- Groupfilters 'latest discussion' and 'popular'  did nothing because they were called 'active' and 'pop' in the case statement
- Site-wide categories didn't save in admin interface
- Group invitations for a user didn't work because of unknown $user in context
