### PR TITLE
Fixes #5795 forces the dropdown menu item to fill the topbar

### DIFF
--- a/mod/aalborg_theme/start.php
+++ b/mod/aalborg_theme/start.php
@@ -53,6 +53,7 @@ function aalborg_theme_pagesetup() {
 			'href' => "#",
 			'priority' => 100,
 			'section' => 'alt',
+			'link_class' => 'elgg-topbar-dropdown',
 		));
 		
 		elgg_unregister_menu_item('topbar', 'usersettings');

--- a/mod/aalborg_theme/views/default/aalborg_theme/css.php
+++ b/mod/aalborg_theme/views/default/aalborg_theme/css.php
@@ -29,7 +29,7 @@
 	TOPBAR MENU DROPDOWN
 *****************************************/
 .elgg-topbar-dropdown {
-	padding-bottom: 8px;
+	padding-bottom: 8px; /* forces button to reach bottom of topbar */
 }
 .elgg-menu-topbar-alt ul {
 	position: absolute;

--- a/mod/aalborg_theme/views/default/aalborg_theme/css.php
+++ b/mod/aalborg_theme/views/default/aalborg_theme/css.php
@@ -26,11 +26,10 @@
 	margin-top: 0;
 }
 /* ***************************************
-	TOPBAR MENU
+	TOPBAR MENU DROPDOWN
 *****************************************/
-.elgg-menu-topbar-alt > li > a {
-	padding: 5px 15px 6px;
-	margin: 1px 0 0;
+.elgg-topbar-dropdown {
+	padding-bottom: 8px;
 }
 .elgg-menu-topbar-alt ul {
 	position: absolute;

--- a/mod/aalborg_theme/views/default/aalborg_theme/css.php
+++ b/mod/aalborg_theme/views/default/aalborg_theme/css.php
@@ -31,6 +31,10 @@
 .elgg-topbar-dropdown {
 	padding-bottom: 8px; /* forces button to reach bottom of topbar */
 }
+.elgg-menu-topbar > li > .elgg-topbar-dropdown:hover {
+	color: #EEE;
+	cursor: default;
+}
 .elgg-menu-topbar-alt ul {
 	position: absolute;
 	display: none;

--- a/mod/aalborg_theme/views/default/css/elements/layout.php
+++ b/mod/aalborg_theme/views/default/css/elements/layout.php
@@ -44,6 +44,7 @@
 /***** TOPBAR ******/
 .elgg-page-topbar {
 	background: #424242;
+	border-top: 1px solid #424242;
 	border-bottom: 1px solid #000000;
 	padding: 0 20px;
 	position: relative;

--- a/mod/aalborg_theme/views/default/css/elements/navigation.php
+++ b/mod/aalborg_theme/views/default/css/elements/navigation.php
@@ -129,12 +129,12 @@
 .elgg-menu-topbar > li {
 	float: left;
 	height: 33px;
-	margin: 0 15px;
 }
 
 .elgg-menu-topbar > li > a {
 	padding-top: 5px;
 	color: #EEE;
+	margin: 0 15px;
 }
 
 .elgg-menu-topbar > li > a:hover {

--- a/mod/aalborg_theme/views/default/css/elements/navigation.php
+++ b/mod/aalborg_theme/views/default/css/elements/navigation.php
@@ -128,12 +128,13 @@
 
 .elgg-menu-topbar > li {
 	float: left;
+	height: 33px;
+	margin: 0 15px;
 }
 
 .elgg-menu-topbar > li > a {
 	padding-top: 5px;
 	color: #EEE;
-	margin: 1px 15px 0;
 }
 
 .elgg-menu-topbar > li > a:hover {


### PR DESCRIPTION
This has the advantage over #5797 of not turning the whole height of the topbar into buttons for additional menu items added to the alt section of the menu. For example, add an icon to the alt section using 5797. You can now click the link without activating the hover of the icon span. This PR only does that for links with the class elgg-topbar-dropdown.
