### PR TITLE
Fixes #4725 - embed form on file upload textarea removes file upload form

### DIFF
--- a/mod/embed/views/default/js/embed/embed.php
+++ b/mod/embed/views/default/js/embed/embed.php
@@ -67,6 +67,8 @@ echo elgg_view('embed/custom_insert_js');
  * @return bool
  */
 elgg.embed.submit = function(event) {
+	$('.embed-wrapper .elgg-form-file-upload').hide();
+	$('.embed-throbber').show();
 	
 	$(this).ajaxSubmit({
 		dataType : 'json',
@@ -82,6 +84,10 @@ elgg.embed.submit = function(event) {
 					var url = elgg.normalize_url('embed/tab/' + forward);
 					url = elgg.embed.addContainerGUID(url);
 					$('.embed-wrapper').parent().load(url);
+				} else {
+					// incorrect response, presumably an error has been displayed
+					$('.embed-throbber').hide();
+					$('.embed-wrapper .elgg-form-file-upload').show();
 				}
 			}
 		},
@@ -89,9 +95,6 @@ elgg.embed.submit = function(event) {
 			// @todo nothing for now
 		}
 	});
-
-	$('.elgg-form-file-upload').hide();
-	$('.embed-throbber').show();
 
 	// this was bubbling up the DOM causing a submission
 	event.preventDefault();


### PR DESCRIPTION
no longer removes file upload form outside of embed lightbox, no longer hangs on throbber when the form returns an error.
