### PR TITLE
Removes errant comma after tag icon

### DIFF
--- a/views/default/css/elements/components.php
+++ b/views/default/css/elements/components.php
@@ -281,6 +281,9 @@
 .elgg-tags li.elgg-tag:last-child:after {
 	content: "";
 }
+.elgg-tags li:first-child:after {
+    content: "";
+}
 .elgg-tagcloud {
 	text-align: justify;
 }


### PR DESCRIPTION
Current css rules are misinterpreted by all major browsers so that the :after content displays after the tag icon.

This shows like <icon>, tag1, tag2, tag3

The first comma shouldn't be there.  This adds a new css rule to remove the errant comma.

No trac ticket for this a trac was down at the time.
