### PR TITLE
Added hook trigger to allow plugins solve problems with mime types.

### DIFF
--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -232,6 +232,10 @@ function file_owner_block_menu($hook, $type, $return, $params) {
  * @return string The overall type
  */
 function file_get_simple_type($mimetype) {
+	
+	if($type = elgg_trigger_plugin_hook('file_simple_type', 'object', $params, null)) {
+		return $type;
+	}
 
 	switch ($mimetype) {
 		case "application/msword":

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -233,8 +233,8 @@ function file_owner_block_menu($hook, $type, $return, $params) {
  */
 function file_get_simple_type($mimetype) {
 	
-	if($type = elgg_trigger_plugin_hook('file_simple_type', 'object', $params, null)) {
-		return $type;
+	if($simpletype = elgg_trigger_plugin_hook('files:simpletype', 'object', $params, null)) {
+		return $simpletype;
 	}
 
 	switch ($mimetype) {


### PR DESCRIPTION
OGG files are an example, their mime type is application/ogg, but they are audio, not applications.

I solved this with two hooks: https://github.com/lorea/audio_html5/commit/ad0149bc78bf67809d9c2636fe05987e2598b0c7

But one is not defined yet in Elgg and for this reason there is this pull request ;-)
