### PR TITLE
Fixes #6379: Makes sure that page menu items exist before trying to prepare them for viewing

### DIFF
--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -380,20 +380,24 @@ function elgg_admin_add_plugin_settings_menu() {
  */
 function elgg_admin_sort_page_menu($hook, $type, $return, $params) {
 	$configure_items = $return['configure'];
-	/* @var ElggMenuItem[] $configure_items */
-	foreach ($configure_items as $menu_item) {
-		if ($menu_item->getName() == 'settings') {
-			$settings = $menu_item;
+	if (is_array($configure_items)) {
+		/* @var ElggMenuItem[] $configure_items */
+		foreach ($configure_items as $menu_item) {
+			if ($menu_item->getName() == 'settings') {
+				$settings = $menu_item;
+			}
+		}
+
+		if (!empty($settings) && $settings instanceof ElggMenuItem) {
+			// keep the basic and advanced settings at the top
+			/* @var ElggMenuItem $settings */
+			$children = $settings->getChildren();
+			$site_settings = array_splice($children, 0, 2);
+			usort($children, array('ElggMenuBuilder', 'compareByText'));
+			array_splice($children, 0, 0, $site_settings);
+			$settings->setChildren($children);
 		}
 	}
-
-	// keep the basic and advanced settings at the top
-	/* @var ElggMenuItem $settings */
-	$children = $settings->getChildren();
-	$site_settings = array_splice($children, 0, 2);
-	usort($children, array('ElggMenuBuilder', 'compareByText'));
-	array_splice($children, 0, 0, $site_settings);
-	$settings->setChildren($children);
 }
 
 /**

--- a/engine/tests/regression/trac_bugs.php
+++ b/engine/tests/regression/trac_bugs.php
@@ -234,4 +234,21 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 			$this->assertIdentical($expected, $friendly_title);
 		}
 	}
+
+	/**
+	 * elgg_admin_sort_page_menu() should not expect that the supplied menu has a certain hierarchy
+	 *
+	 * https://github.com/Elgg/Elgg/issues/6379
+	 */
+	function test_admin_sort_page_menu() {
+
+		elgg_push_context('admin');
+
+		elgg_register_plugin_hook_handler('prepare', 'menu:page', 'elgg_admin_sort_page_menu');
+		$result = elgg_trigger_plugin_hook('prepare', 'menu:page', array(), array());
+		$this->assertTrue(is_array($result), "Admin page menu fails to prepare for viewing");
+
+		elgg_pop_context();
+
+	}
 }


### PR DESCRIPTION
Makes sure that the page menu in admin context has not been modified before trying to prepare it for viewing

Fixes #6379
