### PR TITLE
Ticket #3481: guid datastore for 1.9

### DIFF
--- a/actions/admin/site/update_advanced.php
+++ b/actions/admin/site/update_advanced.php
@@ -77,12 +77,6 @@ if ($site = elgg_get_site_entity()) {
 		unset_config('https_login', $site->getGUID());
 	}
 
-	if (get_input('api')) {
-		unset_config('disable_api', $site->getGUID());
-	} else {
-		set_config('disable_api', 'disabled', $site->getGUID());
-	}
-
 	if ($site->save()) {
 		system_message(elgg_echo("admin:configuration:success"));
 	} else {

--- a/engine/classes/Elgg/CacheHandler.php
+++ b/engine/classes/Elgg/CacheHandler.php
@@ -63,6 +63,12 @@ class Elgg_CacheHandler {
 			$this->sendCacheHeaders($etag);
 
 			$content = $this->getProcessedView($view, $viewtype);
+
+			$dir_name = $this->config->dataroot . 'views_simplecache/';
+			if (!is_dir($dir_name)) {
+				mkdir($dir_name, 0700);
+			}
+			
 			file_put_contents($filename, $content);
 		} else {
 			// if wrong timestamp, don't send HTTP cache

--- a/engine/classes/ElggDiskFilestore.php
+++ b/engine/classes/ElggDiskFilestore.php
@@ -381,11 +381,11 @@ class ElggDiskFilestore extends ElggFilestore {
 	 *
 	 * @param int $guid The entity to contrust a matrix for
 	 *
-	 * @deprecated 1.8 Use ElggDiskFileStore::makeFileMatrix()
+	 * @deprecated 1.9 Use ElggDiskFileStore::makeFileMatrix()
 	 * @return str The
 	 */
 	protected function user_file_matrix($guid) {
-		elgg_deprecated_notice('ElggDiskFilestore::user_file_matrix() is deprecated by ::makeFileMatrix()', 1.8);
+		elgg_deprecated_notice('ElggDiskFilestore::user_file_matrix() is deprecated by ::makeFileMatrix()', 1.9);
 
 		return $this->makeFileMatrix($guid);
 	}

--- a/engine/classes/ElggDiskFilestore.php
+++ b/engine/classes/ElggDiskFilestore.php
@@ -20,7 +20,7 @@ class ElggDiskFilestore extends ElggFilestore {
 	 * You almost certainly don't want to change this.
 	 */
 	const BUCKET_SIZE = 5000;
-
+	
 	/**
 	 * Construct a disk filestore using the given directory root.
 	 *
@@ -338,7 +338,7 @@ class ElggDiskFilestore extends ElggFilestore {
 
 	/**
 	 * Construct a file path matrix for an entity.
-	 * As of 1.8.5 matrixes are based on GUIDs and separated into dirs of 5000 entries
+	 * Matrixes are based on GUIDs and separated into dirs of 5000 entries
 	 * with the dir name being the lower bound for the GUID.
 	 *
 	 * @param int $guid The guid of the entity to store the data under.

--- a/engine/classes/ElggDiskFilestore.php
+++ b/engine/classes/ElggDiskFilestore.php
@@ -16,9 +16,10 @@ class ElggDiskFilestore extends ElggFilestore {
 	private $dir_root;
 
 	/**
-	 * Default depth of file directory matrix
+	 * Number of entries per matrix dir.
+	 * You almost certainly don't want to change this.
 	 */
-	private $matrix_depth = 5;
+	private static $bucket_size = 5000;
 
 	/**
 	 * Construct a disk filestore using the given directory root.
@@ -39,15 +40,14 @@ class ElggDiskFilestore extends ElggFilestore {
 	 * Open a file for reading, writing, or both.
 	 *
 	 * @note All files are opened binary safe.
-	 * @warning This will try to create the a directory if it doesn't exist,
-	 * even in read-only mode.
+	 * @note This will try to create the a directory if it doesn't exist and is opened
+	 * in write or append mode.
 	 *
 	 * @param ElggFile $file The file to open
 	 * @param string   $mode read, write, or append.
 	 *
 	 * @throws InvalidParameterException
 	 * @return resource File pointer resource
-	 * @todo This really shouldn't try to create directories if not writing.
 	 */
 	public function open(ElggFile $file, $mode) {
 		$fullname = $this->getFilenameOnFilestore($file);
@@ -61,15 +61,18 @@ class ElggDiskFilestore extends ElggFilestore {
 		$path = substr($fullname, 0, $ls);
 		$name = substr($fullname, $ls);
 
-		// Try and create the directory
-		try {
-			$this->makeDirectoryRoot($path);
-		} catch (Exception $e) {
-
-		}
-
 		if (($mode != 'write') && (!file_exists($fullname))) {
 			return false;
+		}
+
+		// Try to create the dir for valid write modes
+		if ($mode == 'write' || $mode == 'append') {
+			try {
+				$this->makeDirectoryRoot($path);
+			} catch (Exception $e) {
+				elgg_log("Couldn't create directory: $path", 'WARNING');
+				return false;
+			}
 		}
 
 		switch ($mode) {
@@ -246,7 +249,7 @@ class ElggDiskFilestore extends ElggFilestore {
 	 */
 	public function getSize($prefix = '', $container_guid) {
 		if ($container_guid) {
-			return get_dir_size($this->dir_root . $this->makefileMatrix($container_guid) . $prefix);
+			return get_dir_size($this->dir_root . $this->makeFileMatrix($container_guid) . $prefix);
 		} else {
 			return false;
 		}
@@ -330,26 +333,44 @@ class ElggDiskFilestore extends ElggFilestore {
 	protected function make_file_matrix($identifier) {
 		elgg_deprecated_notice('ElggDiskFilestore::make_file_matrix() is deprecated by ::makeFileMatrix()', 1.8);
 
-		return $this->makefileMatrix($identifier);
+		return $this->makeFileMatrix($identifier);
 	}
 
 	/**
 	 * Construct a file path matrix for an entity.
+	 * Matrixes are based on GUIDs and separated into dirs of 5000 entries
+	 * with the dir name being the lower bound for the GUID.
 	 *
-	 * @param int $guid The guide of the entity to store the data under.
+	 * @param int $guid The guid of the entity to store the data under.
 	 *
-	 * @return str The path where the entity's data will be stored.
+	 * @return str The path where the entity's data will be stored relative to the data dir.
 	 */
 	protected function makeFileMatrix($guid) {
 		$entity = get_entity($guid);
 
-		if (!($entity instanceof ElggEntity) || !$entity->time_created) {
+		if (!$entity instanceof ElggEntity) {
 			return false;
 		}
 
-		$time_created = date('Y/m/d', $entity->time_created);
+		$bound = $this->getLowerBucketBound($guid);
+		return "$bound/$entity->guid/";
+	}
 
-		return "$time_created/$entity->guid/";
+	/**
+	 * Return the lower bound for a guid with a bucket size
+	 *
+	 * @param int $guid        The guid to get a bound for. Must be > 0.
+	 * @param int $bucket_size The size of the bucket. (The number of entries per dir.)
+	 * @return float
+	 */
+	public static function getLowerBucketBound($guid, $bucket_size = null) {
+		if (!$bucket_size || $bucket_size < 1) {
+			$bucket_size = self::$bucket_size;
+		}
+		if ($guid < 1) {
+			return false;
+		}
+		return (int) max(floor($guid / $bucket_size) * $bucket_size, 1);
 	}
 
 	/**
@@ -358,11 +379,9 @@ class ElggDiskFilestore extends ElggFilestore {
 	 * Generates a matrix using the entity's creation time and
 	 * unique guid.
 	 *
-	 * File path matrixes are:
-	 * YYYY/MM/DD/guid/
-	 *
 	 * @param int $guid The entity to contrust a matrix for
 	 *
+	 * @deprecated 1.8 Use ElggDiskFileStore::makeFileMatrix()
 	 * @return str The
 	 */
 	protected function user_file_matrix($guid) {

--- a/engine/classes/ElggDiskFilestore.php
+++ b/engine/classes/ElggDiskFilestore.php
@@ -19,7 +19,7 @@ class ElggDiskFilestore extends ElggFilestore {
 	 * Number of entries per matrix dir.
 	 * You almost certainly don't want to change this.
 	 */
-	private static $bucket_size = 5000;
+	const BUCKET_SIZE = 5000;
 
 	/**
 	 * Construct a disk filestore using the given directory root.
@@ -365,7 +365,7 @@ class ElggDiskFilestore extends ElggFilestore {
 	 */
 	public static function getLowerBucketBound($guid, $bucket_size = null) {
 		if (!$bucket_size || $bucket_size < 1) {
-			$bucket_size = self::$bucket_size;
+			$bucket_size = self::BUCKET_SIZE;
 		}
 		if ($guid < 1) {
 			return false;

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -947,6 +947,8 @@ abstract class ElggEntity extends ElggData implements
 			$user = elgg_get_logged_in_user_entity();
 		}
 
+		$return = false;
+
 		// Test user if possible - should default to false unless a plugin hook says otherwise
 		if ($user) {
 			if ($this->getOwnerGUID() == $user->getGUID()) {

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1420,7 +1420,7 @@ abstract class ElggEntity extends ElggData implements
 		
 		if ($owner_guid != $container_guid) {
 			$container = $this->getContainerEntity();
-			if ($container && !$container->canWriteToContainer(0, $type, $subype)) {
+			if ($container && !$container->canWriteToContainer(0, $type, $subtype)) {
 				return false;
 			}				
 		}

--- a/engine/classes/ElggPluginHookService.php
+++ b/engine/classes/ElggPluginHookService.php
@@ -102,4 +102,13 @@ class ElggPluginHookService {
 			}
 		}
 	}
+
+	/**
+	 * Returns all registered hooks
+	 *
+	 * @return array
+	 */
+	public function getHooks() {
+		return $this->hooks;
+	}
 }

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -458,7 +458,7 @@ class ElggSite extends ElggEntity {
 
 		// always allow index page
 		if ($url == elgg_get_site_url($this->guid)) {
-			return TRUE;
+			return true;
 		}
 
 		// default public pages
@@ -477,8 +477,7 @@ class ElggSite extends ElggEntity {
 			'upgrade\.php',
 			'css/.*',
 			'js/.*',
-			'cache/css/.*',
-			'cache/js/.*',
+			'cache/[0-9]+/js|css/.*',
 			'cron/.*',
 			'services/.*',
 		);
@@ -490,11 +489,11 @@ class ElggSite extends ElggEntity {
 		foreach (array_merge($defaults, $plugins) as $public) {
 			$pattern = "`^{$CONFIG->url}$public/*$`i";
 			if (preg_match($pattern, $url)) {
-				return TRUE;
+				return true;
 			}
 		}
 
 		// non-public page
-		return FALSE;
+		return false;
 	}
 }

--- a/engine/lib/filestore.php
+++ b/engine/lib/filestore.php
@@ -422,6 +422,10 @@ function delete_directory($directory) {
  * @warning This only deletes the physical files and not their entities.
  * This will result in FileExceptions being thrown.  Don't use this function.
  *
+ * @warning This must be kept in sync with ElggDiskFilestore.
+ *
+ * @todo Remove this when all files are entities.
+ *
  * @param ElggUser $user And ElggUser
  *
  * @return void
@@ -429,8 +433,8 @@ function delete_directory($directory) {
 function clear_user_files($user) {
 	global $CONFIG;
 
-	$time_created = date('Y/m/d', (int)$user->time_created);
-	$file_path = "$CONFIG->dataroot$time_created/$user->guid";
+	$bound = ElggDiskFilestore::getLowerBucketBound($user->guid);
+	$file_path = "$CONFIG->dataroot$bound/$user->guid";
 	if (file_exists($file_path)) {
 		delete_directory($file_path);
 	}

--- a/engine/lib/filestore.php
+++ b/engine/lib/filestore.php
@@ -420,6 +420,10 @@ function delete_directory($directory) {
  * @warning This only deletes the physical files and not their entities.
  * This will result in FileExceptions being thrown.  Don't use this function.
  *
+ * @warning This must be kept in sync with ElggDiskFilestore.
+ *
+ * @todo Remove this when all files are entities.
+ *
  * @param ElggUser $user And ElggUser
  *
  * @return void
@@ -427,8 +431,8 @@ function delete_directory($directory) {
 function clear_user_files($user) {
 	global $CONFIG;
 
-	$time_created = date('Y/m/d', (int)$user->time_created);
-	$file_path = "$CONFIG->dataroot$time_created/$user->guid";
+	$bound = ElggDiskFilestore::getLowerBucketBound($user->guid);
+	$file_path = "$CONFIG->dataroot$bound/$user->guid";
 	if (file_exists($file_path)) {
 		delete_directory($file_path);
 	}

--- a/engine/lib/group.php
+++ b/engine/lib/group.php
@@ -25,37 +25,6 @@ function get_group_entity_as_row($guid) {
 }
 
 /**
- * Create or update the entities table for a given group.
- * Call create_entity first.
- *
- * @param int    $guid        GUID
- * @param string $name        Name
- * @param string $description Description
- *
- * @return bool
- * @access private
- */
-function create_group_entity($guid, $name, $description) {
-	global $CONFIG;
-
-	$guid = (int)$guid;
-	$name = sanitise_string($name);
-	$description = sanitise_string($description);
-
-	$row = get_entity_as_row($guid);
-
-	if ($row) {
-		// Exists and you have access to it
-		$exists = get_data_row("SELECT guid from {$CONFIG->dbprefix}groups_entity WHERE guid = {$guid}");
-		if ($exists) {
-		} else {
-		}
-	}
-
-	return false;
-}
-
-/**
  * Add an object to the given group.
  *
  * @param int $group_guid  The group to add the object to.

--- a/engine/lib/objects.php
+++ b/engine/lib/objects.php
@@ -23,60 +23,6 @@ function get_object_entity_as_row($guid) {
 }
 
 /**
- * Create or update the extras table for a given object.
- * Call create_entity first.
- *
- * @param int    $guid        The guid of the entity you're creating (as obtained by create_entity)
- * @param string $title       The title of the object
- * @param string $description The object's description
- *
- * @return bool
- * @access private
- */
-function create_object_entity($guid, $title, $description) {
-	global $CONFIG;
-
-	$guid = (int)$guid;
-	$title = sanitise_string($title);
-	$description = sanitise_string($description);
-
-	$row = get_entity_as_row($guid);
-
-	if ($row) {
-		// Core entities row exists and we have access to it
-		$query = "SELECT guid from {$CONFIG->dbprefix}objects_entity where guid = {$guid}";
-		if ($exists = get_data_row($query)) {
-			$query = "UPDATE {$CONFIG->dbprefix}objects_entity
-				set title='$title', description='$description' where guid=$guid";
-
-			$result = update_data($query);
-			if ($result != false) {
-				// Update succeeded, continue
-				$entity = get_entity($guid);
-				elgg_trigger_event('update', $entity->type, $entity);
-				return $guid;
-			}
-		} else {
-			// Update failed, attempt an insert.
-			$query = "INSERT into {$CONFIG->dbprefix}objects_entity
-				(guid, title, description) values ($guid, '$title','$description')";
-
-			$result = insert_data($query);
-			if ($result !== false) {
-				$entity = get_entity($guid);
-				if (elgg_trigger_event('create', $entity->type, $entity)) {
-					return $guid;
-				} else {
-					$entity->delete();
-				}
-			}
-		}
-	}
-
-	return false;
-}
-
-/**
  * Get the sites this object is part of
  *
  * @param int $object_guid The object's GUID

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -169,12 +169,16 @@ function elgg_clean_vars(array $vars = array()) {
 
 	// backwards compatibility code
 	if (isset($vars['internalname'])) {
-		$vars['name'] = $vars['internalname'];
+		if (!isset($vars['__ignoreInternalname'])) {
+			$vars['name'] = $vars['internalname'];
+		}
 		unset($vars['internalname']);
 	}
 
 	if (isset($vars['internalid'])) {
-		$vars['id'] = $vars['internalid'];
+		if (!isset($vars['__ignoreInternalid'])) {
+			$vars['id'] = $vars['internalid'];
+		}
 		unset($vars['internalid']);
 	}
 

--- a/engine/lib/sites.php
+++ b/engine/lib/sites.php
@@ -49,67 +49,6 @@ function get_site_entity_as_row($guid) {
 }
 
 /**
- * Create or update the entities table for a given site.
- * Call create_entity first.
- *
- * @param int    $guid        Site GUID
- * @param string $name        Site name
- * @param string $description Site Description
- * @param string $url         URL of the site
- *
- * @return bool
- * @access private
- */
-function create_site_entity($guid, $name, $description, $url) {
-	global $CONFIG;
-
-	$guid = (int)$guid;
-	$name = sanitise_string($name);
-	$description = sanitise_string($description);
-	$url = sanitise_string($url);
-
-	$row = get_entity_as_row($guid);
-
-	if ($row) {
-		// Exists and you have access to it
-		$query = "SELECT guid from {$CONFIG->dbprefix}sites_entity where guid = {$guid}";
-		if ($exists = get_data_row($query)) {
-			$query = "UPDATE {$CONFIG->dbprefix}sites_entity
-				set name='$name', description='$description', url='$url' where guid=$guid";
-			$result = update_data($query);
-
-			if ($result != false) {
-				// Update succeeded, continue
-				$entity = get_entity($guid);
-				if (elgg_trigger_event('update', $entity->type, $entity)) {
-					return $guid;
-				} else {
-					$entity->delete();
-					//delete_entity($guid);
-				}
-			}
-		} else {
-			// Update failed, attempt an insert.
-			$query = "INSERT into {$CONFIG->dbprefix}sites_entity
-				(guid, name, description, url) values ($guid, '$name', '$description', '$url')";
-			$result = insert_data($query);
-
-			if ($result !== false) {
-				$entity = get_entity($guid);
-				if (elgg_trigger_event('create', $entity->type, $entity)) {
-					return $guid;
-				} else {
-					$entity->delete();
-					//delete_entity($guid);
-				}
-			}
-		}
-	}
-
-	return false;
-}
-
-/**
  * Add a user to a site.
  *
  * @param int $site_guid Site guid

--- a/engine/lib/upgrades/2012051000-1.8.4-datadir_dates_to_guids-efb02ff11b9d6444.php
+++ b/engine/lib/upgrades/2012051000-1.8.4-datadir_dates_to_guids-efb02ff11b9d6444.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Elgg 1.8.4 upgrade 2012051000
+ * datadir_dates_to_guids
+ *
+ * Rewrites data directory to use owner guids instead of creation dates
+ */
+
+$data_root = elgg_get_config('dataroot');
+
+$failed = array();
+$existing_bucket_dirs = array();
+$cleanup_years = array();
+$users = new ElggBatch('elgg_get_entities', array('type' => 'user', 'limit' => 0), 50);
+foreach ($users as $user) {
+	$from = $data_root . make_matrix_2012051000($user->getGUID());
+	$bucket_dir = $data_root . ElggDiskFilestore::getLowerBucketBound($user->guid);
+	$to =  "$bucket_dir/" . $user->getGUID();
+
+	// make sure bucket dir exists
+	if (!in_array($bucket_dir, $existing_bucket_dirs)) {
+		// for some reason this dir already exists.
+		if (is_dir($bucket_dir)) {
+			$existing_bucket_dirs[] = $bucket_dir;
+		} else {
+			// same perms as ElggDiskFilestore.
+			if (!mkdir($bucket_dir, 0700, true)) {
+				$failed[] = "[Create bucket dir] Dir: $bucket_dir";
+				continue;
+			}
+			$existing_bucket_dirs[] = $bucket_dir;
+		}
+	}
+	
+	if (!rename($from, $to)) {
+		$failed[] = "[$user->guid ($user->username)] From: $from To: $to";
+	}
+
+	// store the year for cleanup
+	$year = date('Y', $user->time_created);
+	if (!in_array($year, $cleanup_years)) {
+		$cleanup_years[] = $year;
+	}
+}
+
+// remove all dirs that are empty.
+foreach ($cleanup_years as $year) {
+	remove_dir_if_empty_2012051000($data_root . $year);
+}
+
+if ($failed) {
+	$h = fopen("$data_root/2012051000_data_migration.log", 'w');
+	fwrite($h, implode("\n", $failed));
+	fclose($h);
+	register_error("Problems migrating user data. See the admin area for more information.");
+	elgg_add_admin_notice('2012051000_data_migration',
+			"There were problems migrating some users' data. See the log file at
+			$data_root/2012051000_data_migration.log for a list of users who were affected.");
+}
+
+
+function make_matrix_2012051000($guid) {
+		$entity = get_entity($guid);
+
+		if (!($entity instanceof ElggEntity) || !$entity->time_created) {
+			return false;
+		}
+
+		$time_created = date('Y/m/d', $entity->time_created);
+
+		return "$time_created/$entity->guid/";
+}
+
+
+function remove_dir_if_empty_2012051000($dir) {
+	$files = scandir($dir);
+
+	foreach ($files as $file) {
+		if ($file == '..' || $file == '.') {
+			continue;
+		}
+
+		// not empty.
+		if (is_file("$dir/$file")) {
+			return false;
+		}
+
+		// subdir not empty
+		if (is_dir("$dir/$file") && !remove_dir_if_empty_2012051000("$dir/$file")) {
+			return false;
+		}
+	}
+
+	// only contains empty subdirs
+	return rmdir($dir);
+}

--- a/engine/lib/user_settings.php
+++ b/engine/lib/user_settings.php
@@ -267,6 +267,10 @@ function elgg_set_user_default_access() {
 function usersettings_pagesetup() {
 	$user = elgg_get_page_owner_entity();
 
+	if (!$user) {
+		return;
+	}
+
 	$params = array(
 		'name' => '1_account',
 		'text' => elgg_echo('usersettings:user:opt:linktext'),

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -31,47 +31,6 @@ function get_user_entity_as_row($guid) {
 }
 
 /**
- * Create or update the entities table for a given user.
- * Call create_entity first.
- *
- * @param int    $guid     The user's GUID
- * @param string $name     The user's display name
- * @param string $username The username
- * @param string $password The password
- * @param string $salt     A salt for the password
- * @param string $email    The user's email address
- * @param string $language The user's default language
- * @param string $code     A code
- *
- * @return bool
- * @access private
- */
-function create_user_entity($guid, $name, $username, $password, $salt, $email, $language, $code) {
-	global $CONFIG;
-
-	$guid = (int)$guid;
-	$name = sanitise_string($name);
-	$username = sanitise_string($username);
-	$password = sanitise_string($password);
-	$salt = sanitise_string($salt);
-	$email = sanitise_string($email);
-	$language = sanitise_string($language);
-	$code = sanitise_string($code);
-
-	$row = get_entity_as_row($guid);
-	if ($row) {
-		// Exists and you have access to it
-		$query = "SELECT guid from {$CONFIG->dbprefix}users_entity where guid = {$guid}";
-		if ($exists = get_data_row($query)) {
-		} else {
-			// Exists query failed, attempt an insert.
-		}
-	}
-
-	return false;
-}
-
-/**
  * Disables all of a user's entities
  *
  * @param int $owner_guid The owner GUID

--- a/engine/tests/ElggCoreFilestoreTest.php
+++ b/engine/tests/ElggCoreFilestoreTest.php
@@ -54,9 +54,8 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 		);
 
 		foreach ($guids as $guid) {
-			// this needs to be synced with ElggDiskFilestore::entries_per_dir.
-			// it's a private attribute
-			$bound = $this->filestore->getLowerBucketBound($guid, 5000);
+			$filestore = $this->filestore;
+			$bound = $filestore->getLowerBucketBound($guid, $filestore::BUCKET_SIZE);
 
 			if ($guid < 5000) {
 				$correct_bound = 1;
@@ -77,7 +76,8 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 	public function testFileMatrix() {
 		// create a test user
 		$user = $this->createTestUser();
-		$bound = $this->filestore->getLowerBucketBound($user->guid, 5000);
+		$filestore = $this->filestore;
+		$bound = $filestore->getLowerBucketBound($user->guid, $filestore::BUCKET_SIZE);
 
 		// check matrix with guid
 		$guid_dir = $this->filestore->makeFileMatrix($user->guid);
@@ -92,7 +92,8 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 		
 		// create a user to own the file
 		$user = $this->createTestUser();
-		$bound = $this->filestore->getLowerBucketBound($user->guid, 5000);
+		$filestore = $this->filestore;
+		$bound = $filestore->getLowerBucketBound($user->guid, $filestore::BUCKET_SIZE);
 		
 		// setup a test file
 		$file = new ElggFile();
@@ -119,7 +120,8 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 		global $CONFIG;
 		
 		$user = $this->createTestUser();
-		$bound = $this->filestore->getLowerBucketBound($user->guid, 5000);
+		$filestore = $this->filestore;
+		$bound = $filestore->getLowerBucketBound($user->guid, $filestore::BUCKET_SIZE);
 		
 		$file = new ElggFile();
 		$file->owner_guid = $user->guid;

--- a/engine/tests/ElggCoreFilestoreTest.php
+++ b/engine/tests/ElggCoreFilestoreTest.php
@@ -12,7 +12,7 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 	 */
 	public function __construct() {
 		parent::__construct();
-		
+
 		// all code should come after here
 	}
 
@@ -29,7 +29,7 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 	public function tearDown() {
 		// do not allow SimpleTest to interpret Elgg notices as exceptions
 		$this->swallowErrors();
-		
+
 		unset($this->filestore);
 	}
 
@@ -82,19 +82,19 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 		// check matrix with guid
 		$guid_dir = $this->filestore->makeFileMatrix($user->guid);
 		$this->assertIdentical($guid_dir, "$bound/$user->guid/");
-		
+
 		// clean up user
 		$user->delete();
 	}
-	
+
 	public function testFilenameOnFilestore() {
 		global $CONFIG;
-		
+
 		// create a user to own the file
 		$user = $this->createTestUser();
 		$filestore = $this->filestore;
 		$bound = $filestore->getLowerBucketBound($user->guid, $filestore::BUCKET_SIZE);
-		
+
 		// setup a test file
 		$file = new ElggFile();
 		$file->owner_guid = $user->guid;
@@ -102,13 +102,13 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 		$file->open('write');
 		$file->write('Testing!');
 		$this->assertTrue($file->close());
-		
+
 		// ensure filename and path is expected
 		$filename = $file->getFilenameOnFilestore($file);
 		$filepath = "$CONFIG->dataroot$bound/$user->guid/testing/filestore.txt";
 		$this->assertIdentical($filename, $filepath);
 		$this->assertTrue(file_exists($filepath));
-		
+
 		// ensure file removed on user delete
 		// Note: this tests clear_user_files() and not ElggFile()->delete()
 		$user->delete();
@@ -122,7 +122,7 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 		$user = $this->createTestUser();
 		$filestore = $this->filestore;
 		$bound = $filestore->getLowerBucketBound($user->guid, $filestore::BUCKET_SIZE);
-		
+
 		$file = new ElggFile();
 		$file->owner_guid = $user->guid;
 		$file->setFilename('testing/ElggFileDelete');
@@ -145,7 +145,7 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 		$user = new ElggUser();
 		$user->username = $username;
 		$guid = $user->save();
-		
+
 		// load user to have access to creation time
 		return get_entity($guid);
 	}

--- a/engine/tests/ElggCoreFilestoreTest.php
+++ b/engine/tests/ElggCoreFilestoreTest.php
@@ -12,7 +12,7 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 	 */
 	public function __construct() {
 		parent::__construct();
-		
+
 		// all code should come after here
 	}
 
@@ -29,7 +29,7 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 	public function tearDown() {
 		// do not allow SimpleTest to interpret Elgg notices as exceptions
 		$this->swallowErrors();
-		
+
 		unset($this->filestore);
 	}
 
@@ -41,28 +41,59 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 		parent::__destruct();
 	}
 
+	public function testFileMatrixBounds() {
+		$guids = array(
+			1,
+			4999,
+			5000,
+			5001,
+			7500,
+			10000,
+			13532,
+			17234
+		);
+
+		foreach ($guids as $guid) {
+			// this needs to be synced with ElggDiskFilestore::entries_per_dir.
+			// it's a private attribute
+			$bound = $this->filestore->getLowerBucketBound($guid, 5000);
+
+			if ($guid < 5000) {
+				$correct_bound = 1;
+			} elseif ($guid < 10000) {
+				$correct_bound = 5000;
+			} elseif ($guid < 15000) {
+				$correct_bound = 10000;
+			} elseif ($guid < 20000) {
+				$correct_bound = 15000;
+			}
+
+			// check bounds
+			$this->assertIdentical($correct_bound, $bound);
+		}
+	}
+
+
 	public function testFileMatrix() {
-		global $CONFIG;
-		
 		// create a test user
 		$user = $this->createTestUser();
-		$created = date('Y/m/d', $user->time_created);
-		
+		$bound = $this->filestore->getLowerBucketBound($user->guid, 5000);
+
 		// check matrix with guid
 		$guid_dir = $this->filestore->makeFileMatrix($user->guid);
-		$this->assertIdentical($guid_dir, "$created/$user->guid/");
-		
+		$this->assertIdentical($guid_dir, "$bound/$user->guid/");
+
 		// clean up user
 		$user->delete();
 	}
-	
+
 	public function testFilenameOnFilestore() {
 		global $CONFIG;
-		
+
 		// create a user to own the file
 		$user = $this->createTestUser();
-		$created = date('Y/m/d', $user->time_created);
-		
+		$bound = $this->filestore->getLowerBucketBound($user->guid, 5000);
+
 		// setup a test file
 		$file = new ElggFile();
 		$file->owner_guid = $user->guid;
@@ -70,24 +101,49 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 		$file->open('write');
 		$file->write('Testing!');
 		$this->assertTrue($file->close());
-		
+
 		// ensure filename and path is expected
 		$filename = $file->getFilenameOnFilestore($file);
-		$filepath = "$CONFIG->dataroot$created/$user->guid/testing/filestore.txt";
+		$filepath = "$CONFIG->dataroot$bound/$user->guid/testing/filestore.txt";
 		$this->assertIdentical($filename, $filepath);
 		$this->assertTrue(file_exists($filepath));
-		
+
 		// ensure file removed on user delete
+		// Note: this tests clear_user_files() and not ElggFile()->delete()
 		$user->delete();
+		clear_user_files();
 		$this->assertFalse(file_exists($filepath));
 	}
 
+	function testElggFileDelete() {
+		global $CONFIG;
+
+		$user = $this->createTestUser();
+		$bound = $this->filestore->getLowerBucketBound($user->guid, 5000);
+
+		$file = new ElggFile();
+		$file->owner_guid = $user->guid;
+		$file->setFilename('testing/ElggFileDelete');
+		$this->assertTrue($file->open('write'));
+		$this->assertTrue($file->write('Test'));
+		$this->assertTrue($file->close());
+		$file->save();
+
+		$filename = $file->getFilenameOnFilestore($file);
+		$filepath = "$CONFIG->dataroot$bound/$user->guid/testing/ElggFileDelete";
+		$this->assertIdentical($filename, $filepath);
+		$this->assertTrue(file_exists($filepath));
+
+		$this->assertTrue($file->delete());
+		$this->assertFalse(file_exists($filepath));
+		$user->delete();
+	}
 
 	protected function createTestUser($username = 'fileTest') {
 		$user = new ElggUser();
 		$user->username = $username;
 		$guid = $user->save();
-		
+
 		// load user to have access to creation time
 		return get_entity($guid);
 	}

--- a/install/ElggInstaller.php
+++ b/install/ElggInstaller.php
@@ -1439,6 +1439,7 @@ class ElggInstaller {
 		datalist_set('version', get_version());
 		datalist_set('simplecache_enabled', 1);
 		datalist_set('system_cache_enabled', 1);
+		datalist_set('simplecache_lastupdate', time());
 
 		// new installations have run all the upgrades
 		$upgrades = elgg_get_upgrade_files($submissionVars['path'] . 'engine/lib/upgrades/');

--- a/mod/developers/classes/ElggInspector.php
+++ b/mod/developers/classes/ElggInspector.php
@@ -32,10 +32,9 @@ class ElggInspector {
 	 * returns [hook,type] => array(handlers)
 	 */
 	public function getPluginHooks() {
-		global $CONFIG;
-
 		$tree = array();
-		foreach ($CONFIG->hooks as $hook => $types) {
+		$hooks = _elgg_services()->hooks->getHooks();
+		foreach ($hooks as $hook => $types) {
 			foreach ($types as $type => $handlers) {
 				$tree[$hook . ',' . $type] = array_values($handlers);
 			}

--- a/mod/embed/views/default/js/embed/embed.php
+++ b/mod/embed/views/default/js/embed/embed.php
@@ -22,8 +22,6 @@ elgg.embed.init = function() {
 /**
  * Inserts data attached to an embed list item in textarea
  *
- * @todo generalize lightbox closing
- *
  * @param {Object} event
  * @return void
  */
@@ -47,7 +45,7 @@ elgg.embed.insert = function(event) {
 echo elgg_view('embed/custom_insert_js');
 ?>
 
-	$.colorbox.close();
+	elgg.ui.lightbox.close();
 
 	event.preventDefault();
 };

--- a/mod/web_services/start.php
+++ b/mod/web_services/start.php
@@ -18,7 +18,7 @@ function ws_init() {
 	elgg_register_page_handler('services', 'ws_page_handler');
 
 	// Register a service handler for the default web services
-	// The name name is a misnomer as they are not RESTful
+	// The name rest is a misnomer as they are not RESTful
 	elgg_ws_register_service_handler('rest', 'ws_rest_handler');
 
 	// expose the list of api methods
@@ -276,7 +276,6 @@ function elgg_ws_unregister_service_handler($handler) {
  * @throws SecurityException|APIException
  */
 function ws_rest_handler() {
-	global $CONFIG;
 
 	elgg_load_library('elgg:ws');
 
@@ -286,11 +285,6 @@ function ws_rest_handler() {
 
 	// Register a default exception handler
 	set_exception_handler('_php_api_exception_handler');
-
-	// Check to see if the api is available
-	if ((isset($CONFIG->disable_api)) && ($CONFIG->disable_api == true)) {
-		throw new SecurityException(elgg_echo('SecurityException:APIAccessDenied'));
-	}
 
 	// plugins should return true to control what API and user authentication handlers are registered
 	if (elgg_trigger_plugin_hook('rest', 'init', null, false) == false) {

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2011110700;
+$version = 2013011000;
 
 // Human-friendly version name
 $release = '1.9.0-dev';

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2013021000;
+$version = 2013022000;
 
 // Human-friendly version name
 $release = '1.9.0-dev';

--- a/views/default/forms/admin/site/update_advanced.php
+++ b/views/default/forms/admin/site/update_advanced.php
@@ -97,16 +97,6 @@ $form_body .= elgg_view("input/checkboxes", array(
 	'value' => (elgg_get_config('https_login') ? 1 : 0)
 )) . "</div>";
 
-$form_body .= "<div>" . elgg_echo('installation:disableapi') . "<br />";
-$disable_api = elgg_get_config('disable_api');
-$on = $disable_api ?  0 : 1;
-$form_body .= elgg_view("input/checkboxes", array(
-	'options' => array(elgg_echo('installation:disableapi:label') => 1),
-	'name' => 'api',
-	'value' => $on,
-));
-$form_body .= "</div>";
-
 $form_body .= elgg_view('input/hidden', array('name' => 'settings', 'value' => 'go'));
 
 $form_body .= '<div class="elgg-foot">';

--- a/views/default/input/dropdown.php
+++ b/views/default/input/dropdown.php
@@ -1,9 +1,7 @@
 <?php
 /**
- * Deprecated dropdown input view - use 'input/select' instead.
+ * Alias of 'input/select'.
  *
- * @deprecated 1.9
  */
 
-elgg_deprecated_notice("input/dropdown was deprecated by input/select", 1.9);
 echo elgg_view('input/select', $vars);

--- a/views/default/input/select.php
+++ b/views/default/input/select.php
@@ -3,13 +3,12 @@
  * Elgg select input
  * Displays a select input field
  *
- * @warning Default values of FALSE or NULL will match '' (empty string) but not 0.
+ * @warning Values of FALSE or NULL will match '' (empty string) but not 0.
  *
  * @package Elgg
  * @subpackage Core
  *
- * @uses $vars['value']          The current value or an array of current values (only valid if
- *                               multiselect is used).
+ * @uses $vars['value']          The current value or an array of current values if multiple is true
  * @uses $vars['options']        An array of strings representing the options for the dropdown field
  * @uses $vars['options_values'] An associative array of "value" => "option"
  *                               where "value" is the name and "option" is
@@ -41,6 +40,7 @@ $options = $vars['options'];
 unset($vars['options']);
 
 $value = is_array($vars['value']) ? $vars['value'] : array($vars['value']);
+$value = array_map('strval', $value);
 unset($vars['value']);
 
 $vars['multiple'] = !empty($vars['multiple']);
@@ -71,7 +71,7 @@ if ($options_values) {
 		foreach ($options as $option) {
 
 			$option_attrs = elgg_format_attributes(array(
-				'selected' => in_array((string)$opt_value, $value)
+				'selected' => in_array((string)$option, $value)
 			));
 
 			echo "<option $option_attrs>$option</option>";

--- a/views/default/js/lightbox.php
+++ b/views/default/js/lightbox.php
@@ -20,23 +20,29 @@
 if (0) { ?><script><?php }
 ?>
 
+elgg.provide('elgg.ui.lightbox');
+
 /**
  * Lightbox initialization
  */
-elgg.ui.lightbox_init = function() {
+elgg.ui.lightbox.init = function() {
 	$.extend($.colorbox.settings, {
 		current: elgg.echo('js:lightbox:current', ['{current}', '{total}']),
 		previous: elgg.echo('previous'),
 		next: elgg.echo('next'),
 		close: elgg.echo('close'),
 		xhrError: elgg.echo('error:default'),
-		imgError: elgg.echo('error:default'),
+		imgError: elgg.echo('error:default')
 	});
 
 	$(".elgg-lightbox").colorbox();
 }
 
-elgg.register_hook_handler('init', 'system', elgg.ui.lightbox_init);
+elgg.ui.lightbox.close = function() {
+	$.colorbox.close();
+}
+
+elgg.register_hook_handler('init', 'system', elgg.ui.lightbox.init);
 
 <?php
 

--- a/views/default/js/lightbox.php
+++ b/views/default/js/lightbox.php
@@ -32,7 +32,8 @@ elgg.ui.lightbox.init = function() {
 		next: elgg.echo('next'),
 		close: elgg.echo('close'),
 		xhrError: elgg.echo('error:default'),
-		imgError: elgg.echo('error:default')
+		imgError: elgg.echo('error:default'),
+		opacity: 0.5
 	});
 
 	$(".elgg-lightbox").colorbox();


### PR DESCRIPTION
Changes the disk datastore to use guids instead of dates. This was originally for 1.8, but I refactored it for 1.9. I'm not caught up on all the improvements in 1.9 yet, so wanted to have someone review this before merging.
