### PR TITLE
Fixes #4951 - Added ElggBogusEntity classes

### DIFF
--- a/engine/classes/ElggBogus.php
+++ b/engine/classes/ElggBogus.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * The parent class for all Elgg Bogus.
+ * Any subclass of this class cannot save any data to db.
+ *
+ * @author Krzysztof Rozalski <cristo.rabani@gmail.com>
+ */
+abstract class ElggBogus extends ElggEntity {
+	private $true_guid;
+	/**
+	 * @see ElggEntity::load()
+	 * @param int $guid 
+	 */
+	protected function load($guid) {
+		$this->true_guid = $guid;
+		parent::load();
+	}
+	/**
+	 * creates bogus entity
+	 * @param int $guid for which we create bogus entity
+	 */
+	function __construct($guid = null) {
+		$this->true_guid = $guid;		
+	}
+	
+	public function save() {
+		return false;
+	}
+	
+	
+	public function set($name, $value) {
+		return false;
+	}
+	
+	public function get($name) {
+		switch($name){
+			case 'guid':
+				return 0;
+			case 'access_id':
+				return ACCESS_PUBLIC;			
+		}
+		
+	}
+	/**
+	 * @see ElggEntity::getGUID()
+	 * @return int always 0
+	 */
+	public function getGUID() {
+		return 0;
+	}
+	/**
+	 *	Returns guid given in constructor
+	 * @return int | null
+	 */
+	public function getTrueGuid(){
+		return $this->true_guid;
+	}
+	/**
+	 * @see ElggEntity::setMetaData()
+	 * @param type $name
+	 * @param type $value
+	 * @param type $value_type
+	 * @param type $multiple
+	 * @return boolean 
+	 */
+	public function setMetaData($name, $value, $value_type = "", $multiple = false) {
+		return false;
+	}
+	/**
+	 * @see ElggEntity::clearMetaData()
+	 * @param type $name
+	 * @return boolean 
+	 */
+	public function clearMetaData($name = '') {
+		return false;
+	}
+	/**
+	 * @see ElggEntity::canEdit()
+	 * @param type $user_guid
+	 * @return boolean 
+	 */
+	function canEdit($user_guid = 0) {
+		return false;
+	}
+	/**
+	 * @see ElggEntity::canWriteToContainer()
+	 * @param type $user_guid
+	 * @param type $type
+	 * @param type $subtype
+	 * @return boolean 
+	 */
+	public function canWriteToContainer($user_guid = 0, $type = 'all', $subtype = 'all') {
+		return false;
+	}
+
+}

--- a/engine/classes/ElggBogusGroup.php
+++ b/engine/classes/ElggBogusGroup.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * ElggBogusGroup
+ *
+ * @author Krzysztof Rozalski <cristo.rabani@gmail.com>
+ */
+class ElggBogusGroup {
+	public function getType(){
+		return "bogus:group";
+	}
+	public function get($name) {
+		switch($name){			
+			case 'name':
+				return elgg_echo('elgg:bogus:name');			
+			default:
+				return parent::get($name);
+		}
+		
+	}
+}

--- a/engine/classes/ElggBogusObject.php
+++ b/engine/classes/ElggBogusObject.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * ElggBogusObject
+ *
+ * @author Krzysztof Rozalski <cristo.rabani@gmail.com>
+ */
+class ElggBogusObject {
+	public function getType(){
+		return "bogus:object";
+	}
+	public function get($name) {
+		switch($name){			
+			case 'name':
+				return elgg_echo('elgg:bogus:object:name');
+			case 'title':
+				return elgg_echo('elgg:bogus:title');
+			default:
+				return parent::get($name);
+		}
+		
+	}	
+}

--- a/engine/classes/ElggBogusUser.php
+++ b/engine/classes/ElggBogusUser.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * ElggBogusUser
+ * Representation of a "bogus user" in the system.
+ * @see ElggBogus
+ * @author Krzysztof Rozalski <cristo.rabani@gmail.com>
+ */
+class ElggBogusUser extends ElggBogus {
+	public function getType(){
+		return "bogus:user";
+	}
+	public function get($name) {
+		switch($name){			
+			case 'name':
+				return elgg_echo('elgg:bogus:user:name');
+			case 'username':
+				return '';
+			default:
+				return parent::get($name);
+		}
+		
+	}
+}

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -563,8 +563,30 @@ function get_entity($guid) {
 	if ($new_entity) {
 		return $new_entity;
 	}
-
-	return entity_row_to_elggstar(get_entity_as_row($guid));
+	if(!($new_entity instanceof ElggEntity)){
+		$hidden = access_get_show_hidden_status();
+		access_show_hidden_entities(true);
+		$access = elgg_set_ignore_access();
+		
+		$entity_row = get_entity_as_row($guid);
+		if(!$entity_row) {
+			$new_entity = entity_row_to_elggstar($entity_row);
+		}
+		
+		elgg_set_ignore_access($hidden);
+		access_show_hidden_entities(true);
+		if($new_entity instanceof ElggObject){
+			return new ElggBogusObject($new_entity->getGUID());
+		}
+		if($new_entity instanceof ElggUser){
+			return new ElggBogusUser($new_entity->getGUID());
+		}
+		if($new_entity instanceof ElggGroup){
+			return new ElggBogusGroup($new_entity->getGUID());
+		}
+		return null;		
+	}
+	return $new_entity;
 }
 
 /**

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -505,7 +505,7 @@ function get_user($guid) {
 		$result = get_entity($guid);
 	}
 
-	if ((!empty($result)) && (!($result instanceof ElggUser))) {
+	if ((!empty($result)) && (!($result instanceof ElggUser) && (!($result instanceof ElggBogusUser)))) {
 		return false;
 	}
 


### PR DESCRIPTION
The idea is to handle situations where related entity (container/owner) is inaccessible but "content" entity is. In such situation we may want to display i.e. owner entity as "Unknown user" or "Private user" and similarly for the group.
Currently such situation usually causes error with calling method on non-object. Replacing such entity with VERY limited representation may standardize the way how to handle such situations and make handling it easier.
Bogus entity would have to be:
only logical representation - nothing is stored in DB
not writable
limited readability, i.e. only name/title
not interfere with processing access control for "content" entity (canEdit, canWriteToContainer)
