### PR TITLE
Cleans up can_write_to_container()

### DIFF
--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -396,34 +396,32 @@ function update_subtype($type, $subtype, $class = '') {
  * A plugin hook container_permissions_check:$entity_type is emitted to allow granular
  * access controls in plugins.
  *
- * @param int    $user_guid      The user guid, or 0 for logged in user
+ * @param int    $user_guid      The user guid, or 0 for logged in user.
  * @param int    $container_guid The container, or 0 for the current page owner.
- * @param string $type           The type of entity we're looking to write
- * @param string $subtype        The subtype of the entity we're looking to write
+ * @param string $type           The type of entity we're looking to create (default: 'all')
+ * @param string $subtype        The subtype of the entity we're looking to create (default: 'all')
  *
  * @return bool
- * @link http://docs.elgg.org/DataModel/Containers
  */
 function can_write_to_container($user_guid = 0, $container_guid = 0, $type = 'all', $subtype = 'all') {
 	$container_guid = (int)$container_guid;
 	if (!$container_guid) {
 		$container_guid = elgg_get_page_owner_guid();
 	}
-
-	$return = false;
-
-	if (!$container_guid) {
-		$return = true;
-	}
-
 	$container = get_entity($container_guid);
 
 	$user_guid = (int)$user_guid;
-	$user = get_entity($user_guid);
-	if (!$user) {
+	if ($user_guid == 0) {
 		$user = elgg_get_logged_in_user_entity();
+		$user_guid = elgg_get_logged_in_user_guid();
+	} else {
+		$user = get_user($user_guid);
+		if (!$user) {
+			return false;
+		}
 	}
 
+	$return = false;
 	if ($container) {
 		// If the user can edit the container, they can also write to it
 		if ($container->canEdit($user_guid)) {

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -386,7 +386,6 @@ function update_subtype($type, $subtype, $class = '') {
 	return $success;
 }
 
-
 /**
  * Determine if a given user can write to an entity container.
  *
@@ -427,15 +426,6 @@ function can_write_to_container($user_guid = 0, $container_guid = 0, $type = 'al
 		if ($container->canEdit($user_guid)) {
 			$return = true;
 		}
-
-		// If still not approved, see if the user is a member of the group
-		// @todo this should be moved to the groups plugin/library
-		if (!$return && $user && $container instanceof ElggGroup) {
-			/* @var ElggGroup $container */
-			if ($container->isMember($user)) {
-				$return = true;
-			}
-		}
 	}
 
 	// See if anyone else has anything to say
@@ -449,7 +439,6 @@ function can_write_to_container($user_guid = 0, $container_guid = 0, $type = 'al
 			),
 			$return);
 }
-
 
 /**
  * Returns a database row from the entities table.

--- a/engine/lib/group.php
+++ b/engine/lib/group.php
@@ -259,6 +259,29 @@ function remove_group_tool_option($name) {
 }
 
 /**
+ * Allow group members to write to the group container
+ * 
+ * @param string $hook   Hook name
+ * @param string $type   Hook type
+ * @param bool   $result The value of the hook
+ * @param array  $params Parameters related to the hook
+ * @return bool
+ * @access private
+ */
+function _elgg_groups_container_override($hook, $type, $result, $params) {
+	$container = $params['container'];
+	$user = $params['user'];
+	if (elgg_instanceof($container, 'group') && $user) {
+		/* @var ElggGroup $container */
+		if ($container->isMember($user)) {
+			return true;
+		}
+	}
+
+	return $result;
+}
+
+/**
  * Runs unit tests for the group entities.
  *
  * @param string $hook  Hook name
@@ -274,4 +297,13 @@ function _elgg_groups_test($hook, $type, $value) {
 	return $value;
 }
 
-elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_groups_test');
+/**
+ * init the groups library
+ * @access private
+ */
+function _elgg_groups_init() {
+	elgg_register_plugin_hook_handler('container_permissions_check', 'all', '_elgg_groups_container_override');
+	elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_groups_test');
+}
+
+elgg_register_event_handler('init', 'system', '_elgg_groups_init');


### PR DESCRIPTION
This should be reviewed carefully. The question is what should happen if someone calls can_write_to_container() and there is no container passed in. 

This used to be an issue with Elgg 1.0-1.7 because content plugins called this when deciding whether to display an add button. It defaults to using the page owner if not container is specified. Returning true for no container, allowed plugins to add a button on pages without a page owner (like listing all blogs). I think defaulting to the page owner is a bad idea and should be deprecated. 

In Elgg 1.8 we replaced this with the elgg_register_title_button() : https://github.com/Elgg/Elgg/blob/master/engine/lib/navigation.php#L179
