### PR TITLE
Fixes #5163. JS elgg.parse_str support for key[]=value1&key[]=value2.

### DIFF
--- a/js/lib/elgglib.js
+++ b/js/lib/elgglib.js
@@ -471,12 +471,22 @@ elgg.parse_str = function(string) {
 	var result,
 		key,
 		value,
-		re = /([^&=]+)=?([^&]*)/g;
+		re = /([^&=]+)=?([^&]*)/g,
+		re2 = /\[\]$/;
 
 	while (result = re.exec(string)) {
 		key = decodeURIComponent(result[1].replace(/\+/g, ' '));
 		value = decodeURIComponent(result[2].replace(/\+/g, ' '));
-		params[key] = value;
+
+		if (re2.test(key)) {
+			key = key.replace(re2, '');
+			if (!params[key]) {
+				params[key] = [];
+			}
+			params[key].push(value);
+		} else {
+			params[key] = value;
+		}
 	}
 	
 	return params;

--- a/js/tests/ElggLibTest.js
+++ b/js/tests/ElggLibTest.js
@@ -170,7 +170,10 @@ define(function(require) {
 		describe("elgg.parse_str()", function () {
 			it("parses values like PHP's urldecode()", function () {
 				[
-					["A+%2B+B=A+%2B+B", {"A + B": "A + B"}]
+					["A+%2B+B=A+%2B+B", {"A + B": "A + B"}],
+					["key1=val1", {'key1': 'val1'}],
+					["key1=val1&key2=val2", {'key1': 'val1', 'key2': 'val2'}],
+					["key1[]=value1&key1[]=value2&key2=value3", {'key1': ['value1', 'value2'], 'key2': 'value3'}]
 				].forEach(function(args) {
 					expect(elgg.parse_str(args[0])).toEqual(args[1]);
 				});


### PR DESCRIPTION
Pulling #5215 into master
