### PR TITLE
Fixes #5594 - Failed registration automatically reopens register form on walled garden login page

### DIFF
--- a/views/default/core/walled_garden/login.php
+++ b/views/default/core/walled_garden/login.php
@@ -29,3 +29,13 @@ echo <<<HTML
 	</div>
 </div>
 HTML;
+
+if (elgg_is_sticky_form('register')) {
+?>
+<script type="text/javascript">
+	elgg.register_hook_handler('init', 'system', function(){
+		elgg.walled_garden.load('register')($.Event("click"));
+	});
+</script>
+<?php
+}

--- a/views/default/js/walled_garden.php
+++ b/views/default/js/walled_garden.php
@@ -42,6 +42,7 @@ elgg.walled_garden.load = function(view) {
 	return function(event) {
 		var id = '#elgg-walledgarden-' + view;
 		id = id.replace('_', '-');
+		//@todo display some visual element that indicates that loading of content is running
 		elgg.get('walled_garden/' + view, {
 			'success' : function(data) {
 				$('.elgg-body-walledgarden').append(data);


### PR DESCRIPTION
Did everything in JS as it's simplest way here. JS code does more than just displaying view fetched via AJAX, we'd have to duplicate it in PHP to avoid AJAX call after redirect.

We might redirect to /register when in walled garden instead (hook on forward in register action?).
