### PR TITLE
DB driver based on zf2

### DIFF
--- a/engine/classes/Elgg/Database/Connection.php
+++ b/engine/classes/Elgg/Database/Connection.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ * 
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+interface Elgg_Database_Connection {
+
+	/**
+	 * Connect
+	 *
+	 * @return Elgg_Database_Connection
+	 */
+	public function connect();
+
+	/**
+	 * Is connected
+	 *
+	 * @return bool
+	 */
+	public function isConnected();
+
+	/**
+	 * Disconnect
+	 *
+	 * @return Elgg_Database_Connection
+	 */
+	public function disconnect();
+
+	/**
+	 * Execute
+	 *
+	 * @param string $sql SQL statement
+	 * @return Elgg_Database_Result
+	 */
+	public function execute($sql);
+
+	/**
+	 * Get last generated id
+	 *
+	 * @return int
+	 */
+	public function getLastGeneratedValue();
+}

--- a/engine/classes/Elgg/Database/Connection.php
+++ b/engine/classes/Elgg/Database/Connection.php
@@ -5,9 +5,12 @@
  *
  * @access private
  * 
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * http://framework.zend.com/license/new-bsd New BSD License
+ *
+ * @package    Elgg.Core
+ * @subpackage Database
+ * @since      1.9.0
  */
 interface Elgg_Database_Connection {
 

--- a/engine/classes/Elgg/Database/Driver.php
+++ b/engine/classes/Elgg/Database/Driver.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ * 
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+interface Elgg_Database_Driver {
+
+	/**
+	 * Check environment
+	 *
+	 * @return bool
+	 */
+	public function checkEnvironment();
+
+	/**
+	 * Get connection
+	 *
+	 * @return Elgg_Database_Connection
+	 */
+	public function getConnection();
+
+	/**
+	 * Create result
+	 *
+	 * @param resource $resource
+	 * @return Elgg_Database_Result
+	 */
+	public function createResult($resource);
+
+	/**
+	 * Get last generated value
+	 *
+	 * @return int
+	 */
+	public function getLastGeneratedValue();
+}

--- a/engine/classes/Elgg/Database/Driver.php
+++ b/engine/classes/Elgg/Database/Driver.php
@@ -5,9 +5,12 @@
  *
  * @access private
  * 
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * http://framework.zend.com/license/new-bsd New BSD License
+ *
+ * @package    Elgg.Core
+ * @subpackage Database
+ * @since      1.9.0
  */
 interface Elgg_Database_Driver {
 
@@ -28,7 +31,7 @@ interface Elgg_Database_Driver {
 	/**
 	 * Create result
 	 *
-	 * @param resource $resource
+	 * @param resource $resource A resource
 	 * @return Elgg_Database_Result
 	 */
 	public function createResult($resource);

--- a/engine/classes/Elgg/Database/MySqlConnection.php
+++ b/engine/classes/Elgg/Database/MySqlConnection.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+class Elgg_Database_MySqlConnection implements Elgg_Database_Connection {
+
+	/**
+	 * @var Elgg_Database_MySqlDriver
+	 */
+	protected $driver = null;
+
+	/**
+	 * Connection parameters
+	 *
+	 * @var array
+	 */
+	protected $connectionParameters = array();
+
+	/**
+	 * @var resource
+	 */
+	protected $resource = null;
+
+	/**
+	 * Constructor
+	 *
+	 * @param array $connectionInfo
+	 */
+	public function __construct(array $connectionInfo) {
+		$this->setConnectionParameters($connectionInfo);
+	}
+
+	/**
+	 * Set driver
+	 * 
+	 * @param Elgg_Database_MySqlDriver $driver
+	 * @return Elgg_Database_MySqlConnection
+	 */
+	public function setDriver(Elgg_Database_MySqlDriver $driver) {
+		$this->driver = $driver;
+		return $this;
+	}
+
+	/**
+	 * Set connection parameters
+	 *
+	 * @param array $connectionParameters
+	 * @return Elgg_Database_MySqlConnection
+	 */
+	public function setConnectionParameters(array $connectionParameters) {
+		$this->connectionParameters = $connectionParameters;
+		return $this;
+	}
+
+	/**
+	 * Get connection parameters
+	 *
+	 * @return array
+	 */
+	public function getConnectionParameters() {
+		return $this->connectionParameters;
+	}
+
+	/**
+	 * Connect
+	 *
+	 * @return Elgg_Database_MySqlConnection
+	 * @throws InvalidArgumentException
+	 */
+	public function connect() {
+		if (is_resource($this->resource)) {
+			return $this;
+		}
+
+		$p = $this->connectionParameters;
+
+		$requiredParameters = array('host', 'user', 'password', 'database');
+		foreach ($requiredParameters as $param) {
+			if (!isset($p[$param])) {
+				throw new InvalidArgumentException("MySqlConnection::connect() requires '$param'.");
+			}
+		}
+
+		$this->resource = mysql_connect($p['host'], $p['user'], $p['password'], true);
+		if (!is_resource($this->resource)) {
+			throw new DatabaseException();
+		}
+
+		if (!mysql_select_db($p['database'], $this->resource)) {
+			throw new DatabaseException();
+		}
+
+		// @todo figure out how Zend expects this to be done
+		mysql_query("SET NAMES utf8");
+
+		return $this;
+	}
+
+	/**
+	 * Is connected
+	 *
+	 * @return bool
+	 */
+	public function isConnected() {
+		return (is_resource($this->resource));
+	}
+
+	/**
+	 * Disconnect
+	 *
+	 * @return void
+	 */
+	public function disconnect() {
+		if (is_resource($this->resource)) {
+			mysql_close($this->resource);
+		}
+		unset($this->resource);
+	}
+
+	/**
+	 * Execute
+	 *
+	 * @param string $sql
+	 * @return Elgg_Database_MySqlResult
+	 */
+	public function execute($sql) {
+		if (!$this->isConnected()) {
+			$this->connect();
+		}
+
+		$results = mysql_query($sql, $this->resource);
+		if ($results === false) {
+			throw new DatabaseException(mysql_error($this->resource) . "\n\n QUERY: $sql");
+		}
+
+		return $this->driver->createResult(($results === true) ? $this->resource : $results);
+	}
+
+	/**
+	 * Get last generated id
+	 *
+	 * @return int
+	 */
+	public function getLastGeneratedValue() {
+		return mysql_insert_id($this->resource);
+	}
+
+}

--- a/engine/classes/Elgg/Database/MySqlConnection.php
+++ b/engine/classes/Elgg/Database/MySqlConnection.php
@@ -5,9 +5,12 @@
  *
  * @access private
  *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * http://framework.zend.com/license/new-bsd New BSD License
+ *
+ * @package    Elgg.Core
+ * @subpackage Database
+ * @since      1.9.0
  */
 class Elgg_Database_MySqlConnection implements Elgg_Database_Connection {
 
@@ -31,7 +34,7 @@ class Elgg_Database_MySqlConnection implements Elgg_Database_Connection {
 	/**
 	 * Constructor
 	 *
-	 * @param array $connectionInfo
+	 * @param array $connectionInfo Connection parameters
 	 */
 	public function __construct(array $connectionInfo) {
 		$this->setConnectionParameters($connectionInfo);
@@ -40,7 +43,7 @@ class Elgg_Database_MySqlConnection implements Elgg_Database_Connection {
 	/**
 	 * Set driver
 	 * 
-	 * @param Elgg_Database_MySqlDriver $driver
+	 * @param Elgg_Database_MySqlDriver $driver MySQL driver
 	 * @return Elgg_Database_MySqlConnection
 	 */
 	public function setDriver(Elgg_Database_MySqlDriver $driver) {
@@ -51,7 +54,7 @@ class Elgg_Database_MySqlConnection implements Elgg_Database_Connection {
 	/**
 	 * Set connection parameters
 	 *
-	 * @param array $connectionParameters
+	 * @param array $connectionParameters Connection parameters
 	 * @return Elgg_Database_MySqlConnection
 	 */
 	public function setConnectionParameters(array $connectionParameters) {
@@ -127,7 +130,7 @@ class Elgg_Database_MySqlConnection implements Elgg_Database_Connection {
 	/**
 	 * Execute
 	 *
-	 * @param string $sql
+	 * @param string $sql The query string
 	 * @return Elgg_Database_MySqlResult
 	 */
 	public function execute($sql) {

--- a/engine/classes/Elgg/Database/MySqlDriver.php
+++ b/engine/classes/Elgg/Database/MySqlDriver.php
@@ -5,9 +5,12 @@
  *
  * @access private
  * 
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * http://framework.zend.com/license/new-bsd New BSD License
+ *
+ * @package    Elgg.Core
+ * @subpackage Database
+ * @since      1.9.0
  */
 class Elgg_Database_MySqlDriver implements Elgg_Database_Driver {
 
@@ -19,7 +22,7 @@ class Elgg_Database_MySqlDriver implements Elgg_Database_Driver {
 	/**
 	 * Constructor
 	 *
-	 * @param array $connectionParameters
+	 * @param array $connectionParameters Connection parameters (user, password, etc)
 	 */
 	public function __construct($connectionParameters) {
 		$connection = new Elgg_Database_MySqlConnection($connectionParameters);
@@ -29,7 +32,7 @@ class Elgg_Database_MySqlDriver implements Elgg_Database_Driver {
 	/**
 	 * Register connection
 	 *
-	 * @param Elgg_Database_MySqlConnection $connection
+	 * @param Elgg_Database_MySqlConnection $connection Connection
 	 * @return Elgg_Database_MySqlDriver
 	 */
 	public function registerConnection(Elgg_Database_MySqlConnection $connection) {
@@ -61,7 +64,7 @@ class Elgg_Database_MySqlDriver implements Elgg_Database_Driver {
 	/**
 	 * Create result
 	 *
-	 * @param resource|bool $resource
+	 * @param resource $resource link resource or result resource
 	 * @return Elgg_Database_MySqlResult
 	 */
 	public function createResult($resource) {

--- a/engine/classes/Elgg/Database/MySqlDriver.php
+++ b/engine/classes/Elgg/Database/MySqlDriver.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ * 
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+class Elgg_Database_MySqlDriver implements Elgg_Database_Driver {
+
+	/**
+	 * @var Elgg_Database_MySqlConnection
+	 */
+	protected $connection = null;
+
+	/**
+	 * Constructor
+	 *
+	 * @param array $connectionParameters
+	 */
+	public function __construct($connectionParameters) {
+		$connection = new Elgg_Database_MySqlConnection($connectionParameters);
+		$this->registerConnection($connection);
+	}
+
+	/**
+	 * Register connection
+	 *
+	 * @param Elgg_Database_MySqlConnection $connection
+	 * @return Elgg_Database_MySqlDriver
+	 */
+	public function registerConnection(Elgg_Database_MySqlConnection $connection) {
+		$this->connection = $connection;
+		$this->connection->setDriver($this);
+		return $this;
+	}
+
+	/**
+	 * Check environment
+	 *
+	 * @return void
+	 */
+	public function checkEnvironment() {
+		if (!extension_loaded('mysql')) {
+			throw new DatabaseException('The mysql extension is required for this adapter but the extension is not loaded');
+		}
+	}
+
+	/**
+	 * Get connection
+	 *
+	 * @return Connection
+	 */
+	public function getConnection() {
+		return $this->connection;
+	}
+
+	/**
+	 * Create result
+	 *
+	 * @param resource|bool $resource
+	 * @return Elgg_Database_MySqlResult
+	 */
+	public function createResult($resource) {
+		$result = new Elgg_Database_MySqlResult();
+		$result->initialize($resource, $this->connection->getLastGeneratedValue());
+		return $result;
+	}
+
+	/**
+	 * Get last generated value
+	 *
+	 * @return int
+	 */
+	public function getLastGeneratedValue() {
+		return $this->connection->getLastGeneratedValue();
+	}
+
+}

--- a/engine/classes/Elgg/Database/MySqlResult.php
+++ b/engine/classes/Elgg/Database/MySqlResult.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ * 
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+class Elgg_Database_MySqlResult implements Elgg_Database_Result {
+
+	/**
+	 * @var resource Either a mysql_link or mysql_result resource
+	 */
+	protected $resource = null;
+
+	/**
+	 * Cursor position
+	 * @var int
+	 */
+	protected $position = 0;
+
+	/**
+	 * Is the value available for the current position
+	 * @var bool
+	 */
+	protected $currentAvailable = false;
+
+	/**
+	 * @var bool
+	 */
+	protected $currentData = false;
+
+	/**
+	 * @var mixed
+	 */
+	protected $generatedValue = null;
+
+	/**
+	 * Initialize
+	 *
+	 * @param resource $resource
+	 * @param int      $generatedValue
+	 * @return Elgg_Database_MySqlResult
+	 * @throws InvalidArgumentException
+	 */
+	public function initialize($resource, $generatedValue) {
+		if (!is_resource($resource)) {
+			throw new InvalidArgumentException('Invalid resource provided.');
+		}
+
+		$this->resource = $resource;
+		$this->generatedValue = $generatedValue;
+		return $this;
+	}
+
+	/**
+	 * Return the resource
+	 *
+	 * @return resource
+	 */
+	public function getResource() {
+		return $this->resource;
+	}
+
+	/**
+	 * Get affected rows
+	 *
+	 * @return int
+	 */
+	public function getAffectedRows() {
+		if (get_resource_type($this->resource) == "mysql result") {
+			return mysql_num_rows($this->resource);
+		} else {
+			return mysql_affected_rows($this->resource);
+		}
+	}
+
+	/**
+	 * Current
+	 *
+	 * @return mixed
+	 */
+	public function current() {
+		if ($this->currentAvailable) {
+			return $this->currentData;
+		}
+
+		$this->loadFromMysqlResult();
+		return $this->currentData;
+	}
+
+	/**
+	 * Load from mysql result
+	 *
+	 * @return bool
+	 */
+	protected function loadFromMysqlResult() {
+		$this->currentData = null;
+
+		if (($data = mysql_fetch_object($this->resource)) === false) {
+			return false;
+		}
+
+		$this->currentData = $data;
+		$this->currentAvailable = true;
+		return true;
+	}
+
+	/**
+	 * Next
+	 *
+	 * @return void
+	 */
+	public function next() {
+		if ($this->currentAvailable == false) {
+			// skipping
+			$this->loadFromMysqlResult();
+		}
+		$this->currentAvailable = false;
+		$this->position++;
+	}
+
+	/**
+	 * Key
+	 *
+	 * @return mixed
+	 */
+	public function key() {
+		return $this->position;
+	}
+
+	/**
+	 * Rewind
+	 *
+	 * @return void
+	 * @throws RuntimeException
+	 */
+	public function rewind() {
+		if ($this->position !== 0) {
+			throw new RuntimeException('Results cannot be rewound for multiple iterations');
+		}
+		$this->currentAvailable = false;
+		$this->position = 0;
+	}
+
+	/**
+	 * Valid
+	 *
+	 * @return bool
+	 */
+	public function valid() {
+		if ($this->currentAvailable) {
+			return true;
+		}
+
+		return $this->loadFromMysqlResult();
+	}
+
+	/**
+	 * Count
+	 *
+	 * @return int
+	 */
+	public function count() {
+		if (is_resource($this->resource)) {
+			return mysql_num_rows($this->resource);
+		} else {
+			return 0;
+		}
+	}
+
+	/**
+	 * Get generated value
+	 *
+	 * @return int|null
+	 */
+	public function getGeneratedValue() {
+		return $this->generatedValue;
+	}
+
+}

--- a/engine/classes/Elgg/Database/MySqlResult.php
+++ b/engine/classes/Elgg/Database/MySqlResult.php
@@ -5,9 +5,12 @@
  *
  * @access private
  * 
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * http://framework.zend.com/license/new-bsd New BSD License
+ *
+ * @package    Elgg.Core
+ * @subpackage Database
+ * @since      1.9.0
  */
 class Elgg_Database_MySqlResult implements Elgg_Database_Result {
 
@@ -41,8 +44,8 @@ class Elgg_Database_MySqlResult implements Elgg_Database_Result {
 	/**
 	 * Initialize
 	 *
-	 * @param resource $resource
-	 * @param int      $generatedValue
+	 * @param resource $resource       results or link resource depending on query type
+	 * @param int      $generatedValue The last insert id or 0
 	 * @return Elgg_Database_MySqlResult
 	 * @throws InvalidArgumentException
 	 */
@@ -175,7 +178,7 @@ class Elgg_Database_MySqlResult implements Elgg_Database_Result {
 	/**
 	 * Get generated value
 	 *
-	 * @return int|null
+	 * @return int
 	 */
 	public function getGeneratedValue() {
 		return $this->generatedValue;

--- a/engine/classes/Elgg/Database/Result.php
+++ b/engine/classes/Elgg/Database/Result.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ * 
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+interface Elgg_Database_Result extends
+	Countable,
+	Iterator
+{
+
+	/**
+	 * Get affected rows
+	 *
+	 * @return int
+	 */
+	public function getAffectedRows();
+
+	/**
+	 * Get generated value
+	 *
+	 * @return int|null
+	 */
+	public function getGeneratedValue();
+
+	/**
+	 * Get the resource
+	 *
+	 * @return mixed
+	 */
+	public function getResource();
+
+}

--- a/engine/classes/Elgg/Database/Result.php
+++ b/engine/classes/Elgg/Database/Result.php
@@ -5,9 +5,12 @@
  *
  * @access private
  * 
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * http://framework.zend.com/license/new-bsd New BSD License
+ *
+ * @package    Elgg.Core
+ * @subpackage Database
+ * @since      1.9.0
  */
 interface Elgg_Database_Result extends
 	Countable,
@@ -24,14 +27,14 @@ interface Elgg_Database_Result extends
 	/**
 	 * Get generated value
 	 *
-	 * @return int|null
+	 * @return int
 	 */
 	public function getGeneratedValue();
 
 	/**
 	 * Get the resource
 	 *
-	 * @return mixed
+	 * @return resource
 	 */
 	public function getResource();
 


### PR DESCRIPTION
This should make it possible to drop zf2 in when we support PHP 5.3
