### PR TITLE
Fix #6238 Return blank arrays

### DIFF
--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -299,17 +299,16 @@ class ElggPlugin extends ElggObject {
 
 		$private_settings = get_data($q);
 
+		$return = array();
+                
 		if ($private_settings) {
-			$return = array();
-
+		
 			foreach ($private_settings as $setting) {
 				$return[$setting->name] = $setting->value;
 			}
+                }
 
-			return $return;
-		}
-
-		return false;
+		return $return;
 	}
 
 	/**
@@ -423,9 +422,10 @@ class ElggPlugin extends ElggObject {
 
 		$private_settings = get_data($q);
 
-		if ($private_settings) {
-			$return = array();
-
+		$return = array();
+		
+                if ($private_settings) {
+		
 			foreach ($private_settings as $setting) {
 				$name = substr($setting->name, $ps_prefix_len);
 				$value = $setting->value;
@@ -433,10 +433,9 @@ class ElggPlugin extends ElggObject {
 				$return[$name] = $value;
 			}
 
-			return $return;
 		}
 
-		return false;
+		return $return;
 	}
 
 	/**


### PR DESCRIPTION
I committed this simple change to return the empty array rather than false for empty settings result for ElggPlugin::getAllSettings and getAllUsersSettings. Put this into 1.8 branch.
