### PR TITLE
Admin reordering widgets

### DIFF
--- a/engine/classes/ElggWidget.php
+++ b/engine/classes/ElggWidget.php
@@ -115,6 +115,7 @@ class ElggWidget extends ElggObject {
 		$options = array(
 			'type' => 'object',
 			'subtype' => 'widget',
+			'owner_guid' => $this->owner_guid,
 			'private_setting_name_value_pairs' => array(
 				array('name' => 'context', 'value' => $this->getContext()),
 				array('name' => 'column', 'value' => $column)


### PR DESCRIPTION
This fixes the issue when an admin reorders widgets. You get strange behaviour (and even influence other users order) without it. Without this setting an admin gets all widgets for a given context and column. Now an admin only gets the appropriate widgets. Need to do this based on $this to allow an admin to move widgets on someone elses profile.
