### PR TITLE
Rewrote PHP coding standard w/r/t PSR-2

### DIFF
--- a/documentation/coding_standards/best_practices.txt
+++ b/documentation/coding_standards/best_practices.txt
@@ -10,6 +10,9 @@ work for developers, which means happier, more productive developers.
 	function.  If you find views that are identical except for a single value,
 	pull it out into a generic view that takes an option.
 
+* 	Embrace the SOLID and GRASP design principles for OO design:
+	http://nikic.github.io/2011/12/27/Dont-be-STUPID-GRASP-SOLID.html
+
 * 	Whitespace is free.  Don't be afraid to use it to separate blocks of code.
 	Use a single space to separate function params and string concatenation.
 
@@ -17,8 +20,8 @@ work for developers, which means happier, more productive developers.
 
 *   Use "positive" variable names. Prefer `$enable = true` to `$disable = false`.
 
-* 	Functions returning an array should return an empty array instead of FALSE
-	on no results.
+* 	Where possible, have functions/methods return a single type, using falsey
+	values such as array(), "", or 0 to indicate no results.
 
 * 	Functions not throwing an exception on error should return FALSE upon
 	failure.
@@ -26,7 +29,7 @@ work for developers, which means happier, more productive developers.
 * 	Functions returning only boolean should be prefaced with is_ or has_ (eg,
 	elgg_is_logged_in(), elgg_has_access_to_entity()).
 
-* 	Ternary syntax is acceptable for single-line, non-embedded statements.
+* 	Ternary syntax is acceptable only for single-line, non-embedded statements.
 
 * 	Use comments effectively.  Good comments describe the "why."  Good code
 	describes the "how."  Ex:

--- a/documentation/coding_standards/php_coding_standards.txt
+++ b/documentation/coding_standards/php_coding_standards.txt
@@ -19,7 +19,7 @@ Elgg's standards differ from and extend PSR-2 in the following ways:
 
 2.4. Indenting
 
-* 	Indent using hard tabs (tabs should appear 4 characters wide in your IDE).
+* 	Indent using one tab character, not spaces.
 
 4.1. Extends and Implements
 
@@ -72,6 +72,3 @@ Miscellaneous
 		
 		Good:
 		echo "Hello, $name!  How is your $time_of_day?"; 
-
-* 	Do not rename public API functions, classes, methods, or properties once they
-	are in a stable version branch.

--- a/documentation/coding_standards/php_coding_standards.txt
+++ b/documentation/coding_standards/php_coding_standards.txt
@@ -1,55 +1,77 @@
 *** PHP CODING STANDARDS ***
 
-These are the coding standards for Elgg.  All core development and bundled
-plugins are required to be in this format. Plugin developers are strongly
-encouraged to adopt these standards.
+These are the required coding standards for Elgg core and all bundled plugins.
+Plugin developers are strongly encouraged to adopt these standards.
 
-* 	Unix line endings.
+Developers should first read the PSR-2 Coding Standard Guide.
+https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
 
-* 	Hard tabs, 4 character tab spacing.
+Elgg's standards differ from and extend PSR-2 in the following ways:
 
-* 	No PHP shortcut tags ( <? or <?= or <% ).
+2.1 Basic Coding Standard
 
-* 	PHPDoc comments on functions and classes (all methods; declared properties
-	when appropriate).
+* 	Compliance with PSR-1 is encouraged, but not required.
 
-* 	Mandatory wrapped {}s around any code blocks. 
-		Bad:
-		if (true) 
-			foreach($arr as $elem) 
-				echo $elem;
-	
-		Good:
-		if (true) {
-			foreach ($arr as $elem) {
-				echo $elem;
-			}
-		}
+2.3. Lines
 
-* 	Name standalone functions using underscore_character().
+* 	Consider refactoring code (e.g. introduce variables) if lines reach over
+	100 characters.
 
-* 	Name classes using CamelCase() and methods using lowerCamelCase().
+2.4. Indenting
+
+* 	Indent using hard tabs (tabs should appear 4 characters wide in your IDE).
+
+4.1. Extends and Implements
+
+* 	Opening braces for classes must go on the same line.
+
+4.3. Methods
+
+* 	Opening braces for methods (and functions) must go on the same line.
+
+The following is not mentioned in PSR-2
+
+Documentation
+
+* 	Include PHPDoc comments on functions and classes (all methods; declared
+	properties when appropriate).
+
+* 	Annotate classes, methods, properties, and functions with "@access private"
+	unless they are intended for public use, are already of limited visibility,
+	or are within a class already marked as private.
+
+* 	Use // or /* */ when commenting.
+
+* 	Use only // comments inside function/method bodies.
+
+Naming
+
+* 	Use underscores to separate words in the names of functions, variables,
+	and properties.
+
+* 	Names of functions for public use must begin with "elgg_".
+
+* 	All other function names must begin with "_elgg_".
+
+* 	The names of all classes and interfaces must use underscores as namespace
+	separators and be within the Elgg namespace. (Elgg_Cache_LRUCache)
 
 * 	Name globals and constants in ALL_CAPS (ACCESS_FRIENDS, $CONFIG).
 
-* 	Use underscores / camel case to separate standard English words in
-	functions, classes, and methods. (get_default_site(), ElggUser->isLoggedIn()).
+Miscellaneous
 
-* 	Space functions like_this($required, $optional = TRUE).
+* 	Use PHP 5.2-compatible syntax in Elgg versions before 1.10.
 
-* 	Space keywords and constructs like this: if (FALSE) { ... }.
+* 	Do not use PHP shortcut tags ( <? or <?= or <% ).
 
-* 	Correctly use spaces, quotes, and {}s in strings: 
-		Bad (hard to read, misuse of quotes and {}s): 
+* 	When creating strings with variables, use double-quoted strings and wrap
+	variables with braces only when necessary.
+
+		Bad (hard to read, misuse of quotes and {}s):
 		echo 'Hello, '.$name."!  How is your {$time_of_day}?";
 		
 		Good:
 		echo "Hello, $name!  How is your $time_of_day?"; 
 
-* 	Line lengths should be reasonable.  If you are writing lines over 100 
-	characters on a line, please revise the code.
-
-* 	Use // or /* */ when commenting.
-
-* 	No closing PHP tag (?>) at EOF unless after a heredoc. (Avoids problems with 
-	trailing whitespace. Required after heredoc by PHP.)
+* 	Do not rename public API functions, classes, methods, or properties once they
+	are in a stable version branch.


### PR DESCRIPTION
Submitting this for debate. The idea is that we should adopt some other well-defined coding standard (this uses PSR-2) as a baseline, documenting only our differences.

One inconsistency I've noticed is property names: lowerCamel vs. under_score. In my PR I recommend under_score because most public API properties follow that.

Eventually I'd like Elgg to shift towards the default styles used in PhpStorm and Netbeans.
