### PR TITLE
fix (view): Tagcloud output

### DIFF
--- a/views/default/output/tagcloud.php
+++ b/views/default/output/tagcloud.php
@@ -49,7 +49,7 @@ if (!empty($vars['tagcloud']) && is_array($vars['tagcloud'])) {
 		if ($size < 100) {
 			$size = 100;
 		}
-		$url = "search?q=". urlencode($tag->tag) . "&search_type=tags$type$subtype";
+		$url = elgg_get_site_url() . 'search?q=' . rawurlencode($tag->tag) . "&search_type=tags$type$subtype";
 
 		$cloud .= elgg_view('output/url', array(
 			'text' => $tag->tag,


### PR DESCRIPTION
Tags with a . in the tag are currently not handled correctly (e.g .net or a website). The site url is stripped of somehow.  This proposed new url fixes the output url to be correct.
