### PR TITLE
Fixed ajax call to endpoint when the Walled Garden is enabled.

### DIFF
--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -428,9 +428,12 @@ class ElggSite extends ElggEntity {
 				elgg_register_plugin_hook_handler('index', 'system', 'elgg_walled_garden_index', 1);
 
 				if (!$this->isPublicPage()) {
-					$_SESSION['last_forward_from'] = current_page_url();
-					register_error(elgg_echo('loggedinrequired'));
-					forward();
+					//We don't want to save xhr url, because after login will be redirected to it.
+					if(!elgg_is_xhr()) {
+						$_SESSION['last_forward_from'] = current_page_url();
+						register_error(elgg_echo('loggedinrequired'));
+						forward();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Problem with ajax querys, when the Walled Garde is enabled.
How to replicate it:
If you are in tab (1) logged in, and into another tab (2) you log out.
Then an ajax call was made into the tab (1).
Then when you try to log in again into tab (2), will be redirected to the 
endpoint file. :S
