### PR TITLE
Fixes #5949: Adds entity preloader and integration

### DIFF
--- a/engine/classes/Elgg/Database/QueryCounter.php
+++ b/engine/classes/Elgg/Database/QueryCounter.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Count queries performed
+ *
+ * Do not use directly.
+ *
+ * @see _elgg_db_get_query_counter()
+ *
+ * @access private
+ *
+ * @package    Elgg.Core
+ * @subpackage Database
+ * @since      1.9.0
+ */
+class Elgg_Database_QueryCounter {
+
+	/**
+	 * @var int
+	 */
+	protected $initial;
+
+	/**
+	 * @var Elgg_Database
+	 */
+	protected $db;
+
+	/**
+	 * @param Elgg_Database $db
+	 */
+	public function __construct(Elgg_Database $db) {
+		$this->db = $db;
+		$this->initial = $db->getQueryCount();
+	}
+
+	/**
+	 * Get the number of queries performed since the object was constructed
+	 *
+	 * @return int
+	 */
+	public function getDelta() {
+		return $this->db->getQueryCount() - $this->initial;
+	}
+
+	/**
+	 * Create header X-ElggQueryDelta-* with the delta
+	 *
+	 * @see getDelta()
+	 *
+	 * @param string $key
+	 */
+	public function setDeltaHeader($key = 'Default') {
+		$delta = $this->getDelta();
+
+		header("X-ElggQueryDelta-$key: $delta", true);
+	}
+
+	/**
+	 * Get SCRIPT element which sends the delta to console.log
+	 *
+	 * @see getDelta()
+	 *
+	 * @param string $key
+	 *
+	 * @return string markup of SCRIPT element
+	 */
+	public function getDeltaScript($key = 'Default') {
+		$delta = $this->getDelta();
+
+		$msg = json_encode("ElggQueryDelta-$key: $delta");
+		return "<script>console.log($msg)</script>";
+	}
+}

--- a/engine/classes/Elgg/Database/QueryCounter.php
+++ b/engine/classes/Elgg/Database/QueryCounter.php
@@ -3,9 +3,7 @@
 /**
  * Count queries performed
  *
- * Do not use directly.
- *
- * @see _elgg_db_get_query_counter()
+ * Do not use directly. Use _elgg_db_get_query_counter().
  *
  * @access private
  *
@@ -26,7 +24,8 @@ class Elgg_Database_QueryCounter {
 	protected $db;
 
 	/**
-	 * @param Elgg_Database $db
+	 *
+	 * @param Elgg_Database $db Elgg's database
 	 */
 	public function __construct(Elgg_Database $db) {
 		$this->db = $db;
@@ -36,7 +35,7 @@ class Elgg_Database_QueryCounter {
 	/**
 	 * Get the number of queries performed since the object was constructed
 	 *
-	 * @return int
+	 * @return int # of queries
 	 */
 	public function getDelta() {
 		return $this->db->getQueryCount() - $this->initial;
@@ -47,7 +46,9 @@ class Elgg_Database_QueryCounter {
 	 *
 	 * @see getDelta()
 	 *
-	 * @param string $key
+	 * @param string $key Key to add to HTTP header name
+	 *
+	 * @return void
 	 */
 	public function setDeltaHeader($key = 'Default') {
 		$delta = $this->getDelta();
@@ -60,7 +61,7 @@ class Elgg_Database_QueryCounter {
 	 *
 	 * @see getDelta()
 	 *
-	 * @param string $key
+	 * @param string $key Key to display in console log
 	 *
 	 * @return string markup of SCRIPT element
 	 */

--- a/engine/classes/Elgg/Database/QueryCounter.php
+++ b/engine/classes/Elgg/Database/QueryCounter.php
@@ -24,6 +24,7 @@ class Elgg_Database_QueryCounter {
 	protected $db;
 
 	/**
+	 * Constructor
 	 *
 	 * @param Elgg_Database $db Elgg's database
 	 */

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -17,6 +17,7 @@
  * @property-read Elgg_Logger                             $logger
  * @property-read ElggVolatileMetadataCache               $metadataCache
  * @property-read Elgg_Notifications_NotificationsService $notifications
+ * @property-read Elgg_Database_QueryCounter              $queryCounter
  * @property-read Elgg_Http_Request                       $request
  * @property-read Elgg_Router                             $router
  * @property-read ElggSession                             $session
@@ -44,6 +45,7 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 		$this->setClassName('hooks', 'Elgg_PluginHooksService');
 		$this->setFactory('logger', array($this, 'getLogger'));
 		$this->setClassName('metadataCache', 'ElggVolatileMetadataCache');
+		$this->setFactory('queryCounter', array($this, 'getQueryCounter'), false);
 		$this->setFactory('request', array($this, 'getRequest'));
 		$this->setFactory('router', array($this, 'getRouter'));
 		$this->setFactory('session', array($this, 'getSession'));
@@ -153,5 +155,15 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 		$sub = new Elgg_Notifications_SubscriptionsService($c->db);
 		$access = elgg_get_access_object();
 		return new Elgg_Notifications_NotificationsService($sub, $queue, $c->hooks, $access);
+	}
+
+	/**
+	 * Query counter factory
+	 *
+	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
+	 * @return Elgg_Database_QueryCounter
+	 */
+	protected function getQueryCounter(Elgg_Di_ServiceProvider $c) {
+		return new Elgg_Database_QueryCounter($c->db);
 	}
 }

--- a/engine/classes/Elgg/EntityPreloader.php
+++ b/engine/classes/Elgg/EntityPreloader.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Preload entities based on properties of fetched objects
+ *
+ * @access private
+ *
+ * @package    Elgg.Core
+ * @since      1.9.0
+ */
+class Elgg_EntityPreloader {
+
+	/**
+	 * @var string
+	 */
+	protected $properties;
+
+	/**
+	 * Configure the preloader to check these properties of fetched objects for GUIDs.
+	 *
+	 * @param string|array $guid_properties e.g. array("owner_guid")
+	 */
+	public function __construct($guid_properties) {
+		$this->properties = (array)$guid_properties;
+	}
+
+	/**
+	 * Preload entities based on the given objects
+	 *
+	 * @param object[] $objects
+	 * @throws RuntimeException
+	 */
+	public function preload($objects) {
+		$guids = $this->getGuidsToLoad($objects);
+		if ($guids) {
+			elgg_get_entities(array(
+				'guids' => $guids,
+			));
+		}
+	}
+
+	/**
+	 * Get GUIDs that need to be loaded
+	 *
+	 * To simplify the user API, this function accepts non-arrays and arrays containing non-objects
+	 *
+	 * @param mixed $objects
+	 * @return int[]
+	 */
+	public function getGuidsToLoad($objects) {
+		if (!is_array($objects) || empty($objects)) {
+			return array();
+		}
+		$preload_guids = array();
+		foreach ($objects as $object) {
+			if (is_object($object)) {
+				foreach ($this->properties as $property) {
+					$guid = $object->{$property};
+					if ($guid && !_elgg_retrieve_cached_entity($guid)) {
+						$preload_guids[] = $guid;
+					}
+				}
+			}
+		}
+		return array_unique($preload_guids);
+	}
+}

--- a/engine/classes/Elgg/EntityPreloader.php
+++ b/engine/classes/Elgg/EntityPreloader.php
@@ -5,8 +5,8 @@
  *
  * @access private
  *
- * @package    Elgg.Core
- * @since      1.9.0
+ * @package Elgg.Core
+ * @since   1.9.0
  */
 class Elgg_EntityPreloader {
 
@@ -27,12 +27,16 @@ class Elgg_EntityPreloader {
 	/**
 	 * Preload entities based on the given objects
 	 *
-	 * @param object[] $objects
+	 * @param object[] $objects objects loaded from an Elgg query
+	 *
+	 * @return void
 	 * @throws RuntimeException
 	 */
 	public function preload($objects) {
 		$guids = $this->getGuidsToLoad($objects);
-		if ($guids) {
+		// If only 1 to load, not worth the overhead of elgg_get_entities(),
+		// get_entity() will handle it later.
+		if (count($guids) > 1) {
 			elgg_get_entities(array(
 				'guids' => $guids,
 			));
@@ -44,7 +48,7 @@ class Elgg_EntityPreloader {
 	 *
 	 * To simplify the user API, this function accepts non-arrays and arrays containing non-objects
 	 *
-	 * @param mixed $objects
+	 * @param mixed $objects objects loaded from an Elgg query
 	 * @return int[]
 	 */
 	public function getGuidsToLoad($objects) {

--- a/engine/lib/database.php
+++ b/engine/lib/database.php
@@ -188,6 +188,23 @@ function _elgg_db_log_profiling_data() {
 }
 
 /**
+ * Get a new query counter that will begin counting from 0. For profiling isolated
+ * sections of code.
+ *
+ * <code>
+ * $counter = _elgg_db_get_query_counter();
+ * ...
+ * $counter->setDeltaHeader();
+ * </code>
+ *
+ * @return Elgg_Database_QueryCounter
+ * @access private
+ */
+function _elgg_db_get_query_counter() {
+	return _elgg_services()->queryCounter;
+}
+
+/**
  * Execute any delayed queries upon shutdown.
  *
  * @return void

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -797,7 +797,9 @@ function elgg_get_entities(array $options = array()) {
 
 		'callback'				=> 'entity_row_to_elggstar',
 
+		// private API
 		'__ElggBatch'			=> null,
+		'__preload'				=> ELGG_ENTITIES_ANY_VALUE,
 	);
 
 	$options = array_merge($defaults, $options);
@@ -921,7 +923,7 @@ function elgg_get_entities(array $options = array()) {
 		}
 
 		if ($dt) {
-			// populate entity and metadata caches
+			// populate entity and metadata caches, and prepare $entities for preloader
 			$guids = array();
 			foreach ($dt as $item) {
 				// A custom callback could result in items that aren't ElggEntity's, so check for them
@@ -938,6 +940,11 @@ function elgg_get_entities(array $options = array()) {
 
 			if ($guids) {
 				_elgg_get_metadata_cache()->populateFromEntities($guids);
+			}
+
+			if ($options['__preload']) {
+				$preloader = new Elgg_EntityPreloader((array)$options['__preload']);
+				$preloader->preload($dt);
 			}
 		}
 		return $dt;

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -249,6 +249,9 @@ function _elgg_get_metastring_based_objects($options) {
 		'joins' => array(),
 
 		'callback' => $callback,
+
+		// private API
+		'__preload' => ELGG_ENTITIES_ANY_VALUE,
 	);
 
 	// @todo Ignore site_guid right now because of #2910
@@ -432,6 +435,12 @@ function _elgg_get_metastring_based_objects($options) {
 		}
 
 		$dt = get_data($query, $options['callback']);
+
+		if ($dt && $options['__preload']) {
+			$preloader = new Elgg_EntityPreloader((array)$options['__preload']);
+			$preloader->preload($dt);
+		}
+
 		return $dt;
 	} else {
 		$result = get_data_row($query);

--- a/mod/blog/lib/blog.php
+++ b/mod/blog/lib/blog.php
@@ -64,6 +64,7 @@ function blog_get_page_content_list($container_guid = NULL) {
 		'subtype' => 'blog',
 		'full_view' => false,
 		'no_results' => elgg_echo('blog:none'),
+		'__preload' => 'owner_guid',
 	);
 
 	$current_user = elgg_get_logged_in_user_entity();
@@ -150,6 +151,7 @@ function blog_get_page_content_friends($user_guid) {
 		'relationship_guid' => $user_guid,
 		'relationship_join_on' => 'container_guid',
 		'no_results' => elgg_echo('blog:none'),
+		'__preload' => 'owner_guid',
 	);
 
 	// admin / owners can see any posts
@@ -209,6 +211,7 @@ function blog_get_page_content_archive($owner_guid, $lower = 0, $upper = 0) {
 		'subtype' => 'blog',
 		'full_view' => false,
 		'no_results' => elgg_echo('blog:none'),
+		'__preload' => 'owner_guid',
 	);
 
 	if ($owner_guid) {

--- a/mod/bookmarks/pages/bookmarks/all.php
+++ b/mod/bookmarks/pages/bookmarks/all.php
@@ -16,6 +16,7 @@ $content = elgg_list_entities(array(
 	'full_view' => false,
 	'view_toggle_type' => false,
 	'no_results' => elgg_echo('bookmarks:none'),
+	'__preload' => 'owner_guid',
 ));
 
 $title = elgg_echo('bookmarks:everyone');

--- a/mod/bookmarks/pages/bookmarks/friends.php
+++ b/mod/bookmarks/pages/bookmarks/friends.php
@@ -25,6 +25,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_guid' => $page_owner->guid,
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo('bookmarks:none'),
+	'__preload' => 'owner_guid',
 ));
 
 $params = array(

--- a/mod/bookmarks/pages/bookmarks/owner.php
+++ b/mod/bookmarks/pages/bookmarks/owner.php
@@ -21,6 +21,7 @@ $content .= elgg_list_entities(array(
 	'full_view' => false,
 	'view_toggle_type' => false,
 	'no_results' => elgg_echo('bookmarks:none'),
+	'__preload' => 'owner_guid',
 ));
 
 $title = elgg_echo('bookmarks:owner', array($page_owner->name));

--- a/mod/file/pages/file/friends.php
+++ b/mod/file/pages/file/friends.php
@@ -26,6 +26,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_guid' => $owner->guid,
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo("file:none"),
+	'__preload' => 'owner_guid',
 ));
 
 $sidebar = file_get_type_cloud($owner->guid, true);

--- a/mod/file/pages/file/owner.php
+++ b/mod/file/pages/file/owner.php
@@ -41,6 +41,7 @@ $content = elgg_list_entities(array(
 	'container_guid' => $owner->guid,
 	'full_view' => false,
 	'no_results' => elgg_echo("file:none"),
+	'__preload' => 'owner_guid',
 ));
 
 $sidebar = file_get_type_cloud(elgg_get_page_owner_guid());

--- a/mod/file/pages/file/search.php
+++ b/mod/file/pages/file/search.php
@@ -80,6 +80,7 @@ $params = array(
 	'container_guid' => $page_owner_guid,
 	'limit' => $limit,
 	'full_view' => false,
+	'__preload' => 'owner_guid',
 );
 
 if ($file_type) {

--- a/mod/file/pages/file/world.php
+++ b/mod/file/pages/file/world.php
@@ -16,6 +16,7 @@ $content = elgg_list_entities(array(
 	'subtype' => 'file',
 	'full_view' => false,
 	'no_results' => elgg_echo("file:none"),
+	'__preload' => 'owner_guid',
 ));
 
 $sidebar = file_get_type_cloud();

--- a/mod/groups/lib/discussion.php
+++ b/mod/groups/lib/discussion.php
@@ -18,6 +18,7 @@ function discussion_handle_all_page() {
 		'limit' => 20,
 		'full_view' => false,
 		'no_results' => elgg_echo('discussion:none'),
+		'__preload' => 'owner_guid',
 	));
 
 	$title = elgg_echo('discussion:latest');
@@ -62,6 +63,7 @@ function discussion_handle_list_page($guid) {
 		'container_guid' => $guid,
 		'full_view' => false,
 		'no_results' => elgg_echo('discussion:none'),
+		'__preload' => 'owner_guid',
 	);
 	$content = elgg_list_entities($options);
 

--- a/mod/likes/views/default/likes/count.php
+++ b/mod/likes/views/default/likes/count.php
@@ -30,7 +30,8 @@ if ($num_of_likes) {
 		'guid' => $guid,
 		'annotation_name' => 'likes',
 		'limit' => 99,
-		'list_class' => 'elgg-list-likes'
+		'list_class' => 'elgg-list-likes',
+		'__preload' => 'owner_guid',
 	));
 	$list .= "</div>";
 	echo $list;

--- a/mod/messageboard/pages/messageboard/owner.php
+++ b/mod/messageboard/pages/messageboard/owner.php
@@ -17,6 +17,7 @@ $options = array(
 	'annotations_name' => 'messageboard',
 	'guid' => $page_owner_guid,
 	'reverse_order_by' => true,
+	'__preload' => 'owner_guid',
 );
 
 if ($history_user) {

--- a/mod/messages/pages/messages/inbox.php
+++ b/mod/messages/pages/messages/inbox.php
@@ -31,6 +31,7 @@ $list = elgg_list_entities_from_metadata(array(
 	'metadata_value' => elgg_get_page_owner_guid(),
 	'owner_guid' => elgg_get_page_owner_guid(),
 	'full_view' => false,
+	'__preload' => 'owner_guid',
 ));
 
 $body_vars = array(

--- a/mod/pages/pages/pages/friends.php
+++ b/mod/pages/pages/pages/friends.php
@@ -25,6 +25,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_guid' => $owner->guid,
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo('pages:none'),
+	'__preload' => 'owner_guid',
 ));
 
 $params = array(

--- a/mod/pages/pages/pages/owner.php
+++ b/mod/pages/pages/pages/owner.php
@@ -25,6 +25,7 @@ $content = elgg_list_entities(array(
 	'container_guid' => elgg_get_page_owner_guid(),
 	'full_view' => false,
 	'no_results' => elgg_echo('pages:none'),
+	'__preload' => 'owner_guid',
 ));
 
 $filter_context = '';

--- a/mod/pages/pages/pages/world.php
+++ b/mod/pages/pages/pages/world.php
@@ -17,6 +17,7 @@ $content = elgg_list_entities(array(
 	'subtype' => 'page_top',
 	'full_view' => false,
 	'no_results' => elgg_echo('pages:none'),
+	'__preload' => 'owner_guid',
 ));
 
 $body = elgg_view_layout('content', array(

--- a/mod/search/search_hooks.php
+++ b/mod/search/search_hooks.php
@@ -36,6 +36,7 @@ function search_objects_hook($hook, $type, $value, $params) {
 	
 	$params['count'] = FALSE;
 	$params['order_by'] = search_get_order_by_sql('e', 'oe', $params['sort'], $params['order']);
+	$params['__preload'] = 'owner_guid';
 	$entities = elgg_get_entities($params);
 
 	// add the volatile data for why these entities have been returned.

--- a/mod/thewire/pages/thewire/everyone.php
+++ b/mod/thewire/pages/thewire/everyone.php
@@ -19,6 +19,7 @@ $content .= elgg_list_entities(array(
 	'type' => 'object',
 	'subtype' => 'thewire',
 	'limit' => get_input('limit', 15),
+	'__preload' => 'owner_guid',
 ));
 
 $body = elgg_view_layout('content', array(

--- a/mod/thewire/pages/thewire/friends.php
+++ b/mod/thewire/pages/thewire/friends.php
@@ -27,6 +27,7 @@ $content .= elgg_list_entities_from_relationship(array(
 	'relationship' => 'friend',
 	'relationship_guid' => $owner->guid,
 	'relationship_join_on' => 'container_guid',
+	'__preload' => 'owner_guid',
 ));
 
 $body = elgg_view_layout('content', array(

--- a/mod/thewire/pages/thewire/thread.php
+++ b/mod/thewire/pages/thewire/thread.php
@@ -16,6 +16,7 @@ $content = elgg_list_entities_from_metadata(array(
 	"type" => "object",
 	"subtype" => "thewire",
 	"limit" => 20,
+	'__preload' => 'owner_guid',
 ));
 
 $body = elgg_view_layout('content', array(

--- a/views/default/page/elements/comments.php
+++ b/views/default/page/elements/comments.php
@@ -38,6 +38,7 @@ $html = elgg_list_entities(array(
 	'reverse_order_by' => true,
 	'full_view' => true,
 	'limit' => $limit,
+	'__preload' => 'owner_guid',
 ));
 
 if ($html) {


### PR DESCRIPTION
I'm already not crazy about my idea to keep this option "private" with the double underscore. There's simply no way to keep an Elgg query function option private and use it in bundled plugins. This makes me think of named queries (#4453), which would allow us to enhance core plugin queries behind the scenes (so devs don't see the private option).
- [ ] change __preload to a public $options key "preload_owners" (bool, false by default).
