### PR TITLE
Cleans up metastring library

### DIFF
--- a/engine/classes/ElggAnnotation.php
+++ b/engine/classes/ElggAnnotation.php
@@ -84,7 +84,7 @@ class ElggAnnotation extends ElggExtender {
 	 */
 	function delete() {
 		elgg_delete_river(array('annotation_id' => $this->id));
-		return elgg_delete_metastring_based_object_by_id($this->id, 'annotations');
+		return _elgg_delete_metastring_based_object_by_id($this->id, 'annotations');
 	}
 
 	/**
@@ -94,7 +94,7 @@ class ElggAnnotation extends ElggExtender {
 	 * @since 1.8
 	 */
 	function disable() {
-		return elgg_set_metastring_based_object_enabled_by_id($this->id, 'no', 'annotations');
+		return _elgg_set_metastring_based_object_enabled_by_id($this->id, 'no', 'annotations');
 	}
 
 	/**
@@ -104,7 +104,7 @@ class ElggAnnotation extends ElggExtender {
 	 * @since 1.8
 	 */
 	function enable() {
-		return elgg_set_metastring_based_object_enabled_by_id($this->id, 'yes', 'annotations');
+		return _elgg_set_metastring_based_object_enabled_by_id($this->id, 'yes', 'annotations');
 	}
 
 	/**

--- a/engine/classes/ElggMetadata.php
+++ b/engine/classes/ElggMetadata.php
@@ -93,7 +93,7 @@ class ElggMetadata extends ElggExtender {
 	 * @return bool
 	 */
 	function delete() {
-		$success = elgg_delete_metastring_based_object_by_id($this->id, 'metadata');
+		$success = _elgg_delete_metastring_based_object_by_id($this->id, 'metadata');
 		if ($success) {
 			// we mark unknown here because this deletes only one value
 			// under this name, and there may be others remaining.
@@ -109,7 +109,7 @@ class ElggMetadata extends ElggExtender {
 	 * @since 1.8
 	 */
 	function disable() {
-		$success = elgg_set_metastring_based_object_enabled_by_id($this->id, 'no', 'metadata');
+		$success = _elgg_set_metastring_based_object_enabled_by_id($this->id, 'no', 'metadata');
 		if ($success) {
 			// we mark unknown here because this disables only one value
 			// under this name, and there may be others remaining.
@@ -125,7 +125,7 @@ class ElggMetadata extends ElggExtender {
 	 * @since 1.8
 	 */
 	function enable() {
-		$success = elgg_set_metastring_based_object_enabled_by_id($this->id, 'yes', 'metadata');
+		$success = _elgg_set_metastring_based_object_enabled_by_id($this->id, 'yes', 'metadata');
 		if ($success) {
 			elgg_get_metadata_cache()->markUnknown($this->entity_guid, $this->name);
 		}

--- a/engine/lib/annotations.php
+++ b/engine/lib/annotations.php
@@ -34,7 +34,7 @@ function row_to_elggannotation($row) {
  * @return ElggAnnotation|false
  */
 function elgg_get_annotation_from_id($id) {
-	return elgg_get_metastring_based_object_from_id($id, 'annotations');
+	return _elgg_get_metastring_based_object_from_id($id, 'annotations');
 }
 
 /**
@@ -218,7 +218,7 @@ function elgg_get_annotations(array $options = array()) {
 	}
 	
 	$options['metastring_type'] = 'annotations';
-	return elgg_get_metastring_based_objects($options);
+	return _elgg_get_metastring_based_objects($options);
 }
 
 /**
@@ -238,7 +238,7 @@ function elgg_delete_annotations(array $options) {
 	}
 
 	$options['metastring_type'] = 'annotations';
-	return elgg_batch_metastring_based_objects($options, 'elgg_batch_delete_callback', false);
+	return _elgg_batch_metastring_based_objects($options, 'elgg_batch_delete_callback', false);
 }
 
 /**
@@ -256,7 +256,7 @@ function elgg_disable_annotations(array $options) {
 	}
 
 	$options['metastring_type'] = 'annotations';
-	return elgg_batch_metastring_based_objects($options, 'elgg_batch_disable_callback', false);
+	return _elgg_batch_metastring_based_objects($options, 'elgg_batch_disable_callback', false);
 }
 
 /**
@@ -277,7 +277,7 @@ function elgg_enable_annotations(array $options) {
 	}
 
 	$options['metastring_type'] = 'annotations';
-	return elgg_batch_metastring_based_objects($options, 'elgg_batch_enable_callback');
+	return _elgg_batch_metastring_based_objects($options, 'elgg_batch_enable_callback');
 }
 
 /**
@@ -366,7 +366,7 @@ function elgg_get_entities_from_annotations(array $options = array()) {
 	'annotation_name_value_pair', 'annotation_owner_guid');
 
 	$options = elgg_normalise_plural_options_array($options, $singulars);
-	$options = elgg_entities_get_metastrings_options('annotation', $options);
+	$options = _elgg_entities_get_metastrings_options('annotation', $options);
 
 	if (!$options) {
 		return false;

--- a/engine/lib/annotations.php
+++ b/engine/lib/annotations.php
@@ -83,12 +83,12 @@ $owner_guid = 0, $access_id = ACCESS_PRIVATE) {
 	$time = time();
 
 	// Add the metastring
-	$value = add_metastring($value);
+	$value = elgg_get_metastring_id($value);
 	if (!$value) {
 		return false;
 	}
 
-	$name = add_metastring($name);
+	$name = elgg_get_metastring_id($name);
 	if (!$name) {
 		return false;
 	}
@@ -151,12 +151,12 @@ function update_annotation($annotation_id, $name, $value, $value_type, $owner_gu
 
 	$access_id = (int)$access_id;
 
-	$value = add_metastring($value);
+	$value = elgg_get_metastring_id($value);
 	if (!$value) {
 		return false;
 	}
 
-	$name = add_metastring($name);
+	$name = elgg_get_metastring_id($name);
 	if (!$name) {
 		return false;
 	}

--- a/engine/lib/deprecated-1.9.php
+++ b/engine/lib/deprecated-1.9.php
@@ -1,6 +1,33 @@
 <?php
 
 /**
+ * When given an ID, returns the corresponding metastring
+ *
+ * @param int $id Metastring ID
+ *
+ * @return string Metastring
+ * @deprecated 1.9
+ */
+function get_metastring($id) {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated.', 1.9);
+	global $CONFIG, $METASTRINGS_CACHE;
+
+	$id = (int) $id;
+
+	if (isset($METASTRINGS_CACHE[$id])) {
+		return $METASTRINGS_CACHE[$id];
+	}
+
+	$row = get_data_row("SELECT * from {$CONFIG->dbprefix}metastrings where id='$id' limit 1");
+	if ($row) {
+		$METASTRINGS_CACHE[$id] = $row->string;
+		return $row->string;
+	}
+
+	return false;
+}
+
+/**
  * Obtains a list of objects owned by a user's friends
  *
  * @param int    $user_guid The GUID of the user to get the friends of

--- a/engine/lib/deprecated-1.9.php
+++ b/engine/lib/deprecated-1.9.php
@@ -1,5 +1,120 @@
 <?php
 
+global $METASTRINGS_DEADNAME_CACHE;
+$METASTRINGS_DEADNAME_CACHE = array();
+
+/**
+ * Return the meta string id for a given tag, or false.
+ *
+ * @param string $string         The value to store
+ * @param bool   $case_sensitive Do we want to make the query case sensitive?
+ *                               If not there may be more than one result
+ *
+ * @return int|array|false meta   string id, array of ids or false if none found
+ * @deprecated 1.9 Use elgg_get_metastring_id()
+ */
+function get_metastring_id($string, $case_sensitive = TRUE) {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use elgg_get_metastring_id()', 1.9);
+	global $CONFIG, $METASTRINGS_CACHE, $METASTRINGS_DEADNAME_CACHE;
+
+	$string = sanitise_string($string);
+
+	// caching doesn't work for case insensitive searches
+	if ($case_sensitive) {
+		$result = array_search($string, $METASTRINGS_CACHE, true);
+
+		if ($result !== false) {
+			return $result;
+		}
+
+		// See if we have previously looked for this and found nothing
+		if (in_array($string, $METASTRINGS_DEADNAME_CACHE, true)) {
+			return false;
+		}
+
+		// Experimental memcache
+		$msfc = null;
+		static $metastrings_memcache;
+		if ((!$metastrings_memcache) && (is_memcache_available())) {
+			$metastrings_memcache = new ElggMemcache('metastrings_memcache');
+		}
+		if ($metastrings_memcache) {
+			$msfc = $metastrings_memcache->load($string);
+		}
+		if ($msfc) {
+			return $msfc;
+		}
+	}
+
+	// Case sensitive
+	if ($case_sensitive) {
+		$query = "SELECT * from {$CONFIG->dbprefix}metastrings where string= BINARY '$string' limit 1";
+	} else {
+		$query = "SELECT * from {$CONFIG->dbprefix}metastrings where string = '$string'";
+	}
+
+	$row = FALSE;
+	$metaStrings = get_data($query);
+	if (is_array($metaStrings)) {
+		if (sizeof($metaStrings) > 1) {
+			$ids = array();
+			foreach ($metaStrings as $metaString) {
+				$ids[] = $metaString->id;
+			}
+			return $ids;
+		} else if (isset($metaStrings[0])) {
+			$row = $metaStrings[0];
+		}
+	}
+
+	if ($row) {
+		$METASTRINGS_CACHE[$row->id] = $row->string; // Cache it
+
+		// Attempt to memcache it if memcache is available
+		if ($metastrings_memcache) {
+			$metastrings_memcache->save($row->string, $row->id);
+		}
+
+		return $row->id;
+	} else {
+		$METASTRINGS_DEADNAME_CACHE[$string] = $string;
+	}
+
+	return false;
+}
+
+/**
+ * Add a metastring.
+ * It returns the id of the metastring. If it does not exist, it will be created.
+ *
+ * @param string $string         The value (whatever that is) to be stored
+ * @param bool   $case_sensitive Do we want to make the query case sensitive?
+ *
+ * @return mixed Integer tag or false.
+ * @deprecated 1.9 Use elgg_get_metastring_id()
+ */
+function add_metastring($string, $case_sensitive = true) {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use elgg_get_metastring_id()', 1.9);
+	global $CONFIG, $METASTRINGS_CACHE, $METASTRINGS_DEADNAME_CACHE;
+
+	$sanstring = sanitise_string($string);
+
+	$id = get_metastring_id($string, $case_sensitive);
+	if ($id) {
+		return $id;
+	}
+
+	$result = insert_data("INSERT into {$CONFIG->dbprefix}metastrings (string) values ('$sanstring')");
+	if ($result) {
+		$METASTRINGS_CACHE[$result] = $string;
+		if (isset($METASTRINGS_DEADNAME_CACHE[$string])) {
+			unset($METASTRINGS_DEADNAME_CACHE[$string]);
+		}
+	}
+
+	return $result;
+}
+
 /**
  * When given an ID, returns the corresponding metastring
  *

--- a/engine/lib/metadata.php
+++ b/engine/lib/metadata.php
@@ -33,7 +33,7 @@ function row_to_elggmetadata($row) {
  * @return ElggMetadata|false  FALSE if not found
  */
 function elgg_get_metadata_from_id($id) {
-	return elgg_get_metastring_based_object_from_id($id, 'metadata');
+	return _elgg_get_metastring_based_object_from_id($id, 'metadata');
 }
 
 /**
@@ -290,7 +290,7 @@ function elgg_get_metadata(array $options = array()) {
 	}
 
 	$options['metastring_type'] = 'metadata';
-	return elgg_get_metastring_based_objects($options);
+	return _elgg_get_metastring_based_objects($options);
 }
 
 /**
@@ -309,7 +309,7 @@ function elgg_delete_metadata(array $options) {
 		return false;
 	}
 	$options['metastring_type'] = 'metadata';
-	$result = elgg_batch_metastring_based_objects($options, 'elgg_batch_delete_callback', false);
+	$result = _elgg_batch_metastring_based_objects($options, 'elgg_batch_delete_callback', false);
 
 	// This moved last in case an object's constructor sets metadata. Currently the batch
 	// delete process has to create the entity to delete its metadata. See #5214
@@ -335,7 +335,7 @@ function elgg_disable_metadata(array $options) {
 	elgg_get_metadata_cache()->invalidateByOptions('disable', $options);
 
 	$options['metastring_type'] = 'metadata';
-	return elgg_batch_metastring_based_objects($options, 'elgg_batch_disable_callback', false);
+	return _elgg_batch_metastring_based_objects($options, 'elgg_batch_disable_callback', false);
 }
 
 /**
@@ -358,7 +358,7 @@ function elgg_enable_metadata(array $options) {
 	elgg_get_metadata_cache()->invalidateByOptions('enable', $options);
 
 	$options['metastring_type'] = 'metadata';
-	return elgg_batch_metastring_based_objects($options, 'elgg_batch_enable_callback');
+	return _elgg_batch_metastring_based_objects($options, 'elgg_batch_enable_callback');
 }
 
 /**
@@ -443,7 +443,7 @@ function elgg_get_entities_from_metadata(array $options = array()) {
 
 	$options = elgg_normalise_plural_options_array($options, $singulars);
 
-	if (!$options = elgg_entities_get_metastrings_options('metadata', $options)) {
+	if (!$options = _elgg_entities_get_metastrings_options('metadata', $options)) {
 		return FALSE;
 	}
 

--- a/engine/lib/metadata.php
+++ b/engine/lib/metadata.php
@@ -91,7 +91,7 @@ function create_metadata($entity_guid, $name, $value, $value_type = '', $owner_g
 	$access_id = (int)$access_id;
 
 	$query = "SELECT * from {$CONFIG->dbprefix}metadata"
-		. " WHERE entity_guid = $entity_guid and name_id=" . add_metastring($name) . " limit 1";
+		. " WHERE entity_guid = $entity_guid and name_id=" . elgg_get_metastring_id($name) . " limit 1";
 
 	$existing = get_data_row($query);
 	if ($existing && !$allow_multiple) {
@@ -108,12 +108,12 @@ function create_metadata($entity_guid, $name, $value, $value_type = '', $owner_g
 		}
 
 		// Add the metastrings
-		$value_id = add_metastring($value);
+		$value_id = elgg_get_metastring_id($value);
 		if (!$value_id) {
 			return false;
 		}
 
-		$name_id = add_metastring($name);
+		$name_id = elgg_get_metastring_id($name);
 		if (!$name_id) {
 			return false;
 		}
@@ -191,12 +191,12 @@ function update_metadata($id, $name, $value, $value_type, $owner_guid, $access_i
 	}
 
 	// Add the metastring
-	$value = add_metastring($value);
+	$value = elgg_get_metastring_id($value);
 	if (!$value) {
 		return false;
 	}
 
-	$name = add_metastring($name);
+	$name = elgg_get_metastring_id($name);
 	if (!$name) {
 		return false;
 	}

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -96,31 +96,6 @@ function get_metastring_id($string, $case_sensitive = TRUE) {
 }
 
 /**
- * When given an ID, returns the corresponding metastring
- *
- * @param int $id Metastring ID
- *
- * @return string Metastring
- */
-function get_metastring($id) {
-	global $CONFIG, $METASTRINGS_CACHE;
-
-	$id = (int) $id;
-
-	if (isset($METASTRINGS_CACHE[$id])) {
-		return $METASTRINGS_CACHE[$id];
-	}
-
-	$row = get_data_row("SELECT * from {$CONFIG->dbprefix}metastrings where id='$id' limit 1");
-	if ($row) {
-		$METASTRINGS_CACHE[$id] = $row->string;
-		return $row->string;
-	}
-
-	return false;
-}
-
-/**
  * Add a metastring.
  * It returns the id of the metastring. If it does not exist, it will be created.
  *
@@ -156,7 +131,7 @@ function add_metastring($string, $case_sensitive = true) {
  * @return bool
  * @access private
  */
-function delete_orphaned_metastrings() {
+function _elgg_delete_orphaned_metastrings() {
 	global $CONFIG;
 
 	// If memcache is enabled then we need to flush it of deleted values
@@ -230,8 +205,8 @@ function delete_orphaned_metastrings() {
  * @return mixed
  * @access private
  */
-function elgg_get_metastring_based_objects($options) {
-	$options = elgg_normalize_metastrings_options($options);
+function _elgg_get_metastring_based_objects($options) {
+	$options = _elgg_normalize_metastrings_options($options);
 
 	switch ($options['metastring_type']) {
 		case 'metadata':
@@ -251,47 +226,47 @@ function elgg_get_metastring_based_objects($options) {
 
 	$defaults = array(
 		// entities
-		'types'					=>	ELGG_ENTITIES_ANY_VALUE,
-		'subtypes'				=>	ELGG_ENTITIES_ANY_VALUE,
-		'type_subtype_pairs'	=>	ELGG_ENTITIES_ANY_VALUE,
+		'types' => ELGG_ENTITIES_ANY_VALUE,
+		'subtypes' => ELGG_ENTITIES_ANY_VALUE,
+		'type_subtype_pairs' => ELGG_ENTITIES_ANY_VALUE,
 
-		'guids'					=>	ELGG_ENTITIES_ANY_VALUE,
-		'owner_guids'			=>	ELGG_ENTITIES_ANY_VALUE,
-		'container_guids'		=>	ELGG_ENTITIES_ANY_VALUE,
-		'site_guids'			=>	get_config('site_guid'),
+		'guids' => ELGG_ENTITIES_ANY_VALUE,
+		'owner_guids' => ELGG_ENTITIES_ANY_VALUE,
+		'container_guids' => ELGG_ENTITIES_ANY_VALUE,
+		'site_guids' => get_config('site_guid'),
 
-		'modified_time_lower'	=>	ELGG_ENTITIES_ANY_VALUE,
-		'modified_time_upper'	=>	ELGG_ENTITIES_ANY_VALUE,
-		'created_time_lower'	=>	ELGG_ENTITIES_ANY_VALUE,
-		'created_time_upper'	=>	ELGG_ENTITIES_ANY_VALUE,
+		'modified_time_lower' => ELGG_ENTITIES_ANY_VALUE,
+		'modified_time_upper' => ELGG_ENTITIES_ANY_VALUE,
+		'created_time_lower' => ELGG_ENTITIES_ANY_VALUE,
+		'created_time_upper' => ELGG_ENTITIES_ANY_VALUE,
 
 		// options are normalized to the plural in case we ever add support for them.
-		'metastring_names'							=>	ELGG_ENTITIES_ANY_VALUE,
-		'metastring_values'							=>	ELGG_ENTITIES_ANY_VALUE,
-		//'metastring_name_value_pairs'				=>	ELGG_ENTITIES_ANY_VALUE,
-		//'metastring_name_value_pairs_operator'	=>	'AND',
+		'metastring_names' => ELGG_ENTITIES_ANY_VALUE,
+		'metastring_values' => ELGG_ENTITIES_ANY_VALUE,
+		//'metastring_name_value_pairs' => ELGG_ENTITIES_ANY_VALUE,
+		//'metastring_name_value_pairs_operator' => 'AND',
 
-		'metastring_case_sensitive' 				=>	TRUE,
-		//'order_by_metastring'						=>	array(),
-		'metastring_calculation'					=>	ELGG_ENTITIES_NO_VALUE,
+		'metastring_case_sensitive' => true,
+		//'order_by_metastring' => array(),
+		'metastring_calculation' => ELGG_ENTITIES_NO_VALUE,
 
-		'metastring_created_time_lower'				=>	ELGG_ENTITIES_ANY_VALUE,
-		'metastring_created_time_upper'				=>	ELGG_ENTITIES_ANY_VALUE,
+		'metastring_created_time_lower' => ELGG_ENTITIES_ANY_VALUE,
+		'metastring_created_time_upper' => ELGG_ENTITIES_ANY_VALUE,
 
-		'metastring_owner_guids'					=>	ELGG_ENTITIES_ANY_VALUE,
+		'metastring_owner_guids' => ELGG_ENTITIES_ANY_VALUE,
 
-		'metastring_ids'							=>	ELGG_ENTITIES_ANY_VALUE,
+		'metastring_ids' => ELGG_ENTITIES_ANY_VALUE,
 
 		// sql
-		'order_by'	=>	'n_table.time_created asc',
-		'limit'		=>	10,
-		'offset'	=>	0,
-		'count'		=>	FALSE,
-		'selects'	=>	array(),
-		'wheres'	=>	array(),
-		'joins'		=>	array(),
+		'order_by' => 'n_table.time_created asc',
+		'limit' => 10,
+		'offset' => 0,
+		'count' => false,
+		'selects' => array(),
+		'wheres' => array(),
+		'joins' => array(),
 
-		'callback'	=> $callback
+		'callback' => $callback
 	);
 
 	// @todo Ignore site_guid right now because of #2910
@@ -405,7 +380,7 @@ function elgg_get_metastring_based_objects($options) {
 	}
 
 	// metastrings
-	$metastring_clauses = elgg_get_metastring_sql('n_table', $options['metastring_names'],
+	$metastring_clauses = _elgg_get_metastring_sql('n_table', $options['metastring_names'],
 		$options['metastring_values'], null, $options['metastring_ids'],
 		$options['metastring_case_sensitive']);
 
@@ -497,7 +472,7 @@ function elgg_get_metastring_based_objects($options) {
  * @return array
  * @access private
  */
-function elgg_get_metastring_sql($table, $names = null, $values = null,
+function _elgg_get_metastring_sql($table, $names = null, $values = null,
 	$pairs = null, $ids = null, $case_sensitive = false) {
 
 	if ((!$names && $names !== 0)
@@ -603,7 +578,7 @@ function elgg_get_metastring_sql($table, $names = null, $values = null,
  * @return array
  * @access private
  */
-function elgg_normalize_metastrings_options(array $options = array()) {
+function _elgg_normalize_metastrings_options(array $options = array()) {
 
 	// support either metastrings_type or metastring_type
 	// because I've made this mistake many times and hunting it down is a pain...
@@ -657,11 +632,11 @@ function elgg_normalize_metastrings_options(array $options = array()) {
  * @since 1.8.0
  * @access private
  */
-function elgg_set_metastring_based_object_enabled_by_id($id, $enabled, $type) {
+function _elgg_set_metastring_based_object_enabled_by_id($id, $enabled, $type) {
 	$id = (int)$id;
 	$db_prefix = elgg_get_config('dbprefix');
 
-	$object = elgg_get_metastring_based_object_from_id($id, $type);
+	$object = _elgg_get_metastring_based_object_from_id($id, $type);
 
 	switch($type) {
 		case 'annotation':
@@ -701,12 +676,12 @@ function elgg_set_metastring_based_object_enabled_by_id($id, $enabled, $type) {
 /**
  * Runs metastrings-based objects found using $options through $callback
  *
- * @warning Unlike elgg_get_metastring_based_objects() this will not accept an
+ * @warning Unlike _elgg_get_metastring_based_objects() this will not accept an
  * empty options array!
  *
  * @warning This returns null on no ops.
  *
- * @param array  $options    An options array. {@See elgg_get_metastring_based_objects()}
+ * @param array  $options    An options array. {@see _elgg_get_metastring_based_objects()}
  * @param string $callback   The callback to pass each result through
  * @param bool   $inc_offset Increment the offset? Pass false for callbacks that delete / disable
  *
@@ -714,12 +689,12 @@ function elgg_set_metastring_based_object_enabled_by_id($id, $enabled, $type) {
  * @since 1.8.0
  * @access private
  */
-function elgg_batch_metastring_based_objects(array $options, $callback, $inc_offset = true) {
+function _elgg_batch_metastring_based_objects(array $options, $callback, $inc_offset = true) {
 	if (!$options || !is_array($options)) {
 		return false;
 	}
 
-	$batch = new ElggBatch('elgg_get_metastring_based_objects', $options, $callback, 50, $inc_offset);
+	$batch = new ElggBatch('_elgg_get_metastring_based_objects', $options, $callback, 50, $inc_offset);
 	return $batch->callbackResult;
 }
 
@@ -728,12 +703,12 @@ function elgg_batch_metastring_based_objects(array $options, $callback, $inc_off
  *
  * @param int    $id   The metastring-based object's ID
  * @param string $type The type: annotation or metadata
- * @return ElggMetadata|ElggAnnotation
+ * @return ElggExtender
  *
  * @since 1.8.0
  * @access private
  */
-function elgg_get_metastring_based_object_from_id($id, $type) {
+function _elgg_get_metastring_based_object_from_id($id, $type) {
 	$id = (int)$id;
 	if (!$id) {
 		return false;
@@ -744,7 +719,7 @@ function elgg_get_metastring_based_object_from_id($id, $type) {
 		'metastring_id' => $id
 	);
 
-	$obj = elgg_get_metastring_based_objects($options);
+	$obj = _elgg_get_metastring_based_objects($options);
 
 	if ($obj && count($obj) == 1) {
 		return $obj[0];
@@ -763,7 +738,7 @@ function elgg_get_metastring_based_object_from_id($id, $type) {
  * @since 1.8.0
  * @access private
  */
-function elgg_delete_metastring_based_object_by_id($id, $type) {
+function _elgg_delete_metastring_based_object_by_id($id, $type) {
 	$id = (int)$id;
 	$db_prefix = elgg_get_config('dbprefix');
 
@@ -781,7 +756,7 @@ function elgg_delete_metastring_based_object_by_id($id, $type) {
 			return false;
 	}
 
-	$obj = elgg_get_metastring_based_object_from_id($id, $type);
+	$obj = _elgg_get_metastring_based_object_from_id($id, $type);
 	$table = $db_prefix . $type;
 
 	if ($obj) {
@@ -808,10 +783,6 @@ function elgg_delete_metastring_based_object_by_id($id, $type) {
 }
 
 /**
- * Entities interface helpers
- */
-
-/**
  * Returns options to pass to elgg_get_entities() for metastrings operations.
  *
  * @param string $type    Metastring type: annotations or metadata
@@ -821,7 +792,7 @@ function elgg_delete_metastring_based_object_by_id($id, $type) {
  * @since 1.7.0
  * @access private
  */
-function elgg_entities_get_metastrings_options($type, $options) {
+function _elgg_entities_get_metastrings_options($type, $options) {
 	$valid_types = array('metadata', 'annotation');
 	if (!in_array($type, $valid_types)) {
 		return FALSE;
@@ -872,22 +843,20 @@ function elgg_entities_get_metastrings_options($type, $options) {
 	return $options;
 }
 
-// unit testing
-elgg_register_plugin_hook_handler('unit_test', 'system', 'metastrings_test');
-
 /**
- * Metadata unit test
+ * Metastring unit tests
  *
  * @param string $hook   unit_test
  * @param string $type   system
- * @param mixed  $value  Array of other tests
- * @param mixed  $params Params
+ * @param array  $value  Array of other tests
  *
  * @return array
  * @access private
  */
-function metastrings_test($hook, $type, $value, $params) {
+function _elgg_metastrings_test($hook, $type, $value) {
 	global $CONFIG;
 	$value[] = $CONFIG->path . 'engine/tests/ElggCoreMetastringsTest.php';
 	return $value;
 }
+
+elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_metastrings_test');

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -130,9 +130,9 @@ function elgg_is_admin_user($user_guid) {
 	$version = (int) datalist_get('version');
 
 	if ($version < 2010040201) {
-		$admin = add_metastring('admin');
-		$yes = add_metastring('yes');
-		$one = add_metastring('1');
+		$admin = elgg_get_metastring_id('admin');
+		$yes = elgg_get_metastring_id('yes');
+		$one = elgg_get_metastring_id('1');
 
 		$query = "SELECT * FROM {$CONFIG->dbprefix}users_entity as e,
 			{$CONFIG->dbprefix}metadata as md

--- a/engine/lib/upgrades/2010040201.php
+++ b/engine/lib/upgrades/2010040201.php
@@ -4,10 +4,10 @@
  * Pull admin metadata setting into users_entity table column
  */
 
-$siteadmin = add_metastring('siteadmin');
-$admin = add_metastring('admin');
-$yes = add_metastring('yes');
-$one = add_metastring('1');
+$siteadmin = elgg_get_metastring_id('siteadmin');
+$admin = elgg_get_metastring_id('admin');
+$yes = elgg_get_metastring_id('yes');
+$one = elgg_get_metastring_id('1');
 
 $qs = array();
 

--- a/engine/lib/upgrades/2010111501.php
+++ b/engine/lib/upgrades/2010111501.php
@@ -13,8 +13,8 @@ $ia = elgg_set_ignore_access(TRUE);
 $hidden_entities = access_get_show_hidden_status();
 access_show_hidden_entities(TRUE);
 
-$validated_id = add_metastring('validated');
-$one_id = add_metastring(1);
+$validated_id = elgg_get_metastring_id('validated');
+$one_id = elgg_get_metastring_id(1);
 
 $query = "SELECT guid FROM {$CONFIG->dbprefix}entities e
 			WHERE e.type = 'user' AND e.enabled = 'no' AND

--- a/engine/tests/ElggCoreMetadataAPITest.php
+++ b/engine/tests/ElggCoreMetadataAPITest.php
@@ -33,11 +33,11 @@ class ElggCoreMetadataAPITest extends ElggCoreUnitTest {
 		}
 
 		// lookup metastring id
-		$cs_ids = get_metastring_id('metaUnitTest', TRUE);
+		$cs_ids = elgg_get_metastring_id('metaUnitTest', TRUE);
 		$this->assertEqual($cs_ids, $this->metastrings['metaUnitTest']);
 
 		// lookup all metastrings, ignoring case
-		$cs_ids = get_metastring_id('metaUnitTest', FALSE);
+		$cs_ids = elgg_get_metastring_id('metaUnitTest', FALSE);
 		$this->assertEqual(count($cs_ids), 3);
 		$this->assertEqual(count($cs_ids), count($this->metastrings));
 		foreach ($cs_ids as $string )
@@ -47,8 +47,8 @@ class ElggCoreMetadataAPITest extends ElggCoreUnitTest {
 	}
 
 	public function testElggGetEntitiesFromMetadata() {
-		global $CONFIG, $METASTRINGS_CACHE, $METASTRINGS_DEADNAME_CACHE;
-		$METASTRINGS_CACHE = $METASTRINGS_DEADNAME_CACHE = array();
+		global $CONFIG, $METASTRINGS_CACHE;
+		$METASTRINGS_CACHE = array();
 
 		$this->object->title = 'Meta Unit Test';
 		$this->object->save();
@@ -210,16 +210,16 @@ class ElggCoreMetadataAPITest extends ElggCoreUnitTest {
 	}
 
 	protected function delete_metastrings($string) {
-		global $CONFIG, $METASTRINGS_CACHE, $METASTRINGS_DEADNAME_CACHE;
-		$METASTRINGS_CACHE = $METASTRINGS_DEADNAME_CACHE = array();
+		global $CONFIG, $METASTRINGS_CACHE;
+		$METASTRINGS_CACHE = array();
 
 		$string = sanitise_string($string);
 		mysql_query("DELETE FROM {$CONFIG->dbprefix}metastrings WHERE string = BINARY '$string'");
 	}
 
 	protected function create_metastring($string) {
-		global $CONFIG, $METASTRINGS_CACHE, $METASTRINGS_DEADNAME_CACHE;
-		$METASTRINGS_CACHE = $METASTRINGS_DEADNAME_CACHE = array();
+		global $CONFIG, $METASTRINGS_CACHE;
+		$METASTRINGS_CACHE = array();
 
 		$string = sanitise_string($string);
 		mysql_query("INSERT INTO {$CONFIG->dbprefix}metastrings (string) VALUES ('$string')");

--- a/engine/tests/ElggCoreMetastringsTest.php
+++ b/engine/tests/ElggCoreMetastringsTest.php
@@ -76,7 +76,7 @@ class ElggCoreMetastringsTest extends ElggCoreUnitTest {
 			$test = get_data($q);
 
 			$this->assertEqual($test[0]->id, $id);
-			$this->assertIdentical(true, elgg_delete_metastring_based_object_by_id($id, $type));
+			$this->assertIdentical(true, _elgg_delete_metastring_based_object_by_id($id, $type));
 			$this->assertIdentical(array(), get_data($q));
 		}
 	}
@@ -88,7 +88,7 @@ class ElggCoreMetastringsTest extends ElggCoreUnitTest {
 
 		foreach ($this->metastringTypes as $type) {
 			$id = ${$type}[0];
-			$test = elgg_get_metastring_based_object_from_id($id, $type);
+			$test = _elgg_get_metastring_based_object_from_id($id, $type);
 
 			$this->assertEqual($id, $test->id);
 		}
@@ -101,7 +101,7 @@ class ElggCoreMetastringsTest extends ElggCoreUnitTest {
 		$annotation = elgg_get_annotation_from_id($id);
 		$this->assertTrue($annotation->disable());
 
-		$test = elgg_get_metastring_based_object_from_id($id, 'annotation');
+		$test = _elgg_get_metastring_based_object_from_id($id, 'annotation');
 		$this->assertEqual(false, $test);
 	}
 
@@ -112,7 +112,7 @@ class ElggCoreMetastringsTest extends ElggCoreUnitTest {
 		$annotation = elgg_get_annotation_from_id($id);
 		$this->assertTrue($annotation->disable());
 
-		$test = elgg_get_metastring_based_objects(array(
+		$test = _elgg_get_metastring_based_objects(array(
 			'metastring_type' => 'annotations',
 			'guid' => $this->object->guid,
 		));
@@ -132,7 +132,7 @@ class ElggCoreMetastringsTest extends ElggCoreUnitTest {
 
 			// disable
 			$this->assertEqual($test[0]->enabled, 'yes');
-			$this->assertTrue(elgg_set_metastring_based_object_enabled_by_id($id, 'no', $type));
+			$this->assertTrue(_elgg_set_metastring_based_object_enabled_by_id($id, 'no', $type));
 
 			$test = get_data($q);
 			$this->assertEqual($test[0]->enabled, 'no');
@@ -140,7 +140,7 @@ class ElggCoreMetastringsTest extends ElggCoreUnitTest {
 			// enable
 			$ashe = access_get_show_hidden_status();
 			access_show_hidden_entities(true);
-			$this->assertTrue(elgg_set_metastring_based_object_enabled_by_id($id, 'yes', $type));
+			$this->assertTrue(_elgg_set_metastring_based_object_enabled_by_id($id, 'yes', $type));
 
 			$test = get_data($q);
 			$this->assertEqual($test[0]->enabled, 'yes');

--- a/mod/garbagecollector/start.php
+++ b/mod/garbagecollector/start.php
@@ -32,7 +32,7 @@ function garbagecollector_cron($hook, $entity_type, $returnvalue, $params) {
 	// Garbage collect metastrings
 	echo elgg_echo('garbagecollector:gc:metastrings');
 
-	if (delete_orphaned_metastrings() !== false) {
+	if (_elgg_delete_orphaned_metastrings() !== false) {
 		echo elgg_echo('garbagecollector:ok');
 	} else {
 		echo elgg_echo('garbagecollector:error');

--- a/mod/messages/start.php
+++ b/mod/messages/start.php
@@ -367,7 +367,7 @@ function messages_get_unread($user_guid = 0, $limit = 10, $offset = 0, $count = 
 	$strings = array('toId', $user_guid, 'readYet', 0, 'msg', 1);
 	$map = array();
 	foreach ($strings as $string) {
-		$id = add_metastring($string);
+		$id = elgg_get_metastring_id($string);
 		$map[$string] = $id;
 	}
 

--- a/mod/pages/upgrades/2012061800.php
+++ b/mod/pages/upgrades/2012061800.php
@@ -27,7 +27,7 @@ function pages_2012061800($page) {
 $previous_access = elgg_set_ignore_access(true);
 
 $dbprefix = elgg_get_config('dbprefix');
-$name_metastring_id = get_metastring_id('parent_guid');
+$name_metastring_id = elgg_get_metastring_id('parent_guid');
 if (!$name_metastring_id) {
 	return;
 }

--- a/mod/search/search_hooks.php
+++ b/mod/search/search_hooks.php
@@ -136,7 +136,7 @@ function search_users_hook($hook, $type, $value, $params) {
 	
 	// get the where clauses for the md names
 	// can't use egef_metadata() because the n_table join comes too late.
-	$clauses = elgg_entities_get_metastrings_options('metadata', array(
+	$clauses = _elgg_entities_get_metastrings_options('metadata', array(
 		'metadata_names' => $profile_fields,
 	));
 

--- a/mod/uservalidationbyemail/lib/functions.php
+++ b/mod/uservalidationbyemail/lib/functions.php
@@ -86,8 +86,8 @@ function uservalidationbyemail_validate_email($user_guid, $code) {
 function uservalidationbyemail_get_unvalidated_users_sql_where() {
 	$db_prefix = elgg_get_config('dbprefix');
 
-	$validated_id = add_metastring('validated');
-	$one_id = add_metastring('1');
+	$validated_id = elgg_get_metastring_id('validated');
+	$one_id = elgg_get_metastring_id('1');
 
 	// thanks to daveb@freenode for the SQL tips!
 	$wheres = array();


### PR DESCRIPTION
In response to #5571, I cleaned up the API. I believe I also fixed 2 bugs. 
1. we were using the sanitized string as the key in memcache
2. when a case insensitive result was requested were returning the results as an integer or array based on how many results rather than always returning as an array.

I also namespaced the private functions in the metastrings library
