### PR TITLE
Fixes #5129: Cacheable views always route through cache handler

### DIFF
--- a/engine/classes/Elgg/AmdConfig.php
+++ b/engine/classes/Elgg/AmdConfig.php
@@ -6,15 +6,11 @@
  * @access private
  */
 class Elgg_AmdConfig {
+	private $baseUrl = '';
+	private $dependencies = array();
 
-	protected $dependencies = array();
-	protected $base_path;
-	protected $viewtype;
-	protected $cache_timestamp;
-
-	public function __construct($base_path, $viewtype) {
-		$this->base_path = $base_path;
-		$this->viewtype = $viewtype;
+	public function setBaseUrl($url) {
+		$this->baseUrl = $url;
 	}
 
 	public function addDependency($name) {
@@ -25,22 +21,12 @@ class Elgg_AmdConfig {
 		return array_keys($this->dependencies);
 	}
 
-	public function useSimplecache($cache_timestamp) {
-		$this->cache_timestamp = (int)$cache_timestamp;
-	}
-
 	public function getConfig() {
-		if (null === $this->cache_timestamp) {
-			$config = array(
-				'baseUrl' => "{$this->base_path}ajax/view/js/",
-				'urlArgs' => "view={$this->viewtype}",
-			);
-		} else {
-			$config = array(
-				'baseUrl' => "{$this->base_path}cache/{$this->cache_timestamp}/{$this->viewtype}/js/",
-			);
-		}
-		$config['deps'] = $this->getDependencies();
+		$config = array(
+			'baseUrl' => $this->baseUrl,
+			'deps' => $this->getDependencies(),
+		);
+		
 		return $config;
 	}
 }

--- a/engine/classes/Elgg/CacheHandler.php
+++ b/engine/classes/Elgg/CacheHandler.php
@@ -32,20 +32,26 @@ class Elgg_CacheHandler {
 		// this may/may not have to connect to the DB
 		$this->setupSimplecache();
 
-		if (!$this->config->simplecache_enabled) {
-			$this->send403();
-		}
-
 		$etag = "\"$ts\"";
 		// If is the same ETag, content didn't change.
 		if (isset($server_vars['HTTP_IF_NONE_MATCH']) && trim($server_vars['HTTP_IF_NONE_MATCH']) === $etag) {
 			header("HTTP/1.1 304 Not Modified");
 			exit;
 		}
-
+		
+		
 		$filename = $this->config->dataroot . 'views_simplecache/' . md5("$viewtype|$view");
 
-		if (file_exists($filename)) {
+		if (!$this->config->simplecache_enabled) {
+			$this->loadEngine();
+			if (!_elgg_is_view_cacheable($view)) {
+				$this->send403();
+			} else {
+				$this->sendCacheHeaders($etag);
+				echo elgg_view($view, array(), $viewtype);
+			}
+			exit;
+		} elseif (file_exists($filename)) {
 			$this->sendCacheHeaders($etag);
 			readfile($filename);
 			exit;

--- a/engine/classes/Elgg/CacheHandler.php
+++ b/engine/classes/Elgg/CacheHandler.php
@@ -48,7 +48,7 @@ class Elgg_CacheHandler {
 				$this->send403();
 			} else {
 				$this->sendCacheHeaders($etag);
-				echo elgg_view($view, array(), $viewtype);
+				echo $this->renderView($view, $viewtype);
 			}
 			exit;
 		} elseif (file_exists($filename)) {

--- a/engine/classes/Elgg/ServiceProvider.php
+++ b/engine/classes/Elgg/ServiceProvider.php
@@ -65,11 +65,8 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 	}
 
 	protected function getAmdConfig(Elgg_DIContainer $c) {
-		$base_path = preg_replace('~^https?\://[^/]+~i', '', elgg_get_site_url());
-		$obj = new Elgg_AmdConfig($base_path, elgg_get_viewtype());
-		if (elgg_is_simplecache_enabled()) {
-			$obj->useSimplecache(elgg_get_config('lastcache'));
-		}
+		$obj = new Elgg_AmdConfig();
+		$obj->setBaseUrl(_elgg_get_simplecache_root() . "js/");
 		return $obj;
 	}
 }

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -195,7 +195,24 @@ function elgg_register_simplecache_view($viewname) {
  * @since 1.8.0
  */
 function elgg_get_simplecache_url($type, $view) {
-	return elgg_get_external_view_url("$type/$view");
+	elgg_register_simplecache_view("$type/$view");
+	return _elgg_get_simplecache_root() . "$type/$view";
+}
+
+
+/**
+ * @return string The simplecache root url for the current viewtype.
+ * @access private
+ */
+function _elgg_get_simplecache_root() {
+	$viewtype = elgg_get_viewtype();
+        if (elgg_is_simplecache_enabled()) {
+                $lastcache = elgg_get_config('lastcache');
+        } else {
+                $lastcache = time();
+        }
+
+	return elgg_normalize_url("/cache/$lastcache/$viewtype/");
 }
 
 /**

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -206,11 +206,11 @@ function elgg_get_simplecache_url($type, $view) {
  */
 function _elgg_get_simplecache_root() {
 	$viewtype = elgg_get_viewtype();
-        if (elgg_is_simplecache_enabled()) {
-                $lastcache = elgg_get_config('lastcache');
-        } else {
-                $lastcache = time();
-        }
+	if (elgg_is_simplecache_enabled()) {
+		$lastcache = elgg_get_config('lastcache');
+	} else {
+		$lastcache = time();
+	}
 
 	return elgg_normalize_url("/cache/$lastcache/$viewtype/");
 }

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -266,23 +266,6 @@ function _elgg_is_view_cacheable($view) {
 }
 
 /**
- * Get the correct URL for a given external view.
- * 
- * @param string $view The name of the view (e.g. 'css/elgg')
- * @return string
- * @since 1.9.0
- */
-function elgg_get_external_view_url($view) {
-	$viewtype = elgg_get_viewtype();
-	if (elgg_is_simplecache_enabled() && _elgg_is_view_cacheable($view)) {
-		$lastcache = elgg_get_config('lastcache');
-		return elgg_normalize_url("/cache/$lastcache/$viewtype/$view");
-	} else {
-		return elgg_normalize_url("/ajax/view/$view?view=$viewtype");
-	}
-}
-
-/**
  * Unregister a view for accessibility via URLs.
  * 
  * @param string $view The view name


### PR DESCRIPTION
Also:
- Simplifies AmdConfig to no longer know about simplecache
- Fixes #4451 -- elgg_get_simplecache_url automatically registers the view as cacheable.
