### PR TITLE
Update CacheHandler.php

### DIFF
--- a/engine/classes/Elgg/CacheHandler.php
+++ b/engine/classes/Elgg/CacheHandler.php
@@ -116,7 +116,7 @@ class Elgg_CacheHandler {
 		// testing showed regex to be marginally faster than array / string functions over 100000 reps
 		// it won't make a difference in real life and regex is easier to read.
 		// <ts>/<viewtype>/<name/of/view.and.dots>.<type>
-		if (!preg_match('#^([0-9]+)/([^/]+)/(.+)$#', $request_var, $matches)) {
+		if (!preg_match('#^/?([0-9]+)/([^/]+)/(.+)$#', $request_var, $matches)) {
 			return array();
 		}
 

--- a/engine/tests/phpunit/Elgg/CacheHandlerTest.php
+++ b/engine/tests/phpunit/Elgg/CacheHandlerTest.php
@@ -39,4 +39,12 @@ class Elgg_CacheHandlerTest extends PHPUnit_Framework_TestCase {
 	public function testParserHasCharWhitelist() {
 		$this->_testParseFail('a1234/default/he~l/8lo-wo_rl.d.js');
 	}
+
+	public function testParseSupportsLeadingSlash() {
+		$this->assertEquals(array(
+			'ts' => '1234',
+			'viewtype' => 'default',
+			'view' => 'hel/8lo-wo_rl.d.js',
+		), $this->handler->parseRequestVar('/1234/default/hel/8lo-wo_rl.d.js'));
+	}
 }


### PR DESCRIPTION
This line looks suspicious. Shouldn't the `$request_var` start with a `/` ?
If I have `/cache/0/default/css/admin`, I'd rather have
  `$request_var = "/0/default/css/admin";`
than 
  `$request_var = "0/default/css/admin";`

I don't know how it works with Apache and others, but with Nginx, it simplifies things--read: it makes it work. Therefore:

  `if (!preg_match('#^/?([0-9]+)/([^/]+)/(.+)$#', $request_var, $matches)) {`

(drop the `?` if that is not needed)
