### PR TITLE
Specifying karma version to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
        - mkdir ../elgg-coding-standards
        - git clone https://github.com/Elgg/elgg-coding-standards.git ../elgg-coding-standards/
        - phpenv rehash
-       - npm install -g karma
+       - npm install -g karma@0.8
       script:
        - phpcs --standard=../elgg-coding-standards/elgg.xml --warning-severity=0 --ignore=*/tests/*,*/upgrades/*,*/deprecated* engine/classes engine/lib
        - karma start js/tests/karma.conf.js --single-run


### PR DESCRIPTION
Karma was upgraded in a non-BC way recently (0.8 -> 0.10). I tried to upgrade our config to be 0.10-compatible, but there were problems getting it to work, so I'm just locking us into 0.8 for now which was a much easier fix. We can worry about upgrading later.
