### PR TITLE
#4433 standardize layouts

### DIFF
--- a/engine/handlers/export_handler.php
+++ b/engine/handlers/export_handler.php
@@ -113,6 +113,8 @@ if (($guid != "") && ($type == "") && ($id_or_name == "")) {
 	throw new InvalidParameterException("Missing parameter, you need to provide a GUID.");
 }
 
-$content = elgg_view_title($title) . $body;
-$body = elgg_view_layout('one_sidebar', array('content' => $content));
+$body = elgg_view_layout('one_sidebar', array(
+	'title' => $title,
+	'content' => $body
+));
 echo elgg_view_page($title, $body);

--- a/engine/lib/pagehandler.php
+++ b/engine/lib/pagehandler.php
@@ -70,12 +70,13 @@ function elgg_front_page_handler() {
 		forward('activity');
 	}
 
-	$content = elgg_view_title(elgg_echo('content:latest'));
-	$content .= elgg_list_river();
+	$title = elgg_echo('content:latest');
+	$content = elgg_list_river();
 
 	$login_box = elgg_view('core/account/login_box');
 
 	$params = array(
+			'title' => $title,
 			'content' => $content,
 			'sidebar' => $login_box
 	);

--- a/engine/lib/tags.php
+++ b/engine/lib/tags.php
@@ -327,17 +327,20 @@ function elgg_get_registered_tag_metadata_names() {
  */
 function elgg_tagcloud_page_handler($page) {
 
-	$title = elgg_view_title(elgg_echo('tags:site_cloud'));
+	$title = elgg_echo('tags:site_cloud');
 	$options = array(
 		'threshold' => 0,
 		'limit' => 100,
 		'tag_name' => 'tags',
 	);
 	$tags = elgg_view_tagcloud($options);
-	$content = $title . $tags;
-	$body = elgg_view_layout('one_sidebar', array('content' => $content));
+	$content = $tags;
+	$body = elgg_view_layout('one_sidebar', array(
+		'title' => $title,
+		'content' => $content
+	));
 
-	echo elgg_view_page(elgg_echo('tags:site_cloud'), $body);
+	echo elgg_view_page($title, $body);
 	return true;
 }
 

--- a/mod/categories/pages/categories/listing.php
+++ b/mod/categories/pages/categories/listing.php
@@ -12,6 +12,8 @@ $owner_guid = get_input("owner_guid", ELGG_ENTITIES_ANY_VALUE);
 $subtype = get_input("subtype", ELGG_ENTITIES_ANY_VALUE);
 $type = get_input("type", 'object');
 
+$title = elgg_echo('categories:results', array($category));
+
 $params = array(
 	'metadata_name' => 'universal_categories',
 	'metadata_value' => $category,
@@ -22,18 +24,11 @@ $params = array(
 	'full_view' => FALSE,
 	'metadata_case_sensitive' => FALSE,
 );
-$objects = elgg_list_entities_from_metadata($params);
+$content = elgg_list_entities_from_metadata($params);
 
-$title = elgg_echo('categories:results', array($category));
-
-$content = elgg_view_title($title);
-$content .= $objects;
-
-$body = elgg_view_layout('content', array(
-	'content' => $content,
+$body = elgg_view_layout('one_sidebar', array(
 	'title' => $title,
-	'filter' => '',
-	'header' => '',
+	'content' => $content	
 ));
 
 echo elgg_view_page($title, $body);

--- a/mod/dashboard/start.php
+++ b/mod/dashboard/start.php
@@ -53,7 +53,10 @@ function dashboard_page_handler() {
 	);
 	$widgets = elgg_view_layout('widgets', $params);
 
-	$body = elgg_view_layout('one_column', array('content' => $widgets));
+	$body = elgg_view_layout('one_column', array(
+		'title' => false,
+		'content' => $widgets
+	));
 
 	echo elgg_view_page($title, $body);
 	return true;

--- a/mod/profile/start.php
+++ b/mod/profile/start.php
@@ -79,7 +79,10 @@ function profile_page_handler($page) {
 	}
 
 	$content = elgg_view('profile/layout', array('entity' => $user));
-	$body = elgg_view_layout('one_column', array('content' => $content));
+	$body = elgg_view_layout('one_column', array(
+		'title' => false,
+		'content' => $content
+	));
 	echo elgg_view_page($user->name, $body);
 	return true;
 }

--- a/mod/reportedcontent/start.php
+++ b/mod/reportedcontent/start.php
@@ -66,17 +66,19 @@ function reportedcontent_page_handler($page) {
 	// only logged in users can report things
 	gatekeeper();
 
-	$content .= elgg_view_title(elgg_echo('reportedcontent:this'));
-	$content .= elgg_view_form('reportedcontent/add');
+	$title = elgg_echo('reportedcontent:this');
+	
+	$content = elgg_view_form('reportedcontent/add');
 	$sidebar = elgg_echo('reportedcontent:instructions');
 
 	$params = array(
+		'title' => $title,
 		'content' => $content,
 		'sidebar' => $sidebar,
 	);
 	$body = elgg_view_layout('one_sidebar', $params);
 
-	echo elgg_view_page(elgg_echo('reportedcontent:this'), $body);
+	echo elgg_view_page($title, $body);
 	return true;
 }
 

--- a/mod/search/pages/search/index.php
+++ b/mod/search/pages/search/index.php
@@ -31,9 +31,11 @@ $display_query = htmlspecialchars($display_query, ENT_QUOTES, 'UTF-8', false);
 if (!$query) {
 	$title = sprintf(elgg_echo('search:results'), "\"$display_query\"");
 	
-	$body  = elgg_view_title(elgg_echo('search:search_error'));
-	$body .= elgg_echo('search:no_query');
-	$layout = elgg_view_layout('one_sidebar', array('content' => $body));
+	$body = elgg_echo('search:no_query');
+	$layout = elgg_view_layout('one_sidebar', array(
+		'title' => elgg_echo('search:search_error'),
+		'content' => $body
+	));
 	echo elgg_view_page($title, $layout);
 
 	return;
@@ -264,19 +266,19 @@ if ($search_type == 'tags') {
 }
 $highlighted_query = search_highlight_words($searched_words, $display_query);
 
-$body = elgg_view_title(elgg_echo('search:results', array("\"$highlighted_query\"")));
+$highlighted_title = elgg_echo('search:results', array("\"$highlighted_query\""));
 
 if (!$results_html) {
-	$body .= elgg_view('search/no_results');
+	$body = elgg_view('search/no_results');
 } else {
-	$body .= $results_html;
+	$body = $results_html;
 }
 
 // this is passed the original params because we don't care what actually
 // matched (which is out of date now anyway).
 // we want to know what search type it is.
 $layout_view = search_get_search_view($params, 'layout');
-$layout = elgg_view($layout_view, array('params' => $params, 'body' => $body));
+$layout = elgg_view($layout_view, array('params' => $params, 'body' => $body, 'title' => $highlighted_title));
 
 $title = elgg_echo('search:results', array("\"$display_query\""));
 

--- a/mod/search/views/default/search/layout.php
+++ b/mod/search/views/default/search/layout.php
@@ -5,4 +5,7 @@
  * @uses $vars['body']
  */
 
-echo elgg_view_layout('one_sidebar', array('content' => $vars['body']));
+echo elgg_view_layout('one_sidebar', array(
+	'title' => $vars['title'],
+	'content' => $vars['body']
+));

--- a/mod/search/views/default/search/list.php
+++ b/mod/search/views/default/search/list.php
@@ -88,9 +88,7 @@ if ($show_more) {
 	$more_link = '';
 }
 
-// @todo once elgg_view_title() supports passing a $vars array use it
-$body = elgg_view('page/elements/title', array(
-	'title' => $type_str,
+$body = elgg_view_title($type_str, array(
 	'class' => 'search-heading-category',
 ));
 

--- a/pages/account/forgotten_password.php
+++ b/pages/account/forgotten_password.php
@@ -11,12 +11,14 @@ if (elgg_is_logged_in()) {
 }
 
 $title = elgg_echo("user:password:lost");
-$content = elgg_view_title($title);
 
-$content .= elgg_view_form('user/requestnewpassword', array(
+$content = elgg_view_form('user/requestnewpassword', array(
 	'class' => 'elgg-form-account',
 ));
 
-$body = elgg_view_layout("one_column", array('content' => $content));
+$body = elgg_view_layout("one_column", array(
+	'title' => $title, 
+	'content' => $content
+));
 
 echo elgg_view_page($title, $body);

--- a/pages/account/login.php
+++ b/pages/account/login.php
@@ -15,6 +15,13 @@ if (elgg_is_logged_in()) {
 	forward('');
 }
 
-$login_box = elgg_view('core/account/login_box');
-$content = elgg_view_layout('one_column', array('content' => $login_box));
-echo elgg_view_page(elgg_echo('login'), $content);
+$title = elgg_echo('login');
+
+$content = elgg_view('core/account/login_box', array("title" => false));
+
+$body = elgg_view_layout('one_column', array(
+	'title' => $title,
+	'content' => $content
+));
+
+echo elgg_view_page($title, $body);

--- a/pages/account/register.php
+++ b/pages/account/register.php
@@ -28,8 +28,6 @@ if (elgg_is_logged_in()) {
 
 $title = elgg_echo("register");
 
-$content = elgg_view_title($title);
-
 // create the registration url - including switching to https if configured
 $register_url = elgg_get_site_url() . 'action/register';
 if (elgg_get_config('https_login')) {
@@ -44,10 +42,13 @@ $body_params = array(
 	'friend_guid' => $friend_guid,
 	'invitecode' => $invitecode
 );
-$content .= elgg_view_form('register', $form_params, $body_params);
+$content = elgg_view_form('register', $form_params, $body_params);
 
 $content .= elgg_view('help/register');
 
-$body = elgg_view_layout("one_column", array('content' => $content));
+$body = elgg_view_layout("one_column", array(
+	'title' => $title,
+	'content' => $content
+));
 
 echo elgg_view_page($title, $body);

--- a/pages/account/reset_password.php
+++ b/pages/account/reset_password.php
@@ -21,15 +21,17 @@ if (!$user instanceof ElggUser) {
 	forward();
 }
 
+$title = elgg_echo('resetpassword');
+
 $params = array(
 	'guid' => $user_guid,
 	'code' => $code,
 );
-$form = elgg_view_form('user/passwordreset', array('class' => 'elgg-form-account'), $params);
+$content = elgg_view_form('user/passwordreset', array('class' => 'elgg-form-account'), $params);
 
-$title = elgg_echo('resetpassword');
-$content = elgg_view_title(elgg_echo('resetpassword')) . $form;
-
-$body = elgg_view_layout('one_column', array('content' => $content));
+$body = elgg_view_layout('one_column', array(
+	'title' => $title,
+	'content' => $content
+));
 
 echo elgg_view_page($title, $body);

--- a/pages/entities/index.php
+++ b/pages/entities/index.php
@@ -38,7 +38,7 @@ if ($entity = get_entity($guid)) {
 	}
 	$area1 = elgg_view_entity($entity, array('full_view' => true));
 	if ($shell) {
-		$body = elgg_view_layout('one_column', array('content' => $area1));
+		$body = elgg_view_layout('one_column', array('title' => $title,'content' => $area1));
 	} else {
 		$body = $area1;
 	}

--- a/pages/friends/collections/add.php
+++ b/pages/friends/collections/add.php
@@ -11,12 +11,13 @@ gatekeeper();
 
 $title = elgg_echo('friends:collections:add');
 
-$content = elgg_view_title($title);
-
-$content .= elgg_view_form('friends/collections/add', array(), array(
+$content = elgg_view_form('friends/collections/add', array(), array(
 	'friends' => get_user_friends(elgg_get_logged_in_user_guid(), "", 9999),
 ));
 
-$body = elgg_view_layout('one_sidebar', array('content' => $content));
+$body = elgg_view_layout('one_sidebar', array(
+	'title' => $title, 
+	'content' => $content
+));
 
-echo elgg_view_page(elgg_echo('friends:collections:add'), $body);
+echo elgg_view_page($title, $body);

--- a/views/default/core/account/login_box.php
+++ b/views/default/core/account/login_box.php
@@ -15,7 +15,8 @@ if (elgg_get_config('https_login')) {
 	$login_url = str_replace("http:", "https:", $login_url);
 }
 
-$title = elgg_echo('login');
+$title = elgg_extract("title", $vars, elgg_echo('login'));
+
 $body = elgg_view_form('login', array('action' => "{$login_url}action/login"));
 
 echo elgg_view_module($module, $title, $body);

--- a/views/default/page/layouts/admin.php
+++ b/views/default/page/layouts/admin.php
@@ -19,22 +19,6 @@
 		?>
 	</div>
 	<div class="elgg-main elgg-body">
-		<div class="elgg-head">
-		<?php
-			echo elgg_view_menu('title', array(
-				'sort_by' => 'priority',
-				'class' => 'elgg-menu-hz',
-			));
-
-			if (isset($vars['title'])) {
-				echo elgg_view_title($vars['title']);
-			}
-		?>
-		</div>
-		<?php
-			if (isset($vars['content'])) {
-				echo $vars['content'];
-			}
-		?>
+		<?php echo elgg_view("page/layouts/content/body", $vars); ?>
 	</div>
 </div>

--- a/views/default/page/layouts/content.php
+++ b/views/default/page/layouts/content.php
@@ -15,39 +15,13 @@
  */
 
 // give plugins an opportunity to add to content sidebars
-$sidebar_content = elgg_extract('sidebar', $vars, '');
 $params = $vars;
-$params['content'] = $sidebar_content;
-$sidebar = elgg_view('page/layouts/content/sidebar', $params);
+$params['content'] = elgg_extract('sidebar', $vars, '');
+$vars['sidebar'] = elgg_view('page/layouts/content/sidebar', $params);
 
-// allow page handlers to override the default header
-if (isset($vars['header'])) {
-	$vars['header_override'] = $vars['header'];
+if (!isset($vars['filter'])) {
+	// tell body it should use a default filter menu
+	$vars['filter'] = true;
 }
-$header = elgg_view('page/layouts/content/header', $vars);
 
-// allow page handlers to override the default filter
-if (isset($vars['filter'])) {
-	$vars['filter_override'] = $vars['filter'];
-}
-$filter = elgg_view('page/layouts/content/filter', $vars);
-
-// the all important content
-$content = elgg_extract('content', $vars, '');
-
-// optional footer for main content area
-$footer_content = elgg_extract('footer', $vars, '');
-$params = $vars;
-$params['content'] = $footer_content;
-$footer = elgg_view('page/layouts/content/footer', $params);
-
-$body = $header . $filter . $content . $footer;
-
-$params = array(
-	'content' => $body,
-	'sidebar' => $sidebar,
-);
-if (isset($vars['class'])) {
-	$params['class'] = $vars['class'];
-}
-echo elgg_view_layout('one_sidebar', $params);
+echo elgg_view_layout('one_sidebar', $vars);

--- a/views/default/page/layouts/content/body.php
+++ b/views/default/page/layouts/content/body.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Layout body
+ *
+ * @uses $vars['nav']  		Navigation (override)
+ * @uses $vars['header'] 	HTML for overriding the default header (override)
+ * @uses $vars['filter'] 	Boolean true if default filter should be used or custom HTML for overriding the default filter (override)
+ * @uses $vars['footer'] 	optional footer for main content area
+ */
+
 // navigation defaults to breadcrumbs
 if (isset($vars['nav'])) {
 	echo $vars['nav'];
@@ -23,9 +32,9 @@ if (!empty($vars['filter'])) {
 
 echo $vars['content'];
 
-// @deprecated 1.8
 if (isset($vars['area1'])) {
-	// @todo: add deprecated notice
+	// @deprecated 1.8
+	elgg_deprecated_notice("Use content instead of area1", 1.8);
 	echo $vars['area1'];
 }
 

--- a/views/default/page/layouts/content/body.php
+++ b/views/default/page/layouts/content/body.php
@@ -1,0 +1,35 @@
+<?php
+// navigation defaults to breadcrumbs
+if (isset($vars['nav'])) {
+	echo $vars['nav'];
+} else {
+	echo elgg_view('navigation/breadcrumbs');
+}
+
+// allow page handlers to override the default header
+if (isset($vars['header'])) {
+	$vars['header_override'] = $vars['header'];
+}
+echo elgg_view('page/layouts/content/header', $vars);
+
+// allow page handlers to override the default filter
+if (!empty($vars['filter'])) {
+	if ($vars['filter'] !== true) {
+		// filter is custom html (override)
+		$vars['filter_override'] = $vars['filter'];
+	}
+	echo elgg_view('page/layouts/content/filter', $vars);
+}
+
+echo $vars['content'];
+
+// @deprecated 1.8
+if (isset($vars['area1'])) {
+	// @todo: add deprecated notice
+	echo $vars['area1'];
+}
+
+// optional footer for main content area
+$params = $vars;
+$params['content'] = elgg_extract('footer', $vars, '');
+echo elgg_view('page/layouts/content/footer', $params);

--- a/views/default/page/layouts/content/header.php
+++ b/views/default/page/layouts/content/header.php
@@ -9,11 +9,6 @@
  * @uses $vars['context']         Page context (override)
  */
 
-if (isset($vars['buttons'])) {
-	// it was a bad idea to implement buttons with a pass through
-	elgg_deprecated_notice("Use elgg_register_menu_item() to register for the title menu", 1.0);
-}
-
 if (isset($vars['header_override'])) {
 	echo $vars['header_override'];
 	return true;
@@ -24,18 +19,16 @@ if (!isset($vars['title'])) {
 
 	$vars["title"] = elgg_echo($context);
 }
+
 if (!empty($vars["title"])) {
 	$title = elgg_view_title($vars["title"], array('class' => 'elgg-heading-main'));
 }
 
-if (isset($vars['buttons']) && $vars['buttons']) {
-	$buttons = $vars['buttons'];
-} else {
-	$buttons = elgg_view_menu('title', array(
-		'sort_by' => 'priority',
-		'class' => 'elgg-menu-hz',
-	));
-}
+$buttons = elgg_view_menu('title', array(
+	'sort_by' => 'priority',
+	'class' => 'elgg-menu-hz',
+));
+
 if (!empty($title) || !empty($buttons)) {
 	echo "<div class='elgg-head clearfix'>";
 	echo $title . $buttons;

--- a/views/default/page/layouts/content/header.php
+++ b/views/default/page/layouts/content/header.php
@@ -19,13 +19,15 @@ if (isset($vars['header_override'])) {
 	return true;
 }
 
-$context = elgg_extract('context', $vars, elgg_get_context());
-
 $title = elgg_extract('title', $vars, '');
-if (!$title) {
+if ($title === '') {
+	$context = elgg_extract('context', $vars, elgg_get_context());
+
 	$title = elgg_echo($context);
 }
-$title = elgg_view_title($title, array('class' => 'elgg-heading-main'));
+if (!empty($title)) {
+	$title = elgg_view_title($title, array('class' => 'elgg-heading-main'));
+}
 
 if (isset($vars['buttons']) && $vars['buttons']) {
 	$buttons = $vars['buttons'];

--- a/views/default/page/layouts/content/header.php
+++ b/views/default/page/layouts/content/header.php
@@ -37,9 +37,8 @@ if (isset($vars['buttons']) && $vars['buttons']) {
 		'class' => 'elgg-menu-hz',
 	));
 }
-
-echo <<<HTML
-<div class="elgg-head clearfix">
-	$title$buttons
-</div>
-HTML;
+if (!empty($title) || !empty($buttons)) {
+	echo "<div class='elgg-head clearfix'>";
+	echo $title . $buttons;
+	echo "</div>";
+}

--- a/views/default/page/layouts/content/header.php
+++ b/views/default/page/layouts/content/header.php
@@ -19,14 +19,13 @@ if (isset($vars['header_override'])) {
 	return true;
 }
 
-$title = elgg_extract('title', $vars, '');
-if ($title === '') {
+if (!isset($vars['title'])) {
 	$context = elgg_extract('context', $vars, elgg_get_context());
 
-	$title = elgg_echo($context);
+	$vars["title"] = elgg_echo($context);
 }
-if (!empty($title)) {
-	$title = elgg_view_title($title, array('class' => 'elgg-heading-main'));
+if (!empty($vars["title"])) {
+	$title = elgg_view_title($vars["title"], array('class' => 'elgg-heading-main'));
 }
 
 if (isset($vars['buttons']) && $vars['buttons']) {

--- a/views/default/page/layouts/default.php
+++ b/views/default/page/layouts/default.php
@@ -8,11 +8,8 @@
  * @uses $vars['content'] Content string
  */
 
-// @todo deprecated so remove in Elgg 2.0
-if (isset($vars['area1'])) {
-	echo $vars['area1'];
+if (!isset($vars["title"])) {
+	$vars["title"] = false;
 }
 
-if (isset($vars['content'])) {
-	echo $vars['content'];
-}
+echo elgg_view("page/layouts/content/body", $vars);

--- a/views/default/page/layouts/one_column.php
+++ b/views/default/page/layouts/one_column.php
@@ -14,25 +14,9 @@ if (isset($vars['class'])) {
 	$class = "$class {$vars['class']}";
 }
 
-// navigation defaults to breadcrumbs
-$nav = elgg_extract('nav', $vars, elgg_view('navigation/breadcrumbs'));
-
 ?>
 <div class="<?php echo $class; ?>">
 	<div class="elgg-body elgg-main">
-	<?php
-		echo $nav;
-
-		if (isset($vars['title'])) {
-			echo elgg_view_title($vars['title']);
-		}
-
-		echo $vars['content'];
-		
-		// @deprecated 1.8
-		if (isset($vars['area1'])) {
-			echo $vars['area1'];
-		}
-	?>
+		<?php echo elgg_view("page/layouts/content/body", $vars); ?>
 	</div>
 </div>

--- a/views/default/page/layouts/one_sidebar.php
+++ b/views/default/page/layouts/one_sidebar.php
@@ -17,32 +17,13 @@ if (isset($vars['class'])) {
 	$class = "$class {$vars['class']}";
 }
 
-// navigation defaults to breadcrumbs
-$nav = elgg_extract('nav', $vars, elgg_view('navigation/breadcrumbs'));
-
 ?>
-
 <div class="<?php echo $class; ?>">
 	<div class="elgg-sidebar">
-		<?php
-			echo elgg_view('page/elements/sidebar', $vars);
-		?>
+		<?php echo elgg_view('page/elements/sidebar', $vars); ?>
 	</div>
 
 	<div class="elgg-main elgg-body">
-		<?php
-			echo $nav;
-			
-			if (isset($vars['title'])) {
-				echo elgg_view_title($vars['title']);
-			}
-			// @todo deprecated so remove in Elgg 2.0
-			if (isset($vars['area1'])) {
-				echo $vars['area1'];
-			}
-			if (isset($vars['content'])) {
-				echo $vars['content'];
-			}
-		?>
+		<?php echo elgg_view("page/layouts/content/body", $vars); ?>
 	</div>
 </div>

--- a/views/default/page/layouts/two_sidebar.php
+++ b/views/default/page/layouts/two_sidebar.php
@@ -28,16 +28,7 @@ if (isset($vars['class'])) {
 			echo elgg_view('page/elements/sidebar_alt', $vars);
 		?>
 	</div>
-
 	<div class="elgg-main elgg-body">
-		<?php
-			// @todo deprecated so remove in Elgg 2.0
-			if (isset($vars['area1'])) {
-				echo $vars['area1'];
-			}
-			if (isset($vars['content'])) {
-				echo $vars['content'];
-			}
-		?>
+		<?php echo elgg_view("page/layouts/content/body", $vars); ?>
 	</div>
 </div>


### PR DESCRIPTION
Standardizes layout views as requested in #4433

All layouts now support the same layout body elements (title, header, buttons, filter, content, footer). Using different layouts now only are used to differentiate between layout elements (such as one or 2 sidebars) or influence default behaviour (as the content layout defaults with a filter).

The PR also contains updates to all pages and pagehandlers that now can use the correct layout params.
