### PR TITLE
Refs #4476, #4494: Simplecache refactors for better AMD + static view file support

### DIFF
--- a/engine/handlers/cache_handler.php
+++ b/engine/handlers/cache_handler.php
@@ -87,11 +87,9 @@ if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']
 switch ($type) {
 	case 'css':
 		header("Content-type: text/css", true);
-		$view = "css/$view";
 		break;
 	case 'js':
 		header('Content-type: text/javascript', true);
-		$view = "js/$view";
 		break;
 }
 

--- a/engine/handlers/cache_handler.php
+++ b/engine/handlers/cache_handler.php
@@ -3,11 +3,10 @@
  * Cache handler.
  *
  * External access to cached CSS and JavaScript views. The cached file URLS
- * should be of the form: cache/<ts>/<viewtype>/<name/of/view> where
- * type is either css or js, view is the name of the cached view, and
- * ts is an identifier that is updated every time the cache is flushed.
+ * should be of the form: cache/<id>/<viewtype>/<name/of/view> where
+ * id is an identifier that is updated every time the cache is flushed.
  * The simplest way to maintain a unique identifier is to use the lastcache
- * variable in Elgg's config object.
+ * timestamp in Elgg's config object.
  *
  * @see elgg_register_simplecache_view()
  *

--- a/engine/handlers/cache_handler.php
+++ b/engine/handlers/cache_handler.php
@@ -91,9 +91,6 @@ switch ($segments[0]) {
 	case 'js':
 		header('Content-type: text/javascript', true);
 		break;
-	default:
-		header('Content-type: text/html', true);
-		break;
 }
 
 header('Expires: ' . gmdate('D, d M Y H:i:s \G\M\T', strtotime("+6 months")), true);

--- a/engine/handlers/cache_handler.php
+++ b/engine/handlers/cache_handler.php
@@ -3,7 +3,7 @@
  * Cache handler.
  *
  * External access to cached CSS and JavaScript views. The cached file URLS
- * should be of the form: cache/<ts>/<viewtype>/<name/of/view>.<type> where
+ * should be of the form: cache/<ts>/<viewtype>/<name/of/view> where
  * type is either css or js, view is the name of the cached view, and
  * ts is an identifier that is updated every time the cache is flushed.
  * The simplest way to maintain a unique identifier is to use the lastcache
@@ -66,7 +66,7 @@ if (!$request || !$simplecache_enabled) {
 // testing showed regex to be marginally faster than array / string functions over 100000 reps
 // it won't make a difference in real life and regex is easier to read.
 // <ts>/<viewtype>/<name/of/view.and.dots>.<type>
-$regex = '#([0-9]+)/([^/]+)/(.+)\.([^/.]+)$#';
+$regex = '#([0-9]+)/([^/]+)/(.+)$#';
 if (!preg_match($regex, $request, $matches)) {
 	echo 'Cache error: bad request';
 	exit;
@@ -75,7 +75,6 @@ if (!preg_match($regex, $request, $matches)) {
 $ts = $matches[1];
 $viewtype = $matches[2];
 $view = $matches[3];
-$type = $matches[4];
 
 // If is the same ETag, content didn't change.
 $etag = $ts;
@@ -84,12 +83,17 @@ if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']
 	exit;
 }
 
-switch ($type) {
+$segments = explode('/', $view);
+
+switch ($segments[0]) {
 	case 'css':
 		header("Content-type: text/css", true);
 		break;
 	case 'js':
 		header('Content-type: text/javascript', true);
+		break;
+	default:
+		header('Content-type: text/html', true);
 		break;
 }
 

--- a/engine/handlers/cache_handler.php
+++ b/engine/handlers/cache_handler.php
@@ -3,9 +3,9 @@
  * Cache handler.
  *
  * External access to cached CSS and JavaScript views. The cached file URLS
- * should be of the form: cache/<type>/<viewtype>/<name/of/view>.<unique_id>.<type> where
+ * should be of the form: cache/<ts>/<viewtype>/<name/of/view>.<type> where
  * type is either css or js, view is the name of the cached view, and
- * unique_id is an identifier that is updated every time the cache is flushed.
+ * ts is an identifier that is updated every time the cache is flushed.
  * The simplest way to maintain a unique identifier is to use the lastcache
  * variable in Elgg's config object.
  *
@@ -65,19 +65,19 @@ if (!$request || !$simplecache_enabled) {
 
 // testing showed regex to be marginally faster than array / string functions over 100000 reps
 // it won't make a difference in real life and regex is easier to read.
-// <type>/<ts>/<viewtype>/<name/of/view.and.dots>.<type>
-$regex = '|([^/]+)/([0-9]+)/([^/]+)/(.+)\.([^/.]+)$|';
+// <ts>/<viewtype>/<name/of/view.and.dots>.<type>
+$regex = '#([0-9]+)/([^/]+)/(.+)\.([^/.]+)$#';
 if (!preg_match($regex, $request, $matches)) {
 	echo 'Cache error: bad request';
 	exit;
 }
 
-$type = $matches[1];
-$ts = $matches[2];
-$viewtype = $matches[3];
-$view = $matches[4];
+$ts = $matches[1];
+$viewtype = $matches[2];
+$view = $matches[3];
+$type = $matches[4];
 
-// If is the same ETag, content didn't changed.
+// If is the same ETag, content didn't change.
 $etag = $ts;
 if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) == "\"$etag\"") {
 	header("HTTP/1.1 304 Not Modified");
@@ -112,6 +112,7 @@ if (file_exists($filename)) {
 	}
 
 	require_once(dirname(dirname(__FILE__)) . "/start.php");
+	// TODO: If ts == lastcache, cache ONLY the requested view and serve it.
 	elgg_regenerate_simplecache();
 
 	elgg_set_viewtype($viewtype);

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -212,7 +212,7 @@ function elgg_get_simplecache_url($type, $view) {
 	if (elgg_is_simplecache_enabled()) {
 		global $CONFIG;
 		$lastcache = (int)$CONFIG->lastcache;
-		$url = elgg_get_site_url() . "cache/$lastcache/$viewtype/$type/$view.$type";
+		$url = elgg_get_site_url() . "cache/$lastcache/$viewtype/$type/$view";
 	} else {
 		$url = elgg_get_site_url() . "ajax/view/$type/$view?view=$viewtype";
 	}

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -191,6 +191,10 @@ function elgg_register_simplecache_view($viewname) {
 	}
 
 	$CONFIG->views->simplecache[] = $viewname;
+	
+	if (!elgg_is_simplecache_enabled()) {
+		elgg_register_ajax_view($viewname);
+	}
 }
 
 /**
@@ -206,12 +210,10 @@ function elgg_register_simplecache_view($viewname) {
 function elgg_get_simplecache_url($type, $view) {
 	$viewtype = elgg_get_viewtype();
 	if (elgg_is_simplecache_enabled()) {
-		elgg_register_simplecache_view("$type/$view");
 		global $CONFIG;
 		$lastcache = (int)$CONFIG->lastcache;
 		$url = elgg_get_site_url() . "cache/$lastcache/$viewtype/$type/$view.$type";
 	} else {
-		elgg_register_ajax_view("$type/$view");
 		$url = elgg_get_site_url() . "ajax/view/$type/$view?view=$viewtype";
 	}
 	
@@ -233,9 +235,9 @@ function elgg_get_simplecache_url($type, $view) {
  */
 function _elgg_get_view_filetype($view) {
 	if (preg_match('~(?:^|/)(css|js)(?:$|/)~', $view, $m)) {
-		$hook_type = $m[1];
+		return $m[1];
 	} else {
-		$hook_type = 'unknown';
+		return 'unknown';
 	}
 }
 

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -200,7 +200,8 @@ function elgg_register_simplecache_view($viewname) {
 /**
  * Get the URL for the cached file
  *
- * @note This will implicitly register the view as cacheable.
+ * @warning You must register the view with elgg_register_simplecache_view()	  	
+ * for caching to work. See elgg_register_simplecache_view() for a full example.
  *
  * @param string $type The file type: css or js
  * @param string $view The view name

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -180,52 +180,22 @@ function elgg_disable_filepath_cache() {
  * @since 1.8.0
  */
 function elgg_register_simplecache_view($viewname) {
-	global $CONFIG;
-
-	if (!isset($CONFIG->views)) {
-		$CONFIG->views = new stdClass;
-	}
-
-	if (!isset($CONFIG->views->simplecache)) {
-		$CONFIG->views->simplecache = array();
-	}
-
-	$CONFIG->views->simplecache[] = $viewname;
-	
-	if (!elgg_is_simplecache_enabled()) {
-		elgg_register_ajax_view($viewname);
-	}
+	elgg_register_external_view($viewname, true);
 }
 
 /**
  * Get the URL for the cached file
  * 
- * @example
- * // These are equivalent. The first is preferred.
- * elgg_get_simplecache_url('js/some/elgg/lib');
- * elgg_get_simplecache_url('js', 'some/elgg/lib');
- *
  * @warning You must register the view with elgg_register_simplecache_view()	  	
  * for caching to work. See elgg_register_simplecache_view() for a full example.
  *
- * @param string $view The view name (Was `$type`: The file type: css or js)
- * @param string $path Deprecated in 1.9. Was `$view`: The view name after css/ or js/
+ * @param string $type The file type: css or js
+ * @param string $view The view name after css/ or js/
  * @return string
  * @since 1.8.0
  */
-function elgg_get_simplecache_url($view, $path = '') {
-	if (!empty($path)) {
-		$view = "$view/$path";
-	}
-
-	$viewtype = elgg_get_viewtype();
-	if (elgg_is_simplecache_enabled()) {
-		global $CONFIG;
-		$lastcache = (int)$CONFIG->lastcache;
-		return elgg_get_site_url() . "cache/$lastcache/$viewtype/$view";
-	} else {
-		return elgg_get_site_url() . "ajax/view/$view?view=$viewtype";
-	}
+function elgg_get_simplecache_url($type, $view) {
+	return elgg_get_external_view_url("$type/$view");
 }
 
 /**

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -199,26 +199,33 @@ function elgg_register_simplecache_view($viewname) {
 
 /**
  * Get the URL for the cached file
+ * 
+ * @example
+ * // These are equivalent. The first is preferred.
+ * elgg_get_simplecache_url('js/some/elgg/lib');
+ * elgg_get_simplecache_url('js', 'some/elgg/lib');
  *
  * @warning You must register the view with elgg_register_simplecache_view()	  	
  * for caching to work. See elgg_register_simplecache_view() for a full example.
  *
- * @param string $type The file type: css or js
- * @param string $view The view name
+ * @param string $view The view name (Was `$type`: The file type: css or js)
+ * @param string $path Deprecated in 1.9. Was `$view`: The view name after css/ or js/
  * @return string
  * @since 1.8.0
  */
-function elgg_get_simplecache_url($type, $view) {
+function elgg_get_simplecache_url($view, $path = '') {
+	if (!empty($path)) {
+		$view = "$view/$path";
+	}
+
 	$viewtype = elgg_get_viewtype();
 	if (elgg_is_simplecache_enabled()) {
 		global $CONFIG;
 		$lastcache = (int)$CONFIG->lastcache;
-		$url = elgg_get_site_url() . "cache/$lastcache/$viewtype/$type/$view";
+		return elgg_get_site_url() . "cache/$lastcache/$viewtype/$view";
 	} else {
-		$url = elgg_get_site_url() . "ajax/view/$type/$view?view=$viewtype";
+		return elgg_get_site_url() . "ajax/view/$view?view=$viewtype";
 	}
-	
-	return $url;
 }
 
 /**

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1636,6 +1636,19 @@ function elgg_ajax_page_handler($page) {
 			$vars['entity'] = get_entity($vars['guid']);
 		}
 
+		// Try to guess the mime-type
+		switch ($page[1]) {
+			case "js":
+				header("Content-Type: text/javascript");
+				break;
+			case "css":
+				header("Content-Type: text/css");
+				break;
+			default:
+				header("Content-Type: text/html");
+				break;
+		}
+
 		echo elgg_view($view, $vars);
 		return true;
 	}

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1644,9 +1644,6 @@ function elgg_ajax_page_handler($page) {
 			case "css":
 				header("Content-Type: text/css");
 				break;
-			default:
-				header("Content-Type: text/html");
-				break;
 		}
 
 		echo elgg_view($view, $vars);

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1374,7 +1374,7 @@ function _elgg_views_minify($hook, $type, $content, $params) {
 		}
 	} elseif ($type == 'css') {
 		if (elgg_get_config('simplecache_minify_css')) {
-			$cssmin = new CSSmin();
+			$cssmin = new CSSMin();
 			return $cssmin->run($content);
 		}
 	}

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -223,13 +223,7 @@ function elgg_does_viewtype_fallback($viewtype) {
  * @since 1.8.3
  */
 function elgg_register_ajax_view($view) {
-	global $CONFIG;
-
-	if (!isset($CONFIG->allowed_ajax_views)) {
-		$CONFIG->allowed_ajax_views = array();
-	}
-
-	$CONFIG->allowed_ajax_views[$view] = true;
+	elgg_register_external_view($view, false);
 }
 
 /**
@@ -240,6 +234,78 @@ function elgg_register_ajax_view($view) {
  * @since 1.8.3
  */
 function elgg_unregister_ajax_view($view) {
+	elgg_unregister_external_view($view);
+}
+
+/**
+ * Registers a view as being available externally (i.e. via URL).
+ *
+ * @param string  $view      The name of the view.
+ * @param boolean $cacheable Whether this view can be cached.
+ * @since 1.9.0
+ */
+function elgg_register_external_view($view, $cacheable = false) {
+	global $CONFIG;
+
+	if (!isset($CONFIG->allowed_ajax_views)) {
+		$CONFIG->allowed_ajax_views = array();
+	}
+
+	$CONFIG->allowed_ajax_views[$view] = true;
+
+	if ($cacheable) {
+		if (!isset($CONFIG->views)) {
+			$CONFIG->views = new stdClass;
+		}
+	
+		if (!isset($CONFIG->views->simplecache)) {
+	                $CONFIG->views->simplecache = array();
+	        }
+	
+	        $CONFIG->views->simplecache[] = $view;
+	}
+}
+
+/**
+ * Check whether a view is registered as cacheable.
+ * 
+ * @param string $view The name of the view.
+ * @return boolean
+ * @access private
+ * @since 1.9.0
+ */
+function _elgg_is_view_cacheable($view) {
+	global $CONFIG;
+	return isset($CONFIG->views) &&
+		isset($CONFIG->views->simplecache) &&
+		in_array($view, $CONFIG->views->simplecache);
+}
+
+/**
+ * Get the correct URL for a given external view.
+ * 
+ * @param string $view The name of the view (e.g. 'css/elgg')
+ * @return string
+ * @since 1.9.0
+ */
+function elgg_get_external_view_url($view) {
+	$viewtype = elgg_get_viewtype();
+	if (elgg_is_simplecache_enabled() && _elgg_is_view_cacheable($view)) {
+		$lastcache = elgg_get_config('lastcache');
+		return elgg_normalize_url("/cache/$lastcache/$viewtype/$view");
+	} else {
+		return elgg_normalize_url("/ajax/view/$view?view=$viewtype");
+	}
+}
+
+/**
+ * Unregister a view for accessibility via URLs.
+ * 
+ * @param string $view The view name
+ * @return void
+ * @since 1.9.0
+ */
+function elgg_unregister_external_view($view) {
 	global $CONFIG;
 
 	if (isset($CONFIG->allowed_ajax_views[$view])) {

--- a/js/lib/languages.js
+++ b/js/lib/languages.js
@@ -29,7 +29,7 @@ elgg.reload_all_translations = function(language) {
 
 	var url, options;
 	if (elgg.config.simplecache_enabled) {
-		url = 'cache/js/' + elgg.config.lastcache + '/default/languages/' + lang + '.js';
+		url = 'cache/' + elgg.config.lastcache + '/default/js/languages/' + lang;
 		options = {};
 	} else {
 		url = 'ajax/view/js/languages';


### PR DESCRIPTION
Main changes:
- Url is now: /cache/:timestamp/:viewtype/:view (Note: no file extension unless part of view name)
- When simplecache is off, use /ajax/view/:view?view=:viewtype
- Better mime type guessing for /ajax/view

Demo: http://elgg19.ewinslow.com
