### PR TITLE
Download button should work as downloading on pc and not as preview.

### DIFF
--- a/mod/file/pages/file/download.php
+++ b/mod/file/pages/file/download.php
@@ -24,7 +24,7 @@ $filename = $file->originalfilename;
 
 // fix for IE https issue
 header("Pragma: public");
-
+header("Content-type: application/force-download");
 header("Content-type: $mime");
 if (strpos($mime, "image/") !== false || $mime == "application/pdf") {
 	header("Content-Disposition: inline; filename=\"$filename\"");

--- a/mod/uservalidationbyemail/start.php
+++ b/mod/uservalidationbyemail/start.php
@@ -184,11 +184,6 @@ function uservalidationbyemail_page_handler($page) {
 				$user->enable();
 				elgg_pop_context();
 
-				try {
-					login($user);
-				} catch(LoginException $e){
-					register_error($e->getMessage());
-				}
 			} else {
 				register_error(elgg_echo('email:confirm:fail'));
 			}


### PR DESCRIPTION
when user try to download some of the png files (for ex.) it automatically opens in browser.
I suggest to add a specific header inside file /mod/file/pages/file/download.php:

header("Content-type: application/force-download");

It allow to display a dialog for saving file on users pc
