### PR TITLE
Use lwp-request instead of its sometimes unavailable GET alias

### DIFF
--- a/documentation/examples/crontab.example
+++ b/documentation/examples/crontab.example
@@ -8,11 +8,14 @@
 #
 # @author Marcus Povey
 
-# Location of GET (see: http://docs.elgg.org/wiki/What_is_get)
-GET='/usr/bin/GET'
-
 # Location of your site (don't forget the trailing slash!)
 ELGG='http://www.example.com/'
+
+# Location of lwp-request
+LWPR='/usr/bin/lwp-request'
+
+# Make GET request and discard content
+GET='$LWPR -m GET -d'
 
 # The crontab
 # Don't edit below this line unless you know what you are doing


### PR DESCRIPTION
It's my understanding that GET is an alias for lwp-request and not available on all systems. Notably OSX.
