### PR TITLE
Update list.php

### DIFF
--- a/mod/embed/views/default/embed/list.php
+++ b/mod/embed/views/default/embed/list.php
@@ -39,6 +39,7 @@ if ($count) {
 		'count' => $count,
 		'limit' => $limit,
 		'offset_key' => $offset_key,
+		'base_url' => elgg_get_site_url() . "embed/",
 	));
 }
 


### PR DESCRIPTION
Fix: unusable pagination in embed colorbox.

View mod/embed/views/defailt/embed/list.php is missing a base_url for navigation.

Function embed_select_tab expects input page to be set, but it isn't.
Adding 'base_url' => elgg_get_site_url() . "embed/" to the options for pagination fixes this

Closes/Fixes/Refs: Issue #6357
