### PR TITLE
Write access array in group context should contain that groups acl

### DIFF
--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -565,7 +565,7 @@ function groups_write_acl_plugin_hook($hook, $entity_type, $returnvalue, $params
 					ACCESS_PRIVATE => elgg_echo('PRIVATE'),
 					ACCESS_LOGGED_IN => elgg_echo('LOGGED_IN'),
 					ACCESS_PUBLIC => elgg_echo('PUBLIC'),
-					$group->group_acl => elgg_echo('groups:acl', array($page_owner->name)),
+					$page_owner->group_acl => elgg_echo('groups:acl', array($page_owner->name)),
 				);
 			}
 		}

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -557,7 +557,7 @@ function groups_write_acl_plugin_hook($hook, $entity_type, $returnvalue, $params
 				// Due to group policy allow only the owner or all group members
 				$returnvalue = array(
 					ACCESS_PRIVATE => elgg_echo('PRIVATE'),
-					$page_owner->group_acl => elgg_echo('groups:group') . ': ' . $page_owner->name,
+					$page_owner->group_acl => elgg_echo('groups:acl', array($page_owner->name)),
 				);
 			} else {
 				// Leave out other groups, friends and friend collections

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -104,6 +104,9 @@ function groups_init() {
 	elgg_register_plugin_hook_handler('access:collections:add_user', 'collection', 'groups_access_collection_override');
 
 	elgg_register_event_handler('upgrade', 'system', 'groups_run_upgrades');
+
+	// Add tests
+	elgg_register_plugin_hook_handler('unit_test', 'system', 'groups_test');
 }
 
 /**
@@ -1262,4 +1265,16 @@ function discussion_reply_menu_setup($hook, $type, $return, $params) {
 	}
 
 	return $return;
+}
+
+
+/**
+ * Runs unit tests for groups
+ *
+ * @return array
+ */
+function groups_test($hook, $type, $value, $params) {
+	global $CONFIG;
+	$value[] = $CONFIG->pluginspath . 'groups/tests/write_access.php';
+	return $value;
 }

--- a/mod/groups/tests/write_access.php
+++ b/mod/groups/tests/write_access.php
@@ -40,6 +40,8 @@ class GroupsWriteAccessTest extends ElggCoreUnitTest {
 		$original_page_owner = elgg_get_page_owner_entity();
 		elgg_set_page_owner_guid($group_guid);
 
+		$ia = elgg_set_ignore_access(false);
+
 		// User is not a member of the group
 		// Member-only group
 		$this->group->setContentAccessMode($membersonly);
@@ -61,6 +63,8 @@ class GroupsWriteAccessTest extends ElggCoreUnitTest {
 		$this->group->setContentAccessMode($unrestricted);
 		$write_access = get_write_access_array($this->user->guid, $this->group->site_guid, true);
 		$this->assertTrue(array_key_exists($this->group->group_acl, $write_access));
+
+		elgg_set_ignore_access($ia);
 
 		$this->group->leave($this->user);
 

--- a/mod/groups/tests/write_access.php
+++ b/mod/groups/tests/write_access.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Test write access arrays
+ */
+class GroupsWriteAccessTest extends ElggCoreUnitTest {
+
+	/**
+	 * @var ElggGroup
+	 */
+	protected $group;
+
+	/**
+	 * @var ElggUser
+	 */
+	protected $user;
+
+	/**
+	 * Called before each test method.
+	 */
+	public function setUp() {
+		$this->group = new ElggGroup();
+		$this->group->membership = ACCESS_PUBLIC;
+		$this->group->access_id = ACCESS_PUBLIC;
+		$this->group->save();
+		$this->user = new ElggUser();
+		$this->user->username = 'test_user_' . rand();
+		$this->user->save();
+	}
+
+	public function testWriteAccessArray() {
+		$membersonly = ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY;
+		$unrestricted = ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED;
+
+		$group_guid = $this->group->guid;
+		$original_page_owner = elgg_get_page_owner_entity();
+		elgg_set_page_owner_guid($group_guid);
+
+		$this->group->setContentAccessMode($membersonly);
+
+		$write_access = get_write_access_array($this->user->guid, $this->group->site_guid, true);
+		$this->assertTrue(array_key_exists($this->group->group_acl, $write_access));
+
+		$this->group->setContentAccessMode($unrestricted);
+
+		$write_access = get_write_access_array($this->user->guid, $this->group->site_guid, true);
+		$this->assertTrue(array_key_exists($this->group->group_acl, $write_access));
+
+		elgg_set_page_owner_guid($original_page_owner);
+
+	}
+
+	/**
+	 * Called after each test method.
+	 */
+	public function tearDown() {
+		$this->group->delete();
+		$this->user->delete();
+	}
+
+}


### PR DESCRIPTION
(this replaces #6413)

fixes a bug introduced by #6393.
adds a regression test.
