### PR TITLE
Fixes #6426: title for new plugins is reset by parent constructor

### DIFF
--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -82,6 +82,10 @@ class ElggPlugin extends ElggObject {
 
 			// load the rest of the plugin
 			parent::__construct($existing_guid);
+
+			if (!$this->title && $plugin_id) {
+				$this->title = $plugin_id;
+			}
 		}
 
 		_elgg_cache_plugin_by_id($this);


### PR DESCRIPTION
Fixes #6426
