### PR TITLE
test(groups): page owner is not an entity when running SimpleTest

### DIFF
--- a/mod/groups/tests/write_access.php
+++ b/mod/groups/tests/write_access.php
@@ -67,7 +67,8 @@ class GroupsWriteAccessTest extends ElggCoreUnitTest {
 
 		$this->group->leave($this->user);
 
-		elgg_set_page_owner_guid($original_page_owner->guid);
+		$original_page_owner_guid = (elgg_instanceof($original_page_owner)) ? $original_page_owner->guid : 0;
+		elgg_set_page_owner_guid($original_page_owner_guid);
 
 	}
 


### PR DESCRIPTION
Fixes #6472
