### PR TITLE
Group tool disabled by default

### DIFF
--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -214,7 +214,7 @@ function pages_owner_block_menu($hook, $type, $return, $params) {
 		$item = new ElggMenuItem('pages', elgg_echo('pages'), $url);
 		$return[] = $item;
 	} else {
-		if ($params['entity']->pages_enable != "no") {
+		if ($params['entity']->pages_enable == "yes) {
 			$url = "pages/group/{$params['entity']->guid}/all";
 			$item = new ElggMenuItem('pages', elgg_echo('pages:group'), $url);
 			$return[] = $item;

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -54,7 +54,7 @@ function pages_init() {
 	elgg_register_plugin_hook_handler('notify:entity:message', 'object', 'page_notify_message');
 
 	// add to groups
-	add_group_tool_option('pages', elgg_echo('groups:enablepages'), true);
+	add_group_tool_option('pages', elgg_echo('groups:enablepages'), false);
 	elgg_extend_view('groups/tool_latest', 'pages/group_module');
 
 	//add a widget


### PR DESCRIPTION
Related to https://github.com/Elgg/Elgg/issues/4472 issue.
Enabling group tool by default makes "remove_group_tool_option" useless.
This allows plugin to define wether tools will be available or not into groups.
