### PR TITLE
Refs #5491 temporary fix for bad can_edit_extender() logic

### DIFF
--- a/engine/lib/extender.php
+++ b/engine/lib/extender.php
@@ -126,14 +126,20 @@ function import_extender_plugin_hook($hook, $entity_type, $returnvalue, $params)
  * @return bool
  */
 function can_edit_extender($extender_id, $type, $user_guid = 0) {
-	if (!elgg_is_logged_in()) {
-		return false;
+	// @todo Since Elgg 1.0, Elgg has returned false from can_edit_extender()
+	// if no user was logged in. This breaks the access override. This is a
+	// temporary work around. This function needs to be rewritten in Elgg 1.9 
+	if (!elgg_check_access_overrides($user_guid)) {
+		if (!elgg_is_logged_in()) {
+			return false;
+		}
 	}
 
 	$user_guid = (int)$user_guid;
-	$user = get_entity($user_guid);
+	$user = get_user($user_guid);
 	if (!$user) {
 		$user = elgg_get_logged_in_user_entity();
+		$user_guid = elgg_get_logged_in_user_guid();
 	}
 
 	$functionname = "elgg_get_{$type}_from_id";
@@ -149,16 +155,16 @@ function can_edit_extender($extender_id, $type, $user_guid = 0) {
 	/* @var ElggExtender $extender */
 
 	// If the owner is the specified user, great! They can edit.
-	if ($extender->getOwnerGUID() == $user->getGUID()) {
+	if ($extender->getOwnerGUID() == $user_guid) {
 		return true;
 	}
 
 	// If the user can edit the entity this is attached to, great! They can edit.
-	if (can_edit_entity($extender->entity_guid, $user->getGUID())) {
+	if (can_edit_entity($extender->entity_guid, $user_guid)) {
 		return true;
 	}
 
-	// Trigger plugin hooks
+	// Trigger plugin hook - note that $user may be null
 	$params = array('entity' => $extender->getEntity(), 'user' => $user);
 	return elgg_trigger_plugin_hook('permissions_check', $type, $params, false);
 }


### PR DESCRIPTION
If no user logged in and delete an entity with more than 50 annotations, causes infinite loop in ElggBatch
