### PR TITLE
Be nice to people named 'pg'

### DIFF
--- a/engine/handlers/page_handler.php
+++ b/engine/handlers/page_handler.php
@@ -35,7 +35,8 @@
 
 // Permanent redirect to pg-less urls
 $url = $_SERVER['REQUEST_URI'];
-$new_url = preg_replace('#^/pg/#', '/', $url, 1);
+$root = parse_url(elgg_get_site_url(), PHP_URL_PATH);
+$new_url = preg_replace("#^{$root}pg/#", '/', $url, 1);
 
 if ($url !== $new_url) {
 	header("HTTP/1.1 301 Moved Permanently");

--- a/engine/handlers/page_handler.php
+++ b/engine/handlers/page_handler.php
@@ -6,7 +6,7 @@
  * from http://site/handler/page1/page2.  The first element after site/ is
  * the page handler name as registered by {@link elgg_register_page_handler()}.
  * The rest of the string is sent to {@link page_handler()}.
- * 
+ *
  * Note that the following handler names are reserved by elgg and should not be
  * registered by any plugins:
  *  * action
@@ -35,11 +35,11 @@
 
 // Permanent redirect to pg-less urls
 $url = $_SERVER['REQUEST_URI'];
-$new_url = preg_replace('#/pg/#', '/', $url, 1);
+$new_url = preg_replace('#^/pg/#', '/', $url, 1);
 
 if ($url !== $new_url) {
-	header("HTTP/1.1 301 Moved Permanently"); 
-	header("Location: $new_url"); 
+	header("HTTP/1.1 301 Moved Permanently");
+	header("Location: $new_url");
 }
 
 require_once(dirname(dirname(__FILE__)) . "/start.php");

--- a/engine/handlers/page_handler.php
+++ b/engine/handlers/page_handler.php
@@ -36,7 +36,7 @@
 // Permanent redirect to pg-less urls
 $url = $_SERVER['REQUEST_URI'];
 $root = parse_url(elgg_get_site_url(), PHP_URL_PATH);
-$new_url = preg_replace("#^{$root}pg/#", '/', $url, 1);
+$new_url = preg_replace("#^{$root}pg/#", $root, $url, 1);
 
 if ($url !== $new_url) {
 	header("HTTP/1.1 301 Moved Permanently");


### PR DESCRIPTION
Hola,

I noticed the `page_handler`'s regular expression to skip `/pg/` actually discriminates any part of an URL's path. E.g., it would break the link to someone's profile called **pg**.

This commit fixes that. It also comes with space fixes, as my Emacs is configured to follow Elgg Coding Standard. I can do two commits if necessary, but the simplicity of the change does not warrant it IMO.
