### PR TITLE
Clean login failures on new password request

### DIFF
--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -742,7 +742,9 @@ function execute_new_password_request($user_guid, $conf_code) {
 
 			if (force_user_password_reset($user_guid, $password)) {
 				remove_private_setting($user_guid, 'passwd_conf_code');
-
+				// clean the logins failures
+				reset_login_failure_count($user_guid);
+				
 				$email = elgg_echo('email:resetpassword:body', array($user->name, $password));
 
 				return notify_user($user->guid, $CONFIG->site->guid,


### PR DESCRIPTION
There were a feature, that the account is blocked when the user fails 5 times in 5 minutes, then the account is blocked, if the user click on "Request new password" and then he generate a new password, then he couldn't login, because him account was blocked for a while, this could scare members.

So have more sense to activate the user when he got a new password.
