### PR TITLE
Fixes #4593: All titles are HTML-escaped plain text

### DIFF
--- a/mod/blog/actions/blog/auto_save_revision.php
+++ b/mod/blog/actions/blog/auto_save_revision.php
@@ -7,7 +7,7 @@
 
 $guid = get_input('guid');
 $user = elgg_get_logged_in_user_entity();
-$title = get_input('title');
+$title = htmlspecialchars(get_input('title', '', false), ENT_QUOTES, 'UTF-8');
 $description = get_input('description');
 $excerpt = get_input('excerpt');
 

--- a/mod/blog/actions/blog/save.php
+++ b/mod/blog/actions/blog/save.php
@@ -57,7 +57,11 @@ $required = array('title', 'description');
 
 // load from POST and do sanity and access checking
 foreach ($values as $name => $default) {
-	$value = get_input($name, $default);
+	if ($name === 'title') {
+		$value = htmlspecialchars(get_input('title', $default, false), ENT_QUOTES, 'UTF-8');
+	} else {
+		$value = get_input($name, $default);
+	}
 
 	if (in_array($name, $required) && empty($value)) {
 		$error = elgg_echo("blog:error:missing:$name");

--- a/mod/bookmarks/actions/bookmarks/save.php
+++ b/mod/bookmarks/actions/bookmarks/save.php
@@ -5,7 +5,7 @@
 * @package Bookmarks
 */
 
-$title = strip_tags(get_input('title'));
+$title = htmlspecialchars(get_input('title', '', false), ENT_QUOTES, 'UTF-8');
 $description = get_input('description');
 $address = get_input('address');
 $access_id = get_input('access_id');

--- a/mod/file/actions/file/upload.php
+++ b/mod/file/actions/file/upload.php
@@ -6,7 +6,7 @@
  */
 
 // Get variables
-$title = get_input("title");
+$title = htmlspecialchars(get_input('title', '', false), ENT_QUOTES, 'UTF-8');
 $desc = get_input("description");
 $access_id = (int) get_input("access_id");
 $container_guid = (int) get_input('container_guid', 0);
@@ -44,7 +44,7 @@ if ($new_file) {
 
 	// if no title on new upload, grab filename
 	if (empty($title)) {
-		$title = $_FILES['upload']['name'];
+		$title = htmlspecialchars($_FILES['upload']['name'], ENT_QUOTES, 'UTF-8');
 	}
 
 } else {

--- a/mod/groups/actions/discussion/save.php
+++ b/mod/groups/actions/discussion/save.php
@@ -4,7 +4,7 @@
  */
 
 // Get variables
-$title = get_input("title");
+$title = htmlspecialchars(get_input('title', '', false), ENT_QUOTES, 'UTF-8');
 $desc = get_input("description");
 $status = get_input("status");
 $access_id = (int) get_input("access_id");

--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -33,8 +33,7 @@ foreach ($CONFIG->group as $shortname => $valuetype) {
 	}
 }
 
-$input['name'] = get_input('name');
-$input['name'] = html_entity_decode($input['name'], ENT_COMPAT, 'UTF-8');
+$input['name'] = htmlspecialchars(get_input('name', '', false), ENT_QUOTES, 'UTF-8');
 
 $user = elgg_get_logged_in_user_entity();
 

--- a/mod/pages/actions/pages/edit.php
+++ b/mod/pages/actions/pages/edit.php
@@ -8,9 +8,10 @@
 $variables = elgg_get_config('pages');
 $input = array();
 foreach ($variables as $name => $type) {
-	$input[$name] = get_input($name);
 	if ($name == 'title') {
-		$input[$name] = strip_tags($input[$name]);
+		$input[$name] = htmlspecialchars(get_input($name, '', false), ENT_QUOTES, 'UTF-8');
+	} else {
+		$input[$name] = get_input($name);
 	}
 	if ($type == 'tags') {
 		$input[$name] = string_to_tag_array($input[$name]);


### PR DESCRIPTION
Simple solution: Each title is treated as plain text. It can be any content, but is stored as escaped markup.
