### PR TITLE
Deprecate get_language() and get_current_language()

### DIFF
--- a/engine/lib/deprecated-1.9.php
+++ b/engine/lib/deprecated-1.9.php
@@ -892,3 +892,15 @@ function get_current_language() {
     return elgg_get_current_language();
 }
 
+/**
+ * Gets the current language in use by the system or user.
+ *
+ * @return string The language code (eg "en") or false if not set
+ * @deprecated 1.9
+ */
+function get_language() {
+    elgg_deprecated_notice('get_language() has been deprecated by elgg_get_language', 1.9);
+
+    return elgg_get_language();
+}
+

--- a/engine/lib/deprecated-1.9.php
+++ b/engine/lib/deprecated-1.9.php
@@ -880,3 +880,15 @@ function leave_group($group_guid, $user_guid) {
 	return false;
 }
 
+/**
+ * Detect the current language being used by the current site or logged in user.
+ *
+ * @return string The language code for the site/user or "en" if not set
+ * @deprecated 1.9
+ */
+function get_current_language() {
+    elgg_deprecated_notice('get_current_language() has been deprecated by elgg_get_current_language', 1.9);
+
+    return elgg_get_current_language();
+}
+

--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -40,7 +40,7 @@ function elgg_echo($message_key, $args = array(), $language = "") {
 	}
 
 	if (!$CURRENT_LANGUAGE) {
-		$CURRENT_LANGUAGE = get_language();
+		$CURRENT_LANGUAGE = elgg_get_language();
 	}
 	if (!$language) {
 		$language = $CURRENT_LANGUAGE;
@@ -103,7 +103,7 @@ function add_translation($country_code, $language_array) {
 function elgg_get_current_language() {
 	global $CONFIG;
 
-	$language = get_language();
+	$language = elgg_get_language();
 
 	if (!$language) {
 		$language = 'en';
@@ -117,7 +117,7 @@ function elgg_get_current_language() {
  *
  * @return string The language code (eg "en") or false if not set
  */
-function get_language() {
+function elgg_get_language() {
 	global $CONFIG;
 
 	$user = elgg_get_logged_in_user_entity();

--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -100,7 +100,7 @@ function add_translation($country_code, $language_array) {
  *
  * @return string The language code for the site/user or "en" if not set
  */
-function get_current_language() {
+function elgg_get_current_language() {
 	global $CONFIG;
 
 	$language = get_language();
@@ -143,7 +143,7 @@ function _elgg_load_translations() {
 
 	if ($CONFIG->system_cache_enabled) {
 		$loaded = true;
-		$languages = array_unique(array('en', get_current_language()));
+		$languages = array_unique(array('en', elgg_get_current_language()));
 		foreach ($languages as $language) {
 			$data = elgg_load_system_cache("$language.php");
 			if ($data) {
@@ -188,7 +188,7 @@ function register_translations($path, $load_all = false) {
 	$CONFIG->language_paths[$path] = true;
 
 	// Get the current language based on site defaults and user preference
-	$current_language = get_current_language();
+	$current_language = elgg_get_current_language();
 	elgg_log("Translations loaded from: $path");
 
 	// only load these files unless $load_all is true.
@@ -343,7 +343,7 @@ function get_missing_language_keys($language) {
  * @access private
  */
 function elgg_languages_init() {
-	$lang = get_current_language();
+	$lang = elgg_get_current_language();
 	elgg_register_simplecache_view("js/languages/$lang");
 }
 

--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -99,6 +99,7 @@ function add_translation($country_code, $language_array) {
  * Detect the current language being used by the current site or logged in user.
  *
  * @return string The language code for the site/user or "en" if not set
+ * @since 1.9
  */
 function elgg_get_current_language() {
 	global $CONFIG;
@@ -116,6 +117,7 @@ function elgg_get_current_language() {
  * Gets the current language in use by the system or user.
  *
  * @return string The language code (eg "en") or false if not set
+ * @since 1.9
  */
 function elgg_get_language() {
 	global $CONFIG;

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -935,7 +935,7 @@ $allow_multiple_emails = false, $friend_guid = 0, $invitecode = '') {
 	$user->password = generate_user_password($user, $password);
 	$user->owner_guid = 0; // Users aren't owned by anyone, even if they are admin created.
 	$user->container_guid = 0; // Users aren't contained by anyone, even if they are admin created.
-	$user->language = get_current_language();
+	$user->language = elgg_get_current_language();
 	$user->save();
 
 	// If $friend_guid has been set, make mutual friends
@@ -1356,7 +1356,7 @@ function elgg_profile_fields_setup() {
 				if ($translation = elgg_get_config("admin_defined_profile_{$listitem}")) {
 					$type = elgg_get_config("admin_defined_profile_type_{$listitem}");
 					$loaded_defaults["admin_defined_profile_{$listitem}"] = $type;
-					add_translation(get_current_language(), array("profile:admin_defined_profile_{$listitem}" => $translation));
+					add_translation(elgg_get_current_language(), array("profile:admin_defined_profile_{$listitem}" => $translation));
 				}
 			}
 		}
@@ -1374,7 +1374,7 @@ function elgg_profile_fields_setup() {
 		if ($type == 'tags' || $type == 'location' || $type == 'tag') {
 			elgg_register_tag_metadata_name($name);
 			// register a tag name translation
-			add_translation(get_current_language(), array("tag_names:$name" => elgg_echo("profile:$name")));
+			add_translation(elgg_get_current_language(), array("tag_names:$name" => elgg_echo("profile:$name")));
 		}
 	}
 }

--- a/install/ElggInstaller.php
+++ b/install/ElggInstaller.php
@@ -511,7 +511,7 @@ class ElggInstaller {
 
 		// bit of a hack to get the password help to show right number of characters
 		global $CONFIG;
-		$lang = get_current_language();
+		$lang = elgg_get_current_language();
 		$CONFIG->translations[$lang]['install:admin:help:password1'] =
 				sprintf($CONFIG->translations[$lang]['install:admin:help:password1'],
 				$CONFIG->min_password_length);

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -83,7 +83,7 @@ function developers_setup_menu() {
 function developers_clear_strings() {
 	global $CONFIG;
 
-	$language = get_language();
+	$language = elgg_get_language();
 	$CONFIG->translations[$language] = array();
 	$CONFIG->translations['en'] = array();
 }

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -127,7 +127,7 @@ function groups_fields_setup() {
 
 			// only shows up in search but why not just set this in en.php as doing it here
 			// means you cannot override it in a plugin
-			add_translation(get_current_language(), array("tag_names:$name" => elgg_echo("groups:$name")));
+			add_translation(elgg_get_current_language(), array("tag_names:$name" => elgg_echo("groups:$name")));
 		}
 	}
 }


### PR DESCRIPTION
Rename get_language() and get_current_language() to elgg_get_language() and elgg_get_current_language() respectively.
Add both get_language() and get_current_language() to the list of deprecated functions in 1.9.
