### PR TITLE
Default group icons are GIFs, not JPGs.

### DIFF
--- a/mod/groups/icon.php
+++ b/mod/groups/icon.php
@@ -28,7 +28,7 @@ if ($filehandler->open("read")) {
 }
 
 if (!$success) {
-	$location = elgg_get_plugins_path() . "groups/graphics/default{$size}.jpg";
+	$location = elgg_get_plugins_path() . "groups/graphics/default{$size}.gif";
 	$contents = @file_get_contents($location);
 }
 


### PR DESCRIPTION
When a group icon cannot be displayed, icon.php had the default icons as JPGs, but they are GIFs.
