### PR TITLE
Deleting and annotation will trigger an event.

### DIFF
--- a/engine/lib/annotations.php
+++ b/engine/lib/annotations.php
@@ -48,7 +48,12 @@ function elgg_delete_annotation_by_id($id) {
 	if (!$annotation) {
 		return false;
 	}
-	return $annotation->delete();
+
+	if (elgg_trigger_event('delete', 'annotation', $annotation)) {
+		return $annotation->delete();
+	}
+
+	return FALSE;
 }
 
 /**


### PR DESCRIPTION
Function elgg_delete_annotation_by_id will trigger annotation delete
event now. That event could be used to capture information about
annotations being deleted and also to prevent delete from happening
