### PR TITLE
Fixes #5538 - Moves additional SELECT columns in ege*() to volatile data

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1588,6 +1588,18 @@ abstract class ElggEntity extends ElggData implements
 		}
 		return true;
 	}
+	
+	/**
+	 * Load fresh row data into existing entity. Overwrite only given data.
+	 * 
+	 * @param stdClass $row
+	 */
+	public function refresh($row) {
+		if ($row instanceof stdClass) {
+			return $this->load($row);
+		}
+		return false;
+	}
 
 	/**
 	 * Disable this entity.

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1577,6 +1577,19 @@ abstract class ElggEntity extends ElggData implements
 	}
 
 	/**
+	 * Handles additional columns that were loaded from database together with attributes.
+	 * 
+	 * @param array $data list of values to handle
+	 * @return bool
+	 */
+	protected function loadAdditionalColumns($data) {
+		foreach ($data as $name => $value) {
+			$this->setVolatileData("row:$name", $value);
+		}
+		return true;
+	}
+
+	/**
 	 * Disable this entity.
 	 *
 	 * Disabled entities are not returned by getter functions.

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1592,7 +1592,8 @@ abstract class ElggEntity extends ElggData implements
 	/**
 	 * Load fresh row data into existing entity. Overwrite only given data.
 	 * 
-	 * @param stdClass $row
+	 * @param stdClass $row DB row with new entity data
+	 * @return bool
 	 */
 	public function refresh($row) {
 		if ($row instanceof stdClass) {

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -430,6 +430,7 @@ class ElggGroup extends ElggEntity
 
 		$this->attributes = $attrs;
 		$this->attributes['tables_loaded'] = 2;
+		$this->loadAdditionalColumns($attr_loader->getAdditionalColumns());
 		_elgg_cache_entity($this);
 
 		return true;

--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -107,6 +107,7 @@ class ElggObject extends ElggEntity {
 
 		$this->attributes = $attrs;
 		$this->attributes['tables_loaded'] = 2;
+		$this->loadAdditionalColumns($attr_loader->getAdditionalColumns());
 		_elgg_cache_entity($this);
 
 		return true;

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -124,6 +124,7 @@ class ElggSite extends ElggEntity {
 
 		$this->attributes = $attrs;
 		$this->attributes['tables_loaded'] = 2;
+		$this->loadAdditionalColumns($attr_loader->getAdditionalColumns());
 		_elgg_cache_entity($this);
 
 		return true;

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -40,6 +40,9 @@ class ElggUser extends ElggEntity
 		$this->attributes['code'] = NULL;
 		$this->attributes['banned'] = "no";
 		$this->attributes['admin'] = 'no';
+		$this->attributes['prev_last_action'] = NULL;
+		$this->attributes['last_login'] = NULL;
+		$this->attributes['prev_last_login'] = NULL;
 		$this->attributes['tables_split'] = 2;
 	}
 
@@ -112,6 +115,7 @@ class ElggUser extends ElggEntity
 
 		$this->attributes = $attrs;
 		$this->attributes['tables_loaded'] = 2;
+		$this->loadAdditionalColumns($attr_loader->getAdditionalColumns());
 		_elgg_cache_entity($this);
 
 		return true;

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -970,6 +970,7 @@ function _elgg_fetch_entities_from_sql($sql) {
 		}
 		$entity = _elgg_retrieve_cached_entity($row->guid);
 		if ($entity) {
+			$entity->refresh($row);
 			$rows[$i] = $entity;
 			continue;
 		}

--- a/engine/tests/ElggCoreRegressionBugsTest.php
+++ b/engine/tests/ElggCoreRegressionBugsTest.php
@@ -242,4 +242,34 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 			$this->assertEqual($output, parse_urls($input));
 		}
 	}
+	
+	/**
+	 * Checks if additional select columns does not leak to entity attributes.
+	 * 
+	 * https://github.com/Elgg/Elgg/issues/5538
+	 */
+	public function test_sql_selects_leak_to_attributes() {
+		global $ENTITY_CACHE;
+		//may not have groups in DB - let's create one	
+		$group = new ElggGroup();
+		$group->name = 'test_group';
+		$group->access_id = ACCESS_PUBLIC;
+		$this->assertTrue($group->save() !== false);
+		
+		//entity cache interferes with our test
+		$ENTITY_CACHE = array();
+		
+		foreach (array('site', 'user', 'group', 'object') as $type) {
+			$entities = elgg_get_entities(array(
+				'type' => $type,
+				'selects' => array('42 as added_col'),
+				'limit' => 1,
+			));
+			$entity = array_shift($entities);
+			$this->assertTrue($entity instanceof ElggEntity);
+			$this->assertEqual($entity->added_col, null, "Additional select columns are leaking to attributes for " . get_class($entity));
+		}
+		
+		$group->delete();
+	}
 }

--- a/engine/tests/ElggCoreRegressionBugsTest.php
+++ b/engine/tests/ElggCoreRegressionBugsTest.php
@@ -250,6 +250,9 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 	 */
 	public function test_sql_selects_leak_to_attributes() {
 		global $ENTITY_CACHE;
+		
+		$access = elgg_set_ignore_access(false); //remove ignore access as it disables entity cache
+		
 		//may not have groups in DB - let's create one	
 		$group = new ElggGroup();
 		$group->name = 'test_group';
@@ -258,6 +261,7 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 		
 		//entity cache interferes with our test
 		$ENTITY_CACHE = array();
+		elgg_get_metadata_cache()->flush();
 		
 		foreach (array('site', 'user', 'group', 'object') as $type) {
 			$entities = elgg_get_entities(array(
@@ -268,7 +272,26 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 			$entity = array_shift($entities);
 			$this->assertTrue($entity instanceof ElggEntity);
 			$this->assertEqual($entity->added_col, null, "Additional select columns are leaking to attributes for " . get_class($entity));
+			$this->assertEqual($entity->getVolatileData('row:added_col'), 42);
 		}
+		
+		//make sure we have our entities cached
+		$this->assertTrue(count($ENTITY_CACHE) >= 4);
+		
+		//run these again but with different value to make sure cache does not interfere
+		foreach (array('site', 'user', 'group', 'object') as $type) {
+			$entities = elgg_get_entities(array(
+				'type' => $type,
+				'selects' => array('64 as added_col'),
+				'limit' => 1,
+			));
+			$entity = array_shift($entities);
+			$this->assertTrue($entity instanceof ElggEntity);
+			$this->assertEqual($entity->added_col, null, "Additional select columns are leaking to attributes for " . get_class($entity));
+			$this->assertEqual($entity->getVolatileData('row:added_col'), 64, "Failed to overwrite volatile data in cached entity");
+		}
+		
+		elgg_set_ignore_access($access);
 		
 		$group->delete();
 	}

--- a/engine/tests/ElggCoreUserTest.php
+++ b/engine/tests/ElggCoreUserTest.php
@@ -63,6 +63,9 @@ class ElggCoreUserTest extends ElggCoreUnitTest {
 		$attributes['code'] = NULL;
 		$attributes['banned'] = 'no';
 		$attributes['admin'] = 'no';
+		$attributes['prev_last_action'] = NULL;
+		$attributes['last_login'] = NULL;
+		$attributes['prev_last_login'] = NULL;
 		ksort($attributes);
 
 		$entity_attributes = $this->user->expose_attributes();


### PR DESCRIPTION
Refs #5538

Problem does not happen if we get entity that already exists in entity cache. Then as the instance gets pulled from cache, we don't have any additional data.
