### PR TITLE
#4873 - blog: possibility to move a blog to a different container_guid

### DIFF
--- a/mod/blog/actions/blog/save.php
+++ b/mod/blog/actions/blog/save.php
@@ -34,6 +34,8 @@ if ($guid) {
 } else {
 	$blog = new ElggBlog();
 	$blog->subtype = 'blog';
+	$blog->container_guid = (int)get_input('container_guid');
+	
 	$new_post = TRUE;
 }
 
@@ -49,7 +51,6 @@ $values = array(
 	'comments_on' => 'On',
 	'excerpt' => '',
 	'tags' => '',
-	'container_guid' => (int)get_input('container_guid'),
 );
 
 // fail if a required entity isn't set
@@ -79,19 +80,6 @@ foreach ($values as $name => $default) {
 		case 'excerpt':
 			if ($value) {
 				$values[$name] = elgg_get_excerpt($value);
-			}
-			break;
-
-		case 'container_guid':
-			// this can't be empty or saving the base entity fails
-			if (!empty($value)) {
-				if (can_write_to_container($user->getGUID(), $value)) {
-					$values[$name] = $value;
-				} else {
-					$error = elgg_echo("blog:error:cannot_write_to_container");
-				}
-			} else {
-				unset($values[$name]);
 			}
 			break;
 

--- a/mod/blog/actions/blog/save.php
+++ b/mod/blog/actions/blog/save.php
@@ -83,11 +83,6 @@ foreach ($values as $name => $default) {
 			}
 			break;
 
-		// don't try to set the guid
-		case 'guid':
-			unset($values['guid']);
-			break;
-
 		default:
 			$values[$name] = $value;
 			break;


### PR DESCRIPTION
only using container_guid on creation of a blog.

fixes: http://trac.elgg.org/ticket/4873

also removed a useless check from the action ($values["guid"])
