### PR TITLE
fix (js) : Avatar cropper positionning bug

### DIFF
--- a/js/lib/ui.avatar_cropper.js
+++ b/js/lib/ui.avatar_cropper.js
@@ -15,7 +15,10 @@ elgg.avatarCropper.init = function() {
 		selectionOpacity: 0,
 		aspectRatio: '1:1',
 		onSelectEnd: elgg.avatarCropper.selectChange,
-		onSelectChange: elgg.avatarCropper.preview
+		onSelectChange: elgg.avatarCropper.preview,
+		parent: '.elgg-form-avatar-crop div div.clearfix',
+		movable: 'true',
+		zIndex: 20
 	};
 
 	if ($('input[name=x2]').val()) {

--- a/js/lib/ui.avatar_cropper.js
+++ b/js/lib/ui.avatar_cropper.js
@@ -16,10 +16,14 @@ elgg.avatarCropper.init = function() {
 		aspectRatio: '1:1',
 		onSelectEnd: elgg.avatarCropper.selectChange,
 		onSelectChange: elgg.avatarCropper.preview,
-		parent: '.elgg-form-avatar-crop div div.clearfix',
+		// Note : parent defaults to body, which has to be set as position:static to work on Chrome
+		parent: '.elgg-form-avatar-crop',
 		movable: 'true',
-		zIndex: 20
+		zIndex: 20,
+		handles:'corners',
+		//keys: true, // Allow keys bindings (control selection position and reisez with Arrows + Shift/Alt/Ctrl)
 	};
+	$('.elgg-form-avatar-crop').css({position:'relative'});
 
 	if ($('input[name=x2]').val()) {
 		params.x1 = $('input[name=x1]').val();


### PR DESCRIPTION
There is a positionning bug on the avatar image crop selection, at least in Chrome (but not in Firefox) : when the page is scrolled, the selection appears under the image, with a offset that increases proportionnally to the scrolling.

Tested on Chromium Version 32.0.1700.107 Ubuntu 12.04, but also reported on (unknown) Chrome versions under Mac OSX and Windows.

This involves a jquery plugin called imgareaselect ; according to this plugin's documentation and forums, this can be resolved by setting the "parent" param to a closer container, that has to be positionned "relative" or "absolute" (no float, no fix, no static).
Also, it requires to set the z-index, and it appears  that setting "movable" to true also helps make it work properly on Chrome.
- [ ] Change commit message to [standard format](http://learn.elgg.org/en/latest/contribute/code.html#commit-message-format)
- [ ] resubmit to 1.9 branch
