### PR TITLE
Fixes #4369: Properly encodes markup in textareas

### DIFF
--- a/views/default/input/longtext.php
+++ b/views/default/input/longtext.php
@@ -38,5 +38,5 @@ echo elgg_view_menu('longtext', array(
 ?>
 
 <textarea <?php echo elgg_format_attributes($vars); ?>>
-<?php echo htmlspecialchars($value, ENT_QUOTES, 'UTF-8', false); ?>
+<?php echo htmlspecialchars($value, ENT_QUOTES, 'UTF-8'); ?>
 </textarea>


### PR DESCRIPTION
With this change you can now include write posts about XML/HTML and re-edit them without having the content mangled.
