### PR TITLE
Coding standards fix

### DIFF
--- a/engine/classes/Elgg/ActionsService.php
+++ b/engine/classes/Elgg/ActionsService.php
@@ -254,7 +254,7 @@ class Elgg_ActionsService {
 			return md5($site_secret . $timestamp . $session_id . $st);
 		}
 	
-		return FALSE;
+		return false;
 	}
 	
 	/**

--- a/engine/classes/Elgg/ActionsService.php
+++ b/engine/classes/Elgg/ActionsService.php
@@ -190,7 +190,7 @@ class Elgg_ActionsService {
 	 * 
 	 * @return bool
 	 */
-	protected function validateTokenTimestamp($ts) {	
+	protected function validateTokenTimestamp($ts) {
 		$timeout = $this->getActionTokenTimeout();
 		$now = time();
 		return ($timeout == 0 || ($ts > $now - $timeout) && ($ts < $now + $timeout));

--- a/engine/classes/Elgg/HooksRegistrationService.php
+++ b/engine/classes/Elgg/HooksRegistrationService.php
@@ -124,5 +124,5 @@ abstract class Elgg_HooksRegistrationService {
 		}
 
 		return $handlers;
-	}	
+	}
 }

--- a/engine/classes/Elgg/Notifications/NotificationsService.php
+++ b/engine/classes/Elgg/Notifications/NotificationsService.php
@@ -45,7 +45,7 @@ class Elgg_Notifications_NotificationsService {
 	 * @param Elgg_PluginHooksService                 $hooks         Plugin hook service
 	 * @param Elgg_Access                             $access        Access control service
 	 */
-	public function __construct(Elgg_Notifications_SubscriptionsService $subscriptions, 
+	public function __construct(Elgg_Notifications_SubscriptionsService $subscriptions,
 			Elgg_Util_Queue $queue, Elgg_PluginHooksService $hooks, Elgg_Access $access) {
 		$this->subscriptions = $subscriptions;
 		$this->queue = $queue;
@@ -423,7 +423,7 @@ class Elgg_Notifications_NotificationsService {
 		$params = array(
 			'event' => $event->getAction(),
 			'object_type' => $entity->getType(),
-			'object' => $entity,			
+			'object' => $entity,
 		);
 		$hookresult = $this->hooks->trigger('object:notifications', $entity->getType(), $params, false);
 		if ($hookresult === true) {

--- a/engine/classes/Elgg/Request.php
+++ b/engine/classes/Elgg/Request.php
@@ -67,7 +67,7 @@ class Elgg_Request {
 	 * 
 	 * @return mixed The value of the input.
 	 */
-	public function getInput($name, $default = NULL, $filter_result = TRUE) {
+	public function getInput($name, $default = null, $filter_result = true) {
 		$result = $default;
 	
 		elgg_push_context('input');

--- a/engine/classes/Elgg/UpgradeService.php
+++ b/engine/classes/Elgg/UpgradeService.php
@@ -59,7 +59,7 @@ class Elgg_UpgradeService {
 	 *
 	 * @return bool
 	 */
-	protected function upgradeCode($version, $quiet = FALSE) {
+	protected function upgradeCode($version, $quiet = false) {
 		// do not remove - some upgrade scripts depend on this
 		global $CONFIG;
 
@@ -370,7 +370,7 @@ class Elgg_UpgradeService {
 	 * @return int The number of upgrades run.
 	 * @deprecated 1.8 Use PHP upgrades for sql changes.
 	 */
-	protected function dbUpgrade($version, $fromdir = "", $quiet = FALSE) {
+	protected function dbUpgrade($version, $fromdir = "", $quiet = false) {
 		global $CONFIG;
 
 		$version = (int) $version;

--- a/engine/classes/Elgg/ViewsService.php
+++ b/engine/classes/Elgg/ViewsService.php
@@ -79,9 +79,9 @@ class Elgg_ViewsService {
 					}
 				}
 			}
-			return TRUE;
+			return true;
 		}
-		return FALSE;
+		return false;
 	}
 
 	/**
@@ -157,7 +157,7 @@ class Elgg_ViewsService {
 			return in_array($viewtype, $CONFIG->viewtype->fallback);
 		}
 
-		return FALSE;
+		return false;
 	}
 
 	/**
@@ -413,25 +413,25 @@ class Elgg_ViewsService {
 		global $CONFIG;
 
 		if (!isset($CONFIG->views)) {
-			return FALSE;
+			return false;
 		}
 
 		if (!isset($CONFIG->views->extensions)) {
-			return FALSE;
+			return false;
 		}
 
 		if (!isset($CONFIG->views->extensions[$view])) {
-			return FALSE;
+			return false;
 		}
 
 		$priority = array_search($view_extension, $CONFIG->views->extensions[$view]);
-		if ($priority === FALSE) {
-			return FALSE;
+		if ($priority === false) {
+			return false;
 		}
 
 		unset($CONFIG->views->extensions[$view][$priority]);
 
-		return TRUE;
+		return true;
 	}
 
 	/**

--- a/engine/classes/ElggAutoP.php
+++ b/engine/classes/ElggAutoP.php
@@ -110,7 +110,7 @@ class ElggAutoP {
 
 		// split AUTOPs into multiples at /\n\n+/
 		$html = preg_replace('/(' . $this->_unique . 'NL){2,}/', '</autop><autop>', $html);
-		$html = str_replace(array($this->_unique . 'BR', $this->_unique . 'NL', '<br>'), 
+		$html = str_replace(array($this->_unique . 'BR', $this->_unique . 'NL', '<br>'),
 				'<br />',
 				$html);
 		$html = str_replace('<br /></autop>', '</autop>', $html);

--- a/engine/classes/ElggBatch.php
+++ b/engine/classes/ElggBatch.php
@@ -375,6 +375,6 @@ class ElggBatch
 			return false;
 		}
 		$key = key($this->results);
-		return ($key !== NULL && $key !== FALSE);
+		return ($key !== null && $key !== false);
 	}
 }

--- a/engine/classes/ElggData.php
+++ b/engine/classes/ElggData.php
@@ -60,7 +60,7 @@ abstract class ElggData implements
 			$this->attributes = array();
 		}
 
-		$this->attributes['time_created'] = NULL;
+		$this->attributes['time_created'] = null;
 	}
 
 	/**
@@ -105,7 +105,7 @@ abstract class ElggData implements
 	 * @return bool
 	 */
 	function __isset($name) {
-		return $this->$name !== NULL;
+		return $this->$name !== null;
 	}
 
 	/**
@@ -196,7 +196,7 @@ abstract class ElggData implements
 	 * This lets an entity's attributes be displayed using foreach as a normal array.
 	 * Example: http://www.sitepoint.com/print/php5-standard-library
 	 */
-	protected $valid = FALSE;
+	protected $valid = false;
 
 	/**
 	 * Iterator interface
@@ -206,7 +206,7 @@ abstract class ElggData implements
 	 * @return void
 	 */
 	public function rewind() {
-		$this->valid = (FALSE !== reset($this->attributes));
+		$this->valid = (false !== reset($this->attributes));
 	}
 
 	/**
@@ -239,7 +239,7 @@ abstract class ElggData implements
 	 * @return void
 	 */
 	public function next() {
-		$this->valid = (FALSE !== next($this->attributes));
+		$this->valid = (false !== next($this->attributes));
 	}
 
 	/**

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -87,18 +87,18 @@ abstract class ElggEntity extends ElggData implements
 	protected function initializeAttributes() {
 		parent::initializeAttributes();
 
-		$this->attributes['guid'] = NULL;
-		$this->attributes['type'] = NULL;
-		$this->attributes['subtype'] = NULL;
+		$this->attributes['guid'] = null;
+		$this->attributes['type'] = null;
+		$this->attributes['subtype'] = null;
 
 		$this->attributes['owner_guid'] = elgg_get_logged_in_user_guid();
 		$this->attributes['container_guid'] = elgg_get_logged_in_user_guid();
 
-		$this->attributes['site_guid'] = NULL;
+		$this->attributes['site_guid'] = null;
 		$this->attributes['access_id'] = ACCESS_PRIVATE;
-		$this->attributes['time_created'] = NULL;
-		$this->attributes['time_updated'] = NULL;
-		$this->attributes['last_action'] = NULL;
+		$this->attributes['time_created'] = null;
+		$this->attributes['time_updated'] = null;
+		$this->attributes['last_action'] = null;
 		$this->attributes['enabled'] = "yes";
 
 		// There now follows a bit of a hack
@@ -192,7 +192,7 @@ abstract class ElggEntity extends ElggData implements
 		// No, so see if its in the meta data for this entity
 		$meta = $this->getMetaData($name);
 
-		// getMetaData returns NULL if $name is not found
+		// getMetaData returns null if $name is not found
 		return $meta;
 	}
 
@@ -224,7 +224,7 @@ abstract class ElggEntity extends ElggData implements
 				case 'guid':
 				case 'time_updated':
 				case 'last_action':
-					return FALSE;
+					return false;
 					break;
 				case 'access_id':
 				case 'owner_guid':
@@ -243,7 +243,7 @@ abstract class ElggEntity extends ElggData implements
 			return $this->setMetaData($name, $value);
 		}
 
-		return TRUE;
+		return true;
 	}
 	
 	/**
@@ -266,7 +266,7 @@ abstract class ElggEntity extends ElggData implements
 	 *
 	 * @param string $name Name
 	 *
-	 * @return mixed The value, or NULL if not found.
+	 * @return mixed The value, or null if not found.
 	 */
 	public function getMetaData($name) {
 		$guid = $this->getGUID();
@@ -522,7 +522,7 @@ abstract class ElggEntity extends ElggData implements
 	 *
 	 * @param string $name The name of the volatile data
 	 *
-	 * @return mixed The value or NULL if not found.
+	 * @return mixed The value or null if not found.
 	 */
 	public function getVolatileData($name) {
 		if (!is_array($this->volatile)) {
@@ -532,7 +532,7 @@ abstract class ElggEntity extends ElggData implements
 		if (array_key_exists($name, $this->volatile)) {
 			return $this->volatile[$name];
 		} else {
-			return NULL;
+			return null;
 		}
 	}
 
@@ -934,12 +934,12 @@ abstract class ElggEntity extends ElggData implements
 	 *
 	 * @return int|false The number of entities or false on failure
 	 */
-	public function countEntitiesFromRelationship($relationship, $inverse_relationship = FALSE) {
+	public function countEntitiesFromRelationship($relationship, $inverse_relationship = false) {
 		return elgg_get_entities_from_relationship(array(
 			'relationship' => $relationship,
 			'relationship_guid' => $this->getGUID(),
 			'inverse_relationship' => $inverse_relationship,
-			'count' => TRUE
+			'count' => true
 		));
 	}
 
@@ -1974,8 +1974,8 @@ abstract class ElggEntity extends ElggData implements
 	 * @return true
 	 * @deprecated 1.9
 	 */
-	public function setCalendarTimeAndDuration($hour = NULL, $minute = NULL, $second = NULL,
-	$day = NULL, $month = NULL, $year = NULL, $duration = NULL) {
+	public function setCalendarTimeAndDuration($hour = null, $minute = null, $second = null,
+	$day = null, $month = null, $year = null, $duration = null) {
 		elgg_deprecated_notice(__METHOD__ . ' has been deprecated', 1.9);
 
 		$start = mktime($hour, $minute, $second, $month, $day, $year);
@@ -2064,7 +2064,7 @@ abstract class ElggEntity extends ElggData implements
 
 		// Now add its attributes
 		foreach ($this->attributes as $k => $v) {
-			$meta = NULL;
+			$meta = null;
 
 			if (in_array($k, $exportable_values)) {
 				switch ($k) {
@@ -2190,7 +2190,7 @@ abstract class ElggEntity extends ElggData implements
 	 *
 	 * @return array
 	 */
-	public function getTags($tag_names = NULL) {
+	public function getTags($tag_names = null) {
 		if ($tag_names && !is_array($tag_names)) {
 			$tag_names = array($tag_names);
 		}

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1440,7 +1440,7 @@ abstract class ElggEntity extends ElggData implements
 			$container = $this->getContainerEntity();
 			if ($container && !$container->canWriteToContainer(0, $type, $subtype)) {
 				return false;
-			}				
+			}
 		}
 		
 		$result = $this->getDatabase()->insertData("INSERT into {$CONFIG->dbprefix}entities
@@ -1448,7 +1448,7 @@ abstract class ElggEntity extends ElggData implements
 				access_id, time_created, time_updated, last_action)
 			values
 			('$type',$subtype_id, $owner_guid, $site_guid, $container_guid,
-				$access_id, $time, $time, $time)");	
+				$access_id, $time, $time, $time)");
 
 		if (!$result) {
 			throw new IOException("Unable to save new object's base entity information!");

--- a/engine/classes/ElggExtender.php
+++ b/engine/classes/ElggExtender.php
@@ -36,7 +36,7 @@ abstract class ElggExtender extends ElggData {
 	protected function initializeAttributes() {
 		parent::initializeAttributes();
 
-		$this->attributes['type'] = NULL;
+		$this->attributes['type'] = null;
 	}
 
 	/**

--- a/engine/classes/ElggFile.php
+++ b/engine/classes/ElggFile.php
@@ -259,7 +259,7 @@ class ElggFile extends ElggObject {
 		$fs = $this->getFilestore();
 
 		if ($fs->close($this->handle)) {
-			$this->handle = NULL;
+			$this->handle = null;
 
 			return true;
 		}

--- a/engine/classes/ElggFileCache.php
+++ b/engine/classes/ElggFileCache.php
@@ -163,7 +163,7 @@ class ElggFileCache extends ElggCache {
 		if (file_exists($dir . $key)) {
 			return unlink($dir . $key);
 		}
-		return TRUE;
+		return true;
 	}
 
 	/**

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -24,8 +24,8 @@ class ElggGroup extends ElggEntity
 		parent::initializeAttributes();
 
 		$this->attributes['type'] = "group";
-		$this->attributes['name'] = NULL;
-		$this->attributes['description'] = NULL;
+		$this->attributes['name'] = null;
+		$this->attributes['description'] = null;
 		$this->attributes['tables_split'] = 2;
 	}
 

--- a/engine/classes/ElggMemcache.php
+++ b/engine/classes/ElggMemcache.php
@@ -59,11 +59,11 @@ class ElggMemcache extends ElggSharedMemoryCache {
 					$this->memcache->addServer(
 						$server[0],
 						isset($server[1]) ? $server[1] : 11211,
-						isset($server[2]) ? $server[2] : FALSE,
+						isset($server[2]) ? $server[2] : false,
 						isset($server[3]) ? $server[3] : 1,
 						isset($server[4]) ? $server[4] : 1,
 						isset($server[5]) ? $server[5] : 15,
-						isset($server[6]) ? $server[6] : TRUE
+						isset($server[6]) ? $server[6] : true
 					);
 
 				} else {

--- a/engine/classes/ElggMenuItem.php
+++ b/engine/classes/ElggMenuItem.php
@@ -93,11 +93,11 @@ class ElggMenuItem {
 	 *
 	 * @param array $options Option array of key value pairs
 	 *
-	 * @return ElggMenuItem or NULL on error
+	 * @return ElggMenuItem or null on error
 	 */
 	public static function factory($options) {
 		if (!isset($options['name']) || !isset($options['text'])) {
-			return NULL;
+			return null;
 		}
 		if (!isset($options['href'])) {
 			$options['href'] = '';

--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -31,8 +31,8 @@ class ElggObject extends ElggEntity {
 		parent::initializeAttributes();
 
 		$this->attributes['type'] = "object";
-		$this->attributes['title'] = NULL;
-		$this->attributes['description'] = NULL;
+		$this->attributes['title'] = null;
+		$this->attributes['description'] = null;
 		$this->attributes['tables_split'] = 2;
 	}
 

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -98,7 +98,7 @@ class ElggPlugin extends ElggObject {
 		if (parent::save()) {
 			// make sure we have a priority
 			$priority = $this->getPriority();
-			if ($priority === FALSE || $priority === NULL) {
+			if ($priority === false || $priority === null) {
 				return $this->setPriority('last');
 			}
 		} else {
@@ -797,7 +797,7 @@ class ElggPlugin extends ElggObject {
 			throw new PluginException($msg);
 		}
 
-		while (FALSE !== ($view_type = readdir($handle))) {
+		while (false !== ($view_type = readdir($handle))) {
 			$view_type_dir = $view_dir . $view_type;
 
 			if ('.' !== substr($view_type, 0, 1) && is_dir($view_type_dir)) {
@@ -884,7 +884,7 @@ class ElggPlugin extends ElggObject {
 
 		if ($meta === false) {
 			// Can't find it, so return null
-			return NULL;
+			return null;
 		}
 
 		return $meta;

--- a/engine/classes/ElggPluginPackage.php
+++ b/engine/classes/ElggPluginPackage.php
@@ -32,7 +32,7 @@ class ElggPluginPackage {
 	 * @var array
 	 */
 	private $textFiles = array(
-		'README.txt', 'CHANGES.txt', 
+		'README.txt', 'CHANGES.txt',
 		'INSTALL.txt', 'COPYRIGHT.txt', 'LICENSE.txt',
 
 		'README', 'README.md', 'README.markdown'

--- a/engine/classes/ElggPriorityList.php
+++ b/engine/classes/ElggPriorityList.php
@@ -351,7 +351,7 @@ class ElggPriorityList
 	public function valid() {
 		$this->sortIfUnsorted();
 		$key = key($this->elements);
-		return ($key !== NULL && $key !== FALSE);
+		return ($key !== null && $key !== false);
 	}
 
 	/**

--- a/engine/classes/ElggSession.php
+++ b/engine/classes/ElggSession.php
@@ -235,8 +235,8 @@ class ElggSession implements ArrayAccess {
 			return $_SESSION[$key];
 		}
 
-		$orig_value = NULL;
-		$value = elgg_trigger_plugin_hook('session:get', $key, NULL, $orig_value);
+		$orig_value = null;
+		$value = elgg_trigger_plugin_hook('session:get', $key, null, $orig_value);
 		if ($orig_value !== $value) {
 			elgg_deprecated_notice("Plugin hook session:get has been deprecated.", 1.9);
 		}

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -40,9 +40,9 @@ class ElggSite extends ElggEntity {
 		parent::initializeAttributes();
 
 		$this->attributes['type'] = "site";
-		$this->attributes['name'] = NULL;
-		$this->attributes['description'] = NULL;
-		$this->attributes['url'] = NULL;
+		$this->attributes['name'] = null;
+		$this->attributes['description'] = null;
+		$this->attributes['url'] = null;
 		$this->attributes['tables_split'] = 2;
 	}
 
@@ -258,7 +258,7 @@ class ElggSite extends ElggEntity {
 			'site_guids' => ELGG_ENTITIES_ANY_VALUE,
 			'relationship' => 'member_of_site',
 			'relationship_guid' => $this->getGUID(),
-			'inverse_relationship' => TRUE,
+			'inverse_relationship' => true,
 			'type' => 'user',
 		);
 
@@ -282,7 +282,7 @@ class ElggSite extends ElggEntity {
 			'site_guids' => ELGG_ENTITIES_ANY_VALUE,
 			'relationship' => 'member_of_site',
 			'relationship_guid' => $this->getGUID(),
-			'inverse_relationship' => TRUE,
+			'inverse_relationship' => true,
 			'type' => 'user',
 		);
 
@@ -486,7 +486,7 @@ class ElggSite extends ElggEntity {
 		);
 
 		// include a hook for plugin authors to include public pages
-		$plugins = elgg_trigger_plugin_hook('public_pages', 'walled_garden', NULL, array());
+		$plugins = elgg_trigger_plugin_hook('public_pages', 'walled_garden', null, array());
 
 		// allow public pages
 		foreach (array_merge($defaults, $plugins) as $public) {

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -31,18 +31,18 @@ class ElggUser extends ElggEntity
 		parent::initializeAttributes();
 
 		$this->attributes['type'] = "user";
-		$this->attributes['name'] = NULL;
-		$this->attributes['username'] = NULL;
-		$this->attributes['password'] = NULL;
-		$this->attributes['salt'] = NULL;
-		$this->attributes['email'] = NULL;
-		$this->attributes['language'] = NULL;
-		$this->attributes['code'] = NULL;
+		$this->attributes['name'] = null;
+		$this->attributes['username'] = null;
+		$this->attributes['password'] = null;
+		$this->attributes['salt'] = null;
+		$this->attributes['email'] = null;
+		$this->attributes['language'] = null;
+		$this->attributes['code'] = null;
 		$this->attributes['banned'] = "no";
 		$this->attributes['admin'] = 'no';
-		$this->attributes['prev_last_action'] = NULL;
-		$this->attributes['last_login'] = NULL;
-		$this->attributes['prev_last_login'] = NULL;
+		$this->attributes['prev_last_action'] = null;
+		$this->attributes['last_login'] = null;
+		$this->attributes['prev_last_login'] = null;
 		$this->attributes['tables_split'] = 2;
 	}
 
@@ -235,7 +235,7 @@ class ElggUser extends ElggEntity
 			return parent::set($name, $value);
 		}
 	
-		return TRUE;
+		return true;
 	}
 
 	/**
@@ -289,13 +289,13 @@ class ElggUser extends ElggEntity
 	public function makeAdmin() {
 		// If already saved, use the standard function.
 		if ($this->guid && !make_user_admin($this->guid)) {
-			return FALSE;
+			return false;
 		}
 
 		// need to manually set attributes since they've already been loaded.
 		$this->attributes['admin'] = 'yes';
 
-		return TRUE;
+		return true;
 	}
 
 	/**
@@ -306,13 +306,13 @@ class ElggUser extends ElggEntity
 	public function removeAdmin() {
 		// If already saved, use the standard function.
 		if ($this->guid && !remove_user_admin($this->guid)) {
-			return FALSE;
+			return false;
 		}
 
 		// need to manually set attributes since they've already been loaded.
 		$this->attributes['admin'] = 'no';
 
-		return TRUE;
+		return true;
 	}
 
 	/**

--- a/engine/classes/Importable.php
+++ b/engine/classes/Importable.php
@@ -9,7 +9,7 @@
 interface Importable {
 	/**
 	 * Accepts an array of data to import, this data is parsed from the XML produced by export.
-	 * The function should return the constructed object data, or NULL.
+	 * The function should return the constructed object data, or null.
 	 *
 	 * @param ODD $data Data in ODD format
 	 *

--- a/engine/classes/Notable.php
+++ b/engine/classes/Notable.php
@@ -22,8 +22,8 @@ interface Notable {
 	 *
 	 * @return bool
 	 */
-	public function setCalendarTimeAndDuration($hour = NULL, $minute = NULL, $second = NULL,
-		$day = NULL, $month = NULL, $year = NULL, $duration = NULL);
+	public function setCalendarTimeAndDuration($hour = null, $minute = null, $second = null,
+		$day = null, $month = null, $year = null, $duration = null);
 
 	/**
 	 * Return the start timestamp.

--- a/engine/classes/ODD.php
+++ b/engine/classes/ODD.php
@@ -57,7 +57,7 @@ abstract class ODD {
 			return $this->attributes[$key];
 		}
 
-		return NULL;
+		return null;
 	}
 
 	/**

--- a/engine/classes/ODDDocument.php
+++ b/engine/classes/ODDDocument.php
@@ -31,7 +31,7 @@ class ODDDocument implements Iterator {
 	 *
 	 * @return void
 	 */
-	public function __construct(array $elements = NULL) {
+	public function __construct(array $elements = null) {
 		if ($elements) {
 			if (is_array($elements)) {
 				$this->elements = $elements;
@@ -144,7 +144,7 @@ class ODDDocument implements Iterator {
 	 * Example: http://www.sitepoint.com/print/php5-standard-library
 	 */
 
-	private $valid = FALSE;
+	private $valid = false;
 
 	/**
 	 * Iterator interface
@@ -154,7 +154,7 @@ class ODDDocument implements Iterator {
 	 * @return void
 	 */
 	function rewind() {
-		$this->valid = (FALSE !== reset($this->elements));
+		$this->valid = (false !== reset($this->elements));
 	}
 
 	/**
@@ -187,7 +187,7 @@ class ODDDocument implements Iterator {
 	 * @return void
 	 */
 	function next() {
-		$this->valid = (FALSE !== next($this->elements));
+		$this->valid = (false !== next($this->elements));
 	}
 
 	/**

--- a/engine/lib/access.php
+++ b/engine/lib/access.php
@@ -807,7 +807,7 @@ function get_user_access_collections($owner_guid, $site_guid = 0) {
  * @see add_user_to_access_collection()
  * @see http://docs.elgg.org/Access/Collections
  */
-function get_members_of_access_collection($collection, $idonly = FALSE) {
+function get_members_of_access_collection($collection, $idonly = false) {
 	global $CONFIG;
 	$collection = (int)$collection;
 
@@ -822,7 +822,7 @@ function get_members_of_access_collection($collection, $idonly = FALSE) {
 			. " WHERE m.access_collection_id = {$collection}";
 		$collection_members = get_data($query);
 		if (!$collection_members) {
-			return FALSE;
+			return false;
 		}
 		foreach ($collection_members as $key => $val) {
 			$collection_members[$key] = $val->guid;
@@ -845,7 +845,7 @@ function get_members_of_access_collection($collection, $idonly = FALSE) {
 function elgg_get_entities_from_access_id(array $options = array()) {
 	// restrict the resultset to access collection provided
 	if (!isset($options['access_id'])) {
-		return FALSE;
+		return false;
 	}
 
 	// @todo add support for an array of collection_ids
@@ -1056,7 +1056,7 @@ function elgg_override_permissions($hook, $type, $value, $params) {
 	}
 
 	// consult other hooks
-	return NULL;
+	return null;
 }
 
 /**

--- a/engine/lib/actions.php
+++ b/engine/lib/actions.php
@@ -130,7 +130,7 @@ function elgg_unregister_action($action) {
  * @link http://docs.elgg.org/Actions/Tokens
  * @access private
  */
-function validate_action_token($visibleerrors = TRUE, $token = NULL, $ts = NULL) {
+function validate_action_token($visibleerrors = true, $token = null, $ts = null) {
 	return _elgg_services()->actions->validateActionToken($visibleerrors, $token, $ts);
 }
 
@@ -190,7 +190,7 @@ function init_site_secret() {
 		return $secret;
 	}
 
-	return FALSE;
+	return false;
 }
 
 /**

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -115,9 +115,9 @@ function elgg_add_admin_notice($id, $message) {
  */
 function elgg_delete_admin_notice($id) {
 	if (!$id) {
-		return FALSE;
+		return false;
 	}
-	$result = TRUE;
+	$result = true;
 	$notices = elgg_get_entities_from_metadata(array(
 		'metadata_name' => 'admin_notice_id',
 		'metadata_value' => $id
@@ -130,7 +130,7 @@ function elgg_delete_admin_notice($id) {
 		}
 		return $result;
 	}
-	return FALSE;
+	return false;
 }
 
 /**
@@ -166,7 +166,7 @@ function elgg_admin_notice_exists($id) {
 	));
 	elgg_set_ignore_access($old_ia);
 
-	return ($notice) ? TRUE : FALSE;
+	return ($notice) ? true : false;
 }
 
 /**
@@ -189,7 +189,7 @@ function elgg_admin_notice_exists($id) {
  * @return bool
  * @since 1.8.0
  */
-function elgg_register_admin_menu_item($section, $menu_id, $parent_id = NULL, $priority = 100) {
+function elgg_register_admin_menu_item($section, $menu_id, $parent_id = null, $priority = 100) {
 
 	// make sure parent is registered
 	if ($parent_id && !elgg_is_menu_item_registered('page', $parent_id)) {
@@ -200,7 +200,7 @@ function elgg_register_admin_menu_item($section, $menu_id, $parent_id = NULL, $p
 	if ($parent_id) {
 		$href = "admin/$parent_id/$menu_id";
 	} else {
-		$href = NULL;
+		$href = null;
 	}
 
 	$name = $menu_id;

--- a/engine/lib/annotations.php
+++ b/engine/lib/annotations.php
@@ -214,7 +214,7 @@ function elgg_get_annotations(array $options = array()) {
 		if (isset($options['count']) && $options['count']) {
 			$options['annotation_calculation'] = 'count';
 			unset($options['count']);
-		}		
+		}
 	}
 	
 	$options['metastring_type'] = 'annotations';

--- a/engine/lib/annotations.php
+++ b/engine/lib/annotations.php
@@ -107,7 +107,7 @@ $owner_guid = 0, $access_id = ACCESS_PRIVATE) {
 			} else {
 				// plugin returned false to reject annotation
 				elgg_delete_annotation_by_id($result);
-				return FALSE;
+				return false;
 			}
 		}
 	}
@@ -183,11 +183,11 @@ function update_annotation($annotation_id, $name, $value, $value_type, $owner_gu
  *
  * @param array $options Array in format:
  *
- * annotation_names              => NULL|ARR Annotation names
- * annotation_values             => NULL|ARR Annotation values
- * annotation_ids                => NULL|ARR annotation ids
+ * annotation_names              => null|ARR Annotation names
+ * annotation_values             => null|ARR Annotation values
+ * annotation_ids                => null|ARR annotation ids
  * annotation_case_sensitive     => BOOL Overall Case sensitive
- * annotation_owner_guids        => NULL|ARR guids for annotation owners
+ * annotation_owner_guids        => null|ARR guids for annotation owners
  * annotation_created_time_lower => INT Lower limit for created time.
  * annotation_created_time_upper => INT Upper limit for created time.
  * annotation_calculation        => STR Perform the MySQL function on the annotation values returned.
@@ -317,26 +317,26 @@ function elgg_list_annotations($options) {
  *
  * @param array $options Array in format:
  *
- * 	annotation_names => NULL|ARR annotations names
+ * 	annotation_names => null|ARR annotations names
  *
- * 	annotation_values => NULL|ARR annotations values
+ * 	annotation_values => null|ARR annotations values
  *
- * 	annotation_name_value_pairs => NULL|ARR (name = 'name', value => 'value',
- * 	'operator' => '=', 'case_sensitive' => TRUE) entries.
+ * 	annotation_name_value_pairs => null|ARR (name = 'name', value => 'value',
+ * 	'operator' => '=', 'case_sensitive' => true) entries.
  * 	Currently if multiple values are sent via an array (value => array('value1', 'value2')
  * 	the pair's operator will be forced to "IN".
  *
- * 	annotation_name_value_pairs_operator => NULL|STR The operator to use for combining
+ * 	annotation_name_value_pairs_operator => null|STR The operator to use for combining
  *  (name = value) OPERATOR (name = value); default AND
  *
  * 	annotation_case_sensitive => BOOL Overall Case sensitive
  *
- *  order_by_annotation => NULL|ARR (array('name' => 'annotation_text1', 'direction' => ASC|DESC,
+ *  order_by_annotation => null|ARR (array('name' => 'annotation_text1', 'direction' => ASC|DESC,
  *  'as' => text|integer),
  *
  *  Also supports array('name' => 'annotation_text1')
  *
- *  annotation_owner_guids => NULL|ARR guids for annotaiton owners
+ *  annotation_owner_guids => null|ARR guids for annotaiton owners
  *
  * @return mixed If count, int. If not count, array. false on errors.
  * @since 1.7.0
@@ -348,7 +348,7 @@ function elgg_get_entities_from_annotations(array $options = array()) {
 		'annotation_name_value_pairs'			=>	ELGG_ENTITIES_ANY_VALUE,
 
 		'annotation_name_value_pairs_operator'	=>	'AND',
-		'annotation_case_sensitive' 			=>	TRUE,
+		'annotation_case_sensitive' 			=>	true,
 		'order_by_annotation'					=>	array(),
 
 		'annotation_created_time_lower'			=>	ELGG_ENTITIES_ANY_VALUE,
@@ -499,11 +499,11 @@ function get_annotation_url($id) {
  * @return bool
  * @since 1.8.0
  */
-function elgg_annotation_exists($entity_guid, $annotation_type, $owner_guid = NULL) {
+function elgg_annotation_exists($entity_guid, $annotation_type, $owner_guid = null) {
 	global $CONFIG;
 
 	if (!$owner_guid && !($owner_guid = elgg_get_logged_in_user_guid())) {
-		return FALSE;
+		return false;
 	}
 
 	$entity_guid = sanitize_int($entity_guid);
@@ -516,10 +516,10 @@ function elgg_annotation_exists($entity_guid, $annotation_type, $owner_guid = NU
 			" AND m.string = '$annotation_type'";
 
 	if (get_data_row($sql)) {
-		return TRUE;
+		return true;
 	}
 
-	return FALSE;
+	return false;
 }
 
 /**

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -78,7 +78,7 @@ function elgg_load_system_cache($type) {
 		}
 	}
 
-	return NULL;
+	return null;
 }
 
 /**

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -78,7 +78,7 @@ function elgg_get_root_path() {
  * Get an Elgg configuration value
  *
  * @param string $name      Name of the configuration value
- * @param int    $site_guid NULL for installation setting, 0 for default site
+ * @param int    $site_guid null for installation setting, 0 for default site
  *
  * @return mixed Configuration value or null if it does not exist
  * @since 1.8.0
@@ -141,7 +141,7 @@ function elgg_set_config($name, $value) {
  *
  * @param string $name      Configuration name (cannot be greater than 255 characters)
  * @param mixed  $value     Configuration value. Should be string for installation setting
- * @param int    $site_guid NULL for installation setting, 0 for default site
+ * @param int    $site_guid null for installation setting, 0 for default site
  *
  * @return bool
  * @since 1.8.0
@@ -158,7 +158,7 @@ function elgg_save_config($name, $value, $site_guid = 0) {
 
 	elgg_set_config($name, $value);
 
-	if ($site_guid === NULL) {
+	if ($site_guid === null) {
 		if (is_array($value) || is_object($value)) {
 			return false;
 		}
@@ -278,7 +278,7 @@ function datalist_set($name, $value) {
 		. " set name = '{$sanitised_name}', value = '{$sanitised_value}'"
 		. " ON DUPLICATE KEY UPDATE value='{$sanitised_value}'");
 
-	if ($success !== FALSE) {
+	if ($success !== false) {
 		$DATALIST_CACHE[$name] = $value;
 		return true;
 	} else {

--- a/engine/lib/deprecated-1.9.php
+++ b/engine/lib/deprecated-1.9.php
@@ -1711,7 +1711,7 @@ function leave_group($group_guid, $user_guid) {
 	$user = get_entity($user_guid);
 	
 	if ($group instanceof ElggGroup && $user instanceof ElggUser) {
-		return $group->leave($user);	
+		return $group->leave($user);
 	}
 
 	return false;

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -65,7 +65,7 @@ function elgg_load_library($name) {
  * Forward to $location.
  *
  * Sends a 'Location: $location' header and exists.  If headers have
- * already been sent, returns FALSE.
+ * already been sent, returns false.
  *
  * @param string $location URL to forward to browser to. Can be path relative to the network's URL.
  * @param string $reason   Short explanation for why we're forwarding
@@ -417,16 +417,16 @@ function _elgg_bootstrap_externals_data_structure($type) {
  * @param string $directory  Directory to look in
  * @param array  $exceptions Array of filenames to ignore
  * @param array  $list       Array of files to append to
- * @param mixed  $extensions Array of extensions to allow, NULL for all. Use a dot: array('.php').
+ * @param mixed  $extensions Array of extensions to allow, null for all. Use a dot: array('.php').
  *
  * @return array Filenames in $directory, in the form $directory/filename.
  */
 function elgg_get_file_list($directory, $exceptions = array(), $list = array(),
-$extensions = NULL) {
+$extensions = null) {
 
 	$directory = sanitise_filepath($directory);
 	if ($handle = opendir($directory)) {
-		while (($file = readdir($handle)) !== FALSE) {
+		while (($file = readdir($handle)) !== false) {
 			if (!is_file($directory . $file) || in_array($file, $exceptions)) {
 				continue;
 			}
@@ -453,7 +453,7 @@ $extensions = NULL) {
  *
  * @return string
  */
-function sanitise_filepath($path, $append_slash = TRUE) {
+function sanitise_filepath($path, $append_slash = true) {
 	// Convert to correct UNIX paths
 	$path = str_replace('\\', '/', $path);
 	$path = str_replace('../', '/', $path);
@@ -1184,7 +1184,7 @@ function full_url() {
  * @return string Full URL
  * @since 1.7.0
  */
-function elgg_http_build_url(array $parts, $html_encode = TRUE) {
+function elgg_http_build_url(array $parts, $html_encode = true) {
 	// build only what's given to us.
 	$scheme = isset($parts['scheme']) ? "{$parts['scheme']}://" : '';
 	$host = isset($parts['host']) ? "{$parts['host']}" : '';
@@ -1219,7 +1219,7 @@ function elgg_http_build_url(array $parts, $html_encode = TRUE) {
  * @since 1.7.0
  * @link http://docs.elgg.org/Tutorials/Actions
  */
-function elgg_add_action_tokens_to_url($url, $html_encode = FALSE) {
+function elgg_add_action_tokens_to_url($url, $html_encode = false) {
 	$components = parse_url(elgg_normalize_url($url));
 
 	if (isset($components['query'])) {
@@ -1327,7 +1327,7 @@ function elgg_http_url_is_identical($url1, $url2, $ignore_params = array('offset
 	// @todo - should probably do something with relative URLs
 
 	if ($url1 == $url2) {
-		return TRUE;
+		return true;
 	}
 
 	$url1_info = parse_url($url1);
@@ -1346,18 +1346,18 @@ function elgg_http_url_is_identical($url1, $url2, $ignore_params = array('offset
 	foreach ($parts as $part) {
 		if ((isset($url1_info[$part]) && isset($url2_info[$part]))
 		&& $url1_info[$part] != $url2_info[$part]) {
-			return FALSE;
+			return false;
 		} elseif (isset($url1_info[$part]) && !isset($url2_info[$part])) {
-			return FALSE;
+			return false;
 		} elseif (!isset($url1_info[$part]) && isset($url2_info[$part])) {
-			return FALSE;
+			return false;
 		}
 	}
 
 	// quick compare of get params
 	if (isset($url1_info['query']) && isset($url2_info['query'])
 	&& $url1_info['query'] == $url2_info['query']) {
-		return TRUE;
+		return true;
 	}
 
 	// compare get params that might be out of order
@@ -1394,10 +1394,10 @@ function elgg_http_url_is_identical($url1, $url2, $ignore_params = array('offset
 	$diff_count = count(array_diff_assoc($url1_params, $url2_params));
 	$diff_count += count(array_diff_assoc($url2_params, $url1_params));
 	if ($diff_count > 0) {
-		return FALSE;
+		return false;
 	}
 
-	return TRUE;
+	return true;
 }
 
 /**
@@ -1456,7 +1456,7 @@ $sort_type = SORT_LOCALE_STRING) {
 		if (isset($v[$element])) {
 			$sort[] = strtolower($v[$element]);
 		} else {
-			$sort[] = NULL;
+			$sort[] = null;
 		}
 	};
 
@@ -1589,7 +1589,7 @@ function _elgg_shutdown_hook() {
 	try {
 		elgg_trigger_event('shutdown', 'system');
 
-		$time = (float)(microtime(TRUE) - $START_MICROTIME);
+		$time = (float)(microtime(true) - $START_MICROTIME);
 		$uri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : 'CLI';
 		// demoted to NOTICE from DEBUG so javascript is not corrupted
 		elgg_log("Page {$uri} generated in $time seconds", 'INFO');
@@ -2083,10 +2083,10 @@ define('ACCESS_FRIENDS', -2);
  * Constant to request the value of a parameter be ignored in elgg_get_*() functions
  *
  * @see elgg_get_entities()
- * @var NULL
+ * @var null
  * @since 1.7
  */
-define('ELGG_ENTITIES_ANY_VALUE', NULL);
+define('ELGG_ENTITIES_ANY_VALUE', null);
 
 /**
  * Constant to request the value of a parameter be nothing in elgg_get_*() functions.

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -576,7 +576,7 @@ function get_entity($guid) {
 	// @todo We need a single Memcache instance with a shared pool of namespace wrappers. This function would pull an instance from the pool.
 	static $shared_cache;
 
-	// We could also use: if (!(int) $guid) { return FALSE }, 
+	// We could also use: if (!(int) $guid) { return FALSE },
 	// but that evaluates to a false positive for $guid = TRUE.
 	// This is a bit slower, but more thorough.
 	if (!is_numeric($guid) || $guid === 0 || $guid === '0') {

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -215,7 +215,7 @@ function _elgg_populate_subtype_cache() {
  *
  * Entities can be registered to always be loaded as a certain class
  * with add_subtype() or update_subtype(). This function returns the class
- * name if found and NULL if not.
+ * name if found and null if not.
  *
  * @param string $type    The type
  * @param string $subtype The subtype
@@ -576,8 +576,8 @@ function get_entity($guid) {
 	// @todo We need a single Memcache instance with a shared pool of namespace wrappers. This function would pull an instance from the pool.
 	static $shared_cache;
 
-	// We could also use: if (!(int) $guid) { return FALSE },
-	// but that evaluates to a false positive for $guid = TRUE.
+	// We could also use: if (!(int) $guid) { return false },
+	// but that evaluates to a false positive for $guid = true.
 	// This is a bit slower, but more thorough.
 	if (!is_numeric($guid) || $guid === 0 || $guid === '0') {
 		return false;
@@ -694,40 +694,40 @@ function elgg_enable_entity($guid, $recursive = true) {
  *
  * @param array $options Array in format:
  *
- * 	types => NULL|STR entity type (type IN ('type1', 'type2')
+ * 	types => null|STR entity type (type IN ('type1', 'type2')
  *           Joined with subtypes by AND. See below)
  *
- * 	subtypes => NULL|STR entity subtype (SQL: subtype IN ('subtype1', 'subtype2))
+ * 	subtypes => null|STR entity subtype (SQL: subtype IN ('subtype1', 'subtype2))
  *              Use ELGG_ENTITIES_NO_VALUE for no subtype.
  *
- * 	type_subtype_pairs => NULL|ARR (array('type' => 'subtype'))
+ * 	type_subtype_pairs => null|ARR (array('type' => 'subtype'))
  *                        (type = '$type' AND subtype = '$subtype') pairs
  *
- *	guids => NULL|ARR Array of entity guids
+ *	guids => null|ARR Array of entity guids
  *
- * 	owner_guids => NULL|ARR Array of owner guids
+ * 	owner_guids => null|ARR Array of owner guids
  *
- * 	container_guids => NULL|ARR Array of container_guids
+ * 	container_guids => null|ARR Array of container_guids
  *
- * 	site_guids => NULL (current_site)|ARR Array of site_guid
+ * 	site_guids => null (current_site)|ARR Array of site_guid
  *
- * 	order_by => NULL (time_created desc)|STR SQL order by clause
+ * 	order_by => null (time_created desc)|STR SQL order by clause
  *
  *  reverse_order_by => BOOL Reverse the default order by clause
  *
- * 	limit => NULL (10)|INT SQL limit clause (0 means no limit)
+ * 	limit => null (10)|INT SQL limit clause (0 means no limit)
  *
- * 	offset => NULL (0)|INT SQL offset clause
+ * 	offset => null (0)|INT SQL offset clause
  *
- * 	created_time_lower => NULL|INT Created time lower boundary in epoch time
+ * 	created_time_lower => null|INT Created time lower boundary in epoch time
  *
- * 	created_time_upper => NULL|INT Created time upper boundary in epoch time
+ * 	created_time_upper => null|INT Created time upper boundary in epoch time
  *
- * 	modified_time_lower => NULL|INT Modified time lower boundary in epoch time
+ * 	modified_time_lower => null|INT Modified time lower boundary in epoch time
  *
- * 	modified_time_upper => NULL|INT Modified time upper boundary in epoch time
+ * 	modified_time_upper => null|INT Modified time upper boundary in epoch time
  *
- * 	count => TRUE|FALSE return a count instead of entities
+ * 	count => true|false return a count instead of entities
  *
  * 	wheres => array() Additional where clauses to AND together
  *
@@ -767,7 +767,7 @@ function elgg_get_entities(array $options = array()) {
 		'group_by'				=>	ELGG_ENTITIES_ANY_VALUE,
 		'limit'					=>	10,
 		'offset'				=>	0,
-		'count'					=>	FALSE,
+		'count'					=>	false,
 		'selects'				=>	array(),
 		'wheres'				=>	array(),
 		'joins'					=>	array(),
@@ -812,8 +812,8 @@ function elgg_get_entities(array $options = array()) {
 	// see if any functions failed
 	// remove empty strings on successful functions
 	foreach ($wheres as $i => $where) {
-		if ($where === FALSE) {
-			return FALSE;
+		if ($where === false) {
+			return false;
 		} elseif (empty($where)) {
 			unset($wheres[$i]);
 		}
@@ -831,8 +831,8 @@ function elgg_get_entities(array $options = array()) {
 	$joins = array_unique($options['joins']);
 
 	foreach ($joins as $i => $join) {
-		if ($join === FALSE) {
-			return FALSE;
+		if ($join === false) {
+			return false;
 		} elseif (empty($join)) {
 			unset($joins[$i]);
 		}
@@ -1019,11 +1019,11 @@ function _elgg_fetch_entities_from_sql($sql) {
  * Returns SQL where clause for type and subtype on main entity table
  *
  * @param string     $table    Entity table prefix as defined in SELECT...FROM entities $table
- * @param NULL|array $types    Array of types or NULL if none.
- * @param NULL|array $subtypes Array of subtypes or NULL if none
- * @param NULL|array $pairs    Array of pairs of types and subtypes
+ * @param null|array $types    Array of types or null if none.
+ * @param null|array $subtypes Array of subtypes or null if none
+ * @param null|array $pairs    Array of pairs of types and subtypes
  *
- * @return FALSE|string
+ * @return false|string
  * @since 1.7.0
  * @access private
  */
@@ -1031,7 +1031,7 @@ function _elgg_get_entity_type_subtype_where_sql($table, $types, $subtypes, $pai
 	// subtype depends upon type.
 	if ($subtypes && !$types) {
 		elgg_log("Cannot set subtypes without type.", 'WARNING');
-		return FALSE;
+		return false;
 	}
 
 	// short circuit if nothing is requested
@@ -1053,7 +1053,7 @@ function _elgg_get_entity_type_subtype_where_sql($table, $types, $subtypes, $pai
 			$subtypes = array($subtypes);
 		}
 
-		// decrementer for valid types.  Return FALSE if no valid types
+		// decrementer for valid types.  Return false if no valid types
 		$valid_types_count = count($types);
 		$valid_subtypes_count = 0;
 		// remove invalid types to get an accurate count of
@@ -1075,7 +1075,7 @@ function _elgg_get_entity_type_subtype_where_sql($table, $types, $subtypes, $pai
 
 		// return false if nothing is valid.
 		if (!$valid_types_count) {
-			return FALSE;
+			return false;
 		}
 
 		// subtypes are based upon types, so we need to look at each
@@ -1107,7 +1107,7 @@ function _elgg_get_entity_type_subtype_where_sql($table, $types, $subtypes, $pai
 
 				// return false if we're all invalid subtypes in the only valid type
 				if ($valid_subtypes_count <= 0) {
-					return FALSE;
+					return false;
 				}
 			}
 
@@ -1139,7 +1139,7 @@ function _elgg_get_entity_type_subtype_where_sql($table, $types, $subtypes, $pai
 		}
 
 		if ($valid_pairs_count <= 0) {
-			return FALSE;
+			return false;
 		}
 		foreach ($pairs as $paired_type => $paired_subtypes) {
 			// this will always be an array because of line 2027, right?
@@ -1162,7 +1162,7 @@ function _elgg_get_entity_type_subtype_where_sql($table, $types, $subtypes, $pai
 
 				// return false if there are no valid subtypes.
 				if ($valid_pairs_subtypes_count <= 0) {
-					return FALSE;
+					return false;
 				}
 
 
@@ -1190,7 +1190,7 @@ function _elgg_get_entity_type_subtype_where_sql($table, $types, $subtypes, $pai
  *
  * @param string     $column Column name the guids should be checked against. Usually
  *                           best to provide in table.column format.
- * @param NULL|array $guids  Array of GUIDs.
+ * @param null|array $guids  Array of GUIDs.
  *
  * @return false|string
  * @since 1.8.0
@@ -1224,7 +1224,7 @@ function _elgg_get_guid_based_where_sql($column, $guids) {
 	$guid_str = implode(',', $guids_sanitized);
 
 	// implode(',', 0) returns 0.
-	if ($guid_str !== FALSE && $guid_str !== '') {
+	if ($guid_str !== false && $guid_str !== '') {
 		$where = "($column IN ($guid_str))";
 	}
 
@@ -1236,17 +1236,17 @@ function _elgg_get_guid_based_where_sql($column, $guids) {
  *
  * @param string   $table              Entity table prefix as defined in
  *                                     SELECT...FROM entities $table
- * @param NULL|int $time_created_upper Time created upper limit
- * @param NULL|int $time_created_lower Time created lower limit
- * @param NULL|int $time_updated_upper Time updated upper limit
- * @param NULL|int $time_updated_lower Time updated lower limit
+ * @param null|int $time_created_upper Time created upper limit
+ * @param null|int $time_created_lower Time created lower limit
+ * @param null|int $time_updated_upper Time updated upper limit
+ * @param null|int $time_updated_lower Time updated lower limit
  *
- * @return FALSE|string FALSE on fail, string on success.
+ * @return false|string false on fail, string on success.
  * @since 1.7.0
  * @access private
  */
-function _elgg_get_entity_time_where_sql($table, $time_created_upper = NULL,
-$time_created_lower = NULL, $time_updated_upper = NULL, $time_updated_lower = NULL) {
+function _elgg_get_entity_time_where_sql($table, $time_created_upper = null,
+$time_created_lower = null, $time_updated_upper = null, $time_updated_lower = null) {
 
 	$wheres = array();
 
@@ -1393,7 +1393,7 @@ $order_by = 'time_created') {
 	} else {
 		if ($subtype) {
 			if (!$subtype_id = get_subtype_id($type, $subtype)) {
-				return FALSE;
+				return false;
 			} else {
 				$where[] = "subtype=$subtype_id";
 			}
@@ -1457,7 +1457,7 @@ function elgg_register_entity_type($type, $subtype = null) {
 
 	$type = strtolower($type);
 	if (!in_array($type, $CONFIG->entity_types)) {
-		return FALSE;
+		return false;
 	}
 
 	if (!isset($CONFIG->registered_entities)) {
@@ -1472,7 +1472,7 @@ function elgg_register_entity_type($type, $subtype = null) {
 		$CONFIG->registered_entities[$type][] = $subtype;
 	}
 
-	return TRUE;
+	return true;
 }
 
 /**
@@ -1492,15 +1492,15 @@ function elgg_unregister_entity_type($type, $subtype = null) {
 
 	$type = strtolower($type);
 	if (!in_array($type, $CONFIG->entity_types)) {
-		return FALSE;
+		return false;
 	}
 
 	if (!isset($CONFIG->registered_entities)) {
-		return FALSE;
+		return false;
 	}
 
 	if (!isset($CONFIG->registered_entities[$type])) {
-		return FALSE;
+		return false;
 	}
 
 	if ($subtype) {
@@ -1508,13 +1508,13 @@ function elgg_unregister_entity_type($type, $subtype = null) {
 			$key = array_search($subtype, $CONFIG->registered_entities[$type]);
 			unset($CONFIG->registered_entities[$type][$key]);
 		} else {
-			return FALSE;
+			return false;
 		}
 	} else {
 		unset($CONFIG->registered_entities[$type]);
 	}
 
-	return TRUE;
+	return true;
 }
 
 /**
@@ -1585,7 +1585,7 @@ function is_registered_entity_type($type, $subtype = null) {
  *
  * 	list_type_toggle => BOOL Display gallery / list switch
  *
- * 	allowed_types => TRUE|ARRAY True to show all types or an array of valid types.
+ * 	allowed_types => true|ARRAY True to show all types or an array of valid types.
  *
  * 	pagination => BOOL Display pagination links
  *
@@ -1597,10 +1597,10 @@ function elgg_list_registered_entities(array $options = array()) {
 	$autofeed = true;
 
 	$defaults = array(
-		'full_view' => FALSE,
-		'allowed_types' => TRUE,
-		'list_type_toggle' => FALSE,
-		'pagination' => TRUE,
+		'full_view' => false,
+		'allowed_types' => true,
+		'list_type_toggle' => false,
+		'pagination' => true,
 		'offset' => 0,
 		'types' => array(),
 		'type_subtype_pairs' => array()
@@ -1617,7 +1617,7 @@ function elgg_list_registered_entities(array $options = array()) {
 	$types = get_registered_entity_types();
 
 	foreach ($types as $type => $subtype_array) {
-		if (in_array($type, $options['allowed_types']) || $options['allowed_types'] === TRUE) {
+		if (in_array($type, $options['allowed_types']) || $options['allowed_types'] === true) {
 			// you must explicitly register types to show up in here and in search for objects
 			if ($type == 'object') {
 				if (is_array($subtype_array) && count($subtype_array)) {
@@ -1634,7 +1634,7 @@ function elgg_list_registered_entities(array $options = array()) {
 	}
 
 	if (!empty($options['type_subtype_pairs'])) {
-		$count = elgg_get_entities(array_merge(array('count' => TRUE), $options));
+		$count = elgg_get_entities(array_merge(array('count' => true), $options));
 		$entities = elgg_get_entities($options);
 	} else {
 		$count = 0;
@@ -1659,7 +1659,7 @@ function elgg_list_registered_entities(array $options = array()) {
  * @return bool
  * @since 1.8.0
  */
-function elgg_instanceof($entity, $type = NULL, $subtype = NULL, $class = NULL) {
+function elgg_instanceof($entity, $type = null, $subtype = null, $class = null) {
 	$return = ($entity instanceof ElggEntity);
 
 	if ($type) {
@@ -1690,7 +1690,7 @@ function elgg_instanceof($entity, $type = NULL, $subtype = NULL, $class = NULL) 
  * @return bool
  * @access private
  */
-function update_entity_last_action($guid, $posted = NULL) {
+function update_entity_last_action($guid, $posted = null) {
 	global $CONFIG;
 	$guid = (int)$guid;
 	$posted = (int)$posted;
@@ -1704,12 +1704,12 @@ function update_entity_last_action($guid, $posted = NULL) {
 		$query = "UPDATE {$CONFIG->dbprefix}entities SET last_action = {$posted} WHERE guid = {$guid}";
 		$result = update_data($query);
 		if ($result) {
-			return TRUE;
+			return true;
 		} else {
-			return FALSE;
+			return false;
 		}
 	} else {
-		return FALSE;
+		return false;
 	}
 }
 

--- a/engine/lib/filestore.php
+++ b/engine/lib/filestore.php
@@ -95,13 +95,13 @@ $square = false, $upscale = false) {
  *
  * @return false|mixed The contents of the resized image, or false on failure
  */
-function get_resized_image_from_existing_file($input_name, $maxwidth, $maxheight, $square = FALSE,
-$x1 = 0, $y1 = 0, $x2 = 0, $y2 = 0, $upscale = FALSE) {
+function get_resized_image_from_existing_file($input_name, $maxwidth, $maxheight, $square = false,
+$x1 = 0, $y1 = 0, $x2 = 0, $y2 = 0, $upscale = false) {
 
 	// Get the size information from the image
 	$imgsizearray = getimagesize($input_name);
-	if ($imgsizearray == FALSE) {
-		return FALSE;
+	if ($imgsizearray == false) {
+		return false;
 	}
 
 	$width = $imgsizearray[0];
@@ -118,7 +118,7 @@ $x1 = 0, $y1 = 0, $x2 = 0, $y2 = 0, $upscale = FALSE) {
 	// make sure the function is available
 	$load_function = "imagecreatefrom" . $accepted_formats[$imgsizearray['mime']];
 	if (!is_callable($load_function)) {
-		return FALSE;
+		return false;
 	}
 
 	// get the parameters for resizing the image
@@ -133,20 +133,20 @@ $x1 = 0, $y1 = 0, $x2 = 0, $y2 = 0, $upscale = FALSE) {
 		'y2' => $y2,
 	);
 	$params = get_image_resize_parameters($width, $height, $options);
-	if ($params == FALSE) {
-		return FALSE;
+	if ($params == false) {
+		return false;
 	}
 
 	// load original image
 	$original_image = call_user_func($load_function, $input_name);
 	if (!$original_image) {
-		return FALSE;
+		return false;
 	}
 
 	// allocate the new image
 	$new_image = imagecreatetruecolor($params['newwidth'], $params['newheight']);
 	if (!$new_image) {
-		return FALSE;
+		return false;
 	}
 
 	// color transparencies white (default is black)
@@ -166,12 +166,12 @@ $x1 = 0, $y1 = 0, $x2 = 0, $y2 = 0, $upscale = FALSE) {
 									$params['selectionwidth'],
 									$params['selectionheight']);
 	if (!$rtn_code) {
-		return FALSE;
+		return false;
 	}
 
 	// grab a compressed jpeg version of the image
 	ob_start();
-	imagejpeg($new_image, NULL, 90);
+	imagejpeg($new_image, null, 90);
 	$jpeg = ob_get_clean();
 
 	imagedestroy($new_image);
@@ -187,7 +187,7 @@ $x1 = 0, $y1 = 0, $x2 = 0, $y2 = 0, $upscale = FALSE) {
  * @param int   $height  Height of the original image
  * @param array $options See $defaults for the options
  *
- * @return array or FALSE
+ * @return array or false
  * @since 1.7.2
  */
 function get_image_resize_parameters($width, $height, $options) {
@@ -196,8 +196,8 @@ function get_image_resize_parameters($width, $height, $options) {
 		'maxwidth' => 100,
 		'maxheight' => 100,
 
-		'square' => FALSE,
-		'upscale' => FALSE,
+		'square' => false,
+		'upscale' => false,
 
 		'x1' => 0,
 		'y1' => 0,
@@ -210,9 +210,9 @@ function get_image_resize_parameters($width, $height, $options) {
 	extract($options);
 
 	// crop image first?
-	$crop = TRUE;
+	$crop = true;
 	if ($x1 == 0 && $y1 == 0 && $x2 == 0 && $y2 == 0) {
-		$crop = FALSE;
+		$crop = false;
 	}
 
 	// how large a section of the image has been selected
@@ -230,8 +230,8 @@ function get_image_resize_parameters($width, $height, $options) {
 		// asking for a square image back
 
 		// detect case where someone is passing crop parameters that are not for a square
-		if ($crop == TRUE && $selection_width != $selection_height) {
-			return FALSE;
+		if ($crop == true && $selection_width != $selection_height) {
+			return false;
 		}
 
 		// size of the new square image
@@ -388,11 +388,11 @@ function file_get_general_file_type($mimetype) {
 function delete_directory($directory) {
 	// sanity check: must be a directory
 	if (!$handle = opendir($directory)) {
-		return FALSE;
+		return false;
 	}
 
 	// loop through all files
-	while (($file = readdir($handle)) !== FALSE) {
+	while (($file = readdir($handle)) !== false) {
 		if (in_array($file, array('.', '..'))) {
 			continue;
 		}
@@ -401,7 +401,7 @@ function delete_directory($directory) {
 		if (is_dir($path)) {
 			// recurse down through directory
 			if (!delete_directory($path)) {
-				return FALSE;
+				return false;
 			}
 		} else {
 			// delete file
@@ -440,7 +440,7 @@ function clear_user_files($user) {
 
 
 /// Variable holding the default datastore
-$DEFAULT_FILE_STORE = NULL;
+$DEFAULT_FILE_STORE = null;
 
 /**
  * Return the default filestore.

--- a/engine/lib/group.php
+++ b/engine/lib/group.php
@@ -113,7 +113,7 @@ function get_group_members($group_guid, $limit = 10, $offset = 0, $site_guid = 0
 	return elgg_get_entities_from_relationship(array(
 		'relationship' => 'member',
 		'relationship_guid' => $group_guid,
-		'inverse_relationship' => TRUE,
+		'inverse_relationship' => true,
 		'type' => 'user',
 		'limit' => $limit,
 		'offset' => $offset,

--- a/engine/lib/input.php
+++ b/engine/lib/input.php
@@ -24,7 +24,7 @@
  *
  * @return mixed
  */
-function get_input($variable, $default = NULL, $filter_result = TRUE) {
+function get_input($variable, $default = null, $filter_result = true) {
 	return _elgg_services()->request->getInput($variable, $default, $filter_result);
 }
 
@@ -141,7 +141,7 @@ function elgg_is_sticky_form($form_name) {
  * @link http://docs.elgg.org/Tutorials/UI/StickyForms
  * @since 1.8.0
  */
-function elgg_get_sticky_value($form_name, $variable = '', $default = NULL, $filter_result = true) {
+function elgg_get_sticky_value($form_name, $variable = '', $default = null, $filter_result = true) {
 	$session = _elgg_services()->session;
 	$data = $session->get('sticky_forms', array());
 	if (isset($data[$form_name][$variable])) {

--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -222,7 +222,7 @@ function register_translations($path, $load_all = false) {
 				$return = false;
 				continue;
 			} elseif (is_array($result)) {
-				add_translation(basename($language, '.php'), $result);	
+				add_translation(basename($language, '.php'), $result);
 			}
 		}
 	}

--- a/engine/lib/metadata.php
+++ b/engine/lib/metadata.php
@@ -30,7 +30,7 @@ function row_to_elggmetadata($row) {
  *
  * @param int $id The id of the metadata object being retrieved.
  *
- * @return ElggMetadata|false  FALSE if not found
+ * @return ElggMetadata|false  false if not found
  */
 function elgg_get_metadata_from_id($id) {
 	return _elgg_get_metastring_based_object_from_id($id, 'metadata');
@@ -53,7 +53,7 @@ function elgg_delete_metadata_by_id($id) {
 /**
  * Create a new metadata object, or update an existing one.
  *
- * Metadata can be an array by setting allow_multiple to TRUE, but it is an
+ * Metadata can be an array by setting allow_multiple to true, but it is an
  * indexed array with no control over the indexing.
  *
  * @param int    $entity_guid    The entity to attach the metadata to
@@ -62,9 +62,9 @@ function elgg_delete_metadata_by_id($id) {
  * @param string $value_type     'text', 'integer', or '' for automatic detection
  * @param int    $owner_guid     GUID of entity that owns the metadata
  * @param int    $access_id      Default is ACCESS_PRIVATE
- * @param bool   $allow_multiple Allow multiple values for one key. Default is FALSE
+ * @param bool   $allow_multiple Allow multiple values for one key. Default is false
  *
- * @return int|false id of metadata or FALSE if failure
+ * @return int|false id of metadata or false if failure
  */
 function create_metadata($entity_guid, $name, $value, $value_type = '', $owner_guid = 0,
 	$access_id = ACCESS_PRIVATE, $allow_multiple = false) {
@@ -81,7 +81,7 @@ function create_metadata($entity_guid, $name, $value, $value_type = '', $owner_g
 	$allow_multiple = (boolean)$allow_multiple;
 
 	if (!isset($value)) {
-		return FALSE;
+		return false;
 	}
 
 	if ($owner_guid == 0) {
@@ -225,7 +225,7 @@ function update_metadata($id, $name, $value, $value_type, $owner_guid, $access_i
  * This function creates metadata from an associative array of "key => value" pairs.
  *
  * To achieve an array for a single key, pass in the same key multiple times with
- * allow_multiple set to TRUE. This creates an indexed array. It does not support
+ * allow_multiple set to true. This creates an indexed array. It does not support
  * associative arrays and there is no guarantee on the ordering in the array.
  *
  * @param int    $entity_guid     The entity to attach the metadata to
@@ -233,7 +233,7 @@ function update_metadata($id, $name, $value, $value_type, $owner_guid, $access_i
  * @param string $value_type      'text', 'integer', or '' for automatic detection
  * @param int    $owner_guid      GUID of entity that owns the metadata
  * @param int    $access_id       Default is ACCESS_PRIVATE
- * @param bool   $allow_multiple  Allow multiple values for one key. Default is FALSE
+ * @param bool   $allow_multiple  Allow multiple values for one key. Default is false
  *
  * @return bool
  */
@@ -264,11 +264,11 @@ $access_id = ACCESS_PRIVATE, $allow_multiple = false) {
  *
  * @param array $options Array in format:
  *
- * metadata_names               => NULL|ARR metadata names
- * metadata_values              => NULL|ARR metadata values
- * metadata_ids                 => NULL|ARR metadata ids
+ * metadata_names               => null|ARR metadata names
+ * metadata_values              => null|ARR metadata values
+ * metadata_ids                 => null|ARR metadata ids
  * metadata_case_sensitive      => BOOL Overall Case sensitive
- * metadata_owner_guids         => NULL|ARR guids for metadata owners
+ * metadata_owner_guids         => null|ARR guids for metadata owners
  * metadata_created_time_lower  => INT Lower limit for created time.
  * metadata_created_time_upper  => INT Upper limit for created time.
  * metadata_calculation         => STR Perform the MySQL function on the metadata values returned.
@@ -392,33 +392,33 @@ function elgg_enable_metadata(array $options) {
  *
  * @param array $options Array in format:
  *
- * 	metadata_names => NULL|ARR metadata names
+ * 	metadata_names => null|ARR metadata names
  *
- * 	metadata_values => NULL|ARR metadata values
+ * 	metadata_values => null|ARR metadata values
  *
- * 	metadata_name_value_pairs => NULL|ARR (
+ * 	metadata_name_value_pairs => null|ARR (
  *                                         name => 'name',
  *                                         value => 'value',
  *                                         'operand' => '=',
- *                                         'case_sensitive' => TRUE
+ *                                         'case_sensitive' => true
  *                                        )
  * 	                             Currently if multiple values are sent via
  *                               an array (value => array('value1', 'value2')
  *                               the pair's operand will be forced to "IN".
  *
- * 	metadata_name_value_pairs_operator => NULL|STR The operator to use for combining
+ * 	metadata_name_value_pairs_operator => null|STR The operator to use for combining
  *                                        (name = value) OPERATOR (name = value); default AND
  *
  * 	metadata_case_sensitive => BOOL Overall Case sensitive
  *
- *  order_by_metadata => NULL|ARR array(
+ *  order_by_metadata => null|ARR array(
  *                                      'name' => 'metadata_text1',
  *                                      'direction' => ASC|DESC,
  *                                      'as' => text|integer
  *                                     )
  *                                Also supports array('name' => 'metadata_text1')
  *
- *  metadata_owner_guids => NULL|ARR guids for metadata owners
+ *  metadata_owner_guids => null|ARR guids for metadata owners
  *
  * @return ElggEntity[]|mixed If count, int. If not count, array. false on errors.
  * @since 1.7.0
@@ -430,7 +430,7 @@ function elgg_get_entities_from_metadata(array $options = array()) {
 		'metadata_name_value_pairs'          => ELGG_ENTITIES_ANY_VALUE,
 
 		'metadata_name_value_pairs_operator' => 'AND',
-		'metadata_case_sensitive'            => TRUE,
+		'metadata_case_sensitive'            => true,
 		'order_by_metadata'                  => array(),
 
 		'metadata_owner_guids'               => ELGG_ENTITIES_ANY_VALUE,
@@ -444,7 +444,7 @@ function elgg_get_entities_from_metadata(array $options = array()) {
 	$options = _elgg_normalize_plural_options_array($options, $singulars);
 
 	if (!$options = _elgg_entities_get_metastrings_options('metadata', $options)) {
-		return FALSE;
+		return false;
 	}
 
 	return elgg_get_entities($options);
@@ -487,15 +487,15 @@ function elgg_list_entities_from_metadata($options) {
  * @since 1.7.0
  * @access private
  */
-function _elgg_get_entity_metadata_where_sql($e_table, $n_table, $names = NULL, $values = NULL,
-$pairs = NULL, $pair_operator = 'AND', $case_sensitive = TRUE, $order_by_metadata = NULL,
-$owner_guids = NULL) {
+function _elgg_get_entity_metadata_where_sql($e_table, $n_table, $names = null, $values = null,
+$pairs = null, $pair_operator = 'AND', $case_sensitive = true, $order_by_metadata = null,
+$owner_guids = null) {
 
 	global $CONFIG;
 
 	// short circuit if nothing requested
 	// 0 is a valid (if not ill-conceived) metadata name.
-	// 0 is also a valid metadata value for FALSE, NULL, or 0
+	// 0 is also a valid metadata value for false, null, or 0
 	// 0 is also a valid(ish) owner_guid
 	if ((!$names && $names !== 0)
 		&& (!$values && $values !== 0)
@@ -529,7 +529,7 @@ $owner_guids = NULL) {
 
 	// get names wheres and joins
 	$names_where = '';
-	if ($names !== NULL) {
+	if ($names !== null) {
 		if (!is_array($names)) {
 			$names = array($names);
 		}
@@ -551,7 +551,7 @@ $owner_guids = NULL) {
 
 	// get values wheres and joins
 	$values_where = '';
-	if ($values !== NULL) {
+	if ($values !== null) {
 		if (!is_array($values)) {
 			$values = array($values);
 		}

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -156,15 +156,15 @@ function _elgg_delete_orphaned_metastrings() {
  *
  * @param array $options Array in format:
  *
- * 	metastring_names              => NULL|ARR metastring names
+ * 	metastring_names              => null|ARR metastring names
  *
- * 	metastring_values             => NULL|ARR metastring values
+ * 	metastring_values             => null|ARR metastring values
  *
- * 	metastring_ids                => NULL|ARR metastring ids
+ * 	metastring_ids                => null|ARR metastring ids
  *
  * 	metastring_case_sensitive     => BOOL     Overall Case sensitive
  *
- *  metastring_owner_guids        => NULL|ARR Guids for metadata owners
+ *  metastring_owner_guids        => null|ARR Guids for metadata owners
  *
  *  metastring_created_time_lower => INT      Lower limit for created time.
  *
@@ -308,8 +308,8 @@ function _elgg_get_metastring_based_objects($options) {
 	// see if any functions failed
 	// remove empty strings on successful functions
 	foreach ($wheres as $i => $where) {
-		if ($where === FALSE) {
-			return FALSE;
+		if ($where === false) {
+			return false;
 		} elseif (empty($where)) {
 			unset($wheres[$i]);
 		}
@@ -350,8 +350,8 @@ function _elgg_get_metastring_based_objects($options) {
 	}
 
 	foreach ($joins as $i => $join) {
-		if ($join === FALSE) {
-			return FALSE;
+		if ($join === false) {
+			return false;
 		} elseif (empty($join)) {
 			unset($joins[$i]);
 		}
@@ -477,7 +477,7 @@ function _elgg_get_metastring_sql($table, $names = null, $values = null,
 
 	// get names wheres and joins
 	$names_where = '';
-	if ($names !== NULL) {
+	if ($names !== null) {
 		if (!is_array($names)) {
 			$names = array($names);
 		}
@@ -499,7 +499,7 @@ function _elgg_get_metastring_sql($table, $names = null, $values = null,
 
 	// get values wheres and joins
 	$values_where = '';
-	if ($values !== NULL) {
+	if ($values !== null) {
 		if (!is_array($values)) {
 			$values = array($values);
 		}
@@ -519,7 +519,7 @@ function _elgg_get_metastring_sql($table, $names = null, $values = null,
 		}
 	}
 
-	if ($ids !== NULL) {
+	if ($ids !== null) {
 		if (!is_array($ids)) {
 			$ids = array($ids);
 		}
@@ -765,7 +765,7 @@ function _elgg_delete_metastring_based_object_by_id($id, $type) {
 function _elgg_entities_get_metastrings_options($type, $options) {
 	$valid_types = array('metadata', 'annotation');
 	if (!in_array($type, $valid_types)) {
-		return FALSE;
+		return false;
 	}
 
 	// the options for annotations are singular (annotation_name) but the table

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -209,7 +209,7 @@ function elgg_register_title_button($handler = null, $name = 'add') {
  * @return void
  * @since 1.8.0
  */
-function elgg_push_breadcrumb($title, $link = NULL) {
+function elgg_push_breadcrumb($title, $link = null) {
 	global $CONFIG;
 	if (!isset($CONFIG->breadcrumbs)) {
 		$CONFIG->breadcrumbs = array();
@@ -232,7 +232,7 @@ function elgg_pop_breadcrumb() {
 		return array_pop($CONFIG->breadcrumbs);
 	}
 
-	return FALSE;
+	return false;
 }
 
 /**

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -236,7 +236,7 @@ elgg_register_event_handler('init', 'system', '_elgg_notifications_init');
  * @return array Compound array of each delivery user/delivery method's success or failure.
  * @access private
  */
-function _elgg_notify_user($to, $from, $subject, $message, array $params = NULL, $methods_override = "") {
+function _elgg_notify_user($to, $from, $subject, $message, array $params = null, $methods_override = "") {
 
 	$notify_service = _elgg_services()->notifications;
 
@@ -288,7 +288,7 @@ function _elgg_notify_user($to, $from, $subject, $message, array $params = NULL,
 					// Trigger handler and retrieve result.
 					try {
 						$result[$guid][$method] = call_user_func($handler,
-							$from ? get_entity($from) : NULL,
+							$from ? get_entity($from) : null,
 							get_entity($guid),
 							$subject,
 							$message,
@@ -484,7 +484,7 @@ function set_user_notification_setting($user_guid, $method, $value) {
  * @throws NotificationException
  * @since 1.7.2
  */
-function elgg_send_email($from, $to, $subject, $body, array $params = NULL) {
+function elgg_send_email($from, $to, $subject, $body, array $params = null) {
 	global $CONFIG;
 
 	if (!$from) {
@@ -503,7 +503,7 @@ function elgg_send_email($from, $to, $subject, $body, array $params = NULL) {
 		"Content-Transfer-Encoding" => "8bit",
 	);
 
-	// return TRUE/FALSE to stop elgg_send_email() from sending
+	// return true/false to stop elgg_send_email() from sending
 	$mail_params = array(
 		'to' => $to,
 		'from' => $from,
@@ -523,7 +523,7 @@ function elgg_send_email($from, $to, $subject, $body, array $params = NULL) {
 				${$key} = $result[$key];
 			}
 		}
-	} elseif ($result !== NULL) {
+	} elseif ($result !== null) {
 		return $result;
 	}
 

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -82,7 +82,7 @@ function elgg_get_excerpt($text, $num_chars = 250) {
 	$space = elgg_strrpos($excerpt, ' ', 0);
 
 	// don't crop if can't find a space.
-	if ($space === FALSE) {
+	if ($space === false) {
 		$space = $num_chars;
 	}
 	$excerpt = trim(elgg_substr($excerpt, 0, $space));
@@ -132,12 +132,12 @@ function elgg_format_attributes(array $attrs) {
 	foreach ($attrs as $attr => $val) {
 		$attr = strtolower($attr);
 
-		if ($val === TRUE) {
-			$val = $attr; //e.g. checked => TRUE ==> checked="checked"
+		if ($val === true) {
+			$val = $attr; //e.g. checked => true ==> checked="checked"
 		}
 
 		// ignore $vars['entity'] => ElggEntity stuff
-		if ($val !== NULL && $val !== false && (is_array($val) || !is_object($val))) {
+		if ($val !== null && $val !== false && (is_array($val) || !is_object($val))) {
 
 			// allow $vars['class'] => array('one', 'two');
 			// @todo what about $vars['style']? Needs to be semi-colon separated...
@@ -275,7 +275,7 @@ function elgg_get_friendly_title($title) {
 
 	// return a URL friendly title to short circuit normal title formatting
 	$params = array('title' => $title);
-	$result = elgg_trigger_plugin_hook('format', 'friendly:title', $params, NULL);
+	$result = elgg_trigger_plugin_hook('format', 'friendly:title', $params, null);
 	if ($result) {
 		return $result;
 	}
@@ -307,7 +307,7 @@ function elgg_get_friendly_time($time, $current_time = null) {
 
 	// return a time string to short circuit normal time formatting
 	$params = array('time' => $time, 'current_time' => $current_time);
-	$result = elgg_trigger_plugin_hook('format', 'friendly:time', $params, NULL);
+	$result = elgg_trigger_plugin_hook('format', 'friendly:time', $params, null);
 	if ($result) {
 		return $result;
 	}

--- a/engine/lib/pageowner.php
+++ b/engine/lib/pageowner.php
@@ -27,7 +27,7 @@ function elgg_get_page_owner_guid($guid = 0) {
 	}
 
 	// return guid of page owner entity
-	$guid = (int)elgg_trigger_plugin_hook('page_owner', 'system', NULL, 0);
+	$guid = (int)elgg_trigger_plugin_hook('page_owner', 'system', null, 0);
 
 	if ($guid) {
 		$page_owner_guid = $guid;
@@ -137,7 +137,7 @@ function default_page_owner_handler($hook, $entity_type, $returnvalue, $params) 
 	}
 
 	// @todo feels hacky
-	if (get_input('page', FALSE)) {
+	if (get_input('page', false)) {
 		$segments = explode('/', $path);
 		if (isset($segments[1]) && isset($segments[2])) {
 			switch ($segments[1]) {
@@ -217,7 +217,7 @@ function elgg_set_context($context) {
  *
  * Since context is a stack, this is equivalent to a peek.
  *
- * @return string|NULL
+ * @return string|null
  * @since 1.8.0
  */
 function elgg_get_context() {
@@ -246,7 +246,7 @@ function elgg_push_context($context) {
 /**
  * Removes and returns the top context string from the stack
  *
- * @return string|NULL
+ * @return string|null
  * @since 1.8.0
  */
 function elgg_pop_context() {
@@ -288,7 +288,7 @@ function page_owner_boot() {
 	// Bootstrap the context stack by setting its first entry to the handler.
 	// This is the first segment of the URL and the handler is set by the rewrite rules.
 	// @todo this does not work for actions
-	$handler = get_input('handler', FALSE);
+	$handler = get_input('handler', false);
 	if ($handler) {
 		elgg_set_context($handler);
 	}

--- a/engine/lib/pam.php
+++ b/engine/lib/pam.php
@@ -33,7 +33,7 @@ $_PAM_HANDLERS = array();
  * Note, $handler must be string callback (not an array/Closure).
  *
  * @param string $handler    Callable global handler function in the format ()
- * 		                     pam_handler($credentials = NULL);
+ * 		                     pam_handler($credentials = null);
  * @param string $importance The importance - "sufficient" (default) or "required"
  * @param string $policy     The policy type, default is "user"
  *

--- a/engine/lib/plugins.php
+++ b/engine/lib/plugins.php
@@ -552,7 +552,7 @@ function elgg_get_calling_plugin_id($mainfilename = false) {
 		}
 	} else {
 		//@todo this is a hack -- plugins do not have to match their page handler names!
-		if ($handler = get_input('handler', FALSE)) {
+		if ($handler = get_input('handler', false)) {
 			return $handler;
 		} else {
 			$file = $_SERVER["SCRIPT_NAME"];
@@ -1023,13 +1023,13 @@ function elgg_unset_all_plugin_settings($plugin_id = null) {
  *
  * @param array $options Array in the format:
  *
- * 	plugin_id => NULL|STR The plugin id. Defaults to calling plugin
+ * 	plugin_id => null|STR The plugin id. Defaults to calling plugin
  *
- * 	plugin_user_setting_names => NULL|ARR private setting names
+ * 	plugin_user_setting_names => null|ARR private setting names
  *
- * 	plugin_user_setting_values => NULL|ARR metadata values
+ * 	plugin_user_setting_values => null|ARR metadata values
  *
- * 	plugin_user_setting_name_value_pairs => NULL|ARR (
+ * 	plugin_user_setting_name_value_pairs => null|ARR (
  *                                         name => 'name',
  *                                         value => 'value',
  *                                         'operand' => '=',
@@ -1038,7 +1038,7 @@ function elgg_unset_all_plugin_settings($plugin_id = null) {
  *                               an array (value => array('value1', 'value2')
  *                               the pair's operand will be forced to "IN".
  *
- * 	plugin_user_setting_name_value_pairs_operator => NULL|STR The operator to use for combining
+ * 	plugin_user_setting_name_value_pairs_operator => null|STR The operator to use for combining
  *                                        (name = value) OPERATOR (name = value); default AND
  *
  * @return mixed int If count, int. If not count, array. false on errors.

--- a/engine/lib/private_settings.php
+++ b/engine/lib/private_settings.php
@@ -17,11 +17,11 @@
  *
  * @param array $options Array in format:
  *
- * 	private_setting_names => NULL|ARR private setting names
+ * 	private_setting_names => null|ARR private setting names
  *
- * 	private_setting_values => NULL|ARR metadata values
+ * 	private_setting_values => null|ARR metadata values
  *
- * 	private_setting_name_value_pairs => NULL|ARR (
+ * 	private_setting_name_value_pairs => null|ARR (
  *                                         name => 'name',
  *                                         value => 'value',
  *                                         'operand' => '=',
@@ -30,7 +30,7 @@
  *                               an array (value => array('value1', 'value2')
  *                               the pair's operand will be forced to "IN".
  *
- * 	private_setting_name_value_pairs_operator => NULL|STR The operator to use for combining
+ * 	private_setting_name_value_pairs_operator => null|STR The operator to use for combining
  *                                        (name = value) OPERATOR (name = value); default AND
  *
  *  private_setting_name_prefix => STR A prefix to apply to all private settings. Used to
@@ -97,8 +97,8 @@ function elgg_get_entities_from_private_settings(array $options = array()) {
  * @since 1.8.0
  * @access private
  */
-function elgg_get_entity_private_settings_where_sql($table, $names = NULL, $values = NULL,
-$pairs = NULL, $pair_operator = 'AND', $name_prefix = '') {
+function elgg_get_entity_private_settings_where_sql($table, $names = null, $values = null,
+$pairs = null, $pair_operator = 'AND', $name_prefix = '') {
 
 	global $CONFIG;
 
@@ -116,7 +116,7 @@ $pairs = NULL, $pair_operator = 'AND', $name_prefix = '') {
 
 	// get names wheres
 	$names_where = '';
-	if ($names !== NULL) {
+	if ($names !== null) {
 		if (!is_array($names)) {
 			$names = array($names);
 		}
@@ -135,7 +135,7 @@ $pairs = NULL, $pair_operator = 'AND', $name_prefix = '') {
 
 	// get values wheres
 	$values_where = '';
-	if ($values !== NULL) {
+	if ($values !== null) {
 		if (!is_array($values)) {
 			$values = array($values);
 		}

--- a/engine/lib/relationships.php
+++ b/engine/lib/relationships.php
@@ -236,7 +236,7 @@ function remove_entity_relationships($guid_one, $relationship = "", $inverse = f
  *
  * @return ElggRelationship[]
  */
-function get_entity_relationships($guid, $inverse_relationship = FALSE) {
+function get_entity_relationships($guid, $inverse_relationship = false) {
 	global $CONFIG;
 
 	$guid = (int)$guid;
@@ -267,13 +267,13 @@ function get_entity_relationships($guid, $inverse_relationship = FALSE) {
  *
  * @param array $options Array in format:
  *
- * 	relationship => NULL|STR relationship
+ * 	relationship => null|STR relationship
  *
- * 	relationship_guid => NULL|INT Guid of relationship to test
+ * 	relationship_guid => null|INT Guid of relationship to test
  *
  * 	inverse_relationship => BOOL Inverse the relationship
  * 
- *  relationship_join_on => NULL|STR How the entities relate: guid (default), container_guid, or owner_guid
+ *  relationship_join_on => null|STR How the entities relate: guid (default), container_guid, or owner_guid
  *                          Add in Elgg 1.9.0. Examples using the relationship 'friend':
  *                          1. use 'guid' if you want the user's friends
  *                          2. use 'owner_guid' if you want the entities the user's friends own (including in groups)
@@ -284,9 +284,9 @@ function get_entity_relationships($guid, $inverse_relationship = FALSE) {
  */
 function elgg_get_entities_from_relationship($options) {
 	$defaults = array(
-		'relationship' => NULL,
-		'relationship_guid' => NULL,
-		'inverse_relationship' => FALSE,
+		'relationship' => null,
+		'relationship_guid' => null,
+		'inverse_relationship' => false,
 		'relationship_join_on' => 'guid',
 	);
 
@@ -344,10 +344,10 @@ function elgg_get_entities_from_relationship($options) {
  * @since 1.7.0
  * @access private
  */
-function elgg_get_entity_relationship_where_sql($column, $relationship = NULL,
-$relationship_guid = NULL, $inverse_relationship = FALSE) {
+function elgg_get_entity_relationship_where_sql($column, $relationship = null,
+$relationship_guid = null, $inverse_relationship = false) {
 
-	if ($relationship == NULL && $relationship_guid == NULL) {
+	if ($relationship == null && $relationship_guid == null) {
 		return '';
 	}
 

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -218,8 +218,8 @@ function elgg_delete_river(array $options = array()) {
 	// see if any functions failed
 	// remove empty strings on successful functions
 	foreach ($wheres as $i => $where) {
-		if ($where === FALSE) {
-			return FALSE;
+		if ($where === false) {
+			return false;
 		} elseif (empty($where)) {
 			unset($wheres[$i]);
 		}
@@ -294,9 +294,9 @@ function elgg_get_river(array $options = array()) {
 		'annotation_ids'       => ELGG_ENTITIES_ANY_VALUE,
 		'action_types'         => ELGG_ENTITIES_ANY_VALUE,
 
-		'relationship'         => NULL,
-		'relationship_guid'    => NULL,
-		'inverse_relationship' => FALSE,
+		'relationship'         => null,
+		'relationship_guid'    => null,
+		'inverse_relationship' => false,
 
 		'types'	               => ELGG_ENTITIES_ANY_VALUE,
 		'subtypes'             => ELGG_ENTITIES_ANY_VALUE,
@@ -307,7 +307,7 @@ function elgg_get_river(array $options = array()) {
 
 		'limit'                => 20,
 		'offset'               => 0,
-		'count'                => FALSE,
+		'count'                => false,
 
 		'order_by'             => 'rv.posted desc',
 		'group_by'             => ELGG_ENTITIES_ANY_VALUE,
@@ -357,8 +357,8 @@ function elgg_get_river(array $options = array()) {
 	// see if any functions failed
 	// remove empty strings on successful functions
 	foreach ($wheres as $i => $where) {
-		if ($where === FALSE) {
-			return FALSE;
+		if ($where === false) {
+			return false;
 		} elseif (empty($where)) {
 			unset($wheres[$i]);
 		}
@@ -477,17 +477,17 @@ function elgg_list_river(array $options = array()) {
 	$defaults = array(
 		'offset'     => (int) max(get_input('offset', 0), 0),
 		'limit'      => (int) max(get_input('limit', 20), 0),
-		'pagination' => TRUE,
+		'pagination' => true,
 		'list_class' => 'elgg-list-river',
 		'no_results' => '',
 	);
 
 	$options = array_merge($defaults, $options);
 
-	$options['count'] = TRUE;
+	$options['count'] = true;
 	$count = elgg_get_river($options);
 
-	$options['count'] = FALSE;
+	$options['count'] = false;
 	$items = elgg_get_river($options);
 
 	$options['count'] = $count;
@@ -507,7 +507,7 @@ function elgg_list_river(array $options = array()) {
  */
 function _elgg_row_to_elgg_river_item($row) {
 	if (!($row instanceof stdClass)) {
-		return NULL;
+		return null;
 	}
 
 	return new ElggRiverItem($row);
@@ -534,9 +534,9 @@ function elgg_river_get_access_sql() {
  * which could be used for all queries once the subtypes have been denormalized.
  *
  * @param string     $table    'rv'
- * @param NULL|array $types    Array of types or NULL if none.
- * @param NULL|array $subtypes Array of subtypes or NULL if none
- * @param NULL|array $pairs    Array of pairs of types and subtypes
+ * @param null|array $types    Array of types or null if none.
+ * @param null|array $subtypes Array of subtypes or null if none
+ * @param null|array $pairs    Array of pairs of types and subtypes
  *
  * @return string
  * @since 1.8.0

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -25,7 +25,7 @@ function elgg_get_session() {
 }
 
 /**
- * Return the current logged in user, or NULL if no user is logged in.
+ * Return the current logged in user, or null if no user is logged in.
  *
  * @warning The plugin hook described below is deprecated
  * If no user can be found in the current session, a plugin
@@ -77,10 +77,10 @@ function elgg_is_admin_logged_in() {
 	$user = elgg_get_logged_in_user_entity();
 
 	if ((elgg_is_logged_in()) && $user->isAdmin()) {
-		return TRUE;
+		return true;
 	}
 
-	return FALSE;
+	return false;
 }
 
 /**
@@ -154,10 +154,10 @@ function elgg_is_admin_user($user_guid) {
 	// normalizing the results from get_data()
 	// See #1242
 	$info = get_data($query);
-	if (!((is_array($info) && count($info) < 1) || $info === FALSE)) {
-		return TRUE;
+	if (!((is_array($info) && count($info) < 1) || $info === false)) {
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
 /**
@@ -422,7 +422,7 @@ function logout() {
 	$session->invalidate();
 	$session->set('msg', $old_msg);
 
-	return TRUE;
+	return true;
 }
 
 /**

--- a/engine/lib/sites.php
+++ b/engine/lib/sites.php
@@ -126,7 +126,7 @@ function get_site_objects($site_guid, $subtype = "", $limit = 10, $offset = 0) {
 	return elgg_get_entities_from_relationship(array(
 		'relationship' => 'member_of_site',
 		'relationship_guid' => $site_guid,
-		'inverse_relationship' => TRUE,
+		'inverse_relationship' => true,
 		'type' => 'object',
 		'subtype' => $subtype,
 		'limit' => $limit,

--- a/engine/lib/tags.php
+++ b/engine/lib/tags.php
@@ -108,26 +108,26 @@ function generate_tag_cloud(array $tags, $buckets = 6) {
  *
  * 	limit => INT number of tags to return
  *
- *  types => NULL|STR entity type (SQL: type = '$type')
+ *  types => null|STR entity type (SQL: type = '$type')
  *
- * 	subtypes => NULL|STR entity subtype (SQL: subtype = '$subtype')
+ * 	subtypes => null|STR entity subtype (SQL: subtype = '$subtype')
  *
- * 	type_subtype_pairs => NULL|ARR (array('type' => 'subtype'))
+ * 	type_subtype_pairs => null|ARR (array('type' => 'subtype'))
  *  (SQL: type = '$type' AND subtype = '$subtype') pairs
  *
- * 	owner_guids => NULL|INT entity guid
+ * 	owner_guids => null|INT entity guid
  *
- * 	container_guids => NULL|INT container_guid
+ * 	container_guids => null|INT container_guid
  *
- * 	site_guids => NULL (current_site)|INT site_guid
+ * 	site_guids => null (current_site)|INT site_guid
  *
- * 	created_time_lower => NULL|INT Created time lower boundary in epoch time
+ * 	created_time_lower => null|INT Created time lower boundary in epoch time
  *
- * 	created_time_upper => NULL|INT Created time upper boundary in epoch time
+ * 	created_time_upper => null|INT Created time upper boundary in epoch time
  *
- * 	modified_time_lower => NULL|INT Modified time lower boundary in epoch time
+ * 	modified_time_lower => null|INT Modified time lower boundary in epoch time
  *
- * 	modified_time_upper => NULL|INT Modified time upper boundary in epoch time
+ * 	modified_time_upper => null|INT Modified time upper boundary in epoch time
  *
  * 	wheres => array() Additional where clauses to AND together
  *
@@ -209,8 +209,8 @@ function elgg_get_tags(array $options = array()) {
 	// see if any functions failed
 	// remove empty strings on successful functions
 	foreach ($wheres as $i => $where) {
-		if ($where === FALSE) {
-			return FALSE;
+		if ($where === false) {
+			return false;
 		} elseif (empty($where)) {
 			unset($wheres[$i]);
 		}
@@ -229,8 +229,8 @@ function elgg_get_tags(array $options = array()) {
 	$joins = array_unique($joins);
 
 	foreach ($joins as $i => $join) {
-		if ($join === FALSE) {
-			return FALSE;
+		if ($join === false) {
+			return false;
 		} elseif (empty($join)) {
 			unset($joins[$i]);
 		}
@@ -318,7 +318,7 @@ function elgg_register_tag_metadata_name($name) {
 		$CONFIG->registered_tag_metadata_names[] = $name;
 	}
 
-	return TRUE;
+	return true;
 }
 
 /**

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -97,10 +97,10 @@ function ban_user($user_guid, $reason = "") {
 			return update_data($query);
 		}
 
-		return FALSE;
+		return false;
 	}
 
-	return FALSE;
+	return false;
 }
 
 /**
@@ -136,10 +136,10 @@ function unban_user($user_guid) {
 			return update_data($query);
 		}
 
-		return FALSE;
+		return false;
 	}
 
-	return FALSE;
+	return false;
 }
 
 /**
@@ -172,10 +172,10 @@ function make_user_admin($user_guid) {
 			return $r;
 		}
 
-		return FALSE;
+		return false;
 	}
 
-	return FALSE;
+	return false;
 }
 
 /**
@@ -208,10 +208,10 @@ function remove_user_admin($user_guid) {
 			return $r;
 		}
 
-		return FALSE;
+		return false;
 	}
 
-	return FALSE;
+	return false;
 }
 
 /**
@@ -232,7 +232,7 @@ function get_user_sites($user_guid, $limit = 10, $offset = 0) {
 		'site_guids' => ELGG_ENTITIES_ANY_VALUE,
 		'relationship' => 'member_of_site',
 		'relationship_guid' => $user_guid,
-		'inverse_relationship' => FALSE,
+		'inverse_relationship' => false,
 		'type' => 'site',
 		'limit' => $limit,
 		'offset' => $offset,
@@ -339,7 +339,7 @@ $offset = 0) {
 	return elgg_get_entities_from_relationship(array(
 		'relationship' => 'friend',
 		'relationship_guid' => $user_guid,
-		'inverse_relationship' => TRUE,
+		'inverse_relationship' => true,
 		'type' => 'user',
 		'subtype' => $subtype,
 		'limit' => $limit,
@@ -476,7 +476,7 @@ function find_active_users($seconds = 600, $limit = 10, $offset = 0, $count = fa
 	$limit = (int)$limit;
 	$offset = (int)$offset;
 	$params = array('seconds' => $seconds, 'limit' => $limit, 'offset' => $offset, 'count' => $count);
-	$data = elgg_trigger_plugin_hook('find_active_users', 'system', $params, NULL);
+	$data = elgg_trigger_plugin_hook('find_active_users', 'system', $params, null);
 	if (!$data) {
 		global $CONFIG;
 
@@ -585,7 +585,7 @@ function execute_new_password_request($user_guid, $conf_code) {
 		}
 	}
 
-	return FALSE;
+	return false;
 }
 
 /**
@@ -1212,7 +1212,7 @@ function elgg_profile_fields_setup() {
 		$profile_defaults = $loaded_defaults;
 	}
 
-	$CONFIG->profile_fields = elgg_trigger_plugin_hook('profile:fields', 'profile', NULL, $profile_defaults);
+	$CONFIG->profile_fields = elgg_trigger_plugin_hook('profile:fields', 'profile', null, $profile_defaults);
 
 	// register any tag metadata names
 	foreach ($CONFIG->profile_fields as $name => $type) {
@@ -1353,7 +1353,7 @@ function users_pagesetup() {
 			'name' => 'logout',
 			'href' => "action/logout",
 			'text' => elgg_echo('logout'),
-			'is_action' => TRUE,
+			'is_action' => true,
 			'priority' => 1000,
 			'section' => 'alt',
 		));

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -483,7 +483,7 @@ function find_active_users($seconds = 600, $limit = 10, $offset = 0, $count = fa
 		$time = time() - $seconds;
 
 		$data = elgg_get_entities(array(
-			'type' => 'user', 
+			'type' => 'user',
 			'limit' => $limit,
 			'offset' => $offset,
 			'count' => $count,
@@ -540,7 +540,7 @@ function force_user_password_reset($user_guid, $password) {
 		$ia = elgg_set_ignore_access();
 
 		$user->salt = generate_random_cleartext_password();
-		$hash = generate_user_password($user, $password);		
+		$hash = generate_user_password($user, $password);
 		$user->password = $hash;
 		$result = (bool)$user->save();
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1377,7 +1377,7 @@ function elgg_views_boot() {
 
 	elgg_register_simplecache_view('js/text.js');
 
-	elgg_register_js('require', '/vendors/requirejs/require-2.1.4.min.js', 'head'); 
+	elgg_register_js('require', '/vendors/requirejs/require-2.1.4.min.js', 'head');
 	elgg_register_js('jquery', '/vendors/jquery/jquery-1.9.1.min.js', 'head');
 	elgg_register_js('jquery-migrate', '/vendors/jquery/jquery-migrate-1.2.1.min.js', 'head');
 	elgg_register_js('jquery-ui', '/vendors/jquery/jquery-ui-1.10.3.min.js', 'head');

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -143,7 +143,7 @@ function elgg_is_registered_viewtype($viewtype) {
 	global $CONFIG;
 
 	if (!isset($CONFIG->view_types) || !is_array($CONFIG->view_types)) {
-		return FALSE;
+		return false;
 	}
 
 	return in_array($viewtype, $CONFIG->view_types);
@@ -426,7 +426,7 @@ function elgg_view_page($title, $body, $page_shell = 'default', $vars = array())
 	$messages = null;
 	if (count_messages()) {
 		// get messages - try for errors first
-		$messages = system_messages(NULL, "error");
+		$messages = system_messages(null, "error");
 		if (count($messages["error"]) == 0) {
 			// no errors so grab rest of messages
 			$messages = system_messages(null, "");
@@ -1430,12 +1430,12 @@ function elgg_views_boot() {
 	// set default icon sizes - can be overridden in settings.php or with plugin
 	if (!isset($CONFIG->icon_sizes)) {
 		$icon_sizes = array(
-			'topbar' => array('w' => 16, 'h' => 16, 'square' => TRUE, 'upscale' => TRUE),
-			'tiny' => array('w' => 25, 'h' => 25, 'square' => TRUE, 'upscale' => TRUE),
-			'small' => array('w' => 40, 'h' => 40, 'square' => TRUE, 'upscale' => TRUE),
-			'medium' => array('w' => 100, 'h' => 100, 'square' => TRUE, 'upscale' => TRUE),
-			'large' => array('w' => 200, 'h' => 200, 'square' => FALSE, 'upscale' => FALSE),
-			'master' => array('w' => 550, 'h' => 550, 'square' => FALSE, 'upscale' => FALSE),
+			'topbar' => array('w' => 16, 'h' => 16, 'square' => true, 'upscale' => true),
+			'tiny' => array('w' => 25, 'h' => 25, 'square' => true, 'upscale' => true),
+			'small' => array('w' => 40, 'h' => 40, 'square' => true, 'upscale' => true),
+			'medium' => array('w' => 100, 'h' => 100, 'square' => true, 'upscale' => true),
+			'large' => array('w' => 200, 'h' => 200, 'square' => false, 'upscale' => false),
+			'master' => array('w' => 550, 'h' => 550, 'square' => false, 'upscale' => false),
 		);
 		elgg_set_config('icon_sizes', $icon_sizes);
 	}

--- a/engine/settings.example.php
+++ b/engine/settings.example.php
@@ -117,23 +117,23 @@ $CONFIG->dbprefix = '{{dbprefix}}';
  * Use non-standard headers for broken MTAs.
  *
  * The default header EOL for headers is \r\n.  This causes problems
- * on some broken MTAs.  Setting this to TRUE will cause Elgg to use
+ * on some broken MTAs.  Setting this to true will cause Elgg to use
  * \n, which will fix some problems sending email on broken MTAs.
  *
  * @global bool $CONFIG->broken_mta
  */
-$CONFIG->broken_mta = FALSE;
+$CONFIG->broken_mta = false;
 
 /**
  * Disable the database query cache
  *
  * Elgg stores each query and its results in a query cache.
  * On large sites or long-running scripts, this cache can grow to be
- * large.  To disable query caching, set this to TRUE.
+ * large.  To disable query caching, set this to true.
  *
  * @global bool $CONFIG->db_disable_query_cache
  */
-$CONFIG->db_disable_query_cache = FALSE;
+$CONFIG->db_disable_query_cache = false;
 
 /**
  * Minimum password length

--- a/engine/tests/ElggCoreAccessCollectionsTest.php
+++ b/engine/tests/ElggCoreAccessCollectionsTest.php
@@ -270,6 +270,6 @@ class ElggCoreAccessCollectionsTest extends ElggCoreUnitTest {
 			$this->assertNotEqual($access, $access2, "Access test for $func");
 		}
 
-		$user->delete();	
+		$user->delete();
 	}
 }

--- a/engine/tests/ElggCoreEntityGetterFunctionsTest.php
+++ b/engine/tests/ElggCoreEntityGetterFunctionsTest.php
@@ -10,7 +10,7 @@ class ElggCoreEntityGetterFunctionsTest extends ElggCoreUnitTest {
 	 * Called before each test object.
 	 */
 	public function __construct() {
-		elgg_set_ignore_access(TRUE);
+		elgg_set_ignore_access(true);
 		$this->entities = array();
 		$this->subtypes = array(
 			'object' => array(),
@@ -64,14 +64,14 @@ class ElggCoreEntityGetterFunctionsTest extends ElggCoreUnitTest {
 	 * Called after each test method.
 	 */
 	public function setUp() {
-		return TRUE;
+		return true;
 	}
 
 	/**
 	 * Called after each test method.
 	 */
 	public function tearDown() {
-		return TRUE;
+		return true;
 	}
 
 	/**
@@ -644,7 +644,7 @@ class ElggCoreEntityGetterFunctionsTest extends ElggCoreUnitTest {
 
 
 	/****************************
-	 * FALSE-RETURNING TESTS
+	 * false-RETURNING TESTS
 	 ****************************
 	 * The original bug corrected returned
 	 * all entities when invalid subtypes were passed.
@@ -782,7 +782,7 @@ class ElggCoreEntityGetterFunctionsTest extends ElggCoreUnitTest {
 		$pair = array();
 
 		foreach ($types as $type) {
-			$pair[$type] = NULL;
+			$pair[$type] = null;
 		}
 
 		$options = array(
@@ -799,7 +799,7 @@ class ElggCoreEntityGetterFunctionsTest extends ElggCoreUnitTest {
 
 		$pair = array();
 		foreach ($types as $type) {
-			$pair[$type] = NULL;
+			$pair[$type] = null;
 		}
 
 		$options = array(

--- a/engine/tests/ElggCoreEntityTest.php
+++ b/engine/tests/ElggCoreEntityTest.php
@@ -31,16 +31,16 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 	 */
 	public function testElggEntityAttributes() {
 		$test_attributes = array();
-		$test_attributes['guid'] = NULL;
-		$test_attributes['type'] = NULL;
-		$test_attributes['subtype'] = NULL;
+		$test_attributes['guid'] = null;
+		$test_attributes['type'] = null;
+		$test_attributes['subtype'] = null;
 		$test_attributes['owner_guid'] = elgg_get_logged_in_user_guid();
 		$test_attributes['container_guid'] = elgg_get_logged_in_user_guid();
-		$test_attributes['site_guid'] = NULL;
+		$test_attributes['site_guid'] = null;
 		$test_attributes['access_id'] = ACCESS_PRIVATE;
-		$test_attributes['time_created'] = NULL;
-		$test_attributes['time_updated'] = NULL;
-		$test_attributes['last_action'] = NULL;
+		$test_attributes['time_created'] = null;
+		$test_attributes['time_updated'] = null;
+		$test_attributes['last_action'] = null;
 		$test_attributes['enabled'] = 'yes';
 		$test_attributes['tables_split'] = 1;
 		$test_attributes['tables_loaded'] = 0;
@@ -141,7 +141,7 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 		$this->assertIdentical($annotations, elgg_get_annotations(array('guid' => $this->entity->getGUID())));
 		$this->assertIdentical($annotations, elgg_get_annotations(array('guid' => $this->entity->getGUID(), 'type' => 'site')));
 		$this->assertIdentical($annotations, elgg_get_annotations(array('guid' => $this->entity->getGUID(), 'type' => 'site', 'subtype' => 'testing')));
-		$this->assertIdentical(FALSE, elgg_get_annotations(array('guid' => $this->entity->getGUID(), 'type' => 'site', 'subtype' => 'fail')));
+		$this->assertIdentical(false, elgg_get_annotations(array('guid' => $this->entity->getGUID(), 'type' => 'site', 'subtype' => 'fail')));
 
 		//  clear annotation
 		$this->assertTrue($this->entity->deleteAnnotations());
@@ -170,7 +170,7 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 		// error on save
 		try {
 			$this->entity->save();
-			$this->assertTrue(FALSE);
+			$this->assertTrue(false);
 		} catch (Exception $e) {
 			$this->assertIsA($e, 'InvalidParameterException');
 		}

--- a/engine/tests/ElggCoreHelpersTest.php
+++ b/engine/tests/ElggCoreHelpersTest.php
@@ -57,7 +57,7 @@ class ElggCoreHelpersTest extends ElggCoreUnitTest {
 
 		$entity->delete();
 
-		$bad_entity = FALSE;
+		$bad_entity = false;
 		$this->assertFalse(elgg_instanceof($bad_entity));
 		$this->assertFalse(elgg_instanceof($bad_entity, 'object'));
 		$this->assertFalse(elgg_instanceof($bad_entity, 'object', 'test_subtype'));

--- a/engine/tests/ElggCoreMetadataAPITest.php
+++ b/engine/tests/ElggCoreMetadataAPITest.php
@@ -33,11 +33,11 @@ class ElggCoreMetadataAPITest extends ElggCoreUnitTest {
 		}
 
 		// lookup metastring id
-		$cs_ids = elgg_get_metastring_id('metaUnitTest', TRUE);
+		$cs_ids = elgg_get_metastring_id('metaUnitTest', true);
 		$this->assertEqual($cs_ids, $this->metastrings['metaUnitTest']);
 
 		// lookup all metastrings, ignoring case
-		$cs_ids = elgg_get_metastring_id('metaUnitTest', FALSE);
+		$cs_ids = elgg_get_metastring_id('metaUnitTest', false);
 		$this->assertEqual(count($cs_ids), 3);
 		$this->assertEqual(count($cs_ids), count($this->metastrings));
 		foreach ($cs_ids as $string )
@@ -59,15 +59,15 @@ class ElggCoreMetadataAPITest extends ElggCoreUnitTest {
 		$this->assertNotEqual(false, create_metadata($this->object->guid, 'metaUnitTest', 'tested'));
 
 		// check value with improper case
-		$options = array('metadata_names' => 'metaUnitTest', 'metadata_values' => 'Tested', 'limit' => 10, 'metadata_case_sensitive' => TRUE);
+		$options = array('metadata_names' => 'metaUnitTest', 'metadata_values' => 'Tested', 'limit' => 10, 'metadata_case_sensitive' => true);
 		$this->assertIdentical(array(), elgg_get_entities_from_metadata($options));
 
 		// compare forced case with ignored case
-		$options = array('metadata_names' => 'metaUnitTest', 'metadata_values' => 'tested', 'limit' => 10, 'metadata_case_sensitive' => TRUE);
+		$options = array('metadata_names' => 'metaUnitTest', 'metadata_values' => 'tested', 'limit' => 10, 'metadata_case_sensitive' => true);
 		$case_true = elgg_get_entities_from_metadata($options);
 		$this->assertIsA($case_true, 'array');
 
-		$options = array('metadata_names' => 'metaUnitTest', 'metadata_values' => 'Tested', 'limit' => 10, 'metadata_case_sensitive' => FALSE);
+		$options = array('metadata_names' => 'metaUnitTest', 'metadata_values' => 'Tested', 'limit' => 10, 'metadata_case_sensitive' => false);
 		$case_false = elgg_get_entities_from_metadata($options);
 		$this->assertIsA($case_false, 'array');
 

--- a/engine/tests/ElggCoreObjectTest.php
+++ b/engine/tests/ElggCoreObjectTest.php
@@ -37,21 +37,21 @@ class ElggCoreObjectTest extends ElggCoreUnitTest {
 
 	public function testElggObjectConstructor() {
 		$attributes = array();
-		$attributes['guid'] = NULL;
+		$attributes['guid'] = null;
 		$attributes['type'] = 'object';
-		$attributes['subtype'] = NULL;
+		$attributes['subtype'] = null;
 		$attributes['owner_guid'] = elgg_get_logged_in_user_guid();
 		$attributes['container_guid'] = elgg_get_logged_in_user_guid();
-		$attributes['site_guid'] = NULL;
+		$attributes['site_guid'] = null;
 		$attributes['access_id'] = ACCESS_PRIVATE;
-		$attributes['time_created'] = NULL;
-		$attributes['time_updated'] = NULL;
-		$attributes['last_action'] = NULL;
+		$attributes['time_created'] = null;
+		$attributes['time_updated'] = null;
+		$attributes['last_action'] = null;
 		$attributes['enabled'] = 'yes';
 		$attributes['tables_split'] = 2;
 		$attributes['tables_loaded'] = 0;
-		$attributes['title'] = NULL;
-		$attributes['description'] = NULL;
+		$attributes['title'] = null;
+		$attributes['description'] = null;
 		ksort($attributes);
 
 		$entity_attributes = $this->entity->expose_attributes();
@@ -87,7 +87,7 @@ class ElggCoreObjectTest extends ElggCoreUnitTest {
 		// fail on wrong type
 		try {
 			$error = new ElggObjectTest(elgg_get_logged_in_user_guid());
-			$this->assertTrue(FALSE);
+			$this->assertTrue(false);
 		} catch (Exception $e) {
 			$this->assertIsA($e, 'InvalidClassException');
 		}

--- a/engine/tests/ElggCoreRegressionBugsTest.php
+++ b/engine/tests/ElggCoreRegressionBugsTest.php
@@ -12,7 +12,7 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 	 * Called before each test object.
 	 */
 	public function __construct() {
-		$this->ia = elgg_set_ignore_access(TRUE);
+		$this->ia = elgg_set_ignore_access(true);
 		parent::__construct();
 
 		// all __construct() code should come after here
@@ -59,8 +59,8 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 		$options = array(
 			'maxwidth' => 50,
 			'maxheight' => 50,
-			'square' => TRUE,
-			'upscale' => FALSE,
+			'square' => true,
+			'upscale' => false,
 
 			'x1' => 25,
 			'y1' => 75,
@@ -80,8 +80,8 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 		$options = array(
 			'maxwidth' => 50,
 			'maxheight' => 50,
-			'square' => TRUE,
-			'upscale' => FALSE,
+			'square' => true,
+			'upscale' => false,
 
 			'x1' => 75,
 			'y1' => 125,

--- a/engine/tests/ElggCoreSiteTest.php
+++ b/engine/tests/ElggCoreSiteTest.php
@@ -37,22 +37,22 @@ class ElggCoreSiteTest extends ElggCoreUnitTest {
 
 	public function testElggSiteConstructor() {
 		$attributes = array();
-		$attributes['guid'] = NULL;
+		$attributes['guid'] = null;
 		$attributes['type'] = 'site';
-		$attributes['subtype'] = NULL;
+		$attributes['subtype'] = null;
 		$attributes['owner_guid'] = elgg_get_logged_in_user_guid();
 		$attributes['container_guid'] = elgg_get_logged_in_user_guid();
-		$attributes['site_guid'] = NULL;
+		$attributes['site_guid'] = null;
 		$attributes['access_id'] = ACCESS_PRIVATE;
-		$attributes['time_created'] = NULL;
-		$attributes['time_updated'] = NULL;
-		$attributes['last_action'] = NULL;
+		$attributes['time_created'] = null;
+		$attributes['time_updated'] = null;
+		$attributes['last_action'] = null;
 		$attributes['enabled'] = 'yes';
 		$attributes['tables_split'] = 2;
 		$attributes['tables_loaded'] = 0;
-		$attributes['name'] = NULL;
-		$attributes['description'] = NULL;
-		$attributes['url'] = NULL;
+		$attributes['name'] = null;
+		$attributes['description'] = null;
+		$attributes['url'] = null;
 		ksort($attributes);
 
 		$entity_attributes = $this->site->expose_attributes();

--- a/engine/tests/ElggCoreSkeletonTest.php
+++ b/engine/tests/ElggCoreSkeletonTest.php
@@ -49,6 +49,6 @@ class ElggCoreSkeletonTest extends ElggCoreUnitTest {
 	}
 
 	public function testFailure() {
-		$this->assertTrue(FALSE);
+		$this->assertTrue(false);
 	}
 }

--- a/engine/tests/ElggCoreUserTest.php
+++ b/engine/tests/ElggCoreUserTest.php
@@ -41,31 +41,31 @@ class ElggCoreUserTest extends ElggCoreUnitTest {
 
 	public function testElggUserConstructor() {
 		$attributes = array();
-		$attributes['guid'] = NULL;
+		$attributes['guid'] = null;
 		$attributes['type'] = 'user';
-		$attributes['subtype'] = NULL;
+		$attributes['subtype'] = null;
 		$attributes['owner_guid'] = elgg_get_logged_in_user_guid();
 		$attributes['container_guid'] = elgg_get_logged_in_user_guid();
-		$attributes['site_guid'] = NULL;
+		$attributes['site_guid'] = null;
 		$attributes['access_id'] = ACCESS_PRIVATE;
-		$attributes['time_created'] = NULL;
-		$attributes['time_updated'] = NULL;
-		$attributes['last_action'] = NULL;
+		$attributes['time_created'] = null;
+		$attributes['time_updated'] = null;
+		$attributes['last_action'] = null;
 		$attributes['enabled'] = 'yes';
 		$attributes['tables_split'] = 2;
 		$attributes['tables_loaded'] = 0;
-		$attributes['name'] = NULL;
-		$attributes['username'] = NULL;
-		$attributes['password'] = NULL;
-		$attributes['salt'] = NULL;
-		$attributes['email'] = NULL;
-		$attributes['language'] = NULL;
-		$attributes['code'] = NULL;
+		$attributes['name'] = null;
+		$attributes['username'] = null;
+		$attributes['password'] = null;
+		$attributes['salt'] = null;
+		$attributes['email'] = null;
+		$attributes['language'] = null;
+		$attributes['code'] = null;
 		$attributes['banned'] = 'no';
 		$attributes['admin'] = 'no';
-		$attributes['prev_last_action'] = NULL;
-		$attributes['last_login'] = NULL;
-		$attributes['prev_last_login'] = NULL;
+		$attributes['prev_last_action'] = null;
+		$attributes['last_login'] = null;
+		$attributes['prev_last_login'] = null;
 		ksort($attributes);
 
 		$entity_attributes = $this->user->expose_attributes();
@@ -84,7 +84,7 @@ class ElggCoreUserTest extends ElggCoreUnitTest {
 		// fail on wrong type
 		try {
 			$error = new ElggUserTest($guid);
-			$this->assertTrue(FALSE);
+			$this->assertTrue(false);
 		} catch (Exception $e) {
 			$this->assertIsA($e, 'InvalidClassException');
 		}
@@ -100,7 +100,7 @@ class ElggCoreUserTest extends ElggCoreUnitTest {
 		// fail with garbage
 		try {
 			$error = new ElggUserTest(array('invalid'));
-			$this->assertTrue(FALSE);
+			$this->assertTrue(false);
 		} catch (Exception $e) {
 			$this->assertIsA($e, 'InvalidParameterException');
 		}

--- a/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
@@ -26,7 +26,7 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 		$this->event->expects($this->any())
 				->method('getObject')
 				->will($this->returnValue($object));
-		$this->db = $this->getMock('Elgg_Database', 
+		$this->db = $this->getMock('Elgg_Database',
 				array('getData', 'getTablePrefix', 'sanitizeString'),
 				array(),
 				'',

--- a/engine/tests/phpunit/Elgg/RouterTest.php
+++ b/engine/tests/phpunit/Elgg/RouterTest.php
@@ -30,7 +30,7 @@ class Elgg_RouterTest extends PHPUnit_Framework_TestCase {
 		
 		$this->assertTrue($handled);
 		$this->assertEquals("Hello, World!", $output);
-	}	
+	}
 	
 	function testCanUnregisterPageHandlers() {
 		$this->router->registerPageHandler('hello', array($this, 'hello_page_handler'));

--- a/engine/tests/phpunit/Elgg/ViewsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ViewsServiceTest.php
@@ -15,7 +15,7 @@ class Elgg_ViewsServiceTest extends PHPUnit_Framework_TestCase {
 		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
 	}
 	
-	public function testCanExtendViews() {				
+	public function testCanExtendViews() {
 		$this->views->extendView('foo', 'bar');
 		
 		// Unextending valid extension succeeds.
@@ -60,7 +60,7 @@ class Elgg_ViewsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRegisterViewsAsCacheable() {
 		$this->assertFalse($this->views->isCacheableView('js/interpreted.js'));
 		
-		$this->views->registerCacheableView('js/interpreted.js');	
+		$this->views->registerCacheableView('js/interpreted.js');
 		
 		$this->assertTrue($this->views->isCacheableView('js/interpreted.js'));
 	}

--- a/engine/tests/phpunit/Elgg/WidgetsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/WidgetsServiceTest.php
@@ -87,7 +87,7 @@ class Elgg_WidgetsServiceTest extends PHPUnit_Framework_TestCase {
 			'widget_type_con_mul' => true,
 		);
 		
-		$contexts = array('all', 'dashboard', 'profile', 'settings'); 
+		$contexts = array('all', 'dashboard', 'profile', 'settings');
 		
 		foreach (array(false, true) as $exact) {
 			foreach ($contexts as $context) {
@@ -118,7 +118,7 @@ class Elgg_WidgetsServiceTest extends PHPUnit_Framework_TestCase {
 			'widget_type_con_mul' => array('Widget name5', 'Widget description5'),
 		);
 		
-		$contexts = array('all', 'dashboard', 'profile', 'settings'); 
+		$contexts = array('all', 'dashboard', 'profile', 'settings');
 		
 		foreach (array(false, true) as $exact) {
 			foreach ($contexts as $context) {

--- a/engine/tests/suite.php
+++ b/engine/tests/suite.php
@@ -70,6 +70,6 @@ if (TextReporter::inCli()) {
 	exit($result);
 }
 
-$old = elgg_set_ignore_access(TRUE);
+$old = elgg_set_ignore_access(true);
 $suite->Run(new HtmlReporter('utf-8'));
 elgg_set_ignore_access($old);

--- a/engine/tests/suite.php
+++ b/engine/tests/suite.php
@@ -63,8 +63,8 @@ if (TextReporter::inCli()) {
 	$mt = microtime(true);
 	$reporter = new TextReporter();
 	$result = $suite->Run($reporter) ? 0 : 1 ;
-	echo sprintf("Time: %.2f seconds, Memory: %.2fMb\n", 
-		microtime(true)-$mt, 
+	echo sprintf("Time: %.2f seconds, Memory: %.2fMb\n",
+		microtime(true)-$mt,
 		memory_get_peak_usage() / 1048576. // in megabytes
 	);
 	exit($result);


### PR DESCRIPTION
See #5406

Addresses:
1. not allowing trailing space
2. using lowercase keywords (false, true, null)

Not sure if we want to merge it while still merging from 1.8 to master as it may cause conflicts.

RegExps used:

```
([;\{\}\(\),.])[ \t]+\r?\n
([^a-zA-Z0-9_])TRUE([^a-zA-Z0-9_])
([^a-zA-Z0-9_])FALSE([^a-zA-Z0-9_])
([^a-zA-Z0-9_])NULL([^a-zA-Z0-9_])
```
