### PR TITLE
Makes sure all group pages respect the limited_groups setting

### DIFF
--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -55,7 +55,7 @@ function groups_handle_all_page() {
 	}
 
 	$filter = elgg_view('groups/group_sort_menu', array('selected' => $selected_tab));
-	
+
 	$sidebar = elgg_view('groups/sidebar/find');
 	$sidebar .= elgg_view('groups/sidebar/featured');
 
@@ -115,7 +115,9 @@ function groups_handle_owned_page() {
 	}
 	elgg_push_breadcrumb($title);
 
-	elgg_register_title_button();
+	if (elgg_get_plugin_setting('limited_groups', 'groups') != 'yes' || elgg_is_admin_logged_in()) {
+		elgg_register_title_button();
+	}
 
 	$content = elgg_list_entities(array(
 		'type' => 'group',
@@ -150,7 +152,9 @@ function groups_handle_mine_page() {
 	}
 	elgg_push_breadcrumb($title);
 
-	elgg_register_title_button();
+	if (elgg_get_plugin_setting('limited_groups', 'groups') != 'yes' || elgg_is_admin_logged_in()) {
+		elgg_register_title_button();
+	}
 
 	$content = elgg_list_entities_from_relationship(array(
 		'type' => 'group',
@@ -181,7 +185,7 @@ function groups_handle_mine_page() {
  */
 function groups_handle_edit_page($page, $guid = 0) {
 	gatekeeper();
-	
+
 	if ($page == 'add') {
 		elgg_set_page_owner_guid(elgg_get_logged_in_user_guid());
 		$title = elgg_echo('groups:add');
@@ -204,7 +208,7 @@ function groups_handle_edit_page($page, $guid = 0) {
 			$content = elgg_echo('groups:noaccess');
 		}
 	}
-	
+
 	$params = array(
 		'content' => $content,
 		'title' => $title,
@@ -266,7 +270,7 @@ function groups_handle_profile_page($guid) {
 	$content = elgg_view('groups/profile/layout', array('entity' => $group));
 	$sidebar = '';
 
-	if (group_gatekeeper(false)) {	
+	if (group_gatekeeper(false)) {
 		if (elgg_is_active_plugin('search')) {
 			$sidebar .= elgg_view('groups/sidebar/search', array('entity' => $group));
 		}
@@ -275,18 +279,18 @@ function groups_handle_profile_page($guid) {
 		$subscribed = false;
 		if (elgg_is_active_plugin('notifications')) {
 			global $NOTIFICATION_HANDLERS;
-			
+
 			foreach ($NOTIFICATION_HANDLERS as $method => $foo) {
 				$relationship = check_entity_relationship(elgg_get_logged_in_user_guid(),
 						'notify' . $method, $guid);
-				
+
 				if ($relationship) {
 					$subscribed = true;
 					break;
 				}
 			}
 		}
-		
+
 		$sidebar .= elgg_view('groups/sidebar/my_status', array(
 			'entity' => $group,
 			'subscribed' => $subscribed
@@ -334,7 +338,7 @@ function groups_handle_activity_page($guid) {
 	if (!$content) {
 		$content = '<p>' . elgg_echo('groups:activity:none') . '</p>';
 	}
-	
+
 	$params = array(
 		'content' => $content,
 		'title' => $title,
@@ -427,7 +431,7 @@ function groups_handle_invite_page($guid) {
 
 /**
  * Manage requests to join a group
- * 
+ *
  * @param int $guid Group entity GUID
  */
 function groups_handle_requests_page($guid) {
@@ -443,7 +447,7 @@ function groups_handle_requests_page($guid) {
 	if ($group && $group->canEdit()) {
 		elgg_push_breadcrumb($group->name, $group->getURL());
 		elgg_push_breadcrumb($title);
-		
+
 		$requests = elgg_get_entities_from_relationship(array(
 			'type' => 'user',
 			'relationship' => 'membership_request',


### PR DESCRIPTION
Now the title button gets hidden correctly from regular users on groups/owner and groups/member pages if group creation has been limited to admins.
