### PR TITLE
chore(embed): embed page isn't passed as array, it's a string

### DIFF
--- a/mod/embed/start.php
+++ b/mod/embed/start.php
@@ -77,9 +77,7 @@ function embed_longtext_menu($hook, $type, $items, $vars) {
  */
 function embed_select_tab($hook, $type, $items, $vars) {
 
-	// can this ba called from page handler instead?
-	$page = get_input('page');
-	$tab_name = array_pop(explode('/', $page));
+	$tab_name = get_input('tab_name');
 	foreach ($items as $item) {
 		if ($item->getName() == $tab_name) {
 			$item->setSelected();
@@ -110,7 +108,7 @@ function embed_page_handler($page) {
 		}
 	}
 
-	set_input('page', $page[1]); 
+	set_input('tab_name', $page[1]);
 
 	echo elgg_view('embed/layout');
 


### PR DESCRIPTION
If there isn't any other case, we are only passing `tab_name` as string. Please check if I'm missing something.

Refs #6363
- [ ] change commit type to fix
- [ ] resubmit to 1.9 branch
