### PR TITLE
Add function to get all groups with a given name

### DIFF
--- a/engine/lib/group.php
+++ b/engine/lib/group.php
@@ -334,3 +334,26 @@ function remove_group_tool_option($name) {
 		}
 	}
 }
+
+/**
+ * Return all groups with a name
+ *
+ * @param string $name The name of the groups
+ *
+ * @return array|false Depending on success
+ * @since 1.8.3
+ */
+function get_groups_by_name($name) {
+	global $CONFIG;
+
+	$name = sanitise_string($name);
+	$access = get_access_sql_suffix('e');
+
+	$query = "SELECT e.* from {$CONFIG->dbprefix}groups_entity u
+		join {$CONFIG->dbprefix}entities e on e.guid=u.guid
+		where u.name='$name' and $access ";
+
+	$groups = get_data($query, 'entity_row_to_elggstar');
+
+	return $groups;
+}


### PR DESCRIPTION
I added a function resembling `get_user_by_username` for groups. Perhaps there is a clean way to do it without this function.

I haven't cached the results, do you think it's necessary for this kind of query?

I could add this function in a plugin but thought this could go into the core if you think it's appropriated.

Let me know what you think.
