### PR TITLE
Fixes #5090: Possible to register js as shimmed AMD module

### DIFF
--- a/engine/classes/Elgg/AmdConfig.php
+++ b/engine/classes/Elgg/AmdConfig.php
@@ -7,10 +7,28 @@
  */
 class Elgg_AmdConfig {
 	private $baseUrl = '';
+	private $paths = array();
+	private $shim = array();
 	private $dependencies = array();
-
+	
+	
 	public function setBaseUrl($url) {
 		$this->baseUrl = $url;
+	}
+
+	public function setPath($module, $path) {
+		if (preg_match("/\.js$/", $path)) {
+			$path = preg_replace("/\.js$/", '', $path);
+		}
+		
+		$this->paths[$module] = $path;
+	}
+	
+	public function setShim($module, array $shimConfig) {
+		$this->shim[$module] = array(
+			'deps' => $shimConfig['deps'],
+			'exports' => $shimConfig['exports'],
+		);
 	}
 
 	public function addDependency($name) {
@@ -22,11 +40,11 @@ class Elgg_AmdConfig {
 	}
 
 	public function getConfig() {
-		$config = array(
+		return array(
 			'baseUrl' => $this->baseUrl,
+			'paths' => $this->paths,
+			'shim' => $this->shim,
 			'deps' => $this->getDependencies(),
 		);
-		
-		return $config;
 	}
 }

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -117,6 +117,16 @@ function forward($location = "", $reason = 'system') {
  * @since 1.8.0
  */
 function elgg_register_js($name, $url, $location = 'head', $priority = null) {
+	if (is_array($url)) {
+		$config = $url;
+		$url = elgg_extract('src', $config);
+		$location = elgg_extract('location', $config, 'footer');
+		$priority = elgg_extract('priority', $config);
+		
+		_elgg_services()->amdConfig->setShim($name, $config);
+		_elgg_services()->amdConfig->setPath($name, elgg_normalize_url($url));
+	}
+
 	return elgg_register_external_file('js', $name, $url, $location, $priority);
 }
 

--- a/engine/tests/phpunit/Elgg/AmdConfigTest.php
+++ b/engine/tests/phpunit/Elgg/AmdConfigTest.php
@@ -1,0 +1,36 @@
+<?php
+
+class Elgg_AmdConfigTest extends PHPUnit_Framework_TestCase {
+	
+	public function testCanConfigureModulePaths() {
+		$amdConfig = new Elgg_AmdConfig();
+		$amdConfig->setPath('jquery', '/some/path.js');
+		
+		$configArray = $amdConfig->getConfig();
+		
+		$this->assertEquals('/some/path', $configArray['paths']['jquery']);
+	}
+	
+	public function testCanConfigureModuleShims() {
+		$amdConfig = new Elgg_AmdConfig();
+		$amdConfig->setShim('jquery', array(
+			'deps' => array(),
+			'exports' => 'jQuery',
+			'random' => 'stuff',
+		));
+		
+		$configArray = $amdConfig->getConfig();
+		
+		$this->assertEquals('jQuery', $configArray['shim']['jquery']['exports']);
+		$this->assertFalse(isset($configArray['shim']['jquery']['random']));
+	}
+	
+	public function testCanRequireUnregisteredAmdModules() {
+		$amdConfig = new Elgg_AmdConfig();
+		$amdConfig->addDependency('jquery');
+		
+		$configArray = $amdConfig->getConfig();
+		
+		$this->assertEquals(array('jquery'), $configArray['deps']);
+	}
+}


### PR DESCRIPTION
Some caveats:
- If you do not specify an "exports" value, RequireJS will load and run the script even if it has already been loaded on the page in the traditional fashion.
- Setting "exports" to "jQuery.fn.pluginName" does not work. It must be the name of a top-level global variable.
- Shimming does not work with legacy simplecache views right now because their urls do not end in ".js" anymore, which RequireJS expects.
