### PR TITLE
invalidate the subtype_cache when removing a subtype

### DIFF
--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -399,7 +399,7 @@ function remove_subtype($type, $subtype) {
 		$SUBTYPE_CACHE = null;
 	}
 	
-	return $success;
+	return (bool) $success;
 }
 
 /**

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -386,13 +386,20 @@ function add_subtype($type, $subtype, $class = "") {
  * @see update_subtype()
  */
 function remove_subtype($type, $subtype) {
-	global $CONFIG;
+	global $CONFIG, $SUBTYPE_CACHE;
 
 	$type = sanitise_string($type);
 	$subtype = sanitise_string($subtype);
 
-	return delete_data("DELETE FROM {$CONFIG->dbprefix}entity_subtypes"
+	$success = delete_data("DELETE FROM {$CONFIG->dbprefix}entity_subtypes"
 		. " WHERE type = '$type' AND subtype = '$subtype'");
+	
+	if ($success) {
+		// invalidate the cache
+		$SUBTYPE_CACHE = null;
+	}
+	
+	return $success;
 }
 
 /**


### PR DESCRIPTION
If the function remove_subtype is called and in the same run you ask for the subtype id of the removed subtype you'll still get the old id.

This is a problem which doesn't appear often (if ever) but still it's a bug
