### PR TITLE
Permit IPv6 addresses in system_log table.

### DIFF
--- a/engine/lib/upgrades/2012052800-1.8.5-admit_ipv6_system_log-df10386ed3930d03.php
+++ b/engine/lib/upgrades/2012052800-1.8.5-admit_ipv6_system_log-df10386ed3930d03.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Elgg 1.8.5 upgrade 2012052800
+ * admit_ipv6_system_log
+ *
+ * system_log_table only has room for textual IPv4 addresses. Lets augment the size of the ip_address
+ * field to 46 bytes (INET6_ADDRSTRLEN) to make room for any IPv6 address.
+ */
+
+$db_prefix = elgg_get_config('dbprefix');
+$q = "ALTER TABLE {$db_prefix}system_log MODIFY COLUMN ip_address varchar(46) NOT NULL";
+
+update_data($q);

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2012041801;
+$version = 2012052800;
 
 // Human-friendly version name
 $release = '1.8.5';


### PR DESCRIPTION
system_log_table only has room for textual IPv4 addresses. Augment
the size of the ip_address field to 46 bytes (INET6_ADDRSTRLEN) to make
room for any IPv6 address.
