### PR TITLE
using dataroot and simplecache_enabled if set in settings.php

### DIFF
--- a/engine/classes/Elgg/CacheHandler.php
+++ b/engine/classes/Elgg/CacheHandler.php
@@ -158,7 +158,7 @@ class Elgg_CacheHandler {
 		}
 		mysql_close($dblink);
 
-		if (!$result || !isset($this->config->dataroot, $this->config->simplecache_enabled)) {
+		if (!$result || !isset($this->config->dataroot)) {
 			$this->send403('Cache error: unable to get the data root');
 		}
 	}

--- a/engine/handlers/cache_handler.php
+++ b/engine/handlers/cache_handler.php
@@ -19,6 +19,12 @@ require_once dirname(dirname(__FILE__)) . '/classes/Elgg/CacheHandler.php';
 require_once dirname(dirname(__FILE__)) . '/settings.php';
 /* @var stdClass $CONFIG */
 
+// dataroot must have trailing slash
+// @todo need a lib with core functions that have no depedencies
+if (isset($CONFIG->dataroot)) {
+	$CONFIG->dataroot = rtrim($CONFIG->dataroot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+}
+
 $handler = new Elgg_CacheHandler($CONFIG);
 
 $handler->handleRequest($_GET, $_SERVER);

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -623,16 +623,30 @@ function _elgg_load_application_config() {
 	if (!empty($path)) {
 		$CONFIG->path = $path;
 	}
-	$dataroot = datalist_get('dataroot');
-	if (!empty($dataroot)) {
-		$CONFIG->dataroot = $dataroot;
-	}
-	$simplecache_enabled = datalist_get('simplecache_enabled');
-	if ($simplecache_enabled !== false) {
-		$CONFIG->simplecache_enabled = $simplecache_enabled;
+
+	// allow sites to set dataroot and simplecache_enabled in settings.php
+	if (isset($CONFIG->dataroot)) {
+		$CONFIG->dataroot = sanitise_filepath($CONFIG->dataroot);
+		$CONFIG->dataroot_in_settings = true;
 	} else {
-		$CONFIG->simplecache_enabled = 1;
+		$dataroot = datalist_get('dataroot');
+		if (!empty($dataroot)) {
+			$CONFIG->dataroot = $dataroot;
+		}
+		$CONFIG->dataroot_in_settings = false;
 	}
+	if (isset($CONFIG->simplecache_enabled)) {
+		$CONFIG->simplecache_enabled_in_settings = true;
+	} else {
+		$simplecache_enabled = datalist_get('simplecache_enabled');
+		if ($simplecache_enabled !== false) {
+			$CONFIG->simplecache_enabled = $simplecache_enabled;
+		} else {
+			$CONFIG->simplecache_enabled = 1;
+		}
+		$CONFIG->simplecache_enabled_in_settings = false;
+	}
+
 	$system_cache_enabled = datalist_get('system_cache_enabled');
 	if ($system_cache_enabled !== false) {
 		$CONFIG->system_cache_enabled = $system_cache_enabled;

--- a/engine/settings.example.php
+++ b/engine/settings.example.php
@@ -114,6 +114,19 @@ $CONFIG->dbprefix = '{{dbprefix}}';
 
 
 /**
+ * Better caching performance
+ *
+ * Configuring the location of your data directory and enabling simplecache in
+ * the settings.php file improves caching performance. It allows Elgg to skip
+ * connecting to the database when serving cached JavaScript and CSS files. If
+ * you uncomment and configure these settings, you will not be able to change
+ * them from the Elgg advanced settings page.
+ */
+//$CONFIG->dataroot = "";
+//$CONFIG->simplecache_enabled = true;
+
+
+/**
  * Use non-standard headers for broken MTAs.
  *
  * The default header EOL for headers is \r\n.  This causes problems

--- a/languages/en.php
+++ b/languages/en.php
@@ -476,6 +476,7 @@ return array(
 	'admin:settings:advanced' => 'Advanced Settings',
 	'admin:site:description' => "This admin panel allows you to control global settings for your site. Choose an option below to get started.",
 	'admin:site:opt:linktext' => "Configure site...",
+	'admin:settings:in_settings_file' => 'This setting is configured in settings.php',
 
 	'admin:dashboard' => 'Dashboard',
 	'admin:widget:online_users' => 'Online users',

--- a/views/default/css/admin.php
+++ b/views/default/css/admin.php
@@ -446,7 +446,8 @@ label {
 	color: #333333;
 	font-size: 110%;
 }
-label.elgg-state-disabled {
+label.elgg-state-disabled,
+input.elgg-state-disabled {
 	opacity: 0.6;
 }
 

--- a/views/default/forms/admin/site/update_advanced.php
+++ b/views/default/forms/admin/site/update_advanced.php
@@ -5,14 +5,25 @@
 $form_body = "";
 
 foreach (array('wwwroot', 'path', 'dataroot') as $field) {
+	$warning = false;
+
 	$form_body .= "<div>";
 	$form_body .= elgg_echo('installation:' . $field) . "<br />";
-	$warning = elgg_echo('installation:warning:' . $field);
-	if ($warning != 'installation:warning:' . $field) {
-		echo "<b>" . $warning . "</b><br />";
+
+	$params = array(
+		'name' => $field,
+		'value' => elgg_get_config($field)
+	);
+	if ($field == 'dataroot' && elgg_get_config('dataroot_in_settings')) {
+		$params['readonly'] = true;
+		$params['class'] = 'elgg-state-disabled';
+		$warning = elgg_echo('admin:settings:in_settings_file');
 	}
-	$value = elgg_get_config($field);
-	$form_body .= elgg_view("input/text",array('name' => $field, 'value' => $value));
+
+	$form_body .= elgg_view("input/text", $params);
+	if ($warning) {
+		$form_body .= "<span class=\"elgg-text-help\">$warning</span>";
+	}
 	$form_body .= "</div>";
 }
 
@@ -21,11 +32,21 @@ $simple_cache_disabled_class = $is_simple_cache_on ? '' : 'elgg-state-disabled';
 $form_body .= '<fieldset class="elgg-fieldset">';
 $form_body .= '<legend>' . elgg_echo('admin:legend:caching') . '</legend>';
 $form_body .= "<div>" . elgg_echo('installation:simplecache:description') . "<br />";
-$form_body .= elgg_view("input/checkbox", array(
+$params = array(
 	'label' => elgg_echo('installation:simplecache:label'),
 	'name' => 'simplecache_enabled',
 	'checked' => $is_simple_cache_on,
-)) . "</div>";
+);
+if (elgg_get_config('simplecache_enabled_in_settings')) {
+	$params['class'] = 'elgg-state-disabled';
+	$params['label_class'] = 'elgg-state-disabled';
+}
+$form_body .= elgg_view("input/checkbox", $params);
+if (elgg_get_config('simplecache_enabled_in_settings')) {
+	$warning = elgg_echo('admin:settings:in_settings_file');
+	$form_body .= "<span class=\"elgg-text-help\">$warning</span>";
+}
+$form_body .= "</div>";
 
 $form_body .= "<div>" . elgg_echo('installation:minify:description') . "<br />";
 $form_body .= elgg_view("input/checkbox", array(

--- a/views/default/js/admin.php
+++ b/views/default/js/admin.php
@@ -49,6 +49,9 @@ elgg.admin.init = function () {
 	// admin notices delete ajax
 	$('a.elgg-admin-notice').click(elgg.admin.deleteNotice);
 
+	// disable checkboxes (readonly does not work for them)
+	$('input:checkbox.elgg-state-disabled').live('click', function() {return false;});
+
 	// disable simple cache compress settings if simple cache is off
 	$('[name=simplecache_enabled]').click(elgg.admin.simplecacheToggle);
 };
@@ -168,11 +171,14 @@ elgg.admin.deleteNotice = function(e) {
  * @return void
  */
 elgg.admin.simplecacheToggle = function() {
-	var names = ['simplecache_minify_js', 'simplecache_minify_css'];
-	for (var i = 0; i < names.length; i++) {
-		var $input = $('input[type!=hidden][name="' + names[i] + '"]');
-		if ($input.length) {
-			$input.parent().toggleClass('elgg-state-disabled');
+	// when the checkbox is disabled, do not toggle the compression checkboxes
+	if (!$this.hasClass('elgg-state-disabled')) {
+		var names = ['simplecache_minify_js', 'simplecache_minify_css'];
+		for (var i = 0; i < names.length; i++) {
+			var $input = $('input[type!=hidden][name="' + names[i] + '"]');
+			if ($input.length) {
+				$input.parent().toggleClass('elgg-state-disabled');
+			}
 		}
 	}
 };


### PR DESCRIPTION
This relates to #5138. It improves support for setting dataroot and simplecache_enabled in settings.php

It does not encourage people to do it. I still need to add comments to settings.example.php.

There is also another ticket about adding a page about improving performance. We could include that on that page.
