### PR TITLE
Fixes #2424 While deleting checked messages confirmation link is displayed

### DIFF
--- a/mod/messages/languages/en.php
+++ b/mod/messages/languages/en.php
@@ -45,7 +45,12 @@ $english = array(
 	'messages:error' => 'There was a problem saving your message. Please try again.',
 
 	'item:object:messages' => 'Messages',
-
+	
+	/**
+	* Confirm message(s) deletion
+	*/
+	'messages:deleteconfirm:selected' => "Are you sure you want to delete the selected item(s)?",
+	
 	/**
 	* Status messages
 	*/

--- a/mod/messages/views/default/forms/messages/process.php
+++ b/mod/messages/views/default/forms/messages/process.php
@@ -19,11 +19,21 @@ echo $messages;
 echo '</div>';
 
 echo '<div class="elgg-foot messages-buttonbank">';
-echo elgg_view('input/submit', array(
+
+//submit button assigned to a variable
+$submit_button = elgg_view('input/submit', array(
 	'value' => elgg_echo('delete'),
 	'name' => 'delete',
 	'class' => 'elgg-button-delete',
 ));
+//confirmation link after which messages are deleted
+echo elgg_view("output/confirmlink", array(
+	'href' => "#",
+	'text' => $submit_button,
+	'confirm' => elgg_echo('messages:deleteconfirm:selected'),
+	'encode_text' => false,
+));
+
 
 if ($vars['folder'] == "inbox") {
 	echo elgg_view('input/submit', array(


### PR DESCRIPTION
Introduced a confirmation link before deletion of messages.
A new entry of confirmation message for deletion message(s) in language.
