### PR TITLE
Check if the $response_format is a valid viewtype

### DIFF
--- a/engine/lib/web_services.php
+++ b/engine/lib/web_services.php
@@ -1268,10 +1268,10 @@ function service_handler($handler, $request) {
 
 	// after the handler, the first identifier is response format
 	// ex) http://example.org/services/api/rest/xml/?method=test
-	$reponse_format = array_shift($request);
+	$response_format = array_shift($request);
 	// Which view - xml, json, ...
-	if ($reponse_format) {
-		elgg_set_viewtype($reponse_format);
+	if ($response_format && elgg_is_valid_view_type($response_format)) {
+		elgg_set_viewtype($response_format);
 	} else {
 		// default to xml
 		elgg_set_viewtype("xml");


### PR DESCRIPTION
Fixes a problem when the $response_format is not a valid viewtype, using xml as default.
If uses for example jsonp, show a blank page.

@lucianomlima
