### PR TITLE
perf(batch): reduce memory usage during batch processes

### DIFF
--- a/engine/classes/ElggBatch.php
+++ b/engine/classes/ElggBatch.php
@@ -299,6 +299,9 @@ class ElggBatch
 		$this->incompleteEntities = array();
 		$this->results = call_user_func_array($this->getter, array($options));
 
+		// batch result sets tend to be large; we don't want to cache these.
+		_elgg_invalidate_query_cache();
+
 		$num_results = count($this->results);
 		$num_incomplete = count($this->incompleteEntities);
 


### PR DESCRIPTION
Result sets for batch queries tend to be large and bloat the query cache without being of much use. Since the LRU cache is limited in key size (not memory size), the simplest solution is to flush it during batch operations.
