### PR TITLE
Adds PHP 5.5 to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
  - 5.2
  - 5.3
  - 5.4
+ - 5.5
 
 branches:
   only:


### PR DESCRIPTION
PHP 5.5 is officially out: http://www.php.net/ChangeLog-5.php#5.5.0

Not sure if Travis still uses 5.5 alpha, but it's probably good time to start testing against 5.5 as well.
