### PR TITLE
fixes duplicate wordcount bug when multiple longtext inputs are rendered...

### DIFF
--- a/mod/ckeditor/views/default/js/elgg/ckeditor.js
+++ b/mod/ckeditor/views/default/js/elgg/ckeditor.js
@@ -34,11 +34,13 @@ define(function(require) {
 		 * @return void
 		 */
 		wordCount: function() {
-			$('#cke_bottom_' + this.name).prepend(
-				'<div id="cke_wordcount_' + this.name + '" class="cke_wordcount">' + 
-					elgg.echo('ckeditor:word_count') + '0' +
-				'</div>'   
-			);
+			if ($('#cke_wordcount_'+this.name).length == 0) {
+				$('#cke_bottom_' + this.name).prepend(
+					'<div id="cke_wordcount_' + this.name + '" class="cke_wordcount">' + 
+						elgg.echo('ckeditor:word_count') + '0' +
+					'</div>'   
+				);
+			}
 			this.document.on('keyup', function(event) {
 				//show the number of words
 				var words = this.getBody().getText().trim().split(' ').length;


### PR DESCRIPTION
... on the same page

ckeditor has the same number of wordcount divs as there are editors on the page.  Eg. if there are 3 longtext inputs, each input will have three wordcounts at the bottom.
This just checks whether a wordcount is already in place for the editor before trying to add a new one.
