### PR TITLE
Fixes #4675 adds a wrapper around the 3 variables passed into views

### DIFF
--- a/engine/classes/Elgg/ServiceProvider.php
+++ b/engine/classes/Elgg/ServiceProvider.php
@@ -11,6 +11,7 @@
  *
  * @property-read ElggVolatileMetadataCache $metadataCache
  * @property-read ElggPluginHookService $hooks
+ * @property-read ElggViewService $views
  * @property-read ElggDatabase $db
  * @property-read ElggAutoloadManager $autoloadManager
  * @property-read ElggLogger $logger
@@ -34,6 +35,7 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 		$this->setValue('autoloadManager', $autoload_manager);
 		$this->setValue('hooks', new ElggPluginHookService());
 
+		$this->setFactory('views', array($this, 'getViews'));
 		$this->setFactory('logger', array($this, 'getLogger'));
 		$this->setFactory('metadataCache', array($this, 'getMetadataCache'));
 		$this->setFactory('db', array($this, 'getDb'));
@@ -49,5 +51,9 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 
 	protected function getLogger(Elgg_DIContainer $c) {
 		return new ElggLogger($c->get('hooks'));
+	}
+
+	protected function getViews(Elgg_DIContainer $c) {
+		return new ElggViewService();
 	}
 }

--- a/engine/classes/Elgg/ServiceProvider.php
+++ b/engine/classes/Elgg/ServiceProvider.php
@@ -12,6 +12,7 @@
  * @property-read ElggVolatileMetadataCache $metadataCache
  * @property-read ElggPluginHookService $hooks
  * @property-read ElggViewService $views
+ * @property-read ElggAutoP $autoP
  * @property-read ElggDatabase $db
  * @property-read ElggAutoloadManager $autoloadManager
  * @property-read ElggLogger $logger
@@ -31,11 +32,11 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 	}
 
 	public function __construct(ElggAutoloadManager $autoload_manager) {
-
 		$this->setValue('autoloadManager', $autoload_manager);
 		$this->setValue('hooks', new ElggPluginHookService());
 
 		$this->setFactory('views', array($this, 'getViews'));
+		$this->setFactory('autoP', array($this, 'getAutoP'));
 		$this->setFactory('logger', array($this, 'getLogger'));
 		$this->setFactory('metadataCache', array($this, 'getMetadataCache'));
 		$this->setFactory('db', array($this, 'getDb'));
@@ -55,5 +56,9 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 
 	protected function getViews(Elgg_DIContainer $c) {
 		return new ElggViewService();
+	}
+
+	protected function getAutoP(Elgg_DIContainer $c) {
+		return new ElggAutoP();
 	}
 }

--- a/engine/classes/ElggAutoP.php
+++ b/engine/classes/ElggAutoP.php
@@ -62,24 +62,6 @@ class ElggAutoP {
 	}
 
 	/**
-	 * Intance of class for singleton pattern.
-	 * @var ElggAutoP
-	 */
-	private static $instance;
-	
-	/**
-	 * Singleton pattern.
-	 * @return ElggAutoP
-	 */
-	public static function getInstance() {
-		$className = __CLASS__;
-		if (!(self::$instance instanceof $className)) {
-			self::$instance = new $className();
-		}
-		return self::$instance;
-	}
-	
-	/**
 	 * Create wrapper P and BR elements in HTML depending on newlines. Useful when
 	 * users use newlines to signal line and paragraph breaks. In all cases output
 	 * should be well-formed markup.

--- a/engine/classes/ElggDeprecationWrapper.php
+++ b/engine/classes/ElggDeprecationWrapper.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Wrap an object and display warnings whenever the object's variables are
+ * accessed or a method is used. It can also be used to wrap a string.
+ *
+ * Note that the wrapper will not share the type of the wrapped object and will
+ * fail type hints, instanceof, etc.
+ *
+ * This was introduced for deprecating passing particular variabled to views
+ * automatically in elgg_view(). It can be removed once that use is no longer
+ * required.
+ *
+ * @access private
+ */
+class ElggDeprecationWrapper {
+	/** @var object */
+	protected $object;
+
+	/** @var string */
+	protected $string;
+
+	/** @var string */
+	protected $message;
+
+	/** @var float */
+	protected $version;
+
+	/** @var callable */
+	protected $reporter;
+
+	/**
+	 * Create the wrapper
+	 * @param mixed  $object  The object or string to wrap
+	 * @param string $message The deprecation message to display when used
+	 * @param float  $version The Elgg version this was deprecated
+	 *
+	 * @param callable $reporter function called to report deprecation
+	 */
+	public function __construct($object, $message, $version, $reporter = 'elgg_deprecated_notice') {
+		if (is_object($object)) {
+			$this->object = $object;
+		} else {
+			$this->string = $object;
+		}
+		$this->message = $message;
+		$this->version = $version;
+		$this->reporter = $reporter;
+	}
+
+	/**
+	 * Get a property on the object
+	 * @param string $name
+	 * @return mixed
+	 */
+	public function __get($name) {
+		$this->displayWarning();
+		return $this->object->$name;
+	}
+
+	/**
+	 * Set a property on the object
+	 * @param string $name
+	 * @param mixed  $value
+	 * @return void
+	 */
+	public function __set($name, $value) {
+		$this->displayWarning();
+		$this->object->$name = $value;
+	}
+
+	/**
+	 * Call a method on the object
+	 * @param string $name
+	 * @param array  $arguments
+	 * @return mixed
+	 */
+	public function __call($name, $arguments) {
+		$this->displayWarning();
+		return call_user_func_array(array($this->object, $name), $arguments);
+	}
+
+	/**
+	 * Display the string
+	 * @return string
+	 */
+	public function __toString() {
+		if (isset($this->string)) {
+			$this->displayWarning();
+			return $this->string;
+		} else {
+			$this->displayWarning();
+			return (string) $this->object;
+		}
+	}
+
+	protected function displayWarning() {
+		// display 3 levels in the function stack to get back to original use
+		// 1 for __get/__call/__toString()
+		// 1 for displayWarning()
+		// 1 for call_user_func()
+		call_user_func($this->reporter, $this->message, $this->version, 3);
+	}
+}

--- a/engine/classes/ElggDeprecationWrapper.php
+++ b/engine/classes/ElggDeprecationWrapper.php
@@ -84,11 +84,10 @@ class ElggDeprecationWrapper {
 	 * @return string
 	 */
 	public function __toString() {
+		$this->displayWarning();
 		if (isset($this->string)) {
-			$this->displayWarning();
 			return $this->string;
 		} else {
-			$this->displayWarning();
 			return (string) $this->object;
 		}
 	}

--- a/engine/lib/deprecated-1.9.php
+++ b/engine/lib/deprecated-1.9.php
@@ -879,3 +879,15 @@ function leave_group($group_guid, $user_guid) {
 
 	return false;
 }
+
+/**
+ * Create paragraphs from text with line spacing
+ *
+ * @param string $string The string
+ * @return string
+ * @deprecated 1.9 Use elgg_autop instead
+ **/
+function autop($string) {
+	elgg_deprecated_notice('autop has been deprecated in favor of elgg_autop', '1.9');
+	return elgg_autop($string);
+}

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -44,25 +44,12 @@ function parse_urls($text) {
 /**
  * Create paragraphs from text with line spacing
  *
- * @param string $pee The string
- * @deprecated Use elgg_autop instead
- * @todo Add deprecation warning in 1.9
- *
- * @return string
- **/
-function autop($pee) {
-	return elgg_autop($pee);
-}
-
-/**
- * Create paragraphs from text with line spacing
- *
  * @param string $string The string
  *
  * @return string
  **/
 function elgg_autop($string) {
-	return ElggAutoP::getInstance()->process($string);
+	return _elgg_services()->autoP->process($string);
 }
 
 /**

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -326,7 +326,7 @@ function elgg_set_view_location($view, $location, $viewtype = '') {
  * @return bool
  */
 function elgg_view_exists($view, $viewtype = '', $recurse = true) {
-	return ElggViewService::getInstance()->viewExists($view, $viewtype, $recurse);
+	return _elgg_services()->views->viewExists($view, $viewtype, $recurse);
 }
 
 /**
@@ -365,7 +365,7 @@ function elgg_view_exists($view, $viewtype = '', $recurse = true) {
  * @link http://docs.elgg.org/View
  */
 function elgg_view($view, $vars = array(), $bypass = false, $ignored = false, $viewtype = '') {
-	return ElggViewService::getInstance()->view($view, $vars, $bypass, $viewtype);
+	return _elgg_services()->views->renderView($view, $vars, $bypass, $viewtype);
 }
 
 /**
@@ -393,7 +393,7 @@ function elgg_view($view, $vars = array(), $bypass = false, $ignored = false, $v
  * @example views/extend.php
  */
 function elgg_extend_view($view, $view_extension, $priority = 501, $viewtype = '') {
-	ElggViewService::getInstance()->extendView($view, $view_extension, $priority, $viewtype);
+	_elgg_services()->views->extendView($view, $view_extension, $priority, $viewtype);
 }
 
 /**
@@ -406,7 +406,7 @@ function elgg_extend_view($view, $view_extension, $priority = 501, $viewtype = '
  * @since 1.7.2
  */
 function elgg_unextend_view($view, $view_extension) {
-	return ElggViewService::getInstance()->unextendView($view, $view_extension);
+	return _elgg_services()->views->unextendView($view, $view_extension);
 }
 
 /**

--- a/engine/tests/phpunit/ElggDeprecationWrapperTest.php
+++ b/engine/tests/phpunit/ElggDeprecationWrapperTest.php
@@ -1,0 +1,61 @@
+<?php
+
+class ElggDeprecationWrapperTest extends PHPUnit_Framework_TestCase {
+
+	public $last_stack_line = '';
+
+	public function setUp() {
+		$this->last_stack_line = '';
+	}
+
+	// to some extent this also tests the stack trace operation, but that's OK
+	public function report($msg, $version, $backtrace_level) {
+		$backtrace = debug_backtrace();
+		// never show this call.
+		array_shift($backtrace);
+		$i = count($backtrace);
+
+		foreach ($backtrace as $trace) {
+			$this->last_stack_line = "{$trace['file']}:{$trace['line']}";
+			$i--;
+			if ($backtrace_level > 0) {
+				if ($backtrace_level <= 1) {
+					break;
+				}
+				$backtrace_level--;
+			}
+		}
+	}
+
+	function testWrapString() {
+		$str = 'Hello';
+		$str = new ElggDeprecationWrapper($str, 'BAD!', 1.8, array($this, 'report'));
+		$file = __FILE__;
+		$new_str = "$str"; $line = __LINE__;
+		$this->assertEquals('Hello', $new_str);
+		$this->assertEquals("$file:$line", $this->last_stack_line);
+	}
+
+	function testWrapObject() {
+		$obj = new ElggDeprecationWrapperTestObj();
+		$obj = new ElggDeprecationWrapper($obj, 'BAD!', 1.8, array($this, 'report'));
+		$file = __FILE__;
+		$foo = $obj->foo; $line = __LINE__;
+		$this->assertEquals($foo, 'foo');
+		$this->assertEquals("$file:$line", $this->last_stack_line);
+
+		$foo = $obj->foo(); $line = __LINE__;
+		$this->assertEquals($foo, 'foo');
+		$this->assertEquals("$file:$line", $this->last_stack_line);
+
+		$foo = "$obj"; $line = __LINE__;
+		$this->assertEquals($foo, 'foo');
+		$this->assertEquals("$file:$line", $this->last_stack_line);
+	}
+}
+
+class ElggDeprecationWrapperTestObj {
+	public $foo = 'foo';
+	public function foo() { return 'foo'; }
+	public function __toString() { return 'foo'; }
+}


### PR DESCRIPTION
This is #314 rebased + handling of __toString on objects + performance improvements in views + unit tests.

Unfortunately I added my work in the middle of the rebase process (there was a view conflict) so it was squashed into @cash's commit. I probably should go back and separate those :/

Not sure how to properly integration test the usage in the view, but it's probably OK.
