### PR TITLE
Fixes #1334. Added dropdown to change the parent of a page.

### DIFF
--- a/mod/pages/actions/pages/edit.php
+++ b/mod/pages/actions/pages/edit.php
@@ -59,6 +59,9 @@ if (sizeof($input) > 0) {
 		if (($name == 'access_id' || $name == 'write_access_id') && !$can_change_access) {
 			continue;
 		}
+		if ($name == 'parent_guid') {
+			continue;
+		}
 
 		$page->$name = $value;
 	}

--- a/mod/pages/actions/pages/edit.php
+++ b/mod/pages/actions/pages/edit.php
@@ -70,7 +70,27 @@ if (sizeof($input) > 0) {
 // need to add check to make sure user can write to container
 $page->container_guid = $container_guid;
 
-if ($parent_guid) {
+if ($parent_guid && $parent_guid != $page_guid) {
+	// Check if parent isn't below of the page in the tree
+	if ($page_guid) {
+		$tree_page = get_entity($parent_guid);
+		while ($tree_page->parent_guid > 0 && $page_guid != $tree_page->guid) {
+			$tree_page = get_entity($tree_page->parent_guid);
+		}
+		// If is below, bring all child elements forward
+		if ($page_guid == $tree_page->guid) {
+			$previous_parent = $page->parent_guid;
+			$children = elgg_get_entities_from_metadata(array(
+				'metadata_name' => 'parent_guid',
+				'metadata_value' => $page->getGUID()
+			));
+			if ($children) {
+				foreach ($children as $child) {
+					$child->parent_guid = $previous_parent;
+				}
+			}
+		}
+	}
 	$page->parent_guid = $parent_guid;
 }
 

--- a/mod/pages/languages/en.php
+++ b/mod/pages/languages/en.php
@@ -61,6 +61,7 @@ View and comment on the new page:
 	'pages:title' => 'Page title',
 	'pages:description' => 'Page text',
 	'pages:tags' => 'Tags',
+	'pages:parent_guid' => 'Parent page',
 	'pages:access_id' => 'Read access',
 	'pages:write_access_id' => 'Write access',
 

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -63,6 +63,7 @@ function pages_init() {
 		'title' => 'text',
 		'description' => 'longtext',
 		'tags' => 'tags',
+		'parent_guid' => 'parent',
 		'access_id' => 'access',
 		'write_access_id' => 'write_access',
 	));

--- a/mod/pages/views/default/forms/pages/edit.php
+++ b/mod/pages/views/default/forms/pages/edit.php
@@ -18,6 +18,9 @@ foreach ($variables as $name => $type) {
 	if (($type == 'access' || $type == 'write_access') && !$can_change_access) {
 		continue;
 	}
+	if ($name == 'parent_guid' && empty($vars['parent_guid'])) {
+		continue;
+	}
 ?>
 <div>
 	<label><?php echo elgg_echo("pages:$name") ?></label>
@@ -29,6 +32,7 @@ foreach ($variables as $name => $type) {
 		echo elgg_view("input/$type", array(
 			'name' => $name,
 			'value' => $vars[$name],
+			'entity' => ($name == 'parent_guid') ? $vars['entity'] : null,
 		));
 	?>
 </div>
@@ -52,12 +56,6 @@ echo elgg_view('input/hidden', array(
 	'name' => 'container_guid',
 	'value' => $vars['container_guid'],
 ));
-if ($vars['parent_guid']) {
-	echo elgg_view('input/hidden', array(
-		'name' => 'parent_guid',
-		'value' => $vars['parent_guid'],
-	));
-}
 
 echo elgg_view('input/submit', array('value' => elgg_echo('save')));
 

--- a/mod/pages/views/default/forms/pages/edit.php
+++ b/mod/pages/views/default/forms/pages/edit.php
@@ -18,7 +18,8 @@ foreach ($variables as $name => $type) {
 	if (($type == 'access' || $type == 'write_access') && !$can_change_access) {
 		continue;
 	}
-	if ($name == 'parent_guid' && empty($vars['parent_guid'])) {
+	// don't show parent picker input for top or new pages.
+	if ($name == 'parent_guid' && (!$vars['parent_guid'] || !$vars['guid'])) {
 		continue;
 	}
 ?>

--- a/mod/pages/views/default/forms/pages/edit.php
+++ b/mod/pages/views/default/forms/pages/edit.php
@@ -57,6 +57,12 @@ echo elgg_view('input/hidden', array(
 	'name' => 'container_guid',
 	'value' => $vars['container_guid'],
 ));
+if (!$vars['guid']) {
+	echo elgg_view('input/hidden', array(
+		'name' => 'parent_guid',
+		'value' => $vars['parent_guid'],
+	));
+}
 
 echo elgg_view('input/submit', array('value' => elgg_echo('save')));
 

--- a/mod/pages/views/default/input/parent.php
+++ b/mod/pages/views/default/input/parent.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Parent picker
+ *
+ * @uses $vars['value'] The current value, if any
+ * @uses $vars['options_values']
+ * @uses $vars['name'] The name of the input field
+ * @uses $vars['entity'] Optional. The child entity (uses container_guid)
+ */
+
+elgg_load_library('elgg:pages');
+
+if (empty($vars['entity'])) {
+	$container = elgg_get_page_owner_entity();
+} else {
+	$container = $vars['entity']->getContainerEntity();
+}
+
+$pages = pages_get_navigation_tree($container);
+$options = array();
+
+foreach ($pages as $page) {
+	$spacing = "";
+	for ($i = 0; $i < $page['depth']; $i++) {
+		$spacing .= "--";
+	}
+	$options[$page['guid']] = "$spacing " . $page['title'];
+}
+
+$defaults = array(
+	'class' => 'elgg-input-parent-picker',
+	'options_values' => $options,
+);
+
+$vars = array_merge($defaults, $vars);
+
+echo elgg_view('input/dropdown', $vars);


### PR DESCRIPTION
Ready for merge.

Pending:
- Check if I used the best names / best practices.
- <del>Break circles. If a page want to be subpage of one of its subpages, its subpages should be moved up one level.</del>

Further discussion:
- <del>Allow top-level pages move as a subpage.</del>[#2649](http://trac.elgg.org/ticket/2649) 
- <del>Allow ordering the pages in the same level.</del>[#4721](http://trac.elgg.org/ticket/4721)
- <del>Override the dropdown with javascript and convert it in a drag&drop-able list.</del> [#4721](http://trac.elgg.org/ticket/4721)
