### PR TITLE
Avatar remove

### DIFF
--- a/actions/avatar/remove.php
+++ b/actions/avatar/remove.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Avatar revert action
+ * Avatar remove action
  */
 
 $guid = get_input('guid');
@@ -14,21 +14,21 @@ if ($user) {
 		$file->setFilename("profile/{$guid}{$name}.jpg");
 		$filepath = $file->getFilenameOnFilestore();
 		if (!$file->delete()) {
-			elgg_log("Avatar file revert failed. Remove $filepath manually, please.", 'WARNING');
+			elgg_log("Avatar file remove failed. Remove $filepath manually, please.", 'WARNING');
 		}
 	}
 	
-	// Revert crop coords
+	// Remove crop coords
 	unset($user->x1);
 	unset($user->x2);
 	unset($user->y1);
 	unset($user->y2);
 	
-	// Revert icon
+	// Remove icon
 	unset($user->icontime);
-	system_message(elgg_echo('avatar:revert:success'));
+	system_message(elgg_echo('avatar:remove:success'));
 } else {
-	register_error(elgg_echo('avatar:revert:fail'));
+	register_error(elgg_echo('avatar:remove:fail'));
 }
 
 forward(REFERER);

--- a/actions/avatar/revert.php
+++ b/actions/avatar/revert.php
@@ -6,6 +6,25 @@
 $guid = get_input('guid');
 $user = get_entity($guid);
 if ($user) {
+	// Delete all icons from diskspace
+	$icon_sizes = elgg_get_config('icon_sizes');
+	foreach ($icon_sizes as $name => $size_info) {
+		$file = new ElggFile();
+		$file->owner_guid = $guid;
+		$file->setFilename("profile/{$guid}{$name}.jpg");
+		$filepath = $file->getFilenameOnFilestore();
+		if (!$file->delete()) {
+			elgg_log("Avatar file revert failed. Remove $filepath manually, please.", 'WARNING');
+		}
+	}
+	
+	// Revert crop coords
+	unset($user->x1);
+	unset($user->x2);
+	unset($user->y1);
+	unset($user->y2);
+	
+	// Revert icon
 	unset($user->icontime);
 	system_message(elgg_echo('avatar:revert:success'));
 } else {

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -1556,7 +1556,7 @@ function users_init() {
 	elgg_register_action('friends/remove');
 	elgg_register_action('avatar/upload');
 	elgg_register_action('avatar/crop');
-	elgg_register_action('avatar/revert');
+	elgg_register_action('avatar/remove');
 	elgg_register_action('profile/edit');
 
 	elgg_register_action('friends/collections/add');

--- a/languages/en.php
+++ b/languages/en.php
@@ -362,7 +362,7 @@ $english = array(
 	'avatar:preview' => 'Preview',
 	'avatar:upload' => 'Upload a new avatar',
 	'avatar:current' => 'Current avatar',
-	'avatar:revert' => 'Revert your avatar to the default icon',
+	'avatar:remove' => 'Remove your avatar and set the default icon',
 	'avatar:crop:title' => 'Avatar cropping tool',
 	'avatar:upload:instructions' => "Your avatar is displayed throughout the site. You can change it as often as you'd like. (File formats accepted: GIF, JPG or PNG)",
 	'avatar:create:instructions' => 'Click and drag a square below to match how you want your avatar cropped. A preview will appear in the box on the right. When you are happy with the preview, click \'Create your avatar\'. This cropped version will be used throughout the site as your avatar.',
@@ -371,8 +371,8 @@ $english = array(
 	'avatar:resize:fail' => 'Resize of the avatar failed',
 	'avatar:crop:success' => 'Cropping the avatar succeeded',
 	'avatar:crop:fail' => 'Avatar cropping failed',
-	'avatar:revert:success' => 'Reverting the avatar succeeded',
-	'avatar:revert:fail' => 'Avatar revert failed',
+	'avatar:remove:success' => 'Removing the avatar succeeded',
+	'avatar:remove:fail' => 'Avatar remove failed',
 
 	'profile:edit' => 'Edit profile',
 	'profile:aboutme' => "About me",
@@ -854,6 +854,7 @@ $english = array(
 	'new' => 'New',
 	'add' => 'Add',
 	'create' => 'Create',
+	'remove' => 'Remove',
 	'revert' => 'Revert',
 
 	'site' => 'Site',

--- a/views/default/core/avatar/upload.php
+++ b/views/default/core/avatar/upload.php
@@ -12,12 +12,12 @@ $user_avatar = elgg_view('output/img', array(
 
 $current_label = elgg_echo('avatar:current');
 
-$revert_button = '';
+$remove_button = '';
 if ($vars['entity']->icontime) {
-	$revert_button = elgg_view('output/url', array(
-		'text' => elgg_echo('revert'),
-		'title' => elgg_echo('avatar:revert'),
-		'href' => 'action/avatar/revert?guid=' . elgg_get_page_owner_guid(),
+	$remove_button = elgg_view('output/url', array(
+		'text' => elgg_echo('remove'),
+		'title' => elgg_echo('avatar:remove'),
+		'href' => 'action/avatar/remove?guid=' . elgg_get_page_owner_guid(),
 		'is_action' => true,
 		'class' => 'elgg-button elgg-button-cancel mll',
 	));
@@ -39,7 +39,7 @@ $image = <<<HTML
 	<label>$current_label</label><br />
 	$user_avatar
 </div>
-$revert_button
+$remove_button
 HTML;
 
 $body = <<<HTML


### PR DESCRIPTION
Two commits, one to delete files in the avatar removings and the other to change names, revert to remove.

I don't think an upgrade script to delete old avatars is necessary. An user with a reverted avatar was occuppying the same space than an user with one.
