### PR TITLE
add_metastring vs get_metastring_id

### DIFF
--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -122,7 +122,7 @@ function get_metastring($id) {
 
 /**
  * Add a metastring.
- * It returns the id of the tag, whether by creating it or updating it.
+ * It returns the id of the metastring. If it does not exist, it will be created.
  *
  * @param string $string         The value (whatever that is) to be stored
  * @param bool   $case_sensitive Do we want to make the query case sensitive?

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -130,9 +130,9 @@ function elgg_is_admin_user($user_guid) {
 	$version = (int) datalist_get('version');
 
 	if ($version < 2010040201) {
-		$admin = get_metastring_id('admin');
-		$yes = get_metastring_id('yes');
-		$one = get_metastring_id('1');
+		$admin = add_metastring('admin');
+		$yes = add_metastring('yes');
+		$one = add_metastring('1');
 
 		$query = "SELECT * FROM {$CONFIG->dbprefix}users_entity as e,
 			{$CONFIG->dbprefix}metadata as md

--- a/engine/lib/upgrades/2010040201.php
+++ b/engine/lib/upgrades/2010040201.php
@@ -4,10 +4,10 @@
  * Pull admin metadata setting into users_entity table column
  */
 
-$siteadmin = get_metastring_id('siteadmin');
-$admin = get_metastring_id('admin');
-$yes = get_metastring_id('yes');
-$one = get_metastring_id('1');
+$siteadmin = add_metastring('siteadmin');
+$admin = add_metastring('admin');
+$yes = add_metastring('yes');
+$one = add_metastring('1');
 
 $qs = array();
 

--- a/engine/lib/upgrades/2010111501.php
+++ b/engine/lib/upgrades/2010111501.php
@@ -13,8 +13,8 @@ $ia = elgg_set_ignore_access(TRUE);
 $hidden_entities = access_get_show_hidden_status();
 access_show_hidden_entities(TRUE);
 
-$validated_id = get_metastring_id('validated');
-$one_id = get_metastring_id(1);
+$validated_id = add_metastring('validated');
+$one_id = add_metastring(1);
 
 $query = "SELECT guid FROM {$CONFIG->dbprefix}entities e
 			WHERE e.type = 'user' AND e.enabled = 'no' AND

--- a/mod/messages/start.php
+++ b/mod/messages/start.php
@@ -367,7 +367,7 @@ function messages_get_unread($user_guid = 0, $limit = 10, $offset = 0, $count = 
 	$strings = array('toId', $user_guid, 'readYet', 0, 'msg', 1);
 	$map = array();
 	foreach ($strings as $string) {
-		$id = get_metastring_id($string);
+		$id = add_metastring($string);
 		$map[$string] = $id;
 	}
 

--- a/mod/uservalidationbyemail/lib/functions.php
+++ b/mod/uservalidationbyemail/lib/functions.php
@@ -84,22 +84,16 @@ function uservalidationbyemail_validate_email($user_guid, $code) {
  * @return array
  */
 function uservalidationbyemail_get_unvalidated_users_sql_where() {
-	global $CONFIG;
+	$db_prefix = elgg_get_config('dbprefix');
 
-	$validated_id = get_metastring_id('validated');
-	if ($validated_id === false) {
-		$validated_id = add_metastring('validated');
-	}
-	$one_id = get_metastring_id('1');
-	if ($one_id === false) {
-		$one_id = add_metastring('1');
-	}
+	$validated_id = add_metastring('validated');
+	$one_id = add_metastring('1');
 
 	// thanks to daveb@freenode for the SQL tips!
 	$wheres = array();
 	$wheres[] = "e.enabled='no'";
 	$wheres[] = "NOT EXISTS (
-			SELECT 1 FROM {$CONFIG->dbprefix}metadata md
+			SELECT 1 FROM {$db_prefix}metadata md
 			WHERE md.entity_guid = e.guid
 				AND md.name_id = $validated_id
 				AND md.value_id = $one_id)";


### PR DESCRIPTION
I prefer the usage of add_metastring over get_metastring_id as the id will be created if it was not already existing. It should not be assumed that get_metastring_id will always return an id. It potentially crashes your code. It was potentially happening in upgrade/2010111501. Other places were not involved, but that was more by accident i think, because the id's were quoted in the queries, and therefore did not crash.
