### PR TITLE
fix(ui): standarize size of input and a buttons

### DIFF
--- a/views/default/css/elements/buttons.php
+++ b/views/default/css/elements/buttons.php
@@ -18,14 +18,11 @@
 	font-weight: bold;
 	border-radius: 5px;
 	width: auto;
-	padding: 2px 4px;
+	padding: 3px 6px;
 	cursor: pointer;
 	outline: none;
 	box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.40);
 	background-color: #ccc;
-}
-a.elgg-button {
-	padding: 3px 6px;
 }
 
 .elgg-button:hover,


### PR DESCRIPTION
Submit inputs and a buttons usually are used together and they should be equivalents.
