### PR TITLE
Fixes #4640 - email change language string

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -1076,7 +1076,7 @@ Once you have logged in, we highly recommend that you change your password.
 	'email:settings' => "Email settings",
 	'email:address:label' => "Your email address",
 
-	'email:save:success' => "New email address saved. Verification is requested.",
+	'email:save:success' => "New email address saved.",
 	'email:save:fail' => "Your new email address could not be saved.",
 
 	'friend:newfriend:subject' => "%s has made you a friend!",


### PR DESCRIPTION
Elgg doesn't send validation emails for changes made in settings
