### PR TITLE
Refs #4970 prevent Firefox from adding files to TinyMCE editor

### DIFF
--- a/mod/tinymce/views/default/js/tinymce.php
+++ b/mod/tinymce/views/default/js/tinymce.php
@@ -66,6 +66,18 @@ elgg.tinymce.init = function() {
 				var text = elgg.echo('tinymce:word_count') + strip.split(' ').length + ' ';
 				tinymce.DOM.setHTML(tinymce.DOM.get(tinyMCE.activeEditor.id + '_path_row'), text);
 			});
+
+			ed.onInit.add(function(ed) {
+				// prevent Firefox from dragging/dropping files into editor
+				if (tinymce.isGecko) {
+					tinymce.dom.Event.add(ed.getBody().parentNode, "drop", function(e) {
+						if (e.dataTransfer.files.length > 0) {
+							e.preventDefault();
+						}
+					});
+				}
+			});
+
 		},
 		content_css: elgg.config.wwwroot + 'mod/tinymce/css/elgg_tinymce.css'
 	});


### PR DESCRIPTION
In my testing Chrome and IE7 did not support dragging and dropping of files.
