### PR TITLE
Fix jquery version

### DIFF
--- a/js/tests/README
+++ b/js/tests/README
@@ -12,9 +12,9 @@ based debuggers. Visit its wiki at the Google Code site for more information.
 Sample Usage
 ============
  1. Put jar file in the base directory of Elgg
- 2. Run the server: java -jar JsTestDriver-1.3.3d.jar --port 4224
+ 2. Run the server: java -jar JsTestDriver-1.3.5.jar --port 4224
  3. Point a web browser at http://localhost:4224
- 4. Run the tests: java -jar JsTestDriver-1.3.3d.jar --config js/tests/jsTestDriver.conf --basePath . --tests all
+ 4. Run the tests: java -jar JsTestDriver-1.3.5.jar --config js/tests/jsTestDriver.conf --basePath . --tests all
 
 
 Configuration Hints

--- a/js/tests/jsTestDriver.conf
+++ b/js/tests/jsTestDriver.conf
@@ -1,7 +1,7 @@
 server: http://localhost:4224
 
 load:
- - vendors/jquery/jquery-1.6.4.min.js
+ - vendors/jquery/jquery-1.7.2.min.js
  - vendors/sprintf.js
  - js/lib/elgglib.js
  - js/lib/hooks.js

--- a/views/installation/page/default.php
+++ b/views/installation/page/default.php
@@ -29,7 +29,7 @@ header('Expires: Fri, 05 Feb 1982 00:00:00 -0500', TRUE);
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="SHORTCUT ICON" href="<?php echo elgg_get_site_url(); ?>_graphics/favicon.ico" />
 		<link rel="stylesheet" href="<?php echo elgg_get_site_url(); ?>install/css/install.css" type="text/css" />
-		<script type="text/javascript" src="<?php echo elgg_get_site_url(); ?>vendors/jquery/jquery-1.6.4.min.js"></script>
+		<script type="text/javascript" src="<?php echo elgg_get_site_url(); ?>vendors/jquery/jquery-1.7.2.min.js"></script>
 		<script type="text/javascript" src="<?php echo elgg_get_site_url(); ?>install/js/install.js"></script>
 	</head>
 	<body>


### PR DESCRIPTION
This pull request fixes an error in the installer that was calling an outdated version of jQuery. 

Mostly harmless. 

Running Javascript tests show two failed tests:

```
setting runnermode QUIET
................EFF.....................
Total 40 tests (Passed: 37; Fails: 2; Errors: 1) (90.00 ms)
  Firefox 10.0.10 Linux: Run 40 tests (Passed: 37; Fails: 2; Errors 1) (90.00 ms)
    ElggLanguagesTest.testLoadTranslations error (1.00 ms): TypeError: elgg.config.translations.en is undefined
      ()@http://localhost:4224/test/js/tests/ElggLanguagesTest.js:29

    ElggLanguagesTest.testElggEchoTranslates failed (2.00 ms): AssertError: expected "en" but was "language"
      ()@http://localhost:4224/test/js/tests/ElggLanguagesTest.js:37

    ElggLanguagesTest.testElggEchoFallsBackToDefaultLanguage failed (0.00 ms): AssertError: expected "en" but was "language"
      ()@http://localhost:4224/test/js/tests/ElggLanguagesTest.js:43
```
