### PR TITLE
Auto-fixes profile URLs broken by #5232

### DIFF
--- a/mod/profile/views/default/profile/details.php
+++ b/mod/profile/views/default/profile/details.php
@@ -23,6 +23,14 @@ if (is_array($profile_fields) && sizeof($profile_fields) > 0) {
 		$value = $user->$shortname;
 
 		if (!empty($value)) {
+
+			// fix profile URLs populated by https://github.com/Elgg/Elgg/issues/5232
+			// @todo Replace with upgrade script, only need to alter users with last_update after 1.8.13
+			if ($valtype == 'url' && $value == 'http://') {
+				$user->$shortname = '';
+				continue;
+			}
+
 			// validate urls
 			if ($valtype == 'url' && !preg_match('~^https?\://~i', $value)) {
 				$value = "http://$value";


### PR DESCRIPTION
I think it's rude to ask users to edit their profile to fix a bug we introduced, so this just auto-fixes it when the profile is displayed.

If there's opposition to editing the data from the view we could at least not display it.
