### PR TITLE
chore(simplecache): rationalize use of elgg_register_simplecache_view()

### DIFF
--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -270,7 +270,6 @@ function _elgg_admin_init() {
 	elgg_register_action('profile/fields/reorder', '', 'admin');
 
 	elgg_register_simplecache_view('css/admin');
-	elgg_register_simplecache_view('js/admin');
 	$url = elgg_get_simplecache_url('js', 'admin');
 	elgg_register_js('elgg.admin', $url);
 	elgg_register_js('elgg.upgrades', 'js/lib/upgrades.js');

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -127,12 +127,6 @@ function elgg_disable_system_cache() {
  * @warning Simple cached views must take no parameters and return
  * the same content no matter who is logged in.
  *
- * @example
- * 		$blog_js = elgg_get_simplecache_url('js', 'blog/save_draft');
- *		elgg_register_simplecache_view('js/blog/save_draft');
- *		elgg_register_js('elgg.blog', $blog_js);
- *		elgg_load_js('elgg.blog');
- *
  * @param string $view_name View name
  *
  * @return void
@@ -147,6 +141,11 @@ function elgg_register_simplecache_view($view_name) {
  * Get the URL for the cached file
  * 
  * This automatically registers the view with Elgg's simplecache.
+ * 
+ * @example
+ * 		$blog_js = elgg_get_simplecache_url('js', 'blog/save_draft');
+ *		elgg_register_js('elgg.blog', $blog_js);
+ *		elgg_load_js('elgg.blog');
  *
  * @param string $type The file type: css or js
  * @param string $view The view name after css/ or js/

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1934,8 +1934,6 @@ function _elgg_walled_garden_ajax_handler($page) {
 function _elgg_walled_garden_init() {
 	global $CONFIG;
 
-	elgg_register_simplecache_view('js/walled_garden');
-	elgg_register_simplecache_view('css/walled_garden');
 	elgg_register_css('elgg.walled_garden', elgg_get_simplecache_url('css', 'walled_garden'));
 	elgg_register_js('elgg.walled_garden', elgg_get_simplecache_url('js', 'walled_garden'));
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1543,7 +1543,6 @@ function elgg_views_boot() {
 	elgg_register_simplecache_view('css/ie7');
 	elgg_register_simplecache_view('css/ie8');
 
-	elgg_register_simplecache_view('js/elgg/require_config');
 	elgg_register_simplecache_view('js/text.js');
 
 	elgg_register_js('elgg.require_config', elgg_get_simplecache_url('js', 'elgg/require_config'), 'head');
@@ -1558,7 +1557,6 @@ function elgg_views_boot() {
 		'exports' => 'jQuery.fn.ajaxForm',
 	));
 
-	elgg_register_simplecache_view('js/elgg');
 	$elgg_js_url = elgg_get_simplecache_url('js', 'elgg');
 	elgg_register_js('elgg', $elgg_js_url, 'head');
 
@@ -1569,13 +1567,11 @@ function elgg_views_boot() {
 	elgg_load_js('jquery-ui');
 	elgg_load_js('elgg');
 
-	elgg_register_simplecache_view('js/lightbox');
 	$lightbox_js_url = elgg_get_simplecache_url('js', 'lightbox');
 	elgg_register_js('lightbox', $lightbox_js_url);
 
 	elgg_register_css('lightbox', 'vendors/jquery/colorbox/theme/colorbox.css');
 
-	elgg_register_simplecache_view('css/elgg');
 	$elgg_css_url = elgg_get_simplecache_url('css', 'elgg');
 	elgg_register_css('elgg', $elgg_css_url);
 

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -32,7 +32,6 @@ function blog_init() {
 
 	// register the blog's JavaScript
 	$blog_js = elgg_get_simplecache_url('js', 'blog/save_draft');
-	elgg_register_simplecache_view('js/blog/save_draft');
 	elgg_register_js('elgg.blog', $blog_js);
 
 	// routing of urls

--- a/mod/embed/start.php
+++ b/mod/embed/start.php
@@ -24,7 +24,6 @@ function embed_init() {
 	elgg_register_page_handler('embed', 'embed_page_handler');
 	
 	$embed_js = elgg_get_simplecache_url('js', 'embed/embed');
-	elgg_register_simplecache_view('js/embed/embed');
 	elgg_register_js('elgg.embed', $embed_js, 'footer');
 }
 

--- a/mod/site_notifications/start.php
+++ b/mod/site_notifications/start.php
@@ -18,7 +18,6 @@ function site_notifications_init() {
 	elgg_extend_view('css/elgg', 'site_notifications/css');
 
 	$js = elgg_get_simplecache_url('js', 'site_notifications');
-	elgg_register_simplecache_view('js/site_notifications');
 	elgg_register_js('elgg.site_notifications', $js, 'footer');
 
 	site_notifications_set_topbar();

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -21,7 +21,6 @@ function thewire_init() {
 
 	// register the wire's JavaScript
 	$thewire_js = elgg_get_simplecache_url('js', 'thewire');
-	elgg_register_simplecache_view('js/thewire');
 	elgg_register_js('elgg.thewire', $thewire_js, 'footer');
 
 	elgg_register_ajax_view('thewire/previous');


### PR DESCRIPTION
Since elgg_get_simplecache_url() already calls it, it has no sense call it twice.
