### PR TITLE
Fixes #5719: Sets context from URL during system boot.

### DIFF
--- a/engine/classes/Elgg/Request.php
+++ b/engine/classes/Elgg/Request.php
@@ -450,6 +450,20 @@ class Elgg_Request {
 	}
 
 	/**
+	 * Get URL segments in an array
+	 *
+	 * @return array
+	 */
+	public function getUrlSegments() {
+		$path = trim($this->getPathInfo(), '/');
+		if (!$path) {
+			return array();
+		}
+
+		return explode('/', $path);
+	}
+
+	/**
 	 * Get the IP address of the client
 	 *
 	 * @return string

--- a/engine/classes/Elgg/Router.php
+++ b/engine/classes/Elgg/Router.php
@@ -36,13 +36,11 @@ class Elgg_Router {
 	 * @access private
 	 */
 	public function route(Elgg_Request $request) {
-		$segments = $this->getUrlSegments($request);
+		$segments = $request->getUrlSegments();
 		if ($segments) {
 			$identifier = array_shift($segments);
-			elgg_set_context($identifier);
 		} else {
 			$identifier = '';
-			elgg_set_context('main');
 
 			// this plugin hook is deprecated. Use elgg_register_page_handler()
 			// to register for the '' (empty string) handler.
@@ -115,20 +113,5 @@ class Elgg_Router {
 	 */
 	public function getPageHandlers() {
 		return $this->handlers;
-	}
-
-	/**
-	 * Get URL segments in an array
-	 *
-	 * @param Elgg_Request $request The request being routed
-	 * @return array
-	 */
-	protected function getUrlSegments(Elgg_Request $request) {
-		$path = trim($request->getPathInfo(), '/');
-		if (!$path) {
-			return array();
-		}
-
-		return explode('/', $path);
 	}
 }

--- a/engine/lib/pageowner.php
+++ b/engine/lib/pageowner.php
@@ -288,9 +288,17 @@ function page_owner_boot() {
 	// Bootstrap the context stack by setting its first entry to the handler.
 	// This is the first segment of the URL and the handler is set by the rewrite rules.
 	// @todo this does not work for actions
-	$handler = get_input('handler', false);
-	if ($handler) {
-		elgg_set_context($handler);
+
+	$request = _elgg_services()->request;
+
+	// don't do this for *_handler.php, etc.
+	if (basename($request->server->get('SCRIPT_FILENAME')) === 'index.php') {
+		$segments = $request->getUrlSegments();
+		if ($segments) {
+			elgg_set_context($segments[0]);
+		} else {
+			elgg_set_context('main');
+		}
 	}
 }
 


### PR DESCRIPTION
This also moves getUrlSegments to the request so we don't have to create another method in the router to set the context. If it would be more appropriate to put this logic in the router than in page_owner_boot, we can go that route instead.
