### PR TITLE
fix(site_notifications): added correct key, link_class, for menu item

### DIFF
--- a/mod/site_notifications/views/default/object/site_notification.php
+++ b/mod/site_notifications/views/default/object/site_notification.php
@@ -31,7 +31,7 @@ elgg_register_menu_item('site_notifications', array(
 	'href' => 'action/site_notifications/delete?guid=' . $entity->guid,
 	'text' => elgg_view_icon('delete'),
 	'is_action' => true,
-	'class' => 'site-notifications-delete',
+	'link_class' => 'site-notifications-delete',
 	'id' => 'site-notifications-delete-' . $entity->guid,
 ));
 $menu = elgg_view_menu('site_notifications', array(


### PR DESCRIPTION
Deprecated in 1.9: ElggMenuItem::factory() does not accept 'class' key anymore
