### PR TITLE
Improved input/dropdown view to allow selection of multiple values

### DIFF
--- a/mod/blog/views/default/forms/blog/save.php
+++ b/mod/blog/views/default/forms/blog/save.php
@@ -72,7 +72,7 @@ if ($vars['guid']) {
 }
 
 $status_label = elgg_echo('blog:status');
-$status_input = elgg_view('input/dropdown', array(
+$status_input = elgg_view('input/select', array(
 	'name' => 'status',
 	'id' => 'blog_status',
 	'value' => $vars['status'],
@@ -83,7 +83,7 @@ $status_input = elgg_view('input/dropdown', array(
 ));
 
 $comments_label = elgg_echo('comments');
-$comments_input = elgg_view('input/dropdown', array(
+$comments_input = elgg_view('input/select', array(
 	'name' => 'comments_on',
 	'id' => 'blog_comments_on',
 	'value' => $vars['comments_on'],

--- a/mod/blog/views/default/widgets/blog/edit.php
+++ b/mod/blog/views/default/widgets/blog/edit.php
@@ -13,7 +13,7 @@ $params = array(
 	'value' => $vars['entity']->num_display,
 	'options' => array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
 );
-$dropdown = elgg_view('input/dropdown', $params);
+$dropdown = elgg_view('input/select', $params);
 
 ?>
 <div>

--- a/mod/bookmarks/views/default/widgets/bookmarks/edit.php
+++ b/mod/bookmarks/views/default/widgets/bookmarks/edit.php
@@ -15,7 +15,7 @@ $params = array(
 	'value' => $vars['entity']->num_display,
 	'options' => array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
 );
-$dropdown = elgg_view('input/dropdown', $params);
+$dropdown = elgg_view('input/select', $params);
 
 ?>
 <div>

--- a/mod/dashboard/views/default/widgets/group_activity/edit.php
+++ b/mod/dashboard/views/default/widgets/group_activity/edit.php
@@ -17,7 +17,7 @@ $params = array(
 	'value' => $vars['entity']->group_guid,
 	'options_values' => $mygroups,
 );
-$group_dropdown = elgg_view('input/dropdown', $params);
+$group_dropdown = elgg_view('input/select', $params);
 ?>
 <div>
 	<?php echo elgg_echo('dashboard:widget:group:select'); ?>:
@@ -35,7 +35,7 @@ $params = array(
 	'value' => $vars['entity']->num_display,
 	'options' => array(5, 8, 10, 12, 15, 20),
 );
-$num_dropdown = elgg_view('input/dropdown', $params);
+$num_dropdown = elgg_view('input/select', $params);
 
 ?>
 <div>

--- a/mod/developers/views/default/forms/developers/inspect.php
+++ b/mod/developers/views/default/forms/developers/inspect.php
@@ -6,7 +6,7 @@
 echo '<div>';
 echo '<p>' . elgg_echo('developers:inspect:help') . '</p>';
 
-echo elgg_view('input/dropdown', array(
+echo elgg_view('input/select', array(
 	'name' => 'inspect_type',
 	'options_values' => array(
 		'Actions' => 'Actions',

--- a/mod/developers/views/default/theme_preview/forms.php
+++ b/mod/developers/views/default/theme_preview/forms.php
@@ -38,12 +38,22 @@
 			?>
 		</div>
 		<div>
-			<label for="f5">Dropdown input (.elgg-input-dropdown):</label><br />
-			<?php echo elgg_view('input/dropdown', array(
+			<label for="f5">Select input (dropdown) (.elgg-input-dropdown):</label><br />
+			<?php echo elgg_view('input/select', array(
 					'name' => 'f5',
 					'id' => 'f5',
 					'options' => array('option 1', 'option 2'),
 					));
+			?>
+		</div>
+        <div>
+			<label for="f51">Select input (multiselect) (.elgg-input-dropdown):</label><br />
+			<?php echo elgg_view('input/select', array(
+					'name' => 'f51[]',
+					'id' => 'f51',
+					'options_values' => array('value 1' => 'option 1', 'value 2' => 'option 2', 'value 3' => 'option 3'),
+					'multiple' => true,
+                    ));
 			?>
 		</div>
 		<div>

--- a/mod/developers/views/default/theme_preview/forms.php
+++ b/mod/developers/views/default/theme_preview/forms.php
@@ -46,14 +46,14 @@
 					));
 			?>
 		</div>
-        <div>
+		<div>
 			<label for="f51">Select input (multiselect) (.elgg-input-dropdown):</label><br />
 			<?php echo elgg_view('input/select', array(
 					'name' => 'f51[]',
 					'id' => 'f51',
 					'options_values' => array('value 1' => 'option 1', 'value 2' => 'option 2', 'value 3' => 'option 3'),
 					'multiple' => true,
-                    ));
+					));
 			?>
 		</div>
 		<div>

--- a/mod/developers/views/default/theme_preview/forms.php
+++ b/mod/developers/views/default/theme_preview/forms.php
@@ -38,7 +38,7 @@
 			?>
 		</div>
 		<div>
-			<label for="f5">Select input (dropdown) (.elgg-input-dropdown):</label><br />
+			<label for="f5">Select input (dropdown) (.elgg-input-select):</label><br />
 			<?php echo elgg_view('input/select', array(
 					'name' => 'f5',
 					'id' => 'f5',
@@ -47,7 +47,7 @@
 			?>
 		</div>
 		<div>
-			<label for="f51">Select input (multiselect) (.elgg-input-dropdown):</label><br />
+			<label for="f51">Select input (multiselect) (.elgg-input-select):</label><br />
 			<?php echo elgg_view('input/select', array(
 					'name' => 'f51[]',
 					'id' => 'f51',

--- a/mod/file/views/default/widgets/filerepo/edit.php
+++ b/mod/file/views/default/widgets/filerepo/edit.php
@@ -16,7 +16,7 @@ $params = array(
 	'value' => $vars['entity']->num_display,
 	'options' => array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20),
 );
-$dropdown = elgg_view('input/dropdown', $params);
+$dropdown = elgg_view('input/select', $params);
 
 ?>
 <div>

--- a/mod/garbagecollector/views/default/plugins/garbagecollector/settings.php
+++ b/mod/garbagecollector/views/default/plugins/garbagecollector/settings.php
@@ -15,7 +15,7 @@ if (!$period) {
 	<?php echo elgg_echo('garbagecollector:period'); ?>
 	
 	<?php
-		echo elgg_view('input/dropdown', array(
+		echo elgg_view('input/select', array(
 			'name' => 'params[period]',
 			'options_values' => array(
 				'weekly' => elgg_echo('garbagecollector:weekly'),

--- a/mod/groups/views/default/forms/discussion/save.php
+++ b/mod/groups/views/default/forms/discussion/save.php
@@ -28,7 +28,7 @@ $guid = elgg_extract('guid', $vars, null);
 <div>
     <label><?php echo elgg_echo("groups:topicstatus"); ?></label><br />
 	<?php
-		echo elgg_view('input/dropdown', array(
+		echo elgg_view('input/select', array(
 			'name' => 'status',
 			'value' => $status,
 			'options_values' => array(

--- a/mod/groups/views/default/plugins/groups/settings.php
+++ b/mod/groups/views/default/plugins/groups/settings.php
@@ -11,7 +11,7 @@ if (!isset($vars['entity']->hidden_groups)) {
 echo '<div>';
 echo elgg_echo('groups:allowhiddengroups');
 echo ' ';
-echo elgg_view('input/dropdown', array(
+echo elgg_view('input/select', array(
 	'name' => 'params[hidden_groups]',
 	'options_values' => array(
 		'no' => elgg_echo('option:no'),

--- a/mod/groups/views/default/widgets/a_users_groups/edit.php
+++ b/mod/groups/views/default/widgets/a_users_groups/edit.php
@@ -16,7 +16,7 @@ $params = array(
 	'value' => $vars['entity']->num_display,
 	'options' => array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20),
 );
-$dropdown = elgg_view('input/dropdown', $params);
+$dropdown = elgg_view('input/select', $params);
 
 ?>
 <div>

--- a/mod/logrotate/views/default/plugins/logrotate/settings.php
+++ b/mod/logrotate/views/default/plugins/logrotate/settings.php
@@ -19,7 +19,7 @@ if (!$delete) {
 	<?php
 
 		echo elgg_echo('logrotate:period') . ' ';
-		echo elgg_view('input/dropdown', array(
+		echo elgg_view('input/select', array(
 			'name' => 'params[period]',
 			'options_values' => array(
 				'weekly' => elgg_echo('logrotate:weekly'),
@@ -34,7 +34,7 @@ if (!$delete) {
 	<?php
 
 		echo elgg_echo('logrotate:delete') . ' ';
-		echo elgg_view('input/dropdown', array(
+		echo elgg_view('input/select', array(
 			'name' => 'params[delete]',
 			'options_values' => array(
 				'weekly' => elgg_echo('logrotate:week'),

--- a/mod/messageboard/views/default/widgets/messageboard/edit.php
+++ b/mod/messageboard/views/default/widgets/messageboard/edit.php
@@ -13,7 +13,7 @@ $params = array(
 	'value' => $vars['entity']->num_display,
 	'options' => array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
 );
-$dropdown = elgg_view('input/dropdown', $params);
+$dropdown = elgg_view('input/select', $params);
 
 ?>
 <div>

--- a/mod/pages/views/default/input/write_access.php
+++ b/mod/pages/views/default/input/write_access.php
@@ -32,4 +32,4 @@ if ($vars['value'] == ACCESS_DEFAULT) {
 }
 $vars['value'] = ($vars['value'] == ACCESS_PUBLIC) ? ACCESS_LOGGED_IN : $vars['value'];
 
-echo elgg_view('input/dropdown', $vars);
+echo elgg_view('input/select', $vars);

--- a/mod/pages/views/default/widgets/pages/edit.php
+++ b/mod/pages/views/default/widgets/pages/edit.php
@@ -15,7 +15,7 @@ $params = array(
 	'value' => $vars['entity']->pages_num,
 	'options' => array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
 );
-$dropdown = elgg_view('input/dropdown', $params);
+$dropdown = elgg_view('input/select', $params);
 
 ?>
 <div>

--- a/mod/reportedcontent/views/default/widgets/reportedcontent/edit.php
+++ b/mod/reportedcontent/views/default/widgets/reportedcontent/edit.php
@@ -13,7 +13,7 @@ $params = array(
 	'value' => $vars['entity']->num_display,
 	'options' => array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
 );
-$dropdown = elgg_view('input/dropdown', $params);
+$dropdown = elgg_view('input/select', $params);
 
 ?>
 <div>

--- a/mod/tagcloud/views/default/widgets/tagcloud/edit.php
+++ b/mod/tagcloud/views/default/widgets/tagcloud/edit.php
@@ -14,7 +14,7 @@ $params = array(
 	'value' => $vars['entity']->num_items,
 	'options' => array(10, 20, 30, 50, 100),
 );
-$dropdown = elgg_view('input/dropdown', $params);
+$dropdown = elgg_view('input/select', $params);
 
 ?>
 <p>

--- a/mod/thewire/views/default/widgets/thewire/edit.php
+++ b/mod/thewire/views/default/widgets/thewire/edit.php
@@ -13,7 +13,7 @@ $params = array(
 	'value' => $vars['entity']->num_display,
 	'options' => array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
 );
-$dropdown = elgg_view('input/dropdown', $params);
+$dropdown = elgg_view('input/select', $params);
 
 ?>
 <div>

--- a/mod/twitter_api/views/default/plugins/twitter_api/settings.php
+++ b/mod/twitter_api/views/default/plugins/twitter_api/settings.php
@@ -20,7 +20,7 @@ $consumer_secret_view = elgg_view('input/text', array(
 ));
 
 $sign_on_with_twitter_string = elgg_echo('twitter_api:login');
-$sign_on_with_twitter_view = elgg_view('input/dropdown', array(
+$sign_on_with_twitter_view = elgg_view('input/select', array(
 	'name' => 'params[sign_on]',
 	'options_values' => array(
 		'yes' => elgg_echo('option:yes'),
@@ -30,7 +30,7 @@ $sign_on_with_twitter_view = elgg_view('input/dropdown', array(
 ));
 
 $new_users_with_twitter = elgg_echo('twitter_api:new_users');
-$new_users_with_twitter_view = elgg_view('input/dropdown', array(
+$new_users_with_twitter_view = elgg_view('input/select', array(
 	'name' => 'params[new_users]',
 	'options_values' => array(
 		'yes' => elgg_echo('option:yes'),

--- a/views/default/core/river/filter.php
+++ b/views/default/core/river/filter.php
@@ -33,6 +33,6 @@ $selector = $vars['selector'];
 if ($selector) {
 	$params['value'] = $selector;
 }
-echo elgg_view('input/dropdown', $params);
+echo elgg_view('input/select', $params);
 
 elgg_load_js('elgg.ui.river');

--- a/views/default/core/settings/account/language.php
+++ b/views/default/core/settings/account/language.php
@@ -11,7 +11,7 @@ $user = elgg_get_page_owner_entity();
 if ($user) {
 	$title = elgg_echo('user:set:language');
 	$content = elgg_echo('user:language:label') . ': ';
-	$content .= elgg_view("input/dropdown", array(
+	$content .= elgg_view("input/select", array(
 		'name' => 'language',
 		'value' => $user->language,
 		'options_values' => get_installed_translations()

--- a/views/default/css/elements/components.php
+++ b/views/default/css/elements/components.php
@@ -171,7 +171,9 @@
 .elgg-river-attachments .elgg-icon {
 	float: left;
 }
-.elgg-river-layout .elgg-input-dropdown {
+<?php //@todo: remove .elgg-input-dropdown after 1.9 ?>
+.elgg-river-layout .elgg-input-dropdown,
+.elgg-river-layout .elgg-input-select {
 	float: right;
 	margin: 10px 0;
 }

--- a/views/default/css/elgg.php
+++ b/views/default/css/elgg.php
@@ -40,7 +40,7 @@ echo elgg_view('css/elements/grid', $vars);
 Skin CSS
  * typography     - fonts, line spacing
  * forms          - forms, inputs
- * buttons        - action, cancel, delete, submit, dropdown, special
+ * buttons        - action, cancel, delete, submit, select, special
  * navigation     - menus, breadcrumbs, pagination
  * icons          - icons, sprites, graphics
  * modules        - modules, widgets

--- a/views/default/forms/admin/menu/save.php
+++ b/views/default/forms/admin/menu/save.php
@@ -39,7 +39,7 @@ for ($i=0; $i<$num_featured_items; $i++) {
 		$current_value = ' ';
 	}
 
-	echo elgg_view('input/dropdown', array(
+	echo elgg_view('input/select', array(
 		'options_values' => $dropdown_values,
 		'name' => 'featured_menu_names[]',
 		'value' => $current_value

--- a/views/default/forms/admin/plugins/filter.php
+++ b/views/default/forms/admin/plugins/filter.php
@@ -8,7 +8,7 @@
  */
 
 echo '<div>';
-echo elgg_view('input/dropdown', array(
+echo elgg_view('input/select', array(
 	'name' => 'category',
 	'options_values' => $vars['category_options'],
 	'value' => $vars['category'],

--- a/views/default/forms/admin/plugins/sort.php
+++ b/views/default/forms/admin/plugins/sort.php
@@ -8,7 +8,7 @@
  */
 
 echo '<div class="mtm">';
-echo elgg_view('input/dropdown', array(
+echo elgg_view('input/select', array(
 	'name' => 'sort',
 	'options_values' => $vars['sort_options'],
 	'value' => $vars['sort'],

--- a/views/default/forms/admin/site/update_advanced.php
+++ b/views/default/forms/admin/site/update_advanced.php
@@ -49,7 +49,7 @@ $form_body .= elgg_view("input/checkboxes", array(
 
 $debug_options = array('0' => elgg_echo('installation:debug:none'), 'ERROR' => elgg_echo('installation:debug:error'), 'WARNING' => elgg_echo('installation:debug:warning'), 'NOTICE' => elgg_echo('installation:debug:notice'));
 $form_body .= "<div>" . elgg_echo('installation:debug');
-$form_body .= elgg_view('input/dropdown', array(
+$form_body .= elgg_view('input/select', array(
 	'options_values' => $debug_options,
 	'name' => 'debug',
 	'value' => elgg_get_config('debug'),

--- a/views/default/forms/admin/site/update_basic.php
+++ b/views/default/forms/admin/site/update_basic.php
@@ -18,7 +18,7 @@ foreach (array('sitename','sitedescription', 'siteemail') as $field) {
 
 $languages = get_installed_translations();
 $form_body .= "<div>" . elgg_echo('installation:language');
-$form_body .= elgg_view("input/dropdown", array(
+$form_body .= elgg_view("input/select", array(
 	'name' => 'language',
 	'value' => elgg_get_config('language'),
 	'options_values' => $languages,

--- a/views/default/forms/profile/fields/add.php
+++ b/views/default/forms/profile/fields/add.php
@@ -7,7 +7,7 @@ $label_text = elgg_echo('profile:label');
 $type_text = elgg_echo('profile:type');
 
 $label_control = elgg_view('input/text', array('name' => 'label'));
-$type_control = elgg_view('input/dropdown', array('name' => 'type', 'options_values' => array(
+$type_control = elgg_view('input/select', array('name' => 'type', 'options_values' => array(
 	'text' => elgg_echo('profile:field:text'),
 	'longtext' => elgg_echo('profile:field:longtext'),
 	'tags' => elgg_echo('profile:field:tags'),

--- a/views/default/input/access.php
+++ b/views/default/input/access.php
@@ -34,5 +34,5 @@ if ($vars['value'] == ACCESS_DEFAULT) {
 }
 
 if (is_array($vars['options_values']) && sizeof($vars['options_values']) > 0) {
-	echo elgg_view('input/dropdown', $vars);
+	echo elgg_view('input/select', $vars);
 }

--- a/views/default/input/dropdown.php
+++ b/views/default/input/dropdown.php
@@ -8,7 +8,7 @@
  * @package Elgg
  * @subpackage Core
  *
- * @uses $vars['value']          The current value, if any
+ * @uses $vars['value']          The current value or an array of current values
  * @uses $vars['options']        An array of strings representing the options for the dropdown field
  * @uses $vars['options_values'] An associative array of "value" => "option"
  *                               where "value" is the name and "option" is
@@ -38,7 +38,7 @@ unset($vars['options_values']);
 $options = $vars['options'];
 unset($vars['options']);
 
-$value = $vars['value'];
+$value = is_array($vars['value'])? $vars['value'] : array($vars['value']);
 unset($vars['value']);
 
 ?>
@@ -47,10 +47,9 @@ unset($vars['value']);
 
 if ($options_values) {
 	foreach ($options_values as $opt_value => $option) {
-
 		$option_attrs = elgg_format_attributes(array(
 			'value' => $opt_value,
-			'selected' => (string)$opt_value == (string)$value,
+			'selected' => in_array((string)$opt_value, $value),
 		));
 
 		echo "<option $option_attrs>$option</option>";
@@ -60,7 +59,7 @@ if ($options_values) {
 		foreach ($options as $option) {
 
 			$option_attrs = elgg_format_attributes(array(
-				'selected' => (string)$option == (string)$value
+				'selected' => in_array((string)$opt_value, $value)
 			));
 
 			echo "<option $option_attrs>$option</option>";

--- a/views/default/input/dropdown.php
+++ b/views/default/input/dropdown.php
@@ -1,70 +1,9 @@
 <?php
 /**
- * Elgg dropdown input
- * Displays a dropdown (select) input field
+ * Deprecated dropdown input view - use 'input/select' instead.
  *
- * @warning Default values of FALSE or NULL will match '' (empty string) but not 0.
- *
- * @package Elgg
- * @subpackage Core
- *
- * @uses $vars['value']          The current value or an array of current values
- * @uses $vars['options']        An array of strings representing the options for the dropdown field
- * @uses $vars['options_values'] An associative array of "value" => "option"
- *                               where "value" is the name and "option" is
- * 								 the value displayed on the button. Replaces
- *                               $vars['options'] when defined.
- * @uses $vars['class']          Additional CSS class
+ * @deprecated 1.8
  */
 
-if (isset($vars['class'])) {
-	$vars['class'] = "elgg-input-dropdown {$vars['class']}";
-} else {
-	$vars['class'] = "elgg-input-dropdown";
-}
-
-$defaults = array(
-	'disabled' => false,
-	'value' => '',
-	'options_values' => array(),
-	'options' => array(),
-);
-
-$vars = array_merge($defaults, $vars);
-
-$options_values = $vars['options_values'];
-unset($vars['options_values']);
-
-$options = $vars['options'];
-unset($vars['options']);
-
-$value = is_array($vars['value'])? $vars['value'] : array($vars['value']);
-unset($vars['value']);
-
-?>
-<select <?php echo elgg_format_attributes($vars); ?>>
-<?php
-
-if ($options_values) {
-	foreach ($options_values as $opt_value => $option) {
-		$option_attrs = elgg_format_attributes(array(
-			'value' => $opt_value,
-			'selected' => in_array((string)$opt_value, $value),
-		));
-
-		echo "<option $option_attrs>$option</option>";
-	}
-} else {
-	if (is_array($options)) {
-		foreach ($options as $option) {
-
-			$option_attrs = elgg_format_attributes(array(
-				'selected' => in_array((string)$opt_value, $value)
-			));
-
-			echo "<option $option_attrs>$option</option>";
-		}
-	}
-}
-?>
-</select>
+elgg_deprecated_notice("input/dropdown was deprecated by input/select", 1.8);
+echo elgg_view('input/select', $vars);

--- a/views/default/input/dropdown.php
+++ b/views/default/input/dropdown.php
@@ -2,8 +2,8 @@
 /**
  * Deprecated dropdown input view - use 'input/select' instead.
  *
- * @deprecated 1.8
+ * @deprecated 1.9
  */
 
-elgg_deprecated_notice("input/dropdown was deprecated by input/select", 1.8);
+elgg_deprecated_notice("input/dropdown was deprecated by input/select", 1.9);
 echo elgg_view('input/select', $vars);

--- a/views/default/input/pulldown.php
+++ b/views/default/input/pulldown.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Deprecated pulldown input view - use 'input/dropdown' instead.
+ * Deprecated pulldown input view - use 'input/select' instead.
  *
  * @deprecated 1.8
  */
 
-elgg_deprecated_notice("input/pulldown was deprecated by input/dropdown", 1.8);
-echo elgg_view('input/dropdown', $vars);
+elgg_deprecated_notice("input/pulldown was deprecated by input/select", 1.8);
+echo elgg_view('input/select', $vars);

--- a/views/default/input/select.php
+++ b/views/default/input/select.php
@@ -13,9 +13,9 @@
  * @uses $vars['options']        An array of strings representing the options for the dropdown field
  * @uses $vars['options_values'] An associative array of "value" => "option"
  *                               where "value" is the name and "option" is
- * 								 the value displayed on the button. Replaces
+ *                               the value displayed on the button. Replaces
  *                               $vars['options'] when defined.
- * @uses $vars['multiselect']    If true, multiselect of values will be allowed in the select box
+ * @uses $vars['multiple']       If true, multiselect of values will be allowed in the select box
  * @uses $vars['class']          Additional CSS class
  */
 

--- a/views/default/input/select.php
+++ b/views/default/input/select.php
@@ -43,12 +43,15 @@ unset($vars['options']);
 $value = is_array($vars['value']) ? $vars['value'] : array($vars['value']);
 unset($vars['value']);
 
+$vars['multiple'] = !empty($vars['multiple']);
+
 ?>
 <select <?php echo elgg_format_attributes($vars); ?>>
 <?php
 
 if ($options_values) {
 	foreach ($options_values as $opt_value => $option) {
+        
 		$option_attrs = elgg_format_attributes(array(
 			'value' => $opt_value,
 			'selected' => in_array((string)$opt_value, $value),

--- a/views/default/input/select.php
+++ b/views/default/input/select.php
@@ -45,13 +45,20 @@ unset($vars['value']);
 
 $vars['multiple'] = !empty($vars['multiple']);
 
+// Add trailing [] to name if multiple is enabled to allow the form to send multiple values
+if ($vars['multiple'] && !empty($vars['name']) && is_string($vars['name'])) {
+    if (substr($vars['name'], -2) != '[]') {
+        $vars['name'] = $vars['name'] . '[]';
+    }
+}
+
 ?>
 <select <?php echo elgg_format_attributes($vars); ?>>
 <?php
 
 if ($options_values) {
 	foreach ($options_values as $opt_value => $option) {
-        
+
 		$option_attrs = elgg_format_attributes(array(
 			'value' => $opt_value,
 			'selected' => in_array((string)$opt_value, $value),

--- a/views/default/input/select.php
+++ b/views/default/input/select.php
@@ -20,9 +20,9 @@
  */
 
 if (isset($vars['class'])) {
-	$vars['class'] = "elgg-input-dropdown {$vars['class']}";
+	$vars['class'] = "elgg-input-select elgg-input-dropdown {$vars['class']}";
 } else {
-	$vars['class'] = "elgg-input-dropdown";
+	$vars['class'] = "elgg-input-select elgg-input-dropdown";
 }
 
 $defaults = array(
@@ -47,8 +47,8 @@ $vars['multiple'] = !empty($vars['multiple']);
 
 // Add trailing [] to name if multiple is enabled to allow the form to send multiple values
 if ($vars['multiple'] && !empty($vars['name']) && is_string($vars['name'])) {
-    if (substr($vars['name'], -2) != '[]') {
-        $vars['name'] = $vars['name'] . '[]';
+    if (substr($vars['name'], -2) !== '[]') {
+        $vars['name'] .= '[]';
     }
 }
 

--- a/views/default/input/select.php
+++ b/views/default/input/select.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Elgg select input
+ * Displays a select input field
+ *
+ * @warning Default values of FALSE or NULL will match '' (empty string) but not 0.
+ *
+ * @package Elgg
+ * @subpackage Core
+ *
+ * @uses $vars['value']          The current value or an array of current values (only valid if
+ *                               multiselect is used).
+ * @uses $vars['options']        An array of strings representing the options for the dropdown field
+ * @uses $vars['options_values'] An associative array of "value" => "option"
+ *                               where "value" is the name and "option" is
+ * 								 the value displayed on the button. Replaces
+ *                               $vars['options'] when defined.
+ * @uses $vars['multiselect']    If true, multiselect of values will be allowed in the select box
+ * @uses $vars['class']          Additional CSS class
+ */
+
+if (isset($vars['class'])) {
+	$vars['class'] = "elgg-input-dropdown {$vars['class']}";
+} else {
+	$vars['class'] = "elgg-input-dropdown";
+}
+
+$defaults = array(
+	'disabled' => false,
+	'value' => '',
+	'options_values' => array(),
+	'options' => array(),
+);
+
+$vars = array_merge($defaults, $vars);
+
+$options_values = $vars['options_values'];
+unset($vars['options_values']);
+
+$options = $vars['options'];
+unset($vars['options']);
+
+$value = is_array($vars['value']) ? $vars['value'] : array($vars['value']);
+unset($vars['value']);
+
+?>
+<select <?php echo elgg_format_attributes($vars); ?>>
+<?php
+
+if ($options_values) {
+	foreach ($options_values as $opt_value => $option) {
+		$option_attrs = elgg_format_attributes(array(
+			'value' => $opt_value,
+			'selected' => in_array((string)$opt_value, $value),
+		));
+
+		echo "<option $option_attrs>$option</option>";
+	}
+} else {
+	if (is_array($options)) {
+		foreach ($options as $option) {
+
+			$option_attrs = elgg_format_attributes(array(
+				'selected' => in_array((string)$opt_value, $value)
+			));
+
+			echo "<option $option_attrs>$option</option>";
+		}
+	}
+}
+?>
+</select>

--- a/views/default/widgets/content_stats/edit.php
+++ b/views/default/widgets/content_stats/edit.php
@@ -14,7 +14,7 @@ $params = array(
 	'value' => $vars['entity']->num_display,
 	'options' => array(5, 8, 10, 12, 15, 20),
 );
-$dropdown = elgg_view('input/dropdown', $params);
+$dropdown = elgg_view('input/select', $params);
 
 ?>
 <p>

--- a/views/default/widgets/friends/edit.php
+++ b/views/default/widgets/friends/edit.php
@@ -14,7 +14,7 @@ $params = array(
 	'value' => $vars['entity']->num_display,
 	'options' => array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 15, 20, 30, 50, 100),
 );
-$display_dropdown = elgg_view('input/dropdown', $params);
+$display_dropdown = elgg_view('input/select', $params);
 
 
 // handle upgrade to 1.7.2 from previous versions
@@ -37,7 +37,7 @@ $params = array(
 		'tiny' => elgg_echo('friends:tiny'),
 	),
 );
-$size_dropdown = elgg_view('input/dropdown', $params);
+$size_dropdown = elgg_view('input/select', $params);
 
 
 ?>

--- a/views/default/widgets/new_users/edit.php
+++ b/views/default/widgets/new_users/edit.php
@@ -14,7 +14,7 @@ $params = array(
 	'value' => $vars['entity']->num_display,
 	'options' => array(5, 8, 10, 12, 15, 20),
 );
-$dropdown = elgg_view('input/dropdown', $params);
+$dropdown = elgg_view('input/select', $params);
 
 ?>
 <p>

--- a/views/default/widgets/online_users/edit.php
+++ b/views/default/widgets/online_users/edit.php
@@ -13,7 +13,7 @@ $params = array(
 	'value' => $vars['entity']->num_display,
 	'options' => array(5, 8, 10, 12, 15, 20),
 );
-$dropdown = elgg_view('input/dropdown', $params);
+$dropdown = elgg_view('input/select', $params);
 
 ?>
 <p>

--- a/views/default/widgets/river_widget/edit.php
+++ b/views/default/widgets/river_widget/edit.php
@@ -16,7 +16,7 @@ if (elgg_in_context('dashboard')) {
 			'all' => elgg_echo('river:widgets:all'),
 		),
 	);
-	$type_dropdown = elgg_view('input/dropdown', $params);
+	$type_dropdown = elgg_view('input/select', $params);
 	?>
 	<div>
 		<?php echo elgg_echo('river:widget:type'); ?>:
@@ -36,7 +36,7 @@ $params = array(
 	'value' => $vars['entity']->num_display,
 	'options' => array(5, 8, 10, 12, 15, 20),
 );
-$num_dropdown = elgg_view('input/dropdown', $params);
+$num_dropdown = elgg_view('input/select', $params);
 
 ?>
 <div>

--- a/views/installation/input/dropdown.php
+++ b/views/installation/input/dropdown.php
@@ -1,36 +1,6 @@
 <?php
-/**
- * Elgg dropdown input
- * Displays a dropdown input field
- *
- * @uses $vars['value'] The current value, if any
- * @uses $vars['name'] The name of the input field
- * @uses $vars['options'] An array of strings representing the options for the dropdown field
- * @uses $vars['options_values'] An associative array of "value" => "option" where "value" is an internal name and "option" is
- * 								 the value displayed on the button. Replaces $vars['options'] when defined.
- */
+// @deprecated Use input/select instead.
 
-$class = "elgg-input-dropdown";
+elgg_deprecated_notice('view: input/dropdown is deprecated by input/select', 1.9);
 
-?>
-<select name="<?php echo $vars['name']; ?>" class="<?php echo $class; ?>">
-<?php
-if (isset($vars['options_values'])) {
-	foreach ($vars['options_values'] as $value => $option) {
-		if ($value != $vars['value']) {
-			echo "<option value=\"$value\">{$option}</option>";
-		} else {
-			echo "<option value=\"$value\" selected=\"selected\">{$option}</option>";
-		}
-	}
-} else {
-	foreach ($vars['options'] as $option) {
-		if ($option != $vars['value']) {
-			echo "<option>{$option}</option>";
-		} else {
-			echo "<option selected=\"selected\">{$option}</option>";
-		}
-	}
-}
-?>
-</select>
+echo elgg_view('input/select', $vars);


### PR DESCRIPTION
I pulled this before in 1.8 branch https://github.com/Elgg/Elgg/pull/173

I needed this feature while developing a plugin so I think that should be useful to share this with the community.

The main change is that an array can be used in `$vars['value']` to allow to select more of one value in dropdown box.
To detect the values `in_array` function is used.

With this change you can use code like this to output a multiple selection dropdown box:

``` php
$options = array(
    'name' => 'annotations[]',
    'options_values' => array('a'=>'a', 'b'='b', 'c'='c'),
    'value' => array('a', 'c'), // single value can be used too, e.g. 'a'
    'multiple' => true,
);
echo elgg_view('input/dropdown', $options);
```

Notes:
- You need to use at the end of dropwdown's name `[]` so the form sends an array of values instead of only one.
- You need to specify `'multiple' => true` so format_attributes translates it in `multiple="multiple"` attribute in select form element.

I'm waiting your comments about this feature ;)
