### PR TITLE
Fixes #2057 (broken internet archive links)

### DIFF
--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -27,7 +27,7 @@ function parse_urls($text) {
 	// By default htmlawed rewrites tags to this format.
 	// if PHP supported conditional negative lookbehinds we could use this:
 	// $r = preg_replace_callback('/(?<!=)(?<![ ])?(?<!["\'])((ht|f)tps?:\/\/[^\s\r\n\t<>"\'\!\(\),]+)/i',
-	$r = preg_replace_callback('/(?<!=)(?<!["\'])((ht|f)tps?:\/\/[^\s\r\n\t<>"\'\(\)]+)/i',
+	$r = preg_replace_callback('/(?<![=\/"\'])((ht|f)tps?:\/\/[^\s\r\n\t<>"\'\(\)]+)/i',
 	create_function(
 		'$matches',
 		'

--- a/engine/tests/regression/trac_bugs.php
+++ b/engine/tests/regression/trac_bugs.php
@@ -288,4 +288,13 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 			$this->assertEqual($output, parse_urls($input));
 		}
 	}
+
+	/**
+	 * Test #2057 -- parse_urls()
+	 * https://github.com/Elgg/Elgg/issues/2057
+	 */
+	public function test_archive_url() {
+		$input = '<a href="http://web.archive.org/web/20000229040250/http://www.google.com/">google</a>';
+		$this->assertEqual($input, parse_urls($input));
+	}
 }

--- a/engine/tests/regression/trac_bugs.php
+++ b/engine/tests/regression/trac_bugs.php
@@ -282,19 +282,12 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 				'ssl <a href="https://example.org/" rel="nofollow">https:/<wbr />/<wbr />example.org/<wbr /></a> test',
 			'ftp ftp://example.org/ test' =>
 				'ftp <a href="ftp://example.org/" rel="nofollow">ftp:/<wbr />/<wbr />example.org/<wbr /></a> test',
+			'<a href="http://web.archive.org/web/20000229040250/http://www.google.com/">google</a>' =>
+				'<a href="http://web.archive.org/web/20000229040250/http://www.google.com/">google</a>'
 
 		);
 		foreach ($cases as $input => $output) {
 			$this->assertEqual($output, parse_urls($input));
 		}
-	}
-
-	/**
-	 * Test #2057 -- parse_urls()
-	 * https://github.com/Elgg/Elgg/issues/2057
-	 */
-	public function test_archive_url() {
-		$input = '<a href="http://web.archive.org/web/20000229040250/http://www.google.com/">google</a>';
-		$this->assertEqual($input, parse_urls($input));
 	}
 }

--- a/engine/tests/regression/trac_bugs.php
+++ b/engine/tests/regression/trac_bugs.php
@@ -282,8 +282,12 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 				'ssl <a href="https://example.org/" rel="nofollow">https:/<wbr />/<wbr />example.org/<wbr /></a> test',
 			'ftp ftp://example.org/ test' =>
 				'ftp <a href="ftp://example.org/" rel="nofollow">ftp:/<wbr />/<wbr />example.org/<wbr /></a> test',
-			'<a href="http://web.archive.org/web/20000229040250/http://www.google.com/">google</a>' =>
-				'<a href="http://web.archive.org/web/20000229040250/http://www.google.com/">google</a>'
+
+			'web archive anchor <a href="http://web.archive.org/web/20000229040250/http://www.google.com/">google</a>' =>
+				'web archive anchor <a href="http://web.archive.org/web/20000229040250/http://www.google.com/">google</a>',
+
+			'single quotes already anchor <a href=\'http://www.yahoo.com\'>yahoo</a>' => 
+				'single quotes already anchor <a href=\'http://www.yahoo.com\'>yahoo</a>'
 
 		);
 		foreach ($cases as $input => $output) {


### PR DESCRIPTION
I combined all the negative lookbehind stuff and added a check for '/' (I'm no regex guru, but it works). Unit tests pass as well. 
