### PR TITLE
Refs #5911 Adds function elgg_get_subscriptions_for_container()

### DIFF
--- a/engine/classes/Elgg/Notifications/SubscriptionsService.php
+++ b/engine/classes/Elgg/Notifications/SubscriptionsService.php
@@ -73,6 +73,36 @@ class Elgg_Notifications_SubscriptionsService {
 	}
 
 	/**
+	 * Get the subscriptions for the container of the entity
+	 *
+	 * The return array is of the form:
+	 *
+	 * array(
+	 *     <user guid> => array('email', 'sms', 'ajax'),
+	 * );
+	 *
+	 * @param ElggEntity $entity Entity being notified about
+	 * @return array
+	 */
+	public function getSubscriptionsForContainer(ElggEntity $entity) {
+
+		$subscriptions = array();
+
+		if (!$this->methods) {
+			return $subscriptions;
+		}
+
+		$prefixLength = strlen(self::RELATIONSHIP_PREFIX);
+		$records = $this->getSubscriptionRecords($entity->getContainerGUID());
+		foreach ($records as $record) {
+			$deliveryMethods = explode(',', $record->methods);
+			$subscriptions[$record->guid] = substr_replace($deliveryMethods, '', 0, $prefixLength);
+		}
+
+		return $subscriptions;
+	}
+
+	/**
 	 * Subscribe a user to notifications about a target entity
 	 * 
 	 * This method will return false if the subscription already exists.

--- a/engine/classes/Elgg/Notifications/SubscriptionsService.php
+++ b/engine/classes/Elgg/Notifications/SubscriptionsService.php
@@ -81,10 +81,10 @@ class Elgg_Notifications_SubscriptionsService {
 	 *     <user guid> => array('email', 'sms', 'ajax'),
 	 * );
 	 *
-	 * @param ElggEntity $entity Entity acting as a container
+	 * @param int $container_guid GUID of the entity acting as a container
 	 * @return array User GUIDs (keys) and their subscription types (values).
 	 */
-	public function getSubscriptionsForContainer(ElggEntity $entity) {
+	public function getSubscriptionsForContainer($container_guid) {
 
 		$subscriptions = array();
 
@@ -93,7 +93,7 @@ class Elgg_Notifications_SubscriptionsService {
 		}
 
 		$prefixLength = strlen(self::RELATIONSHIP_PREFIX);
-		$records = $this->getSubscriptionRecords($entity->guid);
+		$records = $this->getSubscriptionRecords($container_guid);
 		foreach ($records as $record) {
 			$deliveryMethods = explode(',', $record->methods);
 			$subscriptions[$record->guid] = substr_replace($deliveryMethods, '', 0, $prefixLength);

--- a/engine/classes/Elgg/Notifications/SubscriptionsService.php
+++ b/engine/classes/Elgg/Notifications/SubscriptionsService.php
@@ -73,7 +73,7 @@ class Elgg_Notifications_SubscriptionsService {
 	}
 
 	/**
-	 * Get the subscriptions for the container of the entity
+	 * Get the subscriptions for the content created inside this container.
 	 *
 	 * The return array is of the form:
 	 *
@@ -81,8 +81,8 @@ class Elgg_Notifications_SubscriptionsService {
 	 *     <user guid> => array('email', 'sms', 'ajax'),
 	 * );
 	 *
-	 * @param ElggEntity $entity Entity being notified about
-	 * @return array
+	 * @param ElggEntity $entity Entity acting as a container
+	 * @return array User GUIDs (keys) and their subscription types (values).
 	 */
 	public function getSubscriptionsForContainer(ElggEntity $entity) {
 
@@ -93,7 +93,7 @@ class Elgg_Notifications_SubscriptionsService {
 		}
 
 		$prefixLength = strlen(self::RELATIONSHIP_PREFIX);
-		$records = $this->getSubscriptionRecords($entity->getContainerGUID());
+		$records = $this->getSubscriptionRecords($entity->guid);
 		foreach ($records as $record) {
 			$deliveryMethods = explode(',', $record->methods);
 			$subscriptions[$record->guid] = substr_replace($deliveryMethods, '', 0, $prefixLength);

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -145,16 +145,16 @@ function elgg_remove_subscription($user_guid, $method, $target_guid) {
  *     <user guid> => array('email', 'sms', 'ajax'),
  * );
  *
- * @param ElggEntity $entity Entity acting as a container
+ * @param int $container_guid GUID of the entity acting as a container
  * @return array User GUIDs (keys) and their subscription types (values).
  * @since 1.9
  * @todo deprecate once new subscriptions system has been added
  */
-function elgg_get_subscriptions_for_container($entity) {
+function elgg_get_subscriptions_for_container($container_guid) {
 	$methods = _elgg_services()->notifications->getMethods();
 	$db = _elgg_services()->db;
 	$subs = new Elgg_Notifications_SubscriptionsService($db, $methods);
-	return $subs->getSubscriptionsForContainer($entity);
+	return $subs->getSubscriptionsForContainer($container_guid);
 }
 
 /**

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -137,6 +137,31 @@ function elgg_remove_subscription($user_guid, $method, $target_guid) {
 }
 
 /**
+ * Get the subscriptions for the container of the entity.
+ *
+ * When given e.g. a personal blog this returns the subscriptions for
+ * the person who wrote the blog. When given a group blog returns the
+ * subscriptions for the group notifications.
+ *
+ * The return array is of the form:
+ *
+ * array(
+ *     <user guid> => array('email', 'sms', 'ajax'),
+ * );
+ *
+ * @param ElggEntity $entity Entity
+ * @return array
+ * @since 1.9
+ * @todo deprecate once new subscriptions system has been added
+ */
+function elgg_get_subscriptions_for_container($entity) {
+	$methods = _elgg_services()->notifications->getMethods();
+	$db = _elgg_services()->db;
+	$subs = new Elgg_Notifications_SubscriptionsService($db, $methods);
+	return $subs->getSubscriptionsForContainer($entity);
+}
+
+/**
  * Queue a notification event for later handling
  *
  * Checks to see if this event has been registered for notifications.

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -137,11 +137,7 @@ function elgg_remove_subscription($user_guid, $method, $target_guid) {
 }
 
 /**
- * Get the subscriptions for the container of the entity.
- *
- * When given e.g. a personal blog this returns the subscriptions for
- * the person who wrote the blog. When given a group blog this returns
- * the subscriptions for the group notifications.
+ * Get the subscriptions for the content created inside this container.
  *
  * The return array is of the form:
  *
@@ -149,7 +145,7 @@ function elgg_remove_subscription($user_guid, $method, $target_guid) {
  *     <user guid> => array('email', 'sms', 'ajax'),
  * );
  *
- * @param ElggEntity $entity Entity
+ * @param ElggEntity $entity Entity acting as a container
  * @return array User GUIDs (keys) and their subscription types (values).
  * @since 1.9
  * @todo deprecate once new subscriptions system has been added

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -140,8 +140,8 @@ function elgg_remove_subscription($user_guid, $method, $target_guid) {
  * Get the subscriptions for the container of the entity.
  *
  * When given e.g. a personal blog this returns the subscriptions for
- * the person who wrote the blog. When given a group blog returns the
- * subscriptions for the group notifications.
+ * the person who wrote the blog. When given a group blog this returns
+ * the subscriptions for the group notifications.
  *
  * The return array is of the form:
  *
@@ -150,7 +150,7 @@ function elgg_remove_subscription($user_guid, $method, $target_guid) {
  * );
  *
  * @param ElggEntity $entity Entity
- * @return array
+ * @return array User GUIDs (keys) and their subscription types (values).
  * @since 1.9
  * @todo deprecate once new subscriptions system has been added
  */

--- a/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
@@ -99,7 +99,7 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 	}
 
 	public function testGetSubscriptionsForContainerWithProperInput() {
-		$container = $this->getMock('ElggEntity');
+		$container_guid = 132;
 
 		$methods = array('apples', 'bananas');
 		$queryResult = array(
@@ -116,7 +116,7 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 		$service = new Elgg_Notifications_SubscriptionsService($this->db);
 
 		$service->methods = $methods;
-		$this->assertEquals($subscriptions, $service->getSubscriptionsForContainer($container));
+		$this->assertEquals($subscriptions, $service->getSubscriptionsForContainer($container_guid));
 	}
 
 	protected function createObjectFromArray(array $data) {

--- a/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
@@ -98,6 +98,12 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 		$this->assertEquals($subscriptions, $service->getSubscriptions($this->event));
 	}
 
+	public function testGetSubscriptionsForContainerWithNoMethodsRegistered() {
+		$container_guid = 132;
+		$service = new Elgg_Notifications_SubscriptionsService($this->db);
+		$this->assertEquals(array(), $service->getSubscriptionsForContainer($container_guid));
+	}
+
 	public function testGetSubscriptionsForContainerWithProperInput() {
 		$container_guid = 132;
 

--- a/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
@@ -98,6 +98,27 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 		$this->assertEquals($subscriptions, $service->getSubscriptions($this->event));
 	}
 
+	public function testGetSubscriptionsForContainerWithProperInput() {
+		$container = $this->getMock('ElggEntity');
+
+		$methods = array('apples', 'bananas');
+		$queryResult = array(
+			$this->createObjectFromArray(array('guid' => '22', 'methods' => 'notifyapples')),
+			$this->createObjectFromArray(array('guid' => '567', 'methods' => 'notifybananas,notifyapples')),
+		);
+		$subscriptions = array(
+			22 => array('apples'),
+			567 => array('bananas', 'apples'),
+		);
+		$this->db->expects($this->once())
+				->method('getData')
+				->will($this->returnValue($queryResult));
+		$service = new Elgg_Notifications_SubscriptionsService($this->db);
+
+		$service->methods = $methods;
+		$this->assertEquals($subscriptions, $service->getSubscriptionsForContainer($container));
+	}
+
 	protected function createObjectFromArray(array $data) {
 		$obj = new stdClass();
 		foreach ($data as $key => $value) {


### PR DESCRIPTION
This is a partial fix for #5911 that is needed in order to send notifications about group discussion replies. See #5690

I assume this won't need new unit tests since it is just reusing the existing methods?
