### PR TITLE
removed the private attribute pluginID from ElggPlugin

### DIFF
--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -13,7 +13,6 @@ class ElggPlugin extends ElggObject {
 	private $manifest;
 
 	private $path;
-	private $pluginID;
 	private $errorMsg = '';
 
 	/**
@@ -64,10 +63,10 @@ class ElggPlugin extends ElggObject {
 			$this->path = $plugin;
 			$path_parts = explode('/', rtrim($plugin, '/'));
 			$plugin_id = array_pop($path_parts);
-			$this->pluginID = $plugin_id;
+			$this->title = $plugin_id;
 
 			// check if we're loading an existing plugin
-			$existing_plugin = elgg_get_plugin_from_id($this->pluginID);
+			$existing_plugin = elgg_get_plugin_from_id($this->title);
 			$existing_guid = null;
 
 			if ($existing_plugin) {
@@ -93,8 +92,7 @@ class ElggPlugin extends ElggObject {
 		$this->attributes['site_guid'] = $site->guid;
 		$this->attributes['owner_guid'] = $site->guid;
 		$this->attributes['container_guid'] = $site->guid;
-		$this->attributes['title'] = $this->pluginID;
-
+		
 		if (parent::save()) {
 			// make sure we have a priority
 			$priority = $this->getPriority();
@@ -120,7 +118,7 @@ class ElggPlugin extends ElggObject {
 
 	/**
 	 * Returns the manifest's name if available, otherwise the ID.
-	 * 
+	 *
 	 * @return string
 	 * @since 1.8.1
 	 */
@@ -154,7 +152,7 @@ class ElggPlugin extends ElggObject {
 
 	/**
 	 * Returns an array of available markdown files for this plugin
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getAvailableTextFiles() {
@@ -642,7 +640,7 @@ class ElggPlugin extends ElggObject {
 			// we need to do this after it's been fully activated
 			// or the deactivate will be confused.
 			$params = array(
-				'plugin_id' => $this->pluginID,
+				'plugin_id' => $this->getID(),
 				'plugin_entity' => $this
 			);
 
@@ -684,7 +682,7 @@ class ElggPlugin extends ElggObject {
 
 		// emit an event. returning false will cause this to not be deactivated.
 		$params = array(
-			'plugin_id' => $this->pluginID,
+			'plugin_id' => $this->getID(),
 			'plugin_entity' => $this
 		);
 
@@ -919,7 +917,7 @@ class ElggPlugin extends ElggObject {
 		} else {
 			// Hook to validate setting
 			$value = elgg_trigger_plugin_hook('setting', 'plugin', array(
-				'plugin_id' => $this->pluginID,
+				'plugin_id' => $this->getID(),
 				'plugin' => $this,
 				'name' => $name,
 				'value' => $value


### PR DESCRIPTION
the private attribute pluginID of an ElggPlugin only got filled when creating a new plugin, not if you get the plugin from the database (with guid).

This resulted in some weird behaviour in the functions:
->activate
->deactivate
->set
as these functions trigger events/hooks with ->pluginID to help in the events/hooks. But if this is empty you can't check on it and you had to use entity->getID().

this problem probably is left over from migrating from 1.7 to 1.8.

I have tested this change and everything still works fine
