### PR TITLE
Activity: the page title doesn't match the document title

### DIFF
--- a/pages/river.php
+++ b/pages/river.php
@@ -49,6 +49,7 @@ $content = elgg_view('core/river/filter', array('selector' => $selector));
 $sidebar = elgg_view('core/river/sidebar');
 
 $params = array(
+	'title' => $title,
 	'content' =>  $content . $activity,
 	'sidebar' => $sidebar,
 	'filter_context' => $page_filter,


### PR DESCRIPTION
on all the pages of the activity (all, mine and friends) the page title is the save ("Activity"). They don't match the document title which is set correctly to "All site activity", "My activity" and "Friends activity".

This PR makes sure the page title matches the document title
