### PR TITLE
using real __set() and __get()

### DIFF
--- a/engine/classes/ElggData.php
+++ b/engine/classes/ElggData.php
@@ -69,29 +69,6 @@ abstract class ElggData implements
 	}
 
 	/**
-	 * Return an attribute or a piece of metadata.
-	 *
-	 * @param string $name Name
-	 *
-	 * @return mixed
-	 */
-	public function __get($name) {
-		return $this->get($name);
-	}
-
-	/**
-	 * Set an attribute or a piece of metadata.
-	 *
-	 * @param string $name  Name
-	 * @param mixed  $value Value
-	 *
-	 * @return void
-	 */
-	public function __set($name, $value) {
-		$this->set($name, $value);
-	}
-
-	/**
 	 * Test if property is set either as an attribute or metadata.
 	 *
 	 * @tip Use isset($entity->property)
@@ -110,6 +87,7 @@ abstract class ElggData implements
 	 * @param string $name The attribute to fetch
 	 *
 	 * @return mixed The attribute, if it exists.  Otherwise, null.
+	 * @deprecated 1.9
 	 */
 	abstract protected function get($name);
 
@@ -120,6 +98,7 @@ abstract class ElggData implements
 	 * @param mixed  $value The value to set it to
 	 *
 	 * @return bool The success of your set function?
+	 * @deprecated 1.9
 	 */
 	abstract protected function set($name, $value);
 

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -189,8 +189,8 @@ abstract class ElggEntity extends ElggData implements
 	 * @warning Metadata set this way will inherit the entity's owner and 
 	 * access ID. If you want more control over metadata, use ElggEntity::setMetadata()
 	 * 
-	 * @param string $name Name of the attribute or metadata
-	 * @param mixed $value The value to be set
+	 * @param string $name  Name of the attribute or metadata
+	 * @param mixed  $value The value to be set
 	 * @return void
 	 * @see ElggEntity::setMetadata()
 	 */

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -119,19 +119,32 @@ class ElggGroup extends ElggEntity
 	}
 
 	/**
-	 * Returns an attribute or metadata.
+	 * Wrapper around ElggEntity::__get()
 	 *
-	 * @see ElggEntity::get()
+	 * @see ElggEntity::__get()
 	 *
 	 * @param string $name Name
-	 *
 	 * @return mixed
+	 * @todo deprecate appending group to username. Was a hack used for creating
+	 * URLs for group content. We stopped using the hack in 1.8.
 	 */
-	public function get($name) {
+	public function __get($name) {
 		if ($name == 'username') {
 			return 'group:' . $this->getGUID();
 		}
-		return parent::get($name);
+		return parent::__get($name);
+	}
+
+	/**
+	 * Wrapper around ElggEntity::get()
+	 *
+	 * @param string $name Name
+	 * @return mixed
+	 * @deprecated 1.9
+	 */
+	public function get($name) {
+		elgg_deprecated_notice("Use -> instead of get()", 1.9);
+		return $this->__get($name);
 	}
 
 	/**

--- a/engine/classes/ElggRelationship.php
+++ b/engine/classes/ElggRelationship.php
@@ -43,18 +43,30 @@ class ElggRelationship extends ElggData implements
 	}
 
 	/**
-	 * Class member get overloading
+	 * (non-PHPdoc)
 	 *
-	 * @param string $name Name
+	 * @see ElggData::initializeAttributes()
 	 *
-	 * @return mixed
+	 * @return void
 	 */
-	public function get($name) {
-		if (array_key_exists($name, $this->attributes)) {
-			return $this->attributes[$name];
-		}
+	protected function initializeAttributes() {
+		parent::initializeAttributes();
 
-		return null;
+		$this->attributes['id'] = null;
+		$this->attributes['guid_one'] = null;
+		$this->attributes['relationship'] = null;
+		$this->attributes['guid_two'] = null;
+	}
+
+	/**
+	 * Set an attribute of the relationship
+	 *
+	 * @param string $name  Name
+	 * @param mixed  $value Value
+	 * @return void
+	 */
+	public function __set($name, $value) {
+		$this->attributes[$name] = $value;
 	}
 
 	/**
@@ -62,12 +74,39 @@ class ElggRelationship extends ElggData implements
 	 *
 	 * @param string $name  Name
 	 * @param mixed  $value Value
-	 *
 	 * @return mixed
+	 * @deprecated 1.9
 	 */
 	public function set($name, $value) {
-		$this->attributes[$name] = $value;
+		elgg_deprecated_notice("Use -> instead of set()", 1.9);
+		$this->__set($name, $value);
 		return true;
+	}
+
+	/**
+	 * Get an attribute of the relationship
+	 *
+	 * @param string $name Name
+	 * @return mixed
+	 */
+	public function __get($name) {
+		if (array_key_exists($name, $this->attributes)) {
+			return $this->attributes[$name];
+		}
+
+		return null;
+	}
+	
+	/**
+	 * Class member get overloading
+	 *
+	 * @param string $name Name
+	 * @return mixed
+	 * @deprecated 1.9
+	 */
+	public function get($name) {
+		elgg_deprecated_notice("Use -> instead of get()", 1.9);
+		return $this->__get($name);
 	}
 
 	/**

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -210,11 +210,11 @@ class ElggUser extends ElggEntity
 	public function setDisplayName($displayName) {
 		$this->name = $displayName;
 	}
-	
+
 	/**
 	 * {@inheritdoc}
 	 */
-	public function set($name, $value) {
+	public function __set($name, $value) {
 		if (array_key_exists($name, $this->attributes)) {
 			switch ($name) {
 				case 'prev_last_action':
@@ -227,13 +227,21 @@ class ElggUser extends ElggEntity
 					}
 					break;
 				default:
-					return parent::set($name, $value);
+					parent::__set($name, $value);
 					break;
 			}
 		} else {
-			return parent::set($name, $value);
+			parent::__set($name, $value);
 		}
-	
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function set($name, $value) {
+		elgg_deprecated_notice("Use -> instead of set()", 1.9);
+		$this->__set($name, $value);
+
 		return true;
 	}
 
@@ -686,43 +694,6 @@ class ElggUser extends ElggEntity
 			'username',
 			'language',
 		));
-	}
-
-	/**
-	 * Need to catch attempts to make a user an admin.  Remove for 1.9
-	 *
-	 * @param string $name  Name
-	 * @param mixed  $value Value
-	 *
-	 * @return void
-	 */
-	public function __set($name, $value) {
-		if ($name == 'admin' || $name == 'siteadmin') {
-			elgg_deprecated_notice('The admin/siteadmin metadata are not longer used.  Use ElggUser->makeAdmin() and ElggUser->removeAdmin().', 1.7);
-
-			if ($value == 'yes' || $value == '1') {
-				$this->makeAdmin();
-			} else {
-				$this->removeAdmin();
-			}
-		}
-		parent::__set($name, $value);
-	}
-
-	/**
-	 * Need to catch attempts to test user for admin.  Remove for 1.9
-	 *
-	 * @param string $name Name
-	 *
-	 * @return bool
-	 */
-	public function __get($name) {
-		if ($name == 'admin' || $name == 'siteadmin') {
-			elgg_deprecated_notice('The admin/siteadmin metadata are not longer used.  Use ElggUser->isAdmin().', 1.7);
-			return $this->isAdmin();
-		}
-
-		return parent::__get($name);
 	}
 
 	/**

--- a/engine/classes/ElggWidget.php
+++ b/engine/classes/ElggWidget.php
@@ -27,18 +27,18 @@ class ElggWidget extends ElggObject {
 	}
 
 	/**
-	 * Override entity get and sets in order to save data to private data store.
-	 *
-	 * @param string $name Name
-	 *
+	 * Get a value from attributes or private settings
+	 * 
+	 * @param string $name The name of the value
 	 * @return mixed
 	 */
-	public function get($name) {
+	public function __get($name) {
 		// See if its in our base attribute
 		if (array_key_exists($name, $this->attributes)) {
 			return $this->attributes[$name];
 		}
 
+		// @todo clean up now that private settings return null
 		// No, so see if its in the private data store.
 		$meta = $this->getPrivateSetting($name);
 		if ($meta) {
@@ -52,22 +52,46 @@ class ElggWidget extends ElggObject {
 	/**
 	 * Override entity get and sets in order to save data to private data store.
 	 *
-	 * @param string $name  Name
-	 * @param string $value Value
-	 *
-	 * @return bool
+	 * @param string $name Name
+	 * @return mixed
+	 * @deprecated 1.9
 	 */
-	public function set($name, $value) {
+	public function get($name) {
+		elgg_deprecated_notice("Use -> instead of get()", 1.9);
+		return $this->__get($name);
+	}
+
+	/**
+	 * Set an attribute or private setting value
+	 * 
+	 * @param string $name  The name of the value to set
+	 * @param mixed  $value The value to set
+	 * @return void
+	 */
+	public function __set($name, $value) {
 		if (array_key_exists($name, $this->attributes)) {
 			// Check that we're not trying to change the guid!
 			if ((array_key_exists('guid', $this->attributes)) && ($name == 'guid')) {
-				return false;
+				return;
 			}
 
 			$this->attributes[$name] = $value;
 		} else {
-			return $this->setPrivateSetting($name, $value);
+			$this->setPrivateSetting($name, $value);
 		}
+	}
+
+	/**
+	 * Override entity get and sets in order to save data to private data store.
+	 *
+	 * @param string $name  Name
+	 * @param string $value Value
+	 * @return bool
+	 * @deprecated 1.9
+	 */
+	public function set($name, $value) {
+		elgg_deprecated_notice("Use -> instead of set()", 1.9);
+		$this->__set($name, $value);
 
 		return true;
 	}

--- a/engine/lib/plugins.php
+++ b/engine/lib/plugins.php
@@ -455,7 +455,7 @@ function _elgg_set_plugin_priorities(array $order) {
 
 		$priority = array_search($plugin_id, $order) + 1;
 
-		if (!$plugin->set($name, $priority)) {
+		if (!$plugin->setPrivateSetting($name, $priority)) {
 			$return = false;
 			break;
 		}
@@ -468,7 +468,7 @@ function _elgg_set_plugin_priorities(array $order) {
 		}
 		foreach ($missing_plugins as $plugin) {
 			$priority++;
-			if (!$plugin->set($name, $priority)) {
+			if (!$plugin->setPrivateSetting($name, $priority)) {
 				$return = false;
 				break;
 			}

--- a/engine/tests/ElggCoreEntityTest.php
+++ b/engine/tests/ElggCoreEntityTest.php
@@ -68,14 +68,6 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 		unset($this->entity->access_id);
 		$this->assertIdentical($this->entity->access_id, '');
 
-		// unable to directly set guid
-		$this->assertFalse($this->entity->set('guid', 'error'));
-		$this->entity->guid = 'error';
-		$this->assertNotEqual($this->entity->guid, 'error');
-
-		// non-attribute not set as metadata returns null
-		$this->assertNull($this->entity->get('non_existent'));
-
 		// consider helper methods
 		$this->assertIdentical($this->entity->getGUID(), $this->entity->guid );
 		$this->assertIdentical($this->entity->getType(), $this->entity->type );

--- a/engine/tests/ElggCoreEntityTest.php
+++ b/engine/tests/ElggCoreEntityTest.php
@@ -80,7 +80,7 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 
 	public function testElggEntityGetAndSetMetadata() {
 		// ensure metadata not set
-		$this->assertNull($this->entity->get('non_existent'));
+		$this->assertNull($this->entity->non_existent);
 		$this->assertFalse(isset($this->entity->non_existent));
 
 		// create metadata

--- a/engine/tests/phpunit/ElggEntityTest.php
+++ b/engine/tests/phpunit/ElggEntityTest.php
@@ -9,15 +9,23 @@ class ElggEntityTest extends PHPUnit_Framework_TestCase {
 		$this->obj = $this->getMockForAbstractClass('ElggEntity');
 		$reflection = new ReflectionClass('ElggEntity');
 		$method = $reflection->getMethod('initializeAttributes');
-		$method->setAccessible(true);
-		$method->invokeArgs($this->obj, array());
+		if (method_exists($method, 'setAccessible')) {
+			$method->setAccessible(true);
+			$method->invokeArgs($this->obj, array());
+		}
 	}
 
+	/**
+	 * @requires PHP 5.3.2
+	 */
 	public function testSettingAndGettingAttribute() {
 		$this->obj->subtype = 'foo';
 		$this->assertEquals('foo', $this->obj->subtype);
 	}
 
+	/**
+	 * @requires PHP 5.3.2
+	 */
 	public function testSettingIntegerAttributes() {
 		foreach (array('access_id', 'owner_guid', 'container_guid') as $name) {
 			$this->obj->$name = '77';
@@ -25,6 +33,9 @@ class ElggEntityTest extends PHPUnit_Framework_TestCase {
 		}
 	}
 
+	/**
+	 * @requires PHP 5.3.2
+	 */
 	public function testSettingUnsettableAttributes() {
 		foreach (array('guid', 'time_updated', 'last_action') as $name) {
 			$this->obj->$name = 'foo';
@@ -32,6 +43,9 @@ class ElggEntityTest extends PHPUnit_Framework_TestCase {
 		}		
 	}
 
+	/**
+	 * @requires PHP 5.3.2
+	 */
 	public function testSettingMetadataNoDatabase() {
 		$this->obj->foo = 'test';
 		$this->assertEquals('test', $this->obj->foo);
@@ -39,6 +53,9 @@ class ElggEntityTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('overwrite', $this->obj->foo);
 	}
 
+	/**
+	 * @requires PHP 5.3.2
+	 */
 	public function testGettingNonexistentMetadataNoDatabase() {
 		$this->assertNull($this->obj->foo);
 	}

--- a/engine/tests/phpunit/ElggEntityTest.php
+++ b/engine/tests/phpunit/ElggEntityTest.php
@@ -1,0 +1,46 @@
+<?php
+
+class ElggEntityTest extends PHPUnit_Framework_TestCase {
+
+	/** @var ElggEntity */
+	protected $obj;
+
+	protected function setUp() {
+		$this->obj = $this->getMockForAbstractClass('ElggEntity');
+		$reflection = new ReflectionClass('ElggEntity');
+		$method = $reflection->getMethod('initializeAttributes');
+		$method->setAccessible(true);
+		$method->invokeArgs($this->obj, array());
+	}
+
+	public function testSettingAndGettingAttribute() {
+		$this->obj->subtype = 'foo';
+		$this->assertEquals('foo', $this->obj->subtype);
+	}
+
+	public function testSettingIntegerAttributes() {
+		foreach (array('access_id', 'owner_guid', 'container_guid') as $name) {
+			$this->obj->$name = '77';
+			$this->assertSame(77, $this->obj->$name);			
+		}
+	}
+
+	public function testSettingUnsettableAttributes() {
+		foreach (array('guid', 'time_updated', 'last_action') as $name) {
+			$this->obj->$name = 'foo';
+			$this->assertNotEquals('foo', $this->obj->$name);			
+		}		
+	}
+
+	public function testSettingMetadataNoDatabase() {
+		$this->obj->foo = 'test';
+		$this->assertEquals('test', $this->obj->foo);
+		$this->obj->foo = 'overwrite';
+		$this->assertEquals('overwrite', $this->obj->foo);
+	}
+
+	public function testGettingNonexistentMetadataNoDatabase() {
+		$this->assertNull($this->obj->foo);
+	}
+
+}

--- a/engine/tests/phpunit/ElggExtenderTest.php
+++ b/engine/tests/phpunit/ElggExtenderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+// needed for detect_extender_valuetype()
+$engine = dirname(dirname(dirname(__FILE__)));
+require_once "$engine/lib/extender.php";
+
+class ElggExtenderTest extends PHPUnit_Framework_TestCase {
+
+	public function testSettingAndGettingAttribute() {
+		$obj = $this->getMockForAbstractClass('ElggExtender');
+		$obj->name = 'comment';
+		$this->assertEquals('comment', $obj->name);
+	}
+
+	public function testGettingNonexistentAttribute() {
+		$obj = $this->getMockForAbstractClass('ElggExtender');
+		$this->assertNull($obj->foo);
+	}
+
+	public function testSettingValueAttribute() {
+		$obj = $this->getMockForAbstractClass('ElggExtender');
+		$obj->value = '36';
+		$this->assertSame('36', $obj->value);
+		$this->assertEquals('text', $obj->value_type);
+		$obj->value = 78;
+		$this->assertSame(78, $obj->value);
+		$this->assertEquals('integer', $obj->value_type);
+	}
+
+	public function testSettingValueExplicitly() {
+		$obj = $this->getMockForAbstractClass('ElggExtender');
+		$obj->setValue('36', 'integer');
+		$this->assertSame(36, $obj->value);
+		$this->assertEquals('integer', $obj->value_type);		
+	}
+}

--- a/engine/tests/phpunit/ElggRelationshipTest.php
+++ b/engine/tests/phpunit/ElggRelationshipTest.php
@@ -1,0 +1,15 @@
+<?php
+
+class ElggRelationshipTest extends PHPUnit_Framework_TestCase {
+
+	public function testSettingAndGettingAttribute() {
+		$obj = $this->getMockForAbstractClass('ElggRelationship');
+		$obj->relationship = 'hasSister';
+		$this->assertEquals('hasSister', $obj->relationship);
+	}
+
+	public function testGettingNonexistentAttribute() {
+		$obj = $this->getMockForAbstractClass('ElggRelationship');
+		$this->assertNull($obj->foo);
+	}
+}

--- a/engine/tests/phpunit/ElggUserTest.php
+++ b/engine/tests/phpunit/ElggUserTest.php
@@ -7,8 +7,16 @@ class ElggUserTest extends PHPUnit_Framework_TestCase {
 		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
 	}
 	
-	function testCanConstructWithoutArguments() {
+	public function testCanConstructWithoutArguments() {
 		$this->assertNotNull(new ElggUser());
+	}
+
+	public function testSettingUnsettableAttributes() {
+		$obj = new ElggUser();
+		foreach (array('prev_last_action', 'last_login', 'prev_last_login') as $name) {
+			$obj->$name = 'foo';
+			$this->assertNotEquals('foo', $obj->$name);			
+		}		
 	}
 
 }


### PR DESCRIPTION
Elgg has always had this odd way of having __set() and __get() call set() and get(). This cleans that up and adds unit tests for the changes.
