### PR TITLE
Reversing page title and site title to match SEO best practices.

### DIFF
--- a/views/default/page/elements/head.php
+++ b/views/default/page/elements/head.php
@@ -9,7 +9,7 @@
 if (empty($vars['title'])) {
 	$title = elgg_get_config('sitename');
 } else {
-	$title = elgg_get_config('sitename') . ": " . $vars['title'];
+	$title = $vars['title'] . ' : ' . elgg_get_config('sitename');
 }
 
 global $autofeed;


### PR DESCRIPTION
Having the site title after the page title is supposedly better for SEO (Certainly wordpress' All in one... pack does this). 

Whether or not this is true, it certainly makes search listings more useful.
