### PR TITLE
if a $var['entity'] is not set , redirect user to referred page, to avoid Fatal error: Call to a member function getIconUrl() on a non-object

### DIFF
--- a/views/default/core/avatar/upload.php
+++ b/views/default/core/avatar/upload.php
@@ -5,6 +5,10 @@
  * @uses $vars['entity']
  */
 
+if(!$vars['entity']){ 
+    forward();
+}
+
 $user_avatar = elgg_view('output/img', array(
 	'src' => $vars['entity']->getIconUrl('medium'),
 	'alt' => elgg_echo('avatar'),


### PR DESCRIPTION
if a $var['entity'] is not set , redirect user to referred page
