### PR TITLE
Update mod/embed/views/default/embed/list.php

### DIFF
--- a/mod/embed/views/default/embed/list.php
+++ b/mod/embed/views/default/embed/list.php
@@ -39,6 +39,7 @@ if ($count) {
 		'count' => $count,
 		'limit' => $limit,
 		'offset_key' => $offset_key,
+		'base_url' => elgg_get_site_url() . "embed/",
 	));
 }
 


### PR DESCRIPTION
Fix(embed): unusable pagination in embed colorbox.

View mod/embed/views/default/embed/list.php is missing a base_url for navigation.

Adding 'base_url' => elgg_get_site_url() . "embed/" to the options for pagination fixes this

Refs: Issue #6357
