### PR TITLE
Fixes #5058 not forcing a size on an image

### DIFF
--- a/mod/groups/views/default/groups/css.php
+++ b/mod/groups/views/default/groups/css.php
@@ -9,10 +9,6 @@
 .groups-profile > .elgg-image {
 	margin-right: 10px;
 }
-.groups-profile-icon img {
-	width: 100%;
-	height: auto;
-}
 .groups-stats {
 	background: #eeeeee;
 	padding: 5px;

--- a/mod/groups/views/default/groups/profile/summary.php
+++ b/mod/groups/views/default/groups/profile/summary.php
@@ -25,7 +25,14 @@ if (!$owner) {
 <div class="groups-profile clearfix elgg-image-block">
 	<div class="elgg-image">
 		<div class="groups-profile-icon">
-			<?php echo elgg_view_entity_icon($group, 'large', array('href' => '')); ?>
+			<?php
+				// we don't force icons to be square so don't set width/height
+				echo elgg_view_entity_icon($group, 'large', array(
+					'href' => '',
+					'width' => '',
+					'height' => '',
+				)); 
+			?>
 		</div>
 		<div class="groups-stats">
 			<p>

--- a/views/default/icon/default.php
+++ b/views/default/icon/default.php
@@ -44,13 +44,24 @@ if (!isset($vars['height'])) {
 	$vars['height'] = $size != 'master' ? $icon_sizes[$size]['h'] : null;
 }
 
-$img = elgg_view('output/img', array(
+$img_params = array(
 	'src' => $entity->getIconURL($vars['size']),
-	'alt' => $title,
-	'class' => $class,
-	'width' => $vars['width'],
-	'height' => $vars['height'],
-));
+	'alt' => $title,	
+);
+
+if (!empty($class)) {
+	$img_params['class'] = $class;
+}
+
+if (!empty($vars['width'])) {
+	$img_params['width'] = $vars['width'];
+}
+
+if (!empty($vars['height'])) {
+	$img_params['height'] = $vars['height'];
+}
+
+$img = elgg_view('output/img', $img_params);
 
 if ($url) {
 	$params = array(

--- a/views/default/icon/default.php
+++ b/views/default/icon/default.php
@@ -37,12 +37,19 @@ if (isset($vars['href'])) {
 $icon_sizes = elgg_get_config('icon_sizes');
 $size = $vars['size'];
 
+if (!isset($vars['width'])) {
+	$vars['width'] = $size != 'master' ? $icon_sizes[$size]['w'] : null;
+}
+if (!isset($vars['height'])) {
+	$vars['height'] = $size != 'master' ? $icon_sizes[$size]['h'] : null;
+}
+
 $img = elgg_view('output/img', array(
 	'src' => $entity->getIconURL($vars['size']),
 	'alt' => $title,
 	'class' => $class,
-	'width' => $size != 'master' ? $icon_sizes[$size]['w'] : NULL,
-	'height' => $size != 'master' ? $icon_sizes[$size]['h'] : NULL,
+	'width' => $vars['width'],
+	'height' => $vars['height'],
 ));
 
 if ($url) {


### PR DESCRIPTION
Replace a forced size with an unknown size for group profile icons. At some point we should make these entities and store size information on the entity.

I have not tested on IE yet.
