### PR TITLE
Fixes #6024: Adds support for ":before" and ":after" events

### DIFF
--- a/engine/classes/Elgg/EventsService.php
+++ b/engine/classes/Elgg/EventsService.php
@@ -15,15 +15,19 @@ class Elgg_EventsService extends Elgg_HooksRegistrationService {
 	 * Triggers an Elgg event.
 	 * 
 	 * @see elgg_trigger_event
+	 * @see elgg_trigger_after_event
 	 * @access private
 	 */
-	public function trigger($event, $type, $object = null) {
+	public function trigger($event, $type, $object = null, $stoppable = true) {
 		$events = $this->getOrderedHandlers($event, $type);
 		$args = array($event, $type, $object);
 
 		foreach ($events as $callback) {
-			if (is_callable($callback) && (call_user_func_array($callback, $args) === false)) {
-				return false;
+			if (is_callable($callback)) {
+				$return = call_user_func_array($callback, $args);
+				if ($stoppable && ($return === false)) {
+					return false;
+				}
 			}
 		}
 

--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -491,7 +491,12 @@ class Elgg_Http_Request {
 	 * @return string
 	 */
 	public function getClientIp() {
-		return $this->server->get('REMOTE_ADDR');
+		$ip_address = $this->server->get('REMOTE_ADDR');
+		if ($this->server->get('HTTP_X_FORWARDED_FOR')) {
+			// Get the client ip address
+			$ip_address = array_pop(explode(',', $this->server->get('HTTP_X_FORWARDED_FOR')));
+		}
+		return $ip_address;
 	}
 
 	/**

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -587,8 +587,11 @@ function register_error($error) {
  * Events are emitted by Elgg when certain actions occur.  Plugins
  * can respond to these events or halt them completely by registering a handler
  * as a callback to an event.  Multiple handlers can be registered for
- * the same event and will be executed in order of $priority.  Any handler
- * returning false will halt the execution chain.
+ * the same event and will be executed in order of $priority.
+ *
+ * For most events, any handler returning false will halt the execution chain and
+ * cause the event to be "cancelled". For After Events, the return values of the
+ * handlers will be ignored and all handlers will be called.
  *
  * This function is called with the event name, event type, and handler callback name.
  * Setting the optional $priority allows plugin authors to specify when the
@@ -688,6 +691,46 @@ function elgg_unregister_event_handler($event, $object_type, $callback) {
  */
 function elgg_trigger_event($event, $object_type, $object = null) {
 	return _elgg_services()->events->trigger($event, $object_type, $object);
+}
+
+/**
+ * Trigger an event indicating a process is about to begin.
+ *
+ * Like regular events, a handler returning false will cancel the process and false
+ * will be returned.
+ *
+ * To register for a before event, append ":before" to the event name when registering.
+ *
+ * @param string $event       The event type. The event fired will be appended with ":after"
+ * @param string $object_type The object type
+ * @param string $object      The object involved in the event
+ *
+ * @return true
+ *
+ * @see elgg_trigger_event
+ * @see elgg_trigger_after_event
+ */
+function elgg_trigger_before_event($event, $object_type, $object = null) {
+	return _elgg_services()->events->trigger("$event:before", $object_type, $object);
+}
+
+/**
+ * Trigger an event indicating a process has finished.
+ *
+ * Unlike regular events, all the handlers will be called, their return values ignored.
+ *
+ * To register for an after event, append ":after" to the event name when registering.
+ *
+ * @param string $event       The event type. The event fired will be appended with ":after"
+ * @param string $object_type The object type
+ * @param string $object      The object involved in the event
+ *
+ * @return true
+ *
+ * @see elgg_trigger_before_event
+ */
+function elgg_trigger_after_event($event, $object_type, $object = null) {
+	return _elgg_services()->events->trigger("$event:after", $object_type, $object, false);
 }
 
 /**

--- a/engine/tests/phpunit/Elgg/EventsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/EventsServiceTest.php
@@ -1,36 +1,56 @@
 <?php
 
 class Elgg_EventsServiceTest extends PHPUnit_Framework_TestCase {
-	
-	public function testTriggerCallsRegisteredHandlers() {
-		$events = new Elgg_EventsService();
 
-		$this->setExpectedException('InvalidArgumentException');
+	public $counter = 0;
 
-		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'throwInvalidArg'));
-
-		$events->trigger('foo', 'bar');
+	public function setUp() {
+		$this->counter = 0;
 	}
 
-	public function testBubbling() {
+	public function testTriggerCallsRegisteredHandlersAndReturnsTrue() {
 		$events = new Elgg_EventsService();
 
-		// false stops it
+		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
+		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
+
+		$this->assertTrue($events->trigger('foo', 'bar'));
+		$this->assertEquals($this->counter, 2);
+	}
+
+	public function testFalseStopsPropagationAndReturnsFalse() {
+		$events = new Elgg_EventsService();
+
 		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'returnFalse'));
-		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'throwInvalidArg'));
+		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
 
-		$events->trigger('foo', 'bar');
+		$this->assertFalse($events->trigger('foo', 'bar'));
+		$this->assertEquals($this->counter, 0);
+	}
 
-		// null allows it
+	public function testNullDoesNotStopPropagation() {
 		$events = new Elgg_EventsService();
 
-		// false stops it
 		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'returnNull'));
-		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'throwInvalidArg'));
+		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
 
-		$this->setExpectedException('InvalidArgumentException');
-		$events->trigger('foo', 'bar');
-		
+		$this->assertTrue($events->trigger('foo', 'bar'));
+		$this->assertEquals($this->counter, 1);
+	}
+
+	public function testUnstoppableEventsCantBeStoppedAndReturnTrue() {
+		$events = new Elgg_EventsService();
+
+		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'returnFalse'));
+		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
+
+		$this->assertTrue($events->trigger('foo', 'bar', null, false));
+		$this->assertEquals($this->counter, 1);
+	}
+
+	public function incrementCounter() {
+		$this->counter++;
+		return true;
 	}
 
 	public static function throwInvalidArg() {


### PR DESCRIPTION
After events cannot be cancelled, all handlers always run.
