### PR TITLE
Version check

### DIFF
--- a/actions/admin/core/version.php
+++ b/actions/admin/core/version.php
@@ -1,0 +1,10 @@
+<?php
+
+$version = new Elgg_Version();
+$latestRelease = $version->getLatestRelease(true);
+
+if ($latestRelease !== false) {
+	system_message(elgg_echo('admin:version:action:ok', array($latestRelease)));
+} else {
+	register_error(elgg_echo('admin:version:action:fail'));
+}

--- a/actions/admin/core/version.php
+++ b/actions/admin/core/version.php
@@ -1,6 +1,6 @@
 <?php
 
-$version = new Elgg_Version();
+$version = _elgg_services()->version;
 $latestRelease = $version->getLatestRelease(true);
 
 if ($latestRelease !== false) {

--- a/engine/classes/Elgg/ServiceProvider.php
+++ b/engine/classes/Elgg/ServiceProvider.php
@@ -19,6 +19,7 @@
  * @property-read Elgg_Request              $request
  * @property-read Elgg_Router               $router
  * @property-read ElggSession               $session
+ * @property-read Elgg_Version              $version
  * @property-read Elgg_ViewService          $views
  * @property-read Elgg_WidgetsService       $widgets
  * 
@@ -46,6 +47,7 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 		$this->setFactory('request', array($this, 'getRequest'));
 		$this->setFactory('router', array($this, 'getRouter'));
 		$this->setFactory('session', array($this, 'getSession'));
+		$this->setClassName('version', 'Elgg_Version');
 		$this->setFactory('views', array($this, 'getViews'));
 		$this->setClassName('widgets', 'Elgg_WidgetsService');
 	}

--- a/engine/classes/Elgg/Version.php
+++ b/engine/classes/Elgg/Version.php
@@ -31,15 +31,13 @@ class Elgg_Version {
 	private $cachingPeriod = 86400; // 24h
 
 	/**
-	 * Get the current Elgg version information
-	 *
-	 * @param bool $humanreadable Whether to return a human readable version (default: false)
-	 *
-	 * @return string|false Depending on success
+	 * Initializes local variables holding version and release, bu reading version.php file from the main directory.
+	 * 
+	 * @return boolean if values were successfully populated
 	 */
-	function getVersion($humanreadable = false) {
+	private function initVersionAndRelease() {
 		global $CONFIG;
-
+		
 		if (isset($CONFIG->path)) {
 			if (!isset($this->localVersion) || !isset($this->localRelease)) {
 				if (!include($CONFIG->path . "version.php")) {
@@ -48,21 +46,34 @@ class Elgg_Version {
 				$this->localVersion = $version;
 				$this->localRelease = $release;
 			}
-			return (!$humanreadable) ? $this->localVersion : $this->localRelease;
+			return true;
 		}
 
 		return false;
 	}
-
+	
 	/**
-	 * Compares two elgg release strings
-	 * 
-	 * @param string $a first release
-	 * @param string $b second release
-	 * @return int -1 if the first version is lower than the second, 0 if they are equal, and 1 if the second is lower
+	 * Get the current Elgg version information
+	 *
+	 * @return string|false Depending on success
 	 */
-	function compareReleases($a, $b) {
-		return version_compare($a, $b);
+	function getVersion() {
+		if ($this->initVersionAndRelease()) {
+			return $this->localVersion;
+		}
+		return false;
+	}
+	
+	/**
+	 * Get the current Elgg release information
+	 *
+	 * @return string|false Depending on success
+	 */
+	function getRelease() {
+		if ($this->initVersionAndRelease()) {
+			return $this->localRelease;
+		}
+		return false;
 	}
 	
 	/**
@@ -114,7 +125,7 @@ class Elgg_Version {
 				if (strpos($r, 'rc') !== false || strpos($r, 'dev') !== false) {
 					continue;
 				}
-				if (!$release || ($this->compareReleases($r, $release) > 0)) {
+				if (!$release || (version_compare($r, $release) > 0)) {
 					$release = $r;
 				}
 			}
@@ -189,13 +200,13 @@ class Elgg_Version {
 	 */
 	function isLatestRelease($version = null) {
 		if ($version === null) {
-			$version = $this->getVersion(true);
+			$version = $this->getRelease();
 		}
 		$latest = $this->getLatestRelease();
 		if ($latest === false) {
 			throw new IOException(elgg_echo('IOException:UnknownVersion'));
 		}
-		return $this->compareReleases($latest, $version) < 1;
+		return version_compare($latest, $version) < 1;
 	}
 }
 

--- a/engine/classes/Elgg/Version.php
+++ b/engine/classes/Elgg/Version.php
@@ -2,7 +2,9 @@
 /**
  * Class providing ability to check local Elgg version/releace and to get and compare newest release
  * in Github tags or http://elgg.org
- * @see https://elgg.org/
+ * 
+ * @package Elgg.Core
+ * @see     https://elgg.org/
  * @todo consider moving version.php contents to this class as constants 
  */
 class Elgg_Version {
@@ -54,6 +56,7 @@ class Elgg_Version {
 
 	/**
 	 * Compares two elgg release strings
+	 * 
 	 * @param string $a first release
 	 * @param string $b second release
 	 * @return int -1 if the first version is lower than the second, 0 if they are equal, and 1 if the second is lower
@@ -64,6 +67,7 @@ class Elgg_Version {
 	
 	/**
 	 * Tries to fetch contents of the URL.
+	 * 
 	 * @param string $url URL to fetch
 	 * @return string|boolean returns response contents on success or false on failure
 	 */
@@ -139,6 +143,8 @@ class Elgg_Version {
 	
 	/**
 	 * Tries several methods and sources of determining latest Elgg release.
+	 * 
+	 * @param bool $overrideCache forces to query external resource to determine latest release
 	 * @return string|boolean returns release string or false on failure
 	 */
 	function getLatestRelease($overrideCache = false) {
@@ -176,6 +182,7 @@ class Elgg_Version {
 	
 	/**
 	 * Checks if provided version is the same (or newer) than the latest one.
+	 * 
 	 * @param string $version version to check, gets local core version by default
 	 * @throws IOException
 	 * @return boolean

--- a/engine/classes/Elgg/Version.php
+++ b/engine/classes/Elgg/Version.php
@@ -4,7 +4,7 @@
  * in Github tags or http://elgg.org
  * 
  * @package Elgg.Core
- * @see     https://elgg.org/
+ * @see     http://elgg.org/
  * @todo consider moving version.php contents to this class as constants 
  */
 class Elgg_Version {

--- a/engine/classes/Elgg/Version.php
+++ b/engine/classes/Elgg/Version.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Class providing ability to check local Elgg version/releace and to get and compare newest release
+ * in Github tags or http://elgg.org
+ * @see https://elgg.org/
+ * @todo consider moving version.php contents to this class as constants 
+ */
+class Elgg_Version {
+
+	/**
+	 * @var string
+	 */
+	private $localVersion;
+
+	/**
+	 * @var string
+	 */
+	private $localRelease;
+
+	/**
+	 * @var string
+	 */
+	private $latestRelease;
+	
+	/**
+	 * Time in seconds to store latest version in datalist before running external check.
+	 * @var int
+	 */
+	private $cachingPeriod = 86400; // 24h
+
+	/**
+	 * Get the current Elgg version information
+	 *
+	 * @param bool $humanreadable Whether to return a human readable version (default: false)
+	 *
+	 * @return string|false Depending on success
+	 */
+	function getVersion($humanreadable = false) {
+		global $CONFIG;
+
+		if (isset($CONFIG->path)) {
+			if (!isset($this->localVersion) || !isset($this->localRelease)) {
+				if (!include($CONFIG->path . "version.php")) {
+					return false;
+				}
+				$this->localVersion = $version;
+				$this->localRelease = $release;
+			}
+			return (!$humanreadable) ? $this->localVersion : $this->localRelease;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Compares two elgg release strings
+	 * @param string $a first release
+	 * @param string $b second release
+	 * @return int -1 if the first version is lower than the second, 0 if they are equal, and 1 if the second is lower
+	 */
+	function compareReleases($a, $b) {
+		return version_compare($a, $b);
+	}
+	
+	/**
+	 * Tries to fetch contents of the URL.
+	 * @param string $url URL to fetch
+	 * @return string|boolean returns response contents on success or false on failure
+	 */
+	private function getUrl($url) {
+		//try url fopen
+		$file = fopen($url, 'r');
+		if ($file !== false) {
+			$result = stream_get_contents($file);
+			fclose($file);
+			return $result;
+		}
+		//try curl
+		if (extension_loaded('curl')) {
+			$ch = curl_init($url);
+			curl_setopt_array($ch, array(
+				CURLOPT_HEADER => false,
+				CURLOPT_RETURNTRANSFER => true,
+				CURLOPT_SSL_VERIFYPEER => false,
+			));
+			$result = curl_exec($ch);
+			curl_close($ch);
+			if ($result !== false) {
+				return $result;
+			}
+		}
+		return false;
+	}
+	
+	/**
+	 * Fetch latest Elgg release from Github tags via Github API
+	 * @return string|boolean returns release string or false on failure
+	 */
+	private function getLatestFromGithub() {
+		$release = false;
+		$contents = $this->getUrl('https://api.github.com/repos/Elgg/Elgg/git/refs/tags/');
+		if ($contents === false) {
+			return false;
+		}
+		$data = json_decode($contents);
+		if ($data !== null) {
+			foreach ($data as $e) {
+				$r = strtolower(substr($e->ref, strlen('refs/tags/')));
+				//skip release candidates and development versions 
+				if (strpos($r, 'rc') !== false || strpos($r, 'dev') !== false) {
+					continue;
+				}
+				if (!$release || ($this->compareReleases($r, $release) > 0)) {
+					$release = $r;
+				}
+			}
+		}
+		return $release;
+	}
+	
+	/**
+	 * Fetch latest Elgg release from elgg.org main page download link label.
+	 * @return string|boolean returns release string or false on failure
+	 */
+	private function getLatestFromElggOrg() {
+		$release = false;
+		$contents = $this->getUrl('http://elgg.org/');
+		if ($contents !== false) {
+			$regExp = '#<a\s+[^>]*href="download\.php"[^>]*\s+class="download"[^>]*>[^0-9<]*([0-9\.]+)\s*</a>#m';
+			if (preg_match($regExp, $contents, $matches)) {
+				$release = $matches[1];
+				if ($release) {
+					return $release;
+				}
+			}
+		}
+		return false;
+	}
+	
+	/**
+	 * Tries several methods and sources of determining latest Elgg release.
+	 * @return string|boolean returns release string or false on failure
+	 */
+	function getLatestRelease($overrideCache = false) {
+		if ($this->latestRelease !== null) {
+			return $this->latestRelease;
+		}
+		//fetch from datalist if caching period not reached
+		$lastChecked = datalist_get('version_last_checked');
+		$cachedRelease = datalist_get('version_newest');
+		$time = time();
+		if ($cachedRelease && !$overrideCache && $lastChecked + $this->cachingPeriod > $time) {
+			$this->latestRelease = $cachedRelease;
+			return $cachedRelease;
+		}
+		
+		$release = false;
+		$mt = microtime(true);
+		if (!($release = $this->getLatestFromGithub())) {
+			// github is wrong, maybe missing https support, try elgg.org
+			$release = $this->getLatestFromElggOrg();
+		}
+		datalist_set('version_last_checked', $time);
+		datalist_set('version_newest', $release);
+		$this->latestRelease = $release;
+		return $release;
+	}
+
+	/**
+	 * @return null|int timestamp representing last check for external version date 
+	 * or null if never checked
+	 */
+	function getLatestReleaseLastChecked() {
+		return datalist_get('version_last_checked');
+	}
+	
+	/**
+	 * Checks if provided version is the same (or newer) than the latest one.
+	 * @param string $version version to check, gets local core version by default
+	 * @throws IOException
+	 * @return boolean
+	 */
+	function isLatestRelease($version = null) {
+		if ($version === null) {
+			$version = $this->getVersion(true);
+		}
+		$latest = $this->getLatestRelease();
+		if ($latest === false) {
+			throw new IOException(elgg_echo('IOException:UnknownVersion'));
+		}
+		return $this->compareReleases($latest, $version) < 1;
+	}
+}
+

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -239,6 +239,8 @@ function admin_init() {
 
 	elgg_register_action('admin/delete_admin_notice', '', 'admin');
 
+	elgg_register_action('admin/core/version', '', 'admin');
+
 	elgg_register_action('profile/fields/reset', '', 'admin');
 	elgg_register_action('profile/fields/add', '', 'admin');
 	elgg_register_action('profile/fields/edit', '', 'admin');
@@ -313,7 +315,7 @@ function admin_init() {
 	}
 			
 	// widgets
-	$widgets = array('online_users', 'new_users', 'content_stats', 'admin_welcome', 'control_panel');
+	$widgets = array('online_users', 'new_users', 'content_stats', 'admin_welcome', 'control_panel', 'version');
 	foreach ($widgets as $widget) {
 		elgg_register_widget_type(
 				$widget,
@@ -638,7 +640,7 @@ function elgg_add_admin_widgets($event, $type, $user) {
 
 	// In the form column => array of handlers in order, top to bottom
 	$adminWidgets = array(
-		1 => array('control_panel', 'admin_welcome'),
+		1 => array('control_panel', 'admin_welcome', 'version'),
 		2 => array('online_users', 'new_users', 'content_stats'),
 	);
 	

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1006,8 +1006,7 @@ function elgg_dump($value, $to_screen = true) {
  * @since 1.9
  */
 function elgg_get_version($human_readable = false) {
-	$version = new Elgg_Version();
-	return $version->getVersion($human_readable); 
+	return _elgg_services()->version->getVersion($human_readable); 
 }
 
 /**

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1006,7 +1006,11 @@ function elgg_dump($value, $to_screen = true) {
  * @since 1.9
  */
 function elgg_get_version($human_readable = false) {
-	return _elgg_services()->version->getVersion($human_readable); 
+	if ($human_readable) {
+		return _elgg_services()->version->getRelease();
+	} else {
+		return _elgg_services()->version->getVersion();
+	}
 }
 
 /**

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1006,20 +1006,8 @@ function elgg_dump($value, $to_screen = true) {
  * @since 1.9
  */
 function elgg_get_version($human_readable = false) {
-	global $CONFIG;
-
-	static $version, $release;
-
-	if (isset($CONFIG->path)) {
-		if (!isset($version) || !isset($release)) {
-			if (!include($CONFIG->path . "version.php")) {
-				return false;
-			}
-		}
-		return (!$human_readable) ? $version : $release;
-	}
-
-	return false;
+	$version = new Elgg_Version();
+	return $version->getVersion($human_readable); 
 }
 
 /**

--- a/languages/en.php
+++ b/languages/en.php
@@ -87,7 +87,8 @@ return array(
 	'ElggPlugin:Dependencies:Priority:Uninstalled' => '%s is not installed',
 	'ElggPlugin:Dependencies:Suggests:Unsatisfied' => 'Missing',
 
-
+	'IOException:UnknownVersion' => "Unable to fetch newset Elgg version information! Make sure that you have curl extension loaded or alow url fopen PHP setting enabled.",
+	
 	'RegistrationException:EmptyPassword' => 'The password fields cannot be empty',
 	'RegistrationException:PasswordMismatch' => 'Passwords must match',
 	'LoginException:BannedUser' => 'You have been banned from this site and cannot log in',
@@ -472,8 +473,24 @@ return array(
 	'admin:widget:new_users:help' => 'Lists the newest users',
 	'admin:widget:content_stats' => 'Content statistics',
 	'admin:widget:content_stats:help' => 'Keep track of the content created by your users',
+	'admin:widget:version' => 'Version',
+	'admin:widget:version:help' => 'Shows results of check if current core version is up to date',
 	'widget:content_stats:type' => 'Content type',
 	'widget:content_stats:number' => 'Number',
+
+	'admin:widget:version:current' => 'Installed Elgg version: <strong>%s</strong>',
+	'admin:widget:version:newer_found' => 'New Elgg version found: ',
+	'admin:widget:version:status:ok' => 'Up to date',
+	'admin:widget:version:status:bad' => 'Outdated',
+	'admin:widget:version:last_checked' => 'Last checked: %s',
+	'admin:widget:version:check' => 'Check now',
+	'admin:version:local_release' => 'Installed Elgg release',
+	'admin:version:latest_release' => 'Newest release',
+	'admin:version:last_checked' => 'Last checked',
+	'admin:version:status' => 'Status',
+	'admin:version:download' => 'Download Elgg %s',
+	'admin:version:action:ok' => 'Newest release found: <strong>%s</strong>',
+	'admin:version:action:fail' => 'Failed to get newest release',
 
 	'admin:widget:admin_welcome' => 'Welcome',
 	'admin:widget:admin_welcome:help' => "A short introduction to Elgg's admin area",

--- a/views/default/widgets/version/content.php
+++ b/views/default/widgets/version/content.php
@@ -1,0 +1,48 @@
+<?php
+try { 
+	$version = new Elgg_Version();
+	$localRelease = $version->getVersion(true);
+	$latestRelease = $version->getLatestRelease();
+	$isLatest = $version->isLatestRelease($localRelease);
+	$time = $version->getLatestReleaseLastChecked();
+	
+	if (!$isLatest) {
+		echo '<p>';
+		echo elgg_echo('admin:widget:version:newer_found');
+		echo elgg_view('output/url', array(
+			'href' => 'http://elgg.org/getelgg.php?forward=elgg-'.$latestRelease.'.zip',
+			'class' => 'elgg-button elgg-button-action',
+			'text' => elgg_echo('admin:version:download', array($latestRelease)),
+		));
+		echo '</p>';
+		
+		$class = "elgg-state-error elgg-version";
+	} else {
+		$class = "elgg-state-success elgg-version";
+	}
+	
+	$data = array(
+		'local_release' => $localRelease,
+		'latest_release' => $latestRelease, 
+		'last_checked' => elgg_view_friendly_time($time),
+		'status' => elgg_echo('admin:widget:version:status:'.($isLatest?'ok':'bad')),
+	);
+	
+	echo '<table class="elgg-table-alt elgg-version">';
+	foreach ($data as $column => $value) {
+		$column = elgg_echo("admin:version:$column");
+		echo "<tr><td><strong>$column</strong></td><td class=\"$class\">$value</td></tr>";
+	}
+	echo '</table>';
+	
+	echo '<br/>';
+	
+	echo elgg_view('output/url', array(
+		'href' => elgg_add_action_tokens_to_url('action/admin/core/version'),
+		'class' => 'elgg-button elgg-button-action elgg-widget-refresh',
+		'text' => elgg_echo('admin:widget:version:check'),
+	));
+	
+} catch(IOException $e) {
+	echo $e->getMessage();
+}

--- a/views/default/widgets/version/content.php
+++ b/views/default/widgets/version/content.php
@@ -1,7 +1,7 @@
 <?php
 try { 
 	$version = _elgg_services()->version;
-	$localRelease = $version->getVersion(true);
+	$localRelease = $version->getRelease();
 	$latestRelease = $version->getLatestRelease();
 	$isLatest = $version->isLatestRelease($localRelease);
 	$time = $version->getLatestReleaseLastChecked();

--- a/views/default/widgets/version/content.php
+++ b/views/default/widgets/version/content.php
@@ -1,6 +1,6 @@
 <?php
 try { 
-	$version = new Elgg_Version();
+	$version = _elgg_services()->version;
 	$localRelease = $version->getVersion(true);
 	$latestRelease = $version->getLatestRelease();
 	$isLatest = $version->isLatestRelease($localRelease);


### PR DESCRIPTION
Rebased version of https://github.com/Elgg/Elgg/pull/5293

@ewinslow Following your remarks from https://github.com/Elgg/Elgg/pull/5293

The main reason for keeping elgg.org fallback was case with missing openssl and thus https capability required to call Github. It's implementatnion is hacky though and I would consider dropping it and just require openssl for version check to work.

I'm not sure if I can use any specific part of manifest to get repository URL (`repository` element?). It deserves separate page IMHO or direct plugins page integration.
