### PR TITLE
fix(groups): uses correct group ACL in group content access options

### DIFF
--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -562,7 +562,7 @@ function groups_write_acl_plugin_hook($hook, $entity_type, $returnvalue, $params
 					ACCESS_PRIVATE => elgg_echo('PRIVATE'),
 					ACCESS_LOGGED_IN => elgg_echo('LOGGED_IN'),
 					ACCESS_PUBLIC => elgg_echo('PUBLIC'),
-					$group->group_acl => elgg_echo('groups:acl', array($page_owner->name)),
+					$page_owner->group_acl => elgg_echo('groups:acl', array($page_owner->name)),
 				);
 			}
 		}


### PR DESCRIPTION
I had copypasted a row so the variable name is wrong.
