### PR TITLE
Implements #4453: entities/river queries alterable by hooks (WIP)

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -149,6 +149,52 @@ Views
 **head, page**
     In elgg_view_page(), filters $vars['head']
 
+Named query hooks
+=================
+
+If a string is passed in for ``$options["query_name"]`` in some query functions, the ``$options`` parameter
+will be filtered through one of the following hooks.
+
+**entities:options, <query_name>**
+    In elgg_get_entities(), filters the ``$options`` argument if ``$options["query_name"]`` is present.
+
+    With this hook the following query names are used in Elgg core:
+
+    -  ``blog/(all|friends|owner|group|archive)``
+    -  ``bookmarks/(all|owner|friends)``
+    -  ``custom_index/(blog|bookmark|file|member|group)``
+    -  ``discussion/(all|owner|latest)``
+    -  ``file/(all|friends|owner)``
+    -  ``friends(of)``
+    -  ``group_module/(blog|bookmark|discussion|file|page)``
+    -  ``groups/(all|owner|member)``
+    -  ``members/(all|popular)``
+    -  ``messages/(inbox|sent)``
+    -  ``pages/(all|friends|owner)``
+    -  ``sidebar/(featured_groups|group_members|comments_block)``
+    -  ``thewire/(all|friends|owner|thread)``
+
+**river:options, <query_name>**
+    In elgg_get_river(), filters the ``$options`` argument if ``$options["query_name"]`` is present.
+
+    With this hook the following query names are used in Elgg core:
+
+    -  ``activity/(all|friends|owner|group)``
+    -  ``group_module/activity``
+
+**annotations:options, <query_name>**
+    In elgg_get_annotations(), filters the ``$options`` argument if ``$options["query_name"]`` is present.
+
+    With this hook the following query names are used in Elgg core:
+
+    -  ``pages/history``
+    -  ``sidebar/page_history``
+
+E.g. to show 50 river entries on the site-wide activity page, register for the
+``[river:options, activity/all]`` hook, and in your handler set ``$return_value['limit'] = 50;``
+
+Note: Often the hook will be called twice, the first time for a COUNT query.
+
 Other
 =====
 

--- a/engine/lib/annotations.php
+++ b/engine/lib/annotations.php
@@ -198,12 +198,21 @@ function update_annotation($annotation_id, $name, $value, $value_type, $owner_gu
  *                                   objects.
  *                                   See the docs for elgg_get_entities_from_annotation_calculation()
  *                                   for the proper use of the "calculation" option.
- *
+ * query_name                     => STR If provided, $options will be filtered by the plugin hook
+ *                                   ["annotations:options", <query_name>]
  *
  * @return ElggAnnotation[]|mixed
  * @since 1.8.0
  */
 function elgg_get_annotations(array $options = array()) {
+
+	// allow modification of options before the defaults are merged in
+	if (!empty($options['query_name']) && is_string($options['query_name'])) {
+		$params = array(
+			'options' => $options,
+		);
+		$options = elgg_trigger_plugin_hook("annotations:options", $options['query_name'], $params, $options);
+	}
 
 	// @todo remove support for count shortcut - see #4393
 	if (isset($options['__egefac']) && $options['__egefac']) {

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -764,6 +764,9 @@ function elgg_enable_entity($guid, $recursive = true) {
  *
  * 	joins => array() Additional joins
  *
+ *  query_name => string If provided, $options will be filtered by the plugin
+ *                hook ["entities:options", <query_name>]
+ *
  * 	callback => string A callback function to pass each row through
  *
  * @return mixed If count, int. If not count, array. false on errors.
@@ -777,34 +780,42 @@ function elgg_enable_entity($guid, $recursive = true) {
 function elgg_get_entities(array $options = array()) {
 	global $CONFIG;
 
+	// allow modification of options before the defaults are merged in
+	if (!empty($options['query_name']) && is_string($options['query_name'])) {
+		$params = array(
+			'options' => $options,
+		);
+		$options = elgg_trigger_plugin_hook("entities:options", $options['query_name'], $params, $options);
+	}
+
 	$defaults = array(
-		'types'					=>	ELGG_ENTITIES_ANY_VALUE,
-		'subtypes'				=>	ELGG_ENTITIES_ANY_VALUE,
-		'type_subtype_pairs'	=>	ELGG_ENTITIES_ANY_VALUE,
+		'types'                 => ELGG_ENTITIES_ANY_VALUE,
+		'subtypes'              => ELGG_ENTITIES_ANY_VALUE,
+		'type_subtype_pairs'    => ELGG_ENTITIES_ANY_VALUE,
 
-		'guids'					=>	ELGG_ENTITIES_ANY_VALUE,
-		'owner_guids'			=>	ELGG_ENTITIES_ANY_VALUE,
-		'container_guids'		=>	ELGG_ENTITIES_ANY_VALUE,
-		'site_guids'			=>	$CONFIG->site_guid,
+		'guids'                 => ELGG_ENTITIES_ANY_VALUE,
+		'owner_guids'           => ELGG_ENTITIES_ANY_VALUE,
+		'container_guids'       => ELGG_ENTITIES_ANY_VALUE,
+		'site_guids'            => $CONFIG->site_guid,
 
-		'modified_time_lower'	=>	ELGG_ENTITIES_ANY_VALUE,
-		'modified_time_upper'	=>	ELGG_ENTITIES_ANY_VALUE,
-		'created_time_lower'	=>	ELGG_ENTITIES_ANY_VALUE,
-		'created_time_upper'	=>	ELGG_ENTITIES_ANY_VALUE,
+		'modified_time_lower'   => ELGG_ENTITIES_ANY_VALUE,
+		'modified_time_upper'   => ELGG_ENTITIES_ANY_VALUE,
+		'created_time_lower'    => ELGG_ENTITIES_ANY_VALUE,
+		'created_time_upper'    => ELGG_ENTITIES_ANY_VALUE,
 
-		'reverse_order_by'		=>	false,
-		'order_by' 				=>	'e.time_created desc',
-		'group_by'				=>	ELGG_ENTITIES_ANY_VALUE,
-		'limit'					=>	10,
-		'offset'				=>	0,
-		'count'					=>	false,
-		'selects'				=>	array(),
-		'wheres'				=>	array(),
-		'joins'					=>	array(),
+		'reverse_order_by'      => false,
+		'order_by'              => 'e.time_created desc',
+		'group_by'              => ELGG_ENTITIES_ANY_VALUE,
+		'limit'                 => 10,
+		'offset'                => 0,
+		'count'                 => false,
+		'selects'               => array(),
+		'wheres'                => array(),
+		'joins'                 => array(),
 
-		'callback'				=> 'entity_row_to_elggstar',
+		'callback'              => 'entity_row_to_elggstar',
 
-		'__ElggBatch'			=> null,
+		'__ElggBatch'           => null,
 	);
 
 	$options = array_merge($defaults, $options);

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -279,11 +279,22 @@ function elgg_delete_river(array $options = array()) {
  *   order_by             => STR     Order by clause (rv.posted desc)
  *   group_by             => STR     Group by clause
  *
+ *   query_name           => STR     If provided, $options will be filtered by the
+ *                                   plugin hook ["river:options", <query_name>]
+ *
  * @return array|int
  * @since 1.8.0
  */
 function elgg_get_river(array $options = array()) {
 	global $CONFIG;
+
+	// allow modification of options before the defaults are merged in
+	if (!empty($options['query_name']) && is_string($options['query_name'])) {
+		$params = array(
+			'options' => $options,
+		);
+		$options = elgg_trigger_plugin_hook("river:options", $options['query_name'], $params, $options);
+	}
 
 	$defaults = array(
 		'ids'                  => ELGG_ENTITIES_ANY_VALUE,

--- a/engine/tests/ElggCoreAnnotationAPITest.php
+++ b/engine/tests/ElggCoreAnnotationAPITest.php
@@ -145,4 +145,27 @@ class ElggCoreAnnotationAPITest extends ElggCoreUnitTest {
 		$this->assertTrue($e->delete());
 		$this->assertFalse(elgg_annotation_exists($guid, 'test_annotation'));
 	}
+
+	public function testNamedQueriesFilterOptions() {
+		$query_name = __FUNCTION__;
+		elgg_register_plugin_hook_handler('annotations:options', $query_name, __CLASS__ . '::namedQueryHandler');
+
+		// create in case no annotations
+		$user = elgg_get_logged_in_user_entity();
+		$id = $user->annotate('test', 'test');
+
+		$annotations = elgg_get_annotations(array(
+			'query_name' => $query_name,
+			'limit' => 1,
+		));
+		$this->assertIsA($annotations[0], 'stdClass');
+
+		elgg_delete_annotation_by_id($id);
+	}
+
+	public static function namedQueryHandler($hook, $type, $options, $param) {
+		return array_merge($options, array(
+			'callback' => '',
+		));
+	}
 }

--- a/engine/tests/ElggCoreGetEntitiesTest.php
+++ b/engine/tests/ElggCoreGetEntitiesTest.php
@@ -979,4 +979,21 @@ class ElggCoreGetEntitiesTest extends ElggCoreGetEntitiesBaseTest {
 		$entities = elgg_get_entities($options);
 		$this->assertTrue(is_array($entities));
 	}
+
+	public function testNamedQueriesFilterOptions() {
+		$query_name = __FUNCTION__;
+		elgg_register_plugin_hook_handler('entities:options', $query_name, __CLASS__ . '::namedQueryHandler');
+
+		$entities = elgg_get_entities(array(
+			'query_name' => $query_name,
+			'limit' => 1,
+		));
+		$this->assertIsA($entities[0], 'stdClass');
+	}
+
+	public static function namedQueryHandler($hook, $type, $options, $param) {
+		return array_merge($options, array(
+			'callback' => '',
+		));
+	}
 }

--- a/engine/tests/ElggCoreRiverAPITest.php
+++ b/engine/tests/ElggCoreRiverAPITest.php
@@ -98,4 +98,31 @@ class ElggCoreRiverAPITest extends ElggCoreUnitTest {
 		$result = _elgg_get_river_type_subtype_where_sql('rv', $types, $subtypes, null);
 		$this->assertIdentical($result, "((rv.type = 'object') AND ((rv.subtype = 'blog') OR (rv.subtype = 'file')))");
 	}
+
+	public function testNamedQueriesFilterOptions() {
+		$query_name = __FUNCTION__;
+		elgg_register_plugin_hook_handler('river:options', $query_name, __CLASS__ . '::namedQueryHandler');
+
+		// create in case river is empty
+		$user = elgg_get_logged_in_user_entity();
+		$id = elgg_create_river_item(array(
+			'view' => 'river/relationship/friend/create',
+			'action_type' => 'create',
+			'subject_guid' => $user->guid,
+			'object_guid' => $user->guid,
+		));
+
+		$items = elgg_get_river(array(
+			'query_name' => $query_name,
+		));
+		$this->assertTrue(is_int($items));
+		
+		elgg_delete_river(array('id' => $id));
+	}
+
+	public static function namedQueryHandler($hook, $type, $options, $param) {
+		return array_merge($options, array(
+			'count' => true,
+		));
+	}
 }

--- a/mod/blog/lib/blog.php
+++ b/mod/blog/lib/blog.php
@@ -84,15 +84,19 @@ function blog_get_page_content_list($container_guid = NULL) {
 
 		if ($current_user && ($container_guid == $current_user->guid)) {
 			$return['filter_context'] = 'mine';
+			$options['query_name'] = 'blog/owner';
 		} else if (elgg_instanceof($container, 'group')) {
 			$return['filter'] = false;
+			$options['query_name'] = 'blog/group';
 		} else {
 			// do not show button or select a tab when viewing someone else's posts
 			$return['filter_context'] = 'none';
+			$options['query_name'] = 'blog/owner';
 		}
 	} else {
 		$return['filter_context'] = 'all';
 		$return['title'] = elgg_echo('blog:title:all_blogs');
+		$options['query_name'] = 'blog/all';
 		elgg_pop_breadcrumb();
 		elgg_push_breadcrumb(elgg_echo('blog:blogs'));
 	}
@@ -136,6 +140,7 @@ function blog_get_page_content_friends($user_guid) {
 		'relationship_guid' => $user_guid,
 		'relationship_join_on' => 'container_guid',
 		'no_results' => elgg_echo('blog:none'),
+		'query_name' => 'blog/friends',
 	);
 
 	$return['content'] = elgg_list_entities_from_relationship($options);
@@ -178,6 +183,7 @@ function blog_get_page_content_archive($owner_guid, $lower = 0, $upper = 0) {
 		'subtype' => 'blog',
 		'full_view' => false,
 		'no_results' => elgg_echo('blog:none'),
+		'query_name' => 'blog/archive',
 	);
 
 	if ($owner_guid) {

--- a/mod/blog/views/default/blog/group_module.php
+++ b/mod/blog/views/default/blog/group_module.php
@@ -23,7 +23,8 @@ $options = array(
 	'limit' => 6,
 	'full_view' => false,
 	'pagination' => false,
-	'no_results' => elgg_echo('blog:none')
+	'no_results' => elgg_echo('blog:none'),
+	'query_name' => 'group_module/blog',
 );
 $content = elgg_list_entities($options);
 elgg_pop_context();

--- a/mod/bookmarks/pages/bookmarks/all.php
+++ b/mod/bookmarks/pages/bookmarks/all.php
@@ -16,6 +16,7 @@ $content = elgg_list_entities(array(
 	'full_view' => false,
 	'view_toggle_type' => false,
 	'no_results' => elgg_echo('bookmarks:none'),
+	'query_name' => 'bookmarks/all',
 ));
 
 $title = elgg_echo('bookmarks:everyone');

--- a/mod/bookmarks/pages/bookmarks/friends.php
+++ b/mod/bookmarks/pages/bookmarks/friends.php
@@ -25,6 +25,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_guid' => $page_owner->guid,
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo('bookmarks:none'),
+	'query_name' => 'bookmarks/friends',
 ));
 
 $params = array(

--- a/mod/bookmarks/pages/bookmarks/owner.php
+++ b/mod/bookmarks/pages/bookmarks/owner.php
@@ -21,6 +21,7 @@ $content .= elgg_list_entities(array(
 	'full_view' => false,
 	'view_toggle_type' => false,
 	'no_results' => elgg_echo('bookmarks:none'),
+	'query_name' => 'bookmarks/owner',
 ));
 
 $title = elgg_echo('bookmarks:owner', array($page_owner->name));

--- a/mod/bookmarks/views/default/bookmarks/group_module.php
+++ b/mod/bookmarks/views/default/bookmarks/group_module.php
@@ -26,6 +26,7 @@ $options = array(
 	'full_view' => false,
 	'pagination' => false,
 	'no_results' => elgg_echo('bookmarks:none'),
+	'query_name' => 'group_module/bookmark',
 );
 $content = elgg_list_entities($options);
 elgg_pop_context();

--- a/mod/custom_index/index.php
+++ b/mod/custom_index/index.php
@@ -18,14 +18,17 @@ $list_params = array(
 
 //grab the latest 4 blog posts
 $list_params['subtype'] = 'blog';
+$list_params['query_name'] = 'custom_index/blog';
 $blogs = elgg_list_entities($list_params);
 
 //grab the latest bookmarks
 $list_params['subtype'] = 'bookmarks';
+$list_params['query_name'] = 'custom_index/bookmark';
 $bookmarks = elgg_list_entities($list_params);
 
 //grab the latest files
 $list_params['subtype'] = 'file';
+$list_params['query_name'] = 'custom_index/file';
 $files = elgg_list_entities($list_params);
 
 //get the newest members who have an avatar
@@ -38,11 +41,13 @@ $newest_members = elgg_list_entities_from_metadata(array(
 	'list_type' => 'gallery',
 	'gallery_class' => 'elgg-gallery-users',
 	'size' => 'small',
+	'query_name' => 'custom_index/member',
 ));
 
 //newest groups
 $list_params['type'] = 'group';
 unset($list_params['subtype']);
+$list_params['query_name'] = 'custom_index/group';
 $groups = elgg_list_entities($list_params);
 
 //grab the login form

--- a/mod/file/pages/file/friends.php
+++ b/mod/file/pages/file/friends.php
@@ -26,6 +26,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_guid' => $owner->guid,
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo("file:none"),
+	'query_name' => 'file/friends',
 ));
 
 $sidebar = file_get_type_cloud($owner->guid, true);

--- a/mod/file/pages/file/owner.php
+++ b/mod/file/pages/file/owner.php
@@ -41,6 +41,7 @@ $content = elgg_list_entities(array(
 	'container_guid' => $owner->guid,
 	'full_view' => false,
 	'no_results' => elgg_echo("file:none"),
+	'query_name' => 'file/owner',
 ));
 
 $sidebar = file_get_type_cloud(elgg_get_page_owner_guid());

--- a/mod/file/pages/file/world.php
+++ b/mod/file/pages/file/world.php
@@ -16,6 +16,7 @@ $content = elgg_list_entities(array(
 	'subtype' => 'file',
 	'full_view' => false,
 	'no_results' => elgg_echo("file:none"),
+	'query_name' => 'file/all',
 ));
 
 $sidebar = file_get_type_cloud();

--- a/mod/file/views/default/file/group_module.php
+++ b/mod/file/views/default/file/group_module.php
@@ -24,6 +24,7 @@ $options = array(
 	'full_view' => false,
 	'pagination' => false,
 	'no_results' => elgg_echo('file:none'),
+	'query_name' => 'group_module/file',
 );
 $content = elgg_list_entities($options);
 elgg_pop_context();

--- a/mod/groups/lib/discussion.php
+++ b/mod/groups/lib/discussion.php
@@ -18,6 +18,7 @@ function discussion_handle_all_page() {
 		'limit' => 20,
 		'full_view' => false,
 		'no_results' => elgg_echo('discussion:none'),
+		'query_name' => 'discussion/all',
 	));
 
 	$title = elgg_echo('discussion:latest');
@@ -62,6 +63,7 @@ function discussion_handle_list_page($guid) {
 		'container_guid' => $guid,
 		'full_view' => false,
 		'no_results' => elgg_echo('discussion:none'),
+		'query_name' => 'discussion/owner',
 	);
 	$content = elgg_list_entities($options);
 

--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -26,6 +26,7 @@ function groups_handle_all_page() {
 				'inverse_relationship' => false,
 				'full_view' => false,
 				'no_results' => elgg_echo('groups:none'),
+				'query_name' => 'groups/all',
 			));
 			break;
 		case 'discussion':
@@ -36,6 +37,7 @@ function groups_handle_all_page() {
 				'limit' => 40,
 				'full_view' => false,
 				'no_results' => elgg_echo('discussion:none'),
+				'query_name' => 'discussion/latest',
 			));
 			break;
 		case 'newest':
@@ -44,6 +46,7 @@ function groups_handle_all_page() {
 				'type' => 'group',
 				'full_view' => false,
 				'no_results' => elgg_echo('groups:none'),
+				'query_name' => 'groups/all',
 			));
 			break;
 	}
@@ -120,6 +123,7 @@ function groups_handle_owned_page() {
 		'order_by' => 'ge.name ASC',
 		'full_view' => false,
 		'no_results' => elgg_echo('groups:none'),
+		'query_name' => 'groups/owner',
 	));
 
 	$params = array(
@@ -161,6 +165,7 @@ function groups_handle_mine_page() {
 		'joins' => array("JOIN {$dbprefix}groups_entity ge ON e.guid = ge.guid"),
 		'order_by' => 'ge.name ASC',
 		'no_results' => elgg_echo('groups:none'),
+		'query_name' => 'groups/member',
 	));
 
 	$params = array(
@@ -334,6 +339,10 @@ function groups_handle_activity_page($guid) {
 			"(e1.container_guid = $group->guid OR e2.container_guid = $group->guid)",
 		),
 		'no_results' => elgg_echo('groups:activity:none'),
+
+		// Q: Why not "group/activity"? This is for consistency with the other "activity"
+		// query names, and the query does not return groups, but is a river
+		'query_name' => 'activity/group',
 	));
 
 	$params = array(

--- a/mod/groups/views/default/discussion/group_module.php
+++ b/mod/groups/views/default/discussion/group_module.php
@@ -26,6 +26,7 @@ $options = array(
 	'full_view' => false,
 	'pagination' => false,
 	'no_results' => elgg_echo('discussion:none'),
+	'query_name' => 'group_module/discussion',
 );
 $content = elgg_list_entities($options);
 elgg_pop_context();

--- a/mod/groups/views/default/groups/profile/activity_module.php
+++ b/mod/groups/views/default/groups/profile/activity_module.php
@@ -34,6 +34,7 @@ $content = elgg_list_river(array(
 	'wheres' => array(
 		"(e1.container_guid = $group->guid OR e2.container_guid = $group->guid)",
 	),
+	'query_name' => 'group_module/activity',
 ));
 elgg_pop_context();
 

--- a/mod/groups/views/default/groups/sidebar/featured.php
+++ b/mod/groups/views/default/groups/sidebar/featured.php
@@ -10,6 +10,7 @@ $featured_groups = elgg_get_entities_from_metadata(array(
 	'metadata_value' => 'yes',
 	'type' => 'group',
 	'limit' => 10,
+	'query_name' => 'sidebar/featured_groups',
 ));
 
 if ($featured_groups) {

--- a/mod/groups/views/default/groups/sidebar/members.php
+++ b/mod/groups/views/default/groups/sidebar/members.php
@@ -25,6 +25,7 @@ $body = elgg_list_entities_from_relationship(array(
 	'pagination' => false,
 	'list_type' => 'gallery',
 	'gallery_class' => 'elgg-gallery-users',
+	'query_name' => 'sidebar/group_members',
 ));
 
 $body .= "<div class='center mts'>$all_link</div>";

--- a/mod/members/start.php
+++ b/mod/members/start.php
@@ -43,6 +43,7 @@ function members_list_popular($hook, $type, $returnvalue, $params) {
 	$options = $params['options'];
 	$options['relationship'] = 'friend';
 	$options['inverse_relationship'] = false;
+	$options['query_name'] = 'members/popular';
 	return elgg_list_entities_from_relationship_count($options);
 }
 
@@ -59,6 +60,7 @@ function members_list_newest($hook, $type, $returnvalue, $params) {
 	if ($returnvalue !== null) {
 		return;
 	}
+	$params['options']['query_name'] = 'members/all';
 	return elgg_list_entities($params['options']);
 }
 
@@ -75,6 +77,12 @@ function members_list_online($hook, $type, $returnvalue, $params) {
 	if ($returnvalue !== null) {
 		return;
 	}
+
+	// Due to the design of find_active_users, we can't pass query_name down to
+	// it, but devs can already use the [find_active_users, system] hook to alter
+	// this query.
+	//$params['options']['query_name'] = 'members/online';
+
 	return get_online_users();
 }
 

--- a/mod/messages/pages/messages/inbox.php
+++ b/mod/messages/pages/messages/inbox.php
@@ -31,6 +31,7 @@ $list = elgg_list_entities_from_metadata(array(
 	'metadata_value' => elgg_get_page_owner_guid(),
 	'owner_guid' => elgg_get_page_owner_guid(),
 	'full_view' => false,
+	'query_name' => 'messages/inbox',
 ));
 
 $body_vars = array(

--- a/mod/messages/pages/messages/sent.php
+++ b/mod/messages/pages/messages/sent.php
@@ -31,6 +31,7 @@ $list = elgg_list_entities_from_metadata(array(
 	'metadata_value' => elgg_get_page_owner_guid(),
 	'owner_guid' => elgg_get_page_owner_guid(),
 	'full_view' => false,
+	'query_name' => 'messages/sent',
 ));
 
 $body_vars = array(

--- a/mod/pages/pages/pages/friends.php
+++ b/mod/pages/pages/pages/friends.php
@@ -25,6 +25,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_guid' => $owner->guid,
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo('pages:none'),
+	'query_name' => 'pages/friends',
 ));
 
 $params = array(

--- a/mod/pages/pages/pages/history.php
+++ b/mod/pages/pages/pages/history.php
@@ -35,6 +35,7 @@ $content = elgg_list_annotations(array(
 	'annotation_name' => 'page',
 	'limit' => 20,
 	'order_by' => "n_table.time_created desc",
+	'query_name' => 'pages/history',
 ));
 
 $body = elgg_view_layout('content', array(

--- a/mod/pages/pages/pages/owner.php
+++ b/mod/pages/pages/pages/owner.php
@@ -25,6 +25,7 @@ $content = elgg_list_entities(array(
 	'container_guid' => elgg_get_page_owner_guid(),
 	'full_view' => false,
 	'no_results' => elgg_echo('pages:none'),
+	'query_name' => 'pages/owner',
 ));
 
 $filter_context = '';

--- a/mod/pages/pages/pages/world.php
+++ b/mod/pages/pages/pages/world.php
@@ -17,6 +17,7 @@ $content = elgg_list_entities(array(
 	'subtype' => 'page_top',
 	'full_view' => false,
 	'no_results' => elgg_echo('pages:none'),
+	'query_name' => 'pages/all',
 ));
 
 $body = elgg_view_layout('content', array(

--- a/mod/pages/views/default/pages/group_module.php
+++ b/mod/pages/views/default/pages/group_module.php
@@ -28,6 +28,7 @@ $options = array(
 	'full_view' => false,
 	'pagination' => false,
 	'no_results' => elgg_echo('pages:none'),
+	'query_name' => 'group_module/page',
 );
 $content = elgg_list_entities($options);
 elgg_pop_context();

--- a/mod/pages/views/default/pages/sidebar/history.php
+++ b/mod/pages/views/default/pages/sidebar/history.php
@@ -12,7 +12,8 @@ if ($vars['page']) {
 		'guid' => $vars['page']->guid,
 		'annotation_name' => 'page',
 		'limit' => 20,
-		'reverse_order_by' => true
+		'reverse_order_by' => true,
+		'query_name' => 'sidebar/page_history',
 	);
 	elgg_push_context('widgets');
 	$content = elgg_list_annotations($options);

--- a/mod/thewire/pages/thewire/everyone.php
+++ b/mod/thewire/pages/thewire/everyone.php
@@ -19,6 +19,7 @@ $content .= elgg_list_entities(array(
 	'type' => 'object',
 	'subtype' => 'thewire',
 	'limit' => get_input('limit', 15),
+	'query_name' => 'thewire/all',
 ));
 
 $body = elgg_view_layout('content', array(

--- a/mod/thewire/pages/thewire/friends.php
+++ b/mod/thewire/pages/thewire/friends.php
@@ -27,6 +27,7 @@ $content .= elgg_list_entities_from_relationship(array(
 	'relationship' => 'friend',
 	'relationship_guid' => $owner->guid,
 	'relationship_join_on' => 'container_guid',
+	'query_name' => 'thewire/friends',
 ));
 
 $body = elgg_view_layout('content', array(

--- a/mod/thewire/pages/thewire/owner.php
+++ b/mod/thewire/pages/thewire/owner.php
@@ -27,6 +27,7 @@ $content .= elgg_list_entities(array(
 	'subtype' => 'thewire',
 	'owner_guid' => $owner->guid,
 	'limit' => get_input('limit', 15),
+	'query_name' => 'thewire/owner',
 ));
 
 $body = elgg_view_layout('content', array(

--- a/mod/thewire/pages/thewire/thread.php
+++ b/mod/thewire/pages/thewire/thread.php
@@ -16,6 +16,7 @@ $content = elgg_list_entities_from_metadata(array(
 	"type" => "object",
 	"subtype" => "thewire",
 	"limit" => 20,
+	'query_name' => 'thewire/thread',
 ));
 
 $body = elgg_view_layout('content', array(

--- a/pages/friends/index.php
+++ b/pages/friends/index.php
@@ -20,6 +20,7 @@ $options = array(
 	'order_by' => 'ue.name ASC',
 	'full_view' => false,
 	'no_results' => elgg_echo('friends:none'),
+	'query_name' => 'friends',
 );
 $content = elgg_list_entities_from_relationship($options);
 

--- a/pages/friends/of.php
+++ b/pages/friends/of.php
@@ -20,6 +20,7 @@ $options = array(
 	'order_by' => 'ue.name ASC',
 	'full_view' => false,
 	'no_results' => elgg_echo('friends:none'),
+	'query_name' => 'friendsof',
 );
 $content = elgg_list_entities_from_relationship($options);
 if (!$content) {

--- a/pages/river.php
+++ b/pages/river.php
@@ -26,6 +26,9 @@ switch ($page_type) {
 		$title = elgg_echo('river:mine');
 		$page_filter = 'mine';
 		$options['subject_guid'] = elgg_get_logged_in_user_guid();
+
+		// We use "owner" instead of "mine" for consistency with most other core URLs
+		$options['query_name'] = 'activity/owner';
 		break;
 	case 'owner':
 		$subject_username = get_input('subject_username', '', false);
@@ -37,16 +40,19 @@ switch ($page_type) {
 		$title = elgg_echo('river:owner', array(htmlspecialchars($subject->name, ENT_QUOTES, 'UTF-8', false)));
 		$page_filter = 'subject';
 		$options['subject_guid'] = $subject->guid;
+		$options['query_name'] = 'activity/owner';
 		break;
 	case 'friends':
 		$title = elgg_echo('river:friends');
 		$page_filter = 'friends';
 		$options['relationship_guid'] = elgg_get_logged_in_user_guid();
 		$options['relationship'] = 'friend';
+		$options['query_name'] = 'activity/friends';
 		break;
 	default:
 		$title = elgg_echo('river:all');
 		$page_filter = 'all';
+		$options['query_name'] = 'activity/all';
 		break;
 }
 

--- a/views/default/page/elements/comments_block.php
+++ b/views/default/page/elements/comments_block.php
@@ -62,6 +62,8 @@ if ($subtypes) {
 	}
 }
 
+$options['query_name'] = 'sidebar/comments_block';
+
 $title = elgg_echo('generic_comments:latest');
 $comments = elgg_get_entities($options);
 if ($comments) {


### PR DESCRIPTION
DO NOT MERGE

TODO:
- [ ] Allow handlers to see/change the getter function (e.g. to add a relationship constraint to an ege() call.)
- [ ] Rebase
- [ ] Gather more consensus around this.

After this was put in place we could add names to the prominent public-facing lists/river queries. I'd suggest names prefixed with "elgg:" or "core:". E.g. "elgg:activity/all", "elgg:activity/owner", "elgg:blog/all", etc.

With this in place, one could alter $options arrays simply:

``` php
// set the main activity stream limit to 50
function my_plugin_alter_river($h, $t, $v, $p) {
    $v['limit'] => 50;
    return $v;
}
elgg_register_plugin_hook_handler('river:options', 'elgg:activity/all', 'my_plugin_alter_river');
```

Or you could make reusable queries by putting a full set of options in the hook:

``` php
function my_plugin_fetch_foos($h, $t, $v, $p) {
    return array_merge($v, array(
        'type' => 'object',
        'subtype' => 'foo',
    ));
}
elgg_register_plugin_hook_handler('entities:options', 'my_plugin:foos', 'my_plugin_fetch_foos');

echo elgg_list_entities(array('query_name' => 'my_plugin:foos'));
```
