### PR TITLE
Fixes #4429 switches csrf token request to a GET from a POST

### DIFF
--- a/actions/security/refreshtoken.php
+++ b/actions/security/refreshtoken.php
@@ -1,5 +1,0 @@
-<?php
-$ts = time();
-$token = generate_action_token($ts);
-
-echo json_encode(array('__elgg_ts' => $ts, '__elgg_token' => $token));

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -536,7 +536,7 @@ class ElggSite extends ElggEntity {
 			'register',
 			'forgotpassword',
 			'resetpassword',
-			'action/security/refreshtoken',
+			'refresh_token',
 			'ajax/view/js/languages',
 			'upgrade\.php',
 			'css/.*',

--- a/engine/lib/actions.php
+++ b/engine/lib/actions.php
@@ -289,9 +289,14 @@ function _elgg_csrf_token_refresh() {
 
 	$ts = time();
 	$token = generate_action_token($ts);
+	$data = array(
+		'__elgg_ts' => $ts,
+		'__elgg_token' => $token,
+		'logged_in' => elgg_is_logged_in(),
+	);
 
 	header("Content-Type: application/json");
-	echo json_encode(array('__elgg_ts' => $ts, '__elgg_token' => $token));
+	echo json_encode($data);
 
 	return true;
 }

--- a/engine/lib/actions.php
+++ b/engine/lib/actions.php
@@ -277,13 +277,32 @@ function ajax_action_hook() {
 }
 
 /**
+ * Send an updated CSRF token
+ *
+ * @access private
+ */
+function _elgg_csrf_token_refresh() {
+
+	if (!elgg_is_xhr()) {
+		return false;
+	}
+
+	$ts = time();
+	$token = generate_action_token($ts);
+
+	header("Content-Type: application/json");
+	echo json_encode(array('__elgg_ts' => $ts, '__elgg_token' => $token));
+
+	return true;
+}
+
+/**
  * Initialize some ajaxy actions features
  * @access private
  */
 function actions_init() {
 	elgg_register_page_handler('action', '_elgg_action_handler');
-
-	elgg_register_action('security/refreshtoken', '', 'public');
+	elgg_register_page_handler('refresh_token', '_elgg_csrf_token_refresh');
 
 	elgg_register_simplecache_view('js/languages/en');
 

--- a/js/lib/security.js
+++ b/js/lib/security.js
@@ -38,6 +38,10 @@ elgg.security.refreshToken = function() {
 	elgg.getJSON('refresh_token', function(data) {
 		if (data && data.__elgg_ts && data.__elgg_token) {
 			elgg.security.setToken(data);
+			if (elgg.is_logged_in() && data.logged_in == false) {
+				elgg.session.user = null;
+				elgg.register_error(elgg.echo('session_expired'));
+			}
 		}
 	});
 };

--- a/js/lib/security.js
+++ b/js/lib/security.js
@@ -35,11 +35,9 @@ elgg.security.setToken = function(json) {
  * @private
  */
 elgg.security.refreshToken = function() {
-	elgg.action('security/refreshtoken', function(data) {
-		if (data && data.output.__elgg_ts && data.output.__elgg_token) {
-			elgg.security.setToken(data.output);
-		} else {
-			clearInterval(elgg.security.tokenRefreshTimer);
+	elgg.getJSON('refresh_token', function(data) {
+		if (data && data.__elgg_ts && data.__elgg_token) {
+			elgg.security.setToken(data);
 		}
 	});
 };

--- a/languages/en.php
+++ b/languages/en.php
@@ -27,6 +27,7 @@ return array(
 	'logout' => "Log out",
 	'logoutok' => "You have been logged out.",
 	'logouterror' => "We couldn't log you out. Please try again.",
+	'session_expired' => "Your session has expired. Please reload the page to log in.",
 
 	'loggedinrequired' => "You must be logged in to view the requested page.",
 	'adminrequired' => "You must be an administrator to view the requested page.",


### PR DESCRIPTION
Removes the warning when the token expires. Does not require a token to get a token.

One downside to this is if you close your laptop and your session expires, when you open your laptop again you no longer get a notice from the failed token refresh.

We could return a logged in flag with the response and check that against what the page thinks the logged in status is and display a message then. 
