### PR TITLE
fix(tests): Corrected the way the commit message tests are run.

### DIFF
--- a/.scripts/ElggCommitMessage.php
+++ b/.scripts/ElggCommitMessage.php
@@ -99,7 +99,7 @@ class ElggCommitMessage {
 	 *
 	 * @var string
 	 */
-	private $ignoreRegex = '/^(Merge pull request)|(Merge [0-9a-f]{5,40} into [0-9a-f]{5,40})/i';
+	private $ignoreRegex = '/^(Merge pull request)|(Merge [0-9a-f]{5,40} into [0-9a-f]{5,40})|(Merge branch)|(Merge remote-tracking branch)|(Merge commit)/i';
 
 	/**
 	 * Regex to extract the message parts

--- a/.scripts/travis/check_commit_msgs.sh
+++ b/.scripts/travis/check_commit_msgs.sh
@@ -16,6 +16,7 @@ fi
 
 
 if [ "$RANGE" == "" ]; then
+	echo -n "RANGE is empty!"
 	exit 1
 fi
 
@@ -35,6 +36,7 @@ do
 	VALUE=$?
 
 	if [ "$VALUE" -gt 0 ]; then
+		echo -n "./.scripts/validate_commit_msg.php exited with error!"
 		EXIT=$VALUE
 	fi
 done

--- a/engine/tests/phpunit/ElggTravisValidateCommitMsgTest.php
+++ b/engine/tests/phpunit/ElggTravisValidateCommitMsgTest.php
@@ -21,14 +21,18 @@ class ElggTravisValidateCommitMsgTest extends ElggCommitMessageGitHookTest {
 	 */
 	public function testRange() {
 		// baf2df9355a5fc63679ad1aa80f363d00a51572b..3749dda1411437bc8029b1facfe5922059a247f1
-		$range = "baf2df9355a5fc63679ad1aa80f363d00a51572b...3749dda1411437bc8029b1facfe5922059a247f1";
-		$cmd = "TRAVIS_COMMIT_RANGE='$range' bash {$this->travisScript}";
-		$this->assertTrue($this->runCmd($cmd));
+		$cmd = "bash {$this->travisScript}";
+		$result = $this->runCmd($cmd, $output, array(
+			'TRAVIS_COMMIT_RANGE' => "baf2df9355a5fc63679ad1aa80f363d00a51572b...3749dda1411437bc8029b1facfe5922059a247f1",
+		));
+		$this->assertTrue($result, $output);
 
 		// and with two dots
-		$range = "baf2df9355a5fc63679ad1aa80f363d00a51572b..3749dda1411437bc8029b1facfe5922059a247f1";
-		$cmd = "TRAVIS_COMMIT_RANGE='$range' bash {$this->travisScript}";
-		$this->assertTrue($this->runCmd($cmd));
+		$cmd = "bash {$this->travisScript}";
+		$result = $this->runCmd($cmd, $output, array(
+			'TRAVIS_COMMIT_RANGE' => "baf2df9355a5fc63679ad1aa80f363d00a51572b..3749dda1411437bc8029b1facfe5922059a247f1",
+		));
+		$this->assertTrue($result, $output);
 	}
 
 	/**
@@ -36,9 +40,11 @@ class ElggTravisValidateCommitMsgTest extends ElggCommitMessageGitHookTest {
 	 */
 	public function testFailingRange() {
 		// 10e85ea6eff9921d5bed5d501750d660825e9304..fc62de7a6b03c3ca11f2a057db20fe2414c47d1f
-		$range = '10e85ea6eff9921d5bed5d501750d660825e9304..fc62de7a6b03c3ca11f2a057db20fe2414c47d1f';
-		$cmd = "TRAVIS_COMMIT_RANGE='$range' bash {$this->travisScript}";
-		$this->assertFalse($this->runCmd($cmd));
+		$cmd = "bash {$this->travisScript}";
+		$result = $this->runCmd($cmd, $output, array(
+			'TRAVIS_COMMIT_RANGE' => '10e85ea6eff9921d5bed5d501750d660825e9304..fc62de7a6b03c3ca11f2a057db20fe2414c47d1f',
+		));
+		$this->assertFalse($result, $output);
 	}
 
 	/**
@@ -46,9 +52,11 @@ class ElggTravisValidateCommitMsgTest extends ElggCommitMessageGitHookTest {
 	 */
 	public function testSomeFailingRange() {
 		// 6d3886c6b6a01399891f11b3c675fa9135786bd1..6448bb95497db21923542a10983915023c1c2d32
-		$range = '6d3886c6b6a01399891f11b3c675fa9135786bd1..6448bb95497db21923542a10983915023c1c2d32';
-		$cmd = "TRAVIS_COMMIT_RANGE='$range' bash {$this->travisScript}";
-		$this->assertFalse($this->runCmd($cmd));
+		$cmd = "bash {$this->travisScript}";
+		$result = $this->runCmd($cmd, $output, array(
+			'TRAVIS_COMMIT_RANGE' => '6d3886c6b6a01399891f11b3c675fa9135786bd1..6448bb95497db21923542a10983915023c1c2d32',
+		));
+		$this->assertFalse($result, $output);
 	}
 
 	/**
@@ -60,9 +68,11 @@ class ElggTravisValidateCommitMsgTest extends ElggCommitMessageGitHookTest {
 	 */
 	public function testCommit() {
 		// https://github.com/Elgg/Elgg/commit/6c84d2f394530bcaceb377e734c075c227923cb7
-		$sha = '6c84d2f394530bcaceb377e734c075c227923cb7';
-		$cmd = "TRAVIS_COMMIT='$sha' bash {$this->travisScript}";
-		$this->assertTrue($this->runCmd($cmd));
+		$cmd = "bash {$this->travisScript}";
+		$result = $this->runCmd($cmd, $output, array(
+			'TRAVIS_COMMIT' => '6c84d2f394530bcaceb377e734c075c227923cb7',
+		));
+		$this->assertTrue($result, $output);
 	}
 
 	/**
@@ -70,9 +80,11 @@ class ElggTravisValidateCommitMsgTest extends ElggCommitMessageGitHookTest {
 	 */
 	public function testFailingCommit() {
 		// https://github.com/Elgg/Elgg/commit/8f420a15d8fe567d78dca0ee97bc71305842c995
-		$sha = '8f420a15d8fe567d78dca0ee97bc71305842c995';
-		$cmd = "TRAVIS_COMMIT='$sha' bash {$this->travisScript}";
-		$this->assertFalse($this->runCmd($cmd));
+		$cmd = "bash {$this->travisScript}";
+		$result = $this->runCmd($cmd, $output, array(
+			'TRAVIS_COMMIT' => '8f420a15d8fe567d78dca0ee97bc71305842c995',
+		));
+		$this->assertFalse($result, $output);
 	}
 
 	/**
@@ -80,9 +92,11 @@ class ElggTravisValidateCommitMsgTest extends ElggCommitMessageGitHookTest {
 	 */
 	public function testPrMerge() {
 		// https://github.com/Elgg/Elgg/commit/9a54813f36ba019e11561ba4f685021a0f4dbf9a
-		$sha = '9a54813f36ba019e11561ba4f685021a0f4dbf9a';
-		$cmd = "TRAVIS_COMMIT='$sha' bash {$this->travisScript}";
-		$this->assertTrue($this->runCmd($cmd));
+		$cmd = "bash {$this->travisScript}";
+		$result = $this->runCmd($cmd, $output, array(
+			'TRAVIS_COMMIT' => '9a54813f36ba019e11561ba4f685021a0f4dbf9a',
+		));
+		$this->assertTrue($result, $output);
 	}
 
 	/**
@@ -90,9 +104,11 @@ class ElggTravisValidateCommitMsgTest extends ElggCommitMessageGitHookTest {
 	 */
 	public function testFailingPrMerge() {
 		// https://github.com/Elgg/Elgg/commit/cfc2a3fb9e97488e36f5a5771c816fff90e3691f
-		$sha = 'cfc2a3fb9e97488e36f5a5771c816fff90e3691f';
-		$cmd = "TRAVIS_COMMIT='$sha' bash {$this->travisScript}";
-		$this->assertFalse($this->runCmd($cmd));
+		$cmd = "bash {$this->travisScript}";
+		$result = $this->runCmd($cmd, $output, array(
+			'TRAVIS_COMMIT' => 'cfc2a3fb9e97488e36f5a5771c816fff90e3691f',
+		));
+		$this->assertFalse($result, $output);
 	}
 
 	/**
@@ -105,7 +121,8 @@ class ElggTravisValidateCommitMsgTest extends ElggCommitMessageGitHookTest {
 	public function testSHAAsArg() {
 		$sha = '6c84d2f394530bcaceb377e734c075c227923cb7';
 		$cmd = "bash {$this->travisScript} $sha";
-		$this->assertTrue($this->runCmd($cmd));
+		$result = $this->runCmd($cmd, $output);
+		$this->assertTrue($result, $output);
 	}
 
 	/**
@@ -114,12 +131,14 @@ class ElggTravisValidateCommitMsgTest extends ElggCommitMessageGitHookTest {
 	public function testRangeAsArg() {
 		$range = "baf2df9355a5fc63679ad1aa80f363d00a51572b..3749dda1411437bc8029b1facfe5922059a247f1";
 		$cmd = "bash {$this->travisScript} $range";
-		$this->assertTrue($this->runCmd($cmd));
+		$result = $this->runCmd($cmd, $output);
+		$this->assertTrue($result, $output);
 	}
 
 	public function testPrAsArg() {
 		$sha = '9a54813f36ba019e11561ba4f685021a0f4dbf9a';
 		$cmd = "bash {$this->travisScript} $sha";
-		$this->assertTrue($this->runCmd($cmd));
+		$result = $this->runCmd($cmd, $output);
+		$this->assertTrue($result, $output);
 	}
 }


### PR DESCRIPTION
Made more informative errors on phpunit failures. Corrected the way environment variables are passed to subprocess while testng. Allowed more merge commit label formats.

Fixes #6507
