### PR TITLE
Fixes Ticket #4172, Embed headings are now translatable.

### DIFF
--- a/mod/embed/views/default/embed/media.php
+++ b/mod/embed/views/default/embed/media.php
@@ -1,4 +1,4 @@
-<h1 class="mediaModalTitle">Embed / Upload Media</h1>
+<h1 class="mediaModalTitle"><?php echo elgg_echo('media:insert'); ?></h1>
 <?php
 
 	echo elgg_view('embed/tabs',array('tab' => 'media', 'internalname' => $vars['internalname']));

--- a/mod/embed/views/default/embed/upload.php
+++ b/mod/embed/views/default/embed/upload.php
@@ -1,4 +1,4 @@
-<h1 class="mediaModalTitle">Embed / Upload Media</h1>
+<h1 class="mediaModalTitle"><?php echo elgg_echo('media:insert'); ?></h1>
 <?php
 
 	echo elgg_view('embed/tabs',array('tab' => 'upload', 'internalname'=>$vars['internalname']));


### PR DESCRIPTION
The heading "Embed / upload media" is now a translatable string in the Embed/Upload media tabs (added elgg_echo function).
