### PR TITLE
Group tool disabled by default

### DIFF
--- a/mod/bookmarks/start.php
+++ b/mod/bookmarks/start.php
@@ -66,7 +66,7 @@ function bookmarks_init() {
 	elgg_register_entity_type('object', 'bookmarks');
 
 	// Groups
-	add_group_tool_option('bookmarks', elgg_echo('bookmarks:enablebookmarks'), true);
+	add_group_tool_option('bookmarks', elgg_echo('bookmarks:enablebookmarks'), false);
 	elgg_extend_view('groups/tool_latest', 'bookmarks/group_module');
 }
 

--- a/mod/bookmarks/start.php
+++ b/mod/bookmarks/start.php
@@ -231,7 +231,7 @@ function bookmarks_owner_block_menu($hook, $type, $return, $params) {
 		$item = new ElggMenuItem('bookmarks', elgg_echo('bookmarks'), $url);
 		$return[] = $item;
 	} else {
-		if ($params['entity']->bookmarks_enable != 'no') {
+		if ($params['entity']->bookmarks_enable == 'yes') {
 			$url = "bookmarks/group/{$params['entity']->guid}/all";
 			$item = new ElggMenuItem('bookmarks', elgg_echo('bookmarks:group'), $url);
 			$return[] = $item;


### PR DESCRIPTION
Related to https://github.com/Elgg/Elgg/issues/4472 issue.
Enabling group tool by default makes "remove_group_tool_option" useless.
This allows plugin to define wether tools will be available or not into groups.
