### PR TITLE
fix(menus): eliminates warnings in section menus

### DIFF
--- a/views/default/navigation/menu/elements/section.php
+++ b/views/default/navigation/menu/elements/section.php
@@ -10,6 +10,7 @@
  * @uses $vars['show_section_headers'] Do we show headers for each section
  */
 
+$items = elgg_extract('items', $vars, array());
 $headers = elgg_extract('show_section_headers', $vars, false);
 $class = elgg_extract('class', $vars, '');
 $item_class = elgg_extract('item_class', $vars, '');
@@ -21,10 +22,14 @@ if ($headers) {
 }
 
 echo "<ul class=\"$class\">";
-foreach ($vars['items'] as $menu_item) {
-	echo elgg_view('navigation/menu/elements/item', array(
-		'item' => $menu_item,
-		'item_class' => $item_class,
-	));
+
+if (is_array($items)) {
+	foreach ($items as $menu_item) {
+		echo elgg_view('navigation/menu/elements/item', array(
+			'item' => $menu_item,
+			'item_class' => $item_class,
+		));
+	}
 }
+
 echo '</ul>';


### PR DESCRIPTION
Handles case where $vars['items'] is empty/not an array.

Fixes #6558
