### PR TITLE
Fixes #5315: Concatenates loaded JS files to reduce HTTP requests

### DIFF
--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -158,6 +158,12 @@ function elgg_get_simplecache_url($type, $view) {
 	if (($type === 'js' || $type === 'css') && 0 === strpos($view, $type . '/')) {
 		$view = substr($view, strlen($type) + 1);
 	}
+	
+	$endsWithType = substr($view, -strlen($type)) === $type;
+	
+	if (($type === 'js' || $type === 'css') && !$endsWithType) {
+		$view = "$view.$type";
+	}
 
 	elgg_register_simplecache_view("$type/$view");
 	return _elgg_get_simplecache_root() . "$type/$view";


### PR DESCRIPTION
Just wanted to get some eyes on this to see if the approach is acceptable. I'm bundling scripts and identifying the bundle based on the md5 of the other scripts' srcs. That way if you have a different set of scripts loaded on different pages you'll get different bundles. This would imply that users have to re-download any shared scripts that the pages have, which is a bummer, but I think the tradeoff is warranted for the general case.

TODOs:
- [ ] Put it behind an admin checkbox before pulling it in.
- [ ] Refactored and unit-tested if possible, though I was having a hard time coming up with a good class abstraction for this logic. Suggestions there are appreciated.
- [ ] Remove leftover debug statements, etc.

Demo: http://elgg.ewinslow.c9.io
