### PR TITLE
Fixes #5861 adds support for site notifications for code that calls notify_user()

### DIFF
--- a/actions/comment/save.php
+++ b/actions/comment/save.php
@@ -68,7 +68,11 @@ if ($comment_guid) {
 				$entity->getURL(),
 				$user->name,
 				$user->getURL()
-			))
+			)),
+			array(
+				'object' => $comment,
+				'action' => 'create',
+			)
 		);
 	}
 

--- a/mod/site_notifications/start.php
+++ b/mod/site_notifications/start.php
@@ -84,17 +84,22 @@ function site_notifications_send($hook, $type, $result, $params) {
 	/* @var Elgg_Notifications_Notification */
 	$notification = $params['notification'];
 	if ($notification->summary) {
-		$recipient = $notification->getRecipient();
 		$message = $notification->summary;
-		$actor = $notification->getSender();
 		$event = $params['event'];
 		$object = $event->getObject();
+	} else {
+		$message = $notification->subject;
+		$event = null;
+		$object = null;
+	}
 
-		$ia = elgg_set_ignore_access(true);
-		$note = SiteNotificationFactory::create($recipient, $message, $actor, $object);
-		elgg_set_ignore_access($ia);
-		if ($note) {
-			return true;
-		}
+	$actor = $notification->getSender();
+	$recipient = $notification->getRecipient();
+
+	$ia = elgg_set_ignore_access(true);
+	$note = SiteNotificationFactory::create($recipient, $message, $actor, $object);
+	elgg_set_ignore_access($ia);
+	if ($note) {
+		return true;
 	}
 }

--- a/mod/site_notifications/start.php
+++ b/mod/site_notifications/start.php
@@ -85,11 +85,14 @@ function site_notifications_send($hook, $type, $result, $params) {
 	$notification = $params['notification'];
 	if ($notification->summary) {
 		$message = $notification->summary;
+	} else {
+		$message = $notification->subject;
+	}
+
+	if (isset($params['event'])) {
 		$event = $params['event'];
 		$object = $event->getObject();
 	} else {
-		$message = $notification->subject;
-		$event = null;
 		$object = null;
 	}
 


### PR DESCRIPTION
This adds backward compatibility. It could be improved by allowing plugins to pass a 'summary' string to notify_user(). Then plugins can get more descriptive site notifications. This should be enough for the 1.9 release candidate.
