### PR TITLE
#3601: Missing .js and .ico in Etag in .htaccess

### DIFF
--- a/htaccess_dist
+++ b/htaccess_dist
@@ -76,9 +76,12 @@ DirectoryIndex index.php
 </IfModule>
 
 # Configure ETags
-<FilesMatch "\.(jpg|jpeg|gif|png|mp3|flv|mov|avi|3pg|html|htm|swf)$">
+<FilesMatch "\.(jpg|jpeg|gif|png|mp3|flv|mov|avi|3pg|html|htm|swf|js|ico)$">
 	FileETag MTime Size
 </FilesMatch>
+
+#  Add Proper MIME-Type for Favicon to allow expires to work
+AddType image/vnd.microsoft.icon .ico
 
 <IfModule mod_rewrite.c>
 


### PR DESCRIPTION
http://trac.elgg.org/ticket/3601  

For optimal speed, Firebug's Yslow complained that the js and ico files did not have an Etag.
