### PR TITLE
Fixes #6002 and #6004 - Skip content when paging through comments

### DIFF
--- a/mod/blog/views/default/object/blog.php
+++ b/mod/blog/views/default/object/blog.php
@@ -36,7 +36,7 @@ if ($blog->comments_on != 'Off') {
 	if ($comments_count != 0) {
 		$text = elgg_echo("comments") . " ($comments_count)";
 		$comments_link = elgg_view('output/url', array(
-			'href' => $blog->getURL() . '#blog-comments',
+			'href' => $blog->getURL() . '#comments',
 			'text' => $text,
 			'is_trusted' => true,
 		));

--- a/mod/file/views/default/object/file.php
+++ b/mod/file/views/default/object/file.php
@@ -33,7 +33,7 @@ $comments_count = $file->countComments();
 if ($comments_count != 0) {
 	$text = elgg_echo("comments") . " ($comments_count)";
 	$comments_link = elgg_view('output/url', array(
-		'href' => $file->getURL() . '#file-comments',
+		'href' => $file->getURL() . '#comments',
 		'text' => $text,
 		'is_trusted' => true,
 	));

--- a/mod/pages/views/default/object/page_top.php
+++ b/mod/pages/views/default/object/page_top.php
@@ -56,7 +56,7 @@ $comments_count = $page->countComments();
 if ($comments_count != 0 && !$revision) {
 	$text = elgg_echo("comments") . " ($comments_count)";
 	$comments_link = elgg_view('output/url', array(
-		'href' => $page->getURL() . '#page-comments',
+		'href' => $page->getURL() . '#comments',
 		'text' => $text,
 		'is_trusted' => true,
 	));

--- a/views/default/page/elements/comments.php
+++ b/views/default/page/elements/comments.php
@@ -41,7 +41,7 @@ $html = elgg_list_entities(array(
 ));
 
 if ($html) {
-	echo '<h3>' . elgg_echo('comments') . '</h3>';
+	echo '<h3 id="comments">' . elgg_echo('comments') . '</h3>';
 	echo $html;
 }
 


### PR DESCRIPTION
Bookmarks were already using #comments instead of #bookmark-comments, so no need to change that.
