### PR TITLE
fix(embed): make tabs in colorbox popup usable

### DIFF
--- a/mod/embed/start.php
+++ b/mod/embed/start.php
@@ -110,6 +110,8 @@ function embed_page_handler($page) {
 		}
 	}
 
+	set_input('page', $page[1]); 
+
 	echo elgg_view('embed/layout');
 
 	// exit because this is in a modal display.


### PR DESCRIPTION
Function embed_select_tab expects input page to be set, but it isn't.
Adding a set_input('page', $page[1]); to the embed_page_handler function fixes this

Refs: Issue #6357
