### PR TITLE
Pulls the remember cookie out of users table

### DIFF
--- a/engine/classes/ElggSession.php
+++ b/engine/classes/ElggSession.php
@@ -4,7 +4,7 @@
  * Elgg Session Management
  *
  * Reserved keys: last_forward_from, msg, sticky_forms, user, guid, id, code, name, username
- * Deprecated keys: user, id, code, name, username
+ * Deprecated keys: user, id, name, username
  * 
  * ArrayAccess was deprecated in Elgg 1.9. This means you should use 
  * $session->get('foo') rather than $session['foo'].
@@ -43,9 +43,6 @@ class ElggSession implements ArrayAccess {
 	 */
 	public function start() {
 		$result = $this->storage->start();
-		if ($this->has('guid')) {
-			$this->loggedInUser = get_user($this->get('guid'));
-		}
 		$this->generateSessionToken();
 		return $result;
 	}
@@ -273,7 +270,7 @@ class ElggSession implements ArrayAccess {
 	public function offsetGet($key) {
 		elgg_deprecated_notice(__METHOD__ . " has been deprecated.", 1.9);
 
-		if (in_array($key, array('user', 'id', 'code', 'name', 'username'))) {
+		if (in_array($key, array('user', 'id', 'name', 'username'))) {
 			elgg_deprecated_notice("Only 'guid' is stored in session for user now", 1.9);
 			if ($this->loggedInUser) {
 				switch ($key) {
@@ -283,7 +280,6 @@ class ElggSession implements ArrayAccess {
 					case 'id':
 						return $this->loggedInUser->guid;
 						break;
-					case 'code':
 					case 'name':
 					case 'username':
 						return $this->loggedInUser->$key;
@@ -336,7 +332,7 @@ class ElggSession implements ArrayAccess {
 	public function offsetExists($offset) {
 		elgg_deprecated_notice(__METHOD__ . " has been deprecated.", 1.9);
 
-		if (in_array($offset, array('user', 'id', 'code', 'name', 'username'))) {
+		if (in_array($offset, array('user', 'id', 'name', 'username'))) {
 			elgg_deprecated_notice("Only 'guid' is stored in session for user now", 1.9);
 			return (bool)$this->loggedInUser;
 		}

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -35,7 +35,6 @@ class ElggUser extends ElggEntity
 		$this->attributes['salt'] = null;
 		$this->attributes['email'] = null;
 		$this->attributes['language'] = null;
-		$this->attributes['code'] = null;
 		$this->attributes['banned'] = "no";
 		$this->attributes['admin'] = 'no';
 		$this->attributes['prev_last_action'] = null;
@@ -133,11 +132,10 @@ class ElggUser extends ElggEntity
 		$salt = sanitize_string($this->salt);
 		$email = sanitize_string($this->email);
 		$language = sanitize_string($this->language);
-		$code = sanitize_string($this->code);
 
 		$query = "INSERT into {$CONFIG->dbprefix}users_entity
-			(guid, name, username, password, salt, email, language, code)
-			values ($guid, '$name', '$username', '$password', '$salt', '$email', '$language', '$code')";
+			(guid, name, username, password, salt, email, language)
+			values ($guid, '$name', '$username', '$password', '$salt', '$email', '$language')";
 
 		$result = $this->getDatabase()->insertData($query);
 		if ($result === false) {
@@ -165,11 +163,10 @@ class ElggUser extends ElggEntity
 		$salt = sanitize_string($this->salt);
 		$email = sanitize_string($this->email);
 		$language = sanitize_string($this->language);
-		$code = sanitize_string($this->code);
 
 		$query = "UPDATE {$CONFIG->dbprefix}users_entity
 			SET name='$name', username='$username', password='$password', salt='$salt',
-			email='$email', language='$language', code='$code'
+			email='$email', language='$language'
 			WHERE guid = $guid";
 
 		return $this->getDatabase()->updateData($query) !== false;
@@ -181,14 +178,11 @@ class ElggUser extends ElggEntity
 	 * @return bool
 	 */
 	public function delete() {
-		global $USERNAME_TO_GUID_MAP_CACHE, $CODE_TO_GUID_MAP_CACHE;
+		global $USERNAME_TO_GUID_MAP_CACHE;
 
 		// clear cache
 		if (isset($USERNAME_TO_GUID_MAP_CACHE[$this->username])) {
 			unset($USERNAME_TO_GUID_MAP_CACHE[$this->username]);
-		}
-		if (isset($CODE_TO_GUID_MAP_CACHE[$this->code])) {
-			unset($CODE_TO_GUID_MAP_CACHE[$this->code]);
 		}
 
 		clear_user_files($this);

--- a/engine/lib/deprecated-1.9.php
+++ b/engine/lib/deprecated-1.9.php
@@ -2422,7 +2422,6 @@ function create_user_entity($guid, $name, $username, $password, $salt, $email, $
 	$salt = sanitise_string($salt);
 	$email = sanitise_string($email);
 	$language = sanitise_string($language);
-	$code = sanitise_string($code);
 
 	$row = get_entity_as_row($guid);
 	if ($row) {
@@ -2431,7 +2430,7 @@ function create_user_entity($guid, $name, $username, $password, $salt, $email, $
 		if ($exists = get_data_row($query)) {
 			$query = "UPDATE {$CONFIG->dbprefix}users_entity
 				SET name='$name', username='$username', password='$password', salt='$salt',
-				email='$email', language='$language', code='$code'
+				email='$email', language='$language'
 				WHERE guid = $guid";
 
 			$result = update_data($query);
@@ -2447,8 +2446,8 @@ function create_user_entity($guid, $name, $username, $password, $salt, $email, $
 		} else {
 			// Exists query failed, attempt an insert.
 			$query = "INSERT into {$CONFIG->dbprefix}users_entity
-				(guid, name, username, password, salt, email, language, code)
-				values ($guid, '$name', '$username', '$password', '$salt', '$email', '$language', '$code')";
+				(guid, name, username, password, salt, email, language)
+				values ($guid, '$name', '$username', '$password', '$salt', '$email', '$language')";
 
 			$result = insert_data($query);
 			if ($result !== false) {

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -331,7 +331,16 @@ function _elgg_add_remember_me_cookie(ElggUser $user, $code) {
 
 	$query = "INSERT INTO {$prefix}users_remember_me_cookies
 		(code, guid, timestamp) VALUES ('$code', $user->guid, $time)";
-	$db->insertData($query);
+	try {
+		$db->insertData($query);
+	} catch (DatabaseException $e) {
+		if (false !== strpos($e->getMessage(), "users_remember_me_cookies' doesn't exist")) {
+			// schema has not been updated so we swallow this exception
+			return null;
+		} else {
+			throw $e;
+		}
+	}
 }
 
 /**
@@ -348,7 +357,16 @@ function _elgg_delete_remember_me_cookie($code) {
 
 	$query = "DELETE FROM {$prefix}users_remember_me_cookies
 		WHERE code = '$code'";
-	$db->deleteData($query);
+	try {
+		$db->deleteData($query);
+	} catch (DatabaseException $e) {
+		if (false !== strpos($e->getMessage(), "users_remember_me_cookies' doesn't exist")) {
+			// schema has not been updated so we swallow this exception
+			return null;
+		} else {
+			throw $e;
+		}
+	}
 }
 
 /**

--- a/engine/lib/upgrades/2013062200-1.9.0_dev-new_remember_me_table-da1bfc6f36c7952e.php
+++ b/engine/lib/upgrades/2013062200-1.9.0_dev-new_remember_me_table-da1bfc6f36c7952e.php
@@ -26,11 +26,14 @@ $ia = elgg_set_ignore_access(true);
 $options = array(
 	'type' => 'user',
 	'limit' => 0,
+	'selects' => array("u.code as code"),
+	'joins' => array("JOIN {$db_prefix}users_entity u ON e.guid = u.guid"),
 );
 $batch = new ElggBatch('elgg_get_entities', $options);
 foreach ($batch as $entity) {
-	if (isset($entity->code)) {
-		_elgg_add_remember_me_cookie($entity, $entity->code);
+	$code = $entity->getVolatileData('select:code');
+	if ($code) {
+		_elgg_add_remember_me_cookie($entity, $code);
 	}
 }
 elgg_set_ignore_access($ia);

--- a/engine/lib/upgrades/2013062200-1.9.0_dev-new_remember_me_table-da1bfc6f36c7952e.php
+++ b/engine/lib/upgrades/2013062200-1.9.0_dev-new_remember_me_table-da1bfc6f36c7952e.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Elgg 1.9.0-dev upgrade 2013062200
+ * new_remember_me_table
+ *
+ * Moves the remember code into the new table and then drops the code from
+ * the users entity table
+ */
+
+$db_prefix = elgg_get_config('dbprefix');
+
+// create remember me table
+$query1 = <<<SQL
+CREATE TABLE IF NOT EXISTS `{$db_prefix}users_remember_me_cookies` (
+  `code` varchar(32) NOT NULL,
+  `guid` bigint(20) unsigned NOT NULL,
+  `timestamp` int(11) unsigned NOT NULL,
+  PRIMARY KEY (`code`),
+  KEY `timestamp` (`timestamp`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+SQL;
+update_data($query1);
+
+// move codes
+$ia = elgg_set_ignore_access(true);
+$options = array(
+	'type' => 'user',
+	'limit' => 0,
+);
+$batch = new ElggBatch('elgg_get_entities', $options);
+foreach ($batch as $entity) {
+	if (isset($entity->code)) {
+		_elgg_add_remember_me_cookie($entity, $entity->code);
+	}
+}
+elgg_set_ignore_access($ia);
+
+// drop code from users table
+$query2 = "ALTER TABLE {$db_prefix}users_entity DROP code";
+update_data($query2);

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -11,10 +11,6 @@
 global $USERNAME_TO_GUID_MAP_CACHE;
 $USERNAME_TO_GUID_MAP_CACHE = array();
 
-/// Map a user code to a cached GUID
-global $CODE_TO_GUID_MAP_CACHE;
-$CODE_TO_GUID_MAP_CACHE = array();
-
 /**
  * Return the user specific details of a user by a row.
  *
@@ -77,10 +73,6 @@ function ban_user($user_guid, $reason = "") {
 			if ($reason) {
 				create_metadata($user_guid, 'ban_reason', $reason, '', 0, ACCESS_PUBLIC);
 			}
-
-			// clear "remember me" cookie code so user cannot login in using it
-			$user->code = "";
-			$user->save();
 
 			// invalidate memcache for this user
 			static $newentity_cache;
@@ -274,36 +266,26 @@ function get_user_by_username($username) {
 }
 
 /**
- * Get user by session code
+ * Get user by remember me code
  *
- * @param string $code The session code
+ * @param string $code The remember me code
  *
- * @return ElggUser|false Depending on success
+ * @return ElggUser
  */
 function get_user_by_code($code) {
-	global $CONFIG, $CODE_TO_GUID_MAP_CACHE;
+	$db = _elgg_services()->db;	
+	$prefix = $db->getTablePrefix();
+	$code = $db->sanitizeString($code);
 
-	$code = sanitise_string($code);
+	$query = "SELECT guid FROM {$prefix}users_remember_me_cookies
+		WHERE code = '$code'";
+	$result = $db->getDataRow($query);
 
-	$access = get_access_sql_suffix('e');
-
-	// Caching
-	if ((isset($CODE_TO_GUID_MAP_CACHE[$code]))
-	&& (_elgg_retrieve_cached_entity($CODE_TO_GUID_MAP_CACHE[$code]))) {
-
-		return _elgg_retrieve_cached_entity($CODE_TO_GUID_MAP_CACHE[$code]);
+	if ($result) {
+		return get_user($result->guid);
 	}
 
-	$query = "SELECT e.* FROM {$CONFIG->dbprefix}users_entity u
-		JOIN {$CONFIG->dbprefix}entities e ON e.guid = u.guid
-		WHERE u.code = '$code' AND $access";
-
-	$entity = get_data_row($query, 'entity_row_to_elggstar');
-	if ($entity) {
-		$CODE_TO_GUID_MAP_CACHE[$code] = $entity->guid;
-	}
-
-	return $entity;
+	return null;
 }
 
 /**

--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -271,7 +271,6 @@ CREATE TABLE `prefix_users_entity` (
   `salt` varchar(8) NOT NULL DEFAULT '',
   `email` text NOT NULL,
   `language` varchar(6) NOT NULL DEFAULT '',
-  `code` varchar(32) NOT NULL DEFAULT '',
   `banned` enum('yes','no') NOT NULL DEFAULT 'no',
   `admin` enum('yes','no') NOT NULL DEFAULT 'no',
   `last_action` int(11) NOT NULL DEFAULT '0',
@@ -282,12 +281,20 @@ CREATE TABLE `prefix_users_entity` (
   UNIQUE KEY `username` (`username`),
   KEY `password` (`password`),
   KEY `email` (`email`(50)),
-  KEY `code` (`code`),
   KEY `last_action` (`last_action`),
   KEY `last_login` (`last_login`),
   KEY `admin` (`admin`),
   FULLTEXT KEY `name` (`name`),
   FULLTEXT KEY `name_2` (`name`,`username`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+-- user remember me cookies
+CREATE TABLE `prefix_users_remember_me_cookies` (
+  `code` varchar(32) NOT NULL,
+  `guid` bigint(20) unsigned NOT NULL,
+  `timestamp` int(11) unsigned NOT NULL,
+  PRIMARY KEY (`code`),
+  KEY `timestamp` (`timestamp`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 -- user sessions

--- a/engine/tests/ElggCoreUserTest.php
+++ b/engine/tests/ElggCoreUserTest.php
@@ -58,7 +58,6 @@ class ElggCoreUserTest extends ElggCoreUnitTest {
 		$attributes['salt'] = null;
 		$attributes['email'] = null;
 		$attributes['language'] = null;
-		$attributes['code'] = null;
 		$attributes['banned'] = 'no';
 		$attributes['admin'] = 'no';
 		$attributes['prev_last_action'] = null;

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2013051700;
+$version = 2013062200;
 
 // Human-friendly version name
 $release = '1.9.0-dev';


### PR DESCRIPTION
This pulls out the 'code' so that a user can be logged in from multiple browsers using the remember me cookie. This bug has been around for a long time.

I'm going to follow up with gc on the table based on the configuration of the cookie expire time. That way we're not depending on the browser to expire the cookie (and it cleans out the table).
