### PR TITLE
fix(routing): URL-decodes path segments like Elgg 1.8

### DIFF
--- a/engine/classes/Elgg/Http/ParameterBag.php
+++ b/engine/classes/Elgg/Http/ParameterBag.php
@@ -85,7 +85,8 @@ class Elgg_Http_ParameterBag implements IteratorAggregate, Countable {
 	 * @return void
 	 */
 	public function add(array $parameters = array()) {
-		$this->parameters = array_replace($this->parameters, $parameters);
+		// original uses array_replace. using array_merge for 5.2 BC
+		$this->parameters = array_merge($this->parameters, $parameters);
 	}
 
 	/**

--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -210,7 +210,8 @@ class Elgg_Http_Request {
 
 		if (isset($components['query'])) {
 			parse_str(html_entity_decode($components['query']), $qs);
-			$query = array_replace($qs, $query);
+			// original uses array_replace. using array_merge for 5.2 BC
+			$query = array_merge($qs, $query);
 		}
 		$queryString = http_build_query($query, '', '&');
 

--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -461,7 +461,7 @@ class Elgg_Http_Request {
 	 * @return array
 	 */
 	public function getUrlSegments() {
-		$path = trim($this->getPathInfo(), '/');
+		$path = trim($this->query->get('__elgg_uri'), '/');
 		if (!$path) {
 			return array();
 		}

--- a/engine/tests/phpunit/Elgg/RouterTest.php
+++ b/engine/tests/phpunit/Elgg/RouterTest.php
@@ -2,6 +2,11 @@
 
 class Elgg_RouterTest extends PHPUnit_Framework_TestCase {
 
+	/**
+	 * @var Elgg_Router
+	 */
+	protected $router;
+
 	function setUp() {
 		$this->hooks = new Elgg_PluginHooksService();
 		$this->router = new Elgg_Router($this->hooks);
@@ -19,7 +24,7 @@ class Elgg_RouterTest extends PHPUnit_Framework_TestCase {
 		
 		$this->assertTrue($registered);
 		
-		$request = Elgg_Http_Request::create('http://localhost/hello/');
+		$request = Elgg_Http_Request::create('http://localhost/?__elgg_uri=hello%2F');
 		
 		ob_start();
 		$handled = $this->router->route($request);

--- a/engine/tests/phpunit/Elgg/RouterTest.php
+++ b/engine/tests/phpunit/Elgg/RouterTest.php
@@ -23,15 +23,17 @@ class Elgg_RouterTest extends PHPUnit_Framework_TestCase {
 		$registered = $this->router->registerPageHandler('hello', array($this, 'hello_page_handler'));
 		
 		$this->assertTrue($registered);
-		
-		$request = Elgg_Http_Request::create('http://localhost/?__elgg_uri=hello%2F');
+
+		$path = "hello/1/\xE2\x82\xAC"; // euro sign
+		$qs = http_build_query(array('__elgg_uri' => $path));
+		$request = Elgg_Http_Request::create("http://localhost/?$qs");
 		
 		ob_start();
 		$handled = $this->router->route($request);
 		$output = ob_get_clean();
 		
 		$this->assertTrue($handled);
-		$this->assertEquals("Hello, World!", $output);
+		$this->assertEquals($path, $output);
 	}
 	
 	function testCanUnregisterPageHandlers() {

--- a/engine/tests/phpunit/test_files/pages/hello.php
+++ b/engine/tests/phpunit/test_files/pages/hello.php
@@ -1,3 +1,4 @@
 <?php
 
-echo "Hello, World!";
+echo $identifier . '/';
+echo implode('/', $segments);

--- a/htaccess_dist
+++ b/htaccess_dist
@@ -141,6 +141,6 @@ RewriteRule ^rewrite.php$ install.php [L]
 RewriteEngine on
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule ^(.*)$ index.php?elgg_uri=$1 [L,QSA]
+RewriteRule ^(.*)$ index.php?__elgg_uri=$1 [QSA,L]
 
 </IfModule>


### PR DESCRIPTION
Non-ASCII characters get URL encoded in `$_SERVER['PATH_INFO']` so instead we
copy the URL path into a query string var and use that var to build path
segments in the router. This should yield identical behavior as Elgg 1.8.

Fixes #6218 and adds better router tests.
- [x] decide between "routing" and "router"
- [x] change last commit from "fix" to "test"
