### PR TITLE
Fixes #5773 db queue now has an id column

### DIFF
--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -138,7 +138,7 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 	 */
 	protected function getNotifications(Elgg_Di_ServiceProvider $c) {
 		// @todo move queue in service provider
-		$queue = new Elgg_Util_DatabaseQueue(Elgg_Notifications_NotificationsService::QUEUE_NAME, $c->db);
+		$queue = new Elgg_Queue_DatabaseQueue(Elgg_Notifications_NotificationsService::QUEUE_NAME, $c->db);
 		$sub = new Elgg_Notifications_SubscriptionsService($c->db);
 		$access = elgg_get_access_object();
 		return new Elgg_Notifications_NotificationsService($sub, $queue, $c->hooks, $access);

--- a/engine/classes/Elgg/Notifications/NotificationsService.php
+++ b/engine/classes/Elgg/Notifications/NotificationsService.php
@@ -16,7 +16,7 @@ class Elgg_Notifications_NotificationsService {
 	/** @var Elgg_Notifications_SubscriptionsService */
 	protected $subscriptions;
 
-	/** @var Elgg_Util_Queue */
+	/** @var Elgg_Queue_Queue */
 	protected $queue;
 
 	/** @var Elgg_PluginHooksService */
@@ -41,12 +41,12 @@ class Elgg_Notifications_NotificationsService {
 	 * Constructor
 	 *
 	 * @param Elgg_Notifications_SubscriptionsService $subscriptions Subscription service
-	 * @param Elgg_Util_Queue                         $queue         Queue
+	 * @param Elgg_Queue_Queue                         $queue         Queue
 	 * @param Elgg_PluginHooksService                 $hooks         Plugin hook service
 	 * @param Elgg_Access                             $access        Access control service
 	 */
 	public function __construct(Elgg_Notifications_SubscriptionsService $subscriptions,
-			Elgg_Util_Queue $queue, Elgg_PluginHooksService $hooks, Elgg_Access $access) {
+			Elgg_Queue_Queue $queue, Elgg_PluginHooksService $hooks, Elgg_Access $access) {
 		$this->subscriptions = $subscriptions;
 		$this->queue = $queue;
 		$this->hooks = $hooks;

--- a/engine/classes/Elgg/Notifications/NotificationsService.php
+++ b/engine/classes/Elgg/Notifications/NotificationsService.php
@@ -41,7 +41,7 @@ class Elgg_Notifications_NotificationsService {
 	 * Constructor
 	 *
 	 * @param Elgg_Notifications_SubscriptionsService $subscriptions Subscription service
-	 * @param Elgg_Queue_Queue                         $queue         Queue
+	 * @param Elgg_Queue_Queue                        $queue         Queue
 	 * @param Elgg_PluginHooksService                 $hooks         Plugin hook service
 	 * @param Elgg_Access                             $access        Access control service
 	 */

--- a/engine/classes/Elgg/Queue/DatabaseQueue.php
+++ b/engine/classes/Elgg/Queue/DatabaseQueue.php
@@ -54,7 +54,7 @@ class Elgg_Queue_DatabaseQueue implements Elgg_Queue_Queue {
 		$update = "UPDATE {$prefix}queue 
 			SET worker = '$this->workerId'
 			WHERE name = '$this->name' AND worker IS NULL
-			ORDER BY timestamp ASC LIMIT 1";
+			ORDER BY id ASC LIMIT 1";
 		$num = $this->db->updateData($update, true);
 		if ($num === 1) {
 			$select = "SELECT data FROM {$prefix}queue

--- a/engine/classes/Elgg/Queue/DatabaseQueue.php
+++ b/engine/classes/Elgg/Queue/DatabaseQueue.php
@@ -8,10 +8,10 @@
  * @access private
  * 
  * @package    Elgg.Core
- * @subpackage Util
+ * @subpackage Queue
  * @since      1.9.0
  */
-class Elgg_Util_DatabaseQueue implements Elgg_Util_Queue {
+class Elgg_Queue_DatabaseQueue implements Elgg_Queue_Queue {
 
 	/** @var string Name of the queue */
 	protected $name;

--- a/engine/classes/Elgg/Queue/DatabaseQueue.php
+++ b/engine/classes/Elgg/Queue/DatabaseQueue.php
@@ -79,4 +79,13 @@ class Elgg_Queue_DatabaseQueue implements Elgg_Queue_Queue {
 		$prefix = $this->db->getTablePrefix();
 		$this->db->deleteData("DELETE FROM {$prefix}queue WHERE name = '$this->name'");
 	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function size() {
+		$prefix = $this->db->getTablePrefix();
+		$result = $this->db->getDataRow("SELECT COUNT(id) AS total FROM {$prefix}queue WHERE name = '$this->name'");
+		return (int)$result->total;
+	}
 }

--- a/engine/classes/Elgg/Queue/MemoryQueue.php
+++ b/engine/classes/Elgg/Queue/MemoryQueue.php
@@ -43,4 +43,11 @@ class Elgg_Queue_MemoryQueue implements Elgg_Queue_Queue {
 	public function clear() {
 		$this->queue = array();
 	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function size() {
+		return count($this->queue);
+	}
 }

--- a/engine/classes/Elgg/Queue/MemoryQueue.php
+++ b/engine/classes/Elgg/Queue/MemoryQueue.php
@@ -8,10 +8,10 @@
  * @access private
  * 
  * @package    Elgg.Core
- * @subpackage Util
+ * @subpackage Queue
  * @since      1.9.0
  */
-class Elgg_Util_MemoryQueue implements Elgg_Util_Queue {
+class Elgg_Queue_MemoryQueue implements Elgg_Queue_Queue {
 
 	/* @var array */
 	protected $queue = array();

--- a/engine/classes/Elgg/Queue/Queue.php
+++ b/engine/classes/Elgg/Queue/Queue.php
@@ -8,10 +8,10 @@
  * @access private
  * 
  * @package    Elgg.Core
- * @subpackage Util
+ * @subpackage Queue
  * @since      1.9.0
  */
-interface Elgg_Util_Queue {
+interface Elgg_Queue_Queue {
 	/**
 	 * Add an item to the queue
 	 *

--- a/engine/classes/Elgg/Queue/Queue.php
+++ b/engine/classes/Elgg/Queue/Queue.php
@@ -33,4 +33,11 @@ interface Elgg_Queue_Queue {
 	 * @return void
 	 */
 	public function clear();
+
+	/**
+	 * Get the size of the queue
+	 *
+	 * @return int
+	 */
+	public function size();
 }

--- a/engine/lib/upgrades/2013062700-1.9.0_dev-add_db_queue-e6af82afc6d3eee3.php
+++ b/engine/lib/upgrades/2013062700-1.9.0_dev-add_db_queue-e6af82afc6d3eee3.php
@@ -11,10 +11,12 @@ $db_prefix = elgg_get_config('dbprefix');
 // create queue table
 $query = <<<SQL
 CREATE TABLE IF NOT EXISTS `{$db_prefix}queue` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   `data` mediumblob NOT NULL,
   `timestamp` int(11) NOT NULL,
   `worker` varchar(32) NULL,
+  PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `retrieve` (`timestamp`,`worker`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -191,10 +191,12 @@ CREATE TABLE `prefix_private_settings` (
 
 -- queue for asynchronous operations
 CREATE TABLE `prefix_queue` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   `data` mediumblob NOT NULL,
   `timestamp` int(11) NOT NULL,
   `worker` varchar(32) NULL,
+  PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `retrieve` (`timestamp`,`worker`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/engine/tests/ElggCoreDatabaseQueueTest.php
+++ b/engine/tests/ElggCoreDatabaseQueueTest.php
@@ -17,6 +17,8 @@ class ElggCoreDatabaseQueueTest extends ElggCoreUnitTest {
 		$result = $queue->enqueue($second);
 		$this->assertTrue($result);
 
+		$this->assertIdentical(2, $queue->size());
+
 		$data = $queue->dequeue();
 		$this->assertIdentical($first, $data);
 		$data = $queue->dequeue();
@@ -37,6 +39,9 @@ class ElggCoreDatabaseQueueTest extends ElggCoreUnitTest {
 		$result = $queue2->enqueue($second);
 		$this->assertTrue($result);
 
+		$this->assertIdentical(1, $queue1->size());
+		$this->assertIdentical(1, $queue2->size());
+
 		$data = $queue2->dequeue();
 		$this->assertIdentical($second, $data);
 		$data = $queue1->dequeue();
@@ -56,5 +61,6 @@ class ElggCoreDatabaseQueueTest extends ElggCoreUnitTest {
 		$queue->clear();
 		$data = $queue->dequeue();
 		$this->assertIdentical(null, $data);
+		$this->assertIdentical(0, $queue->size());
 	}
 }

--- a/engine/tests/ElggCoreDatabaseQueueTest.php
+++ b/engine/tests/ElggCoreDatabaseQueueTest.php
@@ -14,8 +14,6 @@ class ElggCoreDatabaseQueueTest extends ElggCoreUnitTest {
 
 		$result = $queue->enqueue($first);
 		$this->assertTrue($result);
-		// @todo fix this
-		sleep(1);
 		$result = $queue->enqueue($second);
 		$this->assertTrue($result);
 

--- a/engine/tests/ElggCoreDatabaseQueueTest.php
+++ b/engine/tests/ElggCoreDatabaseQueueTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Elgg_Util_DatabaseQueue tests
+ * Elgg_Queue_DatabaseQueue tests
  *
  * @package Elgg
  * @subpackage Test
@@ -8,7 +8,7 @@
 class ElggCoreDatabaseQueueTest extends ElggCoreUnitTest {
 
 	public function testEnqueueAndDequeue() {
-		$queue = new Elgg_Util_DatabaseQueue('unit:test', _elgg_services()->db);
+		$queue = new Elgg_Queue_DatabaseQueue('unit:test', _elgg_services()->db);
 		$first = array(1, 2, 3);
 		$second = array(4, 5, 6);
 
@@ -29,8 +29,8 @@ class ElggCoreDatabaseQueueTest extends ElggCoreUnitTest {
 	}
 
 	public function testMultipleQueues() {
-		$queue1 = new Elgg_Util_DatabaseQueue('unit:test1', _elgg_services()->db);
-		$queue2 = new Elgg_Util_DatabaseQueue('unit:test2', _elgg_services()->db);
+		$queue1 = new Elgg_Queue_DatabaseQueue('unit:test1', _elgg_services()->db);
+		$queue2 = new Elgg_Queue_DatabaseQueue('unit:test2', _elgg_services()->db);
 		$first = array(1, 2, 3);
 		$second = array(4, 5, 6);
 
@@ -46,7 +46,7 @@ class ElggCoreDatabaseQueueTest extends ElggCoreUnitTest {
 	}
 
 	public function testClear() {
-		$queue = new Elgg_Util_DatabaseQueue('unit:test',  _elgg_services()->db);
+		$queue = new Elgg_Queue_DatabaseQueue('unit:test',  _elgg_services()->db);
 		$first = array(1, 2, 3);
 		$second = array(4, 5, 6);
 

--- a/engine/tests/phpunit/Elgg/Notifications/NotificationsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/NotificationsServiceTest.php
@@ -8,7 +8,7 @@ class Elgg_Notifications_NotificationsServiceTest extends PHPUnit_Framework_Test
 
 	public function setUp() {
 		$this->hooks = new Elgg_PluginHooksService();
-		$this->queue = new Elgg_Util_MemoryQueue();
+		$this->queue = new Elgg_Queue_MemoryQueue();
 		$dbMock = $this->getMockBuilder('Elgg_Database')
 			->disableOriginalConstructor()
 			->getMock();


### PR DESCRIPTION
Also adds a count method and changes the namespace to Elgg_Queue from Elgg_Util

Sites that already have the queue should run something like this:

```
ALTER TABLE `elgg_queue` ADD `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST 
```
