### PR TITLE
Call elgg_register_simplecache_view('css/admin') in admin_init

### DIFF
--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -236,6 +236,7 @@ function admin_init() {
 	elgg_register_action('profile/fields/delete', '', 'admin');
 	elgg_register_action('profile/fields/reorder', '', 'admin');
 
+	elgg_register_simplecache_view('css/admin');
 	elgg_register_simplecache_view('js/admin');
 	$url = elgg_get_simplecache_url('js', 'admin');
 	elgg_register_js('elgg.admin', $url);


### PR DESCRIPTION
Need to properly register simplecache view otherwise simplecache will regenerate on each admin page load. 
