### PR TITLE
Improves performance of user directory migration

### DIFF
--- a/engine/classes/Elgg/EntityDirLocator.php
+++ b/engine/classes/Elgg/EntityDirLocator.php
@@ -39,7 +39,7 @@ class Elgg_EntityDirLocator {
 	
 	/**
 	 * Construct a file path matrix for an entity.
-	 * As of 1.8.5 matrixes are based on GUIDs and separated into dirs of 5000 entries
+	 * As of 1.9.0 matrixes are based on GUIDs and separated into dirs of 5000 entries
 	 * with the dir name being the lower bound for the GUID.
 	 *
 	 * @return string The path where the entity's data will be stored relative to the data dir.
@@ -62,8 +62,8 @@ class Elgg_EntityDirLocator {
 	 * Return the lower bound for a guid with a bucket size
 	 *
 	 * @param int $guid        The guid to get a bound for. Must be > 0.
-	 * @param int $bucket_size The size of the bucket. (The number of entries per dir.)
-	 * @return float
+	 * @param int $bucket_size The size of the bucket. (The number of entities per dir.)
+	 * @return int
 	 */
 	private static function getLowerBucketBound($guid, $bucket_size = null) {
 		if (!$bucket_size || $bucket_size < 1) {

--- a/engine/lib/upgrades/2013022000-1.9.0-datadir_dates_to_guids-efb02ff11b9d6444.php
+++ b/engine/lib/upgrades/2013022000-1.9.0-datadir_dates_to_guids-efb02ff11b9d6444.php
@@ -13,7 +13,7 @@ $existing_bucket_dirs = array();
 $cleanup_years = array();
 $users = new ElggBatch('elgg_get_entities', array('type' => 'user', 'limit' => 0, 'callback' => ''), null, 100);
 foreach ($users as $user_row) {
-	$from = $data_root . make_matrix_2013022000($user_row->guid);
+	$from = $data_root . make_matrix_2013022000($user_row);
 	$bucket_dir = $data_root . getLowerBucketBound_2013022000($user_row->guid);
 	$to =  "$bucket_dir/" . $user_row->guid;
 
@@ -41,7 +41,7 @@ foreach ($users as $user_row) {
 	}
 
 	// store the year for cleanup
-	$year = date('Y', $user->time_created);
+	$year = date('Y', $user_row->time_created);
 	if (!in_array($year, $cleanup_years)) {
 		$cleanup_years[] = $year;
 	}

--- a/engine/lib/upgrades/2013022000-1.9.0-datadir_dates_to_guids-efb02ff11b9d6444.php
+++ b/engine/lib/upgrades/2013022000-1.9.0-datadir_dates_to_guids-efb02ff11b9d6444.php
@@ -11,7 +11,7 @@ $data_root = elgg_get_config('dataroot');
 $failed = array();
 $existing_bucket_dirs = array();
 $cleanup_years = array();
-$users = new ElggBatch('elgg_get_entities', array('type' => 'user', 'limit' => 0, 'callback' => ''), 50);
+$users = new ElggBatch('elgg_get_entities', array('type' => 'user', 'limit' => 0, 'callback' => ''), null, 100);
 foreach ($users as $user) {
 	$from = $data_root . make_matrix_2013022000($user->guid);
 	$bucket_dir = $data_root . getLowerBucketBound_2013022000($user->guid);


### PR DESCRIPTION
10x faster and uses 1/4 of the memory (~40MB to ~10MB)

Not pulling back full entities saved all the memory and made it 3x faster. Upping the chunk size increased the speed another 3x. I don't see why we couldn't up the chunk size again.

This was on a clean, default 1.8 site with 2000 users and no files.
