### PR TITLE
New translation system

### DIFF
--- a/engine/classes/Elgg/I18n/InvalidLanguageException.php
+++ b/engine/classes/Elgg/I18n/InvalidLanguageException.php
@@ -9,4 +9,4 @@
  * @subpackage I18n
  * @since      1.9.0
  */
-class Elgg_I18n_InvalidLanguageException extends Exception {}
+class Elgg_I18n_InvalidLanguageException extends InvalidArgumentException {}

--- a/engine/classes/Elgg/I18n/InvalidLanguageException.php
+++ b/engine/classes/Elgg/I18n/InvalidLanguageException.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Invalid language exception
+ * 
+ * @access private
+ * 
+ * @package    Elgg.Core
+ * @subpackage I18n
+ * @since      1.9.0
+ */
+class Elgg_I18n_InvalidLanguageException extends Exception {}

--- a/engine/classes/Elgg/I18n/TranslationLoader.php
+++ b/engine/classes/Elgg/I18n/TranslationLoader.php
@@ -152,6 +152,7 @@ class Elgg_I18n_TranslationLoader {
 	 *
 	 * @param string $file  Translation file
 	 * @param array  $value Value to cache
+	 * @return void
 	 */
 	protected function setCache($file, $value) {
 		$this->localTranslationCache[$file] = $value;

--- a/engine/classes/Elgg/I18n/TranslationLoader.php
+++ b/engine/classes/Elgg/I18n/TranslationLoader.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ *
+ * @package    Elgg.Core
+ * @subpackage I18n
+ * @since      1.9.0
+ *
+ * @todo keep track of what files have been loaded otherwise we are loading the
+ * same language files again and again
+ */
+class Elgg_I18n_TranslationLoader {
+
+	/** @var array */
+	protected $directories = array();
+
+	/** @var ElggCache */
+	protected $cache;
+
+	/**
+	 * Create the translation loader
+	 *
+	 * @param ElggCache $cache Cache for translations
+	 */
+	public function __construct(ElggCache $cache = null) {
+		$this->cache = $cache;
+	}
+
+	/**
+	 * Add a translation directory
+	 *
+	 * @param string $directory Directory path that has translations
+	 * @return void
+	 */
+	public function addDirectory($directory) {
+		$this->directories[] = rtrim($directory, '/\\');
+	}
+
+	/**
+	 * Get all the translation directory paths
+	 *
+	 * @return array
+	 */
+	public function getDirectories() {
+		return $this->directories;
+	}
+
+	/**
+	 * Load a translation
+	 *
+	 * @param string $language Two letter language code
+	 * @return array
+	 */
+	public function loadTranslation($language) {
+		$translation = array();
+		foreach ($this->directories as $dir) {
+			$language_file = "$dir/$language.php";
+			if (is_readable($language_file)) {
+				$result = include($language_file);
+				if ($result) {
+					if (is_array($result)) {
+						// Elgg 1.9 style language file
+						$translation = array_merge($translation, $result);
+					} else {
+						// Elgg 1.0-1.8 style (add_translation)
+					}
+				} else {
+					// why would this fail
+				}
+			}
+		}
+
+		return $translation;
+	}
+
+	/**
+	 * Get all languages available
+	 *
+	 * @return array
+	 */
+	public function getAllLanguages() {
+		$languages = array();
+		foreach ($this->directories as $dir) {
+			$handle = opendir($dir);
+			if (!$handle) {
+				// log error or throw exception
+				continue;
+			}
+
+			while (false !== ($file = readdir($handle))) {
+				if (substr($file, 0, 1) == '.' || substr($file, -4) !== '.php'
+						|| strlen($file) != 6) {
+					// skip non-language files
+					continue;
+				}
+
+				$languages[] = substr($file, 0, 2);
+			}
+		}
+
+		return array_unique($languages);
+	}
+
+}

--- a/engine/classes/Elgg/I18n/TranslationLoader.php
+++ b/engine/classes/Elgg/I18n/TranslationLoader.php
@@ -8,9 +8,6 @@
  * @package    Elgg.Core
  * @subpackage I18n
  * @since      1.9.0
- *
- * @todo keep track of what files have been loaded otherwise we are loading the
- * same language files again and again
  */
 class Elgg_I18n_TranslationLoader {
 
@@ -20,6 +17,12 @@ class Elgg_I18n_TranslationLoader {
 	/** @var ElggCache */
 	protected $cache;
 
+	/** @var array */
+	protected $uncachedTranslations = array();
+
+	/** @var array */
+	protected $localTranslationCache = array();
+
 	/**
 	 * Create the translation loader
 	 *
@@ -27,6 +30,17 @@ class Elgg_I18n_TranslationLoader {
 	 */
 	public function __construct(ElggCache $cache = null) {
 		$this->cache = $cache;
+	}
+
+	/**
+	 * Caches translations when appriopiate
+	 */
+	public function __destruct() {
+		if ($this->cache && $this->uncachedTranslations) {
+			foreach ($this->uncachedTranslations as $language => $translation) {
+				$this->cache->setVariable("$language.lang", serialize($translation));
+			}
+		}
 	}
 
 	/**
@@ -52,24 +66,43 @@ class Elgg_I18n_TranslationLoader {
 	 * Load a translation
 	 *
 	 * @param string $language Two letter language code
-	 * @return array
+	 * @return array Array of key => translation
 	 */
 	public function loadTranslation($language) {
 		$translation = array();
-		foreach ($this->directories as $dir) {
-			$language_file = "$dir/$language.php";
-			if (is_readable($language_file)) {
-				$result = include($language_file);
-				if ($result) {
-					if (is_array($result)) {
-						// Elgg 1.9 style language file
-						$translation = array_merge($translation, $result);
-					} else {
-						// Elgg 1.0-1.8 style (add_translation)
-					}
+
+		if ($this->cache) {
+			$data = $this->cache->getVariable("$language.lang");
+			if ($data) {
+				$translation = unserialize($data);
+			}
+		}
+
+		if (!$translation) {
+			foreach ($this->directories as $dir) {
+				$language_file = "$dir/$language.php";
+				if ($this->isCached($language_file)) {
+					$translation = array_merge($translation, $this->getCache($language_file));
 				} else {
-					// why would this fail
+					if (is_readable($language_file)) {
+						$result = include($language_file);
+						if ($result) {
+							if (is_array($result)) {
+								// Elgg 1.9 style language file
+								$this->setCache($language_file, $result);
+								$translation = array_merge($translation, $result);
+							} else {
+								// Elgg 1.0-1.8 style (add_translation)
+							}
+						} else {
+							// why would this fail
+						}
+					}
 				}
+			}
+
+			if ($this->cache) {
+				$this->uncachedTranslations[$language] = $translation;
 			}
 		}
 
@@ -102,6 +135,36 @@ class Elgg_I18n_TranslationLoader {
 		}
 
 		return array_unique($languages);
+	}
+
+	/**
+	 * Is this translation file cached
+	 *
+	 * @param string $file Translation file
+	 * @return bool
+	 */
+	protected function isCached($file) {
+		return isset($this->localTranslationCache[$file]);
+	}
+
+	/**
+	 * Set the cached translation for this file
+	 *
+	 * @param string $file  Translation file
+	 * @param array  $value Value to cache
+	 */
+	protected function setCache($file, $value) {
+		$this->localTranslationCache[$file] = $value;
+	}
+
+	/**
+	 * Get the cached translation for this file
+	 *
+	 * @param string $file Translation file
+	 * @return array
+	 */
+	protected function getCache($file) {
+		return $this->localTranslationCache[$file];
 	}
 
 }

--- a/engine/classes/Elgg/I18n/TranslationsService.php
+++ b/engine/classes/Elgg/I18n/TranslationsService.php
@@ -1,0 +1,272 @@
+<?php
+
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ *
+ * @package    Elgg.Core
+ * @subpackage I18n
+ * @since      1.9.0
+ * 
+ * @todo keep track of what files have been loaded otherwise we are loading the
+ * same language files again and again when the cache is off
+ */
+class Elgg_I18n_TranslationsService {
+
+	/** @var ElggCache */
+	protected $cache;
+
+	/** @var string */
+	protected $siteLanguage;
+
+	/** @var string */
+	protected $userLanguage;
+
+	/** @var array */
+	protected $translationDirectories = array();
+
+	/** @var array */
+	protected $translations = array();
+
+	/** @var array */
+	protected $translators = array();
+
+	/**
+	 * Create a translation service
+	 * 
+	 * @param string    $directory The directory for the core language files
+	 * @param string    $language  Two letter language code for default language
+	 * @param ElggCache $cache
+	 */
+	public function __construct($directory, $language = 'en', $cache = null) {
+		$this->siteLanguage = $language;
+		$this->userLanguage = $language;
+		$this->cache = $cache;
+		$this->registerTranslationDirectory($directory);
+	}
+
+	/**
+	 * Set the site language
+	 * 
+	 * @param string $language Two letter language code
+	 * @return void
+	 * @throws Elgg_I18n_InvalidLanguageException
+	 */
+	public function setSiteLanguage($language) {
+		$this->assertValidLanguage($language);
+		$this->siteLanguage = $language;
+	}
+
+	/**
+	 * Get the site language
+	 * 
+	 * @return string
+	 */
+	public function getSiteLanguage() {
+		return $this->siteLanguage;
+	}
+
+	/**
+	 * Set the user's language
+	 * 
+	 * @param string $language Two letter language code
+	 * @return void
+	 * @throws Elgg_I18n_InvalidLanguageException
+	 */
+	public function setUserLanguage($language) {
+		$this->assertValidLanguage($language);
+		$this->userLanguage = $language;
+	}
+
+	/**
+	 * Get the user's language
+	 * 
+	 * @return string
+	 */
+	public function getUserLanguage() {
+		return $this->userLanguage;
+	}
+
+	/**
+	 * Get the translation of a message key 
+	 *
+	 * @param string $key      The message key
+	 * @param array  $args     Optional array of arguments to pass through vsprintf()
+	 * @param string $language Optional 2 letter language code to override default language
+	 * @return string
+	 * @throws Elgg_I18n_InvalidLanguageException
+	 */
+	public function translate($key, $args = array(), $language = '') {
+		$this->loadTranslation($this->userLanguage);
+		$this->loadTranslation($this->siteLanguage);
+		if ($language !== '') {
+			$this->assertValidLanguage($language);
+			$this->loadTranslation($language);			
+		}
+
+		$string = $this->translators[$language]->translate($key, $args);
+		if (!$string) {
+			$string = $this->translators[$this->userLanguage]->translate($key, $args);
+		}
+		if (!$string) {
+			$string = $this->translators[$this->siteLanguage]->translate($key, $args);
+		}
+		if (!$string) {
+			$string = $key;
+		}
+
+		return $string;
+	}
+
+	/**
+	 * Register a directory that holds translations
+	 * 
+	 * @param string $directory Absolute directory
+	 * @return void
+	 */
+	public function registerTranslationDirectory($directory) {
+		$this->translationDirectories[] = rtrim($directory, '/');
+		if (!$this->cache) {
+			$this->translations = array();
+		}
+	}
+
+	/**
+	 * Get the translation array of key => translation
+	 * 
+	 * @param string $language Two letter language code
+	 * @return array
+	 * @throws Elgg_I18n_InvalidLanguageException
+	 */
+	public function getTranslation($language) {
+		$this->assertValidLanguage($language);
+		$this->loadTranslation($language);
+		return $this->translations[$language];
+	}
+
+	/**
+	 * Replace or add to a translation
+	 * 
+	 * @param string $language    Two letter language code
+	 * @param array  $translation Translation array
+	 * @param bool   $replace     Whether to replace or add to a translation
+	 * @return void
+	 * @throws Elgg_I18n_InvalidLanguageException
+	 */
+	public function setTranslation($language, array $translation, $replace = false) {
+		$this->assertValidLanguage($language);
+		if ($replace || !array_key_exists($language, $this->translations)) {
+			$this->translations[$language] = $translation;
+		} else {
+			$this->translations[$language] = array_merge($this->translations[$language], $translation);
+		}
+	}
+
+	/**
+	 * Get translation arrays for all languages
+	 * 
+	 * @return array
+	 */
+	public function getAllTranslations() {
+		$languages = $this->getAllLanguages();
+
+		foreach ($languages as $language) {
+			$this->loadTranslation($language);
+		}
+	
+		return $this->translations;
+	}
+
+	/**
+	 * Load a translation from files or cache
+	 * 
+	 * @param string $language Two letter language code
+	 * @return void
+	 */
+	protected function loadTranslation($language) {
+		if (!array_key_exists($language, $this->translations)) {
+			$translation = null;
+			if ($this->cache) {
+				$data = $this->cache->load($language);
+				if ($data) {
+					$translation = unserialize($data);
+				}
+			}
+
+			if (!$translation) {
+				$translation = $this->loadTranslationFromFiles($language);
+			}
+
+			$this->loadedLanguages[$language] = $translation;
+			$this->translators[$language] = new Elgg_I18n_Translator($language, $translation);
+		}
+	}
+
+	/**
+	 * Load a translation array from language files
+	 * 
+	 * @param string $language Two letter language code
+	 * @return array
+	 */
+	protected function loadTranslationFromFiles($language) {
+		foreach ($this->translationDirectories as $dir) {
+			$language_file = "$dir/$language.php";
+			if (file_exists($language_file)) {
+				$result = include_once($language_file);
+				if ($result) {
+					if (is_array($result)) {
+						// Elgg 1.9 style language file
+						$this->setTranslation($language, $result);
+					} else {
+						// Elgg 1.0-1.8 style (add_translation)
+					}
+				} else {
+					// why would this fail
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get all languages available
+	 * 
+	 * @return array
+	 * @todo if cache is on, we could read this from cache
+	 */
+	protected function getAllLanguages() {
+		$languages = array();
+		foreach ($this->translationDirectories as $dir) {
+			$handle = opendir($dir);
+			if (!$handle) {
+				// log error or throw exception
+				continue;
+			}
+
+			while (false !== ($file = readdir($handle))) {
+				if (substr($file, 0, 1) == '.' || substr($file, -4) !== '.php'
+						|| strlen($file) != 6) {
+					// skip non-language files
+					continue;
+				}
+
+				$languages[] = substr($file, 0, 2);
+			}
+		}
+
+		return array_unique($languages);
+	}
+
+	/**
+	 * Assert that the language code is valid
+	 * 
+	 * @param string $language Two letter language code
+	 * @return void
+	 * @throws Elgg_I18n_InvalidLanguageException
+	 */
+	protected function assertValidLanguage($language) {
+		if (strlen($language) != 2) {
+			throw new Elgg_I18n_InvalidLanguageException("$language is not a valid language code");
+		}
+	}
+}

--- a/engine/classes/Elgg/I18n/TranslationsService.php
+++ b/engine/classes/Elgg/I18n/TranslationsService.php
@@ -8,14 +8,8 @@
  * @package    Elgg.Core
  * @subpackage I18n
  * @since      1.9.0
- * 
- * @todo keep track of what files have been loaded otherwise we are loading the
- * same language files again and again when the cache is off
  */
 class Elgg_I18n_TranslationsService {
-
-	/** @var ElggCache */
-	protected $cache;
 
 	/** @var string */
 	protected $siteLanguage;
@@ -23,44 +17,67 @@ class Elgg_I18n_TranslationsService {
 	/** @var string */
 	protected $userLanguage;
 
-	/** @var array */
-	protected $translationDirectories = array();
+	/** @var Elgg_I18n_TranslationLoader */
+	protected $loader;
 
 	/** @var array */
-	protected $translations = array();
+	protected $loadedLanguages = array();
 
 	/** @var array */
 	protected $translators = array();
 
+	/** @var bool */
+	protected $on = true;
+
 	/**
 	 * Create a translation service
-	 * 
-	 * @param string    $directory The directory for the core language files
-	 * @param string    $language  Two letter language code for default language
-	 * @param ElggCache $cache
+	 *
+	 * @param Elgg_I18n_TranslationLoader $loader       Translation loader
+	 * @param string                      $siteLanguage Two letter language code for default language
+	 * @param string                      $userLanguage Two letter language code for default language
+	 * @throws Elgg_I18n_InvalidLanguageException
 	 */
-	public function __construct($directory, $language = 'en', $cache = null) {
-		$this->siteLanguage = $language;
-		$this->userLanguage = $language;
-		$this->cache = $cache;
-		$this->registerTranslationDirectory($directory);
+	public function __construct($loader, $siteLanguage = 'en', $userLanguage = 'en') {
+		Elgg_I18n_Translator::assertValidLanguage($siteLanguage);
+		Elgg_I18n_Translator::assertValidLanguage($userLanguage);
+		$this->siteLanguage = $siteLanguage;
+		$this->userLanguage = $userLanguage;
+		$this->loader = $loader;
+	}
+
+	/**
+	 * Turn translation off
+	 *
+	 * @return void
+	 */
+	public function turnOff() {
+		$this->on = false;
+	}
+
+	/**
+	 * Turn translation on
+	 *
+	 * @return void
+	 */
+	public function turnOn() {
+		$this->on = true;
 	}
 
 	/**
 	 * Set the site language
-	 * 
+	 *
 	 * @param string $language Two letter language code
 	 * @return void
 	 * @throws Elgg_I18n_InvalidLanguageException
 	 */
 	public function setSiteLanguage($language) {
-		$this->assertValidLanguage($language);
+		Elgg_I18n_Translator::assertValidLanguage($language);
 		$this->siteLanguage = $language;
 	}
 
 	/**
 	 * Get the site language
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getSiteLanguage() {
@@ -69,19 +86,19 @@ class Elgg_I18n_TranslationsService {
 
 	/**
 	 * Set the user's language
-	 * 
+	 *
 	 * @param string $language Two letter language code
 	 * @return void
 	 * @throws Elgg_I18n_InvalidLanguageException
 	 */
 	public function setUserLanguage($language) {
-		$this->assertValidLanguage($language);
+		Elgg_I18n_Translator::assertValidLanguage($language);
 		$this->userLanguage = $language;
 	}
 
 	/**
 	 * Get the user's language
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getUserLanguage() {
@@ -89,7 +106,29 @@ class Elgg_I18n_TranslationsService {
 	}
 
 	/**
-	 * Get the translation of a message key 
+	 * Register a directory that holds translations
+	 *
+	 * @param string $directory Absolute directory
+	 * @return void
+	 */
+	public function registerTranslationDirectory($directory) {
+		$this->loader->addDirectory($directory);
+		$this->loadedLanguages = array();
+	}
+
+	/**
+	 * Get the directories that contain translations
+	 *
+	 * The directory paths do not have a trailing slash
+	 *
+	 * @return array
+	 */
+	public function getTranslationDirectories() {
+		return $this->loader->getDirectories();
+	}
+
+	/**
+	 * Get the translation of a message key
 	 *
 	 * @param string $key      The message key
 	 * @param array  $args     Optional array of arguments to pass through vsprintf()
@@ -98,19 +137,25 @@ class Elgg_I18n_TranslationsService {
 	 * @throws Elgg_I18n_InvalidLanguageException
 	 */
 	public function translate($key, $args = array(), $language = '') {
-		$this->loadTranslation($this->userLanguage);
-		$this->loadTranslation($this->siteLanguage);
-		if ($language !== '') {
-			$this->assertValidLanguage($language);
-			$this->loadTranslation($language);			
+
+		if ($this->on == false) {
+			return $key;
 		}
 
-		$string = $this->translators[$language]->translate($key, $args);
+		$string = '';
+		if ($language !== '') {
+			Elgg_I18n_Translator::assertValidLanguage($language);
+			$this->loadTranslation($language);
+			$string = $this->translators[$language]->get($key, $args);
+		}
+
 		if (!$string) {
-			$string = $this->translators[$this->userLanguage]->translate($key, $args);
+			$this->loadTranslation($this->userLanguage);
+			$string = $this->translators[$this->userLanguage]->get($key, $args);
 		}
 		if (!$string) {
-			$string = $this->translators[$this->siteLanguage]->translate($key, $args);
+			$this->loadTranslation($this->siteLanguage);
+			$string = $this->translators[$this->siteLanguage]->get($key, $args);
 		}
 		if (!$string) {
 			$string = $key;
@@ -120,153 +165,57 @@ class Elgg_I18n_TranslationsService {
 	}
 
 	/**
-	 * Register a directory that holds translations
-	 * 
-	 * @param string $directory Absolute directory
+	 * Set the translator for a language
+	 *
+	 * @param Elgg_I18n_Translator $translator Translator for this language
 	 * @return void
+	 * @throws Elgg_I18n_InvalidLanguageException
 	 */
-	public function registerTranslationDirectory($directory) {
-		$this->translationDirectories[] = rtrim($directory, '/');
-		if (!$this->cache) {
-			$this->translations = array();
-		}
+	public function setTranslator(Elgg_I18n_Translator $translator) {
+		$this->translators[$translator->getLanguage()] = $translator;
 	}
 
 	/**
-	 * Get the translation array of key => translation
-	 * 
+	 * Get the translator for this language
+	 *
 	 * @param string $language Two letter language code
-	 * @return array
+	 * @return Elgg_I18n_Translator
 	 * @throws Elgg_I18n_InvalidLanguageException
 	 */
-	public function getTranslation($language) {
-		$this->assertValidLanguage($language);
+	public function getTranslator($language) {
+		Elgg_I18n_Translator::assertValidLanguage($language);
 		$this->loadTranslation($language);
-		return $this->translations[$language];
+		return $this->translators[$language];
 	}
 
 	/**
-	 * Replace or add to a translation
-	 * 
-	 * @param string $language    Two letter language code
-	 * @param array  $translation Translation array
-	 * @param bool   $replace     Whether to replace or add to a translation
-	 * @return void
-	 * @throws Elgg_I18n_InvalidLanguageException
+	 * Get translators for all languages
+	 *
+	 * The array is of the form language_code => translator
+	 *
+	 * @return Elgg_I18n_Translator[]
 	 */
-	public function setTranslation($language, array $translation, $replace = false) {
-		$this->assertValidLanguage($language);
-		if ($replace || !array_key_exists($language, $this->translations)) {
-			$this->translations[$language] = $translation;
-		} else {
-			$this->translations[$language] = array_merge($this->translations[$language], $translation);
-		}
-	}
-
-	/**
-	 * Get translation arrays for all languages
-	 * 
-	 * @return array
-	 */
-	public function getAllTranslations() {
-		$languages = $this->getAllLanguages();
+	public function getAllTranslators() {
+		$languages = $this->loader->getAllLanguages();
 
 		foreach ($languages as $language) {
 			$this->loadTranslation($language);
 		}
-	
-		return $this->translations;
+
+		return $this->translators;
 	}
 
 	/**
-	 * Load a translation from files or cache
-	 * 
+	 * Load a translation
+	 *
 	 * @param string $language Two letter language code
 	 * @return void
 	 */
 	protected function loadTranslation($language) {
-		if (!array_key_exists($language, $this->translations)) {
-			$translation = null;
-			if ($this->cache) {
-				$data = $this->cache->load($language);
-				if ($data) {
-					$translation = unserialize($data);
-				}
-			}
-
-			if (!$translation) {
-				$translation = $this->loadTranslationFromFiles($language);
-			}
-
-			$this->loadedLanguages[$language] = $translation;
+		if (!in_array($language, $this->loadedLanguages)) {
+			$translation = $this->loader->loadTranslation($language);
+			$this->loadedLanguages[] = $language;
 			$this->translators[$language] = new Elgg_I18n_Translator($language, $translation);
-		}
-	}
-
-	/**
-	 * Load a translation array from language files
-	 * 
-	 * @param string $language Two letter language code
-	 * @return array
-	 */
-	protected function loadTranslationFromFiles($language) {
-		foreach ($this->translationDirectories as $dir) {
-			$language_file = "$dir/$language.php";
-			if (file_exists($language_file)) {
-				$result = include_once($language_file);
-				if ($result) {
-					if (is_array($result)) {
-						// Elgg 1.9 style language file
-						$this->setTranslation($language, $result);
-					} else {
-						// Elgg 1.0-1.8 style (add_translation)
-					}
-				} else {
-					// why would this fail
-				}
-			}
-		}
-	}
-
-	/**
-	 * Get all languages available
-	 * 
-	 * @return array
-	 * @todo if cache is on, we could read this from cache
-	 */
-	protected function getAllLanguages() {
-		$languages = array();
-		foreach ($this->translationDirectories as $dir) {
-			$handle = opendir($dir);
-			if (!$handle) {
-				// log error or throw exception
-				continue;
-			}
-
-			while (false !== ($file = readdir($handle))) {
-				if (substr($file, 0, 1) == '.' || substr($file, -4) !== '.php'
-						|| strlen($file) != 6) {
-					// skip non-language files
-					continue;
-				}
-
-				$languages[] = substr($file, 0, 2);
-			}
-		}
-
-		return array_unique($languages);
-	}
-
-	/**
-	 * Assert that the language code is valid
-	 * 
-	 * @param string $language Two letter language code
-	 * @return void
-	 * @throws Elgg_I18n_InvalidLanguageException
-	 */
-	protected function assertValidLanguage($language) {
-		if (strlen($language) != 2) {
-			throw new Elgg_I18n_InvalidLanguageException("$language is not a valid language code");
 		}
 	}
 }

--- a/engine/classes/Elgg/I18n/Translator.php
+++ b/engine/classes/Elgg/I18n/Translator.php
@@ -6,10 +6,10 @@
  * @access private
  *
  * @package    Elgg.Core
- * @subpackage Translation
+ * @subpackage I18n
  * @since      1.9.0
  */
-class Elgg_Translation_Translator {
+class Elgg_I18n_Translator {
 
 	/** @var array Array of key to translation mapping arrays */
 	protected $mappings = array();

--- a/engine/classes/Elgg/I18n/Translator.php
+++ b/engine/classes/Elgg/I18n/Translator.php
@@ -19,23 +19,25 @@ class Elgg_I18n_Translator {
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param string $language    The two letter code for the primary language
 	 * @param array  $translation Translation array (key => translation)
+	 * @throws Elgg_I18n_InvalidLanguageException
 	 */
 	public function __construct($language, array $translation) {
+		Elgg_I18n_Translator::assertValidLanguage($language);
 		$this->language = $language;
 		$this->translation = $translation;
 	}
 
 	/**
-	 * Get the translation of a message key 
+	 * Get the translation of a message key
 	 *
 	 * @param string $key  The message key
 	 * @param array  $args Optional array of arguments to pass through vsprintf()
 	 * @return string|false The translation or false if no translation
 	 */
-	public function translate($key, $args = array()) {
+	public function get($key, $args = array()) {
 
 		$translation = false;
 		if (isset($this->translation[$key])) {
@@ -47,4 +49,35 @@ class Elgg_I18n_Translator {
 
 		return $translation;
 	}
+
+	/**
+	 * Get the language of this translation
+	 *
+	 * @return string
+	 */
+	public function getLanguage() {
+		return $this->language;
+	}
+
+	/**
+	 * Gets the current translation as an array of key => translation
+	 * @return array
+	 */
+	public function getTranslationAsArray() {
+		return $this->translation;
+	}
+
+	/**
+	 * Assert that the language code is valid
+	 *
+	 * @param string $language Two letter language code
+	 * @return void
+	 * @throws Elgg_I18n_InvalidLanguageException
+	 */
+	public static function assertValidLanguage($language) {
+		if (strlen($language) != 2) {
+			throw new Elgg_I18n_InvalidLanguageException("$language is not a valid language code");
+		}
+	}
+
 }

--- a/engine/classes/Elgg/I18n/Translator.php
+++ b/engine/classes/Elgg/I18n/Translator.php
@@ -11,151 +11,40 @@
  */
 class Elgg_I18n_Translator {
 
-	/** @var array Array of key to translation mapping arrays */
-	protected $mappings = array();
+	/** @var array Key to translation mapping array */
+	protected $translation = array();
 
-	/** @var string Two letter language code for the primary language */
-	protected $primaryLanguage;
-
-	/** @var string Two letter language code for the secondary language */
-	protected $secondaryLanguage;
+	/** @var string Two letter language code */
+	protected $language;
 
 	/**
 	 * Constructor
 	 * 
-	 * @param string $primaryLanguage   The two letter code for the primary language
-	 * @param string $secondaryLanguage Optional fallback language (default: 'en')
+	 * @param string $language    The two letter code for the primary language
+	 * @param array  $translation Translation array (key => translation)
 	 */
-	public function constructor($primaryLanguage, $secondaryLanguage = 'en') {
-		$this->primaryLanguage = $primaryLanguage;
-		$this->secondaryLanguage = $secondaryLanguage;
-
-		$this->mappings[$this->primaryLanguage] = array();
-		$this->mappings[$this->secondaryLanguage] = array();
+	public function __construct($language, array $translation) {
+		$this->language = $language;
+		$this->translation = $translation;
 	}
 
 	/**
 	 * Get the translation of a message key 
 	 *
-	 * @param string $key      The message key
-	 * @param array  $args     Optional array of arguments to pass through vsprintf()
-	 * @param string $language Optional 2 letter language code to override current language
-	 * @return string
+	 * @param string $key  The message key
+	 * @param array  $args Optional array of arguments to pass through vsprintf()
+	 * @return string|false The translation or false if no translation
 	 */
-	public function _($key, $args = array(), $language = '') {
+	public function translate($key, $args = array()) {
 
-		$translation = '';
-		if ($language) {
-			if (isset($this->mappings[$language]) && isset($this->mappings[$language][$key])) {
-				$translation = $this->mappings[$language][$key];
+		$translation = false;
+		if (isset($this->translation[$key])) {
+			$translation = $this->translation[$key];
+			if ($args) {
+				$translation = vsprintf($translation, $args);
 			}
-		}
-
-		if (!$translation) {
-			if (isset($this->mappings[$this->primaryLanguage][$key])) {
-				$translation = $this->mappings[$this->primaryLanguage][$key];
-			} else if (isset($this->mappings[$this->secondaryLanguage][$key])) {
-				$translation = $this->mappings[$this->secondaryLanguage][$key];
-			} else {
-				$translation = $key;
-			}
-		}
-
-		if ($args) {
-			$translation = vsprintf($translation, $args);
 		}
 
 		return $translation;
 	}
-
-	/**
-	 * Set the language used first for translation
-	 * 
-	 * @param string $language Two letter language code
-	 * @return void
-	 */
-	public function setPrimaryLanguage($language) {
-		$this->primaryLanguage = $language;
-		if (!isset($this->mappings[$this->primaryLanguage])) {
-			$this->mappings[$this->primaryLanguage] = array();
-		}
-	}
-
-	/**
-	 * Get the primary language
-	 * 
-	 * @return string Two letter code
-	 */
-	public function getPrimaryLanguage() {
-		return $this->primaryLanguage;
-	}
-
-	/**
-	 * Set the fallback language used for translation
-	 * 
-	 * @param string $language Two letter language code
-	 * @return void
-	 */
-	public function setSecondaryLanguage($language) {
-		$this->secondaryLanguage = $language;
-		if (!isset($this->mappings[$this->secondaryLanguage])) {
-			$this->mappings[$this->secondaryLanguage] = array();
-		}
-	}
-
-	/**
-	 * Get the secondary language
-	 * 
-	 * @return string Two letter language code
-	 */
-	public function getSecondaryLanguage() {
-		return $this->secondaryLanguage;
-	}
-
-	/**
-	 * Set the translation array for the specified language
-	 * 
-	 * @param string $language Two letter language code
-	 * @param array  $data     Array of key => translation
-	 * @return void
-	 */
-	public function setTranslationArray($language, $data) {
-		$this->mappings[$language] = $data;
-	}
-
-	/**
-	 * Add this array for the specified language translation array
-	 * 
-	 * This overwrites any existing keys for that language
-	 * 
-	 * @param string $language Two letter language code
-	 * @param array  $data     Array of key => translation
-	 * @return void
-	 */
-	public function addTranslationArray($language, $data) {
-		if (isset($this->mappings[$language])) {
-			$this->mappings[$language] = $data + $this->mappings[$language];
-		} else {
-			$this->mappings[$language] = $data;
-		}
-	}
-
-	/**
-	 * Get the translation array for the specified language
-	 * 
-	 * @param string $language Two letter language code
-	 * @return array
-	 */
-	public function getTranslationArray($language) {
-		if (isset($this->mappings[$language])) {
-			return $this->mappings[$language];
-		} else {
-			return array();
-		}
-	}
-
-	protected function validateLanguageCode($language) {
-		// throw exception?
-	}
-
 }

--- a/engine/classes/Elgg/I18n/Translator.php
+++ b/engine/classes/Elgg/I18n/Translator.php
@@ -61,10 +61,25 @@ class Elgg_I18n_Translator {
 
 	/**
 	 * Gets the current translation as an array of key => translation
+	 * 
 	 * @return array
 	 */
-	public function getTranslationAsArray() {
+	public function getTranslation() {
 		return $this->translation;
+	}
+
+	/**
+	 * Set or update the translation array
+	 *
+	 * @param array $translation The translation array
+	 * @param bool  $replace     Whether to replace or add to the translation
+	 */
+	public function setTranslation(array $translation, $replace = false) {
+		if ($replace) {
+			$this->translation = $translation;
+		} else {
+			$this->translation = array_merge($this->translation, $translation);
+		}
 	}
 
 	/**

--- a/engine/classes/Elgg/I18n/Translator.php
+++ b/engine/classes/Elgg/I18n/Translator.php
@@ -73,6 +73,7 @@ class Elgg_I18n_Translator {
 	 *
 	 * @param array $translation The translation array
 	 * @param bool  $replace     Whether to replace or add to the translation
+	 * @return void
 	 */
 	public function setTranslation(array $translation, $replace = false) {
 		if ($replace) {

--- a/engine/classes/Elgg/Translation/Translator.php
+++ b/engine/classes/Elgg/Translation/Translator.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ *
+ * @package    Elgg.Core
+ * @subpackage Translation
+ * @since      1.9.0
+ */
+class Elgg_Translation_Translator {
+
+	/** @var array Array of key to translation mapping arrays */
+	protected $mappings = array();
+
+	/** @var string Two letter language code for the primary language */
+	protected $primaryLanguage;
+
+	/** @var string Two letter language code for the secondary language */
+	protected $secondaryLanguage;
+
+	/**
+	 * Constructor
+	 * 
+	 * @param string $primaryLanguage   The two letter code for the primary language
+	 * @param string $secondaryLanguage Optional fallback language (default: 'en')
+	 */
+	public function constructor($primaryLanguage, $secondaryLanguage = 'en') {
+		$this->primaryLanguage = $primaryLanguage;
+		$this->secondaryLanguage = $secondaryLanguage;
+
+		$this->mappings[$this->primaryLanguage] = array();
+		$this->mappings[$this->secondaryLanguage] = array();
+	}
+
+	/**
+	 * Get the translation of a message key 
+	 *
+	 * @param string $key      The message key
+	 * @param array  $args     Optional array of arguments to pass through vsprintf()
+	 * @param string $language Optional 2 letter language code to override current language
+	 * @return string
+	 */
+	public function _($key, $args = array(), $language = '') {
+
+		$translation = '';
+		if ($language) {
+			if (isset($this->mappings[$language]) && isset($this->mappings[$language][$key])) {
+				$translation = $this->mappings[$language][$key];
+			}
+		}
+
+		if (!$translation) {
+			if (isset($this->mappings[$this->primaryLanguage][$key])) {
+				$translation = $this->mappings[$this->primaryLanguage][$key];
+			} else if (isset($this->mappings[$this->secondaryLanguage][$key])) {
+				$translation = $this->mappings[$this->secondaryLanguage][$key];
+			} else {
+				$translation = $key;
+			}
+		}
+
+		if ($args) {
+			$translation = vsprintf($translation, $args);
+		}
+
+		return $translation;
+	}
+
+	/**
+	 * Set the language used first for translation
+	 * 
+	 * @param string $language Two letter language code
+	 * @return void
+	 */
+	public function setPrimaryLanguage($language) {
+		$this->primaryLanguage = $language;
+		if (!isset($this->mappings[$this->primaryLanguage])) {
+			$this->mappings[$this->primaryLanguage] = array();
+		}
+	}
+
+	/**
+	 * Get the primary language
+	 * 
+	 * @return string Two letter code
+	 */
+	public function getPrimaryLanguage() {
+		return $this->primaryLanguage;
+	}
+
+	/**
+	 * Set the fallback language used for translation
+	 * 
+	 * @param string $language Two letter language code
+	 * @return void
+	 */
+	public function setSecondaryLanguage($language) {
+		$this->secondaryLanguage = $language;
+		if (!isset($this->mappings[$this->secondaryLanguage])) {
+			$this->mappings[$this->secondaryLanguage] = array();
+		}
+	}
+
+	/**
+	 * Get the secondary language
+	 * 
+	 * @return string Two letter language code
+	 */
+	public function getSecondaryLanguage() {
+		return $this->secondaryLanguage;
+	}
+
+	/**
+	 * Set the translation array for the specified language
+	 * 
+	 * @param string $language Two letter language code
+	 * @param array  $data     Array of key => translation
+	 * @return void
+	 */
+	public function setTranslationArray($language, $data) {
+		$this->mappings[$language] = $data;
+	}
+
+	/**
+	 * Add this array for the specified language translation array
+	 * 
+	 * This overwrites any existing keys for that language
+	 * 
+	 * @param string $language Two letter language code
+	 * @param array  $data     Array of key => translation
+	 * @return void
+	 */
+	public function addTranslationArray($language, $data) {
+		if (isset($this->mappings[$language])) {
+			$this->mappings[$language] = $data + $this->mappings[$language];
+		} else {
+			$this->mappings[$language] = $data;
+		}
+	}
+
+	/**
+	 * Get the translation array for the specified language
+	 * 
+	 * @param string $language Two letter language code
+	 * @return array
+	 */
+	public function getTranslationArray($language) {
+		if (isset($this->mappings[$language])) {
+			return $this->mappings[$language];
+		} else {
+			return array();
+		}
+	}
+
+	protected function validateLanguageCode($language) {
+		// throw exception?
+	}
+
+}

--- a/engine/tests/phpunit/Elgg/I18n/TranslationLoaderTest.php
+++ b/engine/tests/phpunit/Elgg/I18n/TranslationLoaderTest.php
@@ -1,0 +1,75 @@
+<?php
+
+class Elgg_I18n_TranslationLoaderTest extends PHPUnit_Framework_TestCase {
+
+	/** @var string */
+	protected $coreDir;
+
+	/** @var string */
+	protected $pluginDir;
+
+	protected function setUp() {
+		$this->coreDir = dirname(dirname(dirname(__FILE__))) . '/test_files/languages/core/';
+		$this->pluginDir = dirname(dirname(dirname(__FILE__))) . '/test_files/languages/plugin/';
+	}
+
+	public function testAddDirectory() {
+		$loader = new Elgg_I18n_TranslationLoader();
+		$this->assertEquals(array(), $loader->getDirectories());
+		$loader->addDirectory('/tmp/');
+		$this->assertEquals(array('/tmp'), $loader->getDirectories());
+		$loader->addDirectory('C:\\elgg\\');
+		$this->assertEquals(array('/tmp', 'C:\\elgg'), $loader->getDirectories());
+	}
+
+	public function testGetAllLanguages() {
+		$loader = new Elgg_I18n_TranslationLoader();
+		$loader->addDirectory($this->pluginDir);
+		$this->assertEquals(array('en'), $loader->getAllLanguages());
+		$loader->addDirectory($this->coreDir);
+		$expected = array('en', 'es', 'fr');
+		$languages = $loader->getAllLanguages();
+		$this->assertEquals(sort($expected), sort($languages));
+	}
+
+	public function testLoadTranslationIncrementally() {
+		$loader = new Elgg_I18n_TranslationLoader();
+		$loader->addDirectory($this->coreDir);
+		$expected = array(
+			'n1' => 'one',
+			'n2' => 'two',
+			'n3' => 'three',
+			'greeting' => 'Hello, %s',
+			'unique' => 'not in Spanish',
+		);
+		$this->assertEquals($expected, $loader->loadTranslation('en'));
+		$loader->addDirectory($this->pluginDir);
+		$expected['greeting'] = 'Hey, %s';
+		$expected['empty'] = 'Set by plugin';
+		$this->assertEquals($expected, $loader->loadTranslation('en'));
+	}
+
+	public function testLoadTranslationFromExistingCache() {
+		$cache = new ElggStaticVariableCache('phpunit');
+		$cache->setVariable('en.lang', serialize(array('test' => 'foo')));
+		$loader = new Elgg_I18n_TranslationLoader($cache);
+		$loader->addDirectory($this->coreDir);
+		$this->assertEquals(array('test' => 'foo'), $loader->loadTranslation('en'));
+	}
+
+	public function testCacheSetting() {
+		$cache = new ElggStaticVariableCache('phpunit');
+		$loader = new Elgg_I18n_TranslationLoader($cache);
+		$loader->addDirectory($this->coreDir);
+		$loader->loadTranslation('en');
+		unset($loader);
+		$expected = array(
+			'n1' => 'one',
+			'n2' => 'two',
+			'n3' => 'three',
+			'greeting' => 'Hello, %s',
+			'unique' => 'not in Spanish',
+		);
+		$this->assertEquals($expected, unserialize($cache->getVariable('en.lang')));
+	}
+}

--- a/engine/tests/phpunit/Elgg/I18n/TranslationsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/I18n/TranslationsServiceTest.php
@@ -160,7 +160,7 @@ class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 		$service = $this->getService();
 		$service->registerTranslationDirectory($this->coreDir);
 		$translator = $service->getTranslator('ru');
-		$this->assertEquals(array(), $translator->getTranslationAsArray());
+		$this->assertEquals(array(), $translator->getTranslation());
 	}
 
 	public function testGetTranslatorForDefinedLanguage() {
@@ -174,7 +174,7 @@ class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 			'greeting' => 'Hello, %s',
 			'unique' => 'not in Spanish',
 		);
-		$this->assertEquals($expected, $translator->getTranslationAsArray());
+		$this->assertEquals($expected, $translator->getTranslation());
 	}
 
 	public function testGetAllTranslators() {

--- a/engine/tests/phpunit/Elgg/I18n/TranslationsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/I18n/TranslationsServiceTest.php
@@ -2,16 +2,188 @@
 
 class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 
-	/** @var Elgg_I18n_TranslationsService */
-	protected $nonCacheService;
+	/** @var string */
+	protected $coreDir;
 
-	/** @var Elgg_I18n_TranslationsService */
-	protected $cacheService;
+	/** @var string */
+	protected $pluginDir;
 
 	protected function setUp() {
-		
+		$this->coreDir = dirname(dirname(dirname(__FILE__))) . '/test_files/languages/core/';
+		$this->pluginDir = dirname(dirname(dirname(__FILE__))) . '/test_files/languages/plugin/';
 	}
 
-	public function test() {
+	/**
+	 * @return Elgg_I18n_TranslationLoader
+	 */
+	protected function getLoaderWithoutCache() {
+		return new Elgg_I18n_TranslationLoader();
+	}
+
+	/**
+	 * @return Elgg_I18n_TranslationsService
+	 */
+	protected function getServiceWithoutCache() {
+		$loader = $this->getLoaderWithoutCache();
+		return new Elgg_I18n_TranslationsService($loader);
+	}
+
+	/**
+	 * @expectedException Elgg_I18n_InvalidLanguageException
+	 */
+	public function testConstructorWithInvalidSiteLanguage() {
+		$loader = $this->getLoaderWithoutCache();
+		new Elgg_I18n_TranslationsService($loader, 'english');
+	}
+
+	/**
+	 * @expectedException Elgg_I18n_InvalidLanguageException
+	 */
+	public function testConstructorWithInvalidUserLanguage() {
+		$loader = $this->getLoaderWithoutCache();
+		new Elgg_I18n_TranslationsService($loader, 'es', 'spanish');
+	}
+
+	public function testConstructorWithValidArguments() {
+		$loader = $this->getLoaderWithoutCache();
+		$service = new Elgg_I18n_TranslationsService($loader, 'en', 'es');
+		$this->assertEquals('en', $service->getSiteLanguage());
+		$this->assertEquals('es', $service->getUserLanguage());
+	}
+
+	public function testSetUserLanguageWithValidLanguage() {
+		$service = $this->getServiceWithoutCache();
+		$service->setUserLanguage('fr');
+		$this->assertEquals('fr', $service->getUserLanguage());
+	}
+
+	/**
+	 * @expectedException Elgg_I18n_InvalidLanguageException
+	 */
+	public function testSetUserLanguageWithInvalidLanguage() {
+		$service = $this->getServiceWithoutCache();
+		$service->setUserLanguage('french');
+	}
+
+	public function testSetSiteLanguageWithValidLanguage() {
+		$service = $this->getServiceWithoutCache();
+		$service->setSiteLanguage('fr');
+		$this->assertEquals('fr', $service->getSiteLanguage());
+	}
+
+	/**
+	 * @expectedException Elgg_I18n_InvalidLanguageException
+	 */
+	public function testSetSiteLanguageWithInvalidLanguage() {
+		$service = $this->getServiceWithoutCache();
+		$service->setSiteLanguage('french');
+	}
+
+	public function testRegisterTranslationDirectory() {
+		$service = $this->getServiceWithoutCache();
+		$service->registerTranslationDirectory('/tmp/');
+		$service->registerTranslationDirectory('C:\\elgg');
+		$this->assertEquals(array('/tmp', 'C:\\elgg'), $service->getTranslationDirectories());
+	}
+
+	public function testTranslateWithCacheOffAndUserLanguage() {
+		$service = $this->getServiceWithoutCache();
+		$service->registerTranslationDirectory($this->coreDir);
+		$service->setUserLanguage('es');
+		$this->assertEquals('uno', $service->translate('n1'));
+		$this->assertEquals('Hola, Tom', $service->translate('greeting', array('Tom')));
+	}
+
+	public function testTranslateWithCacheOffAndSiteLanguage() {
+		$service = $this->getServiceWithoutCache();
+		$service->registerTranslationDirectory($this->coreDir);
+		$service->setUserLanguage('es');
+		$this->assertEquals('not in Spanish', $service->translate('unique'));
+	}
+
+	public function testTranslateWithCacheOffAndMissingKey() {
+		$service = $this->getServiceWithoutCache();
+		$service->registerTranslationDirectory($this->coreDir);
+		$service->setUserLanguage('es');
+		$this->assertEquals('empty', $service->translate('empty'));
+	}
+
+	public function testTranslateWithCacheOffAndLanguageOverride() {
+		$service = $this->getServiceWithoutCache();
+		$service->registerTranslationDirectory($this->coreDir);
+		$service->setUserLanguage('es');
+		$this->assertEquals('un', $service->translate('n1', array(), 'fr'));
+		$this->assertEquals('Bonjour, Tom', $service->translate('greeting', array('Tom'), 'fr'));
+	}
+
+	public function testTranslateWithCacheOffAndPluginsLoaded() {
+		$service = $this->getServiceWithoutCache();
+		$service->registerTranslationDirectory($this->coreDir);
+		$service->registerTranslationDirectory($this->pluginDir);
+		$service->setUserLanguage('en');
+		$this->assertEquals('one', $service->translate('n1'));
+		$this->assertEquals('Hey, Tom', $service->translate('greeting', array('Tom')));
+		$this->assertEquals('Set by plugin', $service->translate('empty'));
+	}
+
+	public function testTranslateWithCacheOffAndPluginsLoadedAfterUse() {
+		$service = $this->getServiceWithoutCache();
+		$service->registerTranslationDirectory($this->coreDir);
+		$service->setUserLanguage('en');
+		$this->assertEquals('Hello, Tom', $service->translate('greeting', array('Tom')));
+		$service->registerTranslationDirectory($this->pluginDir);
+		$this->assertEquals('Hey, Tom', $service->translate('greeting', array('Tom')));
+	}
+
+	public function testTranslateOffAndOn() {
+		$service = $this->getServiceWithoutCache();
+		$service->registerTranslationDirectory($this->coreDir);
+		$service->turnOff();
+		$this->assertEquals('n1', $service->translate('n1'));
+		$this->assertEquals('greeting', $service->translate('greeting', array('Tom')));
+		$service->turnOn();
+		$this->assertEquals('one', $service->translate('n1'));
+		$this->assertEquals('Hello, Tom', $service->translate('greeting', array('Tom')));
+	}
+
+	public function testSetTranslator() {
+		$service = $this->getServiceWithoutCache();
+		$service->registerTranslationDirectory($this->coreDir);
+		$this->assertEquals('one', $service->translate('n1'));
+
+		$translator = new Elgg_I18n_Translator('en', array('n1' => 'not one'));
+		$service->setTranslator($translator);
+		$this->assertEquals('not one', $service->translate('n1'));
+	}
+
+	public function testGetTranslatorForUndefinedLanguage() {
+		$service = $this->getServiceWithoutCache();
+		$service->registerTranslationDirectory($this->coreDir);
+		$translator = $service->getTranslator('ru');
+		$this->assertEquals(array(), $translator->getTranslationAsArray());
+	}
+
+	public function testGetTranslatorForDefinedLanguage() {
+		$service = $this->getServiceWithoutCache();
+		$service->registerTranslationDirectory($this->coreDir);
+		$translator = $service->getTranslator('en');
+		$expected = array(
+			'n1' => 'one',
+			'n2' => 'two',
+			'n3' => 'three',
+			'greeting' => 'Hello, %s',
+			'unique' => 'not in Spanish',
+		);
+		$this->assertEquals($expected, $translator->getTranslationAsArray());
+	}
+
+	public function testGetAllTranslators() {
+		$service = $this->getServiceWithoutCache();
+		$service->registerTranslationDirectory($this->coreDir);
+		$translators = $service->getAllTranslators();
+		$this->assertEquals(3, count($translators));
+		$this->assertEquals('one', $translators['en']->get('n1'));
+		$this->assertEquals('uno', $translators['es']->get('n1'));
+		$this->assertEquals('un', $translators['fr']->get('n1'));
 	}
 }

--- a/engine/tests/phpunit/Elgg/I18n/TranslationsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/I18n/TranslationsServiceTest.php
@@ -16,15 +16,15 @@ class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * @return Elgg_I18n_TranslationLoader
 	 */
-	protected function getLoaderWithoutCache() {
+	protected function getLoader() {
 		return new Elgg_I18n_TranslationLoader();
 	}
 
 	/**
 	 * @return Elgg_I18n_TranslationsService
 	 */
-	protected function getServiceWithoutCache() {
-		$loader = $this->getLoaderWithoutCache();
+	protected function getService() {
+		$loader = $this->getLoader();
 		return new Elgg_I18n_TranslationsService($loader);
 	}
 
@@ -32,7 +32,7 @@ class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 	 * @expectedException Elgg_I18n_InvalidLanguageException
 	 */
 	public function testConstructorWithInvalidSiteLanguage() {
-		$loader = $this->getLoaderWithoutCache();
+		$loader = $this->getLoader();
 		new Elgg_I18n_TranslationsService($loader, 'english');
 	}
 
@@ -40,19 +40,19 @@ class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 	 * @expectedException Elgg_I18n_InvalidLanguageException
 	 */
 	public function testConstructorWithInvalidUserLanguage() {
-		$loader = $this->getLoaderWithoutCache();
+		$loader = $this->getLoader();
 		new Elgg_I18n_TranslationsService($loader, 'es', 'spanish');
 	}
 
 	public function testConstructorWithValidArguments() {
-		$loader = $this->getLoaderWithoutCache();
+		$loader = $this->getLoader();
 		$service = new Elgg_I18n_TranslationsService($loader, 'en', 'es');
 		$this->assertEquals('en', $service->getSiteLanguage());
 		$this->assertEquals('es', $service->getUserLanguage());
 	}
 
 	public function testSetUserLanguageWithValidLanguage() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->setUserLanguage('fr');
 		$this->assertEquals('fr', $service->getUserLanguage());
 	}
@@ -61,12 +61,12 @@ class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 	 * @expectedException Elgg_I18n_InvalidLanguageException
 	 */
 	public function testSetUserLanguageWithInvalidLanguage() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->setUserLanguage('french');
 	}
 
 	public function testSetSiteLanguageWithValidLanguage() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->setSiteLanguage('fr');
 		$this->assertEquals('fr', $service->getSiteLanguage());
 	}
@@ -75,19 +75,19 @@ class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 	 * @expectedException Elgg_I18n_InvalidLanguageException
 	 */
 	public function testSetSiteLanguageWithInvalidLanguage() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->setSiteLanguage('french');
 	}
 
 	public function testRegisterTranslationDirectory() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->registerTranslationDirectory('/tmp/');
 		$service->registerTranslationDirectory('C:\\elgg');
 		$this->assertEquals(array('/tmp', 'C:\\elgg'), $service->getTranslationDirectories());
 	}
 
 	public function testTranslateWithCacheOffAndUserLanguage() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->registerTranslationDirectory($this->coreDir);
 		$service->setUserLanguage('es');
 		$this->assertEquals('uno', $service->translate('n1'));
@@ -95,21 +95,21 @@ class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testTranslateWithCacheOffAndSiteLanguage() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->registerTranslationDirectory($this->coreDir);
 		$service->setUserLanguage('es');
 		$this->assertEquals('not in Spanish', $service->translate('unique'));
 	}
 
 	public function testTranslateWithCacheOffAndMissingKey() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->registerTranslationDirectory($this->coreDir);
 		$service->setUserLanguage('es');
 		$this->assertEquals('empty', $service->translate('empty'));
 	}
 
 	public function testTranslateWithCacheOffAndLanguageOverride() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->registerTranslationDirectory($this->coreDir);
 		$service->setUserLanguage('es');
 		$this->assertEquals('un', $service->translate('n1', array(), 'fr'));
@@ -117,7 +117,7 @@ class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testTranslateWithCacheOffAndPluginsLoaded() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->registerTranslationDirectory($this->coreDir);
 		$service->registerTranslationDirectory($this->pluginDir);
 		$service->setUserLanguage('en');
@@ -127,7 +127,7 @@ class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testTranslateWithCacheOffAndPluginsLoadedAfterUse() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->registerTranslationDirectory($this->coreDir);
 		$service->setUserLanguage('en');
 		$this->assertEquals('Hello, Tom', $service->translate('greeting', array('Tom')));
@@ -136,7 +136,7 @@ class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testTranslateOffAndOn() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->registerTranslationDirectory($this->coreDir);
 		$service->turnOff();
 		$this->assertEquals('n1', $service->translate('n1'));
@@ -147,7 +147,7 @@ class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testSetTranslator() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->registerTranslationDirectory($this->coreDir);
 		$this->assertEquals('one', $service->translate('n1'));
 
@@ -157,14 +157,14 @@ class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetTranslatorForUndefinedLanguage() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->registerTranslationDirectory($this->coreDir);
 		$translator = $service->getTranslator('ru');
 		$this->assertEquals(array(), $translator->getTranslationAsArray());
 	}
 
 	public function testGetTranslatorForDefinedLanguage() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->registerTranslationDirectory($this->coreDir);
 		$translator = $service->getTranslator('en');
 		$expected = array(
@@ -178,7 +178,7 @@ class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetAllTranslators() {
-		$service = $this->getServiceWithoutCache();
+		$service = $this->getService();
 		$service->registerTranslationDirectory($this->coreDir);
 		$translators = $service->getAllTranslators();
 		$this->assertEquals(3, count($translators));

--- a/engine/tests/phpunit/Elgg/I18n/TranslationsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/I18n/TranslationsServiceTest.php
@@ -1,0 +1,17 @@
+<?php
+
+class Elgg_I18n_TranslationsServiceTest extends PHPUnit_Framework_TestCase {
+
+	/** @var Elgg_I18n_TranslationsService */
+	protected $nonCacheService;
+
+	/** @var Elgg_I18n_TranslationsService */
+	protected $cacheService;
+
+	protected function setUp() {
+		
+	}
+
+	public function test() {
+	}
+}

--- a/engine/tests/phpunit/Elgg/I18n/TranslatorTest.php
+++ b/engine/tests/phpunit/Elgg/I18n/TranslatorTest.php
@@ -16,16 +16,16 @@ class Elgg_I18n_TranslatorTest extends PHPUnit_Framework_TestCase {
 		$this->translator = new Elgg_I18n_Translator('en', $this->translation);
 	}
 
-	public function testNoArgs() {
-		$this->assertEquals($this->translation['no_args'], $this->translator->translate('no_args'));
+	public function testGetWithNoArgs() {
+		$this->assertEquals($this->translation['no_args'], $this->translator->get('no_args'));
 	}
 
-	public function testWithArgs() {
+	public function testGetWithArgs() {
 		$ans = 'word here and 45';
-		$this->assertEquals($ans, $this->translator->translate('with_args', array('here', 45)));		
+		$this->assertEquals($ans, $this->translator->get('with_args', array('here', 45)));
 	}
 
-	public function testNonExistentKey() {
-		$this->assertFalse($this->translator->translate('non-existent'));
+	public function testGetWithNonExistentKey() {
+		$this->assertFalse($this->translator->get('non-existent'));
 	}
 }

--- a/engine/tests/phpunit/Elgg/I18n/TranslatorTest.php
+++ b/engine/tests/phpunit/Elgg/I18n/TranslatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+class Elgg_I18n_TranslatorTest extends PHPUnit_Framework_TestCase {
+
+	/** @var Elgg_I18n_Translator */
+	protected $translator;
+
+	/** @var array */
+	protected $translation;
+
+	protected function setUp() {
+		$this->translation = array(
+			'no_args' => 'test',
+			'with_args' => 'word %s and %u',
+		);
+		$this->translator = new Elgg_I18n_Translator('en', $this->translation);
+	}
+
+	public function testNoArgs() {
+		$this->assertEquals($this->translation['no_args'], $this->translator->translate('no_args'));
+	}
+
+	public function testWithArgs() {
+		$ans = 'word here and 45';
+		$this->assertEquals($ans, $this->translator->translate('with_args', array('here', 45)));		
+	}
+
+	public function testNonExistentKey() {
+		$this->assertFalse($this->translator->translate('non-existent'));
+	}
+}

--- a/engine/tests/phpunit/Elgg/I18n/TranslatorTest.php
+++ b/engine/tests/phpunit/Elgg/I18n/TranslatorTest.php
@@ -16,6 +16,13 @@ class Elgg_I18n_TranslatorTest extends PHPUnit_Framework_TestCase {
 		$this->translator = new Elgg_I18n_Translator('en', $this->translation);
 	}
 
+	/**
+	 * @expectedException Elgg_I18n_InvalidLanguageException
+	 */
+	public function testConstructorWithInvalidLanguage() {
+		$this->translator = new Elgg_I18n_Translator('english', array());
+	}
+
 	public function testGetWithNoArgs() {
 		$this->assertEquals($this->translation['no_args'], $this->translator->get('no_args'));
 	}
@@ -27,5 +34,22 @@ class Elgg_I18n_TranslatorTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetWithNonExistentKey() {
 		$this->assertFalse($this->translator->get('non-existent'));
+	}
+
+	public function testGetTranslation() {
+		$this->assertEquals($this->translation, $this->translator->getTranslation());
+	}
+
+	public function testSetTranslationWithReplace() {
+		$this->translator->setTranslation(array('foo' => 'test'), true);
+		$this->assertEquals(array('foo' => 'test'), $this->translator->getTranslation());
+	}
+
+	public function testSetTranslationWithoutReplace() {
+		$this->translator->setTranslation(array('no_args' => 'new', 'foo' => 'test'));
+		$expected = $this->translation;
+		$expected['no_args'] = 'new';
+		$expected['foo'] = 'test';
+		$this->assertEquals($expected, $this->translator->getTranslation());
 	}
 }

--- a/engine/tests/phpunit/test_files/languages/core/en.php
+++ b/engine/tests/phpunit/test_files/languages/core/en.php
@@ -1,0 +1,11 @@
+<?php
+
+return array(
+	'n1' => 'one',
+	'n2' => 'two',
+	'n3' => 'three',
+
+	'greeting' => 'Hello, %s',
+
+	'unique' => 'not in Spanish',
+);

--- a/engine/tests/phpunit/test_files/languages/core/es.php
+++ b/engine/tests/phpunit/test_files/languages/core/es.php
@@ -1,0 +1,9 @@
+<?php
+
+return array(
+	'n1' => 'uno',
+	'n2' => 'dos',
+	'n3' => 'tres',
+
+	'greeting' => 'Hola, %s',
+);

--- a/engine/tests/phpunit/test_files/languages/core/fr.php
+++ b/engine/tests/phpunit/test_files/languages/core/fr.php
@@ -1,0 +1,9 @@
+<?php
+
+return array(
+	'n1' => 'un',
+	'n2' => 'deux',
+	'n3' => 'trois',
+
+	'greeting' => 'Bonjour, %s',
+);

--- a/engine/tests/phpunit/test_files/languages/plugin/en.php
+++ b/engine/tests/phpunit/test_files/languages/plugin/en.php
@@ -1,0 +1,6 @@
+<?php
+
+return array(
+	'greeting' => 'Hey, %s',
+	'empty' => 'Set by plugin',
+);


### PR DESCRIPTION
The current translation system is brittle and complicated. [languages.php](https://github.com/Elgg/Elgg/blob/1.9/engine/lib/languages.php)

This separates the translation system into three components:
- Translator - this handles the actual translation of the message
- TranslationLoader - this loads translations from file or cache
- TranslationService - this manages the translators needed for a request. It manages user and site languages.

The only implementation detail that I have noticed that is different is that the new system falls back to the site language while the current system falls back to English. I could add English as a 2nd fall back.
