### PR TITLE
Refs #6142, removes public and logged_in access values from access selec...

### DIFF
--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -29,7 +29,6 @@ elgg.ui.init = function () {
 		elgg.deprecated_notice('Use of .elgg-autofocus is deprecated by html5 autofocus', 1.9);
 	}
 
-	elgg.ui.initAccessInputs();
 };
 
 /**
@@ -362,35 +361,6 @@ elgg.ui.toggleMenuItems = function($menu, nameOfItemToShow, nameOfItemToHide) {
     $menu.find('.elgg-menu-item-' + nameOfItemToHide).addClass('hidden');
 };
 
-/**
- * Initialize input/access for dynamic display of members only warning
- *
- * If a select.elgg-input-access is accompanied by a note (.elgg-input-access-membersonly),
- * then hide the note when the select value is PRIVATE or group members.
- *
- * @return void
- * @since 1.9.0
- */
-elgg.ui.initAccessInputs = function () {
-	$('.elgg-input-access').each(function () {
-		function updateMembersonlyNote() {
-			var val = $select.val();
-			if (val != acl && val != 0) {
-				// .show() failed in Chrome. Maybe a float/jQuery bug
-				$note.css('visibility', 'visible');
-			} else {
-				$note.css('visibility', 'hidden');
-			}
-		}
-		var $select = $(this),
-			acl = $select.data('group-acl'),
-			$note = $('.elgg-input-access-membersonly', this.parentNode);
-		if ($note) {
-			updateMembersonlyNote();
-			$select.change(updateMembersonlyNote);
-		}
-	});
-};
 
 elgg.register_hook_handler('init', 'system', elgg.ui.init);
 elgg.register_hook_handler('init', 'system', elgg.ui.initDatePicker);

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -552,6 +552,10 @@ function groups_write_acl_plugin_hook($hook, $entity_type, $returnvalue, $params
 		if ($page_owner->canWriteToContainer($user_guid)) {
 			$returnvalue[$page_owner->group_acl] = elgg_echo('groups:group') . ': ' . $page_owner->name;
 
+			if ($page_owner->getContentAccessMode() == ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY) {
+				unset($returnvalue[ACCESS_PUBLIC]);
+				unset($returnvalue[ACCESS_LOGGED_IN]);
+			}
 			unset($returnvalue[ACCESS_FRIENDS]);
 		}
 	} else {

--- a/views/default/input/access.php
+++ b/views/default/input/access.php
@@ -26,16 +26,6 @@ $defaults = array(
 $entity = elgg_extract('entity', $vars);
 unset($vars['entity']);
 
-// should we tell users that public/logged-in access levels will be ignored?
-$container = elgg_get_page_owner_entity();
-if (($container instanceof ElggGroup)
-		&& $container->getContentAccessMode() === ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY
-		&& !elgg_in_context('group-edit')
-		&& !($entity && $entity instanceof ElggGroup)) {
-	$show_override_notice = true;
-} else {
-	$show_override_notice = false;
-}
 
 if ($entity) {
 	$defaults['value'] = $entity->access_id;
@@ -48,11 +38,5 @@ if ($vars['value'] == ACCESS_DEFAULT) {
 }
 
 if (is_array($vars['options_values']) && sizeof($vars['options_values']) > 0) {
-	if ($show_override_notice) {
-		$vars['data-group-acl'] = $container->group_acl;
-	}
 	echo elgg_view('input/select', $vars);
-	if ($show_override_notice) {
-		echo "<p class='elgg-text-help'>" . elgg_echo('access:overridenotice')  .  "</p>";
-	}
 }


### PR DESCRIPTION
...tor for members only group content

This does not fixes the whole issue. This pull request only resolves the following requirement: "limit the access levels available in restricted groups to either group only or group only plus private." I'll issue a separate pull request for the rest of requirements.
