### PR TITLE
Fixes #4085 if someone writes a dot after the username

### DIFF
--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -217,7 +217,7 @@ function thewire_filter($text) {
 
 	// usernames
 	$text = preg_replace(
-				'/(^|[^\w])@([\w.?]+)/',
+				'/(^|[^\w])@([\w.]+[\w])/',
 				'$1<a href="' . $CONFIG->wwwroot . 'thewire/owner/$2">@$2</a>',
 				$text);
 

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -217,7 +217,7 @@ function thewire_filter($text) {
 
 	// usernames
 	$text = preg_replace(
-				'/(^|[^\w])@([\w]+)/',
+				'/(^|[^\w])@([\w.?]+)/',
 				'$1<a href="' . $CONFIG->wwwroot . 'thewire/owner/$2">@$2</a>',
 				$text);
 


### PR DESCRIPTION
Fixes #4085 (hope so as it was reopened) Changes the regexp for the last word in the username, so it can contain dots but has to finish in a word. This way if someo writes nacho.pavon. as the username it will include only nacho.pavon as username.
