### PR TITLE
Walled garden external pages

### DIFF
--- a/mod/externalpages/start.php
+++ b/mod/externalpages/start.php
@@ -12,6 +12,9 @@ function expages_init() {
 	elgg_register_page_handler('terms', 'expages_page_handler');
 	elgg_register_page_handler('privacy', 'expages_page_handler');
 	elgg_register_page_handler('expages', 'expages_page_handler');
+	
+	// Register public external pages
+	elgg_register_plugin_hook_handler('public_pages', 'walled_garden', 'expages_public');
 
 	// add a menu item for the admin edit page
 	elgg_register_admin_menu_item('configure', 'expages', 'appearance');
@@ -22,6 +25,15 @@ function expages_init() {
 	// register action
 	$actions_base = elgg_get_plugins_path() . 'externalpages/actions';
 	elgg_register_action("expages/edit", "$actions_base/edit.php", 'admin');
+}
+
+/**
+ * Extend the public pages range
+ *
+ */
+function expages_public($hook, $handler, $return, $params){
+	$pages = array('about', 'terms', 'privacy');
+	return array_merge($pages, $return);
 }
 
 /**

--- a/views/default/css/walled_garden.php
+++ b/views/default/css/walled_garden.php
@@ -28,6 +28,10 @@ $url = elgg_get_site_url();
 	margin: 35px 15px 15px 35px;
 }
 
+#elgg-walledgarden-intro ul {
+	float: left;
+}
+
 #elgg-walledgarden-login {
 	width: 230px;
 	float: left;

--- a/views/default/page/walled_garden.php
+++ b/views/default/page/walled_garden.php
@@ -31,6 +31,7 @@ $title = $site->name;
 						echo $title;
 					?>
 				</h1>
+				<?php echo elgg_view_menu('footer', array('sort_by' => 'priority', 'class' => 'elgg-menu-hz')); ?>
 			</div>
 			<div id="elgg-walledgarden-login">
 				<?php echo $vars['body']; ?>


### PR DESCRIPTION
Closes #3947. External pages are now viewable by visitors in walled-garden sites. Footer menu is also added into walled-garden logging page.
