### PR TITLE
get_user_membership could return more than groups

### DIFF
--- a/engine/lib/group.php
+++ b/engine/lib/group.php
@@ -240,6 +240,7 @@ function leave_group($group_guid, $user_guid) {
  */
 function get_users_membership($user_guid) {
 	$options = array(
+		'type' => 'group',
 		'relationship' => 'member',
 		'relationship_guid' => $user_guid,
 		'inverse_relationship' => false,


### PR DESCRIPTION
According to the function documentation get_user_membership it should return all groups the user is a member of.

However since the 'type' isn't limited to 'group' it could potentially return more than just groups.

Here is the fix
