### PR TITLE
Optimized message count

### DIFF
--- a/mod/messages/start.php
+++ b/mod/messages/start.php
@@ -356,16 +356,11 @@ function messages_count_unread() {
 			"msg_msg.name_id='{$map['msg']}' AND msg_msg.value_id='{$map[1]}'",
 		),
 		'owner_guid' => $user_guid,
-		'limit' => 0
+		'count' => true
 	);
 
-	$num_messages = elgg_get_entities_from_metadata($options);
+	return = elgg_get_entities_from_metadata($options);
 
-	if (is_array($num_messages)) {
-		return sizeof($num_messages);
-	}
-
-	return 0;
 }
 
 /**


### PR DESCRIPTION
EPIC life saver. Get count in query instead of creating numerous objects and count those. This is a big issue when having 100+ unread messages as it produces 200 queries before this fix and only 1 after this fix. This is also the case in Elgg 1.7. I advice this should also be fixed on community.elgg.org as i have 200 unread messages :)
