### PR TITLE
Fixes #6107: data-colorbox-opts on elements now correctly applied

### DIFF
--- a/views/default/js/lightbox.php
+++ b/views/default/js/lightbox.php
@@ -80,17 +80,20 @@ elgg.ui.lightbox.bind = function ($elements, opts) {
 		opts = {};
 	}
 
+	// merge opts into defaults
+	opts = $.extend({}, elgg.ui.lightbox.getSettings(), opts);
+
 	$elements.each(function () {
 		var $this = $(this),
-			optsCopy = $.extend({}, opts);
-
+			dataOpts = $this.data('colorboxOpts');
 		// Q: why not use "colorbox"? A: https://github.com/jackmoore/colorbox/issues/435
-		var dataOpts = $this.data('colorboxOpts');
 
-		if ($.isPlainObject(dataOpts)) {
-			optsCopy = $.extend(optsCopy, dataOpts);
+		if (!$.isPlainObject(dataOpts)) {
+			dataOpts = {};
 		}
-		$this.colorbox(optsCopy);
+
+		// merge data- options into opts
+		$this.colorbox($.extend({}, opts, dataOpts));
 	});
 };
 

--- a/views/default/js/lightbox.php
+++ b/views/default/js/lightbox.php
@@ -46,7 +46,6 @@ elgg.ui.lightbox.init = function() {
 		elgg.register_error("fancybox lightbox has been replaced by colorbox", 9999999999999);
 	}
 
-	$.extend($.colorbox.settings, elgg.ui.lightbox.getSettings());
 	elgg.ui.lightbox.bind($(".elgg-lightbox"));
 
 	if (typeof $.fancybox === 'undefined') {
@@ -73,19 +72,26 @@ elgg.ui.lightbox.init = function() {
 /**
  * Bind colorbox lightbox to HTML
  *
- * @param {Object} $element jQuery object containing colorbox openers
- * @param {Object} opts     Colorbox options. These are overridden by data-colorbox-opts options
+ * @param {Object} $elements jQuery object containing colorbox openers
+ * @param {Object} opts      Colorbox options. These are overridden by data-colorbox-opts options
  */
-elgg.ui.lightbox.bind = function ($element, opts) {
+elgg.ui.lightbox.bind = function ($elements, opts) {
 	if (!$.isPlainObject(opts)) {
 		opts = {};
 	}
-	// Q: why not use "colorbox"? A: https://github.com/jackmoore/colorbox/issues/435
-	var dataOpts = $element.data('colorboxOpts');
-	if ($.isPlainObject(dataOpts)) {
-		opts = $.extend(opts, dataOpts);
-	}
-	$element.colorbox(opts);
+
+	$elements.each(function () {
+		var $this = $(this),
+			optsCopy = $.extend({}, opts);
+
+		// Q: why not use "colorbox"? A: https://github.com/jackmoore/colorbox/issues/435
+		var dataOpts = $this.data('colorboxOpts');
+
+		if ($.isPlainObject(dataOpts)) {
+			optsCopy = $.extend(optsCopy, dataOpts);
+		}
+		$this.colorbox(optsCopy);
+	});
 };
 
 /**


### PR DESCRIPTION
Does a few things:
- handles each bound element separately for proper reading of data-colorbox-opts
- no longer merges Elgg's defaults into the global colorbox settings (I _think_ this is a good idea)
- instead, Elgg's settings are merged in inside bind().
