### PR TITLE
Fixes 3 bugs with moving of widgets

### DIFF
--- a/engine/classes/ElggWidget.php
+++ b/engine/classes/ElggWidget.php
@@ -148,10 +148,19 @@ class ElggWidget extends ElggObject {
 			$this->order = end($widgets)->order + 10;
 		} else {
 			// reorder widgets that are below
-			$this->order = $widgets[$rank]->order;
-			for ($index = $rank; $index < count($widgets); $index++) {
+			$index = $rank;
+			$new_order =  $widgets[$rank]->order;
+			if(($this->column == $column) && ($new_order > $this->order)){
+				// moving up in same column
+				$new_order += 10;
+				$index++;
+			}
+			$this->order = $new_order;
+			
+			for ($index; $index < count($widgets); $index++) {
 				if ($widgets[$index]->guid != $this->guid) {
-					$widgets[$index]-> order += 10;
+					$new_order += 10;
+					$widgets[$index]->order = $new_order;
 				}
 			}
 		}

--- a/engine/classes/ElggWidget.php
+++ b/engine/classes/ElggWidget.php
@@ -128,11 +128,19 @@ class ElggWidget extends ElggObject {
 		}
 
 		usort($widgets, create_function('$a,$b','return (int)$a->order > (int)$b->order;'));
-
+		
+		// determine real rank of the widget (as it could be different from the provided rank due to 'hidden' widgets)
+		foreach($widgets as $widget){
+			if(!elgg_is_widget_type($widget->handler)){
+				// this widget is not showing, but still exists in the widgets array. Therefore increase the new rank position
+				$rank++;
+			}
+		}
+		
 		if ($rank == 0) {
 			// top of the column
 			$this->order = $widgets[0]->order - 10;
-		} elseif ($rank == count($widgets)) {
+		} elseif (($rank + 1) == count($widgets)) {
 			// bottom of the column
 			$this->order = end($widgets)->order + 10;
 		} else {

--- a/engine/classes/ElggWidget.php
+++ b/engine/classes/ElggWidget.php
@@ -140,7 +140,10 @@ class ElggWidget extends ElggObject {
 		if ($rank == 0) {
 			// top of the column
 			$this->order = $widgets[0]->order - 10;
-		} elseif (($rank + 1) == count($widgets)) {
+		} elseif(
+				(($this->column == $column) && (($rank + 1) == count($widgets))) ||
+				(($this->column != $column) && ($rank == count($widgets)))
+			){
 			// bottom of the column
 			$this->order = end($widgets)->order + 10;
 		} else {


### PR DESCRIPTION
- moving a widget to the bottom
- moving widgets with hidden widgets (because a plugin was disabled, but widgets still exist)
- moving widgets in the same column (but not to top or bottom) (example a column with widgets A,B,C and D; it was unable to move B after C)

Still not completely flawless in relation to hidden/broken widgets as elgg_is_widget_type only checks if a handler exists, not if it exists for the current context.
