### PR TITLE
Fixes 4861: Defer full is_callable check until just before use

### DIFF
--- a/engine/classes/ElggPAM.php
+++ b/engine/classes/ElggPAM.php
@@ -53,11 +53,17 @@ class ElggPAM {
 
 		foreach ($_PAM_HANDLERS[$this->policy] as $k => $v) {
 			$handler = $v->handler;
+			if (!is_callable($handler)) {
+				continue;
+			}
+			/* @var callable $handler */
+
 			$importance = $v->importance;
 
 			try {
 				// Execute the handler
-				$result = $handler($credentials);
+				// @todo don't assume $handler is a global function
+				$result = call_user_func($handler, $credentials);
 				if ($result) {
 					$authenticated = true;
 				} elseif ($result === false) {

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -625,7 +625,7 @@ function elgg_register_event_handler($event, $object_type, $callback, $priority 
 		$CONFIG->events[$event][$object_type] = array();
 	}
 
-	if (!is_callable($callback)) {
+	if (!is_callable($callback, true)) {
 		return FALSE;
 	}
 
@@ -711,7 +711,7 @@ function elgg_trigger_event($event, $object_type, $object = null) {
 	foreach ($events as $callback_list) {
 		if (is_array($callback_list)) {
 			foreach ($callback_list as $callback) {
-				if (call_user_func_array($callback, $args) === FALSE) {
+				if (is_callable($callback) && (call_user_func_array($callback, $args) === FALSE)) {
 					return FALSE;
 				}
 			}
@@ -804,7 +804,7 @@ function elgg_register_plugin_hook_handler($hook, $type, $callback, $priority = 
 		$CONFIG->hooks[$hook][$type] = array();
 	}
 
-	if (!is_callable($callback)) {
+	if (!is_callable($callback, true)) {
 		return FALSE;
 	}
 
@@ -911,10 +911,12 @@ function elgg_trigger_plugin_hook($hook, $type, $params = null, $returnvalue = n
 	foreach ($hooks as $callback_list) {
 		if (is_array($callback_list)) {
 			foreach ($callback_list as $hookcallback) {
-				$args = array($hook, $type, $returnvalue, $params);
-				$temp_return_value = call_user_func_array($hookcallback, $args);
-				if (!is_null($temp_return_value)) {
-					$returnvalue = $temp_return_value;
+				if (is_callable($hookcallback)) {
+					$args = array($hook, $type, $returnvalue, $params);
+					$temp_return_value = call_user_func_array($hookcallback, $args);
+					if (!is_null($temp_return_value)) {
+						$returnvalue = $temp_return_value;
+					}
 				}
 			}
 		}

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -1447,7 +1447,7 @@ function import_entity_plugin_hook($hook, $entity_type, $returnvalue, $params) {
 function elgg_register_entity_url_handler($entity_type, $entity_subtype, $function_name) {
 	global $CONFIG;
 
-	if (!is_callable($function_name)) {
+	if (!is_callable($function_name, true)) {
 		return false;
 	}
 

--- a/engine/lib/extender.php
+++ b/engine/lib/extender.php
@@ -136,7 +136,7 @@ function can_edit_extender($extender_id, $type, $user_guid = 0) {
 
 	$functionname = "elgg_get_{$type}_from_id";
 	if (is_callable($functionname)) {
-		$extender = $functionname($extender_id);
+		$extender = call_user_func($functionname, $extender_id);
 	} else {
 		return false;
 	}
@@ -175,7 +175,7 @@ function elgg_register_extender_url_handler($extender_type, $extender_name, $fun
 
 	global $CONFIG;
 
-	if (!is_callable($function_name)) {
+	if (!is_callable($function_name, true)) {
 		return false;
 	}
 
@@ -228,7 +228,7 @@ function get_extender_url(ElggExtender $extender) {
 	if ($url == "") {
 		$nameid = $extender->id;
 		if ($type == 'volatile') {
-			$nameid == $extender->name;
+			$nameid = $extender->name;
 		}
 		$url = "export/$view/$guid/$type/$nameid/";
 	}

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -38,7 +38,7 @@ $NOTIFICATION_HANDLERS = array();
 function register_notification_handler($method, $handler, $params = NULL) {
 	global $NOTIFICATION_HANDLERS;
 
-	if (is_callable($handler)) {
+	if (is_callable($handler, true)) {
 		$NOTIFICATION_HANDLERS[$method] = new stdClass;
 
 		$NOTIFICATION_HANDLERS[$method]->handler = $handler;
@@ -131,8 +131,9 @@ function notify_user($to, $from, $subject, $message, array $params = NULL, $meth
 					// Extract method details from list
 					$details = $NOTIFICATION_HANDLERS[$method];
 					$handler = $details->handler;
+					/* @var callable $handler */
 
-					if ((!$NOTIFICATION_HANDLERS[$method]) || (!$handler)) {
+					if ((!$NOTIFICATION_HANDLERS[$method]) || (!$handler) || (!is_callable($handler))) {
 						error_log(elgg_echo('NotificationException:NoHandlerFound', array($method)));
 					}
 
@@ -140,7 +141,7 @@ function notify_user($to, $from, $subject, $message, array $params = NULL, $meth
 
 					// Trigger handler and retrieve result.
 					try {
-						$result[$guid][$method] = $handler(
+						$result[$guid][$method] = call_user_func($handler,
 							$from ? get_entity($from) : NULL, 	// From entity
 							get_entity($guid), 					// To entity
 							$subject,							// The subject

--- a/engine/lib/pagehandler.php
+++ b/engine/lib/pagehandler.php
@@ -45,7 +45,10 @@ function page_handler($handler, $page) {
 	$page = $request['segments'];
 
 	$result = false;
-	if (isset($CONFIG->pagehandler) && !empty($handler) && isset($CONFIG->pagehandler[$handler])) {
+	if (isset($CONFIG->pagehandler)
+			&& !empty($handler)
+			&& isset($CONFIG->pagehandler[$handler])
+			&& is_callable($CONFIG->pagehandler[$handler])) {
 		$function = $CONFIG->pagehandler[$handler];
 		$result = call_user_func($function, $page, $handler);
 	}
@@ -76,14 +79,14 @@ function page_handler($handler, $page) {
  * @param string $handler  The page type to handle
  * @param string $function Your function name
  *
- * @return true|false Depending on success
+ * @return bool Depending on success
  */
 function elgg_register_page_handler($handler, $function) {
 	global $CONFIG;
 	if (!isset($CONFIG->pagehandler)) {
 		$CONFIG->pagehandler = array();
 	}
-	if (is_callable($function)) {
+	if (is_callable($function, true)) {
 		$CONFIG->pagehandler[$handler] = $function;
 		return true;
 	}

--- a/engine/lib/pam.php
+++ b/engine/lib/pam.php
@@ -30,7 +30,9 @@ $_PAM_HANDLERS = array();
  * failure, return false or throw an exception. Returning nothing indicates that
  * the handler wants to be skipped.
  *
- * @param string $handler    The handler function in the format
+ * Note, $handler must be string callback (not an array/Closure).
+ *
+ * @param string $handler    Callable global handler function in the format ()
  * 		                     pam_handler($credentials = NULL);
  * @param string $importance The importance - "sufficient" (default) or "required"
  * @param string $policy     The policy type, default is "user"
@@ -45,7 +47,8 @@ function register_pam_handler($handler, $importance = "sufficient", $policy = "u
 		$_PAM_HANDLERS[$policy] = array();
 	}
 
-	if (is_callable($handler)) {
+	// @todo remove requirement that $handle be a global function
+	if (is_string($handler) && is_callable($handler, true)) {
 		$_PAM_HANDLERS[$policy][$handler] = new stdClass;
 
 		$_PAM_HANDLERS[$policy][$handler]->handler = $handler;

--- a/engine/lib/relationships.php
+++ b/engine/lib/relationships.php
@@ -416,7 +416,7 @@ function elgg_list_entities_from_relationship_count($options) {
 function elgg_register_relationship_url_handler($relationship_type, $function_name) {
 	global $CONFIG;
 
-	if (!is_callable($function_name)) {
+	if (!is_callable($function_name, true)) {
 		return false;
 	}
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1401,7 +1401,7 @@ function elgg_view_access_collections($owner_guid) {
  */
 function set_template_handler($function_name) {
 	global $CONFIG;
-	if (!empty($function_name) && is_callable($function_name)) {
+	if (is_callable($function_name)) {
 		$CONFIG->template_handler = $function_name;
 		return true;
 	}

--- a/engine/lib/web_services.php
+++ b/engine/lib/web_services.php
@@ -232,6 +232,7 @@ function execute_method($method) {
 	$function = $API_METHODS[$method]["function"];
 	$serialised_parameters = trim($serialised_parameters, ", ");
 
+	// @todo document why we cannot use call_user_func_array here
 	$result = eval("return $function($serialised_parameters);");
 
 	// Sanity check result
@@ -1278,11 +1279,9 @@ function service_handler($handler, $request) {
 		// no handlers set or bad url
 		header("HTTP/1.0 404 Not Found");
 		exit;
-	} else if (isset($CONFIG->servicehandler[$handler])
-	&& is_callable($CONFIG->servicehandler[$handler])) {
-
+	} else if (isset($CONFIG->servicehandler[$handler]) && is_callable($CONFIG->servicehandler[$handler])) {
 		$function = $CONFIG->servicehandler[$handler];
-		$function($request, $handler);
+		call_user_func($function, $request, $handler);
 	} else {
 		// no handler for this web service
 		header("HTTP/1.0 404 Not Found");
@@ -1304,7 +1303,7 @@ function register_service_handler($handler, $function) {
 	if (!isset($CONFIG->servicehandler)) {
 		$CONFIG->servicehandler = array();
 	}
-	if (is_callable($function)) {
+	if (is_callable($function, true)) {
 		$CONFIG->servicehandler[$handler] = $function;
 		return true;
 	}


### PR DESCRIPTION
...allowing lazy-load for static method callbacks.
Allow full range of callable types in notification and web service handlers.
Document requirement that PAM handler must be global function.
Alter URL for volatile extender types (fixed typo allowing intended alteration).
