### PR TITLE
Fix duplicated tags caused by new htmlawed code

### DIFF
--- a/mod/htmlawed/start.php
+++ b/mod/htmlawed/start.php
@@ -18,6 +18,8 @@ function htmlawed_init() {
 
 	$lib = elgg_get_plugins_path() . "htmlawed/vendors/htmLawed/htmLawed.php";
 	elgg_register_library('htmlawed', $lib);
+	
+	elgg_register_plugin_hook_handler('unit_test', 'system', 'htmlawed_test');
 }
 
 /**
@@ -142,4 +144,16 @@ function htmlawed_tag_post_processor($element, $attributes = array()) {
 
 	$r = "<$element$string>";
 	return $r;
+}
+
+/**
+ * Runs unit tests for htmlawed
+ *
+ * @return array
+ *  */
+function htmlawed_test($hook, $type, $value, $params) {
+    global $CONFIG;
+
+    $value[] = dirname(__FILE__) . '/tests/tags.php';
+    return $value;
 }

--- a/mod/htmlawed/start.php
+++ b/mod/htmlawed/start.php
@@ -92,7 +92,13 @@ function htmLawedArray(&$v, $k, $htmlawed_config) {
  * @param array  $attributes An array of attributes
  * @return string
  */
-function htmlawed_tag_post_processor($element, $attributes = array()) {
+function htmlawed_tag_post_processor($element, $attributes = false) {
+    if ($attributes === false) {
+        // This is a closing tag. Prevent further processing to avoid inserting a duplicate tag
+
+        return "</${element}>";
+    }
+
 	// these are the default styles used by tinymce.
 	$allowed_styles = array(
 		'color', 'cursor', 'text-align', 'vertical-align', 'font-size',

--- a/mod/htmlawed/tests/tags.php
+++ b/mod/htmlawed/tests/tags.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Dupplicated tags in htmlawed
+ */
+class HtmLawedDuplicateTagsTest extends ElggCoreUnitTest {
+
+    /**
+     * Called before each test object.
+     */
+    public function __construct() {
+        parent::__construct();
+    }
+    
+    /**
+     * Called before each test method.
+     */
+    public function setUp() {
+    }
+    
+    /**
+     * Called after each test method.
+     */
+    public function tearDown() {
+        // do not allow SimpleTest to interpret Elgg notices as exceptions
+        $this->swallowErrors();
+    }
+    
+    /**
+     * Called after each test object.
+     */
+    public function __destruct() {
+        elgg_set_ignore_access($this->ia);
+        // all __destruct() code should go above here
+        parent::__destruct();
+    }
+    
+    public function testNotDuplicateTags() {
+        $filter_html = '<ul><li>item</li></ul>';    
+        set_input('test', $filter_html);
+        
+        $expected = $filter_html;
+        $result = get_input('test');
+        $this->assertEqual($result, $expected);
+    }
+}


### PR DESCRIPTION
The new version of htmlawed duplicates closing tags, for instance in list created by tinymce.

This pull provides a test case for the error, and fixes it in htmlawed_tag_post_processor by checking that the $attributes parameter is set. If it ain't, then $element is a closing tag and should be returned as such.
