### PR TITLE
Fix default javascript language

### DIFF
--- a/js/lib/languages.js
+++ b/js/lib/languages.js
@@ -4,8 +4,6 @@
  */
 elgg.provide('elgg.config.translations');
 
-elgg.config.language = 'en';
-
 /**
  * Analagous to the php version.  Merges translations for a
  * given language into the current translations map.

--- a/views/default/js/elgg.php
+++ b/views/default/js/elgg.php
@@ -57,6 +57,7 @@ elgg.release = '<?php echo get_version(true); ?>';
 elgg.config.wwwroot = '<?php echo elgg_get_site_url(); ?>';
 elgg.security.interval = 5 * 60 * 1000; <?php //@todo make this configurable ?>
 elgg.config.domReady = false;
+elgg.config.language = '<?php echo isset($CONFIG->language) ? $CONFIG->language : 'en'; ?>';
 elgg.config.languageReady = false;
 
 //After the DOM is ready


### PR DESCRIPTION
The current implementation hardcoded 'en' as the site default language when elgg.echo is called from javascript and there is no logged in user.
This patch uses the site's configure default language as the default one.
