### PR TITLE
Fixes #5446, #5591, #5584 reverts widgets/grid changes to what was in 1.8

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1211,32 +1211,6 @@ function elgg_view_icon($name, $class = '') {
 }
 
 /**
- * Output a single column of widgets.
- *
- * @param ElggUser $user        The owner user entity.
- * @param string   $context     The context (profile, dashboard, etc.)
- * @param int      $column      Which column to output.
- * @param bool     $show_access Show the access control (true by default)
- * @return string
- * @since 1.9.0
- */
-function elgg_view_widgets_column($user, $context, $column, $show_access = true) {
-	$widgets = elgg_get_widgets($user->guid, $context);
-	$column_widgets = $widgets[$column];
-
-	$column_html = '';
-	if (count($column_widgets) > 0) {
-		foreach ($column_widgets as $widget) {
-			if (elgg_is_widget_type($widget->handler)) {
-				$column_html .= elgg_view_entity($widget, array('show_access' => $show_access));
-			}
-		}
-	}
-
-	return $column_html;
-}
-
-/**
  * Displays a user's access collections, using the core/friends/collections view
  *
  * @param int $owner_guid The GUID of the owning user

--- a/mod/developers/views/default/theme_preview/grid.php
+++ b/mod/developers/views/default/theme_preview/grid.php
@@ -74,13 +74,14 @@ h3 { text-align: center; font-weight: normal; }
 <div class="elgg-grid">
 	<?php foreach ($row as $col):
 		$class = "elgg-col elgg-col-" . str_replace('/', 'of', $col);
-		$text = str_replace(' ', '<br>', $class);
+		$text = str_replace(' ', '<br/>', $class);
 	?>
 	<div class="<?php echo $class ?>"><div class="elgg-inner"><?php echo $text ?></div></div>
 	<?php endforeach; ?>
 </div>
 <?php endforeach; ?>
 
+<!--
 <h2 class="elgg-griddemo">With Gutters</h2>
 <p>Each row is wrapped by <code>div.elgg-grid-gutters</code>
 This does not work with IE8 and before without manually adding .elgg-col-last to the last column in a row.</p>
@@ -89,17 +90,18 @@ This does not work with IE8 and before without manually adding .elgg-col-last to
 <div class="elgg-grid-gutters">
 	<?php foreach ($row as $col):
 		$class = "elgg-col elgg-col-" . str_replace('/', 'of', $col);
-		$text = str_replace(' ', '<br>', $class);
+		$text = str_replace(' ', '<br/>', $class);
 	?>
 	<div class="<?php echo $class ?>"><div class="elgg-inner"><?php echo $text ?></div></div>
 	<?php endforeach; ?>
 </div>
 <?php endforeach; ?>
+-->
 
-<h2 class="elgg-griddemo">With Gutters and With Content</h2>
+<h2 class="elgg-griddemo">Without Gutters and With Content</h2>
 <p>Each row is wrapped by <code>div.elgg-grid</code></p>
 
-<div class="elgg-grid-gutters">
+<div class="elgg-grid">
 	<div class="elgg-col elgg-col-1of5">
 		<div class="elgg-inner">
 			<h3>1/5</h3>
@@ -109,7 +111,7 @@ This does not work with IE8 and before without manually adding .elgg-col-last to
 	<div class="elgg-col elgg-col-3of5">
 		<div class="elgg-inner clearfix">
 			<h3>3/5</h3>
-			<div class="elgg-grid-gutters">
+			<div class="elgg-grid">
 				<div class="elgg-col elgg-col-1of2">
 					<div class="elgg-inner">
 						<h3>1/2</h3>
@@ -123,7 +125,7 @@ This does not work with IE8 and before without manually adding .elgg-col-last to
 					</div>
 				</div>
 			</div>
-			<div class="elgg-grid-gutters">
+			<div class="elgg-grid">
 				<div class="elgg-col elgg-col-1of3">
 					<div class="elgg-inner">
 						<h3>1/3</h3>
@@ -133,7 +135,7 @@ This does not work with IE8 and before without manually adding .elgg-col-last to
 				<div class="elgg-col elgg-col-2of3 elgg-col-last">
 					<div class="elgg-inner">
 						<h3>2/3</h3>
-						<div class="elgg-grid-gutters">
+						<div class="elgg-grid">
 							<div class="elgg-col elgg-col-1of2">
 								<div class="elgg-inner">
 									<h3>1/2</h3>
@@ -147,7 +149,7 @@ This does not work with IE8 and before without manually adding .elgg-col-last to
 								</div>
 							</div>
 						</div>
-						<div class="elgg-grid-gutters">
+						<div class="elgg-grid">
 							<div class="elgg-col elgg-col-1of1">
 								<div class="elgg-inner">
 									<h3>1</h3>

--- a/mod/developers/views/default/theme_preview/modules/widgets.php
+++ b/mod/developers/views/default/theme_preview/modules/widgets.php
@@ -34,6 +34,8 @@ $column2 = array($w[2], $w[3]);
 $column3 = array($w[4], $w[5]);
 $widgets = array(1 => $column1, 2 => $column2, 3 => $column3);
 $num_columns = 3;
+
+echo '<div class="elgg-layout-widgets">';
 $widget_class = "elgg-col-1of{$num_columns}";
 for ($column_index = 1; $column_index <= $num_columns; $column_index++) {
 	$column_widgets = $widgets[$column_index];
@@ -46,6 +48,8 @@ for ($column_index = 1; $column_index <= $num_columns; $column_index++) {
 	}
 	echo '</div>';
 }
+echo '</div>';
+
 ?>
 </div>
 <script type="text/javascript">

--- a/mod/profile/views/default/profile/css.php
+++ b/mod/profile/views/default/profile/css.php
@@ -15,6 +15,7 @@
 .profile .elgg-inner {
 	border: 2px solid #eee;
 	border-radius: 8px;
+	margin: 0 5px;
 }
 #profile-details {
 	padding: 15px;

--- a/views/default/css/admin.php
+++ b/views/default/css/admin.php
@@ -1081,12 +1081,6 @@ a.elgg-button {
 .elgg-layout-widgets > .elgg-widgets {
 	float: right;
 }
-.elgg-layout-widgets > .elgg-col > .elgg-inner {
-	padding-left: 15px;
-}
-.elgg-layout-widgets > .elgg-col-last > .elgg-inner {
-	padding-left: 0;
-}
 .elgg-widgets {
 	min-height: 30px;
 }
@@ -1131,7 +1125,7 @@ a.elgg-button {
 .elgg-module-widget {
 	background-color: #dedede;
 	padding: 1px;
-	margin: 0 0 15px;
+	margin: 0 5px 15px;
 	position: relative;
 }
 .elgg-module-widget:hover {

--- a/views/default/css/elements/grid.php
+++ b/views/default/css/elements/grid.php
@@ -6,103 +6,57 @@
  * @subpackage UI
  * 
  * To work around subpixel rounding discrepancies, apply .elgg-col-last to
- * the last column (@todo we need broswer-specific test cases for this).
+ * the last column
+ * @todo we need broswer-specific test cases for this
+ * @todo this should go away as soon as Opera switches to Webkit
  */
-
-$gutter_width_percent = elgg_get_config('elgg_grid_gutter_percentage');
-if ($gutter_width_percent === null) {
-	$gutter_width_percent = 1.6; /* 16px on a 1000px grid */
-}
-
 ?>
 
 /* ***************************************
 	Grid
 *************************************** */
 
-/*
-Gutters do not work with IE8 and before without manually adding .elgg-col-last 
-to the last column in each row.
-*/
-
 /*<style>/**/
 
 .elgg-col {
 	float: left;
 }
-
 .elgg-col-alt {
 	float: right;
 }
-
-.elgg-grid-gutters > .elgg-col {
-	margin-right: <?php echo $gutter_width_percent; ?>%;
-}
-
-.elgg-grid-gutters > .elgg-col-alt {
-	margin-left: <?php echo $gutter_width_percent; ?>%;
-}
-
-.elgg-grid-gutters {
-	margin-top: <?php echo $gutter_width_percent; ?>%;
-	margin-bottom: <?php echo $gutter_width_percent; ?>%;
-}
-
-.elgg-grid-gutters > .elgg-col:last-child,
-.elgg-grid-gutters > .elgg-col-alt:last-child,
-.elgg-grid-gutters > .elgg-col-last {
-	float: none;
-	overflow: hidden;
-	margin: 0;
-	width: auto;
-}
-
 .elgg-col-1of1 {
 	float: none;
 }
-.elgg-grid-gutters > .elgg-col-1of1 {
-	margin: 0;
+.elgg-col-1of2 {
+	width: 50%;
 }
-
-<?php
-
-// build units
-
-// keep map to eliminate duplicates. keys are rounded to thousands (avoid float issues)
-$percentages = array(
-	'100' => array(1, 1),
-);
-
-for ($den = 2; $den <= 6; $den++) {
-	$num_gutters = $den - 1;
-	$column_width_percent = 100 / $den;
-	$column_width_percent_gutters = (100 - $num_gutters * $gutter_width_percent) / $den;
-	for ($num = 1; $num < $den; $num++) {
-		// avoid duplicates
-		$rounded_percentage = (string) round($num / $den, 3);
-		if ($num > 1 && isset($percentages[$rounded_percentage])) {
-			continue;
-		}
-		$percentages[$rounded_percentage] = array($num, $den);
-
-		$width_percent = $num * $column_width_percent;
-		$width_percent_gutters = $num * $column_width_percent_gutters + ($num - 1) * $gutter_width_percent;
-
-		// round to 3 digits, but round last digit down (.666 instead of .667)
-		$width_percent = floor($width_percent * 10000) / 10000;
-		$width_percent_gutters = floor($width_percent_gutters * 10000) / 10000;
-
-		echo <<<CSS
-.elgg-col-{$num}of{$den} {
-	width: $width_percent%;
+.elgg-col-1of3 {
+	width: 33.33%;
 }
-.elgg-grid-gutters > .elgg-col-{$num}of{$den} {
-	width: $width_percent_gutters%;
+.elgg-col-2of3 {
+	width: 66.66%;
 }
-
-CSS;
-	}
+.elgg-col-1of4 {
+	width: 25%;
 }
-
-echo "\n";
-
+.elgg-col-3of4 {
+	width: 75%;
+}
+.elgg-col-1of5 {
+	width: 20%;
+}
+.elgg-col-2of5 {
+	width: 40%;
+}
+.elgg-col-3of5 {
+	width: 60%;
+}
+.elgg-col-4of5 {
+	width: 80%;
+}
+.elgg-col-1of6 {
+	width: 16.66%;
+}
+.elgg-col-5of6 {
+	width: 83.33%;
+}

--- a/views/default/css/elements/layout.php
+++ b/views/default/css/elements/layout.php
@@ -88,12 +88,6 @@
 .elgg-layout-widgets > .elgg-widgets {
 	float: right;
 }
-.elgg-layout-widgets > .elgg-col > .elgg-inner {
-	padding-left: 15px;
-}
-.elgg-layout-widgets > .elgg-col-last > .elgg-inner {
-	padding-left: 0;
-}
 .elgg-sidebar {
 	position: relative;
 	padding: 20px 10px;

--- a/views/default/css/elements/modules.php
+++ b/views/default/css/elements/modules.php
@@ -119,7 +119,7 @@
 .elgg-module-widget {
 	background-color: #dedede;
 	padding: 2px;
-	margin-bottom: 15px;
+	margin: 0 5px 15px;
 	position: relative;
 }
 .elgg-module-widget:hover {

--- a/views/default/page/layouts/widgets.php
+++ b/views/default/page/layouts/widgets.php
@@ -42,17 +42,22 @@ if (isset($vars['content'])) {
 	echo $vars['content'];
 }
 
+$widget_class = "elgg-col-1of{$num_columns}";
 for ($column_index = 1; $column_index <= $num_columns; $column_index++) {
-	$widget_col_class = "elgg-widgets elgg-col elgg-col-1of{$num_columns}";
-	$widget_col_id = "elgg-widget-col-$column_index";
-	if ($column_index == $num_columns) {
-		$widget_col_class .= ' elgg-col-last';	
+	if (isset($widgets[$column_index])) {
+		$column_widgets = $widgets[$column_index];
+	} else {
+		$column_widgets = array();
 	}
 
-	echo "<div class=\"$widget_col_class\" id=\"$widget_col_id\">";
-	echo '<div class="elgg-inner">';
-	echo elgg_view_widgets_column($owner, $context, $column_index, $show_access);
-	echo '</div>';
+	echo "<div class=\"$widget_class elgg-widgets\" id=\"elgg-widget-col-$column_index\">";
+	if (sizeof($column_widgets) > 0) {
+		foreach ($column_widgets as $widget) {
+			if (array_key_exists($widget->handler, $widget_types)) {
+				echo elgg_view_entity($widget, array('show_access' => $show_access));
+			}
+		}
+	}
 	echo '</div>';
 }
 


### PR DESCRIPTION
will give gutters another try using a different approach. Viewing a single column of widgets should probably be a view rather than function since it is not a common operation.
