### PR TITLE
Added preliminary timezones support

### DIFF
--- a/actions/admin/site/update_basic.php
+++ b/actions/admin/site/update_basic.php
@@ -21,6 +21,7 @@ if ($site = elgg_get_site_entity()) {
 	$site->save();
 
 	set_config('language', get_input('language'), $site->getGUID());
+	set_config('timezone', get_input('timezone'), $site->getGUID());
 }
 
 system_message(elgg_echo('admin:configuration:success'));

--- a/engine/classes/Elgg/Timezone.php
+++ b/engine/classes/Elgg/Timezone.php
@@ -1,5 +1,5 @@
 <?php
-class ElggTimezone {
+class Elgg_Timezone {
 
 	/**
 	 * Configurations of particular timezones. Key of main array is the string - id of timezone.
@@ -40,7 +40,7 @@ class ElggTimezone {
 	
 	static function format($format, $ts, $user=null) {
 		$date = new DateTime('@'.$ts);
-		$date->setTimezone(new DateTimeZone(ElggTimezone::getCurrentId($user)));
+		$date->setTimezone(new DateTimeZone(Elgg_Timezone::getCurrentId($user)));
 		return $date->format($format);
 	}
 	

--- a/engine/classes/ElggTimezone.php
+++ b/engine/classes/ElggTimezone.php
@@ -1,0 +1,193 @@
+<?php
+class ElggTimezone {
+
+	/**
+	 * Configurations of particular timezones. Key of main array is the string - id of timezone.
+	 * Sub arrays contain fields: 
+	 * @var array of arrays 
+	 */
+	private static $groupById;
+	
+	static function init() {
+		//let server operate always in UTC and use user defined/default timezone 
+		//only while displaying data to user
+		date_default_timezone_set('UTC');
+	}
+	
+	/**
+	 * @param ElggUser $user optional, user that setting should be checked first
+	 * @return string PHP standard of string identifier for timezones
+	 */
+	static function getCurrentId(ElggUser $user=null) {
+		if($user instanceof ElggUser) {
+			$id = $user->timezone;
+			if($id) {
+				return $id;
+			}
+		}
+		
+		$id = elgg_get_config('timezone');
+		if($id) {
+			return $id;
+		}
+		
+		return date_default_timezone_get();
+	}
+	
+	static function getOffsetFromId($id) {
+		//TODO implement
+	}
+	
+	static function format($format, $ts, $user=null) {
+		$date = new DateTime('@'.$ts);
+		$date->setTimezone(new DateTimeZone(ElggTimezone::getCurrentId($user)));
+		return $date->format($format);
+	}
+	
+	static function getOptionsValues() {
+		if(!is_array(self::$groupById)) {
+			$list = timezone_identifiers_list();
+			$abbreviations = timezone_abbreviations_list();
+			$groupByLabel = array();
+			self::$groupById = array();
+			foreach ($abbreviations as $abbreviation=>$entries) {
+				foreach ($entries as $entry) {
+					//var_dump($entry['offset']/3600);
+					$id = elgg_extract('timezone_id', $entry);
+					if($id!==null) {
+						$entry['abbr'] = $abbreviation;
+						self::$groupById[$id] = $entry;
+						$offset = elgg_extract('offset', $entry);
+						$dst = elgg_extract('dst', $entry);
+						$label = $offset.','.($dst?'1':'0');
+						// 				var_dump($label);
+						if(!isset($groupByLabel[$label])) {
+							$groupByLabel[$label] = array();
+						}
+						try {
+							$tz = new DateTimeZone($id);
+							$groupByLabel[$label][] = array($id, timezone_offset_get($tz));
+						} catch (Exception $e) {
+							// 					var_dump($abbreviation);
+							// 					var_dump($entry);
+							// 					var_dump('Exception: '.$e->getMessage());
+						}
+					}
+				}
+			}
+// 			var_dump(self::$groupById);
+	// 		var_dump($groupByLabel);
+			
+// 			$timezone = new DateTimeZone('Europe/Warsaw');
+// 			$time = time();
+// 			$transitions = $timezone->getTransitions($time, $time);
+// 			var_dump($time, $transitions);
+// 			$transitions = $timezone->getTransitions($time+30*24*3600*6, $time+30*24*3600*6);
+// 			var_dump($time, $transitions);
+// 			for($i=0; $i<=12; $i++) {
+// 				$date = new DateTime('@'.($time+30*24*3600*$i));
+// 				//$date->setTimestamp();
+// 				$date->setTimezone($timezone);
+// 				var_dump($date->format("c I e"));
+				
+// 			}
+			
+			$result = array();
+			$date = new DateTime();
+			foreach(self::$groupById as $id=>$data) {
+				$date->setTimezone(new DateTimeZone($id));
+				list($label, $dst, $hours, $short) = explode(';', $date->format('P;I;Z;T'));
+				self::$groupById[$id]['label'] = $label;
+				self::$groupById[$id]['short'] = $short;
+				self::$groupById[$id]['isdst'] = $dst;
+				self::$groupById[$id]['cmp'] = $hours;
+			}
+			uasort(self::$groupById, array(__CLASS__, 'sortByCmpPredicate'));
+		}
+		foreach(self::$groupById as $id=>$data) {
+			$details = '('.$data['label'].' '.$data['short'].')';
+			//$result[$id] = '('.$data['label'].($data['isdst']?' DST':'').') '.$id.' ('.$data['short'].')';
+			$result[$id] = '(GMT'.$data['label'].','.($data['isdst']?1:0).') '.$id.' ('.$data['short'].')';
+			//$result[$id] = '('.$data['label'].') '.$id.' ('.$data['short'].')';
+		}
+		return $result;
+	}
+	
+	private function sortByOffsetPredicate($a, $b) {
+		return $a['offset'] - $b['offset'];
+	}
+
+	private function sortByCmpPredicate($a, $b) {
+		if($a['cmp'] == $b['cmp']) {
+			if($a['isdst'] == $b['isdst']) {
+				return strcmp($a['timezone_id'], $b['timezone_id']);
+			}
+			return $a['isdst'] - $b['isdst'];
+		}
+		return $a['cmp'] - $b['cmp'];
+	}
+
+	static function getTimeDrift() {
+		$time_servers = array(
+			// 		'tempus1.gum.gov.pl',
+// 			"time.nist.gov",
+			// 		"nist1.datum.com",
+			"time-a.timefreq.bldrdoc.gov",
+// 			"utcnist.colorado.edu",
+// 			'0.pl.pool.ntp.org',
+		);
+		foreach($time_servers as $time_server) {
+			$mt = microtime(true);
+			$fp = fsockopen($time_server, 37, $errno, $errstr, 1);
+			if (!$fp) {
+				echo "$time_server: $errstr ($errno)\n";
+				echo "Trying next available server...\n\n";
+			} else {
+				$data = NULL;
+
+				while (!feof($fp)) {
+					$data .= fgets($fp, 4);
+				}
+				$time = time();
+				fclose($fp);
+				var_dump(microtime(true)-$mt);
+				// 			var_dump($data);
+				if (strlen($data) != 4) {
+					echo "NTP Server {$time_server} returned an invalid response.\n";
+					if ($i != ($ts_count - 1)) {
+						echo "Trying next available server...\n\n";
+					} else {
+						echo "Time server list exhausted\n";
+					}
+				} else {
+					$valid_response = true;
+				}
+				if ($valid_response) {
+					// time server response is a string - convert to numeric
+					// 				for($i=0 ; $i<strlen($data); $i++) {
+					// 					var_dump(ord($data[$i]));
+					// 				}
+					$NTPtime = ord($data[0])<<24 | ord($data[1])<<16 | ord($data[2])<<8 | ord($data[3]);
+					// 				var_dump($NTPtime, date('c',$NTPtime));
+
+					// convert the seconds to the present date & time
+					// 2840140800 = Thu, 1 Jan 2060 00:00:00 UTC
+					// 631152000  = Mon, 1 Jan 1990 00:00:00 UTC
+					$TimeFrom1990 = $NTPtime - 2840140800;
+					$TimeNow = $TimeFrom1990 + 631152000;
+					// 				var_dump($TimeFrom1990, date('c',$TimeFrom1990));
+					var_dump((int)$time, date('c',$time));
+					// 				var_dump((int)$TimeNow, date('c',$TimeNow));
+
+					// set the system time
+					$TheDate = date("c", $TimeNow + $time_adjustment);
+					var_dump($TheDate);
+					var_dump('Diff: '.($time-((int)$TimeNow + (int)$time_adjustment)));
+
+				} else {
+					echo "The system time could not be updated. No time servers available.\n";
+				}
+			}
+		}
+	}
+}

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1934,7 +1934,7 @@ function _elgg_engine_boot() {
 
 	_elgg_load_site_config();
 	
-	ElggTimezone::init();
+	Elgg_Timezone::init();
 
 	_elgg_session_boot();
 

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1933,6 +1933,8 @@ function _elgg_engine_boot() {
 	_elgg_load_autoload_cache();
 
 	_elgg_load_site_config();
+	
+	ElggTimezone::init();
 
 	_elgg_session_boot();
 

--- a/engine/lib/user_settings.php
+++ b/engine/lib/user_settings.php
@@ -20,6 +20,7 @@
  */
 function _elgg_user_settings_save() {
 	_elgg_set_user_language();
+	_elgg_set_user_timezone();
 	_elgg_set_user_password();
 	_elgg_set_user_default_access();
 	_elgg_set_user_name();
@@ -168,6 +169,43 @@ function _elgg_set_user_language() {
 	}
 	return false;
 }
+
+/**
+ * Set a user's time zone
+ *
+ * @return bool
+ * @since 1.9.0
+ * @access private
+ */
+function _elgg_set_user_timezone() {
+	$timezone = get_input('timezone');
+	$user_id = get_input('guid');
+
+	if (!$user_id) {
+		$user = elgg_get_logged_in_user_entity();
+	} else {
+		$user = get_entity($user_id);
+	}
+
+	if (($user) && ($timezone)) {
+		if (strcmp($timezone, $user->timezone) != 0) {
+			$user->timezone = $timezone;
+			if ($user->save()) {
+				system_message(elgg_echo('user:timezone:success'));
+				return true;
+			} else {
+				register_error(elgg_echo('user:timezone:fail'));
+			}
+		} else {
+			// no change
+			return null;
+		}
+	} else {
+		register_error(elgg_echo('user:timezone:fail'));
+	}
+	return false;
+}
+
 
 /**
  * Set a user's email address
@@ -364,6 +402,7 @@ function _elgg_user_settings_init() {
 	elgg_extend_view('forms/account/settings', 'core/settings/account/password', 100);
 	elgg_extend_view('forms/account/settings', 'core/settings/account/email', 100);
 	elgg_extend_view('forms/account/settings', 'core/settings/account/language', 100);
+	elgg_extend_view('forms/account/settings', 'core/settings/account/timezone', 100);
 	elgg_extend_view('forms/account/settings', 'core/settings/account/default_access', 100);
 }
 

--- a/languages/en.php
+++ b/languages/en.php
@@ -414,6 +414,11 @@ return array(
 	'user:language:success' => "Language settings have been updated.",
 	'user:language:fail' => "Language settings could not be saved.",
 
+	'user:set:timezone' => "Time zone settings",
+	'user:timezone:label' => "Your time zone",
+	'user:timezone:success' => "Your time zone settings have been updated.",
+	'user:timezone:fail' => "Your time zone settings could not be saved.",
+	
 	'user:username:notfound' => 'Username %s not found.',
 
 	'user:password:lost' => 'Lost password',
@@ -1013,6 +1018,9 @@ Once you have logged in, we highly recommend that you change your password.
 	'installation:dataroot:warning' => "You must create this directory manually. It should be in a different directory to your Elgg installation.",
 	'installation:sitepermissions' => "The default access permissions:",
 	'installation:language' => "The default language for your site:",
+	'installation:timezone' => "The default time zone for your site:",
+	'installation:debug' => "Debug mode provides extra information which can be used to diagnose faults. However, it can slow your system down so should only be used if you are having problems:",
+	'installation:debug:none' => 'Turn off debug mode (recommended)',
 	'installation:debug' => "Control the amount of information written to the server's log.",
 	'installation:debug:label' => "Log level:",
 	'installation:debug:none' => 'Turn off logging (recommended)',

--- a/views/default/core/settings/account/timezone.php
+++ b/views/default/core/settings/account/timezone.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Provide a way of setting your language prefs
+ *
+ * @package Elgg
+ * @subpackage Core
+ */
+
+$user = elgg_get_page_owner_entity();
+
+if ($user) {
+	$title = elgg_echo('user:set:timezone');
+	$content = elgg_echo('user:timezone:label') . ': ';
+	$content .= elgg_view("input/dropdown", array(
+		'name' => 'timezone',
+		'value' => ElggTimezone::getCurrentId($user),
+		'options_values' => ElggTimezone::getOptionsValues()
+	));
+	echo elgg_view_module('info', $title, $content);
+}

--- a/views/default/core/settings/account/timezone.php
+++ b/views/default/core/settings/account/timezone.php
@@ -13,8 +13,8 @@ if ($user) {
 	$content = elgg_echo('user:timezone:label') . ': ';
 	$content .= elgg_view("input/dropdown", array(
 		'name' => 'timezone',
-		'value' => ElggTimezone::getCurrentId($user),
-		'options_values' => ElggTimezone::getOptionsValues()
+		'value' => Elgg_Timezone::getCurrentId($user),
+		'options_values' => Elgg_Timezone::getOptionsValues()
 	));
 	echo elgg_view_module('info', $title, $content);
 }

--- a/views/default/forms/admin/site/update_basic.php
+++ b/views/default/forms/admin/site/update_basic.php
@@ -29,8 +29,8 @@ $form_body .= elgg_view("input/select", array(
 $form_body .= "<div>" . elgg_echo('installation:timezone');
 $form_body .= elgg_view("input/dropdown", array(
 	'name' => 'timezone',
-	'value' => ElggTimezone::getCurrentId(),
-	'options_values' => ElggTimezone::getOptionsValues(),
+	'value' => Elgg_Timezone::getCurrentId(),
+	'options_values' => Elgg_Timezone::getOptionsValues(),
 )) . "</div>";
 
 $form_body .= '<div class="elgg-foot">';

--- a/views/default/forms/admin/site/update_basic.php
+++ b/views/default/forms/admin/site/update_basic.php
@@ -24,6 +24,15 @@ $form_body .= elgg_view("input/select", array(
 	'options_values' => $languages,
 )) . "</div>";
 
+// $drift = ElggTimezone::getTimeDrift();
+// var_dump(ElggTimezone::getCurrentId());
+$form_body .= "<div>" . elgg_echo('installation:timezone');
+$form_body .= elgg_view("input/dropdown", array(
+	'name' => 'timezone',
+	'value' => ElggTimezone::getCurrentId(),
+	'options_values' => ElggTimezone::getOptionsValues(),
+)) . "</div>";
+
 $form_body .= '<div class="elgg-foot">';
 $form_body .= elgg_view('input/submit', array('value' => elgg_echo("save")));
 $form_body .= '</div>';

--- a/views/default/output/date.php
+++ b/views/default/output/date.php
@@ -11,7 +11,7 @@
 
 // convert timestamps to text for display
 if (is_numeric($vars['value'])) {
-	$vars['value'] = gmdate('Y-m-d', $vars['value']);
+	$vars['value'] = ElggTimezone::format('Y-m-d', $vars['value'], elgg_get_logged_in_user_entity());
 }
 
 echo $vars['value'];

--- a/views/default/output/date.php
+++ b/views/default/output/date.php
@@ -11,7 +11,7 @@
 
 // convert timestamps to text for display
 if (is_numeric($vars['value'])) {
-	$vars['value'] = ElggTimezone::format('Y-m-d', $vars['value'], elgg_get_logged_in_user_entity());
+	$vars['value'] = Elgg_Timezone::format('Y-m-d', $vars['value'], elgg_get_logged_in_user_entity());
 }
 
 echo $vars['value'];


### PR DESCRIPTION
There's some internal cleanup to be done, but it's rebased version of my old timezones pull request.

Features
- default timezone for whole site (settings->basic)
- user's custom timezone (user settings page)
- function for outputting string date taking timezone into account while rendering

TODOs:
- [ ] implement or drop time drift computation (would be neat to use system ntp client or implement it in php)
- [ ] refactor it to use DIC and drop singleton
- [ ] check if we need to integrate it some more with new code
- [ ] clean the mess in the class internals
- [ ] secure against inconsistencies in timezones db (yes they're even more problems than is handled now...). in particular problem with some US `_` vs `/` typo raising an exception when constructing timzone object.
