### PR TITLE
fix(groups): forces content accessibility to members_only for invisible groups

### DIFF
--- a/js/lib/elgglib.js
+++ b/js/lib/elgglib.js
@@ -12,6 +12,13 @@ var elgg = elgg || {};
 elgg.global = this;
 
 /**
+ * Duplicate of the server side ACCESS_PRIVATE access level.
+ *
+ * This is a temporary hack to prevent having to mix up js and PHP in js views.
+ */
+elgg.ACCESS_PRIVATE = 0;
+
+/**
  * Convenience reference to an empty function.
  *
  * Save memory by not generating multiple empty functions.

--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -141,14 +141,19 @@ if ($is_new_group) {
 // is an odd requirement and should be removed. Either the acl creation happens
 // in the action or the visibility moves to a plugin hook
 if (elgg_get_plugin_setting('hidden_groups', 'groups') == 'yes') {
-	$visibility = (int)get_input('vis', '', false);
-	if ($visibility != ACCESS_PUBLIC && $visibility != ACCESS_LOGGED_IN) {
+	$visibility = (int)get_input('vis');
+
+	if ($visibility == ACCESS_PRIVATE) {
+		// Make this group visible only to group members. We need to use
+		// ACCESS_PRIVATE on the form and convert it to group_acl here
+		// because new groups do not have acl until they have been saved once.
 		$visibility = $group->group_acl;
+
+		// Force all new group content to be available only to members
+		$group->setContentAccessMode(ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY);
 	}
 
-	if ($group->access_id != $visibility) {
-		$group->access_id = $visibility;
-	}
+	$group->access_id = $visibility;
 }
 
 $group->save();

--- a/mod/groups/languages/en.php
+++ b/mod/groups/languages/en.php
@@ -42,6 +42,7 @@ return array(
 	'groups:members:more' => "View all members",
 	'groups:membership' => "Group membership permissions",
 	'groups:content_access_mode' => "Accessibility of group content",
+	'groups:content_access_mode:warning' => "Warning: Changing this setting won't change the access permission of existing group content.",
 	'groups:content_access_mode:unrestricted' => "Unrestricted - Access depends on content-level settings",
 	'groups:content_access_mode:membersonly' => "Members Only - Non-members can never access group content",
 	'groups:access' => "Access permissions",

--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -182,6 +182,8 @@ function groups_handle_mine_page() {
 function groups_handle_edit_page($page, $guid = 0) {
 	elgg_gatekeeper();
 
+	elgg_require_js('elgg/groups/edit');
+
 	if ($page == 'add') {
 		elgg_set_page_owner_guid(elgg_get_logged_in_user_guid());
 		$title = elgg_echo('groups:add');

--- a/mod/groups/views/default/groups/edit/access.php
+++ b/mod/groups/views/default/groups/edit/access.php
@@ -17,59 +17,71 @@ $content_access_mode = elgg_extract("content_access_mode", $vars);
 
 ?>
 <div>
-	<label>
-		<?php echo elgg_echo("groups:membership"); ?><br />
-		<?php echo elgg_view("input/select", array(
-			"name" => "membership",
-			"value" => $membership,
+	<label for="groups-membership"><?php echo elgg_echo("groups:membership"); ?></label><br />
+	<?php echo elgg_view("input/select", array(
+		"name" => "membership",
+		"id" => "groups-membership",
+		"value" => $membership,
+		"options_values" => array(
+			ACCESS_PRIVATE => elgg_echo("groups:access:private"),
+			ACCESS_PUBLIC => elgg_echo("groups:access:public"),
+		)
+	));
+	?>
+</div>
+
+<?php if (elgg_get_plugin_setting("hidden_groups", "groups") == "yes"): ?>
+	<div>
+		<label for="groups-vis"><?php echo elgg_echo("groups:visibility"); ?></label><br />
+		<?php echo elgg_view("input/access", array(
+			"name" => "vis",
+			"id" => "groups-vis",
+			"value" => $visibility,
 			"options_values" => array(
-				ACCESS_PRIVATE => elgg_echo("groups:access:private"),
-				ACCESS_PUBLIC => elgg_echo("groups:access:public"),
+				ACCESS_PRIVATE => elgg_echo("groups:access:group"),
+				ACCESS_LOGGED_IN => elgg_echo("LOGGED_IN"),
+				ACCESS_PUBLIC => elgg_echo("PUBLIC"),
 			)
 		));
 		?>
-	</label>
-</div>
-
-<div>
-	<label>
-		<?php echo elgg_echo("groups:content_access_mode"); ?><br />
-		<?php echo elgg_view("input/select", array(
-			"name" => "content_access_mode",
-			"value" => $content_access_mode,
-			"options_values" => array(
-				ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED => elgg_echo("groups:content_access_mode:unrestricted"),
-				ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY => elgg_echo("groups:content_access_mode:membersonly"),
-			),
-		));
-		?>
-	</label>
-</div>
+	</div>
+<?php endif; ?>
 
 <?php
 
-if (elgg_get_plugin_setting("hidden_groups", "groups") == "yes") {
-	$access_options = array(
-		ACCESS_PRIVATE => elgg_echo("groups:access:group"),
-		ACCESS_LOGGED_IN => elgg_echo("LOGGED_IN"),
-		ACCESS_PUBLIC => elgg_echo("PUBLIC"),
-	);
-?>
+$access_mode_params = array(
+	"name" => "content_access_mode",
+	"id" => "groups-content-access-mode",
+	"value" => $content_access_mode,
+	"options_values" => array(
+		ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED => elgg_echo("groups:content_access_mode:unrestricted"),
+		ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY => elgg_echo("groups:content_access_mode:membersonly"),
+	)
+);
 
-<div>
-	<label>
-			<?php echo elgg_echo("groups:visibility"); ?><br />
-			<?php echo elgg_view("input/access", array(
-				"name" => "vis",
-				"value" =>  $visibility,
-				"options_values" => $access_options,
-			));
-			?>
-	</label>
-</div>
-
-<?php
+if ($entity) {
+	// Disable content_access_mode field for hidden groups because the setting
+	// will be forced to members_only regardless of the entered value
+	if ($entity->access_id === $entity->group_acl) {
+		$access_mode_params['disabled'] = 'disabled';
+	}
 }
+?>
+<div>
+	<label for="groups-content-access-mode"><?php echo elgg_echo("groups:content_access_mode"); ?></label><br />
+	<?php
+		echo elgg_view("input/select", $access_mode_params);
+
+		if ($entity && $entity->getContentAccessMode() == ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED) {
+			// Warn the user that changing the content access mode to more
+			// restrictive will not affect the existing group content
+			$access_mode_warning = elgg_echo("groups:content_access_mode:warning");
+			echo "<span class='elgg-text-help'>$access_mode_warning</span>";
+		}
+	?>
+</div>
+
+<?php
 
 if ($entity && ($owner_guid == elgg_get_logged_in_user_guid() || elgg_is_admin_logged_in())) {
 	$members = array();
@@ -87,25 +99,23 @@ if ($entity && ($owner_guid == elgg_get_logged_in_user_guid() || elgg_is_admin_l
 		$option_text = "$member->name (@$member->username)";
 		$members[$member->guid] = htmlspecialchars($option_text, ENT_QUOTES, "UTF-8", false);
 	}
-?>
+	?>
 
-<div>
-	<label>
-			<?php echo elgg_echo("groups:owner"); ?><br />
-			<?php echo elgg_view("input/select", array(
+	<div>
+		<label for="groups-owner-guid"><?php echo elgg_echo("groups:owner"); ?></label><br />
+		<?php
+			echo elgg_view("input/select", array(
 				"name" => "owner_guid",
+				"id" => "groups-owner-guid",
 				"value" =>  $owner_guid,
 				"options_values" => $members,
 				"class" => "groups-owner-input",
 			));
-			?>
-	</label>
-	<?php
-	if ($owner_guid == elgg_get_logged_in_user_guid()) {
-		echo "<span class='elgg-text-help'>" . elgg_echo("groups:owner:warning") . "</span>";
-	}
-	?>
-</div>
 
+			if ($owner_guid == elgg_get_logged_in_user_guid()) {
+				echo "<span class='elgg-text-help'>" . elgg_echo("groups:owner:warning") . "</span>";
+			}
+		?>
+	</div>
 <?php
 }

--- a/mod/groups/views/default/js/elgg/groups/edit.js
+++ b/mod/groups/views/default/js/elgg/groups/edit.js
@@ -1,0 +1,34 @@
+/**
+ * JavaScript used on group creation/editing form
+ */
+define(function(require) {
+	var elgg = require('elgg');
+	var $ = require('jquery');
+
+	/**
+	 * Toggle the availability of content access field
+	 *
+	 * Content access field gets disabled in the group edit form when
+	 * group is made visible only to members. When the visibility is
+	 * made less restrictive, the field is enabled again.
+	 * 
+	 * @param {Object} event
+	 */
+	var toggleContentAccessMode = function(event) {
+		var accessModeField = $('#groups-content-access-mode');
+
+		if ($(this).val() == elgg.ACCESS_PRIVATE) {
+			// Group is hidden, so force members_only mode and disable the field
+			accessModeField.val('members_only').prop('disabled', true);
+		} else {
+			// Enable the field
+			accessModeField.prop('disabled', false);
+		}
+	};
+
+	$('#groups-vis').on('change', toggleContentAccessMode);
+
+	return {
+		toggleContentAccessMode: toggleContentAccessMode
+	};
+});


### PR DESCRIPTION
- [x] When user selects "Group members only" for group visibility, javascript sets the group content accessibility field to "Members only" and disables it.
- [x] For existing groups the above is done also on server side.
- [x] When editing an existing public group, a warning is added under the group content accessibility input saying that changing the setting won't change the access permission of existing group content.

This should pretty much finish fixing #6142

To-do before merging:
- [x] switch js to AMD
- [x] import Elgg (`var elgg = require("elgg")`)
- [x] consider namespacing this module ("elgg/groups/edit")
