### PR TITLE
Keep existing categories intact

### DIFF
--- a/mod/categories/views/default/input/categories.php
+++ b/mod/categories/views/default/input/categories.php
@@ -20,6 +20,11 @@ $categories = elgg_get_site_entity()->categories;
 if (empty($categories)) {
 	$categories = array();
 }
+
+if (!is_array($categories)) {
+	$categories = array($categories);
+}
+
 if (empty($selected_categories)) {
 	$selected_categories = array();
 }

--- a/mod/categories/views/default/input/categories.php
+++ b/mod/categories/views/default/input/categories.php
@@ -24,6 +24,13 @@ if (empty($selected_categories)) {
 	$selected_categories = array();
 }
 
+if (!is_array($selected_categories)) {
+	$selected_categories = array($selected_categories);
+}
+
+$categories = array_merge($categories, $selected_categories);
+$categories = array_unique($categories);
+
 if (!empty($categories)) {
 	if (!is_array($categories)) {
 		$categories = array($categories);


### PR DESCRIPTION
This will make sure that if content already has a category, it will be added to the selectable categories, even if it is not configured anymore. This prevents unwanted data loss of categories that are not used anymore.
