### PR TITLE
Pages/Bookmarks: Match language convention for adding an object

### DIFF
--- a/mod/bookmarks/languages/en.php
+++ b/mod/bookmarks/languages/en.php
@@ -9,7 +9,7 @@ return array(
 	 * Menu items and titles
 	 */
 	'bookmarks' => "Bookmarks",
-	'bookmarks:add' => "Add bookmark",
+	'bookmarks:add' => "Add a bookmark",
 	'bookmarks:edit' => "Edit bookmark",
 	'bookmarks:owner' => "%s's bookmarks",
 	'bookmarks:friends' => "Friends' bookmarks",

--- a/mod/pages/languages/en.php
+++ b/mod/pages/languages/en.php
@@ -15,7 +15,7 @@ return array(
 	'pages:owner' => "%s's pages",
 	'pages:friends' => "Friends' pages",
 	'pages:all' => "All site pages",
-	'pages:add' => "Add page",
+	'pages:add' => "Add a page",
 
 	'pages:group' => "Group pages",
 	'groups:enablepages' => 'Enable group pages',


### PR DESCRIPTION
The differences are mostly noticeable on the group profile. We could alternately go the other way, getting rid of the articles: "Write blog post", etc.
