### PR TITLE
only store guid in the session

### DIFF
--- a/engine/classes/ElggSession.php
+++ b/engine/classes/ElggSession.php
@@ -338,11 +338,7 @@ class ElggSession implements ArrayAccess {
 
 		if (in_array($offset, array('user', 'id', 'code', 'name', 'username'))) {
 			elgg_deprecated_notice("Only 'guid' is stored in session for user now", 1.9);
-			if ($this->loggedInUser) {
-				return true;
-			} else {
-				return false;
-			}
+			return (bool)$this->loggedInUser;
 		}
 
 		if (isset($_SESSION[$offset])) {

--- a/engine/tests/ElggCoreGroupTest.php
+++ b/engine/tests/ElggCoreGroupTest.php
@@ -52,8 +52,8 @@ class ElggCoreGroupTest extends ElggCoreUnitTest {
 	}
 
 	public function testGroupItemVisibility() {
-		$original_user = _elgg_services()->session->get('user');
-		_elgg_services()->session->set('user', $this->user);
+		$original_user = _elgg_services()->session->getLoggedInUser();
+		_elgg_services()->session->setLoggedInUser($this->user);
 		$group_guid = $this->group->guid;
 
 		// unrestricted: pass non-members
@@ -75,7 +75,7 @@ class ElggCoreGroupTest extends ElggCoreUnitTest {
 		$this->assertFalse($vis->shouldHideItems);
 
 		// non-member admins succeed - assumes admin logged in
-		_elgg_services()->session->set('user', $original_user);
+		_elgg_services()->session->setLoggedInUser($original_user);
 		$vis = Elgg_GroupItemVisibility::factory($group_guid, false);
 
 		$this->assertFalse($vis->shouldHideItems);


### PR DESCRIPTION
This change saves at least 2 kb of db transfers per request for logged in users. 
