### PR TITLE
Move only fetches 10 items

### DIFF
--- a/engine/classes/ElggWidget.php
+++ b/engine/classes/ElggWidget.php
@@ -116,6 +116,7 @@ class ElggWidget extends ElggObject {
 			'type' => 'object',
 			'subtype' => 'widget',
 			'owner_guid' => $this->owner_guid,
+			'limit' => false, 
 			'private_setting_name_value_pairs' => array(
 				array('name' => 'context', 'value' => $this->getContext()),
 				array('name' => 'column', 'value' => $column)


### PR DESCRIPTION
Set limit to false to retrieve all widgets in the specified column, instead of the default 10
