### PR TITLE
Fixes several bugs with the new input/select - fixes #5042

### DIFF
--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -169,12 +169,16 @@ function elgg_clean_vars(array $vars = array()) {
 
 	// backwards compatibility code
 	if (isset($vars['internalname'])) {
-		$vars['name'] = $vars['internalname'];
+		if (!isset($vars['__ignoreInternalname'])) {
+			$vars['name'] = $vars['internalname'];
+		}
 		unset($vars['internalname']);
 	}
 
 	if (isset($vars['internalid'])) {
-		$vars['id'] = $vars['internalid'];
+		if (!isset($vars['__ignoreInternalid'])) {
+			$vars['id'] = $vars['internalid'];
+		}
 		unset($vars['internalid']);
 	}
 

--- a/views/default/input/dropdown.php
+++ b/views/default/input/dropdown.php
@@ -1,9 +1,7 @@
 <?php
 /**
- * Deprecated dropdown input view - use 'input/select' instead.
+ * Alias of 'input/select'.
  *
- * @deprecated 1.9
  */
 
-elgg_deprecated_notice("input/dropdown was deprecated by input/select", 1.9);
 echo elgg_view('input/select', $vars);

--- a/views/default/input/select.php
+++ b/views/default/input/select.php
@@ -3,13 +3,12 @@
  * Elgg select input
  * Displays a select input field
  *
- * @warning Default values of FALSE or NULL will match '' (empty string) but not 0.
+ * @warning Values of FALSE or NULL will match '' (empty string) but not 0.
  *
  * @package Elgg
  * @subpackage Core
  *
- * @uses $vars['value']          The current value or an array of current values (only valid if
- *                               multiselect is used).
+ * @uses $vars['value']          The current value or an array of current values if multiple is true
  * @uses $vars['options']        An array of strings representing the options for the dropdown field
  * @uses $vars['options_values'] An associative array of "value" => "option"
  *                               where "value" is the name and "option" is
@@ -41,6 +40,7 @@ $options = $vars['options'];
 unset($vars['options']);
 
 $value = is_array($vars['value']) ? $vars['value'] : array($vars['value']);
+$value = array_map('strval', $value);
 unset($vars['value']);
 
 $vars['multiple'] = !empty($vars['multiple']);
@@ -71,7 +71,7 @@ if ($options_values) {
 		foreach ($options as $option) {
 
 			$option_attrs = elgg_format_attributes(array(
-				'selected' => in_array((string)$opt_value, $value)
+				'selected' => in_array((string)$option, $value)
 			));
 
 			echo "<option $option_attrs>$option</option>";


### PR DESCRIPTION
- we were overriding $vars['name'] if changed in an input view (in output library) which was breaking multiselect support
- the new input/select view completely broke sending in an array of options
- the string casting was broken
- we deprecated input/pulldown in previous version. Let's give the developers a break and just leave it there as an alias. We can always deprecate it later if it really bothers us.

(Summary - the original pull request for this was a nightmare and should have been tested before merging. The original author certainly never tested it at all since he was adding support for multiselect.)
