### PR TITLE
Add rel="nofollow" to links using parse_urls()

### DIFF
--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -8,6 +8,19 @@
  */
 
 /**
+ * elgg_get_site_host -- Extract installation host
+ *
+ * @return String the site hostname
+ */
+function elgg_get_site_host() {
+	static $elgg_host;
+	if (is_null($elgg_host)) {
+		$elgg_host = parse_url(elgg_get_site_url(), PHP_URL_HOST);
+	}
+	return $elgg_host;
+}
+
+/**
  * Takes a string and turns any URLs into formatted links
  *
  * @param string $text The input string
@@ -15,30 +28,31 @@
  * @return string The output string with formatted links
  **/
 function parse_urls($text) {
-	// @todo this causes problems with <attr = "val">
-	// must be in <attr="val"> format (no space).
-	// By default htmlawed rewrites tags to this format.
-	// if PHP supported conditional negative lookbehinds we could use this:
-	// $r = preg_replace_callback('/(?<!=)(?<![ ])?(?<!["\'])((ht|f)tps?:\/\/[^\s\r\n\t<>"\'\!\(\),]+)/i',
-	//
-	// we can put , in the list of excluded char but need to keep . because of domain names.
-	// it is removed in the callback.
-	$r = preg_replace_callback('/(?<!=)(?<!["\'])((ht|f)tps?:\/\/[^\s\r\n\t<>"\'\!\(\),]+)/i',
-	create_function(
-		'$matches',
-		'
-			$url = $matches[1];
-			$period = \'\';
-			if (substr($url, -1, 1) == \'.\') {
-				$period = \'.\';
-				$url = trim($url, \'.\');
-			}
-			$urltext = str_replace("/", "/<wbr />", $url);
-			return "<a href=\"$url\">$urltext</a>$period";
-		'
-	), $text);
 
-	return $r;
+	// Extract all naked URLs and link them
+
+	$regex     = '#(\b\S*(https?|ftps?|irc|mailto|news|xmpp):\S*\b)([\.\s]*)#';
+
+	return preg_replace_callback(
+		$regex,
+		function($matches) {
+			$host      = parse_url($matches[1], PHP_URL_HOST);
+			$site_host = elgg_get_site_host();
+			$scheme    = preg_quote($matches[2]);
+
+			$options = array(
+				'href'       => $matches[1],
+				'text'       => preg_replace("#^{$scheme}:[/]*#", '', $matches[1]),
+				'is_trusted' => ($host == $site_host),
+				'class'      => array($scheme),
+			);
+			$link = sprintf('%s%s',
+							elgg_view('output/url', $options),
+							$matches[3]);
+			return $link;
+		},
+		$text);
+
 }
 
 /**
@@ -235,7 +249,7 @@ function elgg_normalize_url($url) {
 		// '//example.com' (Shortcut for protocol.)
 		// '?query=test', #target
 		return $url;
-	
+
 	} elseif (stripos($url, 'javascript:') === 0 || stripos($url, 'mailto:') === 0) {
 		// 'javascript:' and 'mailto:'
 		// Not covered in FILTER_VALIDATE_URL
@@ -297,7 +311,7 @@ function elgg_get_friendly_title($title) {
  * @since 1.7.2
  */
 function elgg_get_friendly_time($time, $current_time = null) {
-	
+
 	if (!$current_time) {
 		$current_time = time();
 	}
@@ -318,7 +332,7 @@ function elgg_get_friendly_time($time, $current_time = null) {
 	if ($diff < $minute) {
 		return elgg_echo("friendlytime:justnow");
 	}
-	
+
 	if ($diff < $hour) {
 		$granularity = ':minutes';
 		$diff = round($diff / $minute);
@@ -333,7 +347,7 @@ function elgg_get_friendly_time($time, $current_time = null) {
 	if ($diff == 0) {
 		$diff = 1;
 	}
-	
+
 	$future = ((int)$current_time - (int)$time < 0) ? ':future' : '';
 	$singular = ($diff == 1) ? ':singular' : '';
 

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -256,8 +256,8 @@ function elgg_normalize_url($url) {
 		// '?query=test', #target
 		return $url;
 
-	} elseif (stripos($url, 'javascript:') === 0 || stripos($url, 'mailto:') === 0) {
-		// 'javascript:' and 'mailto:'
+	} elseif (stripos($url, 'javascript:') === 0 || stripos($url, 'mailto:') === 0 || stripos($url, 'xmpp:')) {
+		// 'javascript:', 'mailto:', and 'xmpp:'
 		// Not covered in FILTER_VALIDATE_URL
 		return $url;
 

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -11,6 +11,7 @@
  * elgg_get_site_host -- Extract installation host
  *
  * @return String the site hostname
+ * @access private
  */
 function elgg_get_site_host() {
 	static $elgg_host;
@@ -31,26 +32,29 @@ function parse_urls($text) {
 
 	// Extract all naked URLs and link them
 
-	$regex     = '#(\b\S*(https?|ftps?|irc|mailto|news|xmpp):\S*\b)([\.\s]*)#';
+	$regex     = '#(\b\S*(https?|ftps?|irc|mailto|news|xmpp):\S*\b)([\.\s]*)#i';
 
 	return preg_replace_callback(
 		$regex,
-		function($matches) {
-			$host      = parse_url($matches[1], PHP_URL_HOST);
-			$site_host = elgg_get_site_host();
-			$scheme    = preg_quote($matches[2]);
+		create_function() {
+			'$matches',
+				'
+			$host       = parse_url($matches[1], PHP_URL_HOST);
+			$is_trusted = ($host == elgg_get_site_host());
+			$scheme     = preg_quote($matches[2]);
 
 			$options = array(
-				'href'       => $matches[1],
-				'text'       => preg_replace("#^{$scheme}:[/]*#", '', $matches[1]),
-				'is_trusted' => ($host == $site_host),
-				'class'      => array($scheme),
+				"class"      => array("elgg-link-$scheme"),
+				"href"       => $matches[1],
+				"text"       => preg_replace("#^{$scheme}:[/]*#", "", $matches[1]),
+				"is_trusted" => $is_trusted,
 			);
-			$link = sprintf('%s%s',
-							elgg_view('output/url', $options),
+			$link = sprintf("%s%s",
+							elgg_view("output/url", $options),
 							$matches[3]);
 			return $link;
-		},
+			'
+				},
 		$text);
 
 }

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -36,9 +36,9 @@ function parse_urls($text) {
 
 	return preg_replace_callback(
 		$regex,
-		create_function() {
+		create_function(
 			'$matches',
-				'
+			'
 			$host       = parse_url($matches[1], PHP_URL_HOST);
 			$is_trusted = ($host == elgg_get_site_host());
 			$scheme     = preg_quote($matches[2]);
@@ -54,7 +54,7 @@ function parse_urls($text) {
 							$matches[3]);
 			return $link;
 			'
-				},
+		),
 		$text);
 
 }

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -32,26 +32,28 @@ function parse_urls($text) {
 
 	// Extract all naked URLs and link them
 
-	$regex     = '#(\b\S*(https?|ftps?|irc|mailto|news|xmpp):\S*\b)([\.\s]*)#i';
+	$regex     = '#(\b\S*)((https?|ftps?|ircs?|mailto|news|xmpp):\S*\b/?)([\.\s]*)#ui';
 
 	return preg_replace_callback(
 		$regex,
 		create_function(
 			'$matches',
 			'
-			$host       = parse_url($matches[1], PHP_URL_HOST);
+			$host       = parse_url($matches[2], PHP_URL_HOST);
 			$is_trusted = ($host == elgg_get_site_host());
-			$scheme     = preg_quote($matches[2]);
+			$scheme     = preg_quote($matches[3]);
 
 			$options = array(
 				"class"      => array("elgg-link-$scheme"),
-				"href"       => $matches[1],
-				"text"       => preg_replace("#^{$scheme}:[/]*#", "", $matches[1]),
+				"href"       => $matches[2],
+				"text"       => preg_replace("#^{$scheme}:[/]*#", "", $matches[2]),
 				"is_trusted" => $is_trusted,
 			);
-			$link = sprintf("%s%s",
-							elgg_view("output/url", $options),
-							$matches[3]);
+			$link = sprintf(
+						"%s%s%s",
+						$matches[1],
+						elgg_view("output/url", $options),
+						$matches[4]);
 			return $link;
 			'
 		),

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -256,7 +256,7 @@ function elgg_normalize_url($url) {
 		// '?query=test', #target
 		return $url;
 
-	} elseif (stripos($url, 'javascript:') === 0 || stripos($url, 'mailto:') === 0 || stripos($url, 'xmpp:')) {
+	} elseif (stripos($url, 'javascript:') === 0 || stripos($url, 'mailto:') === 0 || stripos($url, 'xmpp:') === 0) {
 		// 'javascript:', 'mailto:', and 'xmpp:'
 		// Not covered in FILTER_VALIDATE_URL
 		return $url;

--- a/engine/tests/ElggCoreRegressionBugsTest.php
+++ b/engine/tests/ElggCoreRegressionBugsTest.php
@@ -247,52 +247,52 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 
 		// Support HTTP
 		$case   = "http://example.com";
-		$expect = '<a class="elgg-link-http" href="http://example.com" rel="nofollow">example.com</a>';
+		$expect = '<a href="http://example.com" rel="nofollow">example.com</a>';
 		$this->assertEqual($expect, parse_urls($case));
 
 		// Support HTTPS
 		$case   = "https://example.com";
-		$expect = '<a class="elgg-link-https" href="https://example.com" rel="nofollow">example.com</a>';
+		$expect = '<a href="https://example.com" rel="nofollow">example.com</a>';
 		$this->assertEqual($expect, parse_urls($case));
 
 		// Support multiple links
 		$case   = "Both insecure http://example.com and secure https://example.com";
-		$expect = 'Both insecure <a class="elgg-link-http" href="http://example.com" rel="nofollow">example.com</a> and secure <a class="elgg-link-https" href="https://example.com" rel="nofollow">example.com</a>';
+		$expect = 'Both insecure <a href="http://example.com" rel="nofollow">example.com</a> and secure <a href="https://example.com" rel="nofollow">example.com</a>';
 		$this->assertEqual($expect, parse_urls($case));
 
 		// Keep trailing slash
 		$case   = "http://example.com/";
-		$expect = '<a class="elgg-link-http" href="http://example.com/" rel="nofollow">example.com/</a>';
+		$expect = '<a href="http://example.com/" rel="nofollow">example.com/</a>';
 		$this->assertEqual($expect, parse_urls($case));
 
 		// Support FTP and FTPS
 		$case   = "FTP: ftp://ftp.example.com/, or ftps://ftp.example.com/.";
-		$expect = 'FTP: <a class="elgg-link-ftp" href="ftp://ftp.example.com/" rel="nofollow">ftp.example.com/</a>, or <a class="elgg-link-ftps" href="ftps://ftp.example.com/" rel="nofollow">ftp.example.com/</a>.';
+		$expect = 'FTP: <a href="ftp://ftp.example.com/" rel="nofollow">ftp.example.com/</a>, or <a href="ftps://ftp.example.com/" rel="nofollow">ftp.example.com/</a>.';
 		$this->assertEqual($expect, parse_urls($case));
 
 		// Support IRC and IRCS
 		$case   = "IRC: irc://irc.example.com/, or ircs://irc.freenode.net/#elgg.";
-		$expect = 'IRC: <a class="elgg-link-irc" href="irc://irc.example.com/" rel="nofollow">irc.example.com/</a>, or <a class="elgg-link-ircs" href="ircs://irc.freenode.net/#elgg" rel="nofollow">irc.freenode.net/#elgg</a>.';
+		$expect = 'IRC: <a href="irc://irc.example.com/" rel="nofollow">irc.example.com/</a>, or <a href="ircs://irc.freenode.net/#elgg" rel="nofollow">irc.freenode.net/#elgg</a>.';
 		$this->assertEqual($expect, parse_urls($case));
 
 		// Support XMPP links
 		$case   = "XMPP: xmpp:example.com/, or xmpp:room.example.com/welcome.";
-		$expect = 'XMPP: <a class="elgg-link-xmpp" href="xmpp:example.com/" rel="nofollow">example.com/</a>, or <a class="elgg-link-xmpp" href="xmpp:room.example.com/welcome" rel="nofollow">room.example.com/welcome</a>.';
+		$expect = 'XMPP: <a href="xmpp:example.com/" rel="nofollow">example.com/</a>, or <a href="xmpp:room.example.com/welcome" rel="nofollow">room.example.com/welcome</a>.';
 		$this->assertEqual($expect, parse_urls($case));
 
 		// Support Email links
 		$case   = "mailto:joe@example.com, or <mailto:jane@example.net>.";
-		$expect = '<a class="elgg-link-mailto" href="mailto:joe@example.com" rel="nofollow">joe@example.com</a>, or <<a class="elgg-link-mailto" href="mailto:jane@example.net" rel="nofollow">jane@example.net</a>>.';
+		$expect = '<a href="mailto:joe@example.com" rel="nofollow">joe@example.com</a>, or <<a href="mailto:jane@example.net" rel="nofollow">jane@example.net</a>>.';
 		$this->assertEqual($expect, parse_urls($case));
 
 		// Support query strings
 		$case   = "http://example.com/to?q=moo, works.";
-		$expect = '<a class="elgg-link-http" href="http://example.com/to?q=moo" rel="nofollow">example.com/to?q=moo</a>, works.';
+		$expect = '<a href="http://example.com/to?q=moo" rel="nofollow">example.com/to?q=moo</a>, works.';
 		$this->assertEqual($expect, parse_urls($case));
 
 		// Support prefix and suffix
 		$case   = "test,http://test.example.net test, and http://foo.example.org...";
-		$expect = 'test,<a class="elgg-link-http" href="http://test.example.net" rel="nofollow">test.example.net</a> test, and <a class="elgg-link-http" href="http://foo.example.org" rel="nofollow">foo.example.org</a>...';
+		$expect = 'test,<a href="http://test.example.net" rel="nofollow">test.example.net</a> test, and <a href="http://foo.example.org" rel="nofollow">foo.example.org</a>...';
 		$this->assertEqual($expect, parse_urls($case));
 
 		// Support multiline text
@@ -303,9 +303,9 @@ hop mailto:foo@example.net
 and have fun.
 ";
 		$expect = "
-Hop <a class=\"elgg-link-http\" href=\"http://example.net\" rel=\"nofollow\">example.net</a>,
+Hop <a href=\"http://example.net\" rel=\"nofollow\">example.net</a>,
 hop
-hop <a class=\"elgg-link-mailto\" href=\"mailto:foo@example.net\" rel=\"nofollow\">foo@example.net</a>
+hop <a href=\"mailto:foo@example.net\" rel=\"nofollow\">foo@example.net</a>
 and have fun.
 ";
 		$this->assertEqual($expect, parse_urls($case));

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -1,9 +1,9 @@
 <?php
 /**
  * Elgg wire plugin
- * 
+ *
  * Forked from Curverider's version
- * 
+ *
  * JHU/APL Contributors:
  * Cash Costello
  * Clark Updike
@@ -35,7 +35,7 @@ function thewire_init() {
 
 	// remove edit and access and add thread, reply, view previous
 	elgg_register_plugin_hook_handler('register', 'menu:entity', 'thewire_setup_entity_menu_items');
-	
+
 	// Extend system CSS with our own styles, which are defined in the thewire/css view
 	elgg_extend_view('css/elgg', 'thewire/css');
 
@@ -150,7 +150,7 @@ function thewire_page_handler($page) {
 
 /**
  * Override the url for a wire post to return the thread
- * 
+ *
  * @param ElggObject $thewirepost Wire post object
  */
 function thewire_url($thewirepost) {
@@ -165,7 +165,7 @@ function thewire_url($thewirepost) {
  */
 function thewire_notify_message($hook, $entity_type, $returnvalue, $params) {
 	global $CONFIG;
-	
+
 	$entity = $params['entity'];
 	if (($entity instanceof ElggEntity) && ($entity->getSubtype() == 'thewire')) {
 		$descr = $entity->description;
@@ -189,7 +189,7 @@ function thewire_notify_message($hook, $entity_type, $returnvalue, $params) {
 
 /**
  * Get an array of hashtags from a text string
- * 
+ *
  * @param string $text The text of a post
  * @return array
  */
@@ -203,22 +203,14 @@ function thewire_get_hashtags($text) {
 
 /**
  * Replace urls, hash tags, and @'s by links
- * 
+ *
  * @param string $text The text of a post
  * @return string
  */
 function thewire_filter($text) {
 	global $CONFIG;
 
-	$text = ' ' . $text;
-
-	// email addresses
-	$text = preg_replace(
-				'/(^|[^\w])([\w\-\.]+)@(([0-9a-z-]+\.)+[0-9a-z]{2,})/i',
-				'$1<a href="mailto:$2@$3">$2@$3</a>',
-				$text);
-
-	// links
+	// links and email addresses
 	$text = parse_urls($text);
 
 	// usernames
@@ -281,7 +273,7 @@ function thewire_save_post($text, $userid, $access_id, $parent_guid = 0, $method
 	// set thread guid
 	if ($parent_guid) {
 		$post->addRelationship($parent_guid, 'parent');
-		
+
 		// name conversation threads by guid of first post (works even if first post deleted)
 		$parent_post = get_entity($parent_guid);
 		$post->wire_thread = $parent_post->wire_thread;
@@ -303,7 +295,7 @@ function thewire_save_post($text, $userid, $access_id, $parent_guid = 0, $method
 		);
 		elgg_trigger_plugin_hook('status', 'user', $params);
 	}
-	
+
 	return $guid;
 }
 
@@ -350,7 +342,7 @@ function thewire_send_response_notification($guid, $parent_guid, $user) {
 
 /**
  * Get the latest wire guid - used for ajax update
- * 
+ *
  * @return guid
  */
 function thewire_latest_guid() {
@@ -368,9 +360,9 @@ function thewire_latest_guid() {
 
 /**
  * Get the parent of a wire post
- * 
+ *
  * @param int $post_guid The guid of the reply
- * @return ElggObject or null 
+ * @return ElggObject or null
  */
 function thewire_get_parent($post_guid) {
 	$parents = elgg_get_entities_from_relationship(array(
@@ -471,7 +463,7 @@ function thewire_test($hook, $type, $value, $params) {
 function thewire_run_upgrades() {
 	$path = dirname(__FILE__) . '/upgrades/';
 	$files = elgg_get_upgrade_files($path);
-	
+
 	foreach ($files as $file) {
 		include $path . $file;
 	}

--- a/mod/thewire/tests/regex.php
+++ b/mod/thewire/tests/regex.php
@@ -69,7 +69,7 @@ class TheWireRegexTest extends ElggCoreUnitTest {
 	 * @return string
 	 */
 	protected function getEmailLink($address) {
-		return "<a href=\"mailto:$address\">$address</a>";
+		return parse_urls($address);
 	}
 
 	/**
@@ -103,7 +103,7 @@ class TheWireRegexTest extends ElggCoreUnitTest {
 		$expected = "test " . $this->getUserWireLink('user') . ", test";
 		$result = thewire_filter($text);
 		$this->assertEqual($result, $expected);
-		
+
 		// preceded by comma
 		$text = "test ,@user test";
 		$expected = "test ," . $this->getUserWireLink('user') . " test";


### PR DESCRIPTION
Should fix #5244.

I have an issue though with the `class` attributes passed to `output/url`: it doesn't seem to ever reach destination, and the class is not set for the link type (according to the URL's scheme).

Another issue (maybe coming from HTMLawed?) is that IRC links are prepended with "denied:". Probably a configuration setting somewhere.
