### PR TITLE
Fixes 4231: untimely termination of entity creation if can't write to owner as container

### DIFF
--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -464,14 +464,6 @@ function can_write_to_container($user_guid = 0, $container_guid = 0, $type = 'al
 		if ($container->canEdit($user_guid)) {
 			$return = true;
 		}
-
-		// If still not approved, see if the user is a member of the group
-		// @todo this should be moved to the groups plugin/library
-		if (!$return && $user && $container instanceof ElggGroup) {
-			if ($container->isMember($user)) {
-				$return = true;
-			}
-		}
 	}
 
 	// See if anyone else has anything to say
@@ -528,14 +520,11 @@ $container_guid = 0) {
 	}
 
 	$user_guid = elgg_get_logged_in_user_guid();
-	if (!can_write_to_container($user_guid, $owner_guid, $type, $subtype)) {
+	if (!can_write_to_container($user_guid, $owner_guid, $type, $subtype)
+		&& !can_write_to_container($user_guid, $container_guid, $type, $subtype)) {
 		return false;
 	}
-	if ($owner_guid != $container_guid) {
-		if (!can_write_to_container($user_guid, $container_guid, $type, $subtype)) {
-			return false;
-		}
-	}
+
 	if ($type == "") {
 		throw new InvalidParameterException(elgg_echo('InvalidParameterException:EntityTypeNotSet'));
 	}
@@ -669,7 +658,7 @@ function get_entity($guid) {
 	static $newentity_cache;
 	$new_entity = false;
 
-	// We could also use: if (!(int) $guid) { return FALSE }, 
+	// We could also use: if (!(int) $guid) { return FALSE },
 	// but that evaluates to a false positive for $guid = TRUE.
 	// This is a bit slower, but more thorough.
 	if (!is_numeric($guid) || $guid === 0 || $guid === '0') {
@@ -1489,7 +1478,7 @@ function delete_entity($guid, $recursive = true) {
 				if (isset($ENTITY_CACHE[$guid])) {
 					invalidate_cache_for_entity($guid);
 				}
-				
+
 				// If memcache is available then delete this entry from the cache
 				static $newentity_cache;
 				if ((!$newentity_cache) && (is_memcache_available())) {

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -61,8 +61,8 @@ function groups_init() {
 
 	// group entity menu
 	elgg_register_plugin_hook_handler('register', 'menu:entity', 'groups_entity_menu_setup');
-	
-	// group user hover menu	
+
+	// group user hover menu
 	elgg_register_plugin_hook_handler('register', 'menu:user_hover', 'groups_user_entity_menu_setup');
 
 	// delete and edit annotations for topic replies
@@ -75,6 +75,9 @@ function groups_init() {
 	// Access permissions
 	elgg_register_plugin_hook_handler('access:collections:write', 'all', 'groups_write_acl_plugin_hook');
 	//elgg_register_plugin_hook_handler('access:collections:read', 'all', 'groups_read_acl_plugin_hook');
+
+	// Allow groups members to write to group container
+	elgg_register_plugin_hook_handler('container_permissions_check', 'group', 'groups_container_persmissions_check');
 
 	// Register profile menu hook
 	elgg_register_plugin_hook_handler('profile_menu', 'profile', 'forum_profile_menu');
@@ -89,7 +92,7 @@ function groups_init() {
 
 	// Register a handler for delete groups
 	elgg_register_event_handler('delete', 'group', 'groups_delete_event_listener');
-	
+
 	elgg_register_event_handler('join', 'group', 'groups_user_join_event_listener');
 	elgg_register_event_handler('leave', 'group', 'groups_user_leave_event_listener');
 	elgg_register_event_handler('pagesetup', 'system', 'groups_setup_sidebar_menus');
@@ -385,14 +388,14 @@ function groups_entity_menu_setup($hook, $type, $return, $params) {
 function groups_user_entity_menu_setup($hook, $type, $return, $params) {
 	if (elgg_is_logged_in()) {
 		$group = elgg_get_page_owner_entity();
-		
+
 		// Check for valid group
 		if (!elgg_instanceof($group, 'group')) {
 			return $return;
 		}
-	
+
 		$entity = $params['entity'];
-		
+
 		// Make sure we have a user and that user is a member of the group
 		if (!elgg_instanceof($entity, 'user') || !$group->isMember($entity)) {
 			return $return;
@@ -411,7 +414,7 @@ function groups_user_entity_menu_setup($hook, $type, $return, $params) {
 				'priority' => 999,
 			);
 			$return[] = ElggMenuItem::factory($options);
-		} 
+		}
 	}
 
 	return $return;
@@ -424,7 +427,7 @@ function groups_annotation_menu_setup($hook, $type, $return, $params) {
 	if (elgg_in_context('widgets')) {
 		return $return;
 	}
-	
+
 	$annotation = $params['annotation'];
 
 	if ($annotation->name != 'group_topic_post') {
@@ -541,6 +544,22 @@ function groups_write_acl_plugin_hook($hook, $entity_type, $returnvalue, $params
 }
 
 /**
+ * Allow group members to write to group
+ */
+function groups_container_permissions_check($hook, $entity_type, $returnvalue, $params) {
+	$group = elgg_extract('container', $params);
+	$user = elgg_extract('user', $params, false);
+
+	if ($user && elgg_instanceof($group, 'group')) {
+	    if ($container->isMember($user)) {
+		return true;
+	    }
+	}
+
+	return $return;
+}
+
+/**
  * Groups deleted, so remove access lists.
  */
 function groups_delete_event_listener($event, $object_type, $object) {
@@ -634,7 +653,7 @@ function groups_join_group($group, $user) {
 	$ia = elgg_set_ignore_access(TRUE);
 	$result = $group->join($user);
 	elgg_set_ignore_access($ia);
-	
+
 	if ($result) {
 		// flush user's access info so the collection is added
 		get_access_list($user->guid, 0, true);
@@ -719,7 +738,7 @@ function discussion_init() {
 
 	// commenting not allowed on discussion topics (use a different annotation)
 	elgg_register_plugin_hook_handler('permissions_check:comment', 'object', 'discussion_comment_override');
-	
+
 	$action_base = elgg_get_plugins_path() . 'groups/actions/discussion';
 	elgg_register_action('discussion/save', "$action_base/save.php");
 	elgg_register_action('discussion/delete', "$action_base/delete.php");


### PR DESCRIPTION
Prevents termination only if both are true: can't write to container and can't write to owner
Moves group container permissions check to groups plugin

I would also look into inconsistencies in owner_guid vs page_owner_guid (the latter is not always a user or a group)
