### PR TITLE
possible that $vars['metas'] may not be defined in the page\elements\head view

### DIFF
--- a/views/default/page/elements/head.php
+++ b/views/default/page/elements/head.php
@@ -18,11 +18,15 @@
  */
 
 echo elgg_format_element('title', array(), $vars['title'], array('encode_text' => true));
-foreach ($vars['metas'] as $attributes) {
-	echo elgg_format_element('meta', $attributes);
+if ($vars['metas']) {
+	foreach ($vars['metas'] as $attributes) {
+		echo elgg_format_element('meta', $attributes);
+	}
 }
-foreach ($vars['links'] as $attributes) {
-	echo elgg_format_element('link', $attributes);
+if ($vars['links']) {
+	foreach ($vars['links'] as $attributes) {
+		echo elgg_format_element('link', $attributes);
+	}
 }
 
 $js = elgg_get_loaded_js('head');


### PR DESCRIPTION
The two foreach statements on $vars['metas'] and $vars['links'] produce a lot of logging because they are empty, so checking if they are empty before trying to run foreach makes good sense
