### PR TITLE
elgg_instanceof can crash easily

### DIFF
--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -712,7 +712,7 @@ function get_entity($guid) {
 	// @todo We need a single Memcache instance with a shared pool of namespace wrappers. This function would pull an instance from the pool.
 	static $shared_cache;
 
-	// We could also use: if (!(int) $guid) { return FALSE }, 
+	// We could also use: if (!(int) $guid) { return FALSE },
 	// but that evaluates to a false positive for $guid = TRUE.
 	// This is a bit slower, but more thorough.
 	if (!is_numeric($guid) || $guid === 0 || $guid === '0') {
@@ -2409,17 +2409,17 @@ function elgg_list_registered_entities(array $options = array()) {
 function elgg_instanceof($entity, $type = NULL, $subtype = NULL, $class = NULL) {
 	$return = ($entity instanceof ElggEntity);
 
-	if ($type) {
+	if ($return && $type) {
 		/* @var ElggEntity $entity */
-		$return = $return && ($entity->getType() == $type);
+		$return = ($entity->getType() == $type);
 	}
 
-	if ($subtype) {
-		$return = $return && ($entity->getSubtype() == $subtype);
+	if ($return && $subtype) {
+		$return = ($entity->getSubtype() == $subtype);
 	}
 
-	if ($class) {
-		$return = $return && ($entity instanceof $class);
+	if ($return && $class) {
+		$return = ($entity instanceof $class);
 	}
 
 	return $return;


### PR DESCRIPTION
If a non Entity is provided to elgg_instanceof and $type or $subtype is set the function will crash.

example:
$entity = get_entity(0);
elgg_instanceof($entity, 'object', 'blog'); 
this will crash the page.

also my PR improves some logic to don't do unnecessary checks
