### PR TITLE
Allow logs to rotate without being deleted

### DIFF
--- a/mod/logrotate/languages/en.php
+++ b/mod/logrotate/languages/en.php
@@ -20,6 +20,7 @@ $english = array(
 	'logrotate:week' => 'week',
 	'logrotate:month' => 'month',
 	'logrotate:year' => 'year',
+	'logrotate:never' => 'never',
 		
 	'logrotate:logdeleted' => "Log deleted\n",
 	'logrotate:lognotdeleted' => "Error deleting log\n",

--- a/mod/logrotate/start.php
+++ b/mod/logrotate/start.php
@@ -21,8 +21,11 @@ function logrotate_init() {
 
 	// Register cron hook for archival of logs
 	elgg_register_plugin_hook_handler('cron', $period, 'logrotate_archive_cron');
-	// Register cron hook for deletion of selected archived logs
-	elgg_register_plugin_hook_handler('cron', $delete, 'logrotate_delete_cron');
+	
+	if ($delete != 'never') {
+		// Register cron hook for deletion of selected archived logs
+		elgg_register_plugin_hook_handler('cron', $delete, 'logrotate_delete_cron');
+	}
 }
 
 /**

--- a/mod/logrotate/views/default/plugins/logrotate/settings.php
+++ b/mod/logrotate/views/default/plugins/logrotate/settings.php
@@ -40,6 +40,7 @@ if (!$delete) {
 				'weekly' => elgg_echo('logrotate:week'),
 				'monthly' => elgg_echo('logrotate:month'),
 				'yearly' => elgg_echo('logrotate:year'),
+				'never' => elgg_echo('logrotate:never'),
 			),
 			'value' => $delete,
 		));


### PR DESCRIPTION
Currently the log rotate plugin only has settings to delete every week/month/year, but if you want to keep all of your logs indefinitely the only option is to disable the plugin and have an ever-expanding single table.  This adds a setting to the delete schedule to allow the logs to rotate without being deleted.
