### PR TITLE
Added the sandbox attribute to iframe

### DIFF
--- a/views/default/output/iframe.php
+++ b/views/default/output/iframe.php
@@ -9,5 +9,5 @@
  *
  */
 ?>
-<iframe src="<?php echo $vars['value']; ?>">
+<iframe sandbox src="<?php echo $vars['value']; ?>">
 </iframe>


### PR DESCRIPTION
If the iframe comes from a different domain, a browser's cross-domain policy would kick in, preventing the iframe from accessing cookies, local storage, or the DOM from its embedding document. 

Even so, cross-domain iframes still have the ability to trigger alerts, run plugins (malicious or otherwise), autoplay videos, and present submittable forms in an attempt to phish users' information.

With this (sandbox) attribute set, the document inside the iframe cannot do any of the following:
- Run any JavaScript, even if it would only affect contents of the iframe.
- Change the parent's URL
- Open pop-ups, new windows, or new tabs
- Submit forms
- Run plug-ins
- Use pointer lock: https://developer.mozilla.org/en-US/docs/WebAPI/Pointer_Lock
- Read cookies or local storage from the parent, even if it's from the same origin
