### PR TITLE
Group tool disabled by default

### DIFF
--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -56,7 +56,7 @@ function blog_init() {
 	elgg_register_entity_type('object', 'blog');
 
 	// Add group option
-	add_group_tool_option('blog', elgg_echo('blog:enableblog'), true);
+	add_group_tool_option('blog', elgg_echo('blog:enableblog'), false);
 	elgg_extend_view('groups/tool_latest', 'blog/group_module');
 
 	// add a blog widget

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -190,7 +190,7 @@ function blog_owner_block_menu($hook, $type, $return, $params) {
 		$item = new ElggMenuItem('blog', elgg_echo('blog'), $url);
 		$return[] = $item;
 	} else {
-		if ($params['entity']->blog_enable != "no") {
+		if ($params['entity']->blog_enable == "yes") {
 			$url = "blog/group/{$params['entity']->guid}/all";
 			$item = new ElggMenuItem('blog', elgg_echo('blog:group'), $url);
 			$return[] = $item;

--- a/mod/bookmarks/views/default/bookmarks/group_module.php
+++ b/mod/bookmarks/views/default/bookmarks/group_module.php
@@ -7,7 +7,7 @@
 
 $group = elgg_get_page_owner_entity();
 
-if ($group->bookmarks_enable == "no") {
+if ($group->bookmarks_enable != "yes") {
 	return true;
 }
 

--- a/mod/file/views/default/file/group_module.php
+++ b/mod/file/views/default/file/group_module.php
@@ -5,7 +5,7 @@
 
 $group = elgg_get_page_owner_entity();
 
-if ($group->file_enable == "no") {
+if ($group->file_enable != "yes") {
 	return true;
 }
 

--- a/mod/pages/views/default/pages/group_module.php
+++ b/mod/pages/views/default/pages/group_module.php
@@ -8,7 +8,7 @@
 
 $group = elgg_get_page_owner_entity();
 
-if ($group->pages_enable == "no") {
+if ($group->pages_enable != "yes") {
 	return true;
 }
 


### PR DESCRIPTION
Related to https://github.com/Elgg/Elgg/issues/4472 issue.
Enabling group tool by default makes "remove_group_tool_option" useless.
This allows plugin to define wether tools will be available or not into groups.
