### PR TITLE
Fix json and xml views breaked by wrap view of developer tools

### DIFF
--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -109,7 +109,7 @@ function developers_wrap_views($hook, $type, $result, $params) {
 		return;
 	}
 
-	$excluded_bases = array('css', 'js', 'input', 'output', 'embed', 'icon',);
+	$excluded_bases = array('css', 'js', 'input', 'output', 'embed', 'icon', 'json', 'xml');
 
 	$excluded_views = array(
 		'page/default',


### PR DESCRIPTION
When developers wrap view option is activated, that's break all json and xml output.
Json data is wrapped by `<!-- developers:begin myview -->{"myjson":"mydata"}<!-- developers:end myview -->`.

**I tried this cases :**
- with my view in myplugin/views/default/myplugin/myview.php and an elgg_register_ajax_view for this view.
  -> view is breaked with wrap view option.
- with my view in myplugin/views/json/myplugin/myview.php and an elgg_register_ajax_view for this view.
  -> view is breaked with wrap view option.

I looked inside elgg core and I think best practice is :
- register view with elgg_register_ajax_view that return json,
- put this view in myplugin/views/json/myplugin/myview.php
- call this view with elgg.post or elgg.get with view: 'json' as parameters

So, for this case, we should add json parameters in $excluded_bases.

Everythings is same with xml output.

I wish I get the right way to get json ouput and wrap view activated.
