### PR TITLE
fixing the issue with registration not showing on walled garden after failed registration

### DIFF
--- a/js/lib/session.js
+++ b/js/lib/session.js
@@ -47,21 +47,18 @@ elgg.session.cookie = function (name, value, options) {
 	}
 	
 	cookies.push(name + '=' + value);
-	
-	if (elgg.isNumber(options.expires)) {
-		if (elgg.isNumber(options.expires)) {
-			date = new Date();
-			date.setTime(date.getTime() + (options.expires * 24 * 60 * 60 * 1000));
-		} else if (options.expires.toUTCString) {
-			date = options.expires;
-		} else {
-			valid = false;
-		}
-		
-		if (valid) {
-			cookies.push('expires=' + date.toUTCString());
-		}
-	}
+
+    if (elgg.isNumber(options.expires)) {
+        date = new Date();
+        date.setTime(date.getTime() + (options.expires * 24 * 60 * 60 * 1000));
+    } else if (options.expires.toUTCString) {
+        date = options.expires;
+    }
+
+    if (date) {
+        cookies.push('expires=' + date.toUTCString());
+    }
+
 	
 	// CAUTION: Needed to parenthesize options.path and options.domain
 	// in the following expressions, otherwise they evaluate to undefined

--- a/pages/account/forgotten_password.php
+++ b/pages/account/forgotten_password.php
@@ -17,6 +17,11 @@ $content .= elgg_view_form('user/requestnewpassword', array(
 	'class' => 'elgg-form-account',
 ));
 
-$body = elgg_view_layout("one_column", array('content' => $content));
-
-echo elgg_view_page($title, $body);
+if (elgg_get_config('walled_garden')) {
+	elgg_load_css('elgg.walled_garden');
+	$body = elgg_view_layout('walled_garden', array('content' => $content));
+	echo elgg_view_page($title, $body, 'walled_garden');
+} else {
+	$body = elgg_view_layout('one_column', array('content' => $content));
+	echo elgg_view_page($title, $body);
+}

--- a/pages/account/login.php
+++ b/pages/account/login.php
@@ -15,6 +15,14 @@ if (elgg_is_logged_in()) {
 	forward('');
 }
 
-$login_box = elgg_view('core/account/login_box');
-$content = elgg_view_layout('one_column', array('content' => $login_box));
-echo elgg_view_page(elgg_echo('login'), $content);
+$title = elgg_echo('login');
+$content = elgg_view('core/account/login_box');
+
+if (elgg_get_config('walled_garden')) {
+	elgg_load_css('elgg.walled_garden');
+	$body = elgg_view_layout('walled_garden', array('content' => $content));
+	echo elgg_view_page($title, $body, 'walled_garden');
+} else {
+	$body = elgg_view_layout('one_column', array('content' => $content));
+	echo elgg_view_page($title, $body);
+}

--- a/pages/account/register.php
+++ b/pages/account/register.php
@@ -48,6 +48,11 @@ $content .= elgg_view_form('register', $form_params, $body_params);
 
 $content .= elgg_view('help/register');
 
-$body = elgg_view_layout("one_column", array('content' => $content));
-
-echo elgg_view_page($title, $body);
+if (elgg_get_config('walled_garden')) {
+	elgg_load_css('elgg.walled_garden');
+	$body = elgg_view_layout('walled_garden', array('content' => $content));
+	echo elgg_view_page($title, $body, 'walled_garden');
+} else {
+	$body = elgg_view_layout('one_column', array('content' => $content));
+	echo elgg_view_page($title, $body);
+}

--- a/pages/account/reset_password.php
+++ b/pages/account/reset_password.php
@@ -30,6 +30,11 @@ $form = elgg_view_form('user/passwordreset', array('class' => 'elgg-form-account
 $title = elgg_echo('resetpassword');
 $content = elgg_view_title(elgg_echo('resetpassword')) . $form;
 
-$body = elgg_view_layout('one_column', array('content' => $content));
-
-echo elgg_view_page($title, $body);
+if (elgg_get_config('walled_garden')) {
+	elgg_load_css('elgg.walled_garden');
+	$body = elgg_view_layout('walled_garden', array('content' => $content));
+	echo elgg_view_page($title, $body, 'walled_garden');
+} else {
+	$body = elgg_view_layout('one_column', array('content' => $content));
+	echo elgg_view_page($title, $body);
+}

--- a/views/default/core/walled_garden/login.php
+++ b/views/default/core/walled_garden/login.php
@@ -29,13 +29,3 @@ echo <<<HTML
 	</div>
 </div>
 HTML;
-
-if (elgg_is_sticky_form('register')) {
-?>
-<script type="text/javascript">
-	elgg.register_hook_handler('init', 'system', function(){
-		$('.registration_link').trigger('click');
-	});
-</script>
-<?php
-}

--- a/views/default/core/walled_garden/login.php
+++ b/views/default/core/walled_garden/login.php
@@ -34,7 +34,7 @@ if (elgg_is_sticky_form('register')) {
 ?>
 <script type="text/javascript">
 	elgg.register_hook_handler('init', 'system', function(){
-		elgg.walled_garden.load('register')($.Event("click"));
+		$('.registration_link').trigger('click');
 	});
 </script>
 <?php

--- a/views/default/core/walled_garden/login.php
+++ b/views/default/core/walled_garden/login.php
@@ -29,3 +29,13 @@ echo <<<HTML
 	</div>
 </div>
 HTML;
+
+if (elgg_is_sticky_form('register')) {
+?>
+<script type="text/javascript">
+	elgg.register_hook_handler('init', 'system', function(){
+		elgg.walled_garden.load('register')($.Event("click"));
+	});
+</script>
+<?php
+}

--- a/views/default/js/walled_garden.php
+++ b/views/default/js/walled_garden.php
@@ -10,7 +10,7 @@ $cancel_button = elgg_view('input/button', array(
 	'value' => elgg_echo('cancel'),
 	'class' => 'elgg-button-cancel mlm',
 ));
-$cancel_button = trim($cancel_button);
+$cancel_button = json_encode($cancel_button);
 
 if (0) { ?><script><?php }
 ?>
@@ -23,10 +23,11 @@ elgg.walled_garden.init = function () {
 	$('.registration_link').click(elgg.walled_garden.load('register'));
 
 	$('input.elgg-button-cancel').live('click', function(event) {
-		if ($('.elgg-walledgarden-single').is(':visible')) {
+		var $wgs = $('.elgg-walledgarden-single');
+		if ($wgs.is(':visible')) {
 			$('.elgg-walledgarden-double').fadeToggle();
-			$('.elgg-walledgarden-single').fadeToggle();
-			$('.elgg-walledgarden-single').remove();
+			$wgs.fadeToggle();
+			$wgs.remove();
 		}
 		event.preventDefault();
 	});
@@ -45,10 +46,28 @@ elgg.walled_garden.load = function(view) {
 		//@todo display some visual element that indicates that loading of content is running
 		elgg.get('walled_garden/' + view, {
 			'success' : function(data) {
-				$('.elgg-body-walledgarden').append(data);
-				$(id).find('input.elgg-button-submit').after('<?php echo $cancel_button; ?>');
-				$('#elgg-walledgarden-login').fadeToggle();
-				$(id).fadeToggle();
+				var $wg = $('.elgg-body-walledgarden');
+				$wg.append(data);
+				$(id).find('input.elgg-button-submit').after(<?php echo $cancel_button; ?>);
+
+				if (view == 'register' && $wg.hasClass('hidden')) {
+					// this was a failed register, display the register form ASAP
+					$('#elgg-walledgarden-login').toggle();
+					$(id).toggle();
+					$wg.removeClass('hidden');
+				} else {
+					$('#elgg-walledgarden-login').fadeToggle();
+					$(id).fadeToggle();
+				}
+
+				if (view == 'register') {
+					$('.elgg-form-register').submit(function () {
+						// set short cookie indicating JS support
+						var date = new Date();
+						date.setTime(date.getTime() + (60 * 1000));
+						elgg.session.cookie('elgg_js_support', '1', { expires: date });
+					});
+				}
 			}
 		});
 		event.preventDefault();

--- a/views/default/js/walled_garden.php
+++ b/views/default/js/walled_garden.php
@@ -5,7 +5,6 @@
  * @since 1.8
  */
 
-// note that this assumes the button view is not using single quotes
 $cancel_button = elgg_view('input/button', array(
 	'value' => elgg_echo('cancel'),
 	'class' => 'elgg-button-cancel mlm',
@@ -52,21 +51,12 @@ elgg.walled_garden.load = function(view) {
 
 				if (view == 'register' && $wg.hasClass('hidden')) {
 					// this was a failed register, display the register form ASAP
-					$('#elgg-walledgarden-login').toggle();
+					$('#elgg-walledgarden-login').toggle(false);
 					$(id).toggle();
 					$wg.removeClass('hidden');
 				} else {
 					$('#elgg-walledgarden-login').fadeToggle();
 					$(id).fadeToggle();
-				}
-
-				if (view == 'register') {
-					$('.elgg-form-register').submit(function () {
-						// set short cookie indicating JS support
-						var date = new Date();
-						date.setTime(date.getTime() + (60 * 1000));
-						elgg.session.cookie('elgg_js_support', '1', { expires: date });
-					});
 				}
 			}
 		});

--- a/views/default/js/walled_garden.php
+++ b/views/default/js/walled_garden.php
@@ -42,6 +42,7 @@ elgg.walled_garden.load = function(view) {
 	return function(event) {
 		var id = '#elgg-walledgarden-' + view;
 		id = id.replace('_', '-');
+		//@todo display some visual element that indicates that loading of content is running
 		elgg.get('walled_garden/' + view, {
 			'success' : function(data) {
 				$('.elgg-body-walledgarden').append(data);

--- a/views/default/page/walled_garden.php
+++ b/views/default/page/walled_garden.php
@@ -5,6 +5,12 @@
  * Used for the walled garden index page
  */
 
+$is_sticky_register = elgg_is_sticky_form('register');
+$wg_body_class = 'elgg-body-walledgarden';
+if ($is_sticky_register && !empty($_COOKIE['elgg_js_support'])) {
+	$wg_body_class .= ' hidden';
+}
+
 // Set the content type
 header("Content-type: text/html; charset=UTF-8");
 ?>
@@ -18,10 +24,17 @@ header("Content-type: text/html; charset=UTF-8");
 	<div class="elgg-page-messages">
 		<?php echo elgg_view('page/elements/messages', array('object' => $vars['sysmessages'])); ?>
 	</div>
-	<div class="elgg-body-walledgarden">
+	<div class="<?php echo $wg_body_class; ?>">
 		<?php echo $vars['body']; ?>
 	</div>
 </div>
+<?php if ($is_sticky_register): ?>
+<script type="text/javascript">
+elgg.register_hook_handler('init', 'system', function() {
+	$('.registration_link').trigger('click');
+});
+</script>
+<?php endif; ?>
 <?php echo elgg_view('page/elements/foot'); ?>
 </body>
 </html>

--- a/views/default/page/walled_garden.php
+++ b/views/default/page/walled_garden.php
@@ -7,7 +7,7 @@
 
 $is_sticky_register = elgg_is_sticky_form('register');
 $wg_body_class = 'elgg-body-walledgarden';
-if ($is_sticky_register && !empty($_COOKIE['elgg_js_support'])) {
+if ($is_sticky_register) {
 	$wg_body_class .= ' hidden';
 }
 


### PR DESCRIPTION
Improved #5620:
- using walled garden page shell for account pages like register/forgotten password
- fixed issue with empty page
- removed unnecessary cookie - people without JS go to separate page and get forwarded back to the page
