### PR TITLE
fix(cache): removes memory leak when clearing an entity's metadata cache

### DIFF
--- a/engine/classes/ElggVolatileMetadataCache.php
+++ b/engine/classes/ElggVolatileMetadataCache.php
@@ -181,7 +181,7 @@ class ElggVolatileMetadataCache {
 	 * @return void
 	 */
 	public function clear($entity_guid) {
-		$this->values[$entity_guid] = array();
+		unset($this->values[$entity_guid]);
 		$this->markOutOfSync($entity_guid);
 	}
 


### PR DESCRIPTION
When clearing the metadata cache for a particular entity, an empty array was unnecessarily left for each GUID removed from cache. This instead removes the entire key for the GUID.
