### PR TITLE
Display correct access options for group content

### DIFF
--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -550,9 +550,21 @@ function groups_write_acl_plugin_hook($hook, $entity_type, $returnvalue, $params
 	// only insert group access for current group
 	if ($page_owner instanceof ElggGroup) {
 		if ($page_owner->canWriteToContainer($user_guid)) {
-			$returnvalue[$page_owner->group_acl] = elgg_echo('groups:group') . ': ' . $page_owner->name;
-
-			unset($returnvalue[ACCESS_FRIENDS]);
+			if ($page_owner->getContentAccessMode() == ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY) {
+				// Due to group policy allow only the owner or all group members
+				$returnvalue = array(
+					ACCESS_PRIVATE => elgg_echo('PRIVATE'),
+					$page_owner->group_acl => elgg_echo('groups:group') . ': ' . $page_owner->name,
+				);
+			} else {
+				// Leave out other groups, friends and friend collections
+				$returnvalue = array(
+					ACCESS_PRIVATE => elgg_echo('PRIVATE'),
+					ACCESS_LOGGED_IN => elgg_echo('LOGGED_IN'),
+					ACCESS_PUBLIC => elgg_echo('PUBLIC'),
+					$group->group_acl => elgg_echo('groups:acl', array($page_owner->name)),
+				);
+			}
 		}
 	} else {
 		// if the user owns the group, remove all access collections manually


### PR DESCRIPTION
Content access options for groups using members-only policy:
- Private
- Members of the group

Content access options for public groups:
- Private
- Logged in users
- Public
- Members of the group

In 1.8 we removed ACCESS_FRIENDS from the list but not friend collections, which is a bit irrational. Now also friend collections get leaved out.

This doesn't fix #6142 completely, so don't close it yet.
