### PR TITLE
WIP towards #5446

### DIFF
--- a/mod/developers/views/default/theme_preview/grid.php
+++ b/mod/developers/views/default/theme_preview/grid.php
@@ -3,49 +3,102 @@
  * Grid CSS
  */
 
-?>
-<div class="elgg-grid">
-	<div class="elgg-col elgg-col-1of1"><div class="elgg-inner"><h3>1/1</h3></div></div>
-</div>
-<div class="elgg-grid">
-	<div class="elgg-col elgg-col-1of2"><div class="elgg-inner"><h3>1/2</h3></div></div>
-	<div class="elgg-col elgg-col-1of2"><div class="elgg-inner"><h3>1/2</h3></div></div>
-</div>
-<div class="elgg-grid">
-	<div class="elgg-col elgg-col-1of3"><div class="elgg-inner"><h3>1/3</h3></div></div>
-	<div class="elgg-col elgg-col-2of3"><div class="elgg-inner"><h3>2/3</h3></div></div>
-</div>
-<div class="elgg-grid">
-	<div class="elgg-col elgg-col-3of4"><div class="elgg-inner"><h3>3/4</h3></div></div>
-	<div class="elgg-col elgg-col-1of4"><div class="elgg-inner"><h3>1/4</h3></div></div>
-</div>
-<div class="elgg-grid">
-	<div class="elgg-col elgg-col-1of5"><div class="elgg-inner"><h3>1/5</h3></div></div>
-	<div class="elgg-col elgg-col-4of5"><div class="elgg-inner"><h3>4/5</h3></div></div>
-</div>
-<div class="elgg-grid">
-	<div class="elgg-col elgg-col-3of5"><div class="elgg-inner"><h3>3/5</h3></div></div>
-	<div class="elgg-col elgg-col-2of5"><div class="elgg-inner"><h3>2/5</h3></div></div>
-</div>
-<div class="elgg-grid">
-	<div class="elgg-col elgg-col-1of6"><div class="elgg-inner"><h3>1/6</h3></div></div>
-	<div class="elgg-col elgg-col-5of6"><div class="elgg-inner"><h3>5/6</h3></div></div>
-</div>
-<div class="elgg-grid">
-	<style>
-		h3 { text-align: center; }
-		.elgg-col > .elgg-inner {
-			border: 1px solid #cccccc;
-			border-radius: 5px;
-			padding: 5px;
+$filler = "<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>\n";
+
+// build list of units (denominators are keys, values are arrays of nominators)
+$units = array(1 => array(1),);
+
+// keep map to avoid duplicates. keys are rounded to thousands (avoid float issues)
+$percentages = array(
+	'100' => array(1, 1),
+);
+
+for ($den = 2; $den <= 6; $den++) {
+	for ($num = 1; $num < $den; $num++) {
+		// avoid duplicates
+		$rounded_percentage = (string)round($num / $den, 3);
+		if ($num > 1 && isset($percentages[$rounded_percentage])) {
+			continue;
 		}
-	</style>
+		$percentages[$rounded_percentage] = array($num, $den);
+		$units[$den][] = $num;
+	}
+}
+
+// build rows
+$rows = array();
+$total = 0;
+for ($den = 1; $den <= count($units); $den++) {
+	// may take multiple rows to use up available units
+	while ($units[$den]) {
+		$row = array();
+		$nom = array_shift($units[$den]);
+		$row[] = "$nom/$den";
+		$total += $nom;
+		if ($total < $den) {
+			$nom = $den - $total;
+			$row[] = "$nom/$den";
+			$total += $nom;
+			$index = array_search($nom, $units[$den]);
+			if ($index !== false) {
+				unset($units[$den][$index]);
+			}
+		}
+		$rows[] = $row;
+		$total = 0;
+	}
+}
+
+?>
+<style>
+h3 { text-align: center; font-weight: normal; }
+.elgg-griddemo { margin: 1em 0 0; font-size: 115%; }
+.elgg-col > .elgg-inner {
+	border: 1px solid #cccccc;
+	border-radius: 5px;
+	padding: 5px;
+	text-align: center;
+	font-size: .65rem;
+}
+.elgg-col p {
+	text-align: left;
+	font-size: .80rem;
+}
+</style>
+
+<h2 class="elgg-griddemo">Without Gutters</h2>
+<p>Each row is wrapped by <code>div.elgg-grid</code></p>
+
+<?php foreach ($rows as $row): ?>
+<div class="elgg-grid">
+	<?php foreach ($row as $col):
+		$class = "elgg-col elgg-col-" . str_replace('/', 'of', $col);
+		$text = str_replace(' ', '<br>', $class);
+	?>
+	<div class="<?php echo $class ?>"><div class="elgg-inner"><?php echo $text ?></div></div>
+	<?php endforeach; ?>
+</div>
+<?php endforeach; ?>
+
+<h2 class="elgg-griddemo">With Gutters</h2>
+<p>Each row is wrapped by <code>div.elgg-grid-gutters</code></p>
+
+<?php foreach ($rows as $row): ?>
+<div class="elgg-grid-gutters">
+	<?php foreach ($row as $col):
+		$class = "elgg-col elgg-col-" . str_replace('/', 'of', $col);
+		$text = str_replace(' ', '<br>', $class);
+	?>
+	<div class="<?php echo $class ?>"><div class="elgg-inner"><?php echo $text ?></div></div>
+	<?php endforeach; ?>
+</div>
+<?php endforeach; ?>
+
+<div class="elgg-grid">
 	<div class="elgg-col elgg-col-1of5">
 		<div class="elgg-inner">
 			<h3>1/5</h3>
-			<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-			<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-			<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+			<?php echo str_repeat($filler, 3) ?>
 		</div>
 	</div>
 	<div class="elgg-col elgg-col-3of5">
@@ -55,13 +108,13 @@
 				<div class="elgg-col elgg-col-1of2">
 					<div class="elgg-inner">
 						<h3>1/2</h3>
-						<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+						<?php echo $filler ?>
 					</div>
 				</div>
 				<div class="elgg-col elgg-col-1of2 elgg-col-last">
 					<div class="elgg-inner">
 						<h3>1/2</h3>
-						<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+						<?php echo $filler ?>
 					</div>
 				</div>
 			</div>
@@ -69,8 +122,7 @@
 				<div class="elgg-col elgg-col-1of3">
 					<div class="elgg-inner">
 						<h3>1/3</h3>
-						<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-						<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+						<?php echo str_repeat($filler, 2) ?>
 					</div>
 				</div>
 				<div class="elgg-col elgg-col-2of3 elgg-col-last">
@@ -80,13 +132,13 @@
 							<div class="elgg-col elgg-col-1of2">
 								<div class="elgg-inner">
 									<h3>1/2</h3>
-									<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+									<?php echo $filler ?>
 								</div>
 							</div>
 							<div class="elgg-col elgg-col-1of2 elgg-col-last">
 								<div class="elgg-inner">
 									<h3>1/2</h3>
-									<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+									<?php echo $filler ?>
 								</div>
 							</div>
 						</div>
@@ -94,7 +146,7 @@
 							<div class="elgg-col elgg-col-1of1">
 								<div class="elgg-inner">
 									<h3>1</h3>
-									<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+									<?php echo $filler ?>
 								</div>
 							</div>
 						</div>
@@ -106,9 +158,7 @@
 	<div class="elgg-col elgg-col-1of5 elgg-col-last">
 		<div class="elgg-inner">
 			<h3>1/5</h3>
-			<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-			<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-			<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+			<?php echo str_repeat($filler, 3) ?>
 		</div>
 	</div>
 </div>

--- a/views/default/css/elements/grid.php
+++ b/views/default/css/elements/grid.php
@@ -9,26 +9,58 @@
  * the last column (@todo we need broswer-specific test cases for this).
  */
 
-$gutterWidthPercent = 1.6; /* 16px on a 1000px grid */
-?>
+$gutter_width_percent = elgg_get_config('elgg_grid_gutter_percentage');
+if ($gutter_width_percent === null) {
+	$gutter_width_percent = 1.6; /* 16px on a 1000px grid */
+}
 
-.elgg-grid + .elgg-grid { margin-top: <?php echo $gutterWidthPercent; ?>%; }
-.elgg-col { float: left; margin-right: <?php echo $gutterWidthPercent; ?>%; }
-.elgg-col-alt { float: right; margin-left: <?php echo $gutterWidthPercent; ?>%; margin-right: 0; }
-.elgg-col-1of1 { float: none; margin: 0; }
+?>
+/*<style>/**/
+
+.elgg-col { float: left; }
+.elgg-col-alt { float: right; }
+
+.elgg-grid-gutters > .elgg-col,
+.elgg-grid-gutters > .elgg-col-alt { margin-left: <?php echo $gutter_width_percent; ?>%; }
+
+.elgg-grid-gutters {
+	margin-top: <?php echo $gutter_width_percent; ?>%;
+	margin-bottom: <?php echo $gutter_width_percent; ?>%;
+}
+
 .elgg-col:last-child, .elgg-col-last { float: none; overflow: hidden; margin: 0; width: auto; }
 
+                     .elgg-col-1of1 { float: none; margin: 0; }
 <?php
 
-for ($i = 2; $i <= 6; $i++) {
-	$gutters = $i - 1;
-	$columnWidthPercent = (100 - $gutters * $gutterWidthPercent)/$i;
-	for ($j = 1; $j < $i; $j++) {
-		if ($j > 1 && ($i/$j) === (int)($i/$j)) {
+// build units
+
+// keep map to eliminate duplicates. keys are rounded to thousands (avoid float issues)
+$percentages = array(
+	'100' => array(1, 1),
+);
+
+for ($den = 2; $den <= 6; $den++) {
+	$num_gutters = $den - 1;
+	$column_width_percent = 100/$den;
+	$column_width_percent_gutters = (100 - $num_gutters * $gutter_width_percent)/$den;
+	for ($num = 1; $num < $den; $num++) {
+		// avoid duplicates
+		$rounded_percentage = (string)round($num / $den, 3);
+		if ($num > 1 && isset($percentages[$rounded_percentage])) {
 			continue;
 		}
+		$percentages[$rounded_percentage] = array($num, $den);
 
-		$widthPercent = $j * $columnWidthPercent + ($j - 1) * $gutterWidthPercent;
-		echo ".elgg-col-{$j}of{$i} { width: $widthPercent%; }\n";
+		$width_percent = $num * $column_width_percent;
+		$width_percent_gutters = $num * $column_width_percent_gutters + ($num - 1) * $gutter_width_percent;
+
+		// round to 3 digits, but round last digit down (.666 instead of .667)
+		$width_percent = floor($width_percent * 10000) / 10000;
+		$width_percent_gutters = floor($width_percent_gutters * 10000) / 10000;
+
+		echo "\n";
+		echo "                     .elgg-col-{$num}of{$den} { width: $width_percent%; }\n";
+		echo ".elgg-grid-gutters > .elgg-col-{$num}of{$den} { width: $width_percent_gutters%; }\n";
 	}
 }


### PR DESCRIPTION
This removes the unneeded 4of6 unit and moves the guttered versions to elgg-grid-gutters.

I may have made a mistake, but from the grid demo it doesn't look like the guttered versions work. The last column is not floated, so the margin is placed before the first column.

I don't see how the gutters can work like they're designed. Consider one row with 1/5 + 4/5 and another row with 1/5 + 2/5 + 2/5. Will these have the same gutters? I'd think the gutters would need to be applied evenly inside the column elements.

I've never had good luck with grids with gutters, mainly because nesting makes the gutters differ in width.
