### PR TITLE
Disallow creating unrestricted content inside a restricted group

### DIFF
--- a/mod/groups/languages/en.php
+++ b/mod/groups/languages/en.php
@@ -44,6 +44,7 @@ return array(
 	'groups:content_access_mode' => "Accessibility of group content",
 	'groups:content_access_mode:unrestricted' => "Unrestricted - Access depends on content-level settings",
 	'groups:content_access_mode:membersonly' => "Members Only - Non-members can never access group content",
+	'groups:content_access_mode:error' => 'The access policy of this group disallows using "%s" as content access. Please provide a value that allows only group members to access the content.',
 	'groups:access' => "Access permissions",
 	'groups:owner' => "Owner",
 	'groups:owner:warning' => "Warning: if you change this value, you will no longer be the owner of this group.",


### PR DESCRIPTION
Refs #6142. Makes sure that the access_id is acceptable when creating content inside a group that is using the members_only policy for group content.
