### PR TITLE
only show notification status if you're a member of the group

### DIFF
--- a/mod/groups/views/default/groups/sidebar/my_status.php
+++ b/mod/groups/views/default/groups/sidebar/my_status.php
@@ -41,7 +41,7 @@ if ($is_owner) {
 }
 
 // notification info
-if (elgg_is_active_plugin('notifications')) {
+if (elgg_is_active_plugin('notifications') && $is_member) {
 	if ($subscribed) {
 		elgg_register_menu_item('groups:my_status', array(
 			'name' => 'subscription_status',


### PR DESCRIPTION
Currently each group shows a link to group notifications with the notification status of the user - this makes no sense if the user isn't a member of the group.
