### PR TITLE
Fixes 4219: reducing risk of infinite loop in can_edit_entity()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@
 !/mod/uservalidationbyemail/
 !/mod/zaudio/
 
+/nbproject/private/


### PR DESCRIPTION
No need to perform all checks if one of the previous conditions is true
