### PR TITLE
Sql optimizations

### DIFF
--- a/engine/classes/ElggLocalCache.php
+++ b/engine/classes/ElggLocalCache.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * PHP in-memory cache for various uses 
+ */
+class ElggLocalCache extends ElggCache {
+
+	/**
+	 * @var array
+	 */
+	protected $data = array();
+	
+	/**
+	 * (non-PHPdoc)
+	 * @see ElggCache::save()
+	 */
+	public function save($key, $data) {
+		$this->data[$key] = $data;
+	}
+	
+	/**
+	 * (non-PHPdoc)
+	 * @see ElggCache::load()
+	 */
+	public function load($key, $offset = 0, $limit = null) {
+		return $this->data[$key];
+	}
+	
+	/**
+	 * (non-PHPdoc)
+	 * @see ElggCache::delete()
+	 */
+	public function delete($key) {
+		unset($this->data[$key]);
+	}
+	
+	/**
+	 * (non-PHPdoc)
+	 * @see ElggCache::clear()
+	 */
+	public function clear() {
+		$this->data = array();
+	}
+	
+	/**
+	 * @var bool
+	 */
+	private $isPopulated = false;
+	
+	/**
+	 * Fills cache with provided values
+	 * @param array $values
+	 */
+	public function populate($values = array()) {
+		if (is_array($values)) {
+			foreach ($values as $key => $val) {
+				$this->save($key, $val);
+			}
+		}
+		$this->isPopulated = true;
+	}
+	
+	/**
+	 * @return bool is cache already populated with data
+	 */
+	public function isPopulated() {
+		return $this->isPopulated;
+	}
+}

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -396,7 +396,7 @@ class ElggPlugin extends ElggObject {
 	 * @return bool
 	 */
 	public function unsetSetting($name) {
-		return remove_private_setting($this->guid, $name);
+		return $this->removePrivateSetting($name);
 	}
 
 	/**
@@ -556,7 +556,7 @@ class ElggPlugin extends ElggObject {
 		// set the namespaced name.
 		$name = elgg_namespace_plugin_private_setting('user_setting', $name, $this->getID());
 
-		return remove_private_setting($user->guid, $name);
+		return $user->removePrivateSetting($name);
 	}
 
 	/**

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -95,11 +95,14 @@ function elgg_get_config($name, $site_guid = 0) {
 		// installation wide setting
 		$value = datalist_get($name);
 	} else {
-		// site specific setting
-		if ($site_guid == 0) {
-			$site_guid = (int) $CONFIG->site_id;
+		// hit DB only if we're not sure if value exists or not
+		if (!isset($CONFIG->site_config_loaded)) {
+			// site specific setting
+			if ($site_guid == 0) {
+				$site_guid = (int) $CONFIG->site_id;
+			}
+			$value = get_config($name, $site_guid);
 		}
-		$value = get_config($name, $site_guid);
 	}
 
 	if ($value !== false) {
@@ -558,6 +561,8 @@ function _elgg_load_site_config() {
 	$CONFIG->url = $CONFIG->wwwroot;
 
 	get_all_config();
+	// gives hint to elgg_get_config function how to approach missing values
+	$CONFIG->site_config_loaded = true;
 }
 
 /**

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -403,11 +403,11 @@ function elgg_get_metastring_based_objects($options) {
 	$is_calculation = $options['metastring_calculation'] ? true : false;
 	
 	if ($custom_callback || $is_calculation) {
-		$joins[] = "JOIN {$db_prefix}metastrings n on n_table.name_id = n.id";
-		$joins[] = "JOIN {$db_prefix}metastrings v on n_table.value_id = v.id";
+		$joins[] = "JOIN {$db_prefix}metastrings msn on n_table.name_id = msn.id";
+		$joins[] = "JOIN {$db_prefix}metastrings msv on n_table.value_id = msv.id";
 
-		$selects[] = 'n.string as name';
-		$selects[] = 'v.string as value';
+		$selects[] = 'msn.string as name';
+		$selects[] = 'msv.string as value';
 	}
 
 	foreach ($joins as $i => $join) {
@@ -440,7 +440,7 @@ function elgg_get_metastring_based_objects($options) {
 
 		$query = "SELECT DISTINCT n_table.*{$select_str} FROM {$db_prefix}$type n_table";
 	} else {
-		$query = "SELECT {$options['metastring_calculation']}(v.string) as calculation FROM {$db_prefix}$type n_table";
+		$query = "SELECT {$options['metastring_calculation']}(msv.string) as calculation FROM {$db_prefix}$type n_table";
 	}
 
 	// remove identical join clauses

--- a/engine/lib/plugins.php
+++ b/engine/lib/plugins.php
@@ -163,7 +163,7 @@ function elgg_generate_plugin_entities() {
 		}
 		// remove the priority.
 		$name = elgg_namespace_plugin_private_setting('internal', 'priority');
-		remove_private_setting($plugin->guid, $name);
+		$plugin->removePrivateSetting($name);
 		$plugin->disable();
 	}
 

--- a/engine/lib/private_settings.php
+++ b/engine/lib/private_settings.php
@@ -283,14 +283,7 @@ function get_private_setting($entity_guid, $name) {
 		return false;
 	}
 
-	$query = "SELECT value from {$CONFIG->dbprefix}private_settings
-		where name = '{$name}' and entity_guid = {$entity_guid}";
-	$setting = get_data_row($query);
-
-	if ($setting) {
-		return $setting->value;
-	}
-	return false;
+	return $entity->getPrivateSettingsCache(true)->load($name);
 }
 
 /**
@@ -321,6 +314,7 @@ function get_all_private_settings($entity_guid) {
 		foreach ($result as $r) {
 			$return[$r->name] = $r->value;
 		}
+		$entity->getPrivateSettingsCache()->populate($return);
 
 		return $return;
 	}
@@ -354,6 +348,8 @@ function set_private_setting($entity_guid, $name, $value) {
 		return false;
 	}
 
+	$entity->getPrivateSettingsCache()->save($name, $value);
+
 	$result = insert_data("INSERT into {$CONFIG->dbprefix}private_settings
 		(entity_guid, name, value) VALUES
 		($entity_guid, '$name', '$value')
@@ -385,6 +381,8 @@ function remove_private_setting($entity_guid, $name) {
 		return false;
 	}
 
+	$entity->getPrivateSettingsCache()->delete($name);
+
 	$name = sanitise_string($name);
 
 	return delete_data("DELETE from {$CONFIG->dbprefix}private_settings
@@ -413,6 +411,8 @@ function remove_all_private_settings($entity_guid) {
 	if (!$entity instanceof ElggEntity) {
 		return false;
 	}
+	
+	$entity->getPrivateSettingsCache()->clear();
 
 	return delete_data("DELETE from {$CONFIG->dbprefix}private_settings
 		WHERE entity_guid = {$entity_guid}");

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -748,7 +748,7 @@ function execute_new_password_request($user_guid, $conf_code) {
 			$password = generate_random_cleartext_password();
 
 			if (force_user_password_reset($user_guid, $password)) {
-				remove_private_setting($user_guid, 'passwd_conf_code');
+				$user->removePrivateSetting('passwd_conf_code');
 				// clean the logins failures
 				reset_login_failure_count($user_guid);
 				


### PR DESCRIPTION
Few things here in one pull request that reduce sql queries count:
- elgg_get_config was hitting DB every call if value wasn't present in DB - avoided by marking moment when whole existing CONFIG is put to object and this avoiding pointless DB hit https://github.com/Srokap/Elgg/commit/e0315f4c6b628cfdedad6458b68a1a19d3153dfa
- renamed join tables to avoid unnecessary double joining with the same table https://github.com/Srokap/Elgg/commit/6b3de1a43619a9a37bc963ce746b1cb416b78828
- fetching subtypes to cache with single query and than serving from it https://github.com/Srokap/Elgg/commit/5975e0f1f70a6ff5a8c8289bd4cc5ed6477d996a
- caching all private settings on entity level instead of fetching them one by one https://github.com/Srokap/Elgg/commit/93d054e8e2c81207ce39f9d7fb5e0db7ca505fcb

Last commit introduces object ElggLocalCache (of course extends ElggCache) that could be basis to develop more standarized caches at PHP level instead of bare arrays.
