### PR TITLE
Added a messages_get_unread function

### DIFF
--- a/mod/messages/start.php
+++ b/mod/messages/start.php
@@ -389,6 +389,52 @@ function messages_count_unread($user_guid = 0) {
 }
 
 /**
+ * Returns the unread messages in a user's inbox
+ *
+ * @param int $user_guid GUID of user whose inbox we're counting (0 for logged in user)
+   * @param int $limit Number of unread messages to return (default = 10)
+ *
+ * @return array
+ */
+function messages_get_unread($user_guid = 0, $limit = 10) {
+  if (!$user_guid) {
+    $user_guid = elgg_get_logged_in_user_guid();
+  }
+  $db_prefix = elgg_get_config('dbprefix');
+
+  // denormalize the md to speed things up.
+  // seriously, 10 joins if you don't.
+  $strings = array('toId', $user_guid, 'readYet', 0, 'msg', 1);
+  $map = array();
+  foreach ($strings as $string) {
+	  $id = get_metastring_id($string);
+	  $map[$string] = $id;
+  }
+
+  $options = array(
+//		'metadata_name_value_pairs' => array(
+//			'toId' => elgg_get_logged_in_user_guid(),
+//			'readYet' => 0,
+//			'msg' => 1
+//		),
+	  'joins' => array(
+		  "JOIN {$db_prefix}metadata msg_toId on e.guid = msg_toId.entity_guid",
+		  "JOIN {$db_prefix}metadata msg_readYet on e.guid = msg_readYet.entity_guid",
+		  "JOIN {$db_prefix}metadata msg_msg on e.guid = msg_msg.entity_guid",
+	  ),
+	  'wheres' => array(
+		  "msg_toId.name_id='{$map['toId']}' AND msg_toId.value_id='{$map[$user_guid]}'",
+		  "msg_readYet.name_id='{$map['readYet']}' AND msg_readYet.value_id='{$map[0]}'",
+		  "msg_msg.name_id='{$map['msg']}' AND msg_msg.value_id='{$map[1]}'",
+	  ),
+	  'owner_guid' => $user_guid,
+	  'limit' => $limit,
+  );
+
+  return elgg_get_entities_from_metadata($options);
+}
+
+/**
  * Notification handler
  *
  * @param ElggEntity $from


### PR DESCRIPTION
The messages_count_unread function is fine, but doesn't really help when building plugin or widgets that aim to display unread messages _only_.
=> This function adds ability to get unread messages.

Other improvement could be to add some parameters, such as "$count = false" to replace messages_count_unread by a more convenient function.
