### PR TITLE
Using HTML5 email and url types where available

### DIFF
--- a/install/languages/en.php
+++ b/install/languages/en.php
@@ -156,9 +156,9 @@ If you are ready to proceed, click the Next button.",
 	'install:error:rewrite:unknown' => 'Oof. We couldn\'t figure out what kind of web server is running on your server and it failed the rewrite rules. We cannot offer any specific advice. Please check the troubleshooting link.',
 	'install:warning:rewrite:unknown' => 'Your server does not support automatic testing of the rewrite rules. You can continue the installation, but you may experience problems with your site. You can manually test the rewrite rules by clicking this link: <a href="%s" target="_blank">test</a>. You will see the word success if the rules are working.',
     
-        // Bring over some error messages you might see in setup
-        'exception:contact_admin' => 'An unrecoverable error has occurred and has been logged. If you are the site administrator check your settings file, otherwise contact the site administrator with the following information:',
-        'DatabaseException:WrongCredentials' => "Elgg couldn't connect to the database using the given credentials. Check the settings file.",
+	// Bring over some error messages you might see in setup
+	'exception:contact_admin' => 'An unrecoverable error has occurred and has been logged. If you are the site administrator check your settings file, otherwise contact the site administrator with the following information:',
+	'DatabaseException:WrongCredentials' => "Elgg couldn't connect to the database using the given credentials. Check the settings file.",
 );
 
 add_translation("en", $english);

--- a/install/languages/en.php
+++ b/install/languages/en.php
@@ -155,6 +155,10 @@ If you are ready to proceed, click the Next button.",
 	'install:error:rewrite:altserver' => 'The rewrite rules test failed. You need to configure your web server with Elgg\'s rewrite rules and try again.',
 	'install:error:rewrite:unknown' => 'Oof. We couldn\'t figure out what kind of web server is running on your server and it failed the rewrite rules. We cannot offer any specific advice. Please check the troubleshooting link.',
 	'install:warning:rewrite:unknown' => 'Your server does not support automatic testing of the rewrite rules. You can continue the installation, but you may experience problems with your site. You can manually test the rewrite rules by clicking this link: <a href="%s" target="_blank">test</a>. You will see the word success if the rules are working.',
+    
+        // Bring over some error messages you might see in setup
+        'exception:contact_admin' => 'An unrecoverable error has occurred and has been logged. If you are the site administrator check your settings file, otherwise contact the site administrator with the following information:',
+        'DatabaseException:WrongCredentials' => "Elgg couldn't connect to the database using the given credentials. Check the settings file.",
 );
 
 add_translation("en", $english);

--- a/views/default/input/email.php
+++ b/views/default/input/email.php
@@ -23,4 +23,4 @@ $vars = array_merge($defaults, $vars);
 
 ?>
 
-<input type="text" <?php echo elgg_format_attributes($vars); ?> />
+<input type="email" <?php echo elgg_format_attributes($vars); ?> />

--- a/views/default/input/url.php
+++ b/views/default/input/url.php
@@ -24,4 +24,4 @@ $vars = array_merge($defaults, $vars);
 
 ?>
 
-<input type="text" <?php echo elgg_format_attributes($vars); ?> />
+<input type="url" <?php echo elgg_format_attributes($vars); ?> />


### PR DESCRIPTION
Minor tweak to use HTML5 input types for emails and urls. 

This lets modern and mobile browsers provide context sensitive editing and validation, older browsers will of course default to "text".
