### PR TITLE
Fixes #5991: Deprecates passing null to ElggRelationship constructor

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -95,6 +95,7 @@ Version 1.9.0-rc1
    * export, import, and opendd libraries (see ElggEntity:toObject())
    * location library
    * xml library
+   * passing null to ElggRelationship constructor
 
   Removed functionality
    * xml-rpc library (now plugin: https://github.com/Elgg/xml-rpc)

--- a/engine/classes/ElggRelationship.php
+++ b/engine/classes/ElggRelationship.php
@@ -21,24 +21,31 @@ class ElggRelationship extends ElggData implements
 	 * Create a relationship object
 	 *
 	 * @param stdClass $row Database row or null for new relationship
+	 * @throws InvalidArgumentException
 	 */
 	public function __construct($row = null) {
 		$this->initializeAttributes();
 
-		if (!empty($row)) {
-			if ($row instanceof stdClass) {
-				$relationship = $row; // Create from db row
-			} else {
-				elgg_deprecated_notice('Passing an ID to constructor is deprecated. Use get_relationship()', 1.9);
-				$relationship = get_relationship($row);
+		if ($row === null) {
+			elgg_deprecated_notice('Passing null to constructor is deprecated. Use add_entity_relationship()', 1.9);
+			return;
+		}
+
+		if (!($row instanceof stdClass)) {
+			if (!is_numeric($row)) {
+				throw new InvalidArgumentException("Constructor accepts only a stdClass or null.");
 			}
 
-			if ($relationship) {
-				$objarray = (array) $relationship;
-				foreach ($objarray as $key => $value) {
-					$this->attributes[$key] = $value;
-				}
+			$id = (int)$row;
+			elgg_deprecated_notice('Passing an ID to constructor is deprecated. Use get_relationship()', 1.9);
+			$row = _elgg_get_relationship_row($id);
+			if (!$row) {
+				throw new InvalidArgumentException("Relationship not found with ID $id");
 			}
+		}
+
+		foreach ((array)$row as $key => $value) {
+			$this->attributes[$key] = $value;
 		}
 	}
 
@@ -321,5 +328,4 @@ class ElggRelationship extends ElggData implements
 	public function getSubtype() {
 		return $this->relationship;
 	}
-
 }

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1014,7 +1014,7 @@ function elgg_get_version($human_readable = false) {
 				return false;
 			}
 		}
-		return (!$human_readable) ? $version : $release;
+		return $human_readable ? $release : $version;
 	}
 
 	return false;

--- a/engine/lib/relationships.php
+++ b/engine/lib/relationships.php
@@ -11,31 +11,47 @@
  *
  * @param stdClass $row Database row from the relationship table
  *
- * @return ElggRelationship|stdClass
+ * @return ElggRelationship|false
  * @access private
  */
 function row_to_elggrelationship($row) {
-	if (!($row instanceof stdClass)) {
-		return $row;
+	if ($row instanceof stdClass) {
+		return new ElggRelationship($row);
+	}
+
+	return false;
+}
+
+/**
+ * Get a relationship by its ID
+ *
+ * @param int $id The relationship ID
+ *
+ * @return ElggRelationship|false False if not found
+ */
+function get_relationship($id) {
+	$row = _elgg_get_relationship_row($id);
+	if (!$row) {
+		return false;
 	}
 
 	return new ElggRelationship($row);
 }
 
 /**
- * Return a relationship.
+ * Get a database row from the relationship table
  *
- * @param int $id The ID of a relationship
+ * @param int $id The relationship ID
  *
- * @return ElggRelationship|false
+ * @return stdClass|false False if no row found
+ * @access private
  */
-function get_relationship($id) {
+function _elgg_get_relationship_row($id) {
 	global $CONFIG;
 
 	$id = (int)$id;
 
-	$query = "SELECT * from {$CONFIG->dbprefix}entity_relationships where id=$id";
-	return row_to_elggrelationship(get_data_row($query));
+	return get_data_row("SELECT * FROM {$CONFIG->dbprefix}entity_relationships WHERE id = $id");
 }
 
 /**

--- a/engine/tests/phpunit/ElggRelationshipTest.php
+++ b/engine/tests/phpunit/ElggRelationshipTest.php
@@ -3,13 +3,19 @@
 class ElggRelationshipTest extends PHPUnit_Framework_TestCase {
 
 	public function testSettingAndGettingAttribute() {
-		$obj = $this->getMockForAbstractClass('ElggRelationship', array(), '', false);
+		$obj = $this->getRelationshipMock();
 		$obj->relationship = 'hasSister';
 		$this->assertEquals('hasSister', $obj->relationship);
 	}
 
 	public function testGettingNonexistentAttribute() {
-		$obj = $this->getMockForAbstractClass('ElggRelationship', array(), '', false);
+		$obj = $this->getRelationshipMock();
 		$this->assertNull($obj->foo);
+	}
+
+	protected function getRelationshipMock() {
+		// do not call constructor because it would cause deprecation warnings
+		// and deprecation is not test-friendly yet.
+		return $this->getMockForAbstractClass('ElggRelationship', array(), '', false);
 	}
 }

--- a/engine/tests/phpunit/ElggRelationshipTest.php
+++ b/engine/tests/phpunit/ElggRelationshipTest.php
@@ -3,13 +3,13 @@
 class ElggRelationshipTest extends PHPUnit_Framework_TestCase {
 
 	public function testSettingAndGettingAttribute() {
-		$obj = $this->getMockForAbstractClass('ElggRelationship');
+		$obj = $this->getMockForAbstractClass('ElggRelationship', array(), '', false);
 		$obj->relationship = 'hasSister';
 		$this->assertEquals('hasSister', $obj->relationship);
 	}
 
 	public function testGettingNonexistentAttribute() {
-		$obj = $this->getMockForAbstractClass('ElggRelationship');
+		$obj = $this->getMockForAbstractClass('ElggRelationship', array(), '', false);
 		$this->assertNull($obj->foo);
 	}
 }


### PR DESCRIPTION
Also adds private API function to fetch a relationship row
