### PR TITLE
The system_log table should be able to store ipv6 addresses

### DIFF
--- a/engine/lib/upgrades/2013052900-1.8.15-ipv6_in_syslog-f5c2cc0196e9e731.php
+++ b/engine/lib/upgrades/2013052900-1.8.15-ipv6_in_syslog-f5c2cc0196e9e731.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Elgg 1.8.15 upgrade 2013052900
+ * ipv6_in_syslog
+ *
+ * Upgrade the ip column in system_log to be able to store ipv6 addresses
+ */
+
+$db_prefix = elgg_get_config('dbprefix');
+$q = "ALTER TABLE {$db_prefix}system_log MODIFY COLUMN ip_address varchar(46) NOT NULL";
+
+update_data($q);

--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -361,7 +361,7 @@ CREATE TABLE `prefix_system_log` (
   `access_id` int(11) NOT NULL,
   `enabled` enum('yes','no') NOT NULL DEFAULT 'yes',
   `time_created` int(11) NOT NULL,
-  `ip_address` varchar(15) NOT NULL,
+  `ip_address` varchar(46) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `object_id` (`object_id`),
   KEY `object_class` (`object_class`),

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2013051700;
+$version = 2013052900;
 
 // Human-friendly version name
 $release = '1.8.15';


### PR DESCRIPTION
A PR (#251) was already made to fix this but it was rejected by @ewinslow. I don't know why?

Since the ip logging was introduced in 1.8.3 it should have been done with a little more vision to the future.

So here is my pull request
