### PR TITLE
Fixes #4946 - In views/default/core/settings/statistics/online.php there's get_system_...

### DIFF
--- a/views/default/core/settings/statistics/online.php
+++ b/views/default/core/settings/statistics/online.php
@@ -8,20 +8,13 @@
 
 $user = elgg_get_page_owner_entity();
 
-$logged_in = 0;
-$log = get_system_log($user->guid, "login", "", 'user', '', 1);
-
-if ($log) {
-	$logged_in = $log[0]->time_created;
-}
-
 $label_name = elgg_echo('usersettings:statistics:label:name');
 $label_email = elgg_echo('usersettings:statistics:label:email');
 $label_member_since = elgg_echo('usersettings:statistics:label:membersince');
 $label_last_login = elgg_echo('usersettings:statistics:label:lastlogin');
 
 $time_created = date("r", $user->time_created);
-$last_login = date("r", $logged_in);
+$last_login = date("r", $user->last_login);
 
 $title = elgg_echo('usersettings:statistics:yourdetails');
 


### PR DESCRIPTION
...log call but system_log call can be supressed by unregistering default handler. Better to use last_login attribute.
