### PR TITLE
Refs #5253: Entity attributes are populated on first save()

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1248,7 +1248,7 @@ abstract class ElggEntity extends ElggData implements
 		}
 
 		if ($url == "") {
-			$url = "view/" . $this_guid;
+			$url = "view/" . $this->guid;
 		}
 
 		return elgg_normalize_url($url);
@@ -1404,13 +1404,13 @@ abstract class ElggEntity extends ElggData implements
 		$subtype_id = add_subtype($type, $subtype);
 		$owner_guid = (int)$this->attributes['owner_guid'];
 		$access_id = (int)$this->attributes['access_id'];
-		$time = time();
+		$time = (string)time();
 
 		$site_guid = $this->attributes['site_guid'];
 		if ($site_guid == 0) {
 			$site_guid = $CONFIG->site_guid;
 		}
-		$site_guid = (int) $site_guid;
+		$site_guid = (int)$site_guid;
 		
 		$container_guid = $this->attributes['container_guid'];
 		if ($container_guid == 0) {
@@ -1442,7 +1442,13 @@ abstract class ElggEntity extends ElggData implements
 		}
 	
 		$this->attributes['guid'] = $result;
-		
+		// Q: why string casts? A: to match how they're populated after load
+		$this->attributes['time_created'] = (string)$time;
+		$this->attributes['time_updated'] = (string)$time;
+		$this->attributes['last_action'] = (string)$time;
+		$this->attributes['site_guid'] = (string)$site_guid;
+		$this->attributes['container_guid'] = (string)$container_guid;
+
 		// Save any unsaved metadata
 		// @todo How to capture extra information (access id etc)
 		if (sizeof($this->temp_metadata) > 0) {

--- a/engine/tests/ElggCoreEntityTest.php
+++ b/engine/tests/ElggCoreEntityTest.php
@@ -6,6 +6,12 @@
  * @subpackage Test
  */
 class ElggCoreEntityTest extends ElggCoreUnitTest {
+
+	/**
+	 * @var ElggEntityTest
+	 */
+	protected $entity;
+
 	/**
 	 * Called before each test method.
 	 */
@@ -182,6 +188,13 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 		$attributes = $this->entity->expose_attributes();
 		$this->assertEqual($attributes['guid'], $guid);
 		$this->assertIdentical($ENTITY_CACHE[$guid], $this->entity);
+
+		// check attributes populated during create()
+		$time_minimum = time() - 5;
+		$this->assertTrue($this->entity->time_created > $time_minimum);
+		$this->assertTrue($this->entity->time_updated > $time_minimum);
+		$this->assertEqual($this->entity->site_guid, elgg_get_site_entity()->guid);
+		$this->assertEqual($this->entity->container_guid, elgg_get_logged_in_user_guid());
 
 		// check metadata
 		$metadata = $this->entity->expose_metadata();


### PR DESCRIPTION
This works for 1.9, but 1.8 needs to be reworked to use something like create().
