### PR TITLE
Async notifications

### DIFF
--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -537,4 +537,42 @@ class Elgg_Database {
 			elgg_log("Query cache invalidated", 'NOTICE');
 		}
 	}
+
+	/**
+	 * Get the prefix for Elgg's tables
+	 *
+	 * @return string
+	 */
+	public function getTablePrefix() {
+		return $this->tablePrefix;
+	}
+
+	/**
+	 * Sanitizes an integer value for use in a query
+	 *
+	 * @param int  $value  Value to sanitize
+	 * @param bool $signed Whether negative values are allowed (default: true)
+	 * @return int
+	 */
+	public function sanitizeInt($value, $signed = true) {
+		$value = (int) $value;
+
+		if ($signed === false) {
+			if ($value < 0) {
+				$value = 0;
+			}
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Sanitizes a string for use in a query
+	 *
+	 * @param string $value Value to escape
+	 * @return string
+	 */
+	public function sanitizeString($value) {
+		return mysql_real_escape_string($value);
+	}
 }

--- a/engine/classes/Elgg/HooksRegistrationService.php
+++ b/engine/classes/Elgg/HooksRegistrationService.php
@@ -14,38 +14,6 @@
 abstract class Elgg_HooksRegistrationService {
 	
 	private $handlers = array();
-
-	/**
-	 * Returns an ordered array of handlers registered for $name and $type.
-	 *
-	 * @see Elgg_HooksRegistrationService::getAllHandlers()
-	 * @access private
-	 */
-	function getOrderedHandlers($name, $type) {
-		$handlers = array();
-		
-		if (isset($this->handlers[$name][$type])) {
-			if ($name != 'all' && $type != 'all') {
-				$handlers = array_merge($handlers, array_values($this->handlers[$name][$type]));
-			}
-		}
-		if (isset($this->handlers['all'][$type])) {
-			if ($type != 'all') {
-				$handlers = array_merge($handlers, array_values($this->handlers['all'][$type]));
-			}
-		}
-		if (isset($this->handlers[$name]['all'])) {
-			if ($name != 'all') {
-				$handlers = array_merge($handlers, array_values($this->handlers[$name]['all']));
-			}
-		}
-		if (isset($this->handlers['all']['all'])) {
-			$handlers = array_merge($handlers, array_values($this->handlers['all']['all']));
-		}
-
-		return $handlers;
-	}
-	
 	
 	/**
 	 * Registers a handler.
@@ -55,7 +23,7 @@ abstract class Elgg_HooksRegistrationService {
 	 *
 	 * @access private
 	 */
-	function registerHandler($name, $type, $callback, $priority = 500) {
+	public function registerHandler($name, $type, $callback, $priority = 500) {
 		if (empty($name) || empty($type) || !is_callable($callback, true)) {
 			return false;
 		}
@@ -80,14 +48,13 @@ abstract class Elgg_HooksRegistrationService {
 
 		return true;
 	}
-
 	
 	/**
 	 * Unregister a handler
 	 * 
 	 * @access private
 	 */
-	function unregisterHandler($name, $type, $callback) {
+	public function unregisterHandler($name, $type, $callback) {
 		if (isset($this->handlers[$name]) && isset($this->handlers[$name][$type])) {
 			foreach ($this->handlers[$name][$type] as $key => $name_callback) {
 				if ($name_callback == $callback) {
@@ -114,4 +81,48 @@ abstract class Elgg_HooksRegistrationService {
 	public function getAllHandlers() {
 		return $this->handlers;
 	}
+
+	/**
+	 * Does the hook have a handler?
+	 * 
+	 * @param string $name The name of the hook
+	 * @param string $type The type of the hook
+	 * @return boolean
+	 */
+	public function hasHandler($name, $type) {
+		return isset($this->handlers[$name][$type]);
+	}
+
+	/**
+	 * Returns an ordered array of handlers registered for $name and $type.
+	 *
+	 * @param string $name The name of the hook
+	 * @param string $type The type of the hook
+	 * @return array
+	 * @see Elgg_HooksRegistrationService::getAllHandlers()
+	 */
+	protected function getOrderedHandlers($name, $type) {
+		$handlers = array();
+		
+		if (isset($this->handlers[$name][$type])) {
+			if ($name != 'all' && $type != 'all') {
+				$handlers = array_merge($handlers, array_values($this->handlers[$name][$type]));
+			}
+		}
+		if (isset($this->handlers['all'][$type])) {
+			if ($type != 'all') {
+				$handlers = array_merge($handlers, array_values($this->handlers['all'][$type]));
+			}
+		}
+		if (isset($this->handlers[$name]['all'])) {
+			if ($name != 'all') {
+				$handlers = array_merge($handlers, array_values($this->handlers[$name]['all']));
+			}
+		}
+		if (isset($this->handlers['all']['all'])) {
+			$handlers = array_merge($handlers, array_values($this->handlers['all']['all']));
+		}
+
+		return $handlers;
+	}	
 }

--- a/engine/classes/Elgg/Notifications/Event.php
+++ b/engine/classes/Elgg/Notifications/Event.php
@@ -1,0 +1,101 @@
+<?php
+
+class Elgg_Notifications_Event {
+	/* @var string The name of the action/event */
+	protected $action;
+
+	/* @var string The type of the action's object */
+	protected $object_type;
+
+	/* @var string the subtype of the action's object */
+	protected $object_subtype;
+
+	/* @var int The identifier of the object (GUID for entity, id for relationship or annotation) */
+	protected $object_id;
+
+	/* @var int The GUID of the user who triggered the event */
+	protected $actor_guid;
+
+
+	/**
+	 * Create a notification event
+	 *
+	 * @param ElggData $object The object of the event (ElggEntity, ElggAnnotation, ElggRelationship)
+	 * @param string   $action  The name of the action (default: create)
+	 * @param ElggUser $actor  The user that caused the event (default: logged in user)
+	 */
+	public function __construct($object, $action, $actor = null) {
+		if (!($object instanceof ElggData)) {
+			// @todo find the best message - probably create generic message
+			throw new InvalidParameterException();
+		}
+
+		if (elgg_instanceof($object)) {
+			$this->object_type = $object->getType();
+			$this->object_subtype = $object->getSubtype();
+			$this->object_id = $object->getGUID();
+		} else {
+			$this->object_type = $object->getType();
+			$this->object_subtype = $object->getSubtype();
+			$this->object_id = $object->id;
+		}
+
+		if ($actor == null) {
+			$this->actor_guid = elgg_get_logged_in_user_guid();
+		} else {
+			$this->actor_guid = $actor->getGUID();
+		}
+
+		$this->action = $action;
+	}
+
+	/**
+	 * Get the actor of the event
+	 *
+	 * @return ElggUser
+	 */
+	public function getActor() {
+		return get_entity($this->actor_guid);
+	}
+
+	/**
+	 * Get the object of the event
+	 *
+	 * @return ElggData
+	 */
+	public function getObject() {
+		switch ($this->object_type) {
+			case 'object':
+			case 'user':
+			case 'site':
+			case 'group':
+				return get_entity($this->object_id);
+				break;
+			case 'relationship':
+				return get_relationship($this->object_id);
+				break;
+			case 'annotation':
+				return elgg_get_annotation_from_id($this->object_id);
+				break;
+		}
+		return null;
+	}
+
+	/**
+	 * Get the name of the action
+	 *
+	 * @return string
+	 */
+	public function getAction() {
+		return $this->action;
+	}
+
+	/**
+	 * Get a description of the event
+	 *
+	 * @return string
+	 */
+	public function getDescription() {
+		return "{$this->action}:{$this->object_type}:{$this->object_subtype}";
+	}
+}

--- a/engine/classes/Elgg/Notifications/Event.php
+++ b/engine/classes/Elgg/Notifications/Event.php
@@ -65,6 +65,15 @@ class Elgg_Notifications_Event {
 	}
 
 	/**
+	 * Get the GUID of the actor
+	 * 
+	 * @return int
+	 */
+	public function getActorGUID() {
+		return $this->actor_guid;
+	}
+
+	/**
 	 * Get the object of the event
 	 *
 	 * @return ElggData

--- a/engine/classes/Elgg/Notifications/Event.php
+++ b/engine/classes/Elgg/Notifications/Event.php
@@ -1,5 +1,13 @@
 <?php
-
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ * 
+ * @package    Elgg.Core
+ * @subpackage Notifications
+ * @since      1.9.0
+ */
 class Elgg_Notifications_Event {
 	/* @var string The name of the action/event */
 	protected $action;
@@ -21,7 +29,7 @@ class Elgg_Notifications_Event {
 	 * Create a notification event
 	 *
 	 * @param ElggData $object The object of the event (ElggEntity, ElggAnnotation, ElggRelationship)
-	 * @param string   $action  The name of the action (default: create)
+	 * @param string   $action The name of the action (default: create)
 	 * @param ElggUser $actor  The user that caused the event (default: logged in user)
 	 */
 	public function __construct($object, $action, $actor = null) {

--- a/engine/classes/Elgg/Notifications/Event.php
+++ b/engine/classes/Elgg/Notifications/Event.php
@@ -29,11 +29,11 @@ class Elgg_Notifications_Event {
 	 * @param ElggData $object The object of the event (ElggEntity, ElggAnnotation, ElggRelationship)
 	 * @param string   $action The name of the action (default: create)
 	 * @param ElggUser $actor  The user that caused the event (default: logged in user)
+	 * @throws InvalidArgumentException
 	 */
 	public function __construct($object, $action, $actor = null) {
 		if (!($object instanceof ElggData)) {
-			// @todo find the best message - probably create generic message
-			throw new InvalidParameterException();
+			throw new InvalidArgumentException('$object is not an instance of ElggData');
 		}
 
 		if (elgg_instanceof($object)) {

--- a/engine/classes/Elgg/Notifications/Event.php
+++ b/engine/classes/Elgg/Notifications/Event.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
- * @access private
+ * Notification event
  * 
  * @package    Elgg.Core
  * @subpackage Notifications

--- a/engine/classes/Elgg/Notifications/Notification.php
+++ b/engine/classes/Elgg/Notifications/Notification.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
- * @access private
+ * Notification container
  * 
  * @package    Elgg.Core
  * @subpackage Notifications

--- a/engine/classes/Elgg/Notifications/Notification.php
+++ b/engine/classes/Elgg/Notifications/Notification.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * 
+ */
+class Elgg_Notifications_Notification {
+	/** @var ElggEntity The entity causing or creating the notification */
+	protected $from;
+
+	/** @var ElggUser The user receiving the notification */
+	protected $to;
+
+	/** @var string The subject string */
+	public $subject;
+
+	/** @var string The body string */
+	public $body;
+
+	/** @var string The language of the notification */
+	public $language;
+
+	/** @var array Additional parameters */
+	public $params;
+
+	/**
+	 * Create a notification
+	 *
+	 * @param ElggEntity $from     The entity sending the notification (usually the site)
+	 * @param ElggEntity $to       The entity receiving the notification
+	 * @param string     $language The language code for the notification
+	 * @param string     $subject  The subject of the notification
+	 * @param string     $body     The body of the notification
+	 * @param array      $params   Optional array of parameters
+	 */
+	public function __construct($from, $to, $language, $subject, $body, array $params = array()) {
+		$this->from = $from;
+		$this->to = $to;
+		$this->language = $language;
+		$this->subject = $subject;
+		$this->body = $body;
+		$this->params = $params;
+	}
+
+	/**
+	 * Get the sender entity
+	 *
+	 * @return ElggEntity
+	 */
+	public function getSender() {
+		return $this->from;
+	}
+
+	/**
+	 * Get the recipient entity
+	 *
+	 * @return ElggEntity
+	 */
+	public function getRecipient() {
+		return $this->to;
+	}
+
+	/**
+	 * Get the formatted address for sender: "Name <email address>"
+	 *
+	 * @return string
+	 */
+	public function getSenderFormattedEmailAddress() {
+		return $this->getEmailAddress($this->from);
+	}
+
+	/**
+	 * Get the formatted address for recipient: "Name <email address>"
+	 *
+	 * @return string
+	 */
+	public function getRecipientFormattedEmailAddress() {
+		return $this->getEmailAddress($this->to);
+	}
+
+	protected function getFormattedEmailAddress($entity) {
+		// need to remove special characters
+		$name = $entity->name;
+		$email = $entity->email;
+		return "$name <$email>";
+	}
+}

--- a/engine/classes/Elgg/Notifications/Notification.php
+++ b/engine/classes/Elgg/Notifications/Notification.php
@@ -1,7 +1,12 @@
 <?php
-
 /**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
  * 
+ * @package    Elgg.Core
+ * @subpackage Notifications
+ * @since      1.9.0
  */
 class Elgg_Notifications_Notification {
 	/** @var ElggEntity The entity causing or creating the notification */
@@ -77,6 +82,14 @@ class Elgg_Notifications_Notification {
 		return $this->getEmailAddress($this->to);
 	}
 
+	/**
+	 * Get an email address string for to/from field
+	 * 
+	 * @todo this should not be here
+	 * 
+	 * @param ElggUser|ElggGroup|ElggSite $entity Entity to get the email address for 
+	 * @return string
+	 */
 	protected function getFormattedEmailAddress($entity) {
 		// need to remove special characters
 		$name = $entity->name;

--- a/engine/classes/Elgg/Notifications/Notification.php
+++ b/engine/classes/Elgg/Notifications/Notification.php
@@ -34,8 +34,15 @@ class Elgg_Notifications_Notification {
 	 * @param string     $subject  The subject of the notification
 	 * @param string     $body     The body of the notification
 	 * @param array      $params   Optional array of parameters
+	 * @throws InvalidArgumentException
 	 */
-	public function __construct($from, $to, $language, $subject, $body, array $params = array()) {
+	public function __construct(ElggEntity $from, ElggEntity $to, $language, $subject, $body, array $params = array()) {
+		if (!$from) {
+			throw new InvalidArgumentException('$from is not a valid ElggEntity');
+		}
+		if (!$to) {
+			throw new InvalidArgumentException('$to is not a valid ElggEntity');
+		}
 		$this->from = $from;
 		$this->to = $to;
 		$this->language = $language;
@@ -78,38 +85,5 @@ class Elgg_Notifications_Notification {
 	 */
 	public function getRecipientGUID() {
 		return $this->to->guid;
-	}
-
-	/**
-	 * Get the formatted address for sender: "Name <email address>"
-	 *
-	 * @return string
-	 */
-	public function getSenderFormattedEmailAddress() {
-		return $this->getEmailAddress($this->from);
-	}
-
-	/**
-	 * Get the formatted address for recipient: "Name <email address>"
-	 *
-	 * @return string
-	 */
-	public function getRecipientFormattedEmailAddress() {
-		return $this->getEmailAddress($this->to);
-	}
-
-	/**
-	 * Get an email address string for to/from field
-	 * 
-	 * @todo this should not be here
-	 * 
-	 * @param ElggUser|ElggGroup|ElggSite $entity Entity to get the email address for 
-	 * @return string
-	 */
-	protected function getFormattedEmailAddress($entity) {
-		// need to remove special characters
-		$name = $entity->name;
-		$email = $entity->email;
-		return "$name <$email>";
 	}
 }

--- a/engine/classes/Elgg/Notifications/Notification.php
+++ b/engine/classes/Elgg/Notifications/Notification.php
@@ -54,12 +54,30 @@ class Elgg_Notifications_Notification {
 	}
 
 	/**
+	 * Get the sender entity guid
+	 *
+	 * @return int
+	 */
+	public function getSenderGUID() {
+		return $this->from->guid;
+	}
+
+	/**
 	 * Get the recipient entity
 	 *
 	 * @return ElggEntity
 	 */
 	public function getRecipient() {
 		return $this->to;
+	}
+
+	/**
+	 * Get the recipient entity guid
+	 *
+	 * @return int
+	 */
+	public function getRecipientGUID() {
+		return $this->to->guid;
 	}
 
 	/**

--- a/engine/classes/Elgg/Notifications/NotificationsService.php
+++ b/engine/classes/Elgg/Notifications/NotificationsService.php
@@ -155,6 +155,8 @@ class Elgg_Notifications_NotificationsService {
 	 */
 	public function processQueue($stopTime) {
 
+		$this->subscriptions->setNotificationMethods($this->methods);
+
 		$count = 0;
 
 		// @todo grab mutex

--- a/engine/classes/Elgg/Notifications/NotificationsService.php
+++ b/engine/classes/Elgg/Notifications/NotificationsService.php
@@ -43,8 +43,10 @@ class Elgg_Notifications_NotificationsService {
 	 * @param Elgg_Notifications_SubscriptionsService $subscriptions Subscription service
 	 * @param Elgg_Util_FifoQueue                     $queue         Queue
 	 * @param Elgg_PluginHookService                  $hooks         Plugin hook service
+	 * @param Elgg_Access                             $access        Access control service
 	 */
-	public function __construct(Elgg_Notifications_SubscriptionsService $subscriptions, Elgg_Util_FifoQueue $queue, Elgg_PluginHookService $hooks, Elgg_Access $access) {
+	public function __construct(Elgg_Notifications_SubscriptionsService $subscriptions, 
+			Elgg_Util_FifoQueue $queue, Elgg_PluginHookService $hooks, Elgg_Access $access) {
 		$this->subscriptions = $subscriptions;
 		$this->queue = $queue;
 		$this->hooks = $hooks;

--- a/engine/classes/Elgg/Notifications/NotificationsService.php
+++ b/engine/classes/Elgg/Notifications/NotificationsService.php
@@ -16,7 +16,7 @@ class Elgg_Notifications_NotificationsService {
 	/** @var Elgg_Notifications_SubscriptionsService */
 	protected $subscriptions;
 
-	/** @var Elgg_Util_FifoQueue */
+	/** @var Elgg_Util_Queue */
 	protected $queue;
 
 	/** @var Elgg_PluginHookService */
@@ -41,12 +41,12 @@ class Elgg_Notifications_NotificationsService {
 	 * Constructor
 	 *
 	 * @param Elgg_Notifications_SubscriptionsService $subscriptions Subscription service
-	 * @param Elgg_Util_FifoQueue                     $queue         Queue
+	 * @param Elgg_Util_Queue                         $queue         Queue
 	 * @param Elgg_PluginHookService                  $hooks         Plugin hook service
 	 * @param Elgg_Access                             $access        Access control service
 	 */
 	public function __construct(Elgg_Notifications_SubscriptionsService $subscriptions, 
-			Elgg_Util_FifoQueue $queue, Elgg_PluginHookService $hooks, Elgg_Access $access) {
+			Elgg_Util_Queue $queue, Elgg_PluginHookService $hooks, Elgg_Access $access) {
 		$this->subscriptions = $subscriptions;
 		$this->queue = $queue;
 		$this->hooks = $hooks;

--- a/engine/classes/Elgg/Notifications/NotificationsService.php
+++ b/engine/classes/Elgg/Notifications/NotificationsService.php
@@ -13,6 +13,9 @@ class Elgg_Notifications_NotificationsService {
 
 	const QUEUE_NAME = 'notifications';
 
+	/** @var Elgg_Notifications_SubscriptionsService */
+	protected $subscriptions;
+
 	/** @var Elgg_Util_FifoQueue */
 	protected $queue;
 
@@ -27,10 +30,13 @@ class Elgg_Notifications_NotificationsService {
 
 	/**
 	 * Constructor
-	 * 
-	 * @param Elgg_Util_FifoQueue $queue Queue
+	 *
+	 * @param Elgg_Notifications_SubscriptionsService $subscriptions Subscription service
+	 * @param Elgg_Util_FifoQueue                     $queue         Queue
+	 * @param Elgg_PluginHookService                  $hooks         Plugin hook service
 	 */
-	public function __construct(Elgg_Util_FifoQueue $queue, Elgg_PluginHookService $hooks) {
+	public function __construct(Elgg_Notifications_SubscriptionsService $subscriptions, Elgg_Util_FifoQueue $queue, Elgg_PluginHookService $hooks) {
+		$this->subscriptions = $subscriptions;
 		$this->queue = $queue;
 		$this->hooks = $hooks;
 	}
@@ -160,7 +166,7 @@ class Elgg_Notifications_NotificationsService {
 				break;
 			}
 
-			$subscriptions = $this->getSubscriptions($event);
+			$subscriptions = $this->subscriptions->getSubscriptions($event);
 
 			// return false to stop the default notification sender
 			$params = array('event' => $event, 'subscriptions' => $subscriptions);
@@ -174,29 +180,6 @@ class Elgg_Notifications_NotificationsService {
 		// release mutex
 
 		return $count;
-	}
-
-	/**
-	 * Get the subscriptions for this notification event
-	 *
-	 * The return array is of the form:
-	 *
-	 * array(
-	 *     <user guid> => array('email', 'sms', 'ajax'),
-	 * );
-	 *
-	 * @param Elgg_Notifications_Event $event Notification event
-	 * @return array
-	 * @access private
-	 */
-	protected function getSubscriptions($event) {
-		// @todo not implemented
-		$users = elgg_get_entities(array('type' => 'user'));
-		$subscriptions = array();
-		foreach ($users as $user) {
-			$subscriptions[$user->guid] = array('site');
-		}
-		return $subscriptions;
 	}
 
 	/**

--- a/engine/classes/Elgg/Notifications/NotificationsService.php
+++ b/engine/classes/Elgg/Notifications/NotificationsService.php
@@ -9,7 +9,7 @@
  * @subpackage Notifications
  * @since      1.9.0
  */
-class Elgg_Notifications_Service {
+class Elgg_Notifications_NotificationsService {
 
 	const QUEUE_NAME = 'notifications';
 

--- a/engine/classes/Elgg/Notifications/Service.php
+++ b/engine/classes/Elgg/Notifications/Service.php
@@ -1,10 +1,13 @@
 <?php
 
 /**
- * 
- * @todo inject plugin hook service
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
  *
  * @access private
+ * 
+ * @package    Elgg.Core
+ * @subpackage Notifications
+ * @since      1.9.0
  */
 class Elgg_Notifications_Service {
 
@@ -13,10 +16,24 @@ class Elgg_Notifications_Service {
 	/** @var Elgg_Util_FifoQueue */
 	protected $queue;
 
+	/**
+	 * Constructor
+	 * 
+	 * @param Elgg_Util_FifoQueue $queue Queue
+	 */
 	public function __construct(Elgg_Util_FifoQueue $queue) {
 		$this->queue = $queue;
 	}
 
+	/**
+	 * Register a event to be notification worthy 
+	 *
+	 * @param string $type    Type of the object of event 
+	 * @param string $subtype Subtype of the object of the event
+	 * @param array  $actions The actions that should trigger notifications
+	 * @return void
+	 * @access private
+	 */
 	public function registerEvent($type, $subtype, array $actions = array()) {
 		global $CONFIG;
 
@@ -38,6 +55,9 @@ class Elgg_Notifications_Service {
 		}
 	}
 
+	/**
+	 * @access private
+	 */
 	public function unregisterEvent($type, $subtype) {
 		global $CONFIG;
 		if (!isset($CONFIG->notification_events) ||
@@ -51,11 +71,17 @@ class Elgg_Notifications_Service {
 		return true;
 	}
 
+	/**
+	 * @access private
+	 */
 	public function getEvents() {
 		global $CONFIG;
 		return $CONFIG->notification_events;
 	}
 
+	/**
+	 * @access private
+	 */
 	public function registerMethod($name) {
 		global $CONFIG;
 
@@ -66,6 +92,9 @@ class Elgg_Notifications_Service {
 		$CONFIG->notification_methods[$name] = $name;
 	}
 
+	/**
+	 * @access private
+	 */
 	public function unregisterMethod($name) {
 		global $CONFIG;
 
@@ -80,11 +109,17 @@ class Elgg_Notifications_Service {
 		return false;
 	}
 
+	/**
+	 * @access private
+	 */
 	public function getMethods() {
 		global $CONFIG;
 		return $CONFIG->notification_methods;
 	}
 
+	/**
+	 * @access private
+	 */
 	public function enqueueEvent($action, $type, $object) {
 		if ($object instanceof ElggData) {
 			$object_type = $object->getType();
@@ -117,6 +152,7 @@ class Elgg_Notifications_Service {
 	 *
 	 * @param int $stopTime The Unix time to stop sending notifications
 	 * @return int The number of notification events handled
+	 * @access private
 	 */
 	public function processQueue($stopTime) {
 
@@ -156,8 +192,9 @@ class Elgg_Notifications_Service {
 	 *     <user guid> => array('email', 'sms', 'ajax'),
 	 * );
 	 *
-	 * @param ElggNotificationEvent $event Notification event
+	 * @param Elgg_Notifications_Event $event Notification event
 	 * @return array
+	 * @access private
 	 */
 	protected function getSubscriptions($event) {
 		// @todo not implemented
@@ -172,9 +209,10 @@ class Elgg_Notifications_Service {
 	/**
 	 * Sends the notifications based on subscriptions
 	 *
-	 * @param ElggNotificationEvent $event         Notification event
-	 * @param array                 $subscriptions Subscriptions for this event
+	 * @param Elgg_Notifications_Event $event         Notification event
+	 * @param array                   $subscriptions Subscriptions for this event
 	 * @return int The number of notifications handled
+	 * @access private
 	 */
 	protected function sendNotifications($event, $subscriptions) {
 
@@ -199,10 +237,11 @@ class Elgg_Notifications_Service {
 	/**
 	 * Send a notification to a subscriber
 	 *
-	 * @param ElggNotificationEvent $event  The notification event
-	 * @param int                   $guid   The guid of the subscriber
-	 * @param string                $method The notification method
+	 * @param Elgg_Notifications_Event $event  The notification event
+	 * @param int                      $guid   The guid of the subscriber
+	 * @param string                   $method The notification method
 	 * @return bool
+	 * @access private
 	 */
 	protected function sendNotification($event, $guid, $method) {
 

--- a/engine/classes/Elgg/Notifications/Service.php
+++ b/engine/classes/Elgg/Notifications/Service.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * 
+ * @todo inject plugin hook service
+ *
+ * @access private
+ */
+class Elgg_Notifications_Service {
+
+	const QUEUE_NAME = 'notifications';
+
+	/** @var Elgg_Util_FifoQueue */
+	protected $queue;
+
+	public function __construct(Elgg_Util_FifoQueue $queue) {
+		$this->queue = $queue;
+	}
+
+	public function registerEvent($type, $subtype, array $actions = array()) {
+		global $CONFIG;
+
+		if (!isset($CONFIG->notification_events)) {
+			$CONFIG->notification_events = array();
+		}
+		if (!isset($CONFIG->notification_events[$type])) {
+			$CONFIG->notification_events[$type] = array();
+		}
+		if (!isset($CONFIG->notification_events[$type][$subtype])) {
+			$CONFIG->notification_events[$type][$subtype] = array();
+		}
+
+		$action_list =& $CONFIG->notification_events[$type][$subtype];
+		if ($actions) {
+			$action_list = array_unique(array_merge($action_list, $actions));
+		} elseif (!in_array('create', $action_list)) {
+			$action_list[] = 'create';
+		}
+	}
+
+	public function unregisterEvent($type, $subtype) {
+		global $CONFIG;
+		if (!isset($CONFIG->notification_events) ||
+			!isset($CONFIG->notification_events[$type]) ||
+			!isset($CONFIG->notification_events[$type][$subtype])) {
+			return false;
+		}
+
+		unset($CONFIG->notification_events[$type][$subtype]);
+
+		return true;
+	}
+
+	public function getEvents() {
+		global $CONFIG;
+		return $CONFIG->notification_events;
+	}
+
+	public function registerMethod($name) {
+		global $CONFIG;
+
+		if (!isset($CONFIG->notification_methods)) {
+			$CONFIG->notification_methods = array();
+		}
+
+		$CONFIG->notification_methods[$name] = $name;
+	}
+
+	public function unregisterMethod($name) {
+		global $CONFIG;
+
+		if (!isset($CONFIG->notification_methods)) {
+			return false;
+		}
+
+		if (isset($CONFIG->notification_methods[$name])) {
+			unset($CONFIG->notification_methods[$name]);
+			return true;
+		}
+		return false;
+	}
+
+	public function getMethods() {
+		global $CONFIG;
+		return $CONFIG->notification_methods;
+	}
+
+	public function enqueueEvent($action, $type, $object) {
+		if ($object instanceof ElggData) {
+			$object_type = $object->getType();
+			$object_subtype = $object->getSubtype();
+
+			$registered = false;
+			global $CONFIG;
+			if (isset($CONFIG->notification_events[$object_type])
+				&& isset($CONFIG->notification_events[$object_type][$object_subtype])
+				&& in_array($action, $CONFIG->notification_events[$object_type][$object_subtype])) {
+				$registered = true;
+			}
+
+			if ($registered) {
+				$params = array(
+					'action' => $action,
+					'object' => $object,
+				);
+				$registered = elgg_trigger_plugin_hook('enqueue', 'notification', $params, $registered);
+			}
+
+			if ($registered) {
+				$this->queue->enqueue(new Elgg_Notifications_Event($object, $action));
+			}
+		}
+	}
+
+	/**
+	 * Pull notification events from queue until stop time is reached
+	 *
+	 * @param int $stopTime The Unix time to stop sending notifications
+	 * @return int The number of notification events handled
+	 */
+	public function processQueue($stopTime) {
+
+		$count = 0;
+
+		// @todo grab mutex
+
+		while (time() < $stopTime) {
+			// dequeue notification event
+			$event = $this->queue->dequeue();
+			if (!$event) {
+				break;
+			}
+
+			$subscriptions = $this->getSubscriptions($event);
+
+			// return false to stop the default notification sender
+			$params = array('event' => $event, 'subscriptions' => $subscriptions);
+			if (elgg_trigger_plugin_hook('send:before', 'notifications', $params, true)) {
+				$this->sendNotifications($event, $subscriptions);
+			}
+			elgg_trigger_plugin_hook('send:after', 'notifications', $params);
+			$count++;
+		}
+
+		// release mutex
+
+		return $count;
+	}
+
+	/**
+	 * Get the subscriptions for this notification event
+	 *
+	 * The return array is of the form:
+	 *
+	 * array(
+	 *     <user guid> => array('email', 'sms', 'ajax'),
+	 * );
+	 *
+	 * @param ElggNotificationEvent $event Notification event
+	 * @return array
+	 */
+	protected function getSubscriptions($event) {
+		// @todo not implemented
+		$users = elgg_get_entities(array('type' => 'user'));
+		$subscriptions = array();
+		foreach ($users as $user) {
+			$subscriptions[$user->guid] = array('site');
+		}
+		return $subscriptions;
+	}
+
+	/**
+	 * Sends the notifications based on subscriptions
+	 *
+	 * @param ElggNotificationEvent $event         Notification event
+	 * @param array                 $subscriptions Subscriptions for this event
+	 * @return int The number of notifications handled
+	 */
+	protected function sendNotifications($event, $subscriptions) {
+
+		$registeredMethods = elgg_get_config('notification_methods');
+		if (!$registeredMethods) {
+			return 0;
+		}
+
+		$count = 0;
+		foreach ($subscriptions as $guid => $methods) {
+			foreach ($methods as $method) {
+				if (in_array($method, $registeredMethods)) {
+					if ($this->sendNotification($event, $guid, $method)) {
+						$count++;
+					}
+				}
+			}
+		}
+		return $count;
+	}
+
+	/**
+	 * Send a notification to a subscriber
+	 *
+	 * @param ElggNotificationEvent $event  The notification event
+	 * @param int                   $guid   The guid of the subscriber
+	 * @param string                $method The notification method
+	 * @return bool
+	 */
+	protected function sendNotification($event, $guid, $method) {
+
+		$recipient = get_entity($guid);
+		if (!$recipient) {
+			return false;
+		}
+		$language = $recipient->language;
+		$params = array(
+			'event' => $event,
+			'method' => $method,
+			'recipient' => $recipient,
+			'language' => $language,
+		);
+
+		$subject = elgg_echo('notification:subject', array(), $language);
+		$body = elgg_echo('notification:body', array(), $language);
+		$notification = new Elgg_Notifications_Notification($event->getActor(), $recipient, $language, $subject, $body);
+
+		$type = 'notification:' . $event->getDescription();
+		$notification = elgg_trigger_plugin_hook('prepare', $type, $params, $notification);
+
+		// return true to indicate the notification has been sent
+		$params = array('notification' => $notification);
+		return elgg_trigger_plugin_hook('send', "notification:$method", $params, false);
+	}
+}

--- a/engine/classes/Elgg/Notifications/Service.php
+++ b/engine/classes/Elgg/Notifications/Service.php
@@ -26,12 +26,7 @@ class Elgg_Notifications_Service {
 	}
 
 	/**
-	 * Register a event to be notification worthy 
-	 *
-	 * @param string $type    Type of the object of event 
-	 * @param string $subtype Subtype of the object of the event
-	 * @param array  $actions The actions that should trigger notifications
-	 * @return void
+	 * @see elgg_register_notification_event()
 	 * @access private
 	 */
 	public function registerEvent($type, $subtype, array $actions = array()) {
@@ -56,6 +51,7 @@ class Elgg_Notifications_Service {
 	}
 
 	/**
+	 * @see elgg_unregister_notification_event()
 	 * @access private
 	 */
 	public function unregisterEvent($type, $subtype) {
@@ -80,6 +76,7 @@ class Elgg_Notifications_Service {
 	}
 
 	/**
+	 * @see elgg_register_notification_method()
 	 * @access private
 	 */
 	public function registerMethod($name) {
@@ -93,6 +90,7 @@ class Elgg_Notifications_Service {
 	}
 
 	/**
+	 * @see elgg_unregister_notification_method()
 	 * @access private
 	 */
 	public function unregisterMethod($name) {
@@ -118,6 +116,12 @@ class Elgg_Notifications_Service {
 	}
 
 	/**
+	 * Add a notification event to the queue
+	 * 
+	 * @param string   $action Action name
+	 * @param string   $type   Type of the object of the action
+	 * @param ElggData $object The object of the action 
+	 * @return void
 	 * @access private
 	 */
 	public function enqueueEvent($action, $type, $object) {
@@ -210,7 +214,7 @@ class Elgg_Notifications_Service {
 	 * Sends the notifications based on subscriptions
 	 *
 	 * @param Elgg_Notifications_Event $event         Notification event
-	 * @param array                   $subscriptions Subscriptions for this event
+	 * @param array                    $subscriptions Subscriptions for this event
 	 * @return int The number of notifications handled
 	 * @access private
 	 */
@@ -257,6 +261,7 @@ class Elgg_Notifications_Service {
 			'language' => $language,
 		);
 
+		// @todo what should the default subject and body be?
 		$subject = elgg_echo('notification:subject', array(), $language);
 		$body = elgg_echo('notification:body', array(), $language);
 		$notification = new Elgg_Notifications_Notification($event->getActor(), $recipient, $language, $subject, $body);

--- a/engine/classes/Elgg/Notifications/SubscriptionsService.php
+++ b/engine/classes/Elgg/Notifications/SubscriptionsService.php
@@ -34,7 +34,7 @@ class Elgg_Notifications_SubscriptionsService {
 	}
 
 	/**
-	 * Set the delivery method names
+	 * Set the delivery methods
 	 *
 	 * @param array $methods Array of delivery method names
 	 * @return void
@@ -96,14 +96,14 @@ class Elgg_Notifications_SubscriptionsService {
 			return array();
 		}
 
-		$container_guid = sanitize_int($container_guid);
+		$container_guid = $this->db->sanitizeInt($container_guid);
 
 		// create IN clause
 		$methods = $this->methods;
-		array_walk($methods, 'sanitize_string');
+		array_walk($methods, array($this->db, 'sanitizeString'));
 		$methods_string = "'" . implode("','", $methods) . "'";
 
-		$db_prefix = elgg_get_config('dbprefix');
+		$db_prefix = $this->db->getTablePrefix();
 		$query = "SELECT guid_one AS guid, GROUP_CONCAT(relationship SEPARATOR ',') AS methods
 			FROM {$db_prefix}entity_relationships
 			WHERE guid_two = $container_guid AND

--- a/engine/classes/Elgg/Notifications/SubscriptionsService.php
+++ b/engine/classes/Elgg/Notifications/SubscriptionsService.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ *
+ * @package    Elgg.Core
+ * @subpackage Notifications
+ * @since      1.9.0
+ */
+class Elgg_Notifications_SubscriptionsService {
+
+	/**
+	 * Get the subscriptions for this notification event
+	 *
+	 * The return array is of the form:
+	 *
+	 * array(
+	 *     <user guid> => array('email', 'sms', 'ajax'),
+	 * );
+	 *
+	 * @param Elgg_Notifications_Event $event Notification event
+	 * @return array
+	 */
+	public function getSubscriptions(Elgg_Notifications_Event $event) {
+		// @todo not implemented
+		$users = elgg_get_entities(array('type' => 'user'));
+		$subscriptions = array();
+		foreach ($users as $user) {
+			$subscriptions[$user->guid] = array('site');
+		}
+		return $subscriptions;
+	}
+}

--- a/engine/classes/Elgg/Notifications/SubscriptionsService.php
+++ b/engine/classes/Elgg/Notifications/SubscriptionsService.php
@@ -12,6 +12,42 @@
 class Elgg_Notifications_SubscriptionsService {
 
 	/**
+	 *  Elgg has historically stored subscriptions as relationships with the prefix 'notify'
+	 */
+	const RELATIONSHIP_PREFIX = 'notify';
+
+	/** @var array Notification delivery method names */
+	protected $methods;
+
+	/** @var Elgg_Database */
+	protected $db;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Elgg_Database $db      Database object
+	 * @param array         $methods Notification delivery method names
+	 */
+	public function __construct(Elgg_Database $db, array $methods = array()) {
+		$this->db = $db;
+		$this->setNotificationMethods($methods);
+	}
+
+	/**
+	 * Set the delivery method names
+	 *
+	 * @param array $methods Array of delivery method names
+	 * @return void
+	 */
+	public function setNotificationMethods(array $methods) {
+		$prefix = self::RELATIONSHIP_PREFIX;
+		$this->methods = array();
+		foreach ($methods as $method) {
+			$this->methods[] = "$prefix$method";
+		}
+	}
+
+	/**
 	 * Get the subscriptions for this notification event
 	 *
 	 * The return array is of the form:
@@ -24,12 +60,54 @@ class Elgg_Notifications_SubscriptionsService {
 	 * @return array
 	 */
 	public function getSubscriptions(Elgg_Notifications_Event $event) {
-		// @todo not implemented
-		$users = elgg_get_entities(array('type' => 'user'));
+
 		$subscriptions = array();
-		foreach ($users as $user) {
-			$subscriptions[$user->guid] = array('site');
+
+		if (!$this->methods) {
+			return $subscriptions;
 		}
+
+		$object = $event->getObject();
+		if (!$object) {
+			return $subscriptions;
+		}
+
+		$prefixLength = strlen(self::RELATIONSHIP_PREFIX);
+		$records = $this->getRecords($object->getContainerGUID());
+		foreach ($records as $record) {
+			$deliveryMethods = explode(',', $record->methods);
+			$subscriptions[$record->guid] = substr_replace($deliveryMethods, '', 0, $prefixLength);
+		}
+
 		return $subscriptions;
+	}
+
+	/**
+	 * Get subscription records from the database
+	 *
+	 * Records are an object with two vars: guid and methods with the latter
+	 * being a comma-separated list of subscription relationship names.
+	 *
+	 * @param int $container_guid The GUID of the subscription target
+	 * @return array
+	 */
+	protected function getRecords($container_guid) {
+		if (!$this->methods) {
+			return array();
+		}
+
+		$container_guid = sanitize_int($container_guid);
+
+		// create IN clause
+		$methods = $this->methods;
+		array_walk($methods, 'sanitize_string');
+		$methods_string = "'" . implode("','", $methods) . "'";
+
+		$db_prefix = elgg_get_config('dbprefix');
+		$query = "SELECT guid_one AS guid, GROUP_CONCAT(relationship SEPARATOR ',') AS methods
+			FROM {$db_prefix}entity_relationships
+			WHERE guid_two = $container_guid AND
+					relationship IN ($methods_string) GROUP BY guid_one";
+		return $this->db->getData($query);
 	}
 }

--- a/engine/classes/Elgg/ServiceProvider.php
+++ b/engine/classes/Elgg/ServiceProvider.php
@@ -127,6 +127,7 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 	protected function getNotifications(Elgg_ServiceProvider $c) {
 		// @todo move queue in service provider
 		$queue = new Elgg_Util_DatabaseQueue(Elgg_Notifications_NotificationsService::QUEUE_NAME);
-		return new Elgg_Notifications_NotificationsService($queue, $c->hooks);
+		$sub = new Elgg_Notifications_SubscriptionsService();
+		return new Elgg_Notifications_NotificationsService($sub, $queue, $c->hooks);
 	}
 }

--- a/engine/classes/Elgg/ServiceProvider.php
+++ b/engine/classes/Elgg/ServiceProvider.php
@@ -48,6 +48,7 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 		$this->setFactory('session', array($this, 'getSession'));
 		$this->setFactory('views', array($this, 'getViews'));
 		$this->setClassName('widgets', 'Elgg_WidgetsService');
+		$this->setFactory('notifications', array($this, 'getNotifications'));
 	}
 
 	/**
@@ -115,5 +116,10 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 	protected function getRouter(Elgg_ServiceProvider $c) {
 		// TODO(evan): Init routes from plugins or cache
 		return new Elgg_Router($c->hooks);
+	}
+
+protected function getNotifications(Elgg_ServiceProvider $c) {
+		// @todo move queue in service provider
+		return new Elgg_Notifications_Service(new Elgg_Util_DatabaseQueue(Elgg_Notifications_Service::QUEUE_NAME));
 	}
 }

--- a/engine/classes/Elgg/ServiceProvider.php
+++ b/engine/classes/Elgg/ServiceProvider.php
@@ -126,6 +126,7 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 	 */
 	protected function getNotifications(Elgg_ServiceProvider $c) {
 		// @todo move queue in service provider
-		return new Elgg_Notifications_Service(new Elgg_Util_DatabaseQueue(Elgg_Notifications_Service::QUEUE_NAME));
+		$queue = new Elgg_Util_DatabaseQueue(Elgg_Notifications_Service::QUEUE_NAME);
+		return new Elgg_Notifications_Service($queue, $c->hooks);
 	}
 }

--- a/engine/classes/Elgg/ServiceProvider.php
+++ b/engine/classes/Elgg/ServiceProvider.php
@@ -118,7 +118,13 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 		return new Elgg_Router($c->hooks);
 	}
 
-protected function getNotifications(Elgg_ServiceProvider $c) {
+	/**
+	 * Notification service factory
+	 * 
+	 * @param Elgg_ServiceProvider $c Dependency injection container
+	 * @return Elgg_Notifications_Service
+	 */
+	protected function getNotifications(Elgg_ServiceProvider $c) {
 		// @todo move queue in service provider
 		return new Elgg_Notifications_Service(new Elgg_Util_DatabaseQueue(Elgg_Notifications_Service::QUEUE_NAME));
 	}

--- a/engine/classes/Elgg/ServiceProvider.php
+++ b/engine/classes/Elgg/ServiceProvider.php
@@ -127,7 +127,7 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 	protected function getNotifications(Elgg_ServiceProvider $c) {
 		// @todo move queue in service provider
 		$queue = new Elgg_Util_DatabaseQueue(Elgg_Notifications_NotificationsService::QUEUE_NAME);
-		$sub = new Elgg_Notifications_SubscriptionsService();
+		$sub = new Elgg_Notifications_SubscriptionsService($c->db);
 		return new Elgg_Notifications_NotificationsService($sub, $queue, $c->hooks);
 	}
 }

--- a/engine/classes/Elgg/ServiceProvider.php
+++ b/engine/classes/Elgg/ServiceProvider.php
@@ -7,20 +7,21 @@
  * IDEs to auto-complete properties and understand the types returned. Extension allows us to keep
  * the container generic.
  * 
- * @property-read Elgg_ActionsService       $actions
- * @property-read Elgg_AmdConfig            $amdConfig
- * @property-read ElggAutoP                 $autoP
- * @property-read Elgg_AutoloadManager      $autoloadManager
- * @property-read Elgg_Database             $db
- * @property-read Elgg_EventService         $events
- * @property-read Elgg_PluginHookService    $hooks
- * @property-read Elgg_Logger               $logger
- * @property-read ElggVolatileMetadataCache $metadataCache
- * @property-read Elgg_Request              $request
- * @property-read Elgg_Router               $router
- * @property-read ElggSession               $session
- * @property-read Elgg_ViewService          $views
- * @property-read Elgg_WidgetsService       $widgets
+ * @property-read Elgg_ActionsService                     $actions
+ * @property-read Elgg_AmdConfig                          $amdConfig
+ * @property-read ElggAutoP                               $autoP
+ * @property-read Elgg_AutoloadManager                    $autoloadManager
+ * @property-read Elgg_Database                           $db
+ * @property-read Elgg_EventService                       $events
+ * @property-read Elgg_PluginHookService                  $hooks
+ * @property-read Elgg_Logger                             $logger
+ * @property-read ElggVolatileMetadataCache               $metadataCache
+ * @property-read Elgg_Notifications_NotificationsService $notifications
+ * @property-read Elgg_Request                            $request
+ * @property-read Elgg_Router                             $router
+ * @property-read ElggSession                             $session
+ * @property-read Elgg_ViewService                        $views
+ * @property-read Elgg_WidgetsService                     $widgets
  * 
  * @package Elgg.Core
  * @access private
@@ -128,6 +129,7 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 		// @todo move queue in service provider
 		$queue = new Elgg_Util_DatabaseQueue(Elgg_Notifications_NotificationsService::QUEUE_NAME);
 		$sub = new Elgg_Notifications_SubscriptionsService($c->db);
-		return new Elgg_Notifications_NotificationsService($sub, $queue, $c->hooks);
+		$access = elgg_get_access_object();
+		return new Elgg_Notifications_NotificationsService($sub, $queue, $c->hooks, $access);
 	}
 }

--- a/engine/classes/Elgg/ServiceProvider.php
+++ b/engine/classes/Elgg/ServiceProvider.php
@@ -122,11 +122,11 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 	 * Notification service factory
 	 * 
 	 * @param Elgg_ServiceProvider $c Dependency injection container
-	 * @return Elgg_Notifications_Service
+	 * @return Elgg_Notifications_NotificationsService
 	 */
 	protected function getNotifications(Elgg_ServiceProvider $c) {
 		// @todo move queue in service provider
-		$queue = new Elgg_Util_DatabaseQueue(Elgg_Notifications_Service::QUEUE_NAME);
-		return new Elgg_Notifications_Service($queue, $c->hooks);
+		$queue = new Elgg_Util_DatabaseQueue(Elgg_Notifications_NotificationsService::QUEUE_NAME);
+		return new Elgg_Notifications_NotificationsService($queue, $c->hooks);
 	}
 }

--- a/engine/classes/Elgg/Util/DatabaseQueue.php
+++ b/engine/classes/Elgg/Util/DatabaseQueue.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * FIFO queue that uses ElggObjects for persistence
+ */
+class Elgg_Util_DatabaseQueue implements Elgg_Util_FifoQueue {
+
+	/* @var string Name of the queue */
+	protected $name;
+
+	/**
+	 * Create a queue
+	 *
+	 * @param string $name Name of the queue
+	 */
+	public function __construct($name) {
+		$this->name = sanitize_string($name);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function enqueue($item) {
+		$object = new ElggObject();
+		$object->subtype = 'elgg:queue';
+		$object->access_id = ACCESS_PUBLIC;
+		$object->title = $this->name;
+		$object->description = serialize($item);
+		return (bool)$object->save();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function dequeue() {
+		$db_prefix = elgg_get_config('dbprefix');
+		$object = elgg_get_entities(array(
+			'type' => 'object',
+			'subtype' => 'elgg:queue',
+			'order_by' => 'e.guid ASC',
+			'limit' => 1,
+			'joins' => array("JOIN {$db_prefix}objects_entity as oe on oe.guid = e.guid"),
+			'wheres' => array("oe.title = '$this->name'"),
+		));
+		if ($object) {
+			$result = unserialize($object[0]->description);
+			$object[0]->delete();
+			return $result;
+		}
+		return null;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function clear() {
+		$db_prefix = elgg_get_config('dbprefix');
+		$options = array(
+			'type' => 'object',
+			'subtype' => 'elgg:queue',
+			'order_by' => 'e.guid ASC',
+			'limit' => 0,
+			'joins' => array("JOIN {$db_prefix}objects_entity as oe on oe.guid = e.guid"),
+			'wheres' => array("oe.title = '$this->name'"),
+		);
+		$batch = new ElggBatch('elgg_get_entities', $options);
+		foreach ($batch as $item) {
+			$item->delete();
+		}
+	}
+}

--- a/engine/classes/Elgg/Util/DatabaseQueue.php
+++ b/engine/classes/Elgg/Util/DatabaseQueue.php
@@ -11,7 +11,7 @@
  * @subpackage Util
  * @since      1.9.0
  */
-class Elgg_Util_DatabaseQueue implements Elgg_Util_FifoQueue {
+class Elgg_Util_DatabaseQueue implements Elgg_Util_Queue {
 
 	/* @var string Name of the queue */
 	protected $name;

--- a/engine/classes/Elgg/Util/DatabaseQueue.php
+++ b/engine/classes/Elgg/Util/DatabaseQueue.php
@@ -2,6 +2,14 @@
 
 /**
  * FIFO queue that uses ElggObjects for persistence
+ *
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ * 
+ * @package    Elgg.Core
+ * @subpackage Util
+ * @since      1.9.0
  */
 class Elgg_Util_DatabaseQueue implements Elgg_Util_FifoQueue {
 

--- a/engine/classes/Elgg/Util/FifoQueue.php
+++ b/engine/classes/Elgg/Util/FifoQueue.php
@@ -1,0 +1,27 @@
+<?php
+
+
+/**
+ * FIFO Queue interface
+ */
+interface Elgg_Util_FifoQueue {
+	/**
+	 * Add an item to the queue
+	 *
+	 * @param mixed $item
+	 * @return bool
+	 */
+	public function enqueue($item);
+
+	/**
+	 * Remove the oldest item from the queue
+	 *
+	 * @return mixed
+	 */
+	public function dequeue();
+
+	/**
+	 * Clear all items from the queue
+	 */
+	public function clear();
+}

--- a/engine/classes/Elgg/Util/FifoQueue.php
+++ b/engine/classes/Elgg/Util/FifoQueue.php
@@ -1,14 +1,21 @@
 <?php
 
-
 /**
  * FIFO Queue interface
+ *
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ * 
+ * @package    Elgg.Core
+ * @subpackage Util
+ * @since      1.9.0
  */
 interface Elgg_Util_FifoQueue {
 	/**
 	 * Add an item to the queue
 	 *
-	 * @param mixed $item
+	 * @param mixed $item Item to add to queue
 	 * @return bool
 	 */
 	public function enqueue($item);
@@ -22,6 +29,8 @@ interface Elgg_Util_FifoQueue {
 
 	/**
 	 * Clear all items from the queue
+	 * 
+	 * @return void
 	 */
 	public function clear();
 }

--- a/engine/classes/Elgg/Util/MemoryQueue.php
+++ b/engine/classes/Elgg/Util/MemoryQueue.php
@@ -1,5 +1,8 @@
 <?php
+
 /**
+ * FIFO queue that is memory based (not persistent)
+ * 
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
  *
  * @access private
@@ -8,7 +11,7 @@
  * @subpackage Util
  * @since      1.9.0
  */
-class Elgg_Util_MemoryQueue implements Elgg_Util_FifoQueue {
+class Elgg_Util_MemoryQueue implements Elgg_Util_Queue {
 
 	/* @var array */
 	protected $queue = array();

--- a/engine/classes/Elgg/Util/MemoryQueue.php
+++ b/engine/classes/Elgg/Util/MemoryQueue.php
@@ -1,0 +1,35 @@
+<?php
+
+class Elgg_Util_MemoryQueue implements Elgg_Util_FifoQueue {
+
+	/* @var array */
+	protected $queue = array();
+
+	/**
+	 * Create a queue
+	 */
+	public function __construct() {
+		$this->queue = array();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function enqueue($item) {
+		return (bool)array_push($this->queue, $item);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function dequeue() {
+		return array_shift($this->queue);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function clear() {
+		$this->queue = array();
+	}
+}

--- a/engine/classes/Elgg/Util/MemoryQueue.php
+++ b/engine/classes/Elgg/Util/MemoryQueue.php
@@ -1,5 +1,13 @@
 <?php
-
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ * 
+ * @package    Elgg.Core
+ * @subpackage Util
+ * @since      1.9.0
+ */
 class Elgg_Util_MemoryQueue implements Elgg_Util_FifoQueue {
 
 	/* @var array */

--- a/engine/classes/Elgg/Util/Queue.php
+++ b/engine/classes/Elgg/Util/Queue.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * FIFO Queue interface
+ * Queue interface
  *
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
  *
@@ -11,7 +11,7 @@
  * @subpackage Util
  * @since      1.9.0
  */
-interface Elgg_Util_FifoQueue {
+interface Elgg_Util_Queue {
 	/**
 	 * Add an item to the queue
 	 *

--- a/engine/lib/deprecated-1.9.php
+++ b/engine/lib/deprecated-1.9.php
@@ -1682,24 +1682,9 @@ $posted = 0, $annotation_id = 0, $target_guid = 0) {
  */
 function register_notification_object($entity_type, $object_subtype, $language_name) {
 	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated by elgg_register_notification_event()', 1.9);
-	global $CONFIG;
 
-	if ($entity_type == '') {
-		$entity_type = '__BLANK__';
-	}
-	if ($object_subtype == '') {
-		$object_subtype = '__BLANK__';
-	}
-
-	if (!isset($CONFIG->register_objects)) {
-		$CONFIG->register_objects = array();
-	}
-
-	if (!isset($CONFIG->register_objects[$entity_type])) {
-		$CONFIG->register_objects[$entity_type] = array();
-	}
-
-	$CONFIG->register_objects[$entity_type][$object_subtype] = $language_name;
+	elgg_register_notification_event($entity_type, $object_subtype);
+	_elgg_services()->notifications->setDeprecatedNotificationSubject($entity_type, $object_subtype, $language_name);
 }
 
 /**
@@ -1730,8 +1715,6 @@ function remove_notification_interest($user_guid, $author_guid) {
 	return remove_entity_relationship($user_guid, 'notify', $author_guid);
 }
 
-elgg_register_event_handler('create', 'object', 'object_notifications');
-
 /**
  * Automatically triggered notification on 'create' events that looks at registered
  * objects and attempts to send notifications to anybody who's interested
@@ -1747,78 +1730,8 @@ elgg_register_event_handler('create', 'object', 'object_notifications');
  * @deprecated 1.9
  */
 function object_notifications($event, $object_type, $object) {
-	// We only want to trigger notification events for ElggEntities
-	if ($object instanceof ElggEntity) {
-		/* @var ElggEntity $object */
-
-		// Get config data
-		global $CONFIG, $SESSION, $NOTIFICATION_HANDLERS;
-
-		$hookresult = elgg_trigger_plugin_hook('object:notifications', $object_type, array(
-			'event' => $event,
-			'object_type' => $object_type,
-			'object' => $object,
-		), false);
-		if ($hookresult === true) {
-			return true;
-		}
-
-		// Have we registered notifications for this type of entity?
-		$object_type = $object->getType();
-		if (empty($object_type)) {
-			$object_type = '__BLANK__';
-		}
-
-		$object_subtype = $object->getSubtype();
-		if (empty($object_subtype)) {
-			$object_subtype = '__BLANK__';
-		}
-
-		if (isset($CONFIG->register_objects[$object_type][$object_subtype])) {
-			$subject = $CONFIG->register_objects[$object_type][$object_subtype];
-			$string = $subject . ": " . $object->getURL();
-
-			// Get users interested in content from this person and notify them
-			// (Person defined by container_guid so we can also subscribe to groups if we want)
-			foreach ($NOTIFICATION_HANDLERS as $method => $foo) {
-				$interested_users = elgg_get_entities_from_relationship(array(
-					'site_guids' => ELGG_ENTITIES_ANY_VALUE,
-					'relationship' => 'notify' . $method,
-					'relationship_guid' => $object->container_guid,
-					'inverse_relationship' => TRUE,
-					'type' => 'user',
-					'limit' => false
-				));
-				/* @var ElggUser[] $interested_users */
-
-				if ($interested_users && is_array($interested_users)) {
-					foreach ($interested_users as $user) {
-						if ($user instanceof ElggUser && !$user->isBanned()) {
-							if (($user->guid != $SESSION['user']->guid) && has_access_to_entity($object, $user)
-							&& $object->access_id != ACCESS_PRIVATE) {
-								$body = elgg_trigger_plugin_hook('notify:entity:message', $object->getType(), array(
-									'entity' => $object,
-									'to_entity' => $user,
-									'method' => $method), $string);
-								if (empty($body) && $body !== false) {
-									$body = $string;
-								}
-								if ($body !== false) {
-									notify_user($user->guid, $object->container_guid, $subject, $body,
-										null, array($method));
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+	throw new BadFunctionCallException("object_notifications is a private function and should not be called directly");
 }
-
-/** Notification handlers */
-global $NOTIFICATION_HANDLERS;
-$NOTIFICATION_HANDLERS = array();
 
 /**
  * This function registers a handler for a given notification type (eg "email")
@@ -1836,22 +1749,8 @@ $NOTIFICATION_HANDLERS = array();
  */
 function register_notification_handler($method, $handler, $params = NULL) {
 	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated by elgg_register_notification_method()', 1.9);
-	global $NOTIFICATION_HANDLERS;
-
-	if (is_callable($handler, true)) {
-		$NOTIFICATION_HANDLERS[$method] = new stdClass;
-
-		$NOTIFICATION_HANDLERS[$method]->handler = $handler;
-		if ($params) {
-			foreach ($params as $k => $v) {
-				$NOTIFICATION_HANDLERS[$method]->$k = $v;
-			}
-		}
-
-		return true;
-	}
-
-	return false;
+	elgg_register_notification_method($method);
+	_elgg_services()->notifications->registerDeprecatedHandler($method, $handler);
 }
 
 /**
@@ -1865,10 +1764,6 @@ function register_notification_handler($method, $handler, $params = NULL) {
  */
 function unregister_notification_handler($method) {
 	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated by elgg_unregister_notification_method()', 1.9);
-	global $NOTIFICATION_HANDLERS;
-
-	if (isset($NOTIFICATION_HANDLERS[$method])) {
-		unset($NOTIFICATION_HANDLERS[$method]);
-	}
+	elgg_unregister_notification_method($method);
 }
 

--- a/engine/lib/deprecated-1.9.php
+++ b/engine/lib/deprecated-1.9.php
@@ -34,6 +34,8 @@ function get_day_end($day = null, $month = null, $year = null) {
 /**
  * Return the notable entities for a given time period.
  *
+ * @todo this function also accepts an array(type => subtypes) for 3rd arg. Should we document this?
+ *
  * @param int     $start_time     The start time as a unix timestamp.
  * @param int     $end_time       The end time as a unix timestamp.
  * @param string  $type           The type of entity (eg "user", "object" etc)
@@ -1667,3 +1669,206 @@ $posted = 0, $annotation_id = 0, $target_guid = 0) {
 		'annotation_id' => $annotation_id,
 	));
 }
+
+/**
+ * Register an entity type and subtype to be eligible for notifications
+ *
+ * @param string $entity_type    The type of entity
+ * @param string $object_subtype Its subtype
+ * @param string $language_name  Its localized notification string (eg "New blog post")
+ *
+ * @return void
+ * @deprecated 1.9 Use elgg_register_notification_event()
+ */
+function register_notification_object($entity_type, $object_subtype, $language_name) {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated by elgg_register_notification_event()', 1.9);
+	global $CONFIG;
+
+	if ($entity_type == '') {
+		$entity_type = '__BLANK__';
+	}
+	if ($object_subtype == '') {
+		$object_subtype = '__BLANK__';
+	}
+
+	if (!isset($CONFIG->register_objects)) {
+		$CONFIG->register_objects = array();
+	}
+
+	if (!isset($CONFIG->register_objects[$entity_type])) {
+		$CONFIG->register_objects[$entity_type] = array();
+	}
+
+	$CONFIG->register_objects[$entity_type][$object_subtype] = $language_name;
+}
+
+/**
+ * Establish a 'notify' relationship between the user and a content author
+ *
+ * @param int $user_guid   The GUID of the user who wants to follow a user's content
+ * @param int $author_guid The GUID of the user whose content the user wants to follow
+ *
+ * @return bool Depending on success
+ * @deprecated 1.9 Use elgg_add_subscription()
+ */
+function register_notification_interest($user_guid, $author_guid) {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated by elgg_add_subscription()', 1.9);
+	return add_entity_relationship($user_guid, 'notify', $author_guid);
+}
+
+/**
+ * Remove a 'notify' relationship between the user and a content author
+ *
+ * @param int $user_guid   The GUID of the user who is following a user's content
+ * @param int $author_guid The GUID of the user whose content the user wants to unfollow
+ *
+ * @return bool Depending on success
+ * @deprecated 1.9 Use elgg_remove_subscription()
+ */
+function remove_notification_interest($user_guid, $author_guid) {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated by elgg_remove_subscription()', 1.9);
+	return remove_entity_relationship($user_guid, 'notify', $author_guid);
+}
+
+elgg_register_event_handler('create', 'object', 'object_notifications');
+
+/**
+ * Automatically triggered notification on 'create' events that looks at registered
+ * objects and attempts to send notifications to anybody who's interested
+ *
+ * @see register_notification_object
+ *
+ * @param string $event       create
+ * @param string $object_type mixed
+ * @param mixed  $object      The object created
+ *
+ * @return bool
+ * @access private
+ * @deprecated 1.9
+ */
+function object_notifications($event, $object_type, $object) {
+	// We only want to trigger notification events for ElggEntities
+	if ($object instanceof ElggEntity) {
+		/* @var ElggEntity $object */
+
+		// Get config data
+		global $CONFIG, $SESSION, $NOTIFICATION_HANDLERS;
+
+		$hookresult = elgg_trigger_plugin_hook('object:notifications', $object_type, array(
+			'event' => $event,
+			'object_type' => $object_type,
+			'object' => $object,
+		), false);
+		if ($hookresult === true) {
+			return true;
+		}
+
+		// Have we registered notifications for this type of entity?
+		$object_type = $object->getType();
+		if (empty($object_type)) {
+			$object_type = '__BLANK__';
+		}
+
+		$object_subtype = $object->getSubtype();
+		if (empty($object_subtype)) {
+			$object_subtype = '__BLANK__';
+		}
+
+		if (isset($CONFIG->register_objects[$object_type][$object_subtype])) {
+			$subject = $CONFIG->register_objects[$object_type][$object_subtype];
+			$string = $subject . ": " . $object->getURL();
+
+			// Get users interested in content from this person and notify them
+			// (Person defined by container_guid so we can also subscribe to groups if we want)
+			foreach ($NOTIFICATION_HANDLERS as $method => $foo) {
+				$interested_users = elgg_get_entities_from_relationship(array(
+					'site_guids' => ELGG_ENTITIES_ANY_VALUE,
+					'relationship' => 'notify' . $method,
+					'relationship_guid' => $object->container_guid,
+					'inverse_relationship' => TRUE,
+					'type' => 'user',
+					'limit' => false
+				));
+				/* @var ElggUser[] $interested_users */
+
+				if ($interested_users && is_array($interested_users)) {
+					foreach ($interested_users as $user) {
+						if ($user instanceof ElggUser && !$user->isBanned()) {
+							if (($user->guid != $SESSION['user']->guid) && has_access_to_entity($object, $user)
+							&& $object->access_id != ACCESS_PRIVATE) {
+								$body = elgg_trigger_plugin_hook('notify:entity:message', $object->getType(), array(
+									'entity' => $object,
+									'to_entity' => $user,
+									'method' => $method), $string);
+								if (empty($body) && $body !== false) {
+									$body = $string;
+								}
+								if ($body !== false) {
+									notify_user($user->guid, $object->container_guid, $subject, $body,
+										null, array($method));
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+/** Notification handlers */
+global $NOTIFICATION_HANDLERS;
+$NOTIFICATION_HANDLERS = array();
+
+/**
+ * This function registers a handler for a given notification type (eg "email")
+ *
+ * @param string $method  The method
+ * @param string $handler The handler function, in the format
+ *                        "handler(ElggEntity $from, ElggUser $to, $subject,
+ *                        $message, array $params = NULL)". This function should
+ *                        return false on failure, and true/a tracking message ID on success.
+ * @param array  $params  An associated array of other parameters for this handler
+ *                        defining some properties eg. supported msg length or rich text support.
+ *
+ * @return bool
+ * @deprecated 1.9 Use elgg_register_notification_method()
+ */
+function register_notification_handler($method, $handler, $params = NULL) {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated by elgg_register_notification_method()', 1.9);
+	global $NOTIFICATION_HANDLERS;
+
+	if (is_callable($handler, true)) {
+		$NOTIFICATION_HANDLERS[$method] = new stdClass;
+
+		$NOTIFICATION_HANDLERS[$method]->handler = $handler;
+		if ($params) {
+			foreach ($params as $k => $v) {
+				$NOTIFICATION_HANDLERS[$method]->$k = $v;
+			}
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * This function unregisters a handler for a given notification type (eg "email")
+ *
+ * @param string $method The method
+ *
+ * @return void
+ * @since 1.7.1
+ * @deprecated 1.9 Use elgg_unregister_notification_method()
+ */
+function unregister_notification_handler($method) {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated by elgg_unregister_notification_method()', 1.9);
+	global $NOTIFICATION_HANDLERS;
+
+	if (isset($NOTIFICATION_HANDLERS[$method])) {
+		unset($NOTIFICATION_HANDLERS[$method]);
+	}
+}
+

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -17,9 +17,9 @@
  *
  * 	   elgg_register_notification_event('relationship', 'friend');
  *
- * @param  string $object_type    'object', 'user', 'group', 'site', 'annotation', 'relationship'
- * @param  string $object_subtype The subtype or name of the entity, annotation or relationship
- * @param  array  $actions        Array of actions or empty array for the action event.
+ * @param string $object_type    'object', 'user', 'group', 'site', 'annotation', 'relationship'
+ * @param string $object_subtype The subtype or name of the entity, annotation or relationship
+ * @param array  $actions        Array of actions or empty array for the action event.
  *                                An event is usually described by the first string passed
  *                                to elgg_trigger_event(). Examples include
  *                                'create', 'update', and 'publish'. The default is 'create'.
@@ -33,8 +33,8 @@ function elgg_register_notification_event($object_type, $object_subtype, array $
 /**
  * Unregister a notification event
  *
- * @param  string $object_type    'object', 'user', 'group', 'site', 'annotation', 'relationship'
- * @param  string $object_subtype The type of the entity or the subtype of the annotation or relationship
+ * @param string $object_type    'object', 'user', 'group', 'site', 'annotation', 'relationship'
+ * @param string $object_subtype The type of the entity or the subtype of the annotation or relationship
  * @return bool
  * @since 1.9
  */

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -1,5 +1,44 @@
 <?php
 /**
+ * Notification Events
+ * =====================
+ * Elgg events registered with the function elgg_register_notification_event() 
+ * trigger the notification system. See the documentation for that function for
+ * more details.
+ *  
+ * 
+ * Notification Methods
+ * ======================
+ * 
+ *   Delivery methods
+ *   -----------------
+ *   Notification delivery methods are registered with the function 
+ *   elgg_register_notification_method(). 
+ * 
+ *   Message content
+ *   ----------------
+ *   The message is determined through a plugin hook that is triggered for each
+ *   notification: 'prepare', 'notification:[event name]'. The event name is of 
+ *   the form [action]:[type]:[subtype]. For example, the publish event for a blog
+ *   would be named 'publish:object:object'. The params for the plugin hook
+ *   has the keys 'event', 'method', 'recipient', and 'language'.
+ * 
+ *   The plugin hook callback modifies a Elgg_Notifications_Notification object
+ *   that holds the message content.
+ * 
+ *   Sending the notification
+ *   ------------------------
+ *   Plugins that register a delivery method should also register for the plugin
+ *   hook for that method. The hook is named 'send', 'notification:[method name]'.
+ *   It receives the notification object in the params array and should return 
+ *   a boolean to indicate whether the message was sent.
+ * 
+ * 
+ * Subscriptions
+ * ================
+ * Users subscribe to receive notifications based on container and delivery method.
+ * 
+ * 
  * @package Elgg.Core
  * @subpackage Notifications
  */
@@ -44,6 +83,10 @@ function elgg_unregister_notification_event($object_type, $object_subtype) {
 
 /**
  * Register a delivery method for notifications
+ * 
+ * Register for the 'send', 'notification:[method name]' plugin hook to handle
+ * sending a notification. A notification object is in the params array for the
+ * hook with the key 'notification'. See Elgg_Notifications_Notification.
  *
  * @param string $name The notification method name
  * @return void

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -7,9 +7,9 @@
  * 2. Register for the notification message plugin hook:
  *    'prepare', 'notification:[event name]'. The event name is of the form 
  *    [action]:[type]:[subtype]. For example, the publish event for a blog 
- *    would be named 'publish:object:object'. 
+ *    would be named 'publish:object:blog'.
  * 
- *    The params for the plugin hook have the keys 'event', 'method', 
+ *    The parameter array for the plugin hook has the keys 'event', 'method',
  *    'recipient', and 'language'. The event is an Elgg_Notifications_Event 
  *    object and can provide access to the original object of the event through 
  *    the method getObject() and the original actor through getActor().

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -1,41 +1,36 @@
 <?php
 /**
- * Notification Events
- * =====================
- * Elgg events registered with the function elgg_register_notification_event() 
- * trigger the notification system. See the documentation for that function for
- * more details.
- *  
+ * Adding a New Notification Event
+ * ===============================
+ * 1. Register the event with elgg_register_notification_event()
  * 
- * Notification Methods
- * ======================
+ * 2. Register for the notification message plugin hook:
+ *    'prepare', 'notification:[event name]'. The event name is of the form 
+ *    [action]:[type]:[subtype]. For example, the publish event for a blog 
+ *    would be named 'publish:object:object'. 
  * 
- *   Delivery methods
- *   -----------------
- *   Notification delivery methods are registered with the function 
- *   elgg_register_notification_method(). 
+ *    The params for the plugin hook have the keys 'event', 'method', 
+ *    'recipient', and 'language'. The event is an Elgg_Notifications_Event 
+ *    object and can provide access to the original object of the event through 
+ *    the method getObject() and the original actor through getActor().
  * 
- *   Message content
- *   ----------------
- *   The message is determined through a plugin hook that is triggered for each
- *   notification: 'prepare', 'notification:[event name]'. The event name is of 
- *   the form [action]:[type]:[subtype]. For example, the publish event for a blog
- *   would be named 'publish:object:object'. The params for the plugin hook
- *   has the keys 'event', 'method', 'recipient', and 'language'.
+ *    The plugin hook callback modifies and returns a 
+ *    Elgg_Notifications_Notification object that holds the message content.
+ *
+ *
+ * Adding a Delivery Method
+ * =========================
+ * 1. Register the delivery method name with elgg_register_notification_method()
  * 
- *   The plugin hook callback modifies a Elgg_Notifications_Notification object
- *   that holds the message content.
- * 
- *   Sending the notification
- *   ------------------------
- *   Plugins that register a delivery method should also register for the plugin
- *   hook for that method. The hook is named 'send', 'notification:[method name]'.
- *   It receives the notification object in the params array and should return 
- *   a boolean to indicate whether the message was sent.
+ * 2. Register for the plugin hook for sending notifications:
+ *    'send', 'notification:[method name]'. It receives the notification object 
+ *    of the class Elgg_Notifications_Notification in the params array with the 
+ *    key 'notification'. The callback should return a boolean to indicate whether 
+ *    the message was sent.
  * 
  * 
- * Subscriptions
- * ================
+ * Subscribing a User for Notifications
+ * ====================================
  * Users subscribe to receive notifications based on container and delivery method.
  * 
  * 

--- a/engine/lib/upgrades/2010071002.php
+++ b/engine/lib/upgrades/2010071002.php
@@ -5,7 +5,7 @@
 
 // loop through all users checking collections and notifications
 global $ENTITY_CACHE, $CONFIG;
-global $NOTIFICATION_HANDLERS;
+$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 $users = mysql_query("SELECT guid, username FROM {$CONFIG->dbprefix}users_entity
 	WHERE username != ''");
 while ($user = mysql_fetch_object($users)) {

--- a/engine/tests/ElggCoreDatabaseQueueTest.php
+++ b/engine/tests/ElggCoreDatabaseQueueTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Elgg_Util_DatabaseQueue tests
+ *
+ * @package Elgg
+ * @subpackage Test
+ */
+class ElggCoreDatabaseQueueTest extends ElggCoreUnitTest {
+
+	public function testEnqueueAndDequeue() {
+		$queue = new Elgg_Util_DatabaseQueue('unit:test');
+		$first = array(1, 2, 3);
+		$second = array(4, 5, 6);
+
+		$result = $queue->enqueue($first);
+		$this->assertTrue($result);
+		$result = $queue->enqueue($second);
+		$this->assertTrue($result);
+
+		$data = $queue->dequeue();
+		$this->assertIdentical($first, $data);
+		$data = $queue->dequeue();
+		$this->assertIdentical($second, $data);
+
+		$data = $queue->dequeue();
+		$this->assertIdentical(null, $data);
+	}
+
+	public function testMultipleQueues() {
+		$queue1 = new Elgg_Util_DatabaseQueue('unit:test1');
+		$queue2 = new Elgg_Util_DatabaseQueue('unit:test2');
+		$first = array(1, 2, 3);
+		$second = array(4, 5, 6);
+
+		$result = $queue1->enqueue($first);
+		$this->assertTrue($result);
+		$result = $queue2->enqueue($second);
+		$this->assertTrue($result);
+
+		$data = $queue2->dequeue();
+		$this->assertIdentical($second, $data);
+		$data = $queue1->dequeue();
+		$this->assertIdentical($first, $data);
+	}
+
+	public function testClear() {
+		$queue = new Elgg_Util_DatabaseQueue('unit:test');
+		$first = array(1, 2, 3);
+		$second = array(4, 5, 6);
+
+		$result = $queue->enqueue($first);
+		$this->assertTrue($result);
+		$result = $queue->enqueue($second);
+		$this->assertTrue($result);
+
+		$queue->clear();
+		$data = $queue->dequeue();
+		$this->assertIdentical(null, $data);
+	}
+}

--- a/engine/tests/phpunit/Elgg/Notifications/NotificationsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/NotificationsServiceTest.php
@@ -1,17 +1,21 @@
 <?php
 
-$engine = dirname(dirname(dirname(__FILE__)));
+// the Event class has a dependency on elgg_instance_of() and get_entity()
+$engine = dirname(dirname(dirname(dirname(dirname(__FILE__)))));
 require_once "$engine/lib/entities.php";
 
-class ElggNotificationsServiceTest extends PHPUnit_Framework_TestCase {
+class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_TestCase {
 
 	public function setUp() {
 		$this->hooks = new Elgg_PluginHookService();
 		$this->queue = new Elgg_Util_MemoryQueue();
+
+		// Event class has dependency on elgg_get_logged_in_user_guid()
+		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
 	}
 
 	public function testRegisterEvent() {
-		$service = new Elgg_Notifications_Service($this->queue, $this->hooks);
+		$service = new Elgg_Notifications_NotificationsService($this->queue, $this->hooks);
 
 		$service->registerEvent('foo', 'bar');
 		$events = array(
@@ -30,7 +34,7 @@ class ElggNotificationsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testUnregisterEvent() {
-		$service = new Elgg_Notifications_Service($this->queue, $this->hooks);
+		$service = new Elgg_Notifications_NotificationsService($this->queue, $this->hooks);
 
 		$service->registerEvent('foo', 'bar');
 		$this->assertTrue($service->unregisterEvent('foo', 'bar'));
@@ -43,7 +47,7 @@ class ElggNotificationsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testRegisterMethod() {
-		$service = new Elgg_Notifications_Service($this->queue, $this->hooks);
+		$service = new Elgg_Notifications_NotificationsService($this->queue, $this->hooks);
 
 		$service->registerMethod('foo');
 		$methods = array('foo' => 'foo');
@@ -51,7 +55,7 @@ class ElggNotificationsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testUnregisterMethod() {
-		$service = new Elgg_Notifications_Service($this->queue, $this->hooks);
+		$service = new Elgg_Notifications_NotificationsService($this->queue, $this->hooks);
 
 		$service->registerMethod('foo');
 		$this->assertTrue($service->unregisterMethod('foo'));
@@ -60,7 +64,7 @@ class ElggNotificationsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testEnqueueEvent() {
-		$service = new Elgg_Notifications_Service($this->queue, $this->hooks);
+		$service = new Elgg_Notifications_NotificationsService($this->queue, $this->hooks);
 
 		$service->registerEvent('object', 'bar');
 		$object = new ElggObject();
@@ -88,7 +92,7 @@ class ElggNotificationsServiceTest extends PHPUnit_Framework_TestCase {
 		$observer->expects($this->once())
 				->method('trigger')
 				->with('enqueue', 'notification', $params, true);
-		$service = new Elgg_Notifications_Service($this->queue, $observer);
+		$service = new Elgg_Notifications_NotificationsService($this->queue, $observer);
 		$service->registerEvent('object', 'bar');
 		$service->enqueueEvent('create', 'object', $object);
 	}
@@ -98,7 +102,7 @@ class ElggNotificationsServiceTest extends PHPUnit_Framework_TestCase {
 		$observer->expects($this->once())
 				->method('trigger')
 				->will($this->returnValue(false));
-		$service = new Elgg_Notifications_Service($this->queue, $observer);
+		$service = new Elgg_Notifications_NotificationsService($this->queue, $observer);
 
 		$service->registerEvent('object', 'bar');
 		$object = new ElggObject();

--- a/engine/tests/phpunit/Elgg/Notifications/NotificationsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/NotificationsServiceTest.php
@@ -10,14 +10,15 @@ class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_Test
 		$this->hooks = new Elgg_PluginHookService();
 		$this->queue = new Elgg_Util_MemoryQueue();
 		$dbMock = $this->getMock('Elgg_Database');
-		$this->sub   = new Elgg_Notifications_SubscriptionsService($dbMock);
+		$this->sub = new Elgg_Notifications_SubscriptionsService($dbMock);
+		$this->access = new Elgg_Access();
 
 		// Event class has dependency on elgg_get_logged_in_user_guid()
 		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
 	}
 
 	public function testRegisterEvent() {
-		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $this->hooks);
+		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $this->hooks, $this->access);
 
 		$service->registerEvent('foo', 'bar');
 		$events = array(
@@ -36,7 +37,7 @@ class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_Test
 	}
 
 	public function testUnregisterEvent() {
-		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $this->hooks);
+		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $this->hooks, $this->access);
 
 		$service->registerEvent('foo', 'bar');
 		$this->assertTrue($service->unregisterEvent('foo', 'bar'));
@@ -49,7 +50,7 @@ class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_Test
 	}
 
 	public function testRegisterMethod() {
-		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $this->hooks);
+		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $this->hooks, $this->access);
 
 		$service->registerMethod('foo');
 		$methods = array('foo' => 'foo');
@@ -57,7 +58,7 @@ class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_Test
 	}
 
 	public function testUnregisterMethod() {
-		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $this->hooks);
+		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $this->hooks, $this->access);
 
 		$service->registerMethod('foo');
 		$this->assertTrue($service->unregisterMethod('foo'));
@@ -66,7 +67,7 @@ class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_Test
 	}
 
 	public function testEnqueueEvent() {
-		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $this->hooks);
+		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $this->hooks, $this->access);
 
 		$service->registerEvent('object', 'bar');
 		$object = new ElggObject();
@@ -94,7 +95,7 @@ class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_Test
 		$mock->expects($this->once())
 			->method('trigger')
 			->with('enqueue', 'notification', $params, true);
-		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $mock);
+		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $mock, $this->access);
 		$service->registerEvent('object', 'bar');
 		$service->enqueueEvent('create', 'object', $object);
 	}
@@ -104,7 +105,7 @@ class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_Test
 		$mock->expects($this->once())
 			->method('trigger')
 			->will($this->returnValue(false));
-		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $mock);
+		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $mock, $this->access);
 
 		$service->registerEvent('object', 'bar');
 		$object = new ElggObject();
@@ -114,7 +115,7 @@ class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_Test
 	}
 
 	public function testProcessQueueNoEvents() {
-		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $this->hooks);
+		$service = new Elgg_Notifications_NotificationsService($this->sub, $this->queue, $this->hooks, $this->access);
 		$this->assertEquals(0, $service->processQueue(time() + 10));
 	}
 
@@ -128,7 +129,7 @@ class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_Test
 		$mock->expects($this->exactly(3))
 			->method('getSubscriptions')
 			->will($this->returnValue(array()));
-		$service = new Elgg_Notifications_NotificationsService($mock, $this->queue, $this->hooks);
+		$service = new Elgg_Notifications_NotificationsService($mock, $this->queue, $this->hooks, $this->access);
 
 		$service->registerEvent('object', 'bar');
 		$object = new ElggObject();
@@ -149,7 +150,7 @@ class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_Test
 				false);
 		$mock->expects($this->exactly(0))
 			->method('getSubscriptions');
-		$service = new Elgg_Notifications_NotificationsService($mock, $this->queue, $this->hooks);
+		$service = new Elgg_Notifications_NotificationsService($mock, $this->queue, $this->hooks, $this->access);
 
 		$service->registerEvent('object', 'bar');
 		$object = new ElggObject();

--- a/engine/tests/phpunit/Elgg/Notifications/NotificationsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/NotificationsServiceTest.php
@@ -9,7 +9,8 @@ class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_Test
 	public function setUp() {
 		$this->hooks = new Elgg_PluginHookService();
 		$this->queue = new Elgg_Util_MemoryQueue();
-		$this->sub   = new Elgg_Notifications_SubscriptionsService();
+		$dbMock = $this->getMock('Elgg_Database');
+		$this->sub   = new Elgg_Notifications_SubscriptionsService($dbMock);
 
 		// Event class has dependency on elgg_get_logged_in_user_guid()
 		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
@@ -118,7 +119,12 @@ class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_Test
 	}
 
 	public function testProcessQueueThreeEvents() {
-		$mock = $this->getMock('Elgg_Notifications_SubscriptionsService', array('getSubscriptions'));
+		$mock = $this->getMock(
+				'Elgg_Notifications_SubscriptionsService',
+				array('getSubscriptions'),
+				array(),
+				'',
+				false);
 		$mock->expects($this->exactly(3))
 			->method('getSubscriptions')
 			->will($this->returnValue(array()));
@@ -135,7 +141,12 @@ class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_Test
 	}
 
 	public function testProcessQueueTimesout() {
-		$mock = $this->getMock('Elgg_Notifications_SubscriptionsService', array('getSubscriptions'));
+		$mock = $this->getMock(
+				'Elgg_Notifications_SubscriptionsService',
+				array('getSubscriptions'),
+				array(),
+				'',
+				false);
 		$mock->expects($this->exactly(0))
 			->method('getSubscriptions');
 		$service = new Elgg_Notifications_NotificationsService($mock, $this->queue, $this->hooks);

--- a/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
@@ -39,12 +39,12 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
 	}
 
-	public function testGetSubscriptionsNoMethods() {
+	public function testGetSubscriptionsWithNoMethodsRegistered() {
 		$service = new Elgg_Notifications_SubscriptionsService($this->db);
 		$this->assertEquals(array(), $service->getSubscriptions($this->event));
 	}
 
-	public function testGetSubscriptionsBadObject() {
+	public function testGetSubscriptionsWithBadObject() {
 		$this->event = $this->getMock(
 				'Elgg_Notifications_Event',
 				array('getObject'),
@@ -59,7 +59,7 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 		$this->assertEquals(array(), $service->getSubscriptions($this->event));
 	}
 
-	public function testQueryGenerationBasedOnMethods() {
+	public function testQueryGenerationForRetrievingSubscriptionRelationships() {
 		$methods = array('apples', 'bananas');
 		$query = "SELECT guid_one AS guid, GROUP_CONCAT(relationship SEPARATOR ',') AS methods
 			FROM elgg_entity_relationships
@@ -75,7 +75,7 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 		$this->assertEquals(array(), $service->getSubscriptions($this->event));
 	}
 
-	public function testGetSubscriptions() {
+	public function testGetSubscriptionsWithProperInput() {
 		$methods = array('apples', 'bananas');
 		$queryResult = array(
 			$this->createObjectFromArray(array('guid' => '22', 'methods' => 'notifyapples')),

--- a/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
@@ -55,7 +55,7 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 				->method('getObject')
 				->will($this->returnValue(null));
 		$service = new Elgg_Notifications_SubscriptionsService($this->db);
-		$service->setNotificationMethods(array('one', 'two'));
+		$service->methods = array('one', 'two');
 		$this->assertEquals(array(), $service->getSubscriptions($this->event));
 	}
 
@@ -71,7 +71,7 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 				->will($this->returnValue(array()));
 		$service = new Elgg_Notifications_SubscriptionsService($this->db);
 
-		$service->setNotificationMethods($methods);
+		$service->methods = $methods;
 		$this->assertEquals(array(), $service->getSubscriptions($this->event));
 	}
 
@@ -90,7 +90,7 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 				->will($this->returnValue($queryResult));
 		$service = new Elgg_Notifications_SubscriptionsService($this->db);
 
-		$service->setNotificationMethods($methods);
+		$service->methods = $methods;
 		$this->assertEquals($subscriptions, $service->getSubscriptions($this->event));
 	}
 

--- a/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
@@ -1,0 +1,104 @@
+<?php
+
+class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_TestCase {
+
+	public function setUp() {
+		$this->containerGuid = 42;
+
+		// mock ElggObject that has a container guid
+		$object = $this->getMock(
+				'ElggObject',
+				array('getContainerGUID'),
+				array(),
+				'',
+				false);
+		$object->expects($this->any())
+				->method('getContainerGUID')
+				->will($this->returnValue($this->containerGuid));
+
+		// mock event that holds the mock object
+		$this->event = $this->getMock(
+				'Elgg_Notifications_Event',
+				array('getObject'),
+				array(),
+				'',
+				false);
+		$this->event->expects($this->any())
+				->method('getObject')
+				->will($this->returnValue($object));
+
+		$this->db = $this->getMock('Elgg_Database', array('getData', 'getTablePrefix', 'sanitizeString'));
+		$this->db->expects($this->any())
+				->method('getTablePrefix')
+				->will($this->returnValue('elgg_'));
+		$this->db->expects($this->any())
+				->method('sanitizeString')
+				->will($this->returnArgument(0));
+
+		// Event class has dependency on elgg_get_logged_in_user_guid()
+		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
+	}
+
+	public function testGetSubscriptionsNoMethods() {
+		$service = new Elgg_Notifications_SubscriptionsService($this->db);
+		$this->assertEquals(array(), $service->getSubscriptions($this->event));
+	}
+
+	public function testGetSubscriptionsBadObject() {
+		$this->event = $this->getMock(
+				'Elgg_Notifications_Event',
+				array('getObject'),
+				array(),
+				'',
+				false);
+		$this->event->expects($this->any())
+				->method('getObject')
+				->will($this->returnValue(null));
+		$service = new Elgg_Notifications_SubscriptionsService($this->db);
+		$service->setNotificationMethods(array('one', 'two'));
+		$this->assertEquals(array(), $service->getSubscriptions($this->event));
+	}
+
+	public function testQueryGenerationBasedOnMethods() {
+		$methods = array('apples', 'bananas');
+		$query = "SELECT guid_one AS guid, GROUP_CONCAT(relationship SEPARATOR ',') AS methods
+			FROM elgg_entity_relationships
+			WHERE guid_two = $this->containerGuid AND
+					relationship IN ('notifyapples','notifybananas') GROUP BY guid_one";
+		$this->db->expects($this->once())
+				->method('getData')
+				->with($this->equalTo($query))
+				->will($this->returnValue(array()));
+		$service = new Elgg_Notifications_SubscriptionsService($this->db);
+
+		$service->setNotificationMethods($methods);
+		$this->assertEquals(array(), $service->getSubscriptions($this->event));
+	}
+
+	public function testGetSubscriptions() {
+		$methods = array('apples', 'bananas');
+		$queryResult = array(
+			$this->createObjectFromArray(array('guid' => '22', 'methods' => 'notifyapples')),
+			$this->createObjectFromArray(array('guid' => '567', 'methods' => 'notifybananas,notifyapples')),
+		);
+		$subscriptions = array(
+			22 => array('apples'),
+			567 => array('bananas', 'apples'),
+		);
+		$this->db->expects($this->once())
+				->method('getData')
+				->will($this->returnValue($queryResult));
+		$service = new Elgg_Notifications_SubscriptionsService($this->db);
+
+		$service->setNotificationMethods($methods);
+		$this->assertEquals($subscriptions, $service->getSubscriptions($this->event));
+	}
+
+	protected function createObjectFromArray(array $data) {
+		$obj = new stdClass();
+		foreach ($data as $key => $value) {
+			$obj->$key = $value;
+		}
+		return $obj;
+	}
+}

--- a/engine/tests/phpunit/ElggNotificationsServiceTest.php
+++ b/engine/tests/phpunit/ElggNotificationsServiceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+$engine = dirname(dirname(dirname(__FILE__)));
+require_once "$engine/lib/entities.php";
+
+class ElggNotificationsServiceTest extends PHPUnit_Framework_TestCase {
+
+	public function testRegisterEvent() {
+		$service = new Elgg_Notifications_Service(new Elgg_Util_MemoryQueue());
+
+		$service->registerEvent('foo', 'bar');
+		$events = array(
+			'foo' => array(
+				'bar' => array('create')
+			)
+		);
+		$this->assertEquals($events, $service->getEvents());
+
+		$service->registerEvent('foo', 'bar', array('test'));
+		$events['foo']['bar'] = array('create', 'test');
+		$this->assertEquals($events, $service->getEvents());
+
+		$service->registerEvent('foo', 'bar');
+		$this->assertEquals($events, $service->getEvents());
+	}
+
+	public function testUnregisterEvent() {
+		$service = new Elgg_Notifications_Service(new Elgg_Util_MemoryQueue());
+
+		$service->registerEvent('foo', 'bar');
+		$this->assertTrue($service->unregisterEvent('foo', 'bar'));
+
+		$events = array(
+			'foo' => array()
+		);
+		$this->assertEquals($events, $service->getEvents());
+		$this->assertFalse($service->unregisterEvent('foo', 'bar'));
+	}
+
+	public function testRegisterMethod() {
+		$service = new Elgg_Notifications_Service(new Elgg_Util_MemoryQueue());
+
+		$service->registerMethod('foo');
+		$methods = array('foo' => 'foo');
+		$this->assertEquals($methods, $service->getMethods());
+	}
+
+	public function testUnregisterMethod() {
+		$service = new Elgg_Notifications_Service(new Elgg_Util_MemoryQueue());
+
+		$service->registerMethod('foo');
+		$this->assertTrue($service->unregisterMethod('foo'));
+		$this->assertEquals(array(), $service->getMethods());
+		$this->assertFalse($service->unregisterMethod('foo'));
+	}
+
+	public function testEnqueueEvent() {
+		$queue = new Elgg_Util_MemoryQueue();
+		$service = new Elgg_Notifications_Service($queue);
+
+		$service->registerEvent('object', 'bar');
+		$object = new ElggObject();
+		$object->subtype = 'bar';
+		$service->enqueueEvent('create', '', $object);
+		$event = new Elgg_Notifications_Event($object, 'create');
+		$this->assertEquals($event, $queue->dequeue());
+		$this->assertNull($queue->dequeue());
+
+		// unregistered action type
+		$service->enqueueEvent('null', '', $object);
+		$this->assertNull($queue->dequeue());
+
+		// unregistered object type
+		$service->enqueueEvent('create', '', new ElggObject());
+		$this->assertNull($queue->dequeue());
+	}
+}

--- a/mod/blog/actions/blog/save.php
+++ b/mod/blog/actions/blog/save.php
@@ -163,8 +163,6 @@ if (!$error) {
 				'object_guid' => $blog->getGUID(),
 			));
 
-			// we only want notifications sent when post published
-			register_notification_object('object', 'blog', elgg_echo('blog:newpost'));
 			elgg_trigger_event('publish', 'object', $blog);
 
 			// reset the creation time for posts that move from draft to published

--- a/mod/blog/classes/ElggBlog.php
+++ b/mod/blog/classes/ElggBlog.php
@@ -39,4 +39,19 @@ class ElggBlog extends ElggObject {
 		return true;
 	}
 
+	/**
+	 * Get the excerpt for this blog post
+	 * 
+	 * @param int $length Length of the excerpt (optional)
+	 * @return string
+	 * @since 1.9.0
+	 */
+	public function getExcerpt($length = 250) {
+		if ($this->excerpt) {
+			return $this->excerpt;
+		} else {
+			return elgg_get_excerpt($this->description, $length);
+		}
+	}
+
 }

--- a/mod/bookmarks/start.php
+++ b/mod/bookmarks/start.php
@@ -50,11 +50,15 @@ function bookmarks_init() {
 			'rel' => 'nofollow',
 		));
 	}
+
+	elgg_register_notification_event('object', 'bookmarks', array('create'));
+	elgg_register_plugin_hook_handler('prepare', 'notification:create:object:bookmarks', 'bookmarks_prepare_notification');
+
 	// Register granular notification for this type
-	register_notification_object('object', 'bookmarks', elgg_echo('bookmarks:new'));
+	//register_notification_object('object', 'bookmarks', elgg_echo('bookmarks:new'));
 
 	// Listen to notification events and supply a more useful message
-	elgg_register_plugin_hook_handler('notify:entity:message', 'object', 'bookmarks_notify_message');
+	//elgg_register_plugin_hook_handler('notify:entity:message', 'object', 'bookmarks_notify_message');
 
 	// Register bookmarks view for ecml parsing
 	elgg_register_plugin_hook_handler('get_views', 'ecml', 'bookmarks_ecml_views_hook');
@@ -239,6 +243,40 @@ function bookmarks_owner_block_menu($hook, $type, $return, $params) {
 	}
 
 	return $return;
+}
+
+/**
+ * Prepare a notification message about a new bookmark
+ * 
+ * @param string                          $hook         Hook name
+ * @param string                          $type         Hook type
+ * @param Elgg_Notifications_Notification $notification The notification to prepare
+ * @param array                           $params       Hook parameters
+ * @return Elgg_Notifications_Notification
+ */
+function bookmarks_prepare_notification($hook, $type, $notification, $params) {
+	$entity = $params['event']->getObject();
+	$owner = $params['event']->getActor();
+	$recipient = $params['recipient'];
+	$language = $params['language'];
+	$method = $params['method'];
+
+	$descr = $entity->description;
+	$title = $entity->title;
+
+	$subject = elgg_echo('bookmarks:new', array(), $language); 
+	$body = elgg_echo('bookmarks:notification', array(
+		$owner->name,
+		$title,
+		$entity->address,
+		$descr,
+		$entity->getURL()
+	), $language);
+
+	$notification->subject = $subject;
+	$notification->body = $body;
+
+	return $notification;
 }
 
 /**

--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -278,8 +278,7 @@ function groups_handle_profile_page($guid) {
 
 		$subscribed = false;
 		if (elgg_is_active_plugin('notifications')) {
-			global $NOTIFICATION_HANDLERS;
-			
+			$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 			foreach ($NOTIFICATION_HANDLERS as $method => $foo) {
 				$relationship = check_entity_relationship(elgg_get_logged_in_user_guid(),
 						'notify' . $method, $guid);

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -989,7 +989,8 @@ function discussion_create_reply_notification($hook, $type, $message, $params) {
  * @return void
  */
 function discussion_reply_notifications($event, $type, $annotation) {
-	global $CONFIG, $NOTIFICATION_HANDLERS;
+	global $CONFIG;
+	$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 
 	if ($annotation->name !== 'group_topic_post') {
 		return;

--- a/mod/messages/start.php
+++ b/mod/messages/start.php
@@ -47,9 +47,11 @@ function messages_init() {
 	elgg_register_plugin_hook_handler('register', 'menu:user_hover', 'messages_user_hover_menu');
 
 	// Register a notification handler for site messages
-	register_notification_handler("site", "messages_site_notify_handler");
-	elgg_register_plugin_hook_handler('notify:entity:message', 'object', 'messages_notification_msg');
-	register_notification_object('object', 'messages', elgg_echo('messages:new'));
+	elgg_register_notification_method('site');
+	elgg_register_plugin_hook_handler('send', 'notification:site', 'messages_send_notification');
+	//register_notification_handler("site", "messages_site_notify_handler");
+	//elgg_register_plugin_hook_handler('notify:entity:message', 'object', 'messages_notification_msg');
+	//register_notification_object('object', 'messages', elgg_echo('messages:new'));
 
 	// delete messages sent by a user when user is deleted
 	elgg_register_event_handler('delete', 'user', 'messages_purge');
@@ -386,6 +388,29 @@ function messages_count_unread($user_guid = 0) {
 	);
 
 	return elgg_get_entities_from_metadata($options);
+}
+
+/**
+ * Send a notification
+ * 
+ * @param string $hook   Hook name
+ * @param string $type   Hook type
+ * @param bool   $result Has anyone sent a message yet?
+ * @param array  $params Hook parameters
+ * @return bool
+ */
+function messages_send_notification($hook, $type, $result, $params) {
+	/* @var Elgg_Notifications_Notification */
+	$message = $params['notification'];
+	return messages_send(
+			$message->subject,
+			$message->body,
+			$message->getRecipientGUID(),
+			$message->getSenderGUID(),
+			0,
+			false,
+			false
+		);
 }
 
 /**

--- a/mod/notifications/actions/groupsave.php
+++ b/mod/notifications/actions/groupsave.php
@@ -25,7 +25,7 @@ $options = array(
 	'limit' => false,
 );
 if ($groupmemberships = elgg_get_entities_from_relationship($options)) {
-	foreach($groupmemberships as $groupmembership) {
+	foreach ($groupmemberships as $groupmembership) {
 		$groups[] = $groupmembership->guid;
 	}
 }
@@ -36,9 +36,9 @@ if (!empty($groups)) {
 		$subscriptions[$method] = get_input($method.'subscriptions', array());
 		foreach ($groups as $group) {
 			if (in_array($group, $subscriptions[$method])) {
-				add_entity_relationship($user->guid, 'notify'.$method, $group);
+				elgg_add_subscription($user->guid, $method, $group);
 			} else {
-				remove_entity_relationship($user->guid, 'notify'.$method, $group);
+				elgg_remove_subscription($user->guid, $method, $group);
 			}
 		}
 	}

--- a/mod/notifications/actions/groupsave.php
+++ b/mod/notifications/actions/groupsave.php
@@ -31,7 +31,7 @@ if ($groupmemberships = elgg_get_entities_from_relationship($options)) {
 }
 
 if (!empty($groups)) {
-	global $NOTIFICATION_HANDLERS;
+	$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 	foreach ($NOTIFICATION_HANDLERS as $method => $foo) {
 		$subscriptions[$method] = get_input($method.'subscriptions', array());
 		foreach ($groups as $group) {

--- a/mod/notifications/actions/save.php
+++ b/mod/notifications/actions/save.php
@@ -18,22 +18,23 @@ if (($user->guid != $current_user->guid) && !$current_user->isAdmin()) {
 
 global $NOTIFICATION_HANDLERS;
 $subscriptions = array();
-foreach($NOTIFICATION_HANDLERS as $method => $foo) {
-	$subscriptions[$method] = get_input($method.'subscriptions');
+foreach ($NOTIFICATION_HANDLERS as $method => $foo) {
 	$personal[$method] = get_input($method.'personal');
-	$collections[$method] = get_input($method.'collections');
+	set_user_notification_setting($user->guid, $method, ($personal[$method] == '1') ? true : false);
 
+	$collections[$method] = get_input($method.'collections');
 	$metaname = 'collections_notifications_preferences_' . $method;
 	$user->$metaname = $collections[$method];
-	set_user_notification_setting($user->guid, $method, ($personal[$method] == '1') ? true : false);
+
+	$subscriptions[$method] = get_input($method.'subscriptions');
 	remove_entity_relationships($user->guid, 'notify' . $method, false, 'user');
 }
 
 // Add new ones
-foreach($subscriptions as $key => $subscription) {
+foreach ($subscriptions as $method => $subscription) {
 	if (is_array($subscription) && !empty($subscription)) {
-		foreach($subscription as $subscriptionperson) {
-			add_entity_relationship($user->guid, 'notify' . $key, $subscriptionperson);
+		foreach ($subscription as $subscriptionperson) {
+			elgg_add_subscription($user->guid, $method, $subscriptionperson);
 		}
 	}
 }

--- a/mod/notifications/actions/save.php
+++ b/mod/notifications/actions/save.php
@@ -16,7 +16,7 @@ if (($user->guid != $current_user->guid) && !$current_user->isAdmin()) {
 	forward();
 }
 
-global $NOTIFICATION_HANDLERS;
+$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 $subscriptions = array();
 foreach ($NOTIFICATION_HANDLERS as $method => $foo) {
 	$personal[$method] = get_input($method.'personal');

--- a/mod/notifications/start.php
+++ b/mod/notifications/start.php
@@ -112,7 +112,7 @@ function notifications_plugin_pagesetup() {
  * @param object $relationship
  */
 function notifications_relationship_remove($event, $object_type, $relationship) {
-	global $NOTIFICATION_HANDLERS;
+	$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 
 	$user_guid = $relationship->guid_one;
 	$object_guid = $relationship->guid_two;
@@ -131,7 +131,7 @@ function notifications_relationship_remove($event, $object_type, $relationship) 
  * @param object $relationship
  */
 function notifications_update_friend_notify($event, $object_type, $relationship) {
-	global $NOTIFICATION_HANDLERS;
+	$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 
 	$user_guid = $relationship->guid_one;
 	$friend_guid = $relationship->guid_two;
@@ -167,7 +167,7 @@ function notifications_update_friend_notify($event, $object_type, $relationship)
  * @param array $params
  */
 function notifications_update_collection_notify($event, $object_type, $returnvalue, $params) {
-	global $NOTIFICATION_HANDLERS;
+	$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 
 	// only update notifications for user owned collections
 	$collection_id = $params['collection_id'];

--- a/mod/notifications/views/default/forms/notificationsettings/groupsave.php
+++ b/mod/notifications/views/default/forms/notificationsettings/groupsave.php
@@ -10,7 +10,7 @@
 /* @var ElggUser $user */
 $user = $vars['user'];
 
-global $NOTIFICATION_HANDLERS;
+$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 foreach ($NOTIFICATION_HANDLERS as $method => $foo) {
 	$subsbig[$method] = elgg_get_entities_from_relationship(array(
 		'relationship' => 'notify' . $method,

--- a/mod/notifications/views/default/notifications/subscriptions/collections.php
+++ b/mod/notifications/views/default/notifications/subscriptions/collections.php
@@ -35,7 +35,7 @@ $user = $vars['user'];
 		<td>&nbsp;</td>
 <?php
 	$i = 0; 
-	global $NOTIFICATION_HANDLERS;
+	$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 	foreach($NOTIFICATION_HANDLERS as $method => $foo) {
 		if ($i > 0) {
 			echo "<td class='spacercolumn'>&nbsp;</td>";

--- a/mod/notifications/views/default/notifications/subscriptions/forminternals.php
+++ b/mod/notifications/views/default/notifications/subscriptions/forminternals.php
@@ -26,7 +26,7 @@ elgg_load_js('jquery.easing');
 // Get friends and subscriptions
 $friends = get_user_friends($user->guid, '', 9999, 0);
 		
-global $NOTIFICATION_HANDLERS;
+$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 foreach($NOTIFICATION_HANDLERS as $method => $foo) {
 	$subsbig[$method] = elgg_get_entities_from_relationship(array(
 		'relationship' => 'notify' . $method,

--- a/mod/notifications/views/default/notifications/subscriptions/jsfuncs.php
+++ b/mod/notifications/views/default/notifications/subscriptions/jsfuncs.php
@@ -1,6 +1,6 @@
 <?php
 
-global $NOTIFICATION_HANDLERS;
+$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 
 ?> 
 <?php //@todo JS 1.8: no ?>

--- a/mod/notifications/views/default/notifications/subscriptions/personal.php
+++ b/mod/notifications/views/default/notifications/subscriptions/personal.php
@@ -6,7 +6,7 @@
 /* @var ElggUser $user */
 $user = $vars['user'];
 
-global $NOTIFICATION_HANDLERS;
+$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 
 ?>
 <div class="notification_personal">

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -328,7 +328,7 @@ function thewire_send_response_notification($guid, $parent_guid, $user) {
 	if ($parent_owner->guid != $user->guid) {
 		// check if parent owner has notification for this user
 		$send_response = true;
-		global $NOTIFICATION_HANDLERS;
+		$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 		foreach ($NOTIFICATION_HANDLERS as $method => $foo) {
 			if (check_entity_relationship($parent_owner->guid, 'notify' . $method, $user->guid)) {
 				$send_response = false;

--- a/views/default/core/settings/account/notifications.php
+++ b/views/default/core/settings/account/notifications.php
@@ -6,7 +6,7 @@
  * @subpackage Core
  */
 
-global $NOTIFICATION_HANDLERS;
+$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
 $notification_settings = get_user_notification_settings(elgg_get_page_owner_guid());
 
 $title = elgg_echo('notifications:usersettings');


### PR DESCRIPTION
See engine/lib/notification.php for a description of how to use the new API.

The major differences are
- queue is used to make notifications asynchronous
- OO rather than procedural
- more control over notifications - can set subject line, multiple language support

Before pulling in:
- update core plugins to use it

Also looking at
- throttling
- separate table for queue
- rewriting notifications plugin (possibly pull site notifications out of private messaging plugin)
