### PR TITLE
Fixes #5587 - Makes profile edit form and user settings sticky

### DIFF
--- a/actions/notifications/settings/usersettings/save.php
+++ b/actions/notifications/settings/usersettings/save.php
@@ -21,9 +21,11 @@ foreach ($method as $k => $v) {
 
 	if (!$result) {
 		register_error(elgg_echo('notifications:usersettings:save:fail'));
+		return false;
 	}
 }
 
 if ($result) {
 	system_message(elgg_echo('notifications:usersettings:save:ok'));
+	return true;
 }

--- a/actions/profile/edit.php
+++ b/actions/profile/edit.php
@@ -4,6 +4,8 @@
  *
  */
 
+elgg_make_sticky_form('profile:edit');
+
 $guid = get_input('guid');
 $owner = get_entity($guid);
 
@@ -107,6 +109,7 @@ if (sizeof($input) > 0) {
 	// Notify of profile update
 	elgg_trigger_event('profileupdate', $owner->type, $owner);
 
+	elgg_clear_sticky_form('profile:edit');
 	system_message(elgg_echo("profile:saved"));
 }
 

--- a/actions/usersettings/save.php
+++ b/actions/usersettings/save.php
@@ -6,6 +6,10 @@
  * @subpackage UserSettings
  */
 
-elgg_trigger_plugin_hook('usersettings:save', 'user');
+elgg_make_sticky_form('usersettings');
+
+if (elgg_trigger_plugin_hook('usersettings:save', 'user', null, true)) {
+	elgg_clear_sticky_form('usersettings');
+}
 
 forward(REFERER);

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -385,10 +385,10 @@ function notification_init() {
  * @todo why can't this call action(...)?
  * @access private
  */
-function notification_user_settings_save() {
+function notification_user_settings_save($hook, $type, $returnvalue) {
 	global $CONFIG;
 	//@todo Wha??
-	include($CONFIG->path . "actions/notifications/settings/usersettings/save.php");
+	return include($CONFIG->path . "actions/notifications/settings/usersettings/save.php") && $returnvalue;
 }
 
 /**

--- a/engine/lib/user_settings.php
+++ b/engine/lib/user_settings.php
@@ -23,6 +23,7 @@ function users_settings_save() {
 	elgg_set_user_default_access();
 	elgg_set_user_name();
 	elgg_set_user_email();
+	//there's nothing we'd like to keep in sticky form here, so we never return false
 }
 
 /**

--- a/views/default/forms/profile/edit.php
+++ b/views/default/forms/profile/edit.php
@@ -13,6 +13,8 @@
 </div>
 <?php
 
+$stickyValues = elgg_get_sticky_values('profile:edit');
+
 $profile_fields = elgg_get_config('profile_fields');
 if (is_array($profile_fields) && count($profile_fields) > 0) {
 	foreach ($profile_fields as $shortname => $valtype) {
@@ -38,6 +40,14 @@ if (is_array($profile_fields) && count($profile_fields) > 0) {
 		} else {
 			$value = '';
 			$access_id = ACCESS_DEFAULT;
+		}
+
+		//sticky form values take precedence over saved ones
+		if (isset($stickyValues[$shortname])) {
+			$value = $stickyValues[$shortname];
+		}
+		if (isset($stickyValues['accesslevel'][$shortname])) {
+			$access_id = $stickyValues['accesslevel'][$shortname];
 		}
 
 ?>


### PR DESCRIPTION
By mistake I've made user settings sticky as well ;-)

I'd like to add here info on top of the form: "This form has unsaved changes". It could be kind of dedicated function/view that takes form name, checks if we have sticky values in session (`elgg_is_sticky_form`) and if yes, displays warning. It makes sense for forms that modify existing data, as values being read from session are not apparent.

It looks 1.9-ish to me though.
