### PR TITLE
Add a lightobx alike instead use popups on tinymce

### DIFF
--- a/mod/tinymce/views/default/js/tinymce.php
+++ b/mod/tinymce/views/default/js/tinymce.php
@@ -39,7 +39,7 @@ elgg.tinymce.init = function() {
 		editor_selector : "elgg-input-longtext",
 		theme : "advanced",
 		language : "<?php echo tinymce_get_site_language(); ?>",
-		plugins : "lists,spellchecker,autosave,fullscreen,paste",
+		plugins : "lists,spellchecker,autosave,fullscreen,paste,inlinepopups",
 		relative_urls : false,
 		remove_script_host : false,
 		document_base_url : elgg.config.wwwroot,


### PR DESCRIPTION
Add a lightobx alike instead use popups while using the TinyMCE controls, for example, when you try to insert an image, watch the HTML content, etc.
