### PR TITLE
Fixes #4560: Adds `init:cookie,name` event before calls to setcookie

### DIFF
--- a/engine/classes/ElggCookie.php
+++ b/engine/classes/ElggCookie.php
@@ -1,6 +1,9 @@
 <?php
 /**
  * A simple object model for an HTTP cookie
+ * 
+ * @see http://php.net/manual/en/function.setcookie.php
+ * @see http://php.net/manual/en/function.session-set-cookie-params.php
  */
 class ElggCookie {
 	/** @var string */
@@ -10,7 +13,10 @@ class ElggCookie {
 	public $value = "";
 	
 	/** @var int */
-	public $expires = 0;
+	public $expire = 0;
+	
+	/** @var string */
+	public $path = "/";
 	
 	/** @var string */
 	public $domain = "";

--- a/engine/classes/ElggCookie.php
+++ b/engine/classes/ElggCookie.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * A simple object model for an HTTP cookie
+ */
+class ElggCookie {
+	/** @var string */
+	private $name;
+	
+	/** @var string */
+	public $value = "";
+	
+	/** @var int */
+	public $expires = 0;
+	
+	/** @var string */
+	public $domain = "";
+	
+	/** @var bool */
+	public $secure = false;
+	
+	/** @var bool */
+	public $httponly = false;
+	
+	/**
+	 * @param string $name The name of the cookie.
+	 */
+	function __construct($name) {
+		$this->name = $name;
+	}
+	
+	function __get($name) {
+		// Make the name field readonly
+		if ($name === 'name') {
+			return $this->name;
+		}
+	}
+}

--- a/engine/lib/deprecated-1.8.php
+++ b/engine/lib/deprecated-1.8.php
@@ -4581,7 +4581,9 @@ function reorder_widgets_from_panel($panelstring1, $panelstring2, $panelstring3,
 						$return = false;
 					} else {
 						// Remove state cookie
-						setcookie('widget' + $dbguid, null);
+						$cookie = new ElggCookie("widget$dbguid");
+						$cookie->value = NULL;
+						elgg_set_cookie($cookie);
 					}
 				}
 			}

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -304,7 +304,13 @@ function login(ElggUser $user, $persistent = false) {
 		$code = (md5($user->name . $user->username . time() . rand()));
 		$_SESSION['code'] = $code;
 		$user->code = md5($code);
-		setcookie("elggperm", $code, (time() + (86400 * 30)), "/");
+		
+		$cookie = new ElggCookie("elggperm");
+		$cookie->value = $code;
+		$cookie->expire = time() + (86400 * 30); // 30 days from now
+		$cookie->domain = "/";
+		
+		elgg_set_cookie($cookie);
 	}
 
 	if (!$user->save() || !elgg_trigger_event('login', 'user', $user)) {
@@ -314,7 +320,13 @@ function login(ElggUser $user, $persistent = false) {
 		unset($_SESSION['guid']);
 		unset($_SESSION['id']);
 		unset($_SESSION['user']);
-		setcookie("elggperm", "", (time() - (86400 * 30)), "/");
+		
+		$cookie = new ElggCookie("elggperm");
+		$cookie->expires = time() - (86400 * 30); // 30 days ago
+		$cookie->domain = "/";
+		
+		elgg_set_cookie($cookie);
+		
 		throw new LoginException(elgg_echo('LoginException:Unknown'));
 	}
 
@@ -326,6 +338,15 @@ function login(ElggUser $user, $persistent = false) {
 	reset_login_failure_count($user->guid); // Reset any previous failed login attempts
 
 	return true;
+}
+
+/**
+ * Initialize a cookie, but allow plugins to customize it first.
+ * @param ElggCookie $cookie
+ */
+function elgg_set_cookie(ElggCookie $cookie) {
+	elgg_trigger_event('init:cookie', $cookie->name, $cookie);
+	setcookie($cookie->name, $cookie->value, $cookie->expire, $cookie->domain, $cookie->secure, $cookie->httponly);
 }
 
 /**
@@ -351,7 +372,11 @@ function logout() {
 	unset($_SESSION['id']);
 	unset($_SESSION['user']);
 
-	setcookie("elggperm", "", (time() - (86400 * 30)), "/");
+	$cookie = new ElggCookie("elggperm");
+	$cookie->expires = time() - (86400 * 30);
+	$cookie->domain = "/";
+
+	elgg_set_cookie($cookie);
 
 	// pass along any messages
 	$old_msg = $_SESSION['msg'];

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -308,7 +308,6 @@ function login(ElggUser $user, $persistent = false) {
 		$cookie = new ElggCookie("elggperm");
 		$cookie->value = $code;
 		$cookie->expire = time() + (86400 * 30); // 30 days from now
-		$cookie->domain = "/";
 		
 		elgg_set_cookie($cookie);
 	}
@@ -323,7 +322,6 @@ function login(ElggUser $user, $persistent = false) {
 		
 		$cookie = new ElggCookie("elggperm");
 		$cookie->expires = time() - (86400 * 30); // 30 days ago
-		$cookie->domain = "/";
 		
 		elgg_set_cookie($cookie);
 		
@@ -346,7 +344,8 @@ function login(ElggUser $user, $persistent = false) {
  */
 function elgg_set_cookie(ElggCookie $cookie) {
 	elgg_trigger_event('init:cookie', $cookie->name, $cookie);
-	setcookie($cookie->name, $cookie->value, $cookie->expire, $cookie->domain, $cookie->secure, $cookie->httponly);
+	setcookie($cookie->name, $cookie->value, $cookie->expire, $cookie->path,
+	          $cookie->domain, $cookie->secure, $cookie->httponly);
 }
 
 /**

--- a/engine/settings.example.php
+++ b/engine/settings.example.php
@@ -121,3 +121,14 @@ $CONFIG->db_disable_query_cache = FALSE;
  * @global int $CONFIG->min_password_length
  */
 $CONFIG->min_password_length = 6;
+
+/**
+ * Optional session cookie configuration.
+ * This is especially useful if you are running your site on HTTPS and you want all 
+ * 
+ * Defaults can be set in your php.ini file.
+ * 
+ * @link http://php.net/manual/en/function.session-set-cookie-params.php
+ */
+// session_set_cookie_params(0, '/elgg', '', false, false); // Good if Elgg's root is at /elgg
+// session_set_cookie_params(0, '/', '', true, false); // Good for HTTPS-only sites

--- a/engine/settings.example.php
+++ b/engine/settings.example.php
@@ -124,7 +124,9 @@ $CONFIG->min_password_length = 6;
 
 /**
  * Optional session cookie configuration.
+ * 
  * This is especially useful if you are running your site on HTTPS and you want all 
+ * cookies to have their secure bit set.
  * 
  * Defaults can be set in your php.ini file.
  * 


### PR DESCRIPTION
init:cookie is the event so that certain hooks could listen for instantiation of all cookies with elgg_register_event_handler('init:cookie', 'all', '...'); This is useful for example in case a site wants every last cookie to have the secure bit set.

New class ElggCookie just provides a clear interface for what fields are settable.

Also adds some docs to settings.example.php to explain how to set up session cookies appropriately for their site. This must be in settings.example.php because session cookie values cannot be set by plugins since plugins do not run early enough in the boot process.
