### PR TITLE
User with username 'read' breaks message plugin. This is the fix.

### DIFF
--- a/mod/messages/start.php
+++ b/mod/messages/start.php
@@ -85,8 +85,17 @@ function messages_page_handler($page) {
 	// supporting the old inbox url /messages/<username>
 	$user = get_user_by_username($page[0]);
 	if ($user) {
-		$page[1] = $page[0];
-		$page[0] = 'inbox';
+		// Need to make sure that the username of the parameter is actually
+		// the username of the logged in user. This will prevent strange 
+		// errors like grabbing the 'read' parameter and looking up
+		// a user with username 'read' and finding it and redirecting
+		// to that other person's inbox. 
+
+		if ($user->username == elgg_get_logged_in_user_entity()->username) {
+			// OK, so it is our username and not someone else's
+			$page[1] = $page[0];
+			$page[0] = 'inbox';
+		}
 	}
 
 	if (!isset($page[1])) {


### PR DESCRIPTION
We had an Elgg user named Chris Read with username 'read'. Once he registered, people's messages stopped working because hitting a message in your inbox was a url like: [site_name]/messages/read/459 - and the message code, supporting the old URL format, looked up the parameter right after messages and did a lookup on that word. So, since it got a user, redirected to Chris's inbox no matter who you were. Yipes! So I put in some code checking that the parameter really is the logged in username, so it would work for Chris, but not for anyone else. It works fine now.
