### PR TITLE
Fixes #4695: Passes more info to input/access and access hooks

### DIFF
--- a/engine/lib/access.php
+++ b/engine/lib/access.php
@@ -239,11 +239,12 @@ function get_access_array($user_guid = 0, $site_guid = 0, $flush = false) {
  * If want you to change the default access based on group of other information,
  * use the 'default', 'access' plugin hook.
  *
- * @param ElggUser $user Get the user's default access. Defaults to logged in user.
+ * @param ElggUser $user         The user for whom we're getting default access. Defaults to logged in user.
+ * @param array    $input_params Parameters passed into an input/access view
  *
  * @return int default access id (see ACCESS defines in elgglib.php)
  */
-function get_default_access(ElggUser $user = null) {
+function get_default_access(ElggUser $user = null, array $input_params = array()) {
 	global $CONFIG;
 
 	// site default access
@@ -263,6 +264,7 @@ function get_default_access(ElggUser $user = null) {
 	$params = array(
 		'user' => $user,
 		'default_access' => $default_access,
+		'input_params' => $input_params,
 	);
 	return elgg_trigger_plugin_hook('default', 'access', $params, $default_access);
 }
@@ -470,13 +472,14 @@ function has_access_to_entity($entity, $user = null) {
  * standard access levels. It does not return access collections that the user
  * belongs to such as the access collection for a group.
  *
- * @param int  $user_guid The user's GUID.
- * @param int  $site_guid The current site.
- * @param bool $flush     If this is set to true, this will ignore a cached access array
+ * @param int   $user_guid    The user's GUID.
+ * @param int   $site_guid    The current site.
+ * @param bool  $flush        If this is set to true, this will ignore a cached access array
+ * @param array $input_params Some parameters passed into an input/access view
  *
  * @return array List of access permissions
  */
-function get_write_access_array($user_guid = 0, $site_guid = 0, $flush = false) {
+function get_write_access_array($user_guid = 0, $site_guid = 0, $flush = false, array $input_params = array()) {
 	global $CONFIG, $init_finished;
 	$cache = _elgg_get_access_cache();
 
@@ -526,10 +529,10 @@ function get_write_access_array($user_guid = 0, $site_guid = 0, $flush = false) 
 
 	$options = array(
 		'user_id' => $user_guid,
-		'site_id' => $site_guid
+		'site_id' => $site_guid,
+		'input_params' => $input_params,
 	);
-	return elgg_trigger_plugin_hook('access:collections:write', 'user',
-		$options, $access_array);
+	return elgg_trigger_plugin_hook('access:collections:write', 'user', $options, $access_array);
 }
 
 /**

--- a/mod/blog/views/default/forms/blog/save.php
+++ b/mod/blog/views/default/forms/blog/save.php
@@ -101,7 +101,10 @@ $access_label = elgg_echo('access');
 $access_input = elgg_view('input/access', array(
 	'name' => 'access_id',
 	'id' => 'blog_access_id',
-	'value' => $vars['access_id']
+	'value' => $vars['access_id'],
+	'entity' => $vars['entity'],
+	'entity_type' => 'object',
+	'entity_subtype' => 'blog',
 ));
 
 $categories_input = elgg_view('input/categories', $vars);

--- a/mod/bookmarks/views/default/forms/bookmarks/save.php
+++ b/mod/bookmarks/views/default/forms/bookmarks/save.php
@@ -42,7 +42,13 @@ if ($categories) {
 ?>
 <div>
 	<label><?php echo elgg_echo('access'); ?></label><br />
-	<?php echo elgg_view('input/access', array('name' => 'access_id', 'value' => $access_id)); ?>
+	<?php echo elgg_view('input/access', array(
+		'name' => 'access_id',
+		'value' => $access_id,
+		'entity' => get_entity($guid),
+		'entity_type' => 'object',
+		'entity_subtype' => 'bookmarks',
+	)); ?>
 </div>
 <div class="elgg-foot">
 <?php

--- a/mod/file/views/default/forms/file/upload.php
+++ b/mod/file/views/default/forms/file/upload.php
@@ -51,7 +51,13 @@ if ($categories) {
 ?>
 <div>
 	<label><?php echo elgg_echo('access'); ?></label><br />
-	<?php echo elgg_view('input/access', array('name' => 'access_id', 'value' => $access_id)); ?>
+	<?php echo elgg_view('input/access', array(
+		'name' => 'access_id',
+		'value' => $access_id,
+		'entity' => get_entity($guid),
+		'entity_type' => 'object',
+		'entity_subtype' => 'file',
+	)); ?>
 </div>
 <div class="elgg-foot">
 <?php

--- a/mod/groups/views/default/forms/discussion/save.php
+++ b/mod/groups/views/default/forms/discussion/save.php
@@ -40,7 +40,13 @@ $guid = elgg_extract('guid', $vars, null);
 </div>
 <div>
 	<label><?php echo elgg_echo('access'); ?></label><br />
-	<?php echo elgg_view('input/access', array('name' => 'access_id', 'value' => $access_id)); ?>
+	<?php echo elgg_view('input/access', array(
+		'name' => 'access_id',
+		'value' => $access_id,
+		'entity' => get_entity($guid),
+		'entity_type' => 'object',
+		'entity_subtype' => 'groupforumtopic',
+	)); ?>
 </div>
 <div class="elgg-foot">
 <?php

--- a/mod/groups/views/default/forms/groups/edit.php
+++ b/mod/groups/views/default/forms/groups/edit.php
@@ -106,6 +106,9 @@ if (elgg_get_plugin_setting('hidden_groups', 'groups') == 'yes') {
 				'name' => 'vis',
 				'value' =>  $vis,
 				'options_values' => $access_options,
+				'entity' => $entity,
+				'entity_type' => 'group',
+				'entity_subtype' => '',
 			));
 			?>
 	</label>

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -411,21 +411,19 @@ function pages_is_page($value) {
  *
  * @param string $hook
  * @param string $type
- * @param array  $value
+ * @param array  $return_value
  * @param array  $params
  *
  * @return array
  */
-function pages_write_access_options_hook($hook, $type, $value, $params) {
-	if (empty($params['input_params']['entity_subtype'])) {
-		return;
-	}
-	if (!in_array($params['input_params']['entity_subtype'], array('page', 'page_top'))) {
-		return;
+function pages_write_access_options_hook($hook, $type, $return_value, $params) {
+	if (empty($params['input_params']['entity_subtype'])
+			|| !in_array($params['input_params']['entity_subtype'], array('page', 'page_top'))) {
+		return null;
 	}
 
 	if ($params['input_params']['purpose'] === 'write') {
-		unset($value[ACCESS_PUBLIC]);
-		return $value;
+		unset($return_value[ACCESS_PUBLIC]);
+		return $return_value;
 	}
 }

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -69,7 +69,7 @@ function pages_init() {
 		'tags' => 'tags',
 		'parent_guid' => 'parent',
 		'access_id' => 'access',
-		'write_access_id' => 'write_access',
+		'write_access_id' => 'access',
 	));
 
 	elgg_register_plugin_hook_handler('register', 'menu:owner_block', 'pages_owner_block_menu');
@@ -77,6 +77,8 @@ function pages_init() {
 	// write permission plugin hooks
 	elgg_register_plugin_hook_handler('permissions_check', 'object', 'pages_write_permission_check');
 	elgg_register_plugin_hook_handler('container_permissions_check', 'object', 'pages_container_permission_check');
+
+	elgg_register_plugin_hook_handler('access:collections:write', 'user', 'pages_write_access_options_hook');
 
 	// icon url override
 	elgg_register_plugin_hook_handler('entity:icon:url', 'object', 'pages_icon_url_override');
@@ -402,4 +404,28 @@ function pages_ecml_views_hook($hook, $entity_type, $return_value, $params) {
  */
 function pages_is_page($value) {
 	return ($value instanceof ElggObject) && in_array($value->getSubtype(), array('page', 'page_top'));
+}
+
+/**
+ * Return options for the write_access_id input
+ *
+ * @param string $hook
+ * @param string $type
+ * @param array  $value
+ * @param array  $params
+ *
+ * @return array
+ */
+function pages_write_access_options_hook($hook, $type, $value, $params) {
+	if (empty($params['input_params']['entity_subtype'])) {
+		return;
+	}
+	if (!in_array($params['input_params']['entity_subtype'], array('page', 'page_top'))) {
+		return;
+	}
+
+	if ($params['input_params']['purpose'] === 'write') {
+		unset($value[ACCESS_PUBLIC]);
+		return $value;
+	}
 }

--- a/mod/pages/views/default/forms/pages/edit.php
+++ b/mod/pages/views/default/forms/pages/edit.php
@@ -15,7 +15,7 @@ if ($user && $entity) {
 
 foreach ($variables as $name => $type) {
 	// don't show read / write access inputs for non-owners or admin when editing
-	if (($type == 'access' || $type == 'write_access') && !$can_change_access) {
+	if (($type == 'access') && !$can_change_access) {
 		continue;
 	}
 	
@@ -38,11 +38,24 @@ foreach ($variables as $name => $type) {
 			echo '<br />';
 		}
 
-		echo elgg_view($input_view, array(
+		$view_vars = array(
 			'name' => $name,
 			'value' => $vars[$name],
 			'entity' => ($name == 'parent_guid') ? $vars['entity'] : null,
-		));
+		);
+		if ($input_view === 'input/access') {
+			$view_vars['entity'] = $entity;
+			$view_vars['entity_type'] = 'object';
+			$view_vars['entity_subtype'] = $vars['parent_guid'] ? 'page': 'page_top';
+			if ($name === 'write_access_id') {
+				$view_vars['purpose'] = 'write';
+				if ($entity) {
+					$view_vars['value'] = $entity->write_access_id;
+				}
+			}
+		}
+
+		echo elgg_view($input_view, $view_vars);
 	?>
 </div>
 <?php

--- a/mod/pages/views/default/input/write_access.php
+++ b/mod/pages/views/default/input/write_access.php
@@ -1,35 +1,3 @@
 <?php
-/**
- * Write access
- *
- * Removes the public option found in input/access
- *
- * @uses $vars['value'] The current value, if any
- * @uses $vars['options_values']
- * @uses $vars['name'] The name of the input field
- * @uses $vars['entity'] Optional. The entity for this access control (uses write_access_id)
- */
 
-$options = get_write_access_array();
-unset($options[ACCESS_PUBLIC]);
-
-$defaults = array(
-	'class' => 'elgg-input-access',
-	'disabled' => FALSE,
-	'value' => get_default_access(),
-	'options_values' => $options,
-);
-
-if (isset($vars['entity'])) {
-	$defaults['value'] = $vars['entity']->write_access_id;
-	unset($vars['entity']);
-}
-
-$vars = array_merge($defaults, $vars);
-
-if ($vars['value'] == ACCESS_DEFAULT) {
-	$vars['value'] = get_default_access();
-}
-$vars['value'] = ($vars['value'] == ACCESS_PUBLIC) ? ACCESS_LOGGED_IN : $vars['value'];
-
-echo elgg_view('input/select', $vars);
+elgg_deprecated_notice("The input/write_access view is deprecated. The pages plugin now uses the ['access:collections:write', 'user'] hook to alter options.", "1.9");

--- a/views/default/input/access.php
+++ b/views/default/input/access.php
@@ -8,30 +8,55 @@
  * @uses $vars['name']           The name of the input field
  * @uses $vars['entity']         Optional. The entity for this access control (uses access_id)
  * @uses $vars['class']          Additional CSS class
+ *
+ * @uses $vars['entity_type']    Optional. Type of the entity
+ * @uses $vars['entity_subtype'] Optional. Subtype of the entity
+ * @uses $vars['container_guid'] Optional. Container GUID of the entity
+ *
  */
 
-if (isset($vars['class'])) {
-	$vars['class'] = "elgg-input-access {$vars['class']}";
-} else {
-	$vars['class'] = "elgg-input-access";
+$vars['class'] = trim("elgg-input-access " . elgg_extract('class', $vars, ''));
+
+// will be passed to plugin hooks ['access:collections:write', 'user'] and ['default', 'access']
+$params = array();
+
+$keys = array(
+	'entity' => null,
+	'entity_type' => null,
+	'entity_subtype' => null,
+	'container_guid' => null,
+	'purpose' => 'read',
+);
+foreach ($keys as $key => $default_value) {
+	$params[$key] = elgg_extract($key, $vars, $default_value);
+	unset($vars[$key]);
+}
+
+/* @var ElggEntity $entity */
+$entity = $params['entity'];
+
+if ($entity) {
+	$params['entity_type'] = $entity->type;
+	$params['entity_subtype'] = $entity->getSubtype();
+	$params['container_guid'] = $entity->container_guid;
+}
+
+$container = elgg_get_page_owner_entity();
+if (!$params['container_guid'] && $container) {
+	$params['container_guid'] = $container->guid;
 }
 
 $defaults = array(
 	'disabled' => false,
-	'value' => get_default_access(),
-	'options_values' => get_write_access_array(),
+	'value' => get_default_access(null, $params),
+	'options_values' => get_write_access_array(0, 0, false, $params),
 );
 
-/* @var ElggEntity $entity */
-$entity = elgg_extract('entity', $vars);
-unset($vars['entity']);
-
 // should we tell users that public/logged-in access levels will be ignored?
-$container = elgg_get_page_owner_entity();
 if (($container instanceof ElggGroup)
 		&& $container->getContentAccessMode() === ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY
 		&& !elgg_in_context('group-edit')
-		&& !($entity && $entity instanceof ElggGroup)) {
+		&& !($entity instanceof ElggGroup)) {
 	$show_override_notice = true;
 } else {
 	$show_override_notice = false;
@@ -44,15 +69,17 @@ if ($entity) {
 $vars = array_merge($defaults, $vars);
 
 if ($vars['value'] == ACCESS_DEFAULT) {
-	$vars['value'] = get_default_access();
+	$vars['value'] = get_default_access(null, $params);
 }
 
-if (is_array($vars['options_values']) && sizeof($vars['options_values']) > 0) {
-	if ($show_override_notice) {
-		$vars['data-group-acl'] = $container->group_acl;
-	}
-	echo elgg_view('input/select', $vars);
-	if ($show_override_notice) {
-		echo "<p class='elgg-text-help'>" . elgg_echo('access:overridenotice')  .  "</p>";
-	}
+if (empty($vars['options_values'])) {
+	return;
+}
+
+if ($show_override_notice) {
+	$vars['data-group-acl'] = $container->group_acl;
+}
+echo elgg_view('input/select', $vars);
+if ($show_override_notice) {
+	echo "<p class='elgg-text-help'>" . elgg_echo('access:overridenotice')  .  "</p>";
 }


### PR DESCRIPTION
First pass at getting more info into the input/access view and underlying hooks. Handlers of these hooks can now tell the type/subtype/container of the entity and are passed the entity itself if it already exists.

Also they're passed a "purpose" which defaults to "read". You can see the pages plugin needs to pass in "write" for the write_access_id instance of input/access. It uses a plugin hook to remove public write privileges instead of needing it's own input view.
