### PR TITLE
adds a standalone db queue

### DIFF
--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -220,15 +220,13 @@ class Elgg_Database {
 	 *
 	 * @note Altering the DB invalidates all queries in the query cache.
 	 *
-	 * @internal Not returning the number of rows updated as this depends on the
-	 * type of update query and whether values were actually changed.
+	 * @param string $query      The query to run.
+	 * @param bool   $getNumRows Return the number of rows affected (default: false)
 	 *
-	 * @param string $query The query to run.
-	 *
-	 * @return bool
+	 * @return bool|int
 	 * @throws DatabaseException
 	 */
-	public function updateData($query) {
+	public function updateData($query, $getNumRows = false) {
 
 		$this->logger->log("DB query $query", Elgg_Logger::INFO);
 
@@ -236,7 +234,15 @@ class Elgg_Database {
 
 		$this->invalidateQueryCache();
 
-		return $this->executeQuery("$query", $dblink);
+		if ($this->executeQuery("$query", $dblink)) {
+			if ($getNumRows) {
+				return mysql_affected_rows($dblink);
+			} else {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/engine/classes/Elgg/ServiceProvider.php
+++ b/engine/classes/Elgg/ServiceProvider.php
@@ -138,7 +138,7 @@ class Elgg_ServiceProvider extends Elgg_DIContainer {
 	 */
 	protected function getNotifications(Elgg_ServiceProvider $c) {
 		// @todo move queue in service provider
-		$queue = new Elgg_Util_DatabaseQueue(Elgg_Notifications_NotificationsService::QUEUE_NAME);
+		$queue = new Elgg_Util_DatabaseQueue(Elgg_Notifications_NotificationsService::QUEUE_NAME, $c->db);
 		$sub = new Elgg_Notifications_SubscriptionsService($c->db);
 		$access = elgg_get_access_object();
 		return new Elgg_Notifications_NotificationsService($sub, $queue, $c->hooks, $access);

--- a/engine/classes/Elgg/Util/DatabaseQueue.php
+++ b/engine/classes/Elgg/Util/DatabaseQueue.php
@@ -42,7 +42,7 @@ class Elgg_Util_DatabaseQueue implements Elgg_Util_Queue {
 		$blob = $this->db->sanitizeString(serialize($item));
 		$time = time();
 		$query = "INSERT INTO {$prefix}queue
-			SET queue = '$this->name', data = '$blob', timestamp = $time";
+			SET name = '$this->name', data = '$blob', timestamp = $time";
 		return $this->db->insertData($query) !== false;
 	}
 
@@ -53,7 +53,7 @@ class Elgg_Util_DatabaseQueue implements Elgg_Util_Queue {
 		$prefix = $this->db->getTablePrefix();
 		$update = "UPDATE {$prefix}queue 
 			SET worker = '$this->workerId'
-			WHERE queue = '$this->name' AND worker IS NULL
+			WHERE name = '$this->name' AND worker IS NULL
 			ORDER BY timestamp ASC LIMIT 1";
 		$num = $this->db->updateData($update, true);
 		if ($num === 1) {
@@ -63,7 +63,7 @@ class Elgg_Util_DatabaseQueue implements Elgg_Util_Queue {
 			if ($obj) {
 				$data = unserialize($obj->data);
 				$delete = "DELETE FROM {$prefix}queue
-					WHERE queue = '$this->name' AND worker = '$this->workerId'";
+					WHERE name = '$this->name' AND worker = '$this->workerId'";
 				$this->db->deleteData($delete);
 				return $data;
 			}
@@ -77,6 +77,6 @@ class Elgg_Util_DatabaseQueue implements Elgg_Util_Queue {
 	 */
 	public function clear() {
 		$prefix = $this->db->getTablePrefix();
-		$this->db->deleteData("DELETE FROM {$prefix}queue WHERE queue = '$this->name'");
+		$this->db->deleteData("DELETE FROM {$prefix}queue WHERE name = '$this->name'");
 	}
 }

--- a/engine/classes/Elgg/Util/DatabaseQueue.php
+++ b/engine/classes/Elgg/Util/DatabaseQueue.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * FIFO queue that uses ElggObjects for persistence
+ * FIFO queue that uses the database for persistence
  *
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
  *
@@ -13,48 +13,62 @@
  */
 class Elgg_Util_DatabaseQueue implements Elgg_Util_Queue {
 
-	/* @var string Name of the queue */
+	/** @var string Name of the queue */
 	protected $name;
+
+	/** @var Elgg_Database Database adapter */
+	protected $db;
+
+	/** @var string The identifier of the worker pulling from the queue */
+	protected $workerId;
 
 	/**
 	 * Create a queue
 	 *
-	 * @param string $name Name of the queue
+	 * @param string        $name Name of the queue. Must be less than 256 characters.
+	 * @param Elgg_Database $db   Database adapter
 	 */
-	public function __construct($name) {
-		$this->name = sanitize_string($name);
+	public function __construct($name, Elgg_Database $db) {
+		$this->db = $db;
+		$this->name = $this->db->sanitizeString($name);
+		$this->workerId = $this->db->sanitizeString(md5(microtime() . getmypid()));
 	}
 
 	/**
 	 * {@inheritdoc}
 	 */
 	public function enqueue($item) {
-		$object = new ElggObject();
-		$object->subtype = 'elgg:queue';
-		$object->access_id = ACCESS_PUBLIC;
-		$object->title = $this->name;
-		$object->description = serialize($item);
-		return (bool)$object->save();
+		$prefix = $this->db->getTablePrefix();
+		$blob = $this->db->sanitizeString(serialize($item));
+		$time = time();
+		$query = "INSERT INTO {$prefix}queue
+			SET queue = '$this->name', data = '$blob', timestamp = $time";
+		return $this->db->insertData($query) !== false;
 	}
 
 	/**
 	 * {@inheritdoc}
 	 */
 	public function dequeue() {
-		$db_prefix = elgg_get_config('dbprefix');
-		$object = elgg_get_entities(array(
-			'type' => 'object',
-			'subtype' => 'elgg:queue',
-			'order_by' => 'e.guid ASC',
-			'limit' => 1,
-			'joins' => array("JOIN {$db_prefix}objects_entity as oe on oe.guid = e.guid"),
-			'wheres' => array("oe.title = '$this->name'"),
-		));
-		if ($object) {
-			$result = unserialize($object[0]->description);
-			$object[0]->delete();
-			return $result;
+		$prefix = $this->db->getTablePrefix();
+		$update = "UPDATE {$prefix}queue 
+			SET worker = '$this->workerId'
+			WHERE queue = '$this->name' AND worker IS NULL
+			ORDER BY timestamp ASC LIMIT 1";
+		$num = $this->db->updateData($update, true);
+		if ($num === 1) {
+			$select = "SELECT data FROM {$prefix}queue
+				WHERE worker = '$this->workerId'";
+			$obj = $this->db->getDataRow($select);
+			if ($obj) {
+				$data = unserialize($obj->data);
+				$delete = "DELETE FROM {$prefix}queue
+					WHERE queue = '$this->name' AND worker = '$this->workerId'";
+				$this->db->deleteData($delete);
+				return $data;
+			}
 		}
+
 		return null;
 	}
 
@@ -62,18 +76,7 @@ class Elgg_Util_DatabaseQueue implements Elgg_Util_Queue {
 	 * {@inheritdoc}
 	 */
 	public function clear() {
-		$db_prefix = elgg_get_config('dbprefix');
-		$options = array(
-			'type' => 'object',
-			'subtype' => 'elgg:queue',
-			'order_by' => 'e.guid ASC',
-			'limit' => 0,
-			'joins' => array("JOIN {$db_prefix}objects_entity as oe on oe.guid = e.guid"),
-			'wheres' => array("oe.title = '$this->name'"),
-		);
-		$batch = new ElggBatch('elgg_get_entities', $options);
-		foreach ($batch as $item) {
-			$item->delete();
-		}
+		$prefix = $this->db->getTablePrefix();
+		$this->db->deleteData("DELETE FROM {$prefix}queue WHERE queue = '$this->name'");
 	}
 }

--- a/engine/classes/Elgg/Util/Queue.php
+++ b/engine/classes/Elgg/Util/Queue.php
@@ -21,7 +21,7 @@ interface Elgg_Util_Queue {
 	public function enqueue($item);
 
 	/**
-	 * Remove the oldest item from the queue
+	 * Remove an item from the queue
 	 *
 	 * @return mixed
 	 */

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -602,3 +602,14 @@ function _elgg_save_notification_user_settings() {
 		system_message(elgg_echo('notifications:usersettings:save:ok'));
 	}
 }
+
+/**
+ * @access private
+ */
+function _elgg_notifications_test($hook, $type, $tests) {
+	global $CONFIG;
+	$tests[] = "{$CONFIG->path}engine/tests/ElggCoreDatabaseQueueTest.php";
+	return $tests;
+}
+
+elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_notifications_test');

--- a/engine/lib/upgrades/2013062700-1.9.0_dev-add_db_queue-e6af82afc6d3eee3.php
+++ b/engine/lib/upgrades/2013062700-1.9.0_dev-add_db_queue-e6af82afc6d3eee3.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Elgg 1.9.0-dev upgrade 2013062700
+ * add_db_queue
+ *
+ * Creates the table for queue support
+ */
+
+$db_prefix = elgg_get_config('dbprefix');
+
+// create queue table
+$query = <<<SQL
+CREATE TABLE IF NOT EXISTS `{$db_prefix}queue` (
+  `name` varchar(255) NOT NULL,
+  `data` mediumblob NOT NULL,
+  `timestamp` int(11) NOT NULL,
+  `worker` varchar(32) NULL,
+  KEY `name` (`name`),
+  KEY `retrieve` (`timestamp`,`worker`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+SQL;
+update_data($query);

--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -191,11 +191,11 @@ CREATE TABLE `prefix_private_settings` (
 
 -- queue for asynchronous operations
 CREATE TABLE `prefix_queue` (
-  `queue` varchar(255) NOT NULL,
+  `name` varchar(255) NOT NULL,
   `data` mediumblob NOT NULL,
   `timestamp` int(11) NOT NULL,
   `worker` varchar(32) NULL,
-  KEY `queue` (`queue`),
+  KEY `name` (`name`),
   KEY `retrieve` (`timestamp`,`worker`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 

--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -189,6 +189,16 @@ CREATE TABLE `prefix_private_settings` (
   KEY `value` (`value`(50))
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
+-- queue for asynchronous operations
+CREATE TABLE `prefix_queue` (
+  `queue` varchar(255) NOT NULL,
+  `data` mediumblob NOT NULL,
+  `timestamp` int(11) NOT NULL,
+  `worker` varchar(32) NULL,
+  KEY `queue` (`queue`),
+  KEY `retrieve` (`timestamp`,`worker`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
 -- activity stream
 CREATE TABLE `prefix_river` (
   `id` int(11) NOT NULL AUTO_INCREMENT,

--- a/engine/tests/ElggCoreDatabaseQueueTest.php
+++ b/engine/tests/ElggCoreDatabaseQueueTest.php
@@ -8,7 +8,7 @@
 class ElggCoreDatabaseQueueTest extends ElggCoreUnitTest {
 
 	public function testEnqueueAndDequeue() {
-		$queue = new Elgg_Util_DatabaseQueue('unit:test');
+		$queue = new Elgg_Util_DatabaseQueue('unit:test', _elgg_services()->db);
 		$first = array(1, 2, 3);
 		$second = array(4, 5, 6);
 
@@ -27,8 +27,8 @@ class ElggCoreDatabaseQueueTest extends ElggCoreUnitTest {
 	}
 
 	public function testMultipleQueues() {
-		$queue1 = new Elgg_Util_DatabaseQueue('unit:test1');
-		$queue2 = new Elgg_Util_DatabaseQueue('unit:test2');
+		$queue1 = new Elgg_Util_DatabaseQueue('unit:test1', _elgg_services()->db);
+		$queue2 = new Elgg_Util_DatabaseQueue('unit:test2', _elgg_services()->db);
 		$first = array(1, 2, 3);
 		$second = array(4, 5, 6);
 
@@ -44,7 +44,7 @@ class ElggCoreDatabaseQueueTest extends ElggCoreUnitTest {
 	}
 
 	public function testClear() {
-		$queue = new Elgg_Util_DatabaseQueue('unit:test');
+		$queue = new Elgg_Util_DatabaseQueue('unit:test',  _elgg_services()->db);
 		$first = array(1, 2, 3);
 		$second = array(4, 5, 6);
 

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2013062200;
+$version = 2013062700;
 
 // Human-friendly version name
 $release = '1.9.0-dev';


### PR DESCRIPTION
@ewinslow here is the db queue from previous discussions. It does not implement state or priority other than FIFO. I think sites that need those kind of capabilities should use a dedicated queue system.

This queue is thread safe as long as 2 workers are not started at the same millisecond in the same process. No table locking either or need for a mutex.
