### PR TITLE
More DIContainer refactoring

### DIFF
--- a/engine/classes/Elgg/DIContainer.php
+++ b/engine/classes/Elgg/DIContainer.php
@@ -102,42 +102,42 @@ class Elgg_DIContainer {
 	/**
 	 * Set a factory to generate a value when the container is read.
 	 *
-	 * @param string   $name    The name of the value
-	 * @param callable $factory Factory for the value
-	 * @param bool     $shared  Whether the same value should be returned for every request
+	 * @param string   $name     The name of the value
+	 * @param callable $callable Factory for the value
+	 * @param bool     $shared   Whether the same value should be returned for every request
 	 * @return Elgg_DIContainer
 	 * @throws InvalidArgumentException
 	 */
-	public function setFactory($name, $factory, $shared = true) {
-		if (!is_callable($factory, true)) {
+	public function setFactory($name, $callable, $shared = true) {
+		if (!is_callable($callable, true)) {
 			throw new InvalidArgumentException('$factory must appear callable');
 		}
 		$this->remove($name);
 		$this->factories[$name] = array(
-			'callable' => $factory,
+			'callable' => $callable,
 			'shared' => $shared
 		);
 		return $this;
 	}
 
 	/**
-	 * Set simple factories based on class names. 
-	 * 
-	 * @param array $map map of container names to class names
+	 * Set a factory based on instantiating a class with no arguments.
+	 *
+	 * @param string $name       Name of the value
+	 * @param string $class_name Class name to be instantiated
+	 * @param bool   $shared     Whether the same value should be returned for every request
 	 * @return Elgg_DIContainer
 	 * @throws InvalidArgumentException
 	 */
-	public function setClassNames(array $map) {
+	public function setClassName($name, $class_name, $shared = true) {
 		$classname_pattern = version_compare(PHP_VERSION, '5.3', '<')
 			? self::CLASS_NAME_PATTERN_52
 			: self::CLASS_NAME_PATTERN_53;
-		foreach ($map as $name => $classname) {
-			if (!is_string($classname) || !preg_match($classname_pattern, $classname)) {
-				throw new InvalidArgumentException('Class names must be valid PHP class names');
-			}
-			$this->setFactory($name, create_function('', "return new $classname();"));
+		if (!is_string($class_name) || !preg_match($classname_pattern, $class_name)) {
+			throw new InvalidArgumentException('Class names must be valid PHP class names');
 		}
-		return $this;
+		$func = create_function('', "return new $class_name();");
+		return $this->setFactory($name, $func, $shared);
 	}
 
 	/**

--- a/engine/classes/Elgg/DIContainer.php
+++ b/engine/classes/Elgg/DIContainer.php
@@ -35,8 +35,9 @@ class Elgg_DIContainer {
 	 * @var array
 	 */
 	protected $cache = array();
-	
-	const CLASS_NAME_PATTERN = '/^(\\\\?[a-z_\x7f-\xff][a-z0-9_\x7f-\xff]*)+$/i';
+
+	const CLASS_NAME_PATTERN_52 = '/^[a-z_\x7f-\xff][a-z0-9_\x7f-\xff]*$/i';
+	const CLASS_NAME_PATTERN_53 = '/^(\\\\?[a-z_\x7f-\xff][a-z0-9_\x7f-\xff]*)+$/i';
 
 	/**
 	 * Fetch a value.
@@ -127,8 +128,11 @@ class Elgg_DIContainer {
 	 * @throws InvalidArgumentException
 	 */
 	public function setClassNames(array $map) {
+		$classname_pattern = version_compare(PHP_VERSION, '5.3', '<')
+			? self::CLASS_NAME_PATTERN_52
+			: self::CLASS_NAME_PATTERN_53;
 		foreach ($map as $name => $classname) {
-			if (!is_string($classname) || !preg_match(self::CLASS_NAME_PATTERN, $classname)) {
+			if (!is_string($classname) || !preg_match($classname_pattern, $classname)) {
 				throw new InvalidArgumentException('Class names must be valid PHP class names');
 			}
 			$this->setFactory($name, create_function('', "return new $classname();"));

--- a/engine/classes/Elgg/ServiceProvider.php
+++ b/engine/classes/Elgg/ServiceProvider.php
@@ -35,23 +35,19 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 	public function __construct(Elgg_AutoloadManager $autoload_manager) {
 		$this->setValue('autoloadManager', $autoload_manager);
 
-		$classNames = array();
-		
-		$classNames['actions'] = 'Elgg_ActionsService';
+		$this->setClassName('actions', 'Elgg_ActionsService');
 		$this->setFactory('amdConfig', array($this, 'getAmdConfig'));
-		$classNames['autoP'] = 'ElggAutoP';
-		$classNames['db'] = 'ElggDatabase';
-		$classNames['events'] = 'ElggEventService';
-		$classNames['hooks'] = 'ElggPluginHookService';
+		$this->setClassName('autoP', 'ElggAutoP');
+		$this->setClassName('db', 'ElggDatabase');
+		$this->setClassName('events', 'ElggEventService');
+		$this->setClassName('hooks', 'ElggPluginHookService');
 		$this->setFactory('logger', array($this, 'getLogger'));
-		$classNames['metadataCache'] = 'ElggVolatileMetadataCache';
+		$this->setClassName('metadataCache', 'ElggVolatileMetadataCache');
 		$this->setFactory('request', array($this, 'getRequest'));
 		$this->setFactory('router', array($this, 'getRouter'));
 		$this->setFactory('session', array($this, 'getSession'));
 		$this->setFactory('views', array($this, 'getViews'));
-		$classNames['widgets'] = 'Elgg_WidgetsService';
-		
-		$this->setClassNames($classNames);
+		$this->setClassName('widgets', 'Elgg_WidgetsService');
 	}
 
 	/**

--- a/engine/classes/Elgg/ServiceProvider.php
+++ b/engine/classes/Elgg/ServiceProvider.php
@@ -28,20 +28,6 @@
 class Elgg_ServiceProvider extends Elgg_DIContainer {
 
 	/**
-	 * Get a value from service provider
-	 * 
-	 * @param string $name Name of the value
-	 * @return mixed
-	 * @throws RuntimeException
-	 */
-	public function __get($name) {
-		if ($this->has($name)) {
-			return $this->get($name);
-		}
-		throw new RuntimeException("Property '$name' does not exist");
-	}
-
-	/**
 	 * Constructor
 	 * 
 	 * @param Elgg_AutoloadManager $autoload_manager Class autoloader
@@ -49,118 +35,52 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 	public function __construct(Elgg_AutoloadManager $autoload_manager) {
 		$this->setValue('autoloadManager', $autoload_manager);
 
-		$this->setFactory('actions', array($this, 'getActions'));
+		$classNames = array();
+		
+		$classNames['actions'] = 'Elgg_ActionsService';
 		$this->setFactory('amdConfig', array($this, 'getAmdConfig'));
-		$this->setFactory('autoP', array($this, 'getAutoP'));
-		$this->setFactory('db', array($this, 'getDb'));
-		$this->setFactory('events', array($this, 'getEvents'));
-		$this->setFactory('hooks', array($this, 'getHooks'));
+		$classNames['autoP'] = 'ElggAutoP';
+		$classNames['db'] = 'ElggDatabase';
+		$classNames['events'] = 'ElggEventService';
+		$classNames['hooks'] = 'ElggPluginHookService';
 		$this->setFactory('logger', array($this, 'getLogger'));
-		$this->setFactory('metadataCache', array($this, 'getMetadataCache'));
+		$classNames['metadataCache'] = 'ElggVolatileMetadataCache';
 		$this->setFactory('request', array($this, 'getRequest'));
 		$this->setFactory('router', array($this, 'getRouter'));
 		$this->setFactory('session', array($this, 'getSession'));
 		$this->setFactory('views', array($this, 'getViews'));
-		$this->setFactory('widgets', array($this, 'getWidgets'));
-	}
-
-	/**
-	 * Actions service factory
-	 * 
-	 * @param Elgg_DIContainer $c Dependency injection container
-	 * @return Elgg_ActionsService
-	 */
-	protected function getActions(Elgg_DIContainer $c) {
-		return new Elgg_ActionsService();
-	}
-
-	/**
-	 * Hooks service factory
-	 * 
-	 * @param Elgg_DIContainer $c Dependency injection container
-	 * @return ElggPluginHookService
-	 */
-	protected function getHooks(Elgg_DIContainer $c) {
-		return new ElggPluginHookService();
-	}
-
-	/**
-	 * Event service factory
-	 * 
-	 * @param Elgg_DIContainer $c Dependency injection container
-	 * @return ElggEventService
-	 */
-	protected function getEvents(Elgg_DIContainer $c) {
-		return new ElggEventService();
-	}
-
-	/**
-	 * Widgets service factory
-	 * 
-	 * @param Elgg_DIContainer $c Dependency injection container
-	 * @return Elgg_WidgetsService
-	 */
-	protected function getWidgets(Elgg_DIContainer $c) {
-		return new Elgg_WidgetsService();
-	}
-
-	/**
-	 * Metadata cache factory
-	 * 
-	 * @param Elgg_DIContainer $c Dependency injection container
-	 * @return ElggVolatileMetadataCache
-	 */
-	protected function getMetadataCache(Elgg_DIContainer $c) {
-		return new ElggVolatileMetadataCache();
-	}
-
-	/**
-	 * Database factory
-	 * 
-	 * @param Elgg_DIContainer $c Dependency injection container
-	 * @return ElggDatabase
-	 */
-	protected function getDb(Elgg_DIContainer $c) {
-		return new ElggDatabase();
+		$classNames['widgets'] = 'Elgg_WidgetsService';
+		
+		$this->setClassNames($classNames);
 	}
 
 	/**
 	 * Logger factory
 	 * 
-	 * @param Elgg_DIContainer $c Dependency injection container
+	 * @param Elgg_ServiceProvider $c Dependency injection container
 	 * @return ElggLogger
 	 */
-	protected function getLogger(Elgg_DIContainer $c) {
-		return new ElggLogger($c->get('hooks'));
+	protected function getLogger(Elgg_ServiceProvider $c) {
+		return new ElggLogger($c->hooks);
 	}
 
 	/**
 	 * Views service factory
 	 * 
-	 * @param Elgg_DIContainer $c Dependency injection container
+	 * @param Elgg_ServiceProvider $c Dependency injection container
 	 * @return ElggViewService
 	 */
-	protected function getViews(Elgg_DIContainer $c) {
+	protected function getViews(Elgg_ServiceProvider $c) {
 		return new ElggViewService($c->hooks, $c->logger);
-	}
-
-	/**
-	 * Paragraph formatter factory
-	 * 
-	 * @param Elgg_DIContainer $c Dependency injection container
-	 * @return ElggAutoP
-	 */
-	protected function getAutoP(Elgg_DIContainer $c) {
-		return new ElggAutoP();
 	}
 
 	/**
 	 * AMD Config factory
 	 * 
-	 * @param Elgg_DIContainer $c Dependency injection container
+	 * @param Elgg_ServiceProvider $c Dependency injection container
 	 * @return Elgg_AmdConfig
 	 */
-	protected function getAmdConfig(Elgg_DIContainer $c) {
+	protected function getAmdConfig(Elgg_ServiceProvider $c) {
 		$obj = new Elgg_AmdConfig();
 		$obj->setBaseUrl(_elgg_get_simplecache_root() . "js/");
 		return $obj;
@@ -169,10 +89,10 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 	/**
 	 * Session factory
 	 * 
-	 * @param Elgg_DIContainer $c Dependency injection container
+	 * @param Elgg_ServiceProvider $c Dependency injection container
 	 * @return ElggSession
 	 */
-	protected function getSession(Elgg_DIContainer $c) {
+	protected function getSession(Elgg_ServiceProvider $c) {
 		$handler = new Elgg_Http_DatabaseSessionHandler($c->db);
 		$storage = new Elgg_Http_NativeSessionStorage($handler);
 		$session = new ElggSession($storage);
@@ -183,20 +103,20 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 	/**
 	 * Request factory
 	 * 
-	 * @param Elgg_DIContainer $c Dependency injection container
+	 * @param Elgg_ServiceProvider $c Dependency injection container
 	 * @return Elgg_Request
 	 */
-	protected function getRequest(Elgg_DIContainer $c) {
+	protected function getRequest(Elgg_ServiceProvider $c) {
 		return new Elgg_Request($c->hooks, $_SERVER, $_REQUEST);
 	}
 	
 	/**
 	 * Router factory
 	 * 
-	 * @param Elgg_DIContainer $c Dependency injection container
+	 * @param Elgg_ServiceProvider $c Dependency injection container
 	 * @return Elgg_Router
 	 */
-	protected function getRouter(Elgg_DIContainer $c) {
+	protected function getRouter(Elgg_ServiceProvider $c) {
 		// TODO(evan): Init routes from plugins or cache
 		return new Elgg_Router($c->hooks);
 	}

--- a/engine/lib/autoloader.php
+++ b/engine/lib/autoloader.php
@@ -20,17 +20,6 @@ function _elgg_services() {
 }
 
 /**
- * @return Elgg_DIContainer
- */
-function elgg_get_dic() {
-	static $dic;
-	if (null === $dic) {
-		$dic = new Elgg_DIContainer();
-	}
-	return $dic;
-}
-
-/**
  * Sets up autoloading and creates the service provider (DIC)
  *
  * Setup global class map and loader instances and add the core classes to the map.

--- a/engine/lib/autoloader.php
+++ b/engine/lib/autoloader.php
@@ -20,6 +20,17 @@ function _elgg_services() {
 }
 
 /**
+ * @return Elgg_DIContainer
+ */
+function elgg_get_dic() {
+	static $dic;
+	if (null === $dic) {
+		$dic = new Elgg_DIContainer();
+	}
+	return $dic;
+}
+
+/**
  * Sets up autoloading and creates the service provider (DIC)
  *
  * Setup global class map and loader instances and add the core classes to the map.

--- a/engine/tests/ElggCoreHelpersTest.php
+++ b/engine/tests/ElggCoreHelpersTest.php
@@ -327,8 +327,18 @@ class ElggCoreHelpersTest extends ElggCoreUnitTest {
 
 		$this->assertEqual(11, $j);
 	}
+	
+	public function testGetDic() {
+		$dic = elgg_get_dic();
+		
+		$this->assertIsA($dic, 'Elgg_DIContainer');
+		$this->assertIdentical($dic, elgg_get_dic());
+		
+		// separate
+		$this->assertNotIdentical($dic, _elgg_services());
+	}
 
-	static function elgg_batch_callback_test($options, $reset = false) {
+	public static function elgg_batch_callback_test($options, $reset = false) {
 		static $count = 1;
 
 		if ($reset) {

--- a/engine/tests/ElggCoreHelpersTest.php
+++ b/engine/tests/ElggCoreHelpersTest.php
@@ -327,16 +327,6 @@ class ElggCoreHelpersTest extends ElggCoreUnitTest {
 
 		$this->assertEqual(11, $j);
 	}
-	
-	public function testGetDic() {
-		$dic = elgg_get_dic();
-		
-		$this->assertIsA($dic, 'Elgg_DIContainer');
-		$this->assertIdentical($dic, elgg_get_dic());
-		
-		// separate
-		$this->assertNotIdentical($dic, _elgg_services());
-	}
 
 	public static function elgg_batch_callback_test($options, $reset = false) {
 		static $count = 1;

--- a/engine/tests/phpunit/ElggDiContainerTest.php
+++ b/engine/tests/phpunit/ElggDiContainerTest.php
@@ -85,12 +85,12 @@ class ElggDIContainerTest extends PHPUnit_Framework_TestCase {
 	
 	public function testSetClassNames() {
 		$di = new Elgg_DIContainer();
-		$di->setClassNames(array('foo' => self::TEST_CLASS));
+		$di->setClassName('foo', self::TEST_CLASS);
 
 		$this->assertInstanceOf(self::TEST_CLASS, $di->foo);
 		
 		$this->setExpectedException('InvalidArgumentException', 'Class names must be valid PHP class names');
-		$di->setClassNames(array('foo' => array()));
+		$di->setClassName('foo', array());
 	}
 	
 	public function testSettingInvalidClassNameThrows() {
@@ -98,19 +98,15 @@ class ElggDIContainerTest extends PHPUnit_Framework_TestCase {
 		
 		$euro = "\xE2\x82\xAC";
 		
-		$map = array(
-			'foo1' => "Foo2{$euro}3",
-		);
+		$di->setClassName('foo1', "Foo2{$euro}3");
 
 		if (version_compare(PHP_VERSION, '5.3', '>=')) {
-			$map['foo2'] = "\\Foo2{$euro}3";
-			$map['foo3'] = "Foo2{$euro}3\\Foo2{$euro}3";
+			$di->setClassName('foo2', "\\Foo2{$euro}3");
+			$di->setClassName('foo3', "Foo2{$euro}3\\Foo2{$euro}3");
 		}
-
-		$di->setClassNames($map);
 		
 		$this->setExpectedException('InvalidArgumentException', 'Class names must be valid PHP class names');
-		$di->setClassNames(array('foo' => 'Not Valid'));
+		$di->setClassName('foo', 'Not Valid');
 	}
 
 	public function testAccessRemovedValue() {

--- a/engine/tests/phpunit/ElggDiContainerTest.php
+++ b/engine/tests/phpunit/ElggDiContainerTest.php
@@ -18,7 +18,7 @@ class ElggDIContainerTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertSame($di, $di->setValue('foo', 'Foo'));
 		$this->assertTrue($di->has('foo'));
-		$this->assertEquals('Foo', $di->get('foo'));
+		$this->assertEquals('Foo', $di->foo);
 	}
 
 	public function testSetFactoryShared() {
@@ -26,8 +26,8 @@ class ElggDIContainerTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertSame($di, $di->setFactory('foo', array($this, 'getFoo')));
 		$this->assertTrue($di->has('foo'));
-		$foo1 = $di->get('foo');
-		$foo2 = $di->get('foo');
+		$foo1 = $di->foo;
+		$foo2 = $di->foo;
 		$this->assertInstanceOf(self::TEST_CLASS, $foo1);
 		$this->assertSame($foo1, $foo2);
 	}
@@ -37,8 +37,8 @@ class ElggDIContainerTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertSame($di, $di->setFactory('foo', array($this, 'getFoo'), false));
 		$this->assertTrue($di->has('foo'));
-		$foo1 = $di->get('foo');
-		$foo2 = $di->get('foo');
+		$foo1 = $di->foo;
+		$foo2 = $di->foo;
 		$this->assertInstanceOf(self::TEST_CLASS, $foo1);
 		$this->assertNotSame($foo1, $foo2);
 	}
@@ -47,7 +47,7 @@ class ElggDIContainerTest extends PHPUnit_Framework_TestCase {
 		$di = new Elgg_DIContainer();
 		$di->setFactory('foo', array($this, 'getFoo'));
 
-		$foo = $di->get('foo');
+		$foo = $di->foo;
 		$this->assertSame($di, $foo->di);
 	}
 
@@ -65,14 +65,14 @@ class ElggDIContainerTest extends PHPUnit_Framework_TestCase {
 		$this->setExpectedException(
 			'Elgg_DIContainer_FactoryUncallableException',
 			"Factory for 'foo' was uncallable: 'not-a-real-callable'");
-		$di->get('foo');
+		$di->foo;
 	}
 
 	public function testGetMissingValue() {
 		$di = new Elgg_DIContainer();
 
 		$this->setExpectedException('Elgg_DIContainer_MissingValueException', "Value or factory was not set for: foo");
-		$di->get('foo');
+		$di->foo;
 	}
 
 	public function testRemove() {
@@ -82,6 +82,30 @@ class ElggDIContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame($di, $di->remove('foo'));
 		$this->assertFalse($di->has('foo'));
 	}
+	
+	public function testSetClassNames() {
+		$di = new Elgg_DIContainer();
+		$di->setClassNames(array('foo' => self::TEST_CLASS));
+
+		$this->assertInstanceOf(self::TEST_CLASS, $di->foo);
+		
+		$this->setExpectedException('InvalidArgumentException', 'Class names must be valid PHP class names');
+		$di->setClassNames(array('foo' => array()));
+	}
+	
+	public function testSettingInvalidClassNameThrows() {
+		$di = new Elgg_DIContainer();
+		
+		$euro = "\xE2\x82\xAC";
+		$di->setClassNames(array(
+			'foo1' => "Foo2{$euro}3",
+			'foo2' => "\\Foo2{$euro}3",
+			'foo3' => "\\Foo2{$euro}3\\Foo2{$euro}3",
+		));
+		
+		$this->setExpectedException('InvalidArgumentException', 'Class names must be valid PHP class names');
+		$di->setClassNames(array('foo' => 'Not Valid'));
+	}
 
 	public function testAccessRemovedValue() {
 		$di = new Elgg_DIContainer();
@@ -89,7 +113,7 @@ class ElggDIContainerTest extends PHPUnit_Framework_TestCase {
 		$di->remove('foo');
 
 		$this->setExpectedException('Elgg_DIContainer_MissingValueException');
-		$di->get('foo');
+		$di->foo;
 	}
 }
 

--- a/engine/tests/phpunit/ElggDiContainerTest.php
+++ b/engine/tests/phpunit/ElggDiContainerTest.php
@@ -97,11 +97,17 @@ class ElggDIContainerTest extends PHPUnit_Framework_TestCase {
 		$di = new Elgg_DIContainer();
 		
 		$euro = "\xE2\x82\xAC";
-		$di->setClassNames(array(
+		
+		$map = array(
 			'foo1' => "Foo2{$euro}3",
-			'foo2' => "\\Foo2{$euro}3",
-			'foo3' => "\\Foo2{$euro}3\\Foo2{$euro}3",
-		));
+		);
+
+		if (version_compare(PHP_VERSION, '5.3', '>=')) {
+			$map['foo2'] = "\\Foo2{$euro}3";
+			$map['foo3'] = "Foo2{$euro}3\\Foo2{$euro}3";
+		}
+
+		$di->setClassNames($map);
 		
 		$this->setExpectedException('InvalidArgumentException', 'Class names must be valid PHP class names');
 		$di->setClassNames(array('foo' => 'Not Valid'));

--- a/engine/tests/phpunit/ElggServiceProviderTest.php
+++ b/engine/tests/phpunit/ElggServiceProviderTest.php
@@ -2,17 +2,32 @@
 
 class ElggServiceProviderTest extends PHPUnit_Framework_TestCase {
 
-	public function testSharedMetadataCache() {
+	public function testPropertiesReturnCorrectClassNames() {
 		$mgr = $this->getMock('Elgg_AutoloadManager', array(), array(), '', false);
 
 		$sp = new Elgg_ServiceProvider($mgr);
 
 		$svcClasses = array(
-			'metadataCache' => 'ElggVolatileMetadataCache',
+			'actions' => 'Elgg_ActionsService',
+			
+			// requires _elgg_get_simplecache_root() to be defined
+			//'amdConfig' => 'Elgg_AmdConfig',
+			
+			'autoP' => 'ElggAutoP',
 			'autoloadManager' => 'Elgg_AutoloadManager',
 			'db' => 'ElggDatabase',
+			'events' => 'ElggEventService',
 			'hooks' => 'ElggPluginHookService',
 			'logger' => 'ElggLogger',
+			'metadataCache' => 'ElggVolatileMetadataCache',
+			'request' => 'Elgg_Request',
+			'router' => 'Elgg_Router',
+			
+			// Will this start session?
+			//'session' => 'ElggSession'
+			
+			'views' => 'ElggViewService',
+			'widgets' => 'Elgg_WidgetsService',
 		);
 
 		foreach ($svcClasses as $key => $class) {


### PR DESCRIPTION
As proposed on dev list
1. Uses property get instead of get()
2. Adds ~~setClassNames()~~ setClassName() to set trivial factories, uses in service provider
3. Adds more to service provider tests
4. ~~Adds separate DIContainer instance available via elgg_get_dic()~~
