### PR TITLE
Fixes #6142, adds update operation for group content when changing group content accessibility from 'unrestricted' to 'group only'

### DIFF
--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -29,7 +29,6 @@ elgg.ui.init = function () {
 		elgg.deprecated_notice('Use of .elgg-autofocus is deprecated by html5 autofocus', 1.9);
 	}
 
-	elgg.ui.initAccessInputs();
 };
 
 /**
@@ -362,35 +361,6 @@ elgg.ui.toggleMenuItems = function($menu, nameOfItemToShow, nameOfItemToHide) {
     $menu.find('.elgg-menu-item-' + nameOfItemToHide).addClass('hidden');
 };
 
-/**
- * Initialize input/access for dynamic display of members only warning
- *
- * If a select.elgg-input-access is accompanied by a note (.elgg-input-access-membersonly),
- * then hide the note when the select value is PRIVATE or group members.
- *
- * @return void
- * @since 1.9.0
- */
-elgg.ui.initAccessInputs = function () {
-	$('.elgg-input-access').each(function () {
-		function updateMembersonlyNote() {
-			var val = $select.val();
-			if (val != acl && val != 0) {
-				// .show() failed in Chrome. Maybe a float/jQuery bug
-				$note.css('visibility', 'visible');
-			} else {
-				$note.css('visibility', 'hidden');
-			}
-		}
-		var $select = $(this),
-			acl = $select.data('group-acl'),
-			$note = $('.elgg-input-access-membersonly', this.parentNode);
-		if ($note) {
-			updateMembersonlyNote();
-			$select.change(updateMembersonlyNote);
-		}
-	});
-};
 
 elgg.register_hook_handler('init', 'system', elgg.ui.init);
 elgg.register_hook_handler('init', 'system', elgg.ui.initDatePicker);

--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -93,6 +93,14 @@ if ($tool_options) {
 $is_public_membership = (get_input('membership') == ACCESS_PUBLIC);
 $group->membership = $is_public_membership ? ACCESS_PUBLIC : ACCESS_PRIVATE;
 
+// Check if we need to update existing group content visibility to a more restrictive access (group only)
+$new_access_mode = get_input('content_access_mode');
+if (($new_access_mode === ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY) && 
+	($group->getContentAccessMode() === ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED) && 
+	(get_input('content_access_update_all', null) == 1)) {
+	elgg_load_library('elgg:groups');
+	groups_update_content_access($group);
+}
 $group->setContentAccessMode(get_input('content_access_mode'));
 
 if ($is_new_group) {

--- a/mod/groups/languages/en.php
+++ b/mod/groups/languages/en.php
@@ -44,6 +44,12 @@ return array(
 	'groups:content_access_mode' => "Accessibility of group content",
 	'groups:content_access_mode:unrestricted' => "Unrestricted - Access depends on content-level settings",
 	'groups:content_access_mode:membersonly' => "Members Only - Non-members can never access group content",
+	'groups:content_access_mode:change:legend' => 'Additional settings for group content',
+	'groups:content_access_mode:change:checkbox' => 'Update existing content access to new policy',
+	'groups:content_access_mode:change:info' => 'Checking this option will modify all previously created "public" or "logged in" group content\'s visibility to members of this group only. Previous group content declared as "private" will not be modified.<br/>
+Unchecking this box will leave all existing content within this group as they are, subsequently created content visibility however will be restricted to "private" or "group only".<br />
+NOTICE: If you leave the box checked, the update operation may take longer than usual. Please do not navigate away or close your browser tab until the page reloads.			
+			',
 	'groups:access' => "Access permissions",
 	'groups:owner' => "Owner",
 	'groups:owner:warning' => "Warning: if you change this value, you will no longer be the owner of this group.",

--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -572,3 +572,114 @@ function groups_prepare_form_vars($group = null) {
 
 	return $values;
 }
+
+/**
+ * Updates group content access ids when changing a group's content accessibility from "unrestricted to "group only".
+ * The function will descend into container hierarchy and update access ids for all nested content as well.
+ * Access updates will be performed on entities, metadata, annotations and river entries.
+ *
+ * @param ElggGroup $group The group entity to change all contained entities' access
+ * @param string $user The user entity to perform the update operation
+ * @return boolean true upon successful operation, false otherwise
+ */
+function groups_update_content_access($group, $user = null) {
+	// Perform some basic sanity checks
+	if (!elgg_instanceof($group, 'group')) {
+		return false;
+	}
+
+	if (!elgg_instanceof($user, 'user')) {
+		$user = elgg_get_logged_in_user_entity();
+	}
+
+	if (!($group->canWriteToContainer($user->guid))) {
+		return false;
+	}
+
+	// Prevent timeouts due to long update operations
+	ini_set('max_execution_time', 0);
+
+	// Grant privileges for changing access_id of any group contained entity
+	$access = elgg_set_ignore_access(true);
+
+	// Start with the target groups as container
+	$container_guids = array($group->guid);
+	$target_access_id = $group->group_acl;
+	$change_access_ids = array(ACCESS_PUBLIC, ACCESS_LOGGED_IN);
+	$change_access_ids_str = implode(', ', $change_access_ids);
+	$dbprefix = elgg_get_config('dbprefix');
+	$entity_chunk_size = 100; // Number of entity guids to process at a single SQL statement
+
+	while (!empty($container_guids)) {
+
+		// Get all entities' guids contained by the current container
+		$container_guids_str = implode(',', $container_guids);
+		$guid_query = "SELECT guid FROM {$dbprefix}entities WHERE container_guid IN ({$container_guids_str})";
+		$guid_results = get_data($guid_query);
+
+		if (is_array($guid_results) && !empty($guid_results)) {
+
+			// Get all contained entity guids and use them as a comma separated string for update statements
+			$entity_guids = array();
+			foreach ($guid_results as $guid_obj) {
+				$entity_guids[] = $guid_obj->guid;
+			}
+			$entity_guids_str = implode(',', $entity_guids);
+
+			// Update entity access ids
+			// Allow 3rd party plugins to modify the list of guids before executing the actual update statement
+			elgg_trigger_plugin_hook('group_access_update', 'entity', array(), $entity_guids);
+			// Use chunks to prevent errors raised by too long SQL commands
+			$entity_guids_chunks = array_chunk($entity_guids, $entity_chunk_size);
+			foreach ($entity_guids_chunks as $entity_guids_chunk) {
+				$entity_guids_str = implode(',', $entity_guids_chunk);
+				$update_statement = "UPDATE {$dbprefix}entities SET access_id = {$target_access_id} WHERE
+				(access_id IN ({$change_access_ids_str}) AND guid IN ({$entity_guids_str}))";
+				
+				update_data($update_statement);
+			}
+
+			// Update metadata access ids
+			elgg_trigger_plugin_hook('group_access_update', 'metadata', array(), $entity_guids);
+			$entity_guids_chunks = array_chunk($entity_guids, $entity_chunk_size);
+			foreach ($entity_guids_chunks as $entity_guids_chunk) {
+				$entity_guids_str = implode(',', $entity_guids_chunk);
+				$update_statement = "UPDATE {$dbprefix}metadata SET access_id = {$target_access_id} WHERE
+				(access_id IN ({$change_access_ids_str}) AND entity_guid IN ({$entity_guids_str}))";
+				
+				update_data($update_statement);
+			}
+
+			// Update annotation access ids
+			elgg_trigger_plugin_hook('group_access_update', 'annotation', array(), $entity_guids);
+			$entity_guids_chunks = array_chunk($entity_guids, $entity_chunk_size);
+			foreach ($entity_guids_chunks as $entity_guids_chunk) {
+				$entity_guids_str = implode(',', $entity_guids_chunk);
+				$update_statement = "UPDATE {$dbprefix}annotations SET access_id = {$target_access_id} WHERE
+				(access_id IN ({$change_access_ids_str}) AND entity_guid IN ({$entity_guids_str}))";
+				
+				update_data($update_statement);
+			}
+
+			// Update river access ids
+			elgg_trigger_plugin_hook('group_access_update', 'river', array(), $entity_guids);
+			$entity_guids_chunks = array_chunk($entity_guids, $entity_chunk_size);
+			foreach ($entity_guids_chunks as $entity_guids_chunk) {
+				$entity_guids_str = implode(',', $entity_guids_chunk);
+				$update_statement = "UPDATE {$dbprefix}river SET access_id = {$target_access_id} WHERE
+				(access_id IN ({$change_access_ids_str}) AND object_guid IN ({$entity_guids_str}))";
+				
+				update_data($update_statement);
+			}
+
+		} else {
+			$entity_guids = array();
+		}
+
+			// Descend one level in container hierarchy - use the previously updated entities as containers for the next round
+		$container_guids = $entity_guids;
+	}
+
+	elgg_set_ignore_access($access);
+	return true;
+}

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -552,6 +552,10 @@ function groups_write_acl_plugin_hook($hook, $entity_type, $returnvalue, $params
 		if ($page_owner->canWriteToContainer($user_guid)) {
 			$returnvalue[$page_owner->group_acl] = elgg_echo('groups:group') . ': ' . $page_owner->name;
 
+			if ($page_owner->getContentAccessMode() == ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY) {
+				unset($returnvalue[ACCESS_PUBLIC]);
+				unset($returnvalue[ACCESS_LOGGED_IN]);
+			}
 			unset($returnvalue[ACCESS_FRIENDS]);
 		}
 	} else {

--- a/mod/groups/views/default/forms/groups/edit.php
+++ b/mod/groups/views/default/forms/groups/edit.php
@@ -88,6 +88,22 @@ foreach ((array)$group_profile_fields as $shortname => $valtype) {
 		?>
 	</label>
 </div>
+
+<?php if ($entity && ($entity->getContentAccessMode() == ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED)) : ?>
+<fieldset class="hidden group_access_mode_change">
+	<legend><?php echo elgg_echo('groups:content_access_mode:change:legend'); ?></legend>
+	<label>
+		<?php echo elgg_view('input/checkbox', array(
+			'name' => 'content_access_update_all',
+			'value' => 1,
+			'checked' => 'checked'
+		));
+		?>
+		<?php echo elgg_echo('groups:content_access_mode:change:checkbox'); ?>
+	</label>
+	<p class="elgg-text-help"><?php echo elgg_echo('groups:content_access_mode:change:info'); ?></p>
+</div>
+<?php endif; ?>
 	
 <?php
 

--- a/mod/groups/views/default/groups/css.php
+++ b/mod/groups/views/default/groups/css.php
@@ -63,3 +63,17 @@
 	background-color: #4690D6;
 	color: white;
 }
+
+fieldset.group_access_mode_change {
+	padding: 5px 5px 10px;
+    margin: 0px 0px 15px 10px;
+    border: 1px solid;
+    border-radius 5px;
+}
+
+fieldset.group_access_mode_change > legend {
+	color: #333333;
+	font-size: 110%;
+	font-weight: bold;
+	padding: 0 3px;
+}

--- a/mod/groups/views/default/groups/js.php
+++ b/mod/groups/views/default/groups/js.php
@@ -10,6 +10,15 @@
 elgg.register_hook_handler('init', 'system', function() {
 	// jQuery uses 0-based indexing
 	$('#groups-tools').children('li:even').addClass('odd');
+	
+	// Show/hide additional option for group content accessibility on group edit pages
+	$('select[name="content_access_mode"]').change(function() {
+		if ($(this).val() == 'members_only') {
+			$('fieldset.group_access_mode_change').show();
+		} else {
+			$('fieldset.group_access_mode_change').hide();
+		}
+	});
 });
 
 elgg.ui.registerTogglableMenuItems('feature', 'unfeature');

--- a/views/default/input/access.php
+++ b/views/default/input/access.php
@@ -26,16 +26,6 @@ $defaults = array(
 $entity = elgg_extract('entity', $vars);
 unset($vars['entity']);
 
-// should we tell users that public/logged-in access levels will be ignored?
-$container = elgg_get_page_owner_entity();
-if (($container instanceof ElggGroup)
-		&& $container->getContentAccessMode() === ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY
-		&& !elgg_in_context('group-edit')
-		&& !($entity && $entity instanceof ElggGroup)) {
-	$show_override_notice = true;
-} else {
-	$show_override_notice = false;
-}
 
 if ($entity) {
 	$defaults['value'] = $entity->access_id;
@@ -48,11 +38,5 @@ if ($vars['value'] == ACCESS_DEFAULT) {
 }
 
 if (is_array($vars['options_values']) && sizeof($vars['options_values']) > 0) {
-	if ($show_override_notice) {
-		$vars['data-group-acl'] = $container->group_acl;
-	}
 	echo elgg_view('input/select', $vars);
-	if ($show_override_notice) {
-		echo "<p class='elgg-text-help'>" . elgg_echo('access:overridenotice')  .  "</p>";
-	}
 }


### PR DESCRIPTION
This changeset implements the following requirements from @cash's checklist:
- limit the access levels available in restricted groups to group only plus private

The options for changing the restricted access setting for a group include:
- don't change old content - make that explicit in the help text
- rewrite all the old access information for group content when becoming more restrictive but not the other way

Note: group administrators, when changing content access settings, can decide (via a checkbox) if they'd like to update the access level of existing group content, or leave previous content as they are.
