### PR TITLE
Unify elgg_require_js and elgg_load_js

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -84,7 +84,6 @@ Version 1.9.0-rc1
    * Adds support for returning translations as arrays from language files
    * Adds ElggEntity::getDisplayName()
    * Adds ElggEntity::toObject()
-   * Adds elgg_require_js() to auto-load AMD module with page
    * Replaces add_to_river() with elgg_create_river_item()
    * Adds target_guid to the river
    * Adds elgg_get_entities_from_attributes()

--- a/docs/design/amd.rst
+++ b/docs/design/amd.rst
@@ -1,0 +1,104 @@
+AMD
+###
+
+.. toctree::
+   :maxdepth: 2
+
+As of Elgg 1.9, we are encouraging all developers to adopt the `AMD (Asynchronous Module Definition) <http://requirejs.org/docs/whyamd.html>`_ standard for writing Javascript code in Elgg.
+
+Usage
+=====
+
+Defining and loading a module in Elgg 1.9 takes two steps:
+
+1. Define your module as asynchronous JavaScript
+2. Use ``require`` or ``elgg_load_js`` to asynchronously execute your module in the current page.
+
+Read on for details.
+
+1. Define your module as asynchronous JavaScript
+------------------------------------------------
+
+You can define a module via a view or an URL.
+
+Define your module in the appropriate view (js/my/module.js)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Place the code for "my/module" at "views/default/js/**my/module**.js". There is no need to use ``elgg_register_js()`` in this case.
+
+A basic module will look like this:
+
+.. code-block:: javascript
+
+ define(function(require) {
+     var elgg = require("elgg");
+     var $ = require("jquery");
+     return function() { /** Some logic in here */ };
+ });
+
+Define your module via an URL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can register an existing AMD module using ``elgg_register_js()`` by setting the third parameter to 'async'.
+
+.. code-block:: php
+
+    <?php
+    // AMD module
+    elgg_register_js('backbone', '/vendors/backbone/backbone.js', 'async');
+
+Traditional (brower-globals) JavaScript files can also be defined as AMD modules if you shim them.
+
+.. code-block:: php
+
+    <?php
+    // AMD shimed module
+    elgg_register_js('jquery.form', array(
+        'src' => '/vendors/jquery/jquery.form.js',
+        'deps' => array('jquery'),
+        'exports' => 'jQuery.fn.ajaxForm',
+    ));
+
+Some things to note
+^^^^^^^^^^^^^^^^^^^
+
+1. Do not use ``elgg.provide()`` or ``elgg.require()`` anymore. They are fully replaced by ``define()`` and ``require()`` respectively.
+2. There is no need to put the name of the module in your code. It is named implicitly based on where you put it in the views system.
+3. Return the value of the module instead of adding to a global variable.
+4. Now that Elgg 1.9 supports static files as views, you no longer need a .php extension. Since the view is static, it is automatically minified and cached by Elgg's simplecache system.
+
+2. Use require or elgg_load_js to load the module on the current page
+---------------------------------------------------------------------
+Once an AMD module is defined, you can use ``require("my/module")`` from JavaScript to get access to its "exported" value.
+
+Also, calling ``elgg_load_js("my/module")`` from PHP tells Elgg to execute the module code on the current page.
+
+
+I have a lot of JS written for Elgg 1.8. What does this mean for me?
+====================================================================
+First thing's first: **Your current javascript modules will continue to work with Elgg**. We do not anticipate any backwards compatibility issues with this new direction and will fix any issues that do come up. We think developing in the AMD format will be great, but we understand that you don't always have the cycles to convert to The New Way immediately, so we want to give everyone flexibility to switch to the new standard when it's most convenient for them. For developers ready to make the switch to AMD, read on.
+
+
+Why AMD?
+========
+
+For some time now, we have been working hard to make Elgg's Javascript more maintainable and useful. We made some strides in 1.8 with the introduction of the "elgg" javascript object and library, but have quickly realized that based on the number of features we'd like to see added to the platform, the approach we were taking was not scalable. The size of `JS on the web is growing <http://httparchive.org/trends.php?s=All&minlabel=Feb+11+2011&maxlabel=Feb+1+2013#bytesJS&reqJS>`_ quickly, and JS in Elgg is growing too. We want Elgg to be able to offer a solution that makes JS development as productive and maintainable as possible for everyone going forward.
+
+The `reasons to choose AMD <http://requirejs.org/docs/whyamd.html>`_ are plenteous and well-documented. Let's highlight just a few of the most relevant reasons as they relate to Elgg specifically.
+
+1. Simplified dependency management
+-----------------------------------
+No more "priority" or "location" arguments for your scripts. You *don't even need to call* ``elgg_register_js()`` for new AMD modules. They load asynchronously and execute as soon as their dependencies are available. Also, you don't need to worry about explicitly loading your module's dependencies using ``elgg_load_js()``. The AMD loader (RequireJS in this case) takes care of all that hassle for you. It's also possible have `text dependencies <http://requirejs.org/docs/api.html#text>`_ with the RequireJS text plugin, so client-side templating should be a breeze.
+
+2. AMD works in all browsers. Today.
+------------------------------------
+Elgg developers are already writing lots of Javascript. We know you want to write more. We cannot accept waiting 5-10 years for a native JS modules solution to be available in all browsers before we can organize our javascript in a maintainable way.
+
+3. You do not need a build step to develop in AMD.
+--------------------------------------------------
+We like the edit-refresh cycle of web development. We wanted to make sure everyone developing on Elgg could continue experiencing that joy. Synchronous module formats like Closure or CommonJS just weren't an option for us. But even though AMD doesn't require a build step, *it is still very build-friendly*. Because of the ``define()`` wrapper, It's possible to concatenate multiple modules into a single file and ship them all at once in a production environment. [*]_
+
+AMD is a battle-tested and well thought out module loading system for the web today. We're very thankful for the work that has gone into it, and are excited to offer it as the standard solution for Javascript development in Elgg starting with Elgg 1.9.
+
+.. [*] This is not currently supported by Elgg core, but we'll be looking into it, since reducing round-trips is critical for a good first-view experience, especially on mobile devices.
+

--- a/docs/design/index.rst
+++ b/docs/design/index.rst
@@ -9,3 +9,4 @@ and why it's built the way it is.
    
    database
    events
+   amd

--- a/engine/classes/Elgg/Amd/Config.php
+++ b/engine/classes/Elgg/Amd/Config.php
@@ -42,7 +42,17 @@ class Elgg_Amd_Config {
 	}
 
 	/**
-	 * Method that does something
+	 * Unset the path for a module
+	 *
+	 * @param string $module Module name
+	 * @return void
+	 */
+	public function unsetPath($module) {
+		unset($this->paths[$module]);
+	}
+
+	/**
+	 * Sets the shim for a module
 	 *
 	 * @todo update documentation
 	 * 
@@ -53,10 +63,28 @@ class Elgg_Amd_Config {
 	 * @return void
 	 */
 	public function setShim($module, array $shimConfig) {
-		$this->shim[$module] = array(
-			'deps' => elgg_extract('deps', $shimConfig, array()),
-			'exports' => elgg_extract('exports', $shimConfig),
-		);
+		$deps = elgg_extract('deps', $shimConfig, array());
+		$exports = elgg_extract('exports', $shimConfig);
+
+		if (!empty($deps) || !empty($exports)) {
+			$this->shim[$module] = array();
+		}
+		if (!empty($deps)) {
+			$this->shim[$module]['deps'] = $deps;
+		}
+		if (!empty($exports)) {
+			$this->shim[$module]['exports'] = $exports;
+		}
+	}
+
+	/**
+	 * Unset the shim of a module
+	 *
+	 * @param string $module Module name
+	 * @return void
+	 */
+	public function unsetShim($module) {
+		unset($this->shim[$module]);
 	}
 
 	/**
@@ -67,6 +95,16 @@ class Elgg_Amd_Config {
 	 */
 	public function addDependency($name) {
 		$this->dependencies[$name] = true;
+	}
+
+	/**
+	 * Removes a dependency
+	 *
+	 * @param string $name Name of the dependency
+	 * @return void
+	 */
+	public function removeDependency($name) {
+		unset($this->dependencies[$name]);
 	}
 
 	/**

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1552,7 +1552,6 @@ function elgg_views_boot() {
 	elgg_register_js('jquery-ui', '/vendors/jquery/jquery-ui-1.10.3.min.js', 'head');
 	elgg_register_js('jquery.form', array(
 		'src' => '/vendors/jquery/jquery.form.js',
-		'location' => 'head',
 		'deps' => array('jquery'),
 		'exports' => 'jQuery.fn.ajaxForm',
 	));

--- a/engine/tests/ElggCoreHelpersTest.php
+++ b/engine/tests/ElggCoreHelpersTest.php
@@ -242,6 +242,29 @@ class ElggCoreHelpersTest extends ElggCoreUnitTest {
 	}
 
 	/**
+	 * Test elgg_register_js() async mode
+	 */
+	public function testElggRegisterAMD() {
+		elgg_register_js('key', 'http://test1.com', 'async');
+
+		$amd = _elgg_services()->amdConfig->getConfig();
+		$this->assertIdentical($amd['paths']['key'], 'http://test1.com');
+
+		elgg_register_js('key', array(
+			'src' => 'http://test1.com',
+			'deps' => array('jquery'),
+			'exports' => 'jQuery.fn.keyTest',
+		));
+
+		$amd = _elgg_services()->amdConfig->getConfig();
+		$this->assertIdentical($amd['paths']['key'], 'http://test1.com');
+		$this->assertIdentical($amd['shim']['key'], array(
+			'deps' => array('jquery'),
+			'exports' => 'jQuery.fn.keyTest',
+		));
+	}
+
+	/**
 	 * Test elgg_register_css()
 	 */
 	public function testElggRegisterCSS() {
@@ -322,11 +345,26 @@ class ElggCoreHelpersTest extends ElggCoreUnitTest {
 
 		// load before register
 		elgg_load_js('key');
+		elgg_load_js('key2');
 		$result = elgg_register_js('key', 'http://test1.com', 'footer');
 		$this->assertTrue($result);
-		
+
 		$js_urls = elgg_get_loaded_js('footer');
+		$js_deps = _elgg_services()->amdConfig->getDependencies();
 		$this->assertIdentical(array(500 => 'http://test1.com'), $js_urls);
+		$this->assertFalse(in_array('key', $js_deps));
+
+		// register again with AMD
+		$result = elgg_register_js('key', 'http://test2.com', 'async');
+		$this->assertTrue($result);
+		$result = elgg_register_js('key2', 'http://test2.com', 'async');
+		$this->assertTrue($result);
+
+		$js_urls = elgg_get_loaded_js('footer');
+		$js_deps = _elgg_services()->amdConfig->getDependencies();
+		$this->assertIdentical(array(), $js_urls);
+		$this->assertTrue(in_array('key', $js_deps));
+		$this->assertTrue(in_array('key2', $js_deps));
 	}
 
 	/**

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -25,13 +25,12 @@ function developers_init() {
 
 	elgg_register_js('jquery.jstree', array(
 		'src' => '/mod/developers/vendors/jsTree/jquery.jstree.js',
-		'location' => 'footer',
 		'exports' => 'jQuery.fn.jstree',
 		'deps' => array('jquery'),
 	));
 	elgg_register_css('jquery.jstree', '/mod/developers/vendors/jsTree/themes/default/style.css');
 
-	elgg_require_js('elgg/dev');
+	elgg_load_js('elgg/dev');
 }
 
 function developers_process_settings() {

--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -182,7 +182,7 @@ function groups_handle_mine_page() {
 function groups_handle_edit_page($page, $guid = 0) {
 	elgg_gatekeeper();
 
-	elgg_require_js('elgg/groups/edit');
+	elgg_load_js('elgg/groups/edit');
 
 	if ($page == 'add') {
 		elgg_set_page_owner_guid(elgg_get_logged_in_user_guid());


### PR DESCRIPTION
### Covered cases
#### Vanilla js vendor

``` php
elgg_register_js($name, $src);
elgg_load_js($name);
```
#### Vanilla js simplecache view

``` php
elgg_register_js($name, elgg_get_simplecache_url('js', $view));
elgg_load_js($name);
```
#### AMD vendor

``` php
elgg_register_js($name, $src, 'async'); // or elgg_register_js($name, array('src' => $src));
elgg_load_js($name);
```
#### AMD shimed vendor

``` php
elgg_register_js($name, array('src' => $src, 'deps' => $deps, 'exports' => $exports));
elgg_load_js($name);
```
#### AMD view

``` php
elgg_load_js($view);
```

Have in mind `elgg_load_js` can also be called before `elgg_register_js`.

Refs #6496.
- [x] Make sure @mrclay is no longer blocking the PR
- [x] Convert [blog post](http://blog.elgg.org/pg/blog/evan/read/224/elgg-19-amd-for-js-modules) to rst and add to this PR (with corrections)
- [ ] Point to the rst doc from Evan's [AMD refering blog post](http://blog.elgg.org/pg/blog/evan/read/224/elgg-19-amd-for-js-modules)
- [x] Check for existing elgg_require_js() calls (still used at least in the groups plugin)
