### PR TITLE
elgg_invalidate_simplecache() bug

### DIFF
--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -333,7 +333,7 @@ function elgg_invalidate_simplecache() {
 	$return = true;
 	while (false !== ($file = readdir($handle))) {
 		if ($file != "." && $file != "..") {
-			$return = $return && unlink($CONFIG->dataroot . 'views_simplecache/' . $file);
+			$return &= unlink($CONFIG->dataroot . 'views_simplecache/' . $file);
 		}
 	}
 	closedir($handle);
@@ -346,8 +346,8 @@ function elgg_invalidate_simplecache() {
 	}
 
 	foreach ($viewtypes as $viewtype) {
-		$return = $return && datalist_set("simplecache_lastupdate_$viewtype", 0);
-		$return = $return && datalist_set("simplecache_lastcached_$viewtype", 0);
+		$return &= datalist_set("simplecache_lastupdate_$viewtype", 0);
+		$return &= datalist_set("simplecache_lastcached_$viewtype", 0);
 	}
 
 	return $return;


### PR DESCRIPTION
lazy boolean expression evaluation doesn't execute functions down the evaluation chain
