### PR TITLE
Group tool disabled by default

### DIFF
--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -45,7 +45,7 @@ function file_init() {
 	elgg_register_plugin_hook_handler('notify:entity:message', 'object', 'file_notify_message');
 
 	// add the group files tool option
-	add_group_tool_option('file', elgg_echo('groups:enablefiles'), true);
+	add_group_tool_option('file', elgg_echo('groups:enablefiles'), false);
 
 	// Register entity type for search
 	elgg_register_entity_type('object', 'file');

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -223,7 +223,7 @@ function file_owner_block_menu($hook, $type, $return, $params) {
 		$item = new ElggMenuItem('file', elgg_echo('file'), $url);
 		$return[] = $item;
 	} else {
-		if ($params['entity']->file_enable != "no") {
+		if ($params['entity']->file_enable == "yes") {
 			$url = "file/group/{$params['entity']->guid}/all";
 			$item = new ElggMenuItem('file', elgg_echo('file:group'), $url);
 			$return[] = $item;


### PR DESCRIPTION
Related to https://github.com/Elgg/Elgg/issues/4472 issue.
Enabling group tool by default makes "remove_group_tool_option" useless.
This allows plugin to define wether tools will be available or not into groups.
