### PR TITLE
fixes jumping avatar icons IE8

### DIFF
--- a/views/default/css/ie.php
+++ b/views/default/css/ie.php
@@ -6,3 +6,13 @@
 .elgg-avatar {
 	display: block;
 }
+
+/* fixes issue in ie8 hovering over an avatar in a widget or group sidebar listing */
+.elgg-gallery-users > .elgg-item {
+	float: left;
+	margin-bottom: 5px;
+}
+
+.elgg-gallery-users {
+	display: inline-block;
+}


### PR DESCRIPTION
fixes issue in ie8 hovering over an avatar in a widget or group sidebar listing
