### PR TITLE
Fixes walled garden issue

### DIFF
--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -448,6 +448,11 @@ class ElggSite extends ElggEntity {
 	 */
 	public function isPublicPage($url = '') {
 		global $CONFIG;
+		
+		// pages invoked from the command line are always considered to be public
+		if (PHP_SAPI === 'cli') {
+			return TRUE;
+		}
 
 		if (empty($url)) {
 			$url = current_page_url();


### PR DESCRIPTION
In particular, this allows iZap videos to work with walled garden sites, but more generally, any plugin that accesses the Elgg engine through the command line would need this fix for walled garden sites.
