### PR TITLE
fix(install): fatal exception during installation

### DIFF
--- a/install/ElggInstaller.php
+++ b/install/ElggInstaller.php
@@ -868,6 +868,7 @@ class ElggInstaller {
 		$CONFIG->entity_types = array('group', 'object', 'site', 'user');
 		// required by elgg_view_page()
 		$CONFIG->sitename = '';
+		$CONFIG->sitedescription = '';
 	}
 
 	/**


### PR DESCRIPTION
During the installation process 'normal' pages are drawn. Part if the
page is the metatag for sitedescription. This isn't available in $CONFIG
so the system goes to the database, which is unavailable.

fixes issue caused by 66f06919735e3de97b8262cc13c7044df755795b
