### PR TITLE
Fixes #6142, group content accessibility can only be set at group creation time (non-editable property)

### DIFF
--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -29,7 +29,6 @@ elgg.ui.init = function () {
 		elgg.deprecated_notice('Use of .elgg-autofocus is deprecated by html5 autofocus', 1.9);
 	}
 
-	elgg.ui.initAccessInputs();
 };
 
 /**
@@ -362,35 +361,6 @@ elgg.ui.toggleMenuItems = function($menu, nameOfItemToShow, nameOfItemToHide) {
     $menu.find('.elgg-menu-item-' + nameOfItemToHide).addClass('hidden');
 };
 
-/**
- * Initialize input/access for dynamic display of members only warning
- *
- * If a select.elgg-input-access is accompanied by a note (.elgg-input-access-membersonly),
- * then hide the note when the select value is PRIVATE or group members.
- *
- * @return void
- * @since 1.9.0
- */
-elgg.ui.initAccessInputs = function () {
-	$('.elgg-input-access').each(function () {
-		function updateMembersonlyNote() {
-			var val = $select.val();
-			if (val != acl && val != 0) {
-				// .show() failed in Chrome. Maybe a float/jQuery bug
-				$note.css('visibility', 'visible');
-			} else {
-				$note.css('visibility', 'hidden');
-			}
-		}
-		var $select = $(this),
-			acl = $select.data('group-acl'),
-			$note = $('.elgg-input-access-membersonly', this.parentNode);
-		if ($note) {
-			updateMembersonlyNote();
-			$select.change(updateMembersonlyNote);
-		}
-	});
-};
 
 elgg.register_hook_handler('init', 'system', elgg.ui.init);
 elgg.register_hook_handler('init', 'system', elgg.ui.initDatePicker);

--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -93,7 +93,7 @@ if ($tool_options) {
 $is_public_membership = (get_input('membership') == ACCESS_PUBLIC);
 $group->membership = $is_public_membership ? ACCESS_PUBLIC : ACCESS_PRIVATE;
 
-$group->setContentAccessMode(get_input('content_access_mode'));
+$group->setContentAccessMode(get_input('content_access_mode', $group->getContentAccessMode()));
 
 if ($is_new_group) {
 	$group->access_id = ACCESS_PUBLIC;

--- a/mod/groups/languages/en.php
+++ b/mod/groups/languages/en.php
@@ -44,6 +44,7 @@ return array(
 	'groups:content_access_mode' => "Accessibility of group content",
 	'groups:content_access_mode:unrestricted' => "Unrestricted - Access depends on content-level settings",
 	'groups:content_access_mode:membersonly' => "Members Only - Non-members can never access group content",
+	'groups:content_access_mode:info' => "Please consider carefully the group content accessibility type. You won't be able to modify this setting later.",
 	'groups:access' => "Access permissions",
 	'groups:owner' => "Owner",
 	'groups:owner:warning' => "Warning: if you change this value, you will no longer be the owner of this group.",

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -552,6 +552,10 @@ function groups_write_acl_plugin_hook($hook, $entity_type, $returnvalue, $params
 		if ($page_owner->canWriteToContainer($user_guid)) {
 			$returnvalue[$page_owner->group_acl] = elgg_echo('groups:group') . ': ' . $page_owner->name;
 
+			if ($page_owner->getContentAccessMode() == ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY) {
+				unset($returnvalue[ACCESS_PUBLIC]);
+				unset($returnvalue[ACCESS_LOGGED_IN]);
+			}
 			unset($returnvalue[ACCESS_FRIENDS]);
 		}
 	} else {

--- a/mod/groups/views/default/forms/groups/edit.php
+++ b/mod/groups/views/default/forms/groups/edit.php
@@ -74,6 +74,7 @@ foreach ((array)$group_profile_fields as $shortname => $valtype) {
 	</label>
 </div>
 
+<?php if (!$entity) : ?>
 <div>
 	<label>
 		<?php echo elgg_echo('groups:content_access_mode'); ?><br />
@@ -86,8 +87,10 @@ foreach ((array)$group_profile_fields as $shortname => $valtype) {
 			),
 		));
 		?>
+		<p class="elgg-text-help"><?php echo elgg_echo('groups:content_access_mode:info'); ?></p>
 	</label>
 </div>
+<?php endif; ?>
 	
 <?php
 

--- a/views/default/input/access.php
+++ b/views/default/input/access.php
@@ -26,16 +26,6 @@ $defaults = array(
 $entity = elgg_extract('entity', $vars);
 unset($vars['entity']);
 
-// should we tell users that public/logged-in access levels will be ignored?
-$container = elgg_get_page_owner_entity();
-if (($container instanceof ElggGroup)
-		&& $container->getContentAccessMode() === ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY
-		&& !elgg_in_context('group-edit')
-		&& !($entity && $entity instanceof ElggGroup)) {
-	$show_override_notice = true;
-} else {
-	$show_override_notice = false;
-}
 
 if ($entity) {
 	$defaults['value'] = $entity->access_id;
@@ -48,11 +38,5 @@ if ($vars['value'] == ACCESS_DEFAULT) {
 }
 
 if (is_array($vars['options_values']) && sizeof($vars['options_values']) > 0) {
-	if ($show_override_notice) {
-		$vars['data-group-acl'] = $container->group_acl;
-	}
 	echo elgg_view('input/select', $vars);
-	if ($show_override_notice) {
-		echo "<p class='elgg-text-help'>" . elgg_echo('access:overridenotice')  .  "</p>";
-	}
 }


### PR DESCRIPTION
This changeset implements the following requirements from @cash's checklist:
- limit the access levels available in restricted groups to group only plus private
- don't allow changing the restricted access setting for a group - it is a one time decision when creating the group
