### PR TITLE
Add widget setting access label

### DIFF
--- a/views/default/core/settings/account/name.php
+++ b/views/default/core/settings/account/name.php
@@ -9,7 +9,22 @@
  */
 
 $user = elgg_get_page_owner_entity();
+?>
+<div class="elgg-module elgg-module-info">
+  <div class="elgg-head">
+		<h3><?php echo elgg_echo('user:name:label'); ?></h3>
+	</div>
+	<div class="elgg-body">
+		<p>
+			<?php echo elgg_echo('name'); ?>:
+			<?php
+			echo elgg_view('input/text', array('name' => 'name', 'value' => $user->name));
+			?>
+		</p>
+	</div>
+</div>
+
+<?php
 
 // all hidden, but necessary for properly updating user details
-echo elgg_view('input/hidden', array('name' => 'name', 'value' => $user->name));
 echo elgg_view('input/hidden', array('name' => 'guid', 'value' => $user->guid));

--- a/views/default/forms/widgets/save.php
+++ b/views/default/forms/widgets/save.php
@@ -14,7 +14,7 @@ $custom_form_section = elgg_view($edit_view, array('entity' => $widget));
 
 $access = '';
 if ($show_access) {
-	$access = elgg_view('input/access', array(
+	$access = elgg_echo('access').': '.elgg_view('input/access', array(
 		'name' => 'params[access_id]',
 		'value' => $widget->access_id,
 	));


### PR DESCRIPTION
When editting widget settings, the 'access' label was missing. - Added on line 17
