### PR TITLE
Normalize image rotation for images sourced from cameras/mobile devices

### DIFF
--- a/mod/file/actions/file/upload.php
+++ b/mod/file/actions/file/upload.php
@@ -124,7 +124,11 @@ if (isset($_FILES['upload']['name']) && !empty($_FILES['upload']['name'])) {
 	// Open the file to guarantee the directory exists
 	$file->open("write");
 	$file->close();
-	move_uploaded_file($_FILES['upload']['tmp_name'], $file->getFilenameOnFilestore());
+	
+	if (is_uploaded_file($_FILES['upload']['tmp_name'])) {
+		// moves the file and normalizes rotation if it's an image
+		normalize_image_rotation($_FILES['upload']['tmp_name'], $file->getFilenameOnFilestore());
+	}
 
 	$guid = $file->save();
 


### PR DESCRIPTION
Images uploaded from mobile devices that were taken at various orientations are normalized on the devices, but when uploaded to Elgg appear rotated.  This checks uploaded files for EXIF data relating to orientation and normalizes the orientation before the file is saved - the image will then be displayed properly in Elgg.
