### PR TITLE
fixed issue when reordering plugins to second last position of other column that has more than 2 widgets

### DIFF
--- a/engine/classes/ElggWidget.php
+++ b/engine/classes/ElggWidget.php
@@ -146,10 +146,15 @@ class ElggWidget extends ElggObject {
 			}
 		}
 
+		$bottom_rank = count($widgets);
+		if ($column == $this->column) {
+			$bottom_rank--;
+		}
+		
 		if ($rank == 0) {
 			// top of the column
 			$this->order = reset($widgets)->order - 10;
-		} elseif ($rank == (count($widgets) - 1)) {
+		} elseif ($rank == $bottom_rank) {
 			// bottom of the column of active widgets
 			$this->order = end($widgets)->order + 10;
 		} else {


### PR DESCRIPTION
Reproduce steps:

Profile page of user
- add 3 widgets
- 2 widgets in column 1 and 1 widget in column 2
- move widget from column 2 between the 2 widgets in column 1
- refresh the page
- result is widget is positioned at the last position instead of between the 2 widgets

Reason is that the move algorithm always extracts 1 from the widget count, but that is only the case when moving to the same column.

This is also still the problem in Elgg 1.9
