### PR TITLE
fix(routing): alert site owner if .htaccess needs updating

### DIFF
--- a/htaccess_dist
+++ b/htaccess_dist
@@ -138,7 +138,6 @@ RewriteRule ^export\/([A-Za-z]+)\/([0-9]+)\/([A-Za-z]+)\/([A-Za-z0-9\_]+)\/$ eng
 RewriteRule ^rewrite.php$ install.php [L]
 
 # Everything else that isn't a file gets routed through Elgg
-RewriteEngine on
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)$ index.php?__elgg_uri=$1 [QSA,L]

--- a/index.php
+++ b/index.php
@@ -6,6 +6,14 @@
  * @subpackage Core
  */
 
+// allow testing from the upgrade page before the site is upgraded.
+if (isset($_GET['__testing_rewrite'])) {
+	if (isset($_GET['__elgg_uri']) && false !== strpos($_GET['__elgg_uri'], '__testing_rewrite')) {
+		echo "success";
+	}
+	exit;
+}
+
 require_once(dirname(__FILE__) . "/engine/start.php");
 
 $router = _elgg_services()->router;

--- a/install/ElggRewriteTester.php
+++ b/install/ElggRewriteTester.php
@@ -89,7 +89,7 @@ class ElggRewriteTester {
 	 *
 	 * @return bool
 	 */
-	protected function runRewriteTest($url) {
+	public function runRewriteTest($url) {
 
 		$this->serverSupportsRemoteRead = TRUE;
 

--- a/languages/en.php
+++ b/languages/en.php
@@ -1060,6 +1060,8 @@ Once you have logged in, we highly recommend that you change your password.
 	'installation:minify_js:label' => "Compress JavaScript (recommended)",
 	'installation:minify_css:label' => "Compress CSS (recommended)",
 
+	'installation:htaccess:needs_upgrade' => "You must update your .htaccess file so that the path is injected into the GET parameter __elgg_uri (you can use htaccess_dist as a guide).",
+
 	'installation:systemcache:description' => "The system cache decreases the loading time of Elgg by caching data to files.",
 	'installation:systemcache:label' => "Use system cache (recommended)",
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -30,6 +30,23 @@ if (get_input('upgrade') == 'upgrade') {
 		forward();
 	}
 } else {
+	// test the URL rewrite rules
+	if (!class_exists('ElggRewriteTester')) {
+		require dirname(__FILE__) . '/install/ElggRewriteTester.php';
+	}
+	$rewriteTester = new ElggRewriteTester();
+	$url = elgg_get_site_url() . "__testing_rewrite?__testing_rewrite=1";
+	if (!$rewriteTester->runRewriteTest($url)) {
+		// note: translation may not be available until after upgrade
+		$msg = elgg_echo("installation:htaccess:needs_upgrade");
+		if ($msg === "installation:htaccess:needs_upgrade") {
+			$msg = "You must update your .htaccess file so that the path is injected "
+				. "into the GET parameter __elgg_uri (you can use htaccess_dist as a guide).";
+		}
+		echo $msg;
+		exit;
+	}
+
 	// if upgrading from < 1.8.0, check for the core view 'welcome' and bail if it's found.
 	// see https://github.com/elgg/elgg/issues/3064
 	// we're not checking the view itself because it's likely themes will override this view.


### PR DESCRIPTION
The router relies on a querystring added via URL rewriting by
the web server. If missing, this would lead to looping redirects
or showing only the index page. This instead sends a 500 error
page with a message to update .htaccess.

Fixes #6521
