### PR TITLE
Fix the order of the $params and $returnvalue parameters

### DIFF
--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -68,7 +68,7 @@ $posted = 0, $annotation_id = 0) {
 	);
 
 	// return false to stop insert
-	$params = elgg_trigger_plugin_hook('creating', 'river', null, $params);
+	$params = elgg_trigger_plugin_hook('creating', 'river', $params, null);
 	if ($params == false) {
 		// inserting did not fail - it was just prevented
 		return true;

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -68,7 +68,7 @@ $posted = 0, $annotation_id = 0) {
 	);
 
 	// return false to stop insert
-	$params = elgg_trigger_plugin_hook('creating', 'river', $params, null);
+	$params = elgg_trigger_plugin_hook('creating', 'river', $params, true);
 	if ($params == false) {
 		// inserting did not fail - it was just prevented
 		return true;


### PR DESCRIPTION
In the call to elgg_trigger_plugin_hook the order of $params and
$returnvalue was reverted.
