### PR TITLE
#2845 - persist 'selected' state of site menu

### DIFF
--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -321,21 +321,12 @@ function elgg_site_menu_setup($hook, $type, $return, $params) {
 	}
 	
 	if (!$selected) {
-		// nothing selected, match by handler
-		$handler = get_input('handler');
-		
+		// nothing selected, match name to context
 		foreach ($return as $section_name => $section) {
 			foreach ($section as $key => $item) {
-				// determine the 'handler' of this url, if there is one
+				// only highlight internal links
 				if (strpos($item->getHref(), elgg_get_site_url()) === 0) {
-					// this is an internal link, so it has a page handler
-					$path = array(str_replace(elgg_get_site_url(), '', $item->getHref()));
-					$separators = array('/', '?', '#');
-					foreach ($separators as $separator) {
-						$path = explode($separator, $path[0]);
-					}
-					
-					if ($path[0] == $handler) {
+					if ($item->getName() == elgg_get_context()) {
 						$return[$section_name][$key]->setSelected(true);
 						break 2;
 					}

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -308,6 +308,41 @@ function elgg_site_menu_setup($hook, $type, $return, $params) {
 			$return['more'] = array_splice($return['default'], $max_display_items);
 		}
 	}
+	
+	// check if we have anything selected
+	$selected = false;
+	foreach ($return as $section_name => $section) {
+		foreach ($section as $key => $item) {
+			if ($item->getSelected()) {
+				$selected = true;
+				break 2;
+			}
+		}
+	}
+	
+	if (!$selected) {
+		// nothing selected, match by handler
+		$handler = get_input('handler');
+		
+		foreach ($return as $section_name => $section) {
+			foreach ($section as $key => $item) {
+				// determine the 'handler' of this url, if there is one
+				if (strpos($item->getHref(), elgg_get_site_url()) === 0) {
+					// this is an internal link, so it has a page handler
+					$path = array(str_replace(elgg_get_site_url(), '', $item->getHref()));
+					$separators = array('/', '?', '#');
+					foreach ($separators as $separator) {
+						$path = explode($separator, $path[0]);
+					}
+					
+					if ($path[0] == $handler) {
+						$return[$section_name][$key]->setSelected(true);
+						break 2;
+					}
+				}
+			}
+		}
+	}
 
 	return $return;
 }


### PR DESCRIPTION
Not sure if this is the best way (I doubt it) but wanted to get some feedback.
It works for all default links (activity,blog,bookmarks,groups,files,members,pages) - but it seems quite hacky.
Please see the line notes.

[edit] - the group activity page uses the groups handler, not the activity handler - so this highlights the groups tab for that page which isn't consistent.
