### PR TITLE
Fixes #5091: Automatically consider static views cacheable

### DIFF
--- a/engine/classes/Elgg/CacheHandler.php
+++ b/engine/classes/Elgg/CacheHandler.php
@@ -52,7 +52,8 @@ class Elgg_CacheHandler {
 		}
 
 		$this->loadEngine();
-
+		
+		elgg_set_viewtype($viewtype);
 		if (!_elgg_is_view_cacheable($view)) {
 			$this->send403();
 		}

--- a/engine/classes/ElggViewService.php
+++ b/engine/classes/ElggViewService.php
@@ -410,9 +410,23 @@ class ElggViewService {
 		if (isset($CONFIG->views->simplecache[$view])) {
 			return $CONFIG->views->simplecache[$view];	
 		} else {
-			$view_file = $this->getViewLocation($view, 'default') . "default/$view";
-			$CONFIG->views->simplecache[$view] = file_exists($view_file);
-			return $CONFIG->views->simplecache[$view];
+			$currentViewtype = elgg_get_viewtype();
+			$viewtypes = array($currentViewtype);
+			
+			if ($this->doesViewtypeFallback($currentViewtype) && $currentViewtype != 'default') {
+				$viewtypes[] = 'defaut';
+			}
+			
+			// If a static view file is found in any viewtype, it's considered cacheable
+			foreach ($viewtypes as $viewtype) {
+				$view_file = $this->getViewLocation($view, $viewtype) . "$viewtype/$view";
+				if (file_exists($view_file)) {			
+					return true;
+				}
+			}
+			
+			// Assume not-cacheable by default
+			return false;
 		}
 	}
 }

--- a/engine/classes/ElggViewService.php
+++ b/engine/classes/ElggViewService.php
@@ -381,4 +381,38 @@ class ElggViewService {
 	
 		return TRUE;
 	}
+	
+	public function registerCacheableView($view) {
+		global $CONFIG;
+		
+		if (!isset($CONFIG->views)) {
+			$CONFIG->views = new stdClass;
+		}
+
+		if (!isset($CONFIG->views->simplecache)) {
+			$CONFIG->views->simplecache = array();
+		}
+
+		$CONFIG->views->simplecache[$view] = true;
+	}
+	
+	public function isCacheableView($view) {
+		global $CONFIG;
+		
+		if (!isset($CONFIG->views)) {
+			$CONFIG->views = new stdClass;
+		}
+
+		if (!isset($CONFIG->views->simplecache)) {
+			$CONFIG->views->simplecache = array();
+		}
+		
+		if (isset($CONFIG->views->simplecache[$view])) {
+			return $CONFIG->views->simplecache[$view];	
+		} else {
+			$view_file = $this->getViewLocation($view, 'default') . "default/$view";
+			$CONFIG->views->simplecache[$view] = file_exists($view_file);
+			return $CONFIG->views->simplecache[$view];
+		}
+	}
 }

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -238,15 +238,7 @@ function elgg_register_external_view($view, $cacheable = false) {
 	$CONFIG->allowed_ajax_views[$view] = true;
 
 	if ($cacheable) {
-		if (!isset($CONFIG->views)) {
-			$CONFIG->views = new stdClass;
-		}
-
-		if (!isset($CONFIG->views->simplecache)) {
-			$CONFIG->views->simplecache = array();
-		}
-
-		$CONFIG->views->simplecache[] = $view;
+		_elgg_services()->views->registerCacheableView($view);
 	}
 }
 
@@ -259,10 +251,7 @@ function elgg_register_external_view($view, $cacheable = false) {
  * @since 1.9.0
  */
 function _elgg_is_view_cacheable($view) {
-	global $CONFIG;
-	return isset($CONFIG->views) &&
-		isset($CONFIG->views->simplecache) &&
-		in_array($view, $CONFIG->views->simplecache);
+	return _elgg_services()->views->isCacheableView($view);
 }
 
 /**

--- a/engine/tests/phpunit/ElggViewServiceTest.php
+++ b/engine/tests/phpunit/ElggViewServiceTest.php
@@ -53,4 +53,16 @@ class ElggViewServiceTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($this->views->viewExists('js/interpreted.js', 'mobile'));
 		$this->assertEquals('// PHP', $this->views->renderView('js/interpreted.js', array(), false, 'mobile'));
 	}
+	
+	public function testCanRegisterViewsAsCacheable() {
+		$this->assertFalse($this->views->isCacheableView('js/interpreted.js'));
+		
+		$this->views->registerCacheableView('js/interpreted.js');	
+		
+		$this->assertTrue($this->views->isCacheableView('js/interpreted.js'));
+	}
+	
+	public function testStaticViewsAreAlwaysCacheable() {
+		$this->assertTrue($this->views->isCacheableView('js/static.js'));
+	}
 }


### PR DESCRIPTION
Note that this does not auto-recognize static views as accessible via "ajax/view" since I assumed we're switching back to using the /cache/ handler some time soon.

Includes unit tests for ElggViewService + manually end-to-end tested on my private 1.9 instance.
