### PR TITLE
Strip slashes added by output/confirmlink in elgg.ui.requiresConfirmation

### DIFF
--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -220,7 +220,7 @@ elgg.ui.initHoverMenu = function(parent) {
  * @return void
  */
 elgg.ui.requiresConfirmation = function(e) {
-	var confirmText = $(this).attr('rel') || elgg.echo('question:areyousure');
+	var confirmText = $(this).attr('rel').replace(/\\/g, '') || elgg.echo('question:areyousure');
 	if (!confirm(confirmText)) {
 		e.preventDefault();
 	}


### PR DESCRIPTION
The output/confirmlink view adds slashes (via addslashes) to the confirm text. Which is all well and good considering this gets loaded into the 'rel' attribute. But, the slashes are never stripped out when the alert dialog is displayed by the elgg.ui.requiresConfirmation function.

I added a simple regex replace on the text. Not sure if its worth adding a new helper function or not. 
