### PR TITLE
Fixes #6065: Log display no longer emits deprecation warnings and uses fewer queries

### DIFF
--- a/mod/logbrowser/views/default/logbrowser/table.php
+++ b/mod/logbrowser/views/default/logbrowser/table.php
@@ -43,7 +43,7 @@ $log_entries = $vars['log_entries'];
 			$user_guid_link = $user_link = '&nbsp;';
 		}
 
-		$object = get_object_from_log_entry($entry->id);
+		$object = get_object_from_log_entry($entry);
 		if (is_callable(array($object, 'getURL'))) {
 			$object_link = elgg_view('output/url', array(
 				'href' => $object->getURL(),


### PR DESCRIPTION
This passes the already-loaded log entry rows directly to the object fetcher (saving 1 query/row), and uses various loading techniques based on the type of object.

The bad news is this loading logic can become out-of-date as core changes, but I can't see a way around it, and at the worst we'll get deprecation warnings again telling us to update it.
