### PR TITLE
Ckeditor init fix

### DIFF
--- a/mod/ckeditor/views/default/ckeditor/init.php
+++ b/mod/ckeditor/views/default/ckeditor/init.php
@@ -8,6 +8,8 @@
 ?>
 <script>
 require(['elgg/ckeditor', 'jquery', 'jquery.ckeditor'], function(elggCKEditor, $) {
-	$('.elgg-input-longtext').ckeditor(elggCKEditor.init, elggCKEditor.config);
+	$('.elgg-input-longtext:not([data-cke-init])')
+		.attr('data-cke-init', true)
+		.ckeditor(elggCKEditor.init, elggCKEditor.config);
 });
 </script>

--- a/mod/ckeditor/views/default/ckeditor/init.php
+++ b/mod/ckeditor/views/default/ckeditor/init.php
@@ -7,9 +7,6 @@
 
 ?>
 <script>
-// This global variable must be set before the editor script loading.
-CKEDITOR_BASEPATH = elgg.config.wwwroot + 'mod/ckeditor/vendors/ckeditor/';
-
 require(['elgg/ckeditor', 'jquery', 'jquery.ckeditor'], function(elggCKEditor, $) {
 	$('.elgg-input-longtext').ckeditor(elggCKEditor.init, elggCKEditor.config);
 });

--- a/mod/ckeditor/views/default/js/elgg/ckeditor.js
+++ b/mod/ckeditor/views/default/js/elgg/ckeditor.js
@@ -1,3 +1,6 @@
+// This global variable must be set before the editor script loading.
+CKEDITOR_BASEPATH = elgg.config.wwwroot + 'mod/ckeditor/vendors/ckeditor/';
+
 define(function(require) {
 	var elgg = require('elgg');
 	var $ = require('jquery'); require('jquery.ckeditor');


### PR DESCRIPTION
Steps to reproduce:
1- Disable ckeditor input by clicking `Edit HTML`.
2- Click over `Embed content`
3- Click over `Upload a file tab`, that contains another ckeditor
4- Close lightbox
Issue: first ckedior is enabled again.
