### PR TITLE
Adds warnings for uncallable handlers in hooks/events.

### DIFF
--- a/engine/classes/Elgg/Di/DiContainer.php
+++ b/engine/classes/Elgg/Di/DiContainer.php
@@ -54,7 +54,10 @@ class Elgg_Di_DiContainer {
 			throw new Elgg_Di_MissingValueException("Value or factory was not set for: $name");
 		}
 		$value = $this->build($this->factories[$name]['callable'], $name);
-		if ($this->factories[$name]['shared']) {
+
+		// Why check existence of factory here? A: the builder function may have set the value
+		// directly, in which case the factory will no longer exist.
+		if (!empty($this->factories[$name]) && $this->factories[$name]['shared']) {
 			$this->cache[$name] = $value;
 		}
 		return $value;

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -41,8 +41,8 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 		$this->setFactory('amdConfig', array($this, 'getAmdConfig'));
 		$this->setClassName('autoP', 'ElggAutoP');
 		$this->setFactory('db', array($this, 'getDatabase'));
-		$this->setClassName('events', 'Elgg_EventsService');
-		$this->setClassName('hooks', 'Elgg_PluginHooksService');
+		$this->setFactory('events', array($this, 'getEvents'));
+		$this->setFactory('hooks', array($this, 'getHooks'));
 		$this->setFactory('logger', array($this, 'getLogger'));
 		$this->setClassName('metadataCache', 'ElggVolatileMetadataCache');
 		$this->setFactory('queryCounter', array($this, 'getQueryCounter'), false);
@@ -66,13 +66,53 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 	}
 
 	/**
+	 * Events service factory
+	 *
+	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
+	 * @return Elgg_EventsService
+	 */
+	protected function getEvents(Elgg_Di_ServiceProvider $c) {
+		return $this->resolveLoggerDependencies('events');
+	}
+
+	/**
 	 * Logger factory
 	 * 
 	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
 	 * @return Elgg_Logger
 	 */
 	protected function getLogger(Elgg_Di_ServiceProvider $c) {
-		return new Elgg_Logger($c->hooks);
+		return $this->resolveLoggerDependencies('logger');
+	}
+
+	/**
+	 * Plugin hooks service factory
+	 *
+	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
+	 * @return Elgg_PluginHooksService
+	 */
+	protected function getHooks(Elgg_Di_ServiceProvider $c) {
+		return $this->resolveLoggerDependencies('hooks');
+	}
+
+	/**
+	 * Returns the first requested service of the logger, events, and hooks. It sets the
+	 * hooks and events up in the right order to prevent circular dependency.
+	 *
+	 * @param string $service_needed The service requested first
+	 * @return mixed
+	 */
+	protected function resolveLoggerDependencies($service_needed) {
+		$svcs['hooks'] = new Elgg_PluginHooksService();
+		$svcs['logger'] = new Elgg_Logger($svcs['hooks']);
+		$svcs['hooks']->setLogger($svcs['logger']);
+		$svcs['events'] = new Elgg_EventsService();
+		$svcs['events']->setLogger($svcs['logger']);
+
+		foreach ($svcs as $key => $service) {
+			$this->setValue($key, $service);
+		}
+		return $svcs[$service_needed];
 	}
 
 	/**

--- a/engine/classes/Elgg/EventsService.php
+++ b/engine/classes/Elgg/EventsService.php
@@ -42,7 +42,10 @@ class Elgg_EventsService extends Elgg_HooksRegistrationService {
 
 		foreach ($events as $callback) {
 			if (!is_callable($callback)) {
-				// @todo should this produce a warning?
+				if ($this->logger) {
+					$this->logger->warn("handler for event [$event, $type] is not callable: "
+										. $this->describeCallable($callback));
+				}
 				continue;
 			}
 

--- a/engine/classes/Elgg/HooksRegistrationService.php
+++ b/engine/classes/Elgg/HooksRegistrationService.php
@@ -14,6 +14,22 @@
 abstract class Elgg_HooksRegistrationService {
 	
 	private $handlers = array();
+
+	/**
+	 * @var Elgg_Logger
+	 */
+	protected $logger;
+
+	/**
+	 * Set a logger instance, e.g. for reporting uncallable handlers
+	 *
+	 * @param Elgg_Logger $logger The logger
+	 * @return self
+	 */
+	public function setLogger(Elgg_Logger $logger = null) {
+		$this->logger = $logger;
+		return $this;
+	}
 	
 	/**
 	 * Registers a handler.
@@ -129,5 +145,35 @@ abstract class Elgg_HooksRegistrationService {
 		}
 
 		return $handlers;
+	}
+
+	/**
+	 * Get a string description of a callback
+	 *
+	 * E.g. "function_name", "Static::method", "(ClassName)->method", "(Closure path/to/file.php:23)"
+	 *
+	 * @param mixed $callable The callable value to describe
+	 * @return string
+	 */
+	protected function describeCallable($callable) {
+		if (is_string($callable)) {
+			return $callable;
+		}
+		if (is_array($callable) && array_keys($callable) === array(0, 1) && is_string($callable[1])) {
+			if (is_string($callable[0])) {
+				return "{$callable[0]}::{$callable[1]}";
+			}
+			return "(" . get_class($callable[0]) . ")->{$callable[1]}";
+		}
+		if ($callable instanceof Closure) {
+			$ref = new ReflectionFunction($callable);
+			$file = $ref->getFileName();
+			$line = $ref->getStartLine();
+			return "(Closure {$file}:{$line})";
+		}
+		if (is_object($callable)) {
+			return "(" . get_class($callable) . ")->__invoke()";
+		}
+		return "(unknown)";
 	}
 }

--- a/engine/classes/Elgg/Logger.php
+++ b/engine/classes/Elgg/Logger.php
@@ -196,8 +196,8 @@ class Elgg_Logger {
 		}
 
 		if ($display == true) {
-			echo '<pre>';
-			print_r($data);
+			echo '<pre class="elgg-logger-data">';
+			echo htmlspecialchars(print_r($data, true), ENT_QUOTES, 'UTF-8');
 			echo '</pre>';
 		} else {
 			error_log(print_r($data, true));

--- a/engine/classes/Elgg/PluginHooksService.php
+++ b/engine/classes/Elgg/PluginHooksService.php
@@ -23,12 +23,18 @@ class Elgg_PluginHooksService extends Elgg_HooksRegistrationService {
 		$hooks = $this->getOrderedHandlers($hook, $type);
 		
 		foreach ($hooks as $callback) {
-			if (is_callable($callback)) {
-				$args = array($hook, $type, $returnvalue, $params);
-				$temp_return_value = call_user_func_array($callback, $args);
-				if (!is_null($temp_return_value)) {
-					$returnvalue = $temp_return_value;
+			if (!is_callable($callback)) {
+				if ($this->logger) {
+					$this->logger->warn("handler for plugin hook [$hook, $type] is not callable: "
+										. $this->describeCallable($callback));
 				}
+				continue;
+			}
+
+			$args = array($hook, $type, $returnvalue, $params);
+			$temp_return_value = call_user_func_array($callback, $args);
+			if (!is_null($temp_return_value)) {
+				$returnvalue = $temp_return_value;
 			}
 		}
 	

--- a/engine/tests/phpunit/Elgg/EventsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/EventsServiceTest.php
@@ -50,13 +50,22 @@ class Elgg_EventsServiceTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($this->counter, 1);
 	}
 
+	public function testUncallableHandlersAreLogged() {
+		$events = new Elgg_EventsService();
+
+		$loggerMock = $this->getMock('Elgg_Logger', array(), array(), '', false);
+		$events->setLogger($loggerMock);
+		$events->registerHandler('foo', 'bar', array(new stdClass(), 'uncallableMethod'));
+
+		$expectedMsg = 'handler for event [foo, bar] is not callable: (stdClass)->uncallableMethod';
+		$loggerMock->expects($this->once())->method('warn')->with($expectedMsg);
+
+		$events->trigger('foo', 'bar');
+	}
+
 	public function incrementCounter() {
 		$this->counter++;
 		return true;
-	}
-
-	public static function throwInvalidArg() {
-		throw new InvalidArgumentException();
 	}
 
 	public static function returnTrue() {

--- a/engine/tests/phpunit/Elgg/PluginHooksServiceTest.php
+++ b/engine/tests/phpunit/Elgg/PluginHooksServiceTest.php
@@ -22,6 +22,19 @@ class Elgg_PluginHooksServiceTest extends PHPUnit_Framework_TestCase {
 		
 		$this->assertEquals(2, $returnval);
 	}
+
+	public function testUncallableHandlersAreLogged() {
+		$hooks = new Elgg_PluginHooksService();
+
+		$loggerMock = $this->getMock('Elgg_Logger', array(), array(), '', false);
+		$hooks->setLogger($loggerMock);
+		$hooks->registerHandler('foo', 'bar', array(new stdClass(), 'uncallableMethod'));
+
+		$expectedMsg = 'handler for plugin hook [foo, bar] is not callable: (stdClass)->uncallableMethod';
+		$loggerMock->expects($this->once())->method('warn')->with($expectedMsg);
+
+		$hooks->trigger('foo', 'bar');
+	}
 	
 	public static function returnTwo() {
 		return 2;


### PR DESCRIPTION
Adds units for the warnings.
Injects logger into events/hooks services.
Ensures logger, events, and hooks are setup in right order in service provider.
Fixes small bug in DI container.
