### PR TITLE
wrong default behaviour in can_edit_entity_metadata

### DIFF
--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -761,7 +761,7 @@ function get_entity($guid) {
 	// @todo We need a single Memcache instance with a shared pool of namespace wrappers. This function would pull an instance from the pool.
 	static $shared_cache;
 
-	// We could also use: if (!(int) $guid) { return FALSE }, 
+	// We could also use: if (!(int) $guid) { return FALSE },
 	// but that evaluates to a false positive for $guid = TRUE.
 	// This is a bit slower, but more thorough.
 	if (!is_numeric($guid) || $guid === 0 || $guid === '0') {
@@ -2126,7 +2126,7 @@ function can_edit_entity_metadata($entity_guid, $user_guid = 0, $metadata = null
 
 		$return = null;
 
-		if ($metadata->owner_guid == 0) {
+		if ($metadata && ($metadata->owner_guid == 0)) {
 			$return = true;
 		}
 		if (is_null($return)) {


### PR DESCRIPTION
as requested by Cash.

I found a problem/bug in the function can_edit_entity_metadata (/engine/lib/entities.php).

When this function is called without supplying a metadata object the default behaviour is that it returns true. I don't think this is what is suppose to happen.

My use case where I found the problem was, I had a special role for my plugin, and only persons with this role should be able to edit some of the metadata. Also if they could $entity->canEditMetadata() a menu item would appear. I found that for all users the menu item would appear.

I checked the Elgg core for occurrences of ->canEditMetadata and found only two (ElggEntity and ElggMetadata). I checked for can_edit_entity_metadata() and found two (ElggEntity and ElggMetadata).
As for the hook in can_edit_entity_metadata (permissions_check:metadata, $entity->type), there is only one (messages) which does its check correctly and will not be affected by my patch.

To test this bug. Write a public blog, logout and in /views/default/object/blog.php add var_dump($blog->canEditMetadata()), you will see a "true"????!!!
