### PR TITLE
Fixes styles of group module header.

### DIFF
--- a/mod/aalborg_theme/views/default/groups/css.php
+++ b/mod/aalborg_theme/views/default/groups/css.php
@@ -40,7 +40,7 @@
 	margin-right: 4%;
 }
 
-.groups-widget-viewall {
+.groups-widget-add {
 	float: right;
 	font-size: 85%;
 }

--- a/mod/groups/views/default/groups/css.php
+++ b/mod/groups/views/default/groups/css.php
@@ -38,7 +38,7 @@
 	margin-right: 4%;
 }
 
-.groups-widget-more {
+.groups-widget-add {
 	float: right;
 	font-size: 85%;
 }

--- a/mod/groups/views/default/groups/profile/module.php
+++ b/mod/groups/views/default/groups/profile/module.php
@@ -11,7 +11,7 @@
 $group = elgg_get_page_owner_entity();
 
 if ($group->canWriteToContainer() && isset($vars['add_link'])) {
-    $header = "<span class='groups-widget-more'>{$vars['add_link']}</span>";
+    $header = "<span class='groups-widget-add'>{$vars['add_link']}</span>";
 }
 $header .= '<h3>' . $vars['all_link'] . '</h3>';
 


### PR DESCRIPTION
This fixes the styles broken by #5504
- Uses correct terminology: .groups-widget-add instead of .groups-widget-more
- The original style change was missing from Aalborg theme
