### PR TITLE
Fixes #5314: Automatically names anonymous AMD modules

### DIFF
--- a/engine/classes/Elgg/Amd/Config.php
+++ b/engine/classes/Elgg/Amd/Config.php
@@ -8,7 +8,7 @@
  * @package    Elgg.Core
  * @subpackage JavaScript
  */
-class Elgg_AmdConfig {
+class Elgg_Amd_Config {
 	private $baseUrl = '';
 	private $paths = array();
 	private $shim = array();

--- a/engine/classes/Elgg/Amd/ViewFilter.php
+++ b/engine/classes/Elgg/Amd/ViewFilter.php
@@ -1,0 +1,31 @@
+<?php
+
+class Elgg_Amd_ViewFilter {
+	/**
+	 * @param string $name The name of the view (e.g., js/elgg/module.js)
+	 * 
+	 * @return string The AMD name (e.g., 'elgg/module'), or blank for no AMD name.
+	 */
+	private function getAmdName($name) {
+		$pieces = explode("/", $name); // [js, elgg, module.js]
+		if (count($pieces) <= 1 || $pieces[0] != 'js') {
+			return '';
+		}
+	
+		array_shift($pieces); // [elgg, module.js]
+		$basename = basename(array_pop($pieces), ".js"); // module
+		array_push($pieces, $basename); // [elgg, module]
+		
+		return implode("/", $pieces); // elgg/module
+	}
+	
+	public function filter($viewName, $content) {
+		$amdName = $this->getAmdName($viewName);
+		
+		if (!empty($amdName)) {
+			$content = preg_replace('/^define\(([^\'"])/m', "define(\"$amdName\", \$1", $content, 1);
+		}
+		
+		return $content;
+	}
+}

--- a/engine/classes/Elgg/Amd/ViewFilter.php
+++ b/engine/classes/Elgg/Amd/ViewFilter.php
@@ -7,8 +7,8 @@
  * 
  * @package    Elgg.Core
  * @subpackage JavaScript
+ * @since      1.9
  * 
- * @since 1.9
  * @access private
  */
 class Elgg_Amd_ViewFilter {

--- a/engine/classes/Elgg/Amd/ViewFilter.php
+++ b/engine/classes/Elgg/Amd/ViewFilter.php
@@ -5,6 +5,9 @@
  * 
  * This filter adds AMD names to anonymous AMD modules defined in views.
  * 
+ * @package    Elgg.Core
+ * @subpackage JavaScript
+ * 
  * @since 1.9
  * @access private
  */

--- a/engine/classes/Elgg/Amd/ViewFilter.php
+++ b/engine/classes/Elgg/Amd/ViewFilter.php
@@ -1,8 +1,18 @@
 <?php
 
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * 
+ * This filter adds AMD names to anonymous AMD modules defined in views.
+ * 
+ * @since 1.9
+ * @access private
+ */
 class Elgg_Amd_ViewFilter {
 	/**
-	 * @param string $name The name of the view (e.g., js/elgg/module.js)
+	 * Given the view name, returns the AMD name.
+	 * 
+	 * @param string $name The name of the view (e.g., 'js/elgg/module.js')
 	 * 
 	 * @return string The AMD name (e.g., 'elgg/module'), or blank for no AMD name.
 	 */
@@ -19,6 +29,14 @@ class Elgg_Amd_ViewFilter {
 		return implode("/", $pieces); // elgg/module
 	}
 	
+	/**
+	 * Inserts the AMD name into `$content` and returns the new value.
+	 * 
+	 * @param string $viewName The name of the view.
+	 * @param string $content  The output of the view to be filtered.
+	 * 
+	 * @return string The new content with the AMD name inserted, if applicable.
+	 */
 	public function filter($viewName, $content) {
 		$amdName = $this->getAmdName($viewName);
 		

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -8,7 +8,7 @@
  * the container generic.
  * 
  * @property-read Elgg_ActionsService                     $actions
- * @property-read Elgg_AmdConfig                          $amdConfig
+ * @property-read Elgg_Amd_Config                         $amdConfig
  * @property-read ElggAutoP                               $autoP
  * @property-read Elgg_AutoloadManager                    $autoloadManager
  * @property-read Elgg_Database                           $db
@@ -87,10 +87,10 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 	 * AMD Config factory
 	 * 
 	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
-	 * @return Elgg_AmdConfig
+	 * @return Elgg_Amd_Config
 	 */
 	protected function getAmdConfig(Elgg_Di_ServiceProvider $c) {
-		$obj = new Elgg_AmdConfig();
+		$obj = new Elgg_Amd_Config();
 		$obj->setBaseUrl(_elgg_get_simplecache_root() . "js/");
 		return $obj;
 	}

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1342,6 +1342,24 @@ function _elgg_views_minify($hook, $type, $content, $params) {
 	}
 }
 
+
+/**
+ * Inserts module names into anonymous modules by handling the "simplecache:generate" hook.
+ * 
+ * @param string $hook    The name of the hook
+ * @param string $type    View type (css, js, or unknown)
+ * @param string $content Content of the view
+ * @param array  $params  Array of parameters
+ *
+ * @return string|null View content minified (if css/js type)
+ * @access private
+ * 
+ */
+function _elgg_views_amd($hook, $type, $content, $params) {
+	$filter = new Elgg_Amd_ViewFilter();	
+	return $filter->filter($params['view'], $content);
+}
+
 /**
  * Add the rss link to the extras when if needed
  *
@@ -1435,6 +1453,7 @@ function elgg_views_boot() {
 
 	elgg_register_ajax_view('js/languages');
 
+	elgg_register_plugin_hook_handler('simplecache:generate', 'js', '_elgg_views_amd');
 	elgg_register_plugin_hook_handler('simplecache:generate', 'css', '_elgg_views_minify');
 	elgg_register_plugin_hook_handler('simplecache:generate', 'js', '_elgg_views_minify');
 

--- a/engine/tests/phpunit/Elgg/Amd/ConfigTest.php
+++ b/engine/tests/phpunit/Elgg/Amd/ConfigTest.php
@@ -1,9 +1,9 @@
 <?php
 
-class Elgg_AmdConfigTest extends PHPUnit_Framework_TestCase {
+class Elgg_Amd_ConfigTest extends PHPUnit_Framework_TestCase {
 	
 	public function testCanConfigureModulePaths() {
-		$amdConfig = new Elgg_AmdConfig();
+		$amdConfig = new Elgg_Amd_Config();
 		$amdConfig->setPath('jquery', '/some/path.js');
 		
 		$configArray = $amdConfig->getConfig();
@@ -12,7 +12,7 @@ class Elgg_AmdConfigTest extends PHPUnit_Framework_TestCase {
 	}
 	
 	public function testCanConfigureModuleShims() {
-		$amdConfig = new Elgg_AmdConfig();
+		$amdConfig = new Elgg_Amd_Config();
 		$amdConfig->setShim('jquery', array(
 			'deps' => array(),
 			'exports' => 'jQuery',
@@ -26,7 +26,7 @@ class Elgg_AmdConfigTest extends PHPUnit_Framework_TestCase {
 	}
 	
 	public function testCanRequireUnregisteredAmdModules() {
-		$amdConfig = new Elgg_AmdConfig();
+		$amdConfig = new Elgg_Amd_Config();
 		$amdConfig->addDependency('jquery');
 		
 		$configArray = $amdConfig->getConfig();

--- a/engine/tests/phpunit/Elgg/Amd/ViewFilterTest.php
+++ b/engine/tests/phpunit/Elgg/Amd/ViewFilterTest.php
@@ -1,0 +1,21 @@
+<?php
+
+class Elgg_Amd_ViewFilterTest extends PHPUnit_Framework_TestCase {
+	
+	public function testInsertsNamesForAnonymousModules() {
+		$viewFilter = new Elgg_Amd_ViewFilter();
+		
+		$originalContent = "// Comment\ndefine({})";
+		$filteredContent = $viewFilter->filter('js/my/mod.js', $originalContent);
+		
+		$this->assertEquals("// Comment\ndefine(\"my/mod\", {})", $filteredContent);
+	}
+	
+	public function testLeavesNamedModulesAlone() {
+		$viewFilter = new Elgg_Amd_ViewFilter();
+		
+		$originalContent = "// Comment\ndefine('any/mod', {})";
+		$filteredContent = $viewFilter->filter('js/my/mod.js', $originalContent);
+		$this->assertEquals($originalContent, $filteredContent);
+	}
+}

--- a/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
+++ b/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
@@ -11,7 +11,7 @@ class Elgg_Di_ServiceProviderTest extends PHPUnit_Framework_TestCase {
 			'actions' => 'Elgg_ActionsService',
 			
 			// requires _elgg_get_simplecache_root() to be defined
-			//'amdConfig' => 'Elgg_AmdConfig',
+			//'amdConfig' => 'Elgg_Amd_Config',
 			
 			'autoP' => 'ElggAutoP',
 			'autoloadManager' => 'Elgg_AutoloadManager',

--- a/engine/tests/phpunit/bootstrap.php
+++ b/engine/tests/phpunit/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 $engine = dirname(dirname(dirname(__FILE__)));
 
+date_default_timezone_set('America/Los_Angeles');
+
 /**
  * This is here as a temporary solution only. Instead of adding more global
  * state to this file as we migrate tests, try to refactor the code to be


### PR DESCRIPTION
Uses a simple regex that is not robust in theory but should be in practice:

 It assumes the typical format for AMD modules is like so:

``` js
/**
 * Some module description?
 */
define({});
```

The following would break it, since it would insert the name into the define call within the comments, which is probably not what was intended.

``` js
/*
define() becomes define('module/name')
*/
define({});
```

Also, the following would not work, since `define()` doesn't start on it's own line.

``` js
/** Brief description */ define({});
```
