### PR TITLE
Fix plugin dependent chain problem on installation

### DIFF
--- a/engine/lib/plugins.php
+++ b/engine/lib/plugins.php
@@ -561,28 +561,26 @@ function elgg_get_calling_plugin_id($mainfilename = false) {
  * @access private
  */
 function elgg_get_plugins_provides($type = null, $name = null) {
-	static $provides = null;
 	$active_plugins = elgg_get_plugins('active');
 
-	if (!isset($provides)) {
-		$provides = array();
+	$provides = array();
 
-		foreach ($active_plugins as $plugin) {
-			$plugin_provides = array();
-			$manifest = $plugin->getManifest();
-			if ($manifest instanceof ElggPluginManifest) {
-				$plugin_provides = $plugin->getManifest()->getProvides();
-			}
-			if ($plugin_provides) {
-				foreach ($plugin_provides as $provided) {
-					$provides[$provided['type']][$provided['name']] = array(
-						'version' => $provided['version'],
-						'provided_by' => $plugin->getID()
-					);
-				}
+	foreach ($active_plugins as $plugin) {
+		$plugin_provides = array();
+		$manifest = $plugin->getManifest();
+		if ($manifest instanceof ElggPluginManifest) {
+			$plugin_provides = $plugin->getManifest()->getProvides();
+		}
+		if ($plugin_provides) {
+			foreach ($plugin_provides as $provided) {
+				$provides[$provided['type']][$provided['name']] = array(
+					'version' => $provided['version'],
+					'provided_by' => $plugin->getID()
+				);
 			}
 		}
 	}
+
 
 	if ($type && $name) {
 		if (isset($provides[$type][$name])) {


### PR DESCRIPTION
if B plugin depends on A plugin, and C plugin depends on B plugin. 
C plugin can not be activated on install, if static provides in used in
elgg_get_plugins_provides() function.
