### PR TITLE
Change to views.php to fix #5566 (and get 1.8.17/1.9RC1 out the door!)

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1529,7 +1529,7 @@ function elgg_views_boot() {
 			'tiny' => array('w' => 25, 'h' => 25, 'square' => true, 'upscale' => true),
 			'small' => array('w' => 40, 'h' => 40, 'square' => true, 'upscale' => true),
 			'medium' => array('w' => 100, 'h' => 100, 'square' => true, 'upscale' => true),
-			'large' => array('w' => 200, 'h' => 200, 'square' => false, 'upscale' => false),
+			'large' => array('w' => 200, 'h' => 200, 'square' => true, 'upscale' => false),
 			'master' => array('w' => 550, 'h' => 550, 'square' => false, 'upscale' => false),
 		);
 		elgg_set_config('icon_sizes', $icon_sizes);


### PR DESCRIPTION
This fixes Issue #5566, where your uploaded image for large avatar - before you optionally manually crop it - ends up not being a 200x200 square, even if you gave it a much larger image. According to my testing, if I submitted a huge image, I got 200x150. But with this tiny change the initial crop works fine and you get 200x200. I don't know if the master setting on the line below should also have the square parameter set to true, but 550x550 looks like a square to me, so go ahead and do that also here if you know what the master is used for :-)
