### PR TITLE
Deprecate footer/analytics view

### DIFF
--- a/views/default/page/elements/foot.php
+++ b/views/default/page/elements/foot.php
@@ -2,7 +2,7 @@
 
 $analytics = elgg_view('footer/analytics');
 if ($analytics) {
-	elgg_deprecated_notice("The analytics view has been deprecated. Extend page/elements/footer instead", 1.8);
+	elgg_deprecated_notice("The analytics view has been deprecated. Extend page/elements/foot instead", 1.8);
 	echo $analytics;
 }
 

--- a/views/default/page/elements/foot.php
+++ b/views/default/page/elements/foot.php
@@ -1,6 +1,10 @@
 <?php
 
-echo elgg_view('footer/analytics');
+$analytics = elgg_view('footer/analytics');
+if ($analytics) {
+	elgg_deprecated_notice("The analytics view has been deprecated. Extend page/elements/footer instead", 1.8);
+	echo $analytics;
+}
 
 $js = elgg_get_loaded_js('footer');
 foreach ($js as $script) { ?>

--- a/views/default/page/elements/foot.php
+++ b/views/default/page/elements/foot.php
@@ -1,5 +1,6 @@
 <?php
 
+echo elgg_view('footer/analytics');
 
 $js = elgg_get_loaded_js('footer');
 foreach ($js as $script) { ?>

--- a/views/default/page/elements/foot.php
+++ b/views/default/page/elements/foot.php
@@ -1,6 +1,5 @@
 <?php
 
-echo elgg_view('footer/analytics');
 
 $js = elgg_get_loaded_js('footer');
 foreach ($js as $script) { ?>


### PR DESCRIPTION
This is a reference to a view that is missing from the core views. This results in a PHP notice generated every time the view is requested. We may want to handle this  similar to the way the old metatags view was handled in head.php by only echoing it if there is a value with a deprecated notice.
