### PR TITLE
Making the character limit in the Wire configurable.

### DIFF
--- a/mod/thewire/languages/en.php
+++ b/mod/thewire/languages/en.php
@@ -55,5 +55,11 @@ return array(
 	'thewire:notify:subject' => "New wire post",
 	'thewire:notify:reply' => '%s responded to %s on the wire:',
 	'thewire:notify:post' => '%s posted on the wire:',
+    
+    	/**
+	 * Settings
+	 */
+	 'thewire:settings:limit' => "Maximum number of characters for wire messages:",
+	 'thewire:settings:limit:none' => "No limit",
 
 );

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -253,8 +253,10 @@ function thewire_save_post($text, $userid, $access_id, $parent_guid = 0, $method
 	$post->owner_guid = $userid;
 	$post->access_id = $access_id;
 
-	// only 200 characters allowed
-	$text = elgg_substr($text, 0, 200);
+	// Character limit is now from config
+	$limit = elgg_get_plugin_setting('limit', 'thewire');
+	if ($limit > 0)
+		$text = elgg_substr($text, 0, $limit);
 
 	// no html tags allowed so we escape
 	$post->description = htmlspecialchars($text, ENT_NOQUOTES, 'UTF-8');

--- a/mod/thewire/views/default/forms/thewire/add.php
+++ b/mod/thewire/views/default/forms/thewire/add.php
@@ -28,7 +28,19 @@ echo elgg_view('input/plaintext', array(
 ));
 ?>
 <div id="thewire-characters-remaining">
-	<span>140</span> <?php echo elgg_echo('thewire:charleft'); ?>
+<?php
+
+$limit = elgg_get_plugin_setting('limit', 'thewire');
+if (!empty($limit)) {
+
+?>
+	<span><?php echo $limit; ?></span> <?php echo elgg_echo('thewire:charleft'); ?>
+<?php
+
+	}
+
+?>
+
 </div>
 <div class="elgg-foot mts">
 <?php

--- a/mod/thewire/views/default/js/thewire.php
+++ b/mod/thewire/views/default/js/thewire.php
@@ -4,20 +4,23 @@
  */
 
 $site_url = elgg_get_site_url();
+$limit = elgg_get_plugin_setting('limit', 'thewire');
 
 ?>
 
 elgg.provide('elgg.thewire');
 
 elgg.thewire.init = function() {
+<?php if ($limit > 0) { ?>
 	$("#thewire-textarea").live('keydown', function() {
-		elgg.thewire.textCounter(this, $("#thewire-characters-remaining span"), 140);
+		elgg.thewire.textCounter(this, $("#thewire-characters-remaining span"), <?php echo $limit; ?>);
 	});
 	$("#thewire-textarea").live('keyup', function() {
-		elgg.thewire.textCounter(this, $("#thewire-characters-remaining span"), 140);
+		elgg.thewire.textCounter(this, $("#thewire-characters-remaining span"), <?php echo $limit; ?>);
 	});
 
 	$(".thewire-previous").live('click', elgg.thewire.viewPrevious);
+<?php } ?>
 };
 
 /**

--- a/mod/thewire/views/default/plugins/thewire/settings.php
+++ b/mod/thewire/views/default/plugins/thewire/settings.php
@@ -1,0 +1,9 @@
+<p>
+  <?php echo elgg_echo('thewire:settings:limit'); ?>
+ 
+  <select name="params[limit]">
+  	<option value="0" <?php if ($vars['entity']->limit == 0) echo 'selected = "selected"'; ?>><?php echo elgg_echo('thewire:settings:limit:none'); ?></option>
+  	<option value="140" <?php if ($vars['entity']->limit == 140) echo 'selected = "selected"'; ?>>140</option>
+  	<option value="256" <?php if ($vars['entity']->limit == 256) echo 'selected = "selected"'; ?>>256</option>
+  </select>
+</p>


### PR DESCRIPTION
Removed the 140-character limit as a hardcoded setting, although it's there if the site administrator wants to use it. 140 characters makes less sense for many users, in a post-SMS, post-explicitly-emulating-Twitter universe.
