### PR TITLE
Fix #4578

### DIFF
--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -118,6 +118,10 @@ function elgg_echo($message_key, $args = array(), $language = "") {
 		$language = $CURRENT_LANGUAGE;
 	}
 
+	if (!isset($CONFIG->translations[$language])) {
+	    reload_all_translations(); // FIXME: This is a brute force approach
+	}
+	
 	if (isset($CONFIG->translations[$language][$message_key])) {
 		$string = $CONFIG->translations[$language][$message_key];
 	} else if (isset($CONFIG->translations["en"][$message_key])) {

--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -28,13 +28,15 @@ function add_translation($country_code, $language_array) {
 
 	$country_code = strtolower($country_code);
 	$country_code = trim($country_code);
-	if (is_array($language_array) && sizeof($language_array) > 0 && $country_code != "") {
-		if (!isset($CONFIG->translations[$country_code])) {
-			$CONFIG->translations[$country_code] = $language_array;
-		} else {
-			$CONFIG->translations[$country_code] = $language_array + $CONFIG->translations[$country_code];
-		}
-		return true;
+	
+	if ($country_code != "") {
+	    if (!isset($CONFIG->translations[$country_code])) {
+    	    $CONFIG->translations[$country_code] = array();
+    	}
+	    if (is_array($language_array) && sizeof($language_array) > 0) {
+		    $CONFIG->translations[$country_code] = $language_array + $CONFIG->translations[$country_code];
+		    return true;
+	    }
 	}
 	return false;
 }


### PR DESCRIPTION
Load all language translations if the translation array is not available for the chosen lang

This is brute force approach with the current API to let a user call elgg_echo with a language different from the one returned by get_current_language().

This is useful, for instance, for sending notitications to users in different languages.
