### PR TITLE
split the group edit form into seperate parts for extendability

### DIFF
--- a/mod/groups/views/default/forms/groups/edit.php
+++ b/mod/groups/views/default/forms/groups/edit.php
@@ -5,198 +5,42 @@
  * @package ElggGroups
  */
 
-// only extract these elements.
-$name = $membership = $vis = $entity = null;
-extract($vars, EXTR_IF_EXISTS);
-
 /* @var ElggGroup $entity */
-
-if (isset($vars['entity'])) {
-	$entity = $vars['entity'];
-	$owner_guid = $vars['entity']->owner_guid;
-	$content_access_mode = $entity->getContentAccessMode();
-} else {
-	$entity = false;
-	$content_access_mode = ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED;
-}
+$entity = elgg_extract("entity", $vars, false);
 
 // context needed for input/access view
-elgg_push_context('group-edit');
+elgg_push_context("group-edit");
 
-?>
-<div>
-	<label><?php echo elgg_echo("groups:icon"); ?></label><br />
-	<?php echo elgg_view("input/file", array('name' => 'icon')); ?>
-</div>
-<div>
-	<label><?php echo elgg_echo("groups:name"); ?></label><br />
-	<?php echo elgg_view("input/text", array(
-		'name' => 'name',
-		'value' => $name,
-	));
-	?>
-</div>
-<?php
+// build the group profile fields
+echo elgg_view("groups/edit/profile", $vars);
 
-$group_profile_fields = elgg_get_config('group');
-foreach ((array)$group_profile_fields as $shortname => $valtype) {
-	if ($valtype == 'hidden') {
-		echo elgg_view("input/{$valtype}", array(
-			'name' => $shortname,
-			'value' => elgg_extract($shortname, $vars),
-		));
-		continue;
-	}
+// build the group access options
+echo elgg_view("groups/edit/access", $vars);
 
-	$line_break = ($valtype == 'longtext') ? '' : '<br />';
-	$label = elgg_echo("groups:{$shortname}");
-	$input = elgg_view("input/{$valtype}", array(
-		'name' => $shortname,
-		'value' => elgg_extract($shortname, $vars),
-	));
+// build the group tools options
+echo elgg_view("groups/edit/tools", $vars);
 
-	echo "<div><label>{$label}</label>{$line_break}{$input}</div>";
-}
-?>
-
-<div>
-	<label>
-		<?php echo elgg_echo('groups:membership'); ?><br />
-		<?php echo elgg_view('input/select', array(
-			'name' => 'membership',
-			'value' => $membership,
-			'options_values' => array(
-				ACCESS_PRIVATE => elgg_echo('groups:access:private'),
-				ACCESS_PUBLIC => elgg_echo('groups:access:public'),
-			)
-		));
-		?>
-	</label>
-</div>
-
-<div>
-	<label>
-		<?php echo elgg_echo('groups:content_access_mode'); ?><br />
-		<?php echo elgg_view('input/select', array(
-			'name' => 'content_access_mode',
-			'value' => $content_access_mode,
-			'options_values' => array(
-				ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED => elgg_echo('groups:content_access_mode:unrestricted'),
-				ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY => elgg_echo('groups:content_access_mode:membersonly'),
-			),
-		));
-		?>
-	</label>
-</div>
-	
-<?php
-
-if (elgg_get_plugin_setting('hidden_groups', 'groups') == 'yes') {
-	$access_options = array(
-		ACCESS_PRIVATE => elgg_echo('groups:access:group'),
-		ACCESS_LOGGED_IN => elgg_echo("LOGGED_IN"),
-		ACCESS_PUBLIC => elgg_echo("PUBLIC"),
-	);
-?>
-
-<div>
-	<label>
-			<?php echo elgg_echo('groups:visibility'); ?><br />
-			<?php echo elgg_view('input/access', array(
-				'name' => 'vis',
-				'value' =>  $vis,
-				'options_values' => $access_options,
-			));
-			?>
-	</label>
-</div>
-
-<?php
-}
-
-if ($entity && ($owner_guid == elgg_get_logged_in_user_guid() || elgg_is_admin_logged_in())) {
-	$members = array();
-
-	$options = array(
-		'relationship' => 'member',
-		'relationship_guid' => $vars['entity']->getGUID(),
-		'inverse_relationship' => true,
-		'type' => 'user',
-		'limit' => 0,
-	);
-
-	$batch = new ElggBatch('elgg_get_entities_from_relationship', $options);
-	foreach ($batch as $member) {
-		$option_text = "$member->name (@$member->username)";
-		$members[$member->guid] = htmlspecialchars($option_text, ENT_QUOTES, 'UTF-8', false);
-	}
-?>
-
-<div>
-	<label>
-			<?php echo elgg_echo('groups:owner'); ?><br />
-			<?php echo elgg_view('input/select', array(
-				'name' => 'owner_guid',
-				'value' =>  $owner_guid,
-				'options_values' => $members,
-				'class' => 'groups-owner-input',
-			));
-			?>
-	</label>
-	<?php
-	if ($owner_guid == elgg_get_logged_in_user_guid()) {
-		echo '<span class="elgg-text-help">' . elgg_echo('groups:owner:warning') . '</span>';
-	}
-	?>
-</div>
-
-<?php
-}
-
-$tools = elgg_get_config('group_tool_options');
-if ($tools) {
-	usort($tools, create_function('$a,$b', 'return strcmp($a->label,$b->label);'));
-	foreach ($tools as $group_option) {
-		$group_option_toggle_name = $group_option->name . "_enable";
-		$value = elgg_extract($group_option_toggle_name, $vars);
-?>
-<div>
-	<label>
-		<?php echo $group_option->label; ?><br />
-	</label>
-		<?php echo elgg_view("input/radio", array(
-			"name" => $group_option_toggle_name,
-			"value" => $value,
-			'options' => array(
-				elgg_echo('option:yes') => 'yes',
-				elgg_echo('option:no') => 'no',
-			),
-		));
-		?>
-</div>
-<?php
-	}
-}
+// display the save button and some additional form data
 ?>
 <div class="elgg-foot">
 <?php
 
 if ($entity) {
-	echo elgg_view('input/hidden', array(
-		'name' => 'group_guid',
-		'value' => $entity->getGUID(),
+	echo elgg_view("input/hidden", array(
+		"name" => "group_guid",
+		"value" => $entity->getGUID(),
 	));
 }
 
-echo elgg_view('input/submit', array('value' => elgg_echo('save')));
+echo elgg_view("input/submit", array("value" => elgg_echo("save")));
 
 if ($entity) {
-	$delete_url = 'action/groups/delete?guid=' . $entity->getGUID();
-	echo elgg_view('output/confirmlink', array(
-		'text' => elgg_echo('groups:delete'),
-		'href' => $delete_url,
-		'confirm' => elgg_echo('groups:deletewarning'),
-		'class' => 'elgg-button elgg-button-delete float-alt',
+	$delete_url = "action/groups/delete?guid=" . $entity->getGUID();
+	echo elgg_view("output/confirmlink", array(
+		"text" => elgg_echo("groups:delete"),
+		"href" => $delete_url,
+		"confirm" => elgg_echo("groups:deletewarning"),
+		"class" => "elgg-button elgg-button-delete float-alt",
 	));
 }
 

--- a/mod/groups/views/default/groups/edit/access.php
+++ b/mod/groups/views/default/groups/edit/access.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Group edit form
+ *
+ * This view contains everything related to group access.
+ * eg: how can people join this group, who can see the group, etc
+ *
+ * @package ElggGroups
+ */
+
+$entity = elgg_extract("entity", $vars, false);
+$membership = elgg_extract("membership", $vars);
+$visibility = elgg_extract("vis", $vars);
+
+if ($entity) {
+	$owner_guid = $entity->getOwnerGUID();
+	$content_access_mode = $entity->getContentAccessMode();
+} else {
+	$content_access_mode = ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED;
+}
+
+?>
+<div>
+	<label>
+		<?php echo elgg_echo("groups:membership"); ?><br />
+		<?php echo elgg_view("input/select", array(
+			"name" => "membership",
+			"value" => $membership,
+			"options_values" => array(
+				ACCESS_PRIVATE => elgg_echo("groups:access:private"),
+				ACCESS_PUBLIC => elgg_echo("groups:access:public"),
+			)
+		));
+		?>
+	</label>
+</div>
+
+<div>
+	<label>
+		<?php echo elgg_echo("groups:content_access_mode"); ?><br />
+		<?php echo elgg_view("input/select", array(
+			"name" => "content_access_mode",
+			"value" => $content_access_mode,
+			"options_values" => array(
+				ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED => elgg_echo("groups:content_access_mode:unrestricted"),
+				ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY => elgg_echo("groups:content_access_mode:membersonly"),
+			),
+		));
+		?>
+	</label>
+</div>
+	
+<?php
+
+if (elgg_get_plugin_setting("hidden_groups", "groups") == "yes") {
+	$access_options = array(
+		ACCESS_PRIVATE => elgg_echo("groups:access:group"),
+		ACCESS_LOGGED_IN => elgg_echo("LOGGED_IN"),
+		ACCESS_PUBLIC => elgg_echo("PUBLIC"),
+	);
+?>
+
+<div>
+	<label>
+			<?php echo elgg_echo("groups:visibility"); ?><br />
+			<?php echo elgg_view("input/access", array(
+				"name" => "vis",
+				"value" =>  $visibility,
+				"options_values" => $access_options,
+			));
+			?>
+	</label>
+</div>
+
+<?php
+}
+
+if ($entity && ($owner_guid == elgg_get_logged_in_user_guid() || elgg_is_admin_logged_in())) {
+	$members = array();
+
+	$options = array(
+		"relationship" => "member",
+		"relationship_guid" => $entity->getGUID(),
+		"inverse_relationship" => true,
+		"type" => "user",
+		"limit" => 0,
+	);
+
+	$batch = new ElggBatch("elgg_get_entities_from_relationship", $options);
+	foreach ($batch as $member) {
+		$option_text = "$member->name (@$member->username)";
+		$members[$member->guid] = htmlspecialchars($option_text, ENT_QUOTES, "UTF-8", false);
+	}
+?>
+
+<div>
+	<label>
+			<?php echo elgg_echo("groups:owner"); ?><br />
+			<?php echo elgg_view("input/select", array(
+				"name" => "owner_guid",
+				"value" =>  $owner_guid,
+				"options_values" => $members,
+				"class" => "groups-owner-input",
+			));
+			?>
+	</label>
+	<?php
+	if ($owner_guid == elgg_get_logged_in_user_guid()) {
+		echo "<span class='elgg-text-help'>" . elgg_echo("groups:owner:warning") . "</span>";
+	}
+	?>
+</div>
+
+<?php
+}

--- a/mod/groups/views/default/groups/edit/profile.php
+++ b/mod/groups/views/default/groups/edit/profile.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Group edit form
+ *
+ * This view contains the group profile field configuration
+ *
+ * @package ElggGroups
+ */
+
+$name = elgg_extract("name", $vars);
+$group_profile_fields = elgg_get_config("group");
+
+?>
+<div>
+<label><?php echo elgg_echo("groups:icon"); ?></label><br />
+	<?php echo elgg_view("input/file", array("name" => "icon")); ?>
+</div>
+<div>
+	<label><?php echo elgg_echo("groups:name"); ?></label><br />
+	<?php echo elgg_view("input/text", array(
+		"name" => "name",
+		"value" => $name,
+	));
+	?>
+</div>
+<?php
+
+// show the configured group profile fields
+foreach ((array)$group_profile_fields as $shortname => $valtype) {
+	if ($valtype == "hidden") {
+		echo elgg_view("input/{$valtype}", array(
+			"name" => $shortname,
+			"value" => elgg_extract($shortname, $vars),
+		));
+		continue;
+	}
+
+	$line_break = ($valtype == "longtext") ? "" : "<br />";
+	$label = elgg_echo("groups:{$shortname}");
+	$input = elgg_view("input/{$valtype}", array(
+		"name" => $shortname,
+		"value" => elgg_extract($shortname, $vars),
+	));
+
+	echo "<div><label>{$label}</label>{$line_break}{$input}</div>";
+}

--- a/mod/groups/views/default/groups/edit/tools.php
+++ b/mod/groups/views/default/groups/edit/tools.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Group edit form
+ *
+ * This view contains the group tool options provided by the different plugins
+ *
+ * @package ElggGroups
+ */
+
+$tools = elgg_get_config("group_tool_options");
+if ($tools) {
+	usort($tools, create_function('$a, $b', 'return strcmp($a->label, $b->label);'));
+	
+	foreach ($tools as $group_option) {
+		$group_option_toggle_name = $group_option->name . "_enable";
+		$value = elgg_extract($group_option_toggle_name, $vars);
+		?>
+<div>
+	<label>
+		<?php echo $group_option->label; ?><br />
+	</label>
+		<?php echo elgg_view("input/radio", array(
+			"name" => $group_option_toggle_name,
+			"value" => $value,
+			"options" => array(
+				elgg_echo("option:yes") => "yes",
+				elgg_echo("option:no") => "no",
+			),
+		));
+		?>
+</div>
+<?php
+	}
+}


### PR DESCRIPTION
#4391

I moved the different parts of the group edit form to their own views so it's easier for plugin developers to overrule/extend the different parts.

Use case:
Profile manager wants to overrule the group profile options (including form parts) and group tools wants to edit the group tool options. In the old case both of these plugins would be fighting over the form view.
Now that is split it up into different parts profile manager can just edit the profile part and group tools can take the other part.
