### PR TITLE
Update start.php

### DIFF
--- a/mod/htmlawed/start.php
+++ b/mod/htmlawed/start.php
@@ -45,6 +45,7 @@ function htmlawed_filter_tags($hook, $type, $result, $params) {
 	$htmlawed_config = array(
 		// seems to handle about everything we need.
 		'safe' => true,
+		'comment'=> 1,
 		'deny_attribute' => 'class, on*',
 		'hook_tag' => 'htmlawed_tag_post_processor',
 


### PR DESCRIPTION
Remove HTML comments from source input. Default settings will include HTML comments in content as text (which is user unfriendly and a bit stupid)
