### PR TITLE
Added more microformats to the profile page

### DIFF
--- a/mod/profile/views/default/profile/details.php
+++ b/mod/profile/views/default/profile/details.php
@@ -8,10 +8,18 @@ $user = elgg_get_page_owner_entity();
 
 $profile_fields = elgg_get_config('profile_fields');
 
-echo '<div id="profile-details" class="elgg-body pll h-card vcard">';
+echo '<div id="profile-details" class="elgg-body pll">';
+echo "<span class=\"hidden nickname p-nickname\">{$user->username}</span>";
 echo "<h2 class=\"p-name fn\">{$user->name}</h2>";
 
 echo elgg_view("profile/status", array("entity" => $user));
+
+$microformats = array(
+	'mobile' => 'tel p-tel',
+	'phone' => 'tel p-tel',
+	'website' => 'url u-url',
+	'contactemail' => 'email u-email',
+);
 
 $even_odd = null;
 if (is_array($profile_fields) && sizeof($profile_fields) > 0) {
@@ -42,7 +50,17 @@ if (is_array($profile_fields) && sizeof($profile_fields) > 0) {
 			<div class="<?php echo $even_odd; ?>">
 				<b><?php echo elgg_echo("profile:{$shortname}"); ?>: </b>
 				<?php
-					echo elgg_view("output/{$valtype}", array('value' => $value));
+					$params = array(
+						'value' => $value
+					);
+					if (isset($microformats[$shortname])) {
+						$class = $microformats[$shortname];
+					} else {
+						$class = '';
+					}
+					echo "<span class=\"$class\">";
+					echo elgg_view("output/{$valtype}", $params);
+					echo "</span>";
 				?>
 			</div>
 			<?php

--- a/mod/profile/views/default/profile/owner_block.php
+++ b/mod/profile/views/default/profile/owner_block.php
@@ -14,6 +14,7 @@ if (!$user) {
 $icon = elgg_view_entity_icon($user, 'large', array(
 	'use_hover' => false,
 	'use_link' => false,
+	'img_class' => 'photo u-photo',
 ));
 
 // grab the actions and admin menu items from user hover

--- a/mod/profile/views/default/profile/wrapper.php
+++ b/mod/profile/views/default/profile/wrapper.php
@@ -7,7 +7,7 @@
 
 <?php /* We add mrn here because we're doing stupid things with the grid system. Remove this hack */ ?>
 <div class="profile elgg-col-2of3 mrn">
-	<div class="elgg-inner clearfix">
+	<div class="elgg-inner clearfix h-card vcard">
 		<?php echo elgg_view('profile/owner_block'); ?>
 		<?php echo elgg_view('profile/details'); ?>
 	</div>


### PR DESCRIPTION
I've added some more microformats to profile page than single one that we had before.

Tested with [Micorformats for Goole Chrome](https://chrome.google.com/webstore/detail/microformats-for-google-c/oalbifknmclbnmjlljdemhjjlkmppjjl)

Keeping `$microformats` hardcoded is not very extension friendly nor elegant, but you can override whole `profile/details` view if you really want.

P.S.
That implements these formats:
- http://microformats.org/wiki/hcard
- http://microformats.org/wiki/h-card
