### PR TITLE
Revert "Fixes #6030 - Hide group bookmarklet from non-members"

### DIFF
--- a/mod/bookmarks/start.php
+++ b/mod/bookmarks/start.php
@@ -235,11 +235,8 @@ function bookmarks_page_menu($hook, $type, $return, $params) {
 			if (!$page_owner) {
 				$page_owner = elgg_get_logged_in_user_entity();
 			}
-
+			
 			if ($page_owner instanceof ElggGroup) {
-				if (!$page_owner->isMember()) {
-					return $return;
-				}
 				$title = elgg_echo('bookmarks:bookmarklet:group');
 			} else {
 				$title = elgg_echo('bookmarks:bookmarklet');


### PR DESCRIPTION
This reverts commit 5a6b259a320256c2f75828193aa8da93eebe226e.

The commit will be added to 1.8 branch instead.
