### PR TITLE
Fixes #4395: Register group profile title buttons earlier

### DIFF
--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -245,14 +245,14 @@ function groups_handle_profile_page($guid) {
 
 	elgg_push_breadcrumb($group->name);
 
+	groups_register_profile_buttons($group);
+
 	$content = elgg_view('groups/profile/layout', array('entity' => $group));
 	if (group_gatekeeper(false)) {
 		$sidebar = elgg_view('groups/sidebar/members', array('entity' => $group));
 	} else {
 		$sidebar = '';
 	}
-
-	groups_register_profile_buttons($group);
 
 	$params = array(
 		'content' => $content,


### PR DESCRIPTION
Register title buttons earlier, so that they can be unregistered from group views
