### PR TITLE
Change var maxHeight = 0; to var maxHeight = height + 'px';

### DIFF
--- a/js/lib/ui.widgets.js
+++ b/js/lib/ui.widgets.js
@@ -190,7 +190,7 @@ elgg.ui.widgets.saveSettings = function(event) {
  * @return void
  */
 elgg.ui.widgets.equalHeight = function(selector) {
-	var maxHeight = 0;
+	var maxHeight = height + 'px';
 	$(selector).each(function() {
 		if ($(this).height() > maxHeight) {
 			maxHeight = $(this).height();


### PR DESCRIPTION
This removes the overflow with the profile widgets.
http://trac.elgg.org/ticket/4192
