### PR TITLE
Allow pages revisions to be reverted or deleted

### DIFF
--- a/actions/comments/delete.php
+++ b/actions/comments/delete.php
@@ -5,11 +5,6 @@
  * @package Elgg
  */
 
-// Ensure we're logged in
-if (!elgg_is_logged_in()) {
-	forward();
-}
-
 // Make sure we can get the comment in question
 $annotation_id = (int) get_input('annotation_id');
 $comment = elgg_get_annotation_from_id($annotation_id);

--- a/mod/pages/actions/annotations/page/delete.php
+++ b/mod/pages/actions/annotations/page/delete.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Remove a page (revision) annotation
+ *
+ * @package ElggPages
+ */
+
+// Ensure we're logged in
+if (!elgg_is_logged_in()) {
+	forward();
+}
+
+// Make sure we can get the annotations and entity in question
+$annotation_id = (int) get_input('annotation_id');
+$annotation = elgg_get_annotation_from_id($annotation_id);
+$entity = get_entity($annotation->entity_guid);
+
+if ($annotation && $entity->canEdit() && $annotation->canEdit()) {
+	$annotation->delete();
+	system_message(elgg_echo("pages:revision:delete:success"));
+} else {
+	register_error(elgg_echo("pages:revision:delete:failure"));
+}
+
+forward("pages/history/{$annotation->entity_guid}");

--- a/mod/pages/actions/annotations/page/delete.php
+++ b/mod/pages/actions/annotations/page/delete.php
@@ -5,11 +5,6 @@
  * @package ElggPages
  */
 
-// Ensure we're logged in
-if (!elgg_is_logged_in()) {
-	forward();
-}
-
 // Make sure we can get the annotations and entity in question
 $annotation_id = (int) get_input('annotation_id');
 $annotation = elgg_get_annotation_from_id($annotation_id);

--- a/mod/pages/languages/en.php
+++ b/mod/pages/languages/en.php
@@ -25,6 +25,8 @@ $english = array(
 	'pages:history' => "History",
 	'pages:view' => "View page",
 	'pages:revision' => "Revision",
+	'pages:current_revision' => "Current Revision",
+	'pages:revert' => "Revert",
 
 	'pages:navigation' => "Navigation",
 	'pages:new' => "A new page",
@@ -75,6 +77,9 @@ View and comment on the new page:
 	'pages:error:no_title' => 'You must specify a title for this page.',
 	'pages:delete:success' => 'The page was successfully deleted.',
 	'pages:delete:failure' => 'The page could not be deleted.',
+	'pages:revision:delete:success' => 'The page revision was successfully deleted.',
+	'pages:revision:delete:failure' => 'The page revision could not be deleted.',
+	'pages:revision:not_found' => 'Cannot find this revision.',
 
 	/**
 	 * Page

--- a/mod/pages/lib/pages.php
+++ b/mod/pages/lib/pages.php
@@ -9,7 +9,7 @@
  * @param ElggObject $page
  * @return array
  */
-function pages_prepare_form_vars($page = null, $parent_guid = 0) {
+function pages_prepare_form_vars($page = null, $parent_guid = 0, $revision = null) {
 
 	// input names => defaults
 	$values = array(
@@ -40,6 +40,11 @@ function pages_prepare_form_vars($page = null, $parent_guid = 0) {
 	}
 
 	elgg_clear_sticky_form('page');
+
+	// load the revision annotation if requested
+	if ($revision instanceof ElggAnnotation && $revision->entity_guid == $page->getGUID()) {
+		$values['description'] = $revision->value;
+	}
 
 	return $values;
 }

--- a/mod/pages/pages/pages/edit.php
+++ b/mod/pages/pages/pages/edit.php
@@ -8,6 +8,7 @@
 gatekeeper();
 
 $page_guid = (int)get_input('guid');
+$revision = (int)get_input('annotation_id');
 $page = get_entity($page_guid);
 if (!$page) {
 	register_error(elgg_echo('noaccess'));
@@ -28,7 +29,17 @@ elgg_push_breadcrumb(elgg_echo('edit'));
 $title = elgg_echo("pages:edit");
 
 if ($page->canEdit()) {
-	$vars = pages_prepare_form_vars($page);
+
+	if ($revision) {
+		$revision = elgg_get_annotation_from_id($revision);
+		if (!$revision || !($revision->entity_guid == $page_guid)) {
+			register_error(elgg_echo('pages:revision:not_found'));
+			forward(REFERER);
+		}
+	}
+
+	$vars = pages_prepare_form_vars($page, $page->parent_guid, $revision);
+	
 	$content = elgg_view_form('pages/edit', array(), $vars);
 } else {
 	$content = elgg_echo("pages:noaccess");

--- a/mod/pages/views/default/annotation/page.php
+++ b/mod/pages/views/default/annotation/page.php
@@ -39,4 +39,22 @@ $body = <<< HTML
 <p class="elgg-subtext">$subtitle</p>
 HTML;
 
+if (!elgg_in_context('widgets')) {
+	$menu = elgg_view_menu('annotation', array(
+		'annotation' => $annotation,
+		'sort_by' => 'priority',
+		'class' => 'elgg-menu-hz float-alt',
+	));
+}
+
+$body = <<<HTML
+<div class="mbn">
+	$menu
+	<h3>$title_link</h3>
+	<span class="elgg-subtext">
+		$subtitle
+	</span>
+</div>
+HTML;
+
 echo elgg_view_image_block($icon, $body);

--- a/mod/pages/views/default/object/page_top.php
+++ b/mod/pages/views/default/object/page_top.php
@@ -60,18 +60,26 @@ if ($comments_count != 0 && !$revision) {
 	$comments_link = '';
 }
 
-$metadata = elgg_view_menu('entity', array(
-	'entity' => $vars['entity'],
-	'handler' => 'pages',
-	'sort_by' => 'priority',
-	'class' => 'elgg-menu-hz',
-));
-
 $subtitle = "$editor_text $comments_link $categories";
 
 // do not show the metadata and controls in widget view
-if (elgg_in_context('widgets') || $revision) {
-	$metadata = '';
+if (!elgg_in_context('widgets')) {
+	// If we're looking at a revision, display annotation menu
+	if ($revision) {
+		$metadata = elgg_view_menu('annotation', array(
+			'annotation' => $annotation,
+			'sort_by' => 'priority',
+			'class' => 'elgg-menu-hz float-alt',
+		));
+	} else {
+		// Regular entity menu
+		$metadata = elgg_view_menu('entity', array(
+			'entity' => $vars['entity'],
+			'handler' => 'pages',
+			'sort_by' => 'priority',
+			'class' => 'elgg-menu-hz',
+		));
+	}
 }
 
 if ($full) {

--- a/mod/pages/views/default/pages/sidebar/history.php
+++ b/mod/pages/views/default/pages/sidebar/history.php
@@ -14,6 +14,7 @@ if ($vars['page']) {
 		'limit' => 20,
 		'reverse_order_by' => true
 	);
+	elgg_push_context('widgets');
 	$content = elgg_list_annotations($options);
 }
 


### PR DESCRIPTION
User's can delete/revert page revisions if they have access to both the annotation and the page entity.
