### PR TITLE
Fix 3790: rendering of tabs

### DIFF
--- a/mod/tinymce/views/default/js/tinymce.php
+++ b/mod/tinymce/views/default/js/tinymce.php
@@ -38,7 +38,7 @@ elgg.tinymce.init = function() {
 		mode : "specific_textareas",
 		editor_selector : "elgg-input-longtext",
 		theme : "advanced",
-		plugins : "spellchecker,autosave,fullscreen,paste",
+		plugins : "lists,spellchecker,autosave,fullscreen,paste",
 		relative_urls : false,
 		remove_script_host : false,
 		document_base_url : elgg.config.wwwroot,

--- a/views/default/navigation/tabs.php
+++ b/views/default/navigation/tabs.php
@@ -5,8 +5,8 @@
  * @uses string $vars['type'] horizontal || vertical - Defaults to horizontal
  * @uses string $vars['class'] Additional class to add to ul
  * @uses array $vars['tabs'] A multi-dimensional array of tab entries in the format array(
- * 	'title' => string, // Title of link
- * 	'url' => string, // URL for the link
+ * 	'text' => string, // Title of link
+ * 	'href' => string, // URL for the link
  * 	'class' => string  // Class of the li element
  * 	'id' => string, // ID of the li element
  * 	'selected' => bool // if this li element is currently selected
@@ -15,58 +15,68 @@
  * )
  */
 
+$options = elgg_clean_vars($vars);
+
 $type = elgg_extract('type', $vars, 'horizontal');
+
 if ($type == 'horizontal') {
-	$type_class = "elgg-tabs elgg-htabs";
+	$options['class'] = "elgg-tabs elgg-htabs";
 } else {
-	$type_class = "elgg-tabs elgg-vtabs";
+	$options['class'] = "elgg-tabs elgg-vtabs";
+}
+if (isset($vars['class'])) {
+	$options['class'] = "{$options['class']} {$vars['class']}";
 }
 
-if (isset($vars['class'])) {
-	$type_class = "$type_class {$vars['class']}";
-}
+unset($options['tabs']);
+unset($options['type']);
+
+$options = elgg_format_attributes($options);
 
 if (isset($vars['tabs']) && is_array($vars['tabs']) && !empty($vars['tabs'])) {
-?>
-	<ul class="<?php echo $type_class; ?>">
-	<?php
-	foreach ($vars['tabs'] as $info) {
-		$class = elgg_extract('class', $info, '');
-		$id = elgg_extract('id', $info, '');
-		
-		$selected = elgg_extract('selected', $info, FALSE);
-		if ($selected) {
-			$class .= ' elgg-state-selected';
-		}
+    ?>
+    <ul <?php echo $options ?>>
+        <?php
+        foreach ($vars['tabs'] as $info) {
+            $class = elgg_extract('class', $info, '');
+            $id = elgg_extract('id', $info, '');
 
-		$class_str = ($class) ? "class=\"$class\"" : '';
-		$id_str = ($id) ? "id=\"$id\"" : '';
-		$title = htmlspecialchars($info['title'], ENT_QUOTES, 'UTF-8');
-		$url = htmlspecialchars($info['url'], ENT_QUOTES, 'UTF-8');
+            $selected = elgg_extract('selected', $info, FALSE);
+            if ($selected) {
+                $class .= ' elgg-state-selected';
+            }
 
-		$options = array(
-			'href' => $url,
-			'title' => $title,
-			'text' => $title,
-		);
+            $class_str = ($class) ? "class=\"$class\"" : '';
+            $id_str = ($id) ? "id=\"$id\"" : '';
 
-		if (isset($info['url_class'])) {
-			$options['class'] = $info['url_class'];
-		}
+            $options = $info;
+            unset($options['class']);
+            unset($options['id']);
+            unset($options['selected']);
 
-		if (isset($info['url_id'])) {
-			$options['id'] = $info['url_id'];
-		}
+            if (!isset($info['href']) && isset($info['url'])) {
+                $options['href'] = $info['url'];
+                unset($options['url']);
+            }
+            if (!isset($info['text']) && isset($info['title'])) {
+                $options['text'] = $options['title'];
+                unset($options['title']);
+            }
+            if (isset($info['url_class'])) {
+                $options['class'] = $options['url_class'];
+                unset($options['url_class']);
+            }
 
-		if (!isset($info['rel']) && !isset($info['is_trusted'])) {
-			$options['is_trusted'] = true;
-		}
+            if (isset($info['url_id'])) {
+                $options['id'] = $options['url_id'];
+                unset($options['url_id']);
+            }
 
-		$link = elgg_view('output/url', $options);
+			$link = elgg_view('output/url', $options);
 
-		echo "<li $class_str $js>$link</li>";
-	}
-	?>
-		</ul>
-	<?php
+            echo "<li $id_str $class_str>$link</li>";
+        }
+        ?>
+    </ul>
+    <?php
 }


### PR DESCRIPTION
This ensures consistency in rendering urls within navigation items. With this fix:
-- ul element acquires an attribute parameter (if set)
-- li element acquires an id parameter (if set)
-- a element acquires all other parameters set for a given tab, so that those can be rendered via elgg_format_attributes
