### PR TITLE
last_forward_from is lost in a failed login

### DIFF
--- a/actions/login.php
+++ b/actions/login.php
@@ -6,17 +6,6 @@
  * @subpackage User.Authentication
  */
 
-// set forward url
-if (!empty($_SESSION['last_forward_from'])) {
-	$forward_url = $_SESSION['last_forward_from'];
-	unset($_SESSION['last_forward_from']);
-} elseif (get_input('returntoreferer')) {
-	$forward_url = REFERER;
-} else {
-	// forward to main index page
-	$forward_url = '';
-}
-
 $username = get_input('username');
 $password = get_input('password', null, false);
 $persistent = (bool) get_input("persistent");
@@ -60,6 +49,17 @@ if ($user->language) {
 	$message = elgg_echo('loginok', array(), $user->language);
 } else {
 	$message = elgg_echo('loginok');
+}
+
+// set forward url
+if (!empty($_SESSION['last_forward_from'])) {
+	$forward_url = $_SESSION['last_forward_from'];
+	unset($_SESSION['last_forward_from']);
+} elseif (get_input('returntoreferer')) {
+	$forward_url = REFERER;
+} else {
+	// forward to main index page
+	$forward_url = '';
 }
 
 system_message($message);


### PR DESCRIPTION
if a logged out user accesses a page with gatekeeper last_forward_from is set, if however the login fails this is lost. So the next login attempt will not return the user to the correct page.

Also it's harder for plugin authors to influence the landing page on successful login (eg our plugin loing_redirector).

I changed the login action code back to how it was handled in Elgg 1.7
