### PR TITLE
#4553: Database object

### DIFF
--- a/engine/classes/ElggData.php
+++ b/engine/classes/ElggData.php
@@ -61,6 +61,16 @@ abstract class ElggData implements
 	}
 
 	/**
+	 * Provides a pointer to the database object. Use this instead of
+	 * elgg_get_database() in subclasses to make mocking possible for unit tests.
+	 *
+	 * @return ElggDatabase The database where this data is (will be) stored.
+	 */
+	protected function getDatabase() {
+		return elgg_get_database();	
+	}
+
+	/**
 	 * Return an attribute or a piece of metadata.
 	 *
 	 * @param string $name Name

--- a/engine/classes/ElggDatabase.php
+++ b/engine/classes/ElggDatabase.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * An object representing a single Elgg database.
+ *
+ * WARNING: THIS API IS IN FLUX. PLUGIN AUTHORS SHOULD NOT USE. See lib/database.php instead.
+ *
+ * TODO: Convert query cache to a private local variable (or remove completely).
+ * TODO: Convert delayed queries to private local variable.
+ * TODO: Convert db link registry to private local variable.
+ *
+ * @access private
+ */
 class ElggDatabase {
 	
 	private $tablePrefix;
@@ -9,6 +20,115 @@ class ElggDatabase {
 		
 		$this->tablePrefix = $CONFIG->dbprefix;
 	}
+	
+	/**
+	 * Returns (if required, also creates) a database link resource.
+	 *
+	 * Database link resources are stored in the {@link $dblink} global.  These
+	 * resources are created by {@link setup_db_connections()}, which is called if
+	 * no links exist.
+	 *
+	 * @param string $dblinktype The type of link we want: "read", "write" or "readwrite".
+	 *
+	 * @return object Database link
+	 * @access private
+	 */
+	function getLink($dblinktype) {
+		global $dblink;
+	
+		if (isset($dblink[$dblinktype])) {
+			return $dblink[$dblinktype];
+		} else if (isset($dblink['readwrite'])) {
+			return $dblink['readwrite'];
+		} else {
+			$this->setupConnections();
+			return $this->getLink($dblinktype);
+		}
+	}
+
+	/**
+	 * Establish database connections
+	 *
+	 * If the configuration has been set up for multiple read/write databases, set those
+	 * links up separately; otherwise just create the one database link.
+	 *
+	 * @return void
+	 * @access private
+	 */
+	public function setupConnections() {
+		global $CONFIG;
+	
+		if (!empty($CONFIG->db->split)) {
+			$this->establishLink('read');
+			$this->establishLink('write');
+		} else {
+			$this->establishLink('readwrite');
+		}
+	}
+
+
+	/**
+	 * Establish a connection to the database servser
+	 *
+	 * Connect to the database server and use the Elgg database for a particular database link
+	 *
+	 * @param string $dblinkname The type of database connection. Used to identify the
+	 * resource. eg "read", "write", or "readwrite".
+	 *
+	 * @return void
+	 * @access private
+	 */
+	public function establishLink($dblinkname = "readwrite") {
+		// Get configuration, and globalise database link
+		global $CONFIG, $dblink, $DB_QUERY_CACHE, $dbcalls;
+	
+		if ($dblinkname != "readwrite" && isset($CONFIG->db[$dblinkname])) {
+			if (is_array($CONFIG->db[$dblinkname])) {
+				$index = rand(0, sizeof($CONFIG->db[$dblinkname]));
+				$dbhost = $CONFIG->db[$dblinkname][$index]->dbhost;
+				$dbuser = $CONFIG->db[$dblinkname][$index]->dbuser;
+				$dbpass = $CONFIG->db[$dblinkname][$index]->dbpass;
+				$dbname = $CONFIG->db[$dblinkname][$index]->dbname;
+			} else {
+				$dbhost = $CONFIG->db[$dblinkname]->dbhost;
+				$dbuser = $CONFIG->db[$dblinkname]->dbuser;
+				$dbpass = $CONFIG->db[$dblinkname]->dbpass;
+				$dbname = $CONFIG->db[$dblinkname]->dbname;
+			}
+		} else {
+			$dbhost = $CONFIG->dbhost;
+			$dbuser = $CONFIG->dbuser;
+			$dbpass = $CONFIG->dbpass;
+			$dbname = $CONFIG->dbname;
+		}
+	
+		// Connect to database
+		if (!$dblink[$dblinkname] = mysql_connect($dbhost, $dbuser, $dbpass, true)) {
+			$msg = elgg_echo('DatabaseException:WrongCredentials',
+					array($dbuser, $dbhost, "****"));
+			throw new DatabaseException($msg);
+		}
+	
+		if (!mysql_select_db($dbname, $dblink[$dblinkname])) {
+			$msg = elgg_echo('DatabaseException:NoConnect', array($dbname));
+			throw new DatabaseException($msg);
+		}
+	
+		// Set DB for UTF8
+		mysql_query("SET NAMES utf8");
+	
+		$db_cache_off = FALSE;
+		if (isset($CONFIG->db_disable_query_cache)) {
+			$db_cache_off = $CONFIG->db_disable_query_cache;
+		}
+	
+		// Set up cache if global not initialized and query cache not turned off
+		if ((!$DB_QUERY_CACHE) && (!$db_cache_off)) {
+			$DB_QUERY_CACHE = new ElggStaticVariableCache('db_query_cache');
+		}
+	}
+
+	
 	
 	/**
 	 * Retrieve rows from the database.
@@ -285,4 +405,127 @@ class ElggDatabase {
 		
 	}
 	
+	/**
+	 * Runs a full database script from disk.
+	 *
+	 * The file specified should be a standard SQL file as created by
+	 * mysqldump or similar.  Statements must be terminated with ;
+	 * and a newline character (\n or \r\n) with only one statement per line.
+	 *
+	 * The special string 'prefix_' is replaced with the database prefix
+	 * as defined in {@link $this->tablePrefix}.
+	 *
+	 * @warning Errors do not halt execution of the script.  If a line
+	 * generates an error, the error message is saved and the
+	 * next line is executed.  After the file is run, any errors
+	 * are displayed as a {@link DatabaseException}
+	 *
+	 * @param string $scriptlocation The full path to the script
+	 *
+	 * @return void
+	 * @throws DatabaseException
+	 * @access private
+	 */
+	function runSqlScript($scriptlocation) {
+		if ($script = file_get_contents($scriptlocation)) {
+			global $CONFIG;
+	
+			$errors = array();
+	
+			// Remove MySQL -- style comments
+			$script = preg_replace('/\-\-.*\n/', '', $script);
+	
+			// Statements must end with ; and a newline
+			$sql_statements = preg_split('/;[\n\r]+/', $script);
+	
+			foreach ($sql_statements as $statement) {
+				$statement = trim($statement);
+				$statement = str_replace("prefix_", $this->tablePrefix, $statement);
+				if (!empty($statement)) {
+					try {
+						$result = $this->updateData($statement);
+					} catch (DatabaseException $e) {
+						$errors[] = $e->getMessage();
+					}
+				}
+			}
+			if (!empty($errors)) {
+				$errortxt = "";
+				foreach ($errors as $error) {
+					$errortxt .= " {$error};";
+				}
+	
+				$msg = elgg_echo('DatabaseException:DBSetupIssues') . $errortxt;
+				throw new DatabaseException($msg);
+			}
+		} else {
+			$msg = elgg_echo('DatabaseException:ScriptNotFound', array($scriptlocation));
+			throw new DatabaseException($msg);
+		}
+	}
+	
+	/**
+	 * Queue a query for execution upon shutdown.
+	 *
+	 * You can specify a handler function if you care about the result. This function will accept
+	 * the raw result from {@link mysql_query()}.
+	 *
+	 * @param string   $query   The query to execute
+	 * @param resource $dblink  The database link to use or the link type (read | write)
+	 * @param string   $handler A callback function to pass the results array to
+	 *
+	 * @return boolean Whether registering was successful.
+	 * @access private
+	 */
+	function registerDelayedQuery($query, $dblink, $handler = "") {
+		global $DB_DELAYED_QUERIES;
+	
+		if (!isset($DB_DELAYED_QUERIES)) {
+			$DB_DELAYED_QUERIES = array();
+		}
+	
+		if (!is_resource($dblink) && $dblink != 'read' && $dblink != 'write') {
+			return false;
+		}
+	
+		// Construct delayed query
+		$delayed_query = array();
+		$delayed_query['q'] = $query;
+		$delayed_query['l'] = $dblink;
+		$delayed_query['h'] = $handler;
+	
+		$DB_DELAYED_QUERIES[] = $delayed_query;
+	
+		return TRUE;
+	}
+
+	
+	/**
+	 * Trigger all queries that were registered as "delayed" queries. This is
+	 * called by the system automatically on shutdown.
+	 */
+	public function executeDelayedQueries() {
+		global $DB_DELAYED_QUERIES;
+
+		foreach ($DB_DELAYED_QUERIES as $query_details) {
+			try {
+				$link = $query_details['l'];
+	
+				if ($link == 'read' || $link == 'write') {
+					$link = get_db_link($link);
+				} elseif (!is_resource($link)) {
+					elgg_log("Link for delayed query not valid resource or db_link type. Query: {$query_details['q']}", 'WARNING');
+				}
+				
+				$result = $this->executeQuery($query_details['q'], $link);
+				
+				if ((isset($query_details['h'])) && (is_callable($query_details['h']))) {
+					$query_details['h']($result);
+				}
+			} catch (Exception $e) {
+				// Suppress all errors since these can't be dealt with here
+				elgg_log($e, 'WARNING');
+			}
+		}
+	}
 }

--- a/engine/classes/ElggDatabase.php
+++ b/engine/classes/ElggDatabase.php
@@ -1,0 +1,43 @@
+<?php
+
+class ElggDatabase {
+	
+	public function __construct() {}
+	
+	/**
+	 * Retrieve rows from the database.
+	 *
+	 * Queries are executed with {@link execute_query()} and results
+	 * are retrieved with {@link mysql_fetch_object()}.  If a callback
+	 * function $callback is defined, each row will be passed as the single
+	 * argument to $callback.  If no callback function is defined, the
+	 * entire result set is returned as an array.
+	 *
+	 * @param mixed  $query    The query being passed.
+	 * @param string $callback Optionally, the name of a function to call back to on each row
+	 *
+	 * @return array An array of database result objects or callback function results. If the query
+	 *               returned nothing, an empty array.
+	 * @access private
+	 */
+	public function getData($query, $callback = '') {
+		return elgg_query_runner($query, $callback, false);	
+	}
+	
+	/**
+	 * Retrieve a single row from the database.
+	 *
+	 * Similar to {@link ElggDatabase::getData()} but returns only the first row
+	 * matched.  If a callback function $callback is specified, the row will be passed
+	 * as the only argument to $callback.
+	 *
+	 * @param mixed  $query    The query to execute.
+	 * @param string $callback A callback function
+	 *
+	 * @return mixed A single database result object or the result of the callback function.
+	 * @access private
+	 */
+	public function getDataRow($query, $callback = '') {
+		return elgg_query_runner($query, $callback, true);	
+	}
+}

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1599,7 +1599,7 @@ abstract class ElggEntity extends ElggData implements
 			access_show_hidden_entities(true);
 			$ia = elgg_set_ignore_access(true);
 			
-			$sub_entities = get_data("SELECT * FROM {$CONFIG->dbprefix}entities
+			$sub_entities = $this->getDatabase()->getData("SELECT * FROM {$CONFIG->dbprefix}entities
 				WHERE (
 				container_guid = $guid
 				OR owner_guid = $guid

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -14,7 +14,7 @@
  * declared will be assumed to be metadata and written to the database
  * as metadata on the object.  All children classes must declare which
  * properties are columns of the type table or they will be assumed
- * to be metadata.  See ElggObject::initialise_entities() for examples.
+ * to be metadata.  See ElggObject::initialiseAttributes() for examples.
  *
  * Core supports 4 types of entities: ElggObject, ElggUser, ElggGroup, and
  * ElggSite.
@@ -28,11 +28,11 @@
  * @property string $type           object, user, group, or site (read-only after save)
  * @property string $subtype        Further clarifies the nature of the entity (read-only after save)
  * @property int    $guid           The unique identifier for this entity (read only)
- * @property int    $owner_guid     The GUID of the creator of this entity
+ * @property int    $owner_guid     The GUID of the owner of this entity (usually the creator)
  * @property int    $container_guid The GUID of the entity containing this entity
  * @property int    $site_guid      The GUID of the website this entity is associated with
  * @property int    $access_id      Specifies the visibility level of this entity
- * @property int    $time_created   A UNIX timestamp of when the entity was created (read-only, set on first save)
+ * @property int    $time_created   A UNIX timestamp of when the entity was created
  * @property int    $time_updated   A UNIX timestamp of when the entity was last updated (automatically updated on save)
  */
 abstract class ElggEntity extends ElggData implements

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1417,7 +1417,7 @@ abstract class ElggEntity extends ElggData implements
 			}				
 		}
 		
-		$result = insert_data("INSERT into {$CONFIG->dbprefix}entities
+		$result = $this->getDatabase()->insertData("INSERT into {$CONFIG->dbprefix}entities
 			(type, subtype, owner_guid, site_guid, container_guid,
 				access_id, time_created, time_updated, last_action)
 			values
@@ -1484,7 +1484,7 @@ abstract class ElggEntity extends ElggData implements
 			return false;
 		}
 		
-		$ret = update_data("UPDATE {$CONFIG->dbprefix}entities
+		$ret = $this->getDatabase()->updateData("UPDATE {$CONFIG->dbprefix}entities
 			set owner_guid='$owner_guid', access_id='$access_id',
 			container_guid='$container_guid', time_created='$time_created',
 			time_updated='$time' WHERE guid=$guid");
@@ -1620,7 +1620,7 @@ abstract class ElggEntity extends ElggData implements
 		$this->disableMetadata();
 		$this->disableAnnotations();
 
-		$res = update_data("UPDATE {$CONFIG->dbprefix}entities
+		$res = $this->getDatabase()->updateData("UPDATE {$CONFIG->dbprefix}entities
 			SET enabled = 'no'
 			WHERE guid = $guid");
 
@@ -1662,7 +1662,7 @@ abstract class ElggEntity extends ElggData implements
 		$old_access_status = access_get_show_hidden_status();
 		access_show_hidden_entities(true);
 	
-		$result = update_data("UPDATE {$CONFIG->dbprefix}entities
+		$result = $this->getDatabase()->updateData("UPDATE {$CONFIG->dbprefix}entities
 			SET enabled = 'yes'
 			WHERE guid = $guid");
 
@@ -1796,7 +1796,7 @@ abstract class ElggEntity extends ElggData implements
 		elgg_delete_river(array('object_guid' => $guid));
 		remove_all_private_settings($guid);
 
-		$res = delete_data("DELETE from {$CONFIG->dbprefix}entities where guid={$guid}");
+		$res = $this->getDatabase()->deleteData("DELETE from {$CONFIG->dbprefix}entities where guid={$guid}");
 		if ($res) {
 			$sub_table = "";
 
@@ -1817,7 +1817,7 @@ abstract class ElggEntity extends ElggData implements
 			}
 
 			if ($sub_table) {
-				delete_data("DELETE from $sub_table where guid={$guid}");
+				$this->getDatabase()->deleteData("DELETE from $sub_table where guid={$guid}");
 			}
 		}
 

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -385,7 +385,7 @@ class ElggGroup extends ElggEntity
 		$query = "UPDATE {$CONFIG->dbprefix}groups_entity set"
 			. " name='$name', description='$description' where guid=$guid";
 
-		return update_data($query) !== false;
+		return $this->getDatabase()->updateData($query) !== false;
 	}
 	
 	/** @override */
@@ -399,7 +399,7 @@ class ElggGroup extends ElggEntity
 		$query = "INSERT into {$CONFIG->dbprefix}groups_entity"
 			. " (guid, name, description) values ($guid, '$name', '$description')";
 
-		$result = insert_data($query);
+		$result = $this->getDatabase()->insertData($query);
 		if ($result === false) {
 			// TODO(evan): Throw an exception here?
 			return false;

--- a/engine/classes/ElggHMACCache.php
+++ b/engine/classes/ElggHMACCache.php
@@ -15,6 +15,17 @@ class ElggHMACCache extends ElggCache {
 	function __construct($max_age = 0) {
 		$this->setVariable("max_age", $max_age);
 	}
+	
+
+	/**
+	 * Provides a pointer to the database object. Use this instead of
+	 * to make mocking possible for unit tests.
+	 *
+	 * @return ElggDatabase The database where this data is (will be) stored.
+	 */
+	protected function getDatabase() {
+		return elgg_get_database();	
+	}
 
 	/**
 	 * Save a key
@@ -31,7 +42,7 @@ class ElggHMACCache extends ElggCache {
 		$time = time();
 
 		$query = "INSERT into {$CONFIG->dbprefix}hmac_cache (hmac, ts) VALUES ('$key', '$time')";
-		return insert_data($query);
+		return $this->getDatabase()->insertData($query);
 	}
 
 	/**
@@ -48,7 +59,7 @@ class ElggHMACCache extends ElggCache {
 
 		$key = sanitise_string($key);
 
-		$row = get_data_row("SELECT * from {$CONFIG->dbprefix}hmac_cache where hmac='$key'");
+		$row = $this->getDatabase()->getDataRow("SELECT * from {$CONFIG->dbprefix}hmac_cache where hmac='$key'");
 		if ($row) {
 			return $row->hmac;
 		}
@@ -68,7 +79,7 @@ class ElggHMACCache extends ElggCache {
 
 		$key = sanitise_string($key);
 
-		return delete_data("DELETE from {$CONFIG->dbprefix}hmac_cache where hmac='$key'");
+		return $this->getDatabase()->deleteData("DELETE from {$CONFIG->dbprefix}hmac_cache where hmac='$key'");
 	}
 
 	/**
@@ -94,6 +105,6 @@ class ElggHMACCache extends ElggCache {
 
 		$expires = $time - $age;
 
-		delete_data("DELETE from {$CONFIG->dbprefix}hmac_cache where ts<$expires");
+		$this->getDatabase()->deleteData("DELETE from {$CONFIG->dbprefix}hmac_cache where ts<$expires");
 	}
 }

--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -145,7 +145,7 @@ class ElggObject extends ElggEntity {
 		$query = "INSERT into {$CONFIG->dbprefix}objects_entity
 			(guid, title, description) values ($guid, '$title', '$description')";
 
-		$result = insert_data($query);
+		$result = $this->getDatabase()->insertData($query);
 		if ($result === false) {
 			// TODO(evan): Throw an exception here?
 			return false;
@@ -169,7 +169,7 @@ class ElggObject extends ElggEntity {
 		$query = "UPDATE {$CONFIG->dbprefix}objects_entity
 			set title='$title', description='$description' where guid=$guid";
 
-		return update_data($query) !== false;
+		return $this->getDatabase()->updateData($query) !== false;
 	}
 
 

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -356,7 +356,7 @@ class ElggPlugin extends ElggObject {
 			AND name NOT LIKE '$us_prefix%'
 			AND name NOT LIKE '$is_prefix%'";
 
-		$private_settings = get_data($q);
+		$private_settings = $this->getDatabase()->getData($q);
 
 		if ($private_settings) {
 			$return = array();
@@ -480,7 +480,7 @@ class ElggPlugin extends ElggObject {
 			WHERE entity_guid = {$user->guid}
 			AND name LIKE '$ps_prefix%'";
 
-		$private_settings = get_data($q);
+		$private_settings = $this->getDatabase()->getData($q);
 
 		if ($private_settings) {
 			$return = array();

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -305,7 +305,7 @@ class ElggPlugin extends ElggObject {
 				AND name = '$name'
 				AND $where";
 
-			if (!update_data($q)) {
+			if (!$this->getDatabase()->updateData($q)) {
 				return false;
 			}
 
@@ -418,7 +418,7 @@ class ElggPlugin extends ElggObject {
 			WHERE entity_guid = $this->guid
 			AND name NOT LIKE '$ps_prefix%'";
 
-		return delete_data($q);
+		return $this->getDatabase()->deleteData($q);
 	}
 
 
@@ -580,7 +580,7 @@ class ElggPlugin extends ElggObject {
 			WHERE entity_guid = $user_guid
 			AND name LIKE '$ps_prefix%'";
 
-		return delete_data($q);
+		return $this->getDatabase()->deleteData($q);
 	}
 
 	/**
@@ -598,7 +598,7 @@ class ElggPlugin extends ElggObject {
 		$q = "DELETE FROM {$db_prefix}private_settings
 			WHERE name LIKE '$ps_prefix%'";
 
-		return delete_data($q);
+		return $this->getDatabase()->deleteData($q);
 	}
 
 

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -165,7 +165,7 @@ class ElggSite extends ElggEntity {
 		$query = "INSERT into {$CONFIG->dbprefix}sites_entity
 			(guid, name, description, url) values ($guid, '$name', '$description', '$url')";
 
-		$result = insert_data($query);
+		$result = $this->getDatabase()->insertData($query);
 		if ($result === false) {
 			// TODO(evan): Throw an exception here?
 			return false;
@@ -190,7 +190,7 @@ class ElggSite extends ElggEntity {
 		$query = "UPDATE {$CONFIG->dbprefix}sites_entity
 			set name='$name', description='$description', url='$url' where guid=$guid";
 
-		return update_data($query) !== false;
+		return $this->getDatabase()->updateData($query) !== false;
 	}
 
 	/** @override */
@@ -206,7 +206,7 @@ class ElggSite extends ElggEntity {
 		// make sure the site guid is set (if not, set to self)
 		if (!$this->get('site_guid')) {
 			$guid = (int)$this->get('guid');
-			update_data("UPDATE {$CONFIG->dbprefix}entities SET site_guid=$guid WHERE guid=$guid");
+			$this->getDatabase()->updateData("UPDATE {$CONFIG->dbprefix}entities SET site_guid=$guid WHERE guid=$guid");
 		}
 		
 		return $result;

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -159,7 +159,7 @@ class ElggUser extends ElggEntity
 			(guid, name, username, password, salt, email, language, code)
 			values ($guid, '$name', '$username', '$password', '$salt', '$email', '$language', '$code')";
 
-		$result = insert_data($query);
+		$result = $this->getDatabase()->insertData($query);
 		if ($result === false) {
 			// TODO(evan): Throw an exception here?
 			return false;
@@ -190,7 +190,7 @@ class ElggUser extends ElggEntity
 			email='$email', language='$language', code='$code'
 			WHERE guid = $guid";
 
-		return update_data($query) !== false;
+		return $this->getDatabase()->updateData($query) !== false;
 	}
 
 	/**

--- a/engine/lib/database.php
+++ b/engine/lib/database.php
@@ -396,36 +396,7 @@ function delete_data($query) {
  * @access private
  */
 function get_db_tables() {
-	global $CONFIG;
-	static $tables;
-
-	if (isset($tables)) {
-		return $tables;
-	}
-
-	try{
-		$result = elgg_get_database()->getData("show tables like '" . $CONFIG->dbprefix . "%'");
-	} catch (DatabaseException $d) {
-		// Likely we can't handle an exception here, so just return false.
-		return FALSE;
-	}
-
-	$tables = array();
-
-	if (is_array($result) && !empty($result)) {
-		foreach ($result as $row) {
-			$row = (array) $row;
-			if (is_array($row) && !empty($row)) {
-				foreach ($row as $element) {
-					$tables[] = $element;
-				}
-			}
-		}
-	} else {
-		return FALSE;
-	}
-
-	return $tables;
+	return elgg_get_database()->getTables();
 }
 
 /**

--- a/engine/lib/database.php
+++ b/engine/lib/database.php
@@ -63,6 +63,15 @@ $dblink = array();
 global $dbcalls;
 $dbcalls = 0;
 
+function elgg_get_database() {
+	global $CONFIG;
+	if (!isset($CONFIG->databaseObj)) {
+		$CONFIG->databaseObj = new ElggDatabase();	
+	}
+	
+	return $CONFIG->databaseObj;
+}
+
 /**
  * Establish a connection to the database servser
  *
@@ -348,9 +357,10 @@ function execute_delayed_read_query($query, $handler = "") {
  * @return array An array of database result objects or callback function results. If the query
  *               returned nothing, an empty array.
  * @access private
+ * @deprecated 1.9 Use ElggDatabase::getData() instead!
  */
 function get_data($query, $callback = "") {
-	return elgg_query_runner($query, $callback, false);
+	return elgg_get_database()->getData($query, $callback);
 }
 
 /**
@@ -365,9 +375,10 @@ function get_data($query, $callback = "") {
  *
  * @return mixed A single database result object or the result of the callback function.
  * @access private
+ * @deprecated 1.9 Use ElggDatabase::getDataRow() instead!
  */
 function get_data_row($query, $callback = "") {
-	return elgg_query_runner($query, $callback, true);
+	return elgg_get_database()->getDataRow($query, $callback);
 }
 
 /**
@@ -550,7 +561,7 @@ function get_db_tables() {
 	}
 
 	try{
-		$result = get_data("show tables like '" . $CONFIG->dbprefix . "%'");
+		$result = elgg_get_database()->getData("show tables like '" . $CONFIG->dbprefix . "%'");
 	} catch (DatabaseException $d) {
 		// Likely we can't handle an exception here, so just return false.
 		return FALSE;

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -165,21 +165,22 @@ function elgg_format_attributes(array $attrs) {
 	foreach ($attrs as $attr => $val) {
 		$attr = strtolower($attr);
 
-		if ($val === TRUE) {
-			$val = $attr; //e.g. checked => TRUE ==> checked="checked"
+		// allow $vars['class'] => array('one', 'two');
+		// @todo what about $vars['style']? Needs to be semi-colon separated...
+		if (is_array($val)) {
+			$val = implode(' ', $val);
 		}
 
 		// ignore $vars['entity'] => ElggEntity stuff
-		if ($val !== NULL && $val !== false && (is_array($val) || !is_object($val))) {
+		if ($val !== NULL && $val !== false && !is_object($val)) {
 
-			// allow $vars['class'] => array('one', 'two');
-			// @todo what about $vars['style']? Needs to be semi-colon separated...
-			if (is_array($val)) {
-				$val = implode(' ', $val);
+			if ($val === true) {
+				// array(multiple => true) becomes "multiple"
+				$attributes[] = $attr;	
+			} else {
+				$val = htmlspecialchars($val, ENT_QUOTES, 'UTF-8', false);
+				$attributes[] = "$attr=\"$val\"";
 			}
-
-			$val = htmlspecialchars($val, ENT_QUOTES, 'UTF-8', false);
-			$attributes[] = "$attr=\"$val\"";
 		}
 	}
 

--- a/engine/tests/ElggCoreEntityTest.php
+++ b/engine/tests/ElggCoreEntityTest.php
@@ -162,20 +162,20 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 		$this->entity->non_existent = 'testing';
 
 		// save
-		$this->AssertEqual($this->entity->getGUID(), 0);
+		$this->assertEqual($this->entity->getGUID(), 0);
 		$guid = $this->entity->save();
-		$this->AssertNotEqual($guid, 0);
+		$this->assertNotEqual($guid, 0);
 
 		// check guid
-		$this->AssertEqual($this->entity->getGUID(), $guid);
+		$this->assertEqual($this->entity->getGUID(), $guid);
 		$attributes = $this->entity->expose_attributes();
-		$this->AssertEqual($attributes['guid'], $guid);
-		$this->AssertIdentical($ENTITY_CACHE[$guid], $this->entity);
+		$this->assertEqual($attributes['guid'], $guid);
+		$this->assertIdentical($ENTITY_CACHE[$guid], $this->entity);
 
 		// check metadata
 		$metadata = $this->entity->expose_metadata();
-		$this->AssertFalse(in_array('non_existent', $metadata));
-		$this->AssertEqual($this->entity->get('non_existent'), 'testing');
+		$this->assertFalse(in_array('non_existent', $metadata));
+		$this->assertEqual($this->entity->get('non_existent'), 'testing');
 
 		// clean up with delete
 		$this->assertIdentical(true, $this->entity->delete());

--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -20,7 +20,7 @@ elgg.ui.init = function () {
 
 	$('.elgg-requires-confirmation').live('click', elgg.ui.requiresConfirmation);
 
-	$('.elgg-autofocus').focus();
+	$('.elgg-autofocus, [autofocus]').first().focus();
 };
 
 /**

--- a/mod/developers/views/default/theme_preview/forms.php
+++ b/mod/developers/views/default/theme_preview/forms.php
@@ -134,5 +134,23 @@
 					));
 			?>
 		</div>
+		<div>
+			<label for="f16">Number input (.elgg-input-number):</label>
+			<?php echo elgg_view('input/number', array(
+					'name' => 'f16',
+					'id' => 'f16',
+					'value' => 12345,
+					));
+			?>
+		</div>
+		<div>
+			<label for="f17">Location input (.elgg-input-location):</label>
+			<?php echo elgg_view('input/location', array(
+					'name' => 'f17',
+					'id' => 'f17',
+					'value' => 'Elgg, Switzerland',
+					));
+			?>
+		</div>
 	</fieldset>
 </form>

--- a/views/default/css/elements/forms.php
+++ b/views/default/css/elements/forms.php
@@ -41,6 +41,10 @@ input, textarea {
 	box-sizing: border-box;
 }
 
+input:invalid {
+	border-color: red;	
+}
+
 input[type=text]:focus, textarea:focus {
 	border: solid 1px #4690d6;
 	background: #e4ecf5;

--- a/views/default/input/email.php
+++ b/views/default/input/email.php
@@ -9,18 +9,10 @@
  * @uses $vars['class'] Additional CSS class
  */
 
-if (isset($vars['class'])) {
-	$vars['class'] = "elgg-input-email {$vars['class']}";
-} else {
-	$vars['class'] = "elgg-input-email";
-}
+$vars['type'] = 'email';
 
-$defaults = array(
-	'disabled' => false,
-);
+$class = elgg_extract('class', $vars, '');
+$vars['class'] = "$class elgg-input-email";
 
-$vars = array_merge($defaults, $vars);
-
-?>
-
-<input type="text" <?php echo elgg_format_attributes($vars); ?> />
+$attrs = elgg_format_attributes($vars);
+echo "<input $attrs />";

--- a/views/default/input/password.php
+++ b/views/default/input/password.php
@@ -11,18 +11,10 @@
  * @uses $vars['class'] Additional CSS class
  */
 
-if (isset($vars['class'])) {
-	$vars['class'] = "elgg-input-password {$vars['class']}";
-} else {
-	$vars['class'] = "elgg-input-password";
-}
+$vars['type'] = 'password';
 
-$defaults = array(
-	'disabled' => false,
-	'value' => '',
-);
+$class = elgg_extract('class', $vars, '');
+$vars['class'] = "$class elgg-input-password";
 
-$attrs = array_merge($defaults, $vars);
-?>
-
-<input type="password" <?php echo elgg_format_attributes($attrs); ?> />
+$attrs = elgg_format_attributes($vars);
+echo "<input $attrs />";

--- a/views/default/input/tag.php
+++ b/views/default/input/tag.php
@@ -8,18 +8,10 @@
  * @uses $vars['class'] Additional CSS class
  */
 
-if (isset($vars['class'])) {
-	$vars['class'] = "elgg-input-tag {$vars['class']}";
-} else {
-	$vars['class'] = "elgg-input-tag";
-}
+$vars['type'] = 'text';
 
-$defaults = array(
-	'value' => '',
-	'disabled' => false,
-);
+$class = elgg_extract('class', $vars, '');
+$vars['class'] = "$class elgg-input-tag";
 
-$vars = array_merge($defaults, $vars);
-?>
-
-<input type="text" <?php echo elgg_format_attributes($vars); ?> />
+$attrs = elgg_format_attributes($vars);
+echo "<input $attrs />";

--- a/views/default/input/tags.php
+++ b/views/default/input/tags.php
@@ -9,11 +9,8 @@
  * @uses $vars['entity']   Optional. Entity whose tags are being displayed (metadata ->tags)
  */
 
-if (isset($vars['class'])) {
-	$vars['class'] = "elgg-input-tags {$vars['class']}";
-} else {
-	$vars['class'] = "elgg-input-tags";
-}
+$class = elgg_extract('class', $vars, '');
+$vars['class'] = "$class elgg-input-tags";
 
 $defaults = array(
 	'value' => '',

--- a/views/default/input/url.php
+++ b/views/default/input/url.php
@@ -9,19 +9,10 @@
  * @uses $vars['class'] Additional CSS class
  */
 
-if (isset($vars['class'])) {
-	$vars['class'] = "elgg-input-url {$vars['class']}";
-} else {
-	$vars['class'] = "elgg-input-url";
-}
+$vars['type'] = 'url';
 
-$defaults = array(
-	'value' => '',
-	'disabled' => false,
-);
+$class = elgg_extract('class', $vars, '');
+$vars['class'] = "$class elgg-input-url";
 
-$vars = array_merge($defaults, $vars);
-
-?>
-
-<input type="text" <?php echo elgg_format_attributes($vars); ?> />
+$attrs = elgg_format_attributes($vars);
+echo "<input $attrs />";


### PR DESCRIPTION
This is a pretty straightforward refactor -- basically a 1-to-1 replacement for all the procedural methods in lib/database.php. Also updates some of the usage in Entity classes to go through the DB object instead of using the procedural methods.

Unit tests are passing.
