### PR TITLE
Sets naming convention for relationships, adds docs

### DIFF
--- a/docs/design/database.rst
+++ b/docs/design/database.rst
@@ -852,4 +852,3 @@ lookups more efficient.
 
 Core developers will place schema upgrades in
 ``/engine/schema/upgrades/*``.
-

--- a/docs/design/database.rst
+++ b/docs/design/database.rst
@@ -743,18 +743,18 @@ populated with your first site.
 
 It contains the following fields:
 
-guid: An auto-incrementing counter producing a GUID that uniquely
+-  **guid** An auto-incrementing counter producing a GUID that uniquely
 identifies this entity in the system.
-type: The type of entity - object, user, group or site
-subtype: A link to the `entity_subtypes` table.
-owner\_guid: The GUID of the owner's entity.
-site\_guid: The site the entity belongs to.
-container\_guid: The GUID this entity is contained by - either a user or
+-  **type** The type of entity - object, user, group or site
+-  **subtype** A link to the `entity_subtypes` table.
+-  **owner\_guid** The GUID of the owner's entity.
+-  **site\_guid** The site the entity belongs to.
+-  **container\_guid** The GUID this entity is contained by - either a user or
 a group.
-access\_id: Access controls on this entity.
-time\_created: Unix timestamp of when the entity is created.
-time\_updated: Unix timestamp of when the entity was updated.
-enabled: If this is 'yes' an entity is accessible, if 'no' the entity
+-  **access\_id** Access controls on this entity.
+-  **time\_created** Unix timestamp of when the entity is created.
+-  **time\_updated** Unix timestamp of when the entity was updated.
+-  **enabled** If this is 'yes' an entity is accessible, if 'no' the entity
 has been disabled (Elgg treats it as if it were deleted without actually
 removing it from the database).
 

--- a/docs/design/database.rst
+++ b/docs/design/database.rst
@@ -809,9 +809,9 @@ Table: relationships
 
 This table defines `Relationships`_, these link one entity with another.
 
--  **guid\_one** entity number one.
--  **relationship** Relationship string.
--  **guid\_two** entity number two.
+-  **guid\_one** The GUID of the subject entity.
+-  **relationship** The type of the relationship.
+-  **guid\_two** The GUID of the target entity.
 
 Table: objects\_entity
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/design/database.rst
+++ b/docs/design/database.rst
@@ -737,7 +737,7 @@ Elgg installation, the tables will have a prefix (typically "elgg\_").
 Table: entities
 ~~~~~~~~~~~~~~~
 
-This is the main Elgg table containing Elgg users, sites,
+This is the main `Entities`_ table containing Elgg users, sites,
 objects and groups. When you first install Elgg this is automatically
 populated with your first site.
 
@@ -771,7 +771,7 @@ This table contains entity subtype information:
 Table: metadata
 ~~~~~~~~~~~~~~~
 
-This table contains extra information attached to an entity.
+This table contains `Metadata`_, extra information attached to an entity.
 
 -  **id** A counter.
 -  **entity\_guid** The entity this is attached to.
@@ -789,7 +789,7 @@ This table contains extra information attached to an entity.
 Table: annotations
 ~~~~~~~~~~~~~~~~~~
 
-This table contains annotations, this is distinct from metadata.
+This table contains `Annotations`_, this is distinct from `Metadata`_.
 
 -  **id** A counter.
 -  **entity\_guid** The entity this is attached to.
@@ -807,7 +807,7 @@ This table contains annotations, this is distinct from metadata.
 Table: relationships
 ~~~~~~~~~~~~~~~~~~~~
 
-This table defines relationships, these link one entity with another.
+This table defines `Relationships`_, these link one entity with another.
 
 -  **guid\_one** entity number one.
 -  **relationship** Relationship string.

--- a/docs/design/database.rst
+++ b/docs/design/database.rst
@@ -566,12 +566,18 @@ API name          Models          Represents
 ``guid_two``      The target      The entity to which the subject is bound
 ================  ===========     =========================================
 
+The type of relationship may alternately be a verb, making the statement:
+
+    "**{subject}** **{verb}** **{target}**."
+
+    E.g. User A "likes" blog post B
+
 **Each relationship has direction.** Imagine an archer shoots
 an arrow at a target; The arrow moves in one direction, binding
 the subject (the archer) to the target.
 
-**A relationship does not imply reciprocity**. **A** being a
-follower of **B** does not imply that **B** follows **A**.
+**A relationship does not imply reciprocity**. **A** follows **B** does
+not imply that **B** follows **A**.
 
 **Relationships_ do not have access control.** They're never
 hidden from view and can be edited with code at any privilege

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -623,29 +623,29 @@ abstract class ElggEntity extends ElggData implements
 	 *
 	 * @tip Read the relationship like "$guid is a $relationship of this entity."
 	 *
-	 * @param int    $guid         Entity to link to.
+	 * @param int    $guid_two     GUID of the target entity of the relationship.
 	 * @param string $relationship The type of relationship.
 	 *
 	 * @return bool
 	 * @see ElggEntity::removeRelationship()
 	 * @see ElggEntity::deleteRelationships()
 	 */
-	public function addRelationship($guid, $relationship) {
-		return add_entity_relationship($this->getGUID(), $relationship, $guid);
+	public function addRelationship($guid_two, $relationship) {
+		return add_entity_relationship($this->getGUID(), $relationship, $guid_two);
 	}
 
 	/**
 	 * Remove a relationship
 	 *
-	 * @param int $guid         GUID of the entity to make a relationship with
-	 * @param str $relationship Name of relationship
+	 * @param int    $guid_two     GUID of the target entity of the relationship.
+	 * @param string $relationship The type of relationship.
 	 *
 	 * @return bool
 	 * @see ElggEntity::addRelationship()
 	 * @see ElggEntity::deleteRelationships()
 	 */
-	public function removeRelationship($guid, $relationship) {
-		return remove_entity_relationship($this->getGUID(), $relationship, $guid);
+	public function removeRelationship($guid_two, $relationship) {
+		return remove_entity_relationship($this->getGUID(), $relationship, $guid_two);
 	}
 
 	/**

--- a/engine/classes/ElggRelationship.php
+++ b/engine/classes/ElggRelationship.php
@@ -7,8 +7,8 @@
  * 
  * @property int    $id           The unique identifier (read-only)
  * @property int    $guid_one     The GUID of the subject of the relationship
- * @property string $relationship The name of the relationship (limit of 50 characters long)
- * @property int    $guid_two     The GUID of the object of the relationship
+ * @property string $relationship The type of the relationship (limit of 50 characters long)
+ * @property int    $guid_two     The GUID of the target of the relationship
  * @property int    $time_created A UNIX timestamp of when the relationship was created (read-only, set on first save)
  */
 class ElggRelationship extends ElggData implements
@@ -112,7 +112,7 @@ class ElggRelationship extends ElggData implements
 	/**
 	 * Save the relationship
 	 *
-	 * @return int the relationship id
+	 * @return int the relationship ID
 	 * @throws IOException
 	 */
 	public function save() {
@@ -129,7 +129,7 @@ class ElggRelationship extends ElggData implements
 	}
 
 	/**
-	 * Delete a given relationship.
+	 * Delete this relationship from the database.
 	 *
 	 * @return bool
 	 */

--- a/engine/lib/relationships.php
+++ b/engine/lib/relationships.php
@@ -39,7 +39,7 @@ function get_relationship($id) {
 }
 
 /**
- * Delete a specific relationship.
+ * Delete a relationship by its ID
  *
  * @param int $id The relationship ID
  *
@@ -60,14 +60,14 @@ function delete_relationship($id) {
 }
 
 /**
- * Define an arbitrary relationship between two entities.
- * This relationship could be a friendship, a group membership or a site membership.
+ * Create a relationship between two entities. E.g. friendship, group membership, site membership.
  *
- * This function lets you make the statement "$guid_one is a $relationship of $guid_two".
+ * This function lets you make the statement "$guid_one is a $relationship of $guid_two". In the statement,
+ * $guid_one is the subject of the relationship, $guid_two is the target, and $relationship is the type.
  *
- * @param int    $guid_one     First GUID
- * @param string $relationship Relationship name
- * @param int    $guid_two     Second GUID
+ * @param int    $guid_one     GUID of the subject entity of the relationship
+ * @param string $relationship Type of the relationship
+ * @param int    $guid_two     GUID of the target entity of the relationship
  *
  * @return bool
  * @throws InvalidArgumentException
@@ -112,12 +112,13 @@ function add_entity_relationship($guid_one, $relationship, $guid_two) {
 }
 
 /**
- * Determine if a relationship between two entities exists
- * and returns the relationship object if it does
+ * Check if a relationship exists between two entities. If so, the relationship object is returned.
  *
- * @param int    $guid_one     The GUID of the entity "owning" the relationship
- * @param string $relationship The type of relationship
- * @param int    $guid_two     The GUID of the entity the relationship is with
+ * This function lets you ask "Is $guid_one a $relationship of $guid_two?"
+ *
+ * @param int    $guid_one     GUID of the subject entity of the relationship
+ * @param string $relationship Type of the relationship
+ * @param int    $guid_two     GUID of the target entity of the relationship
  *
  * @return ElggRelationship|false Depending on success
  */
@@ -142,11 +143,13 @@ function check_entity_relationship($guid_one, $relationship, $guid_two) {
 }
 
 /**
- * Remove an arbitrary relationship between two entities.
+ * Delete a relationship between two entities.
  *
- * @param int    $guid_one     First GUID
- * @param string $relationship Relationship name
- * @param int    $guid_two     Second GUID
+ * This function lets you say "$guid_one is no longer a $relationship of $guid_two."
+ *
+ * @param int    $guid_one     GUID of the subject entity of the relationship
+ * @param string $relationship Type of the relationship
+ * @param int    $guid_two     GUID of the target entity of the relationship
  *
  * @return bool
  */
@@ -179,19 +182,20 @@ function remove_entity_relationship($guid_one, $relationship, $guid_two) {
 }
 
 /**
- * Removes all arbitrary relationships originating from a particular entity
+ * Removes all relationships originating from a particular entity
  *
- * @param int    $guid_one     The GUID of the entity
- * @param string $relationship The name of the relationship (optional)
- * @param bool   $inverse      Whether we're deleting inverse relationships (default false)
- * @param string $type         The type of entity to the delete to (defaults to all)
+ * @param int    $guid                 GUID of the subject or target entity (see $inverse)
+ * @param string $relationship         Type of the relationship (optional, default is all relationships)
+ * @param bool   $inverse_relationship Is $guid the target of the deleted relationships? By default, $guid is the
+ *                                     subject of the relationships.
+ * @param string $type                 The type of entity related to $guid (defaults to all)
  *
- * @return bool Depending on success
+ * @return true
  */
-function remove_entity_relationships($guid_one, $relationship = "", $inverse = false, $type = '') {
+function remove_entity_relationships($guid, $relationship = "", $inverse_relationship = false, $type = '') {
 	global $CONFIG;
 
-	$guid_one = (int) $guid_one;
+	$guid = (int) $guid;
 
 	if (!empty($relationship)) {
 		$relationship = sanitize_string($relationship);
@@ -202,34 +206,35 @@ function remove_entity_relationships($guid_one, $relationship = "", $inverse = f
 
 	if (!empty($type)) {
 		$type = sanitize_string($type);
-		if (!$inverse) {
+		if (!$inverse_relationship) {
 			$join = "JOIN {$CONFIG->dbprefix}entities e ON e.guid = er.guid_two";
 		} else {
 			$join = "JOIN {$CONFIG->dbprefix}entities e ON e.guid = er.guid_one";
-			$where .= " and ";
+			$where .= " AND ";
 		}
 		$where .= " AND e.type = '$type'";
 	} else {
 		$join = "";
 	}
 
-	if (!$inverse) {
-		$sql = "DELETE er FROM {$CONFIG->dbprefix}entity_relationships AS er
-			$join WHERE guid_one = $guid_one $where";
-	} else {
-		$sql = "DELETE er FROM {$CONFIG->dbprefix}entity_relationships AS er
-			$join WHERE
-			guid_two = $guid_one $where";
-	}
+	$guid_col = $inverse_relationship ? "guid_two" : "guid_one";
 
-	return delete_data($sql) !== false;
+	delete_data("
+		DELETE er FROM {$CONFIG->dbprefix}entity_relationships AS er
+		$join
+		WHERE $guid_col = $guid
+		$where
+	");
+
+	return true;
 }
 
 /**
- * Get all the relationships for a given guid.
+ * Get all the relationships for a given GUID.
  *
- * @param int  $guid                 The GUID of the relationship owner
- * @param bool $inverse_relationship Inverse relationship owners?
+ * @param int  $guid                 GUID of the subject or target entity (see $inverse)
+ * @param bool $inverse_relationship Is $guid the target of the deleted relationships? By default $guid is
+ *                                   the subject of the relationships.
  *
  * @return ElggRelationship[]
  */
@@ -264,11 +269,12 @@ function get_entity_relationships($guid, $inverse_relationship = false) {
  *
  * @param array $options Array in format:
  *
- * 	relationship => null|STR relationship
+ *  relationship         => null|STR Type of the relationship
  *
- * 	relationship_guid => null|INT Guid of relationship to test
+ *  relationship_guid    => null|INT GUID of the subject or target entity
  *
- * 	inverse_relationship => BOOL Inverse the relationship
+ *  inverse_relationship => false|BOOL Is relationship_guid is the target entity of the relationship? By default,
+ * 	                        relationship_guid is the subject.
  * 
  *  relationship_join_on => null|STR How the entities relate: guid (default), container_guid, or owner_guid
  *                          Add in Elgg 1.9.0. Examples using the relationship 'friend':
@@ -327,15 +333,15 @@ function elgg_get_entities_from_relationship($options) {
 }
 
 /**
- * Returns sql appropriate for relationship joins and wheres
+ * Returns SQL appropriate for relationship joins and wheres
  *
  * @todo add support for multiple relationships and guids.
  *
- * @param string $column               Column name the guid should be checked against.
+ * @param string $column               Column name the GUID should be checked against.
  *                                     Provide in table.column format.
- * @param string $relationship         Relationship string
- * @param int    $relationship_guid    Entity guid to check
- * @param bool $inverse_relationship Inverse relationship check?
+ * @param string $relationship         Type of the relationship
+ * @param int    $relationship_guid    Entity GUID to check
+ * @param bool   $inverse_relationship Is $relationship_guid the target of the relationship?
  *
  * @return mixed
  * @since 1.7.0
@@ -398,8 +404,8 @@ function elgg_list_entities_from_relationship(array $options = array()) {
  * This is a good way to get out the users with the most friends, or the groups with the
  * most members.
  *
- * @param array $options An options array compatible with
- *                       elgg_get_entities_from_relationship()
+ * @param array $options An options array compatible with elgg_get_entities_from_relationship()
+ *
  * @return ElggEntity[]|int|boolean If count, int. If not count, array. false on errors.
  * @since 1.8.0
  */


### PR DESCRIPTION
This promotes using the names "subject" and "target" for `guid_one` and `guid_two`, respectively. I think the archer/(literal) target metaphor in the docs makes this clearer.

For now I left variables named $guid_one, etc. because I wanted to keep the API consistent with existing ElggRelationship property names.

What does everyone think of deprecating the `guid_one`-type properties using __get/set? It seems like few devs are actually using these.
