### PR TITLE
Do not use link with file icon when using full_view

### DIFF
--- a/mod/file/views/default/object/file.php
+++ b/mod/file/views/default/object/file.php
@@ -26,8 +26,6 @@ $owner_link = elgg_view('output/url', array(
 ));
 $author_text = elgg_echo('byline', array($owner_link));
 
-$file_icon = elgg_view_entity_icon($file, 'small');
-
 $date = elgg_view_friendly_time($file->time_created);
 
 $comments_count = $file->countComments();
@@ -78,6 +76,8 @@ if ($full && !elgg_in_context('gallery')) {
 	$text = elgg_view('output/longtext', array('value' => $file->description));
 	$body = "$text $extra";
 
+	$file_icon = elgg_view_entity_icon($file, 'small', array('href' => false));
+
 	echo elgg_view('object/elements/full', array(
 		'entity' => $file,
 		'icon' => $file_icon,
@@ -93,6 +93,8 @@ if ($full && !elgg_in_context('gallery')) {
 	echo '</div>';
 } else {
 	// brief view
+
+	$file_icon = elgg_view_entity_icon($file, 'small');
 
 	$params = array(
 		'entity' => $file,


### PR DESCRIPTION
Users get confused because they are already viewing the file but still the file icon appears as a link.
