### PR TITLE
fix(css): prevent stretching images in IE8

### DIFF
--- a/mod/aalborg_theme/views/default/css/elements/typography.php
+++ b/mod/aalborg_theme/views/default/css/elements/typography.php
@@ -157,6 +157,7 @@ h6 { font-size: 0.8em; }
 	padding: 3px 5px;
 }
 .elgg-output img {
+	width: auto;
 	max-width: 100%;
 	height: auto;
 }

--- a/views/default/css/elements/typography.php
+++ b/views/default/css/elements/typography.php
@@ -160,6 +160,7 @@ h6 { font-size: 0.8em; }
 	padding: 3px 5px;
 }
 .elgg-output img {
+	width: auto;
 	max-width: 100%;
 	height: auto;
 }


### PR DESCRIPTION
Fixes #6523
