### PR TITLE
Fixes #5238: More reliably redirect URLs with /pg/

### DIFF
--- a/engine/handlers/page_handler.php
+++ b/engine/handlers/page_handler.php
@@ -35,7 +35,8 @@
 
 // Permanent redirect to pg-less urls
 $url = $_SERVER['REQUEST_URI'];
-$new_url = preg_replace('#^/pg/#', '/', $url, 1);
+$root = parse_url(elgg_get_site_url(), PHP_URL_PATH);
+$new_url = preg_replace("#^{$root}pg/#", '/', $url, 1);
 
 if ($url !== $new_url) {
 	header("HTTP/1.1 301 Moved Permanently");

--- a/engine/handlers/page_handler.php
+++ b/engine/handlers/page_handler.php
@@ -32,18 +32,19 @@
  * @link http://docs.elgg.org/Tutorials/PageHandlers
  */
 
+require_once(dirname(dirname(__FILE__)) . "/start.php");
 
 // Permanent redirect to pg-less urls
-$url = $_SERVER['REQUEST_URI'];
-$root = parse_url(elgg_get_site_url(), PHP_URL_PATH);
-$new_url = preg_replace("#^{$root}pg/#", $root, $url, 1);
+$uri = $_SERVER['REQUEST_URI'];
+$site_path = parse_url(elgg_get_site_url(), PHP_URL_PATH);
+$site_path_quoted = preg_quote($site_path, '#');
+$new_uri = preg_replace("#^{$site_path_quoted}pg/#", $site_path, $uri, 1);
 
-if ($url !== $new_url) {
+if ($uri !== $new_uri) {
 	header("HTTP/1.1 301 Moved Permanently");
-	header("Location: $new_url");
+	header("Location: $new_uri");
+	exit;
 }
-
-require_once(dirname(dirname(__FILE__)) . "/start.php");
 
 $handler = get_input('handler');
 $page = get_input('page');

--- a/engine/handlers/page_handler.php
+++ b/engine/handlers/page_handler.php
@@ -6,7 +6,7 @@
  * from http://site/handler/page1/page2.  The first element after site/ is
  * the page handler name as registered by {@link elgg_register_page_handler()}.
  * The rest of the string is sent to {@link page_handler()}.
- * 
+ *
  * Note that the following handler names are reserved by elgg and should not be
  * registered by any plugins:
  *  * action
@@ -35,11 +35,11 @@
 
 // Permanent redirect to pg-less urls
 $url = $_SERVER['REQUEST_URI'];
-$new_url = preg_replace('#/pg/#', '/', $url, 1);
+$new_url = preg_replace('#^/pg/#', '/', $url, 1);
 
 if ($url !== $new_url) {
-	header("HTTP/1.1 301 Moved Permanently"); 
-	header("Location: $new_url"); 
+	header("HTTP/1.1 301 Moved Permanently");
+	header("Location: $new_url");
 }
 
 require_once(dirname(dirname(__FILE__)) . "/start.php");

--- a/engine/handlers/page_handler.php
+++ b/engine/handlers/page_handler.php
@@ -36,7 +36,7 @@
 // Permanent redirect to pg-less urls
 $url = $_SERVER['REQUEST_URI'];
 $root = parse_url(elgg_get_site_url(), PHP_URL_PATH);
-$new_url = preg_replace("#^{$root}pg/#", '/', $url, 1);
+$new_url = preg_replace("#^{$root}pg/#", $root, $url, 1);
 
 if ($url !== $new_url) {
 	header("HTTP/1.1 301 Moved Permanently");


### PR DESCRIPTION
This replaces #5238. Biggest different from master is that the redirect has to happen _after_ start.php. I think it's worth it to redirect more accurately though.
