### PR TITLE
Fixes #5190: Correctly strips duplicate (type)/ from simplecache URL

### DIFF
--- a/js/lib/configuration.js
+++ b/js/lib/configuration.js
@@ -23,6 +23,9 @@ elgg.get_simplecache_url = function(type, view) {
 	} else {
 		lastcache = 0;
 	}
+	if ((type === 'js' || type === 'css') && 0 == view.indexOf(type + '/')) {
+		view = view.substr(type.length + 1);
+	}
 	var path = '/cache/' + lastcache + '/' + elgg.config.viewtype + '/' + type + '/' + view;
 	return elgg.normalize_url(path);
 }


### PR DESCRIPTION
Not sure if this needs to be limited to css/js or not...
