### PR TITLE
Do not display form label for hidden form fields.

### DIFF
--- a/mod/groups/views/default/forms/groups/edit.php
+++ b/mod/groups/views/default/forms/groups/edit.php
@@ -45,14 +45,21 @@ if ($group_profile_fields > 0) {
 		if ($valtype == 'longtext') {
 			$line_break = '';
 		}
-		echo '<div><label>';
-		echo elgg_echo("groups:{$shortname}");
-		echo "</label>$line_break";
-		echo elgg_view("input/{$valtype}", array(
-			'name' => $shortname,
-			'value' => elgg_extract($shortname, $vars),
-		));
-		echo '</div>';
+		if ($valtype == 'hidden') {
+			echo elgg_view("input/{$valtype}", array(
+				'name' => $shortname,
+				'value' => elgg_extract($shortname, $vars),
+			));			
+		} else {
+			echo '<div><label>';
+			echo elgg_echo("groups:{$shortname}");
+			echo "</label>$line_break";
+			echo elgg_view("input/{$valtype}", array(
+				'name' => $shortname,
+				'value' => elgg_extract($shortname, $vars),
+			));
+			echo '</div>';
+	}
 	}
 }
 ?>


### PR DESCRIPTION
The group plugin_hook for "profile:fields" accepts an array of form
fields and the edit.php page that outputs these values attempts to
output a label for the hidden fields.
