### PR TITLE
Refs #4662. First workarroud forms validation with javascript.

### DIFF
--- a/pages/account/register.php
+++ b/pages/account/register.php
@@ -37,7 +37,7 @@ if (elgg_get_config('https_login')) {
 }
 $form_params = array(
 	'action' => $register_url,
-	'class' => 'elgg-form-account',
+	'class' => 'elgg-form-account elgg-validate-form',
 );
 
 $body_params = array(

--- a/views/default/css/elements/forms.php
+++ b/views/default/css/elements/forms.php
@@ -81,6 +81,11 @@ input[type="radio"] {
 	max-width: 450px;
 }
 
+.elgg-validate-error, .elgg-validate-error:focus {
+	background: #F8DBDB !important;
+	border-color: #E77776 !important;
+}
+
 /* ***************************************
 	FRIENDS PICKER
 *************************************** */

--- a/views/default/forms/register.php
+++ b/views/default/forms/register.php
@@ -6,6 +6,9 @@
  * @subpackage Core
  */
 
+elgg_register_js('elgg.validate', elgg_get_site_url() . 'js/validate.js');
+elgg_load_js('elgg.validate');
+
 $password = $password2 = '';
 $username = get_input('u');
 $email = get_input('e');
@@ -23,7 +26,7 @@ if (elgg_is_sticky_form('register')) {
 	echo elgg_view('input/text', array(
 		'name' => 'name',
 		'value' => $name,
-		'class' => 'elgg-autofocus',
+		'class' => 'elgg-autofocus elgg-validate elgg-validate-required',
 	));
 	?>
 </div>
@@ -33,6 +36,7 @@ if (elgg_is_sticky_form('register')) {
 	echo elgg_view('input/text', array(
 		'name' => 'email',
 		'value' => $email,
+		'class' => 'elgg-validate elgg-validate-required elgg-validate-email',
 	));
 	?>
 </div>
@@ -42,6 +46,7 @@ if (elgg_is_sticky_form('register')) {
 	echo elgg_view('input/text', array(
 		'name' => 'username',
 		'value' => $username,
+		'class' => 'elgg-validate elgg-validate-required elgg-validate-username',
 	));
 	?>
 </div>
@@ -51,6 +56,7 @@ if (elgg_is_sticky_form('register')) {
 	echo elgg_view('input/password', array(
 		'name' => 'password',
 		'value' => $password,
+		'class' => 'elgg-validate elgg-validate-required elgg-validate-password1',
 	));
 	?>
 </div>
@@ -60,6 +66,7 @@ if (elgg_is_sticky_form('register')) {
 	echo elgg_view('input/password', array(
 		'name' => 'password2',
 		'value' => $password2,
+		'class' => 'elgg-validate elgg-validate-required elgg-validate-password2',
 	));
 	?>
 </div>

--- a/views/default/js/validate.php
+++ b/views/default/js/validate.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Validate form specific javascript functions.
+ *
+ * @since 1.9
+ */
+?>
+
+elgg.provide('elgg.validate');
+elgg.provide('elgg.validate.checks');
+
+elgg.validate.checks.required = function(evt, elem) {
+	if (!elem.val()) {
+		return elgg.echo('register:fields');
+	}
+}
+
+elgg.validate.checks.email = function(evt, elem) {
+    if (!/\S+@\S+\.\S+/.test(elem.val())) {
+		return elgg.echo('registration:notemail');
+	/*} else if (@todo get if email is already registered) {
+		return elgg.echo('registration:dupeemail');*/
+	}
+}
+
+elgg.validate.checks.username = function(evt, elem) {
+	if (elem.val().length < 4) {
+		return elgg.echo('registration:usernametooshort', [4]);
+	} else if (elem.val().length > 128) {
+		return elgg.echo('registration:usernametoolong', [128]);
+	/*} else if (@todo check invalid chars) {
+		return elgg.echo('registration:invalidchars');*/
+	/*} else if (@todo check if username already exists) {
+		return elgg.echo('registration:userexists');*/
+	}
+}
+
+elgg.validate.checks.password1 = function(evt, elem) {
+	if (elem.val().length < 6) {
+		return elgg.echo('registration:passwordtooshort', [6]);
+	}
+}
+
+elgg.validate.checks.password2 = function(evt, elem) {	
+	if (elem.val() != elem.parent().prev().find('.elgg-validate-password1').val()) {
+		return elgg.echo('RegistrationException:PasswordMismatch');
+	}
+}
+
+elgg.validate.check = function(evt) {
+	$this = $(this);
+	
+	// Do not check error while writting.
+	if (evt.type == 'keyup' && !$this.hasClass('elgg-validate-error')) {
+		return true;
+	}
+	
+	allowed_checks = [];
+	
+	for (allowed_check in elgg.validate.checks) {
+		allowed_checks.push(allowed_check);
+	}
+
+	var classes = $this.attr('class').split(/\s+/);
+	var error = false;
+
+	for (c in classes) {
+		check = classes[c].replace('elgg-validate-', '');
+		if ($.inArray(check, allowed_checks) > -1) {
+			error = error || window['elgg']['validate']['checks'][check](evt, $this);
+		}
+
+	}
+
+	if (error && !$this.hasClass('elgg-validate-error')) {
+		$this.addClass('elgg-validate-error').after('<p class="elgg-text-help">'+error+'</p>');
+	} else if (!error && $this.hasClass('elgg-validate-error')) {
+		$this.removeClass('elgg-validate-error').next().remove();
+	} else if (error && $this.hasClass('elgg-validate-error')) {
+		$this.next().text(error);
+	}
+}
+
+elgg.validate.init = function () {
+	$('.elgg-validate-form .elgg-validate').blur(elgg.validate.check).keyup(elgg.validate.check);
+	$('.elgg-validate-form .elgg-validate-password1').keyup(function() {
+		$(this).parent().next().find('.elgg-validate-password2').blur();
+	});
+	$('.elgg-validate-form').submit(function() {
+		$(this).find('.elgg-validate').blur();
+		return !$(this).find('.elgg-validate-error').length;
+	});
+}
+
+elgg.register_hook_handler('init', 'system', elgg.validate.init);


### PR DESCRIPTION
This merge isn't ready to merge yet.

It present a completely working patch for register form, and we have to discuss about the functions, if we put them in a library and how we call and work with them.

Things to do:
- Add new ajax end points to be able to call `validate_username`, `validate_password` and `validate_email_address` PHP functions.
- Add a hook structure to the new javascript functions.

Things to discuss:
- Improve the way it is deployed and think in plugin extensions.
- Move to a library.
- Make as easy as add an `elgg-validate-*` CSS class to validate a field.
- Use it in the other plugin forms (edit, etc) to check required fields and whatever.
- Study more use cases.
