### PR TITLE
Alphabetize friends/friends-of, group notifications, group owned/member lists

### DIFF
--- a/engine/lib/access.php
+++ b/engine/lib/access.php
@@ -826,7 +826,8 @@ function get_user_access_collections($owner_guid, $site_guid = 0) {
 
 	$query = "SELECT * FROM {$CONFIG->dbprefix}access_collections
 			WHERE owner_guid = {$owner_guid}
-			AND site_guid = {$site_guid}";
+			AND site_guid = {$site_guid}
+			ORDER BY name ASC";
 
 	$collections = get_data($query);
 

--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -109,9 +109,12 @@ function groups_handle_owned_page() {
 
 	elgg_register_title_button();
 
+	$dbprefix = elgg_get_config('dbprefix');
 	$content = elgg_list_entities(array(
 		'type' => 'group',
 		'owner_guid' => elgg_get_page_owner_guid(),
+		'joins' => array("JOIN {$dbprefix}groups_entity ge ON e.guid = ge.guid"),
+		'order_by' => 'ge.name ASC',
 		'full_view' => false,
 		'no_results' => elgg_echo('groups:none'),
 	));

--- a/mod/notifications/groups.php
+++ b/mod/notifications/groups.php
@@ -22,13 +22,13 @@ $title = elgg_echo('notifications:subscriptions:changesettings:groups');
 elgg_push_breadcrumb(elgg_echo('settings'), "settings/user/$user->username");
 elgg_push_breadcrumb($title);
 
-// Get the form
-$people = array();
-
+$dbprefix = elgg_get_config('dbprefix');
 $groupmemberships = elgg_get_entities_from_relationship(array(
 	'relationship' => 'member',
 	'relationship_guid' => $user->guid,
 	'type' => 'group',
+	'joins' => array("JOIN {$dbprefix}groups_entity ge ON e.guid = ge.guid"),
+	'order_by' => 'ge.name ASC',
 	'limit' => false,
 ));
 

--- a/pages/friends/index.php
+++ b/pages/friends/index.php
@@ -10,11 +10,14 @@ $owner = elgg_get_page_owner_entity();
 
 $title = elgg_echo("friends:owned", array($owner->name));
 
+$dbprefix = elgg_get_config('dbprefix');
 $options = array(
 	'relationship' => 'friend',
 	'relationship_guid' => $owner->getGUID(),
 	'inverse_relationship' => false,
 	'type' => 'user',
+	'joins' => array("JOIN {$dbprefix}users_entity ue ON e.guid = ue.guid"),
+	'order_by' => 'ue.name ASC',
 	'full_view' => false,
 	'no_results' => elgg_echo('friends:none'),
 );

--- a/pages/friends/of.php
+++ b/pages/friends/of.php
@@ -10,11 +10,14 @@ $owner = elgg_get_page_owner_entity();
 
 $title = elgg_echo("friends:of:owned", array($owner->name));
 
+$dbprefix = elgg_get_config('dbprefix');
 $options = array(
 	'relationship' => 'friend',
 	'relationship_guid' => $owner->getGUID(),
 	'inverse_relationship' => true,
 	'type' => 'user',
+	'joins' => array("JOIN {$dbprefix}users_entity ue ON e.guid = ue.guid"),
+	'order_by' => 'ue.name ASC',
 	'full_view' => false,
 	'no_results' => elgg_echo('friends:none'),
 );


### PR DESCRIPTION
Some lists ordered by time_created doesn't make any sense for the user.  Sort these alphabetically instead.
