### PR TITLE
Improved input/dropdown view to allow selection of multiple values

### DIFF
--- a/views/default/input/dropdown.php
+++ b/views/default/input/dropdown.php
@@ -8,7 +8,7 @@
  * @package Elgg
  * @subpackage Core
  *
- * @uses $vars['value']          The current value, if any
+ * @uses $vars['value']          The current value or an array of current values
  * @uses $vars['options']        An array of strings representing the options for the dropdown field
  * @uses $vars['options_values'] An associative array of "value" => "option"
  *                               where "value" is the name and "option" is
@@ -38,7 +38,7 @@ unset($vars['options_values']);
 $options = $vars['options'];
 unset($vars['options']);
 
-$value = $vars['value'];
+$value = is_array($vars['value'])? $vars['value'] : array($vars['value']);
 unset($vars['value']);
 
 ?>
@@ -47,10 +47,9 @@ unset($vars['value']);
 
 if ($options_values) {
 	foreach ($options_values as $opt_value => $option) {
-
 		$option_attrs = elgg_format_attributes(array(
 			'value' => $opt_value,
-			'selected' => (string)$opt_value == (string)$value,
+			'selected' => in_array((string)$opt_value, $value),
 		));
 
 		echo "<option $option_attrs>$option</option>";
@@ -60,7 +59,7 @@ if ($options_values) {
 		foreach ($options as $option) {
 
 			$option_attrs = elgg_format_attributes(array(
-				'selected' => (string)$option == (string)$value
+				'selected' => in_array((string)$opt_value, $value)
 			));
 
 			echo "<option $option_attrs>$option</option>";


### PR DESCRIPTION
I needed this feature while developing a plugin so I think that should be useful to share this with the community.

The main change is that an array can be used in `$vars['value']` to allow to select more of one value in dropdown box.
To detect the values `in_array` function is used.

With this change you can use code like this to output a multiple selection dropdown box:

``` php
$options = array(
    'name' => 'annotations[]',
    'options_values' => array('a'=>'a', 'b'='b', 'c'='c'),
    'value' => array('a', 'c'), // single value can be used too, e.g. 'a'
    'multiple' => true,
);
echo elgg_view('input/dropdown', $options);
```

Notes:
- You need to use at the end of dropwdown's name `[]` so the form sends an array of values instead of only one.
- You need to specify `'multiple' => true` so format_attributes translates it in `multiple="multiple"` attribute in select form element.

I'm waiting your comments about this feature ;)
