### PR TITLE
Detect pagination needs

### DIFF
--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -120,7 +120,7 @@ $posted = 0, $annotation_id = 0) {
  *   subtypes             => STR|ARR Entity subtype string(s)
  *   type_subtype_pairs   => ARR     Array of type => subtype pairs where subtype
  *                                   can be an array of subtype strings
- * 
+ *
  *   posted_time_lower    => INT     The lower bound on the time posted
  *   posted_time_upper    => INT     The upper bound on the time posted
  *
@@ -434,8 +434,13 @@ function elgg_list_river(array $options = array()) {
 		'pagination' => TRUE,
 		'list_class' => 'elgg-list-river elgg-river', // @todo remove elgg-river in Elgg 1.9
 	);
-
+	
 	$options = array_merge($defaults, $options);
+	
+	if (!$options["limit"] && !$options["offset"]) {
+		// no need for pagination if listing is unlimited
+		$options["pagination"] = false;
+	}
 
 	$options['count'] = TRUE;
 	$count = elgg_get_river($options);
@@ -445,6 +450,7 @@ function elgg_list_river(array $options = array()) {
 
 	$options['count'] = $count;
 	$options['items'] = $items;
+	
 	return elgg_view('page/components/list', $options);
 }
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -218,7 +218,7 @@ function elgg_register_ajax_view($view) {
 
 /**
  * Unregister a view for ajax calls
- * 
+ *
  * @param string $view The view name
  * @return void
  * @since 1.8.3
@@ -992,6 +992,11 @@ function elgg_view_annotation(ElggAnnotation $annotation, array $vars = array(),
 function elgg_view_entity_list($entities, $vars = array(), $offset = 0, $limit = 10, $full_view = true,
 $list_type_toggle = true, $pagination = true) {
 
+	if (!$vars["limit"] && !$vars["offset"]) {
+		// no need for pagination if listing is unlimited
+		$vars["pagination"] = false;
+	}
+		
 	if (!is_int($offset)) {
 		$offset = (int)get_input('offset', 0);
 	}
@@ -1064,8 +1069,13 @@ function elgg_view_annotation_list($annotations, array $vars = array()) {
 		'full_view' => true,
 		'offset_key' => 'annoff',
 	);
-
+	
 	$vars = array_merge($defaults, $vars);
+	
+	if (!$vars["limit"] && !$vars["offset"]) {
+		// no need for pagination if listing is unlimited
+		$vars["pagination"] = false;
+	}
 
 	return elgg_view('page/components/list', $vars);
 }
@@ -1334,12 +1344,12 @@ function elgg_view_list_item($item, array $vars = array()) {
 
 /**
  * View one of the elgg sprite icons
- * 
+ *
  * Shorthand for <span class="elgg-icon elgg-icon-$name"></span>
- * 
+ *
  * @param string $name  The specific icon to display
  * @param string $class Additional class: float, float-alt, or custom class
- * 
+ *
  * @return string The html for displaying an icon
  */
 function elgg_view_icon($name, $class = '') {


### PR DESCRIPTION
This is probably a long standing issue, but is easily fixed. The following situation will show the problem.

Pagination will show up even if it is not needed if you do the following:

``` php
elgg_list_entities(array("type" => "object", "subtype" => "blog", "limit" => false));
```

Even with limit is false (or 0, whatever your preference), you will get pagination, because pagination is defaulted to true and doesn't handle this well.

So solution is easy, if you start at 0 (`!$offset`) and have no limit (`!$limit`) we set pagination to false.

This fix saves you the trouble of adding `"pagination" => false` to all unlimited list_entities.

Real life problem here: https://github.com/ColdTrick/profile_manager/issues/9
