### PR TITLE
Prevent break of pagination elements when wrapped

### DIFF
--- a/views/default/css/elements/navigation.php
+++ b/views/default/css/elements/navigation.php
@@ -17,7 +17,6 @@
 }
 .elgg-pagination li {
 	display: inline-block;
-	height: 16px;
 	margin: 0 6px 0 0;
 	text-align: center;
 }
@@ -25,7 +24,8 @@
 	-webkit-border-radius: 4px;
 	-moz-border-radius: 4px;
 	border-radius: 4px;
-	
+
+	display: block;
 	padding: 2px 6px;
 	color: #4690d6;
 	border: 1px solid #4690d6;

--- a/views/default/css/elements/navigation.php
+++ b/views/default/css/elements/navigation.php
@@ -16,7 +16,8 @@
 	text-align: center;
 }
 .elgg-pagination li {
-	display: inline;
+	display: inline-block;
+	height: 16px;
 	margin: 0 6px 0 0;
 	text-align: center;
 }

--- a/views/default/css/ie7.php
+++ b/views/default/css/ie7.php
@@ -24,6 +24,7 @@
 .elgg-menu-footer > li > a,
 .elgg-menu-footer li,
 .elgg-menu-general > li > a,
+.elgg-pagination li,
 .elgg-menu-general li {
 	display: inline;
 }


### PR DESCRIPTION
This rebases #5271 for 1.8. Since the LIs are inline-block, I eliminated the height and made the inner links/spans display:block in order to prevent these elements from overlapping when wrapped.

Have not tested on IE yet.
