### PR TITLE
possible fix for CLI installer warnings

### DIFF
--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -50,8 +50,7 @@ function elgg_echo($message_key, $args = array(), $language = "") {
 		$string = $CONFIG->translations[$language][$message_key];
 	} else if (isset($CONFIG->translations["en"][$message_key])) {
 		$string = $CONFIG->translations["en"][$message_key];
-		$lang = $CONFIG->translations["en"][$language];
-		elgg_log(sprintf('Missing %s translation for "%s" language key', $lang, $message_key), 'NOTICE');
+		elgg_log(sprintf('Missing %s translation for "%s" language key', $language, $message_key), 'NOTICE');
 	} else {
 		$string = $message_key;
 		elgg_log(sprintf('Missing English translation for "%s" language key', $message_key), 'NOTICE');

--- a/install/ElggInstaller.php
+++ b/install/ElggInstaller.php
@@ -832,6 +832,7 @@ class ElggInstaller {
 
 			_elgg_services()->db->setupConnections();
 			register_translations(dirname(dirname(__FILE__)) . "/languages/");
+			$CONFIG->language = 'en';
 
 			if ($stepIndex > $settingsIndex) {
 				$CONFIG->site_guid = (int) datalist_get('default_site');


### PR DESCRIPTION
display two letter language code for missing translations and set English as language in installer for the installation
