### PR TITLE
#2276 - another way to solve friendly title issue

### DIFF
--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -318,9 +318,12 @@ function elgg_get_friendly_title($title) {
 	//$title = preg_replace('/[^\p{L}\- ]/u', '', $title);
 
 	// use A-Za-z0-9_ instead of \w because \w is locale sensitive
-	$title = preg_replace("/[^A-Za-z0-9_\- ]/", "", $title);
-	$title = str_replace(" ", "-", $title);
+	//$title = preg_replace("/[^A-Za-z0-9_\- ]/", "", $title);
+	//$title = str_replace(" ", "-", $title);
 	$title = str_replace("--", "-", $title);
+	$title = preg_replace('/\//', '-', $title);
+	$title = preg_replace('/\s+/', '-', $title);
+	$title = utf8_encode(rawurlencode($title));
 	$title = trim($title);
 	$title = elgg_strtolower($title);
 	return $title;


### PR DESCRIPTION
I don't know if it's correct or not and if it's SEO friendly, but this code work well on my local server.

I create a page with this title :

```
ÀÁÂÃÄÅÆŒÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖÙÚÛÜÝßàáâãäåæœçèéêëìíîïðñòóôõöùúûüý +—_-\/'`"’̛<>[]{}()«»%=°*|~,;.:?¿!¡^@&$€
```

When I hover the link, I got this url :

```
http://my_elgg.com/pages/view/456/ÀÁÂÃÄÅÆŒÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖÙÚÛÜÝßàáâãäåæœçèéêëìíîïðñòóôõöùúûüý-+—_-\/'`"’̛&lt;&gt;[]{}()«»%=°*|~,;.:?¿!¡^@&amp;$€
```

Look that < > and & have been replaced by &lt; &gt; and &amp;

When I view this page, I got in my Firefox URL bar the link :

```
http://my_elgg.com/pages/view/456/ÀÁÂÃÄÅÆŒÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖÙÚÛÜÝßàáâãäåæœçèéêëìíîïðñòóôõöùúûüý-%2b—_-\-'`"’̛%26lt%3b%26gt%3b[]{}()«»%25%3d°*|~%2c%3b.%3a%3f¿!¡^%40%26amp%3b%24€
```

I ran an elgg core unit test who return "16/16 test cases complete: 1258 passes, 0 fails and 0 exceptions."

It seems to be a good way to solve this issue...
