### PR TITLE
ElggFile->delete() can return false on success or null on failure

### DIFF
--- a/engine/classes/ElggFile.php
+++ b/engine/classes/ElggFile.php
@@ -275,9 +275,14 @@ class ElggFile extends ElggObject {
 	 */
 	public function delete() {
 		$fs = $this->getFilestore();
-		if ($fs->delete($this)) {
-			return parent::delete();
+		
+		$result = $fs->delete($this);
+		
+		if ($this->getGUID() && $result) {
+			$result = parent::delete();
 		}
+		
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
If you have a non saved ElggFile (eq user avatar / group icon) and call ElggFile->delete() the result will be false (as parent::delete() returns false)

This can be checked in the action /avatar/remove.

Also if something goes wrong on the ElggFilestore side the result will be null

here is the solution, tested and all still works fine
