### PR TITLE
Fixes #6312, Makes content_access_mode field sticky

### DIFF
--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -149,7 +149,7 @@ function groups_handle_mine_page() {
 	if (elgg_get_plugin_setting('limited_groups', 'groups') != 'yes' || elgg_is_admin_logged_in()) {
 		elgg_register_title_button();
 	}
-	
+
 	$dbprefix = elgg_get_config('dbprefix');
 
 	$content = elgg_list_entities_from_relationship(array(
@@ -529,7 +529,9 @@ function groups_prepare_form_vars($group = null) {
 		'membership' => ACCESS_PUBLIC,
 		'vis' => ACCESS_PUBLIC,
 		'guid' => null,
-		'entity' => null
+		'entity' => null,
+		'owner_guid' => elgg_get_logged_in_user_guid(),
+		'content_access_mode' => ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED
 	);
 
 	// handle customizable profile fields
@@ -564,6 +566,10 @@ function groups_prepare_form_vars($group = null) {
 		} else {
 			$values['vis'] = $group->access_id;
 		}
+
+		// The content_access_mode was introduced in 1.9. This method must be
+		// used for backwards compatibility with groups created before 1.9.
+		$values['content_access_mode'] = $group->getContentAccessMode();
 
 		$values['entity'] = $group;
 	}

--- a/mod/groups/views/default/groups/edit/access.php
+++ b/mod/groups/views/default/groups/edit/access.php
@@ -12,13 +12,8 @@
 $entity = elgg_extract("entity", $vars, false);
 $membership = elgg_extract("membership", $vars);
 $visibility = elgg_extract("vis", $vars);
-
-if ($entity) {
-	$owner_guid = $entity->getOwnerGUID();
-	$content_access_mode = $entity->getContentAccessMode();
-} else {
-	$content_access_mode = ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED;
-}
+$owner_guid = elgg_extract("owner_guid", $vars);
+$content_access_mode = elgg_extract("content_access_mode", $vars);
 
 ?>
 <div>
@@ -50,7 +45,7 @@ if ($entity) {
 		?>
 	</label>
 </div>
-	
+
 <?php
 
 if (elgg_get_plugin_setting("hidden_groups", "groups") == "yes") {


### PR DESCRIPTION
Value of group content_access_mode field is now correctly retrieved from sticky form cache after user has been sent back to the form because of failed form validation.
