### PR TITLE
fix(core): MenuBuilder sortByName should use strnatcmp

### DIFF
--- a/engine/classes/ElggMenuBuilder.php
+++ b/engine/classes/ElggMenuBuilder.php
@@ -263,7 +263,7 @@ class ElggMenuBuilder {
 		$an = $a->getName();
 		$bn = $b->getName();
 
-		$result = strcmp($an, $bn);
+		$result = strnatcmp($an, $bn);
 		if ($result === 0) {
 			return $a->getData('original_order') - $b->getData('original_order');
 		}


### PR DESCRIPTION
Just as MenuBuilder sortByText, the sortByName function should use
strnatcmp instead of strcmp

fixes #5569
- [ ] remove whitespace from doc block
- [ ] use "menus" as component instead of "core"
