### PR TITLE
Wrong argument order in route hook in file pagehandler.php.

### DIFF
--- a/engine/lib/pagehandler.php
+++ b/engine/lib/pagehandler.php
@@ -36,7 +36,7 @@ function page_handler($handler, $page) {
 		'handler' => $handler,
 		'segments' => $page,
 	);
-	$params = elgg_trigger_plugin_hook('route', $handler, NULL, $params);
+	$params = elgg_trigger_plugin_hook('route', $handler, $params, NULL);
 	if ($params === false) {
 		return true;
 	}


### PR DESCRIPTION
In the call to elgg_trigger_plugin_hook the order of $params and
$returnvalue was reverted.
