### PR TITLE
Register lightbox simplecache view: elgg_register_simplecache_view('css/lightbox')

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1595,6 +1595,7 @@ function elgg_views_boot() {
 	elgg_load_js('elgg');
 
 	elgg_register_simplecache_view('js/lightbox');
+	elgg_register_simplecache_view('css/lightbox');
 	$lightbox_js_url = elgg_get_simplecache_url('js', 'lightbox');
 	elgg_register_js('lightbox', $lightbox_js_url);
 	$lightbox_css_url = elgg_get_simplecache_url('css', 'lightbox');


### PR DESCRIPTION
We're having all kinds of simplecache related problems, even on a clean elgg install (See: http://trac.elgg.org/ticket/3859).

We noticed that the embed plugin seemed to be causing the issue, specifically when it tries to load the lightbox JS. Properly registering the CSS view seems to fix the problem.
