### PR TITLE
Show only excerpts of messageboard posts in activity stream

### DIFF
--- a/mod/messageboard/views/default/river/object/messageboard/create.php
+++ b/mod/messageboard/views/default/river/object/messageboard/create.php
@@ -4,8 +4,9 @@
  */
 
 $messageboard = $vars['item']->getAnnotation();
+$excerpt=elgg_get_excerpt($messageboard->value);
 
 echo elgg_view('river/elements/layout', array(
 	'item' => $vars['item'],
-	'message' => $messageboard->value,
-));
+	'message' => $excerpt,
+	));


### PR DESCRIPTION
Instead of full text on the river only an excerpt is needed.
