### PR TITLE
Fixes #4525: Decouples group content visibility from membership policy

### DIFF
--- a/engine/classes/Elgg/UserStatus.php
+++ b/engine/classes/Elgg/UserStatus.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This object represents the logged in/out state of a user.
+ *
+ * Why is this needed? Some functions need to distinguish between 1. knowing a user is not logged
+ * in and 2. not knowing the status of a user (e.g. passing this object as null)
+ *
+ * Consider a function that type-hints ElggUser with default null. If null is passed in (or the
+ * argument is not supplied), the function cannot tell if null means "not logged in" or
+ * "status unknown". If this is important, the author can type-hint on this class instead.
+ *
+ * @access private
+ */
+class Elgg_UserStatus {
+
+	protected $user;
+
+	/**
+	 * @param ElggUser|null $logged_in_user
+	 */
+	public function __construct(ElggUser $logged_in_user = null) {
+		$this->user = $logged_in_user;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isLoggedIn() {
+		return (bool) $this->user;
+	}
+
+	/**
+	 * @return ElggUser|null
+	 */
+	public function getUser() {
+		return $this->user;
+	}
+
+	/**
+	 * @return Elgg_UserStatus
+	 */
+	public static function fromSession() {
+		return new self(elgg_get_logged_in_user_entity());
+	}
+}

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -12,6 +12,9 @@
 class ElggGroup extends ElggEntity
 	implements Friendable {
 
+	const GATEKEEPER_MODE_UNRESTRICTED = 'unrestricted';
+	const GATEKEEPER_MODE_MEMBERSONLY = 'membersonly';
+
 	/**
 	 * Sets the type to group.
 	 *
@@ -278,16 +281,49 @@ class ElggGroup extends ElggEntity
 	}
 
 	/**
-	 * Returns whether the current group is public membership or not.
+	 * Returns whether the current group has open membership or not.
 	 *
 	 * @return bool
 	 */
 	public function isPublicMembership() {
-		if ($this->membership == ACCESS_PUBLIC) {
-			return true;
+		return ($this->membership == ACCESS_PUBLIC);
+	}
+
+	/**
+	 * Return the content restriction mode used by group_gatekeeper()
+	 *
+	 * @return string One of GATEKEEPER_MODE_* constants
+	 */
+	public function getGatekeeperMode() {
+		$mode = $this->gatekeeper_mode;
+
+		if (!is_string($mode)) {
+			// fallback to 1.8 default behavior
+			$mode = $this->isPublicMembership()
+				? self::GATEKEEPER_MODE_UNRESTRICTED
+				: self::GATEKEEPER_MODE_MEMBERSONLY;
+			$this->gatekeeper_mode = $mode;
 		}
 
-		return false;
+		// only support two models for now
+		if ($mode === self::GATEKEEPER_MODE_MEMBERSONLY) {
+			return $mode;
+		}
+		return self::GATEKEEPER_MODE_UNRESTRICTED;
+	}
+
+	/**
+	 * Set the content restriction mode used by group_gatekeeper()
+	 *
+	 * @param string $mode One of GATEKEEPER_MODE_* constants
+	 */
+	public function setGatekeeperMode($mode) {
+		// only support two models for now
+		if ($mode !== self::GATEKEEPER_MODE_MEMBERSONLY) {
+			$mode = self::GATEKEEPER_MODE_UNRESTRICTED;
+		}
+
+		$this->gatekeeper_mode = $mode;
 	}
 
 	/**

--- a/engine/classes/ElggGroupItemVisibility.php
+++ b/engine/classes/ElggGroupItemVisibility.php
@@ -30,12 +30,14 @@ class ElggGroupItemVisibility {
 	 * Determine visibility of items within a container for the current user
 	 *
 	 * @param int $container_guid GUID of a container (may/may not be a group)
+	 * @param Elgg_UserStatus $user_status
+	 * @param bool $use_cache use the cached result of
 	 *
 	 * @return ElggGroupItemVisibility
 	 *
 	 * @todo Make this faster, considering it must run for every river item.
 	 */
-	static public function factory($container_guid) {
+	static public function factory($container_guid, Elgg_UserStatus $user_status = null, $use_cache = true) {
 		// cache because this may be called repeatedly during river display, and
 		// due to need to check group visibility, cache will be disabled for some
 		// get_entity() calls
@@ -47,13 +49,16 @@ class ElggGroupItemVisibility {
 			return $ret;
 		}
 
-		$user = elgg_get_logged_in_user_entity();
+		if (!$user_status) {
+			$user_status = Elgg_UserStatus::fromSession();
+		}
+		$user = $user_status->getUser();
 		$user_guid = $user ? $user->guid : 0;
 
 		$container_guid = (int) $container_guid;
 
 		$cache_key = "$container_guid|$user_guid";
-		if (empty($cache[$cache_key])) {
+		if (empty($cache[$cache_key]) || !$use_cache) {
 			// compute
 
 			$container = get_entity($container_guid);
@@ -70,7 +75,7 @@ class ElggGroupItemVisibility {
 				/* @var ElggGroup $container */
 
 				if ($is_visible) {
-					if (!$container->isPublicMembership()) {
+					if ($container->getGatekeeperMode() === ElggGroup::GATEKEEPER_MODE_MEMBERSONLY) {
 						if ($user) {
 							if (!$container->isMember($user) && !$user->isAdmin()) {
 								$ret->shouldHideItems = true;
@@ -88,6 +93,15 @@ class ElggGroupItemVisibility {
 			}
 			$cache[$cache_key] = $ret;
 		}
-		return $cache[$cache_key];
+
+		$return = $cache[$cache_key];
+
+		// don't exhaust memory in extreme uses
+		if (count($cache) > 500) {
+			reset($cache);
+			unset($cache[key($cache)]);
+		}
+
+		return $return;
 	}
 }

--- a/engine/lib/group.php
+++ b/engine/lib/group.php
@@ -21,7 +21,7 @@ function get_group_entity_as_row($guid) {
 
 	$guid = (int)$guid;
 
-	return get_data_row("SELECT * from {$CONFIG->dbprefix}groups_entity where guid=$guid");
+	return elgg_get_database()->getDataRow("SELECT * from {$CONFIG->dbprefix}groups_entity where guid=$guid");
 }
 
 /**
@@ -46,7 +46,7 @@ function create_group_entity($guid, $name, $description) {
 
 	if ($row) {
 		// Exists and you have access to it
-		$exists = get_data_row("SELECT guid from {$CONFIG->dbprefix}groups_entity WHERE guid = {$guid}");
+		$exists = elgg_get_database()->getDataRow("SELECT guid from {$CONFIG->dbprefix}groups_entity WHERE guid = {$guid}");
 		if ($exists) {
 		} else {
 		}
@@ -194,11 +194,16 @@ function get_users_membership($user_guid) {
  * @param boolean $forward If set to true (default), will forward the page;
  *                         if set to false, will return true or false.
  *
+ * @param int $page_owner_guid The current page owner guid. If not set, this will be
+ *                             pulled from elgg_get_page_owner_guid().
+ *
  * @return bool If $forward is set to false.
  */
-function group_gatekeeper($forward = true) {
+function group_gatekeeper($forward = true, $page_owner_guid = null) {
+	if (null === $page_owner_guid) {
+		$page_owner_guid = elgg_get_page_owner_guid();
+	}
 
-	$page_owner_guid = elgg_get_page_owner_guid();
 	if (!$page_owner_guid) {
 		return true;
 	}
@@ -277,3 +282,21 @@ function remove_group_tool_option($name) {
 		}
 	}
 }
+
+/**
+ * Runs unit tests for the group entities.
+ *
+ * @param string $hook
+ * @param string $type
+ * @param array $value
+ * @param array $params
+ *
+ * @return array
+ */
+function _elgg_groups_test($hook, $type, $value, $params) {
+	global $CONFIG;
+	$value[] = $CONFIG->path . 'engine/tests/ElggCoreGroupTest.php';
+	return $value;
+}
+
+elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_groups_test');

--- a/engine/tests/ElggCoreGroupTest.php
+++ b/engine/tests/ElggCoreGroupTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Elgg Test ElggGroup
+ *
+ * @package Elgg
+ * @subpackage Test
+ */
+class ElggCoreGroupTest extends ElggCoreUnitTest {
+	/**
+	 * @var ElggGroup
+	 */
+	protected $group;
+
+	/**
+	 * @var ElggUser
+	 */
+	protected $user;
+
+	/**
+	 * Called before each test method.
+	 */
+	public function setUp() {
+		$this->group = new ElggGroup();
+		$this->group->membership = ACCESS_PUBLIC;
+		$this->group->save();
+		$this->user = new ElggUser();
+		$this->user->username = 'test_user_' . rand();
+		$this->user->save();
+	}
+
+	public function testGatekeeperMode() {
+		$unrestricted = ElggGroup::GATEKEEPER_MODE_UNRESTRICTED;
+		$membersonly = ElggGroup::GATEKEEPER_MODE_MEMBERSONLY;
+
+		// if mode not set, open groups are unrestricted
+		$this->assertEqual($this->group->getGatekeeperMode(), $unrestricted);
+
+		// after first check, metadata is set
+		$this->assertEqual($this->group->gatekeeper_mode, $unrestricted);
+
+		// if mode not set, closed groups are membersonly
+		$this->group->deleteMetadata('gatekeeper_mode');
+		$this->group->membership = ACCESS_PRIVATE;
+		$this->assertEqual($this->group->getGatekeeperMode(), $membersonly);
+
+		// test set
+		$this->group->setGatekeeperMode($unrestricted);
+		$this->assertEqual($this->group->getGatekeeperMode(), $unrestricted);
+		$this->group->setGatekeeperMode($membersonly);
+		$this->assertEqual($this->group->getGatekeeperMode(), $membersonly);
+	}
+
+	public function testGroupItemVisibility() {
+		$user_status = new Elgg_UserStatus($this->user);
+		$group_guid = $this->group->guid;
+
+		// unrestricted: pass non-members
+		$this->group->setGatekeeperMode(ElggGroup::GATEKEEPER_MODE_UNRESTRICTED);
+		$vis = ElggGroupItemVisibility::factory($group_guid, $user_status, false);
+
+		$this->assertFalse($vis->shouldHideItems);
+
+		// membersonly: non-members fail
+		$this->group->setGatekeeperMode(ElggGroup::GATEKEEPER_MODE_MEMBERSONLY);
+		$vis = ElggGroupItemVisibility::factory($group_guid, $user_status, false);
+
+		$this->assertTrue($vis->shouldHideItems);
+
+		// non-member admins succeed
+		$user_status = Elgg_UserStatus::fromSession();
+		$vis = ElggGroupItemVisibility::factory($group_guid, $user_status, false);
+
+		$this->assertFalse($vis->shouldHideItems);
+
+		// members succeed
+		$this->group->join($this->user);
+		$user_status = new Elgg_UserStatus($this->user);
+		$vis = ElggGroupItemVisibility::factory($group_guid, $user_status, false);
+
+		$this->assertFalse($vis->shouldHideItems);
+	}
+
+	/**
+	 * Called after each test method.
+	 */
+	public function tearDown() {
+		$this->group->delete();
+		$this->user->delete();
+	}
+}

--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -21,6 +21,8 @@ elgg.ui.init = function () {
 	$('.elgg-requires-confirmation').live('click', elgg.ui.requiresConfirmation);
 
 	$('.elgg-autofocus').focus();
+
+	elgg.ui.initAccessInputs();
 };
 
 /**
@@ -345,11 +347,40 @@ elgg.ui.registerTogglableMenuItems = function(menuItemNameA, menuItemNameB) {
 		// Don't want to actually click the link
 		return false;
 	});
-}
+};
 
 elgg.ui.toggleMenuItems = function($menu, nameOfItemToShow, nameOfItemToHide) {
     $menu.find('.elgg-menu-item-' + nameOfItemToShow).removeClass('hidden').find('a').focus();
     $menu.find('.elgg-menu-item-' + nameOfItemToHide).addClass('hidden');
+};
+
+/**
+ * Initialize input/access for dynamic display of members only notifications
+ *
+ * If a select.elgg-input-access is accompanied by a note (.elgg-input-access-membersonly),
+ * then hide the note when the select value is PRIVATE or group members.
+ *
+ * @return void
+ */
+elgg.ui.initAccessInputs = function () {
+	$('.elgg-input-access').each(function () {
+		function updateMembersonlyNote() {
+			var val = $select.val();
+			if (val != acl && val != 0) {
+				// .show() failed in Chrome. Maybe a float/jQuery bug
+				$note.css('visibility', 'visible');
+			} else {
+				$note.css('visibility', 'hidden');
+			}
+		}
+		var $select = $(this),
+			acl = $select.data('group-acl'),
+			$note = $('.elgg-input-access-membersonly', this.parentNode);
+		if ($note) {
+			updateMembersonlyNote();
+			$select.change(updateMembersonlyNote);
+		}
+	});
 };
 
 elgg.register_hook_handler('init', 'system', elgg.ui.init);

--- a/languages/en.php
+++ b/languages/en.php
@@ -273,6 +273,7 @@ return array(
 	'LOGGED_OUT' => "Logged out users",
 	'access:friends:label' => "Friends",
 	'access' => "Access",
+	'access:overridenotice' => "Note: Due to group policy, this content will be accessible only by group members.",
 	'access:limited:label' => "Limited",
 	'access:help' => "The access level",
 	'access:read' => "Read access",

--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -79,6 +79,8 @@ if ($tool_options) {
 $is_public_membership = (get_input('membership') == ACCESS_PUBLIC);
 $group->membership = $is_public_membership ? ACCESS_PUBLIC : ACCESS_PRIVATE;
 
+$group->setGatekeeperMode(get_input('gatekeeper_mode'));
+
 if ($is_new_group) {
 	$group->access_id = ACCESS_PUBLIC;
 }

--- a/mod/groups/languages/en.php
+++ b/mod/groups/languages/en.php
@@ -41,6 +41,9 @@ return array(
 	'groups:members:title' => 'Members of %s',
 	'groups:members:more' => "View all members",
 	'groups:membership' => "Group membership permissions",
+	'groups:gatekeeper_mode' => "Accessibility of group content",
+	'groups:gatekeeper_mode:unrestricted' => "Unrestricted - Access depends on content-level settings",
+	'groups:gatekeeper_mode:membersonly' => "Members Only - Non-members can never access group content",
 	'groups:access' => "Access permissions",
 	'groups:owner' => "Owner",
 	'groups:owner:warning' => "Warning: if you change this value, you will no longer be the owner of this group.",
@@ -126,8 +129,11 @@ View and reply to the discussion:
 	'groups:access:private' => 'Closed - Users must be invited',
 	'groups:access:public' => 'Open - Any user may join',
 	'groups:access:group' => 'Group members only',
-	'groups:closedgroup' => 'This group has a closed membership.',
-	'groups:closedgroup:request' => 'To ask to be added, click the "request membership" menu link.',
+	'groups:closedgroup' => "This group's membership is closed.",
+	'groups:closedgroup:request' => 'To ask to be added, click the "Request membership" menu link.',
+	'groups:closedgroup:membersonly' => "This group's membership is closed and its content is accessible only by members.",
+	'groups:opengroup:membersonly' => "This group's content is accessible only by members.",
+	'groups:opengroup:membersonly:join' => 'To be a member, click the "Join group" menu link.',
 	'groups:visibility' => 'Who can see this group?',
 
 	/*

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -364,6 +364,7 @@ function groups_entity_menu_setup($hook, $type, $return, $params) {
 		return $return;
 	}
 
+	/* @var ElggGroup $entity */
 	$entity = $params['entity'];
 	$handler = elgg_extract('handler', $params, false);
 	if ($handler != 'groups') {
@@ -377,12 +378,12 @@ function groups_entity_menu_setup($hook, $type, $return, $params) {
 	}
 
 	// membership type
-	$membership = $entity->membership;
-	if ($membership == ACCESS_PUBLIC) {
+	if ($entity->isPublicMembership()) {
 		$mem = elgg_echo("groups:open");
 	} else {
 		$mem = elgg_echo("groups:closed");
 	}
+
 	$options = array(
 		'name' => 'membership',
 		'text' => $mem,

--- a/mod/groups/views/default/groups/profile/closed_membership.php
+++ b/mod/groups/views/default/groups/profile/closed_membership.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Display message about closed membership
+ * Message for non-members on closed membership group profile pages.
  * 
  * @package ElggGroups
  */
 
 ?>
 <p class="mtm">
-<?php 
+<?php
 echo elgg_echo('groups:closedgroup');
 if (elgg_is_logged_in()) {
 	echo ' ' . elgg_echo('groups:closedgroup:request');

--- a/mod/groups/views/default/groups/profile/layout.php
+++ b/mod/groups/views/default/groups/profile/layout.php
@@ -5,9 +5,21 @@
  * @uses $vars['entity']
  */
 
+/* @var ElggGroup $group */
+$group = elgg_extract('entity', $vars);
+
 echo elgg_view('groups/profile/summary', $vars);
+
 if (group_gatekeeper(false)) {
+	if (!$group->isPublicMembership() && !$group->isMember()) {
+		echo elgg_view('groups/profile/closed_membership');
+	}
+
 	echo elgg_view('groups/profile/widgets', $vars);
 } else {
-	echo elgg_view('groups/profile/closed_membership');
+	if ($group->isPublicMembership()) {
+		echo elgg_view('groups/profile/membersonly_open');
+	} else {
+		echo elgg_view('groups/profile/membersonly_closed');
+	}
 }

--- a/mod/groups/views/default/groups/profile/membersonly_closed.php
+++ b/mod/groups/views/default/groups/profile/membersonly_closed.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Message on members only, closed membership group profile pages when user
+ * cannot access group content.
+ *
+ * @package ElggGroups
+ */
+
+?>
+<p class="mtm">
+<?php
+echo elgg_echo('groups:closedgroup:membersonly');
+if (elgg_is_logged_in()) {
+	echo ' ' . elgg_echo('groups:closedgroup:request');
+}
+?>
+</p>

--- a/mod/groups/views/default/groups/profile/membersonly_open.php
+++ b/mod/groups/views/default/groups/profile/membersonly_open.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Message on members only, open membership group profile pages when user
+ * cannot access group content.
+ *
+ * @package ElggGroups
+ */
+
+?>
+<p class="mtm">
+<?php
+echo elgg_echo('groups:opengroup:membersonly');
+if (elgg_is_logged_in()) {
+	echo ' ' . elgg_echo('groups:opengroup:membersonly:join');
+}
+?>
+</p>

--- a/views/default/css/elements/forms.php
+++ b/views/default/css/elements/forms.php
@@ -57,6 +57,11 @@ input[type=text]:focus, textarea:focus {
 .elgg-input-access {
 	margin:5px 0 0 0;
 }
+.elgg-input-access-membersonly {
+	float:right;
+	width:50%;
+	margin:0;
+}
 
 input[type="checkbox"],
 input[type="radio"] {

--- a/views/default/input/access.php
+++ b/views/default/input/access.php
@@ -22,9 +22,23 @@ $defaults = array(
 	'options_values' => get_write_access_array(),
 );
 
-if (isset($vars['entity'])) {
-	$defaults['value'] = $vars['entity']->access_id;
-	unset($vars['entity']);
+/* @var ElggEntity $entity */
+$entity = elgg_extract('entity', $vars);
+unset($vars['entity']);
+
+// should we tell users that public/logged-in access levels will be ignored?
+$container = elgg_get_page_owner_entity();
+if (($container instanceof ElggGroup)
+		&& $container->getGatekeeperMode() === ElggGroup::GATEKEEPER_MODE_MEMBERSONLY
+		&& !elgg_in_context('group-edit')
+		&& !($entity && $entity instanceof ElggGroup)) {
+	$show_override_notice = true;
+} else {
+	$show_override_notice = false;
+}
+
+if ($entity) {
+	$defaults['value'] = $entity->access_id;
 }
 
 $vars = array_merge($defaults, $vars);
@@ -34,5 +48,9 @@ if ($vars['value'] == ACCESS_DEFAULT) {
 }
 
 if (is_array($vars['options_values']) && sizeof($vars['options_values']) > 0) {
+	if ($show_override_notice) {
+		$vars['data-group-acl'] = $container->group_acl;
+		echo "<p class='elgg-input-access-membersonly'>" . elgg_echo('access:overridenotice')  .  "</p>";
+	}
 	echo elgg_view('input/select', $vars);
 }


### PR DESCRIPTION
This succeeds #276 (and #233), rebasing the previous work and adapting it to use the recently-added GroupItemVisibility component. 
- This should implement the item visibility rules shown in the [spreadsheet of doom](https://docs.google.com/a/elgg.org/spreadsheet/ccc?key=0AlAO5SiXoBNGdExuTjgySk1xeDdubm04dmZHU01WQVE#gid=0).
- To group edit form adds "Accessibility of group content" dropdown
- To content edit form adds notice that's always displayed when user has selected an access level that will be overridden by group policy
- Adds basic tests for ElggGroupItemVisibility
- On the group profile, displays several different messages when content is inaccessible for some reason
- On group edit form, properly encodes user names on the dropdown to transfer ownership 
- Adds Elgg_UserStatus component (mainly for unit testing purposes)

The minimal tests pass, but obviously this will need some serious testing.
