### PR TITLE
WIP: Separates URL normalization from validation

### DIFF
--- a/actions/admin/site/update_advanced.php
+++ b/actions/admin/site/update_advanced.php
@@ -14,7 +14,13 @@ if ($site = elgg_get_site_entity()) {
 		throw new InstallationException(elgg_echo('InvalidParameterException:NonElggSite'));
 	}
 
-	$site->url = rtrim(get_input('wwwroot', '', false), '/') . '/';
+	// validate URL
+	$wwwroot = rtrim(get_input('wwwroot', '', false), '/') . '/';
+	if (!_elgg_validate_url($wwwroot)) {
+		register_error(elgg_echo('admin:configuration:site_url'));
+		forward(REFERER);
+	}
+	$site->url = $wwwroot;
 
 	datalist_set('path', sanitise_filepath(get_input('path', '', false)));
 	$dataroot = sanitise_filepath(get_input('dataroot', '', false));

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -208,54 +208,49 @@ function elgg_clean_vars(array $vars = array()) {
 }
 
 /**
- * Converts shorthand urls to absolute urls.
+ * Makes routing URLs absolute and prepends "http://" to URL that start
+ * with a hostname. No validation is performed.
  *
- * If the url is already absolute or protocol-relative, no change is made.
+ * No change is made if the URL begins with a scheme, is scheme-relative, or contains
+ * only a query string or fragment.
+ *
+ * In the special case that a PHP filename is given, it is assumed to be located
+ * at the root of the Elgg install. E.g. "install.php"
+ *
+ * Note that URLs starting with hostnames without a period (e.g. "localhost/foo")
+ * will not be recognized, and will be misinterpreted as a path.
  *
  * @example
- * elgg_normalize_url('');                   // 'http://my.site.com/'
- * elgg_normalize_url('dashboard');          // 'http://my.site.com/dashboard'
- * elgg_normalize_url('http://google.com/'); // no change
- * elgg_normalize_url('//google.com/');      // no change
+ * elgg_normalize_url('');                     // 'http://my.site.com/'
+ * elgg_normalize_url('dashboard');            // 'http://my.site.com/dashboard'
+ * elgg_normalize_url('example.com/path');     // 'http://example.com/path'
+ * elgg_normalize_url('example.php?query');    // 'http://my.site.com/example.php?query'
+ * elgg_normalize_url('http://google.com/');   // no change
+ * elgg_normalize_url('any-scheme:foo');       // no change
+ * elgg_normalize_url('//google.com/');        // no change
+ * elgg_normalize_url('?query');               // no change
+ * elgg_normalize_url('#fragment');            // no change
+ * elgg_normalize_url('javascript:...');       // no change
+ * elgg_normalize_url('mailto:...');           // no change
+ * elgg_normalize_url('localhost/path');       // 'http://my.site.com/localhost/path'
  *
  * @param string $url The URL to normalize
  *
- * @return string The absolute url
+ * @return string The normalized URL
  */
 function elgg_normalize_url($url) {
-	// see https://bugs.php.net/bug.php?id=51192
-	// from the bookmarks save action.
-	$php_5_2_13_and_below = version_compare(PHP_VERSION, '5.2.14', '<');
-	$php_5_3_0_to_5_3_2 = version_compare(PHP_VERSION, '5.3.0', '>=') &&
-			version_compare(PHP_VERSION, '5.3.3', '<');
-
-	if ($php_5_2_13_and_below || $php_5_3_0_to_5_3_2) {
-		$tmp_address = str_replace("-", "", $url);
-		$validated = filter_var($tmp_address, FILTER_VALIDATE_URL);
-	} else {
-		$validated = filter_var($url, FILTER_VALIDATE_URL);
-	}
-
-	// work around for handling absoluate IRIs (RFC 3987) - see #4190
-	if (!$validated && (strpos($url, 'http:') === 0) || (strpos($url, 'https:') === 0)) {
-		$validated = true;
-	}
-
-	if ($validated) {
-		// all normal URLs including mailto:
+	if (preg_match("#^[a-z0-9][a-z0-9\-\.]*\:#i", $url)) {
+		// starts with any scheme:
+		// http://en.wikipedia.org/wiki/URI_scheme#Examples
 		return $url;
 
-	} elseif (preg_match("#^(\#|\?|//)#i", $url)) {
-		// '//example.com' (Shortcut for protocol.)
-		// '?query=test', #target
-		return $url;
-	
-	} elseif (stripos($url, 'javascript:') === 0 || stripos($url, 'mailto:') === 0) {
-		// 'javascript:' and 'mailto:'
-		// Not covered in FILTER_VALIDATE_URL
+	} elseif (preg_match("#^(\#|\?|//)#", $url)) {
+		// '#target'
+		// '//example.com' (Scheme-relative URL)
+		// '?query=test'
 		return $url;
 
-	} elseif (preg_match("#^[^/]*\.php(\?.*)?$#i", $url)) {
+	} elseif (preg_match("#^[^/]*\.php([\?\#].*)?$#", $url)) {
 		// 'install.php', 'install.php?step=step'
 		return elgg_get_site_url() . $url;
 
@@ -270,6 +265,36 @@ function elgg_normalize_url($url) {
 		// with a trailing /
 		return elgg_get_site_url() . ltrim($url, '/');
 	}
+}
+
+/**
+ * Validate a URL using PHP's validator with a few modifications
+ *
+ * @param string $url       The URL to validate
+ * @param bool   $only_http Only accept URLs beginning with "http://" or "https://"
+ * @return bool
+ * @access private
+ */
+function _elgg_validate_url($url, $only_http = true) {
+	if ($only_http && !preg_match('~^https?\://~', $url)) {
+		return false;
+	}
+
+	// see https://bugs.php.net/bug.php?id=51192
+	$php_5_2_13_and_below = version_compare(PHP_VERSION, '5.2.14', '<');
+	$php_5_3_0_to_5_3_2 = version_compare(PHP_VERSION, '5.3.0', '>=') &&
+		version_compare(PHP_VERSION, '5.3.3', '<');
+	if ($php_5_2_13_and_below || $php_5_3_0_to_5_3_2) {
+		$url = str_replace("-", "", $url);
+	}
+
+	// Elgg produces paths containing non-ASCII chars (usernames). We just remove
+	// these before validating because PHP won't accept them
+	if (preg_match('~^(https?\://[^/]+/)(.*)~', $url, $m)) {
+		$url = $m[1] . preg_replace('/[^\x20-\x7E]/', '', $m[2]);
+	}
+
+	return (false !== filter_var($url, FILTER_VALIDATE_URL));
 }
 
 /**

--- a/engine/tests/api/helpers.php
+++ b/engine/tests/api/helpers.php
@@ -76,24 +76,41 @@ class ElggCoreHelpersTest extends ElggCoreUnitTest {
 			'https://example.com' => 'https://example.com',
 			'http://example-time.com' => 'http://example-time.com',
 
+			// https://github.com/Elgg/Elgg/issues/4190
+			'http://example.com/profile/தமிழ்' => 'http://example.com/profile/தமிழ்',
+
 			'//example.com' => '//example.com',
+			'?query' => '?query',
+			'#fragment' => '#fragment',
+
+			// any schemes are passed through
 			'ftp://example.com/file' => 'ftp://example.com/file',
-			'mailto:brett@elgg.org' => 'mailto:brett@elgg.org',
-			'javascript:alert("test")' => 'javascript:alert("test")',
+			'MAILto:brett@elgg.org' => 'MAILto:brett@elgg.org',
+			'javaSCript:alert("test")' => 'javaSCript:alert("test")',
+			'chrome-extension:foo' => 'chrome-extension:foo',
+			'z39.50r:foo' => 'z39.50r:foo',
 			'app://endpoint' => 'app://endpoint',
 
+			// prepends scheme if seems to be hostname
 			'example.com' => 'http://example.com',
+			'123.123.123.123' => 'http://123.123.123.123',
 			'example.com/subpage' => 'http://example.com/subpage',
+			// should fail if hostname has no period
+			'localhost/subpage' =>              elgg_get_site_url() . 'localhost/subpage',
 
-			'page/handler' =>                	elgg_get_site_url() . 'page/handler',
-			'page/handler?p=v&p2=v2' =>      	elgg_get_site_url() . 'page/handler?p=v&p2=v2',
+			'page/handler' =>                   elgg_get_site_url() . 'page/handler',
+			'page/handler?p=v&p2=v2' =>         elgg_get_site_url() . 'page/handler?p=v&p2=v2',
 			'mod/plugin/file.php' =>            elgg_get_site_url() . 'mod/plugin/file.php',
 			'mod/plugin/file.php?p=v&p2=v2' =>  elgg_get_site_url() . 'mod/plugin/file.php?p=v&p2=v2',
 			'rootfile.php' =>                   elgg_get_site_url() . 'rootfile.php',
 			'rootfile.php?p=v&p2=v2' =>         elgg_get_site_url() . 'rootfile.php?p=v&p2=v2',
+			'rootfile.php#fragment' =>          elgg_get_site_url() . 'rootfile.php#fragment',
 
-			'/page/handler' =>               	elgg_get_site_url() . 'page/handler',
-			'/page/handler?p=v&p2=v2' =>     	elgg_get_site_url() . 'page/handler?p=v&p2=v2',
+			// https://github.com/Elgg/Elgg/issues/4190
+			'profile/தமிழ்' =>                   elgg_get_site_url() . 'profile/தமிழ்',
+
+			'/page/handler' =>                  elgg_get_site_url() . 'page/handler',
+			'/page/handler?p=v&p2=v2' =>        elgg_get_site_url() . 'page/handler?p=v&p2=v2',
 			'/mod/plugin/file.php' =>           elgg_get_site_url() . 'mod/plugin/file.php',
 			'/mod/plugin/file.php?p=v&p2=v2' => elgg_get_site_url() . 'mod/plugin/file.php?p=v&p2=v2',
 			'/rootfile.php' =>                  elgg_get_site_url() . 'rootfile.php',
@@ -105,6 +122,31 @@ class ElggCoreHelpersTest extends ElggCoreUnitTest {
 		}
 	}
 
+	/**
+	 * Test _elgg_validate_url()
+	 */
+	public function testElggValidateURL() {
+		$results = array(
+			'http://example.com' => true,
+			'https://example.com' => true,
+			'ftp://example.com/file' => false,
+			'app://endpoint' => false,
+
+			// https://github.com/Elgg/Elgg/issues/4190
+			'http://example.com/profile/தமிழ்' => true,
+		);
+		foreach ($results as $input => $output) {
+			$this->assertIdentical($output, _elgg_validate_url($input));
+		}
+
+		$results = array(
+			'ftp://example.com/file' => true,
+			'app://endpoint' => true,
+		);
+		foreach ($results as $input => $output) {
+			$this->assertIdentical($output, _elgg_validate_url($input, false));
+		}
+	}
 
 	/**
 	 * Test elgg_register_js()

--- a/languages/en.php
+++ b/languages/en.php
@@ -568,6 +568,7 @@ $english = array(
 
 	'admin:configuration:success' => "Your settings have been saved.",
 	'admin:configuration:fail' => "Your settings could not be saved.",
+	'admin:configuration:site_url' => "Please provide a valid site URL",
 	'admin:configuration:dataroot:relative_path' => 'Cannot set "%s" as the dataroot because it is not an absolute path.',
 
 	'admin:unknown_section' => 'Invalid Admin Section.',


### PR DESCRIPTION
This is motivated by #6163 and the fact that elgg_normalize_url() struck me as a bad mix of normalization plus validation.

As it is, if the validation failed, we still USE the value, we just stick it after the site URL. Effectively this function is not validating URLs at all, just breaking some of them. It's obviously not a security mechanism because it allows values like `javascript:alert(1)` and dangerous URLs like `php://` which could result in code execution if used in some stream functions.

This PR makes elgg_normalize_url() strictly normalize the URL to the best of its ability (we don't use this function to validate user input anyway), while allowing pass-through of all values beginning with a scheme.
