### PR TITLE
Fixes #6024: Adds support for ":before" and ":after" events

### DIFF
--- a/docs/design/events.rst
+++ b/docs/design/events.rst
@@ -25,13 +25,12 @@ Elgg Events vs. Plugin Hooks
 
 There are a few big differences between `Elgg Events`_ and `Plugin Hooks`_:
 
-#. Elgg events can be cancelled; if a handler returns `false`, no more
-   handlers are called.
-#. Elgg events return a boolean value. If any handler returned `false`, the
-   event is `false`, otherwise `true`.
+#. Most Elgg events can be cancelled; unless the event is an "after" event,
+   a handler that returns `false` can cancel the event, and no more handlers
+   are called.
+#. Plugin hooks cannot be cancelled; all handlers are always called.
 #. Plugin hooks pass an arbitrary value through the handlers, giving each
    a chance to alter along the way.
-#. Plugin hooks cannot be cancelled; all handlers are always called.
 
 Note: Plugin hooks also allow passing a parameters array to the handlers,
 though this will eventually come to Elgg events as well.
@@ -43,13 +42,32 @@ Elgg Events are triggered when an Elgg object is created, updated, or
 deleted; and at important milestones while the Elgg framework is
 loading. Examples: a blog post being created or a user logging in.
 
-Unlike `Plugin Hooks`_, *Elgg events can be cancelled*, halting the
+Unlike `Plugin Hooks`_, *most Elgg events can be cancelled*, halting the
 execution of the handlers, and possibly cancelling or reverting some
 action in the Elgg core.
 
 Each Elgg event has a name and an object type (system, user, object,
 relationship name, annotation, group) describing the type of object
 passed to the handlers.
+
+Before and After Events
+-----------------------
+
+Some events are split into "before" and "after". This avoids confusion
+around the state of the system while in flux. E.g. Should the user be
+logged in during the [login, user] event?
+
+Before Events have names ending in ":before" and are triggered before
+something happens. Like traditional events, handlers can cancel the
+event by returning `false`.
+
+After Events, with names ending in ":after", are triggered after
+something happens. Unlike traditional events, handlers *cannot* cancel
+these events; all handlers will always be called.
+
+Where before and after events are available, developers are encouraged
+to transition to them, though older events will be supported for
+backwards compatibility.
 
 Elgg Event Handlers
 -------------------

--- a/engine/classes/Elgg/EventsService.php
+++ b/engine/classes/Elgg/EventsService.php
@@ -15,15 +15,19 @@ class Elgg_EventsService extends Elgg_HooksRegistrationService {
 	 * Triggers an Elgg event.
 	 * 
 	 * @see elgg_trigger_event
+	 * @see elgg_trigger_after_event
 	 * @access private
 	 */
-	public function trigger($event, $type, $object = null) {
+	public function trigger($event, $type, $object = null, $stoppable = true) {
 		$events = $this->getOrderedHandlers($event, $type);
 		$args = array($event, $type, $object);
 
 		foreach ($events as $callback) {
-			if (is_callable($callback) && (call_user_func_array($callback, $args) === false)) {
-				return false;
+			if (is_callable($callback)) {
+				$return = call_user_func_array($callback, $args);
+				if ($stoppable && ($return === false)) {
+					return false;
+				}
 			}
 		}
 

--- a/engine/classes/Elgg/EventsService.php
+++ b/engine/classes/Elgg/EventsService.php
@@ -23,11 +23,14 @@ class Elgg_EventsService extends Elgg_HooksRegistrationService {
 		$args = array($event, $type, $object);
 
 		foreach ($events as $callback) {
-			if (is_callable($callback)) {
-				$return = call_user_func_array($callback, $args);
-				if ($stoppable && ($return === false)) {
-					return false;
-				}
+			if (!is_callable($callback)) {
+				// @todo should this produce a warning?
+				continue;
+			}
+
+			$return = call_user_func_array($callback, $args);
+			if ($stoppable && ($return === false)) {
+				return false;
 			}
 		}
 

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -589,8 +589,9 @@ function register_error($error) {
  * as a callback to an event.  Multiple handlers can be registered for
  * the same event and will be executed in order of $priority.
  *
- * Any handler returning false will halt the execution chain and cause the event
- * to be "cancelled".
+ * For most events, any handler returning false will halt the execution chain and
+ * cause the event to be "cancelled". For After Events, the return values of the
+ * handlers will be ignored and all handlers will be called.
  *
  * This function is called with the event name, event type, and handler callback name.
  * Setting the optional $priority allows plugin authors to specify when the
@@ -693,6 +694,46 @@ function elgg_unregister_event_handler($event, $object_type, $callback) {
  */
 function elgg_trigger_event($event, $object_type, $object = null) {
 	return _elgg_services()->events->trigger($event, $object_type, $object);
+}
+
+/**
+ * Trigger an event indicating a process is about to begin.
+ *
+ * Like regular events, a handler returning false will cancel the process and false
+ * will be returned.
+ *
+ * To register for a before event, append ":before" to the event name when registering.
+ *
+ * @param string $event       The event type. The event fired will be appended with ":after"
+ * @param string $object_type The object type
+ * @param string $object      The object involved in the event
+ *
+ * @return true
+ *
+ * @see elgg_trigger_event
+ * @see elgg_trigger_after_event
+ */
+function elgg_trigger_before_event($event, $object_type, $object = null) {
+	return _elgg_services()->events->trigger("$event:before", $object_type, $object);
+}
+
+/**
+ * Trigger an event indicating a process has finished.
+ *
+ * Unlike regular events, all the handlers will be called, their return values ignored.
+ *
+ * To register for an after event, append ":after" to the event name when registering.
+ *
+ * @param string $event       The event type. The event fired will be appended with ":after"
+ * @param string $object_type The object type
+ * @param string $object      The object involved in the event
+ *
+ * @return true
+ *
+ * @see elgg_trigger_before_event
+ */
+function elgg_trigger_after_event($event, $object_type, $object = null) {
+	return _elgg_services()->events->trigger("$event:after", $object_type, $object, false);
 }
 
 /**

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -733,7 +733,31 @@ function elgg_trigger_before_event($event, $object_type, $object = null) {
  * @see elgg_trigger_before_event
  */
 function elgg_trigger_after_event($event, $object_type, $object = null) {
-	return _elgg_services()->events->trigger("$event:after", $object_type, $object, false);
+	$options = array(
+		Elgg_EventsService::OPTION_STOPPABLE => false,
+	);
+	return _elgg_services()->events->trigger("$event:after", $object_type, $object, $options);
+}
+
+/**
+ * Trigger an event normally, but send a notice about deprecated use if any handlers are registered.
+ *
+ * @param string $event       The event type
+ * @param string $object_type The object type
+ * @param string $object      The object involved in the event
+ * @param string $message     The deprecation message
+ * @param string $version     Human-readable *release* version: 1.9, 1.10, ...
+ *
+ * @return bool
+ *
+ * @see elgg_trigger_event
+ */
+function elgg_trigger_deprecated_event($event, $object_type, $object = null, $message, $version) {
+	$options = array(
+		Elgg_EventsService::OPTION_DEPRECATION_MESSAGE => $message,
+		Elgg_EventsService::OPTION_DEPRECATION_VERSION => $version,
+	);
+	return _elgg_services()->events->trigger("$event:after", $object_type, $object, $options);
 }
 
 /**

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -697,18 +697,18 @@ function elgg_trigger_event($event, $object_type, $object = null) {
 }
 
 /**
- * Trigger an event indicating a process is about to begin.
+ * Trigger a "Before event" indicating a process is about to begin.
  *
  * Like regular events, a handler returning false will cancel the process and false
  * will be returned.
  *
  * To register for a before event, append ":before" to the event name when registering.
  *
- * @param string $event       The event type. The event fired will be appended with ":after"
+ * @param string $event       The event type. The fired event type will be appended with ":before".
  * @param string $object_type The object type
  * @param string $object      The object involved in the event
  *
- * @return true
+ * @return bool False if any handler returned false, otherwise true
  *
  * @see elgg_trigger_event
  * @see elgg_trigger_after_event
@@ -718,13 +718,13 @@ function elgg_trigger_before_event($event, $object_type, $object = null) {
 }
 
 /**
- * Trigger an event indicating a process has finished.
+ * Trigger an "After event" indicating a process has finished.
  *
  * Unlike regular events, all the handlers will be called, their return values ignored.
  *
  * To register for an after event, append ":after" to the event name when registering.
  *
- * @param string $event       The event type. The event fired will be appended with ":after"
+ * @param string $event       The event type. The fired event type will be appended with ":after".
  * @param string $object_type The object type
  * @param string $object      The object involved in the event
  *

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -419,8 +419,14 @@ function logout() {
 		return false;
 	}
 
-	// plugins can prevent a logout
-	if (!elgg_trigger_event('logout', 'user', $user)) {
+	if (!elgg_trigger_before_event('logout', 'user', $user)) {
+		return false;
+	}
+
+	// deprecate event
+	$message = "The 'logout' event was deprecated. Register for 'logout:before' or 'logout:after'";
+	$version = "1.9";
+	if (!elgg_trigger_deprecated_event('logout', 'user', $user, $message, $version)) {
 		return false;
 	}
 
@@ -444,6 +450,8 @@ function logout() {
 	$old_msg = $session->get('msg');
 	$session->invalidate();
 	$session->set('msg', $old_msg);
+
+	elgg_trigger_after_event('logout', 'user', $user);
 
 	return true;
 }

--- a/engine/tests/phpunit/Elgg/EventsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/EventsServiceTest.php
@@ -1,36 +1,56 @@
 <?php
 
 class Elgg_EventsServiceTest extends PHPUnit_Framework_TestCase {
-	
-	public function testTriggerCallsRegisteredHandlers() {
-		$events = new Elgg_EventsService();
 
-		$this->setExpectedException('InvalidArgumentException');
+	public $counter = 0;
 
-		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'throwInvalidArg'));
-
-		$events->trigger('foo', 'bar');
+	public function setUp() {
+		$this->counter = 0;
 	}
 
-	public function testBubbling() {
+	public function testTriggerCallsRegisteredHandlersAndReturnsTrue() {
 		$events = new Elgg_EventsService();
 
-		// false stops it
+		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
+		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
+
+		$this->assertTrue($events->trigger('foo', 'bar'));
+		$this->assertEquals($this->counter, 2);
+	}
+
+	public function testFalseStopsPropagationAndReturnsFalse() {
+		$events = new Elgg_EventsService();
+
 		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'returnFalse'));
-		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'throwInvalidArg'));
+		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
 
-		$events->trigger('foo', 'bar');
+		$this->assertFalse($events->trigger('foo', 'bar'));
+		$this->assertEquals($this->counter, 0);
+	}
 
-		// null allows it
+	public function testNullDoesNotStopPropagation() {
 		$events = new Elgg_EventsService();
 
-		// false stops it
 		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'returnNull'));
-		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'throwInvalidArg'));
+		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
 
-		$this->setExpectedException('InvalidArgumentException');
-		$events->trigger('foo', 'bar');
-		
+		$this->assertTrue($events->trigger('foo', 'bar'));
+		$this->assertEquals($this->counter, 1);
+	}
+
+	public function testUnstoppableEventsCantBeStoppedAndReturnTrue() {
+		$events = new Elgg_EventsService();
+
+		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'returnFalse'));
+		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
+
+		$this->assertTrue($events->trigger('foo', 'bar', null, false));
+		$this->assertEquals($this->counter, 1);
+	}
+
+	public function incrementCounter() {
+		$this->counter++;
+		return true;
 	}
 
 	public static function throwInvalidArg() {


### PR DESCRIPTION
":after" events cannot be cancelled; all handlers run and the trigger always returns true.
