### PR TITLE
Fixes #5543 - Adds ElggEntity::loadAdditionalColumns that loads additional select columns into volatile data with prefix row:

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1577,6 +1577,19 @@ abstract class ElggEntity extends ElggData implements
 	}
 
 	/**
+	 * Handles additional columns that were loaded from database together with attributes.
+	 * 
+	 * @param array $data list of values to handle
+	 * @return bool
+	 */
+	protected function loadAdditionalColumns($data) {
+		foreach ($data as $name => $value) {
+			$this->setVolatileData("row:$name", $value);
+		}
+		return true;
+	}
+
+	/**
 	 * Disable this entity.
 	 *
 	 * Disabled entities are not returned by getter functions.

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -430,6 +430,7 @@ class ElggGroup extends ElggEntity
 
 		$this->attributes = $attrs;
 		$this->attributes['tables_loaded'] = 2;
+		$this->loadAdditionalColumns($attr_loader->getAdditionalColumns());
 		_elgg_cache_entity($this);
 
 		return true;

--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -107,6 +107,7 @@ class ElggObject extends ElggEntity {
 
 		$this->attributes = $attrs;
 		$this->attributes['tables_loaded'] = 2;
+		$this->loadAdditionalColumns($attr_loader->getAdditionalColumns());
 		_elgg_cache_entity($this);
 
 		return true;

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -124,6 +124,7 @@ class ElggSite extends ElggEntity {
 
 		$this->attributes = $attrs;
 		$this->attributes['tables_loaded'] = 2;
+		$this->loadAdditionalColumns($attr_loader->getAdditionalColumns());
 		_elgg_cache_entity($this);
 
 		return true;

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -40,6 +40,9 @@ class ElggUser extends ElggEntity
 		$this->attributes['code'] = NULL;
 		$this->attributes['banned'] = "no";
 		$this->attributes['admin'] = 'no';
+		$this->attributes['prev_last_action'] = NULL;
+		$this->attributes['last_login'] = NULL;
+		$this->attributes['prev_last_login'] = NULL;
 		$this->attributes['tables_split'] = 2;
 	}
 

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -115,6 +115,7 @@ class ElggUser extends ElggEntity
 
 		$this->attributes = $attrs;
 		$this->attributes['tables_loaded'] = 2;
+		$this->loadAdditionalColumns($attr_loader->getAdditionalColumns());
 		_elgg_cache_entity($this);
 
 		return true;

--- a/engine/tests/ElggCoreRegressionBugsTest.php
+++ b/engine/tests/ElggCoreRegressionBugsTest.php
@@ -242,4 +242,41 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 			$this->assertEqual($output, parse_urls($input));
 		}
 	}
+	
+	/**
+	 * Checks if additional select columns does not leak to entity attributes.
+	 * 
+	 * https://github.com/Elgg/Elgg/issues/5538
+	 */
+	public function testSqlAdditionalSelectsLeakToAttributes() {
+		global $ENTITY_CACHE;
+		
+		$access = elgg_set_ignore_access(false); //remove ignore access as it disables entity cache
+		
+		//may not have groups in DB - let's create one	
+		$group = new ElggGroup();
+		$group->name = 'test_group';
+		$group->access_id = ACCESS_PUBLIC;
+		$this->assertTrue($group->save() !== false);
+		
+		//entity cache interferes with our test
+		$ENTITY_CACHE = array();
+		elgg_get_metadata_cache()->flush();
+		
+		foreach (array('site', 'user', 'group', 'object') as $type) {
+			$entities = elgg_get_entities(array(
+				'type' => $type,
+				'selects' => array('42 as added_col1'),
+				'limit' => 1,
+			));
+			$entity = array_shift($entities);
+			$this->assertTrue($entity instanceof ElggEntity);
+			$this->assertEqual($entity->added_col1, null, "Additional select columns are leaking to attributes for " . get_class($entity));
+		}
+		
+		elgg_set_ignore_access($access);
+		
+		$group->delete();
+	}
+
 }

--- a/engine/tests/ElggCoreRegressionBugsTest.php
+++ b/engine/tests/ElggCoreRegressionBugsTest.php
@@ -278,5 +278,42 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 		
 		$group->delete();
 	}
+	
+	/**
+	 * Checks if additional select columns are readable as volatile data
+	 *
+	 * https://github.com/Elgg/Elgg/issues/5543
+	 */
+	public function testSqlAdditionalSelectsAsVolatileData() {
+		global $ENTITY_CACHE;
+	
+		$access = elgg_set_ignore_access(false); //remove ignore access as it disables entity cache
+	
+		//may not have groups in DB - let's create one
+		$group = new ElggGroup();
+		$group->name = 'test_group';
+		$group->access_id = ACCESS_PUBLIC;
+		$this->assertTrue($group->save() !== false);
+	
+		//entity cache interferes with our test
+		$ENTITY_CACHE = array();
+		elgg_get_metadata_cache()->flush();
+	
+		foreach (array('site', 'user', 'group', 'object') as $type) {
+			$entities = elgg_get_entities(array(
+				'type' => $type,
+				'selects' => array('42 as added_col2'),
+				'limit' => 1,
+			));
+			$entity = array_shift($entities);
+			$this->assertTrue($entity instanceof ElggEntity);
+			$this->assertEqual($entity->added_col2, null, "Additional select columns are leaking to attributes for " . get_class($entity));
+			$this->assertEqual($entity->getVolatileData('row:added_col2'), 42);
+		}
+	
+		elgg_set_ignore_access($access);
+	
+		$group->delete();
+	}
 
 }

--- a/engine/tests/ElggCoreUserTest.php
+++ b/engine/tests/ElggCoreUserTest.php
@@ -63,6 +63,9 @@ class ElggCoreUserTest extends ElggCoreUnitTest {
 		$attributes['code'] = NULL;
 		$attributes['banned'] = 'no';
 		$attributes['admin'] = 'no';
+		$attributes['prev_last_action'] = NULL;
+		$attributes['last_login'] = NULL;
+		$attributes['prev_last_login'] = NULL;
 		ksort($attributes);
 
 		$entity_attributes = $this->user->expose_attributes();


### PR DESCRIPTION
Followup of #5546. Splitted part of #5539. Simpletests pass.
