### PR TITLE
chore(session): moves persistent login logic to service

### DIFF
--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -18,6 +18,7 @@
  * @property-read Elgg_Logger                             $logger
  * @property-read ElggVolatileMetadataCache               $metadataCache
  * @property-read Elgg_Notifications_NotificationsService $notifications
+ * @property-read Elgg_PersistentLoginService             $persistentLogin
  * @property-read Elgg_Database_QueryCounter              $queryCounter
  * @property-read Elgg_Http_Request                       $request
  * @property-read Elgg_Router                             $router
@@ -47,6 +48,7 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 		$this->setFactory('hooks', array($this, 'getHooks'));
 		$this->setFactory('logger', array($this, 'getLogger'));
 		$this->setClassName('metadataCache', 'ElggVolatileMetadataCache');
+		$this->setFactory('persistentLogin', array($this, 'getPersistentLogin'));
 		$this->setFactory('queryCounter', array($this, 'getQueryCounter'), false);
 		$this->setFactory('request', array($this, 'getRequest'));
 		$this->setFactory('router', array($this, 'getRouter'));
@@ -197,6 +199,20 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 		$sub = new Elgg_Notifications_SubscriptionsService($c->db);
 		$access = elgg_get_access_object();
 		return new Elgg_Notifications_NotificationsService($sub, $queue, $c->hooks, $access);
+	}
+
+	/**
+	 * Persistent login service factory
+	 *
+	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
+	 * @return Elgg_PersistentLoginService
+	 */
+	protected function getPersistentLogin(Elgg_Di_ServiceProvider $c) {
+		$cookies_config = elgg_get_config('cookies');
+		$remember_me_cookies_config = $cookies_config['remember_me'];
+		$cookie_name = $remember_me_cookies_config['name'];
+		$cookie_token = $c->request->cookies->get($cookie_name, '');
+		return new Elgg_PersistentLoginService($c->db, $c->session, $c->crypto, $remember_me_cookies_config, $cookie_token);
 	}
 
 	/**

--- a/engine/classes/Elgg/PersistentLoginService.php
+++ b/engine/classes/Elgg/PersistentLoginService.php
@@ -1,0 +1,352 @@
+<?php
+/**
+ * Elgg_PersistentLoginService
+ *
+ * If a user selects a persistent login, a long, random token is generated and stored in the cookie
+ * called "elggperm", and a hash of the token is stored in the DB. If the user's PHP session expires,
+ * the session boot sequence will try to log the user in via the token in the cookie.
+ *
+ * Before Elgg 1.9, the token hashes were stored as "code" in the users_entity table.
+ *
+ * In Elgg 1.9, the token hashes are stored as "code" in the users_remember_me_cookies
+ * table, allowing multiple browsers to maintain persistent logins.
+ *
+ * @todo Rename the "code" DB column to "hash"
+ *
+ * Legacy notes: This feature used to be called "remember me"; confusingly, both the tokens and the
+ * hashes were called "codes"; old tokens were hexadecimal and lower entropy; new tokens are
+ * base64 URL and always begin with the letter "z"; the boot sequence replaces old tokens whenever
+ * possible.
+ *
+ * @package Elgg.Core
+ *
+ * @access private
+ */
+class Elgg_PersistentLoginService {
+
+	/**
+	 * Constructor
+	 *
+	 * @param Elgg_Database $db            The DB service
+	 * @param ElggSession   $session       The Elgg session
+	 * @param ElggCrypto    $crypto        The cryptography service
+	 * @param array         $cookie_config The persistent login cookie settings
+	 * @param string        $cookie_token  The token from the request cookie
+	 */
+	public function __construct(
+			Elgg_Database $db,
+			ElggSession $session,
+			ElggCrypto $crypto,
+			array $cookie_config,
+			$cookie_token) {
+		$this->db = $db;
+		$this->session = $session;
+		$this->crypto = $crypto;
+		$this->cookie_config = $cookie_config;
+		$this->cookie_token = $cookie_token;
+
+		$prefix = $this->db->getTablePrefix();
+		$this->table = "{$prefix}users_remember_me_cookies";
+	}
+
+	/**
+	 * Make the user's login persistent
+	 *
+	 * @param ElggUser $user The user who logged in
+	 * @return void
+	 */
+	public function makeLoginPersistent(ElggUser $user) {
+		$token = $this->generateToken();
+		$hash = $this->hashToken($token);
+
+		$this->storeHash($user, $hash);
+		$this->setCookie($token);
+		$this->setSession($token);
+	}
+
+	/**
+	 * Remove the persisted login token from client and server
+	 * @return void
+	 */
+	public function removePersistentLogin() {
+		if ($this->cookie_token) {
+			$client_hash = $this->hashToken($this->cookie_token);
+			$this->removeHash($client_hash);
+		}
+
+		$this->setCookie("");
+		$this->setSession("");
+	}
+
+	/**
+	 * Handle a password change
+	 *
+	 * @param ElggUser $subject  The user whose password changed
+	 * @param ElggUser $modifier The user who changed the password
+	 * @return void
+	 */
+	public function handlePasswordChange(ElggUser $subject, ElggUser $modifier = null) {
+		$this->removeAllHashes($subject);
+		if (!$modifier || ($modifier->guid !== $subject->guid) || !$this->cookie_token) {
+			return;
+		}
+
+		$this->makeLoginPersistent($modifier);
+	}
+
+	/**
+	 * Boot the persistent login session, possibly returning the user who should be
+	 * silently logged in.
+	 *
+	 * @return ElggUser|null
+	 */
+	public function bootSession() {
+		if (!$this->cookie_token) {
+			return null;
+		}
+
+		// is this token good?
+		$cookie_hash = $this->hashToken($this->cookie_token);
+		$user = $this->getUserFromHash($cookie_hash);
+		if ($user) {
+			$this->setSession($this->cookie_token);
+			// note: if the token is legacy, we don't both replacing it here because
+			// it will be replaced during the next request boot
+			return $user;
+		} else {
+			if ($this->isLegacyToken($this->cookie_token)) {
+				// may be attempt to brute force legacy low-entropy tokens
+				call_user_func($this->_callable_sleep, 1);
+			}
+			$this->setCookie('');
+		}
+	}
+
+	/**
+	 * Replace the user's token if it's a legacy hexadecimal token
+	 *
+	 * @param ElggUser $logged_in_user The logged in user
+	 * @return void
+	 */
+	public function replaceLegacyToken(ElggUser $logged_in_user) {
+		if (!$this->cookie_token || !$this->isLegacyToken($this->cookie_token)) {
+			return;
+		}
+
+		// replace user's old weaker-entropy code with new one
+		$this->removeHash($this->hashToken($this->cookie_token));
+		$this->makeLoginPersistent($logged_in_user);
+	}
+
+	/**
+	 * Find a user with the given hash
+	 *
+	 * @param string $hash The hashed token
+	 * @return ElggUser|null
+	 */
+	public function getUserFromHash($hash) {
+		if (!$hash) {
+			return null;
+		}
+
+		$hash = $this->db->sanitizeString($hash);
+		$query = "SELECT guid FROM {$this->table} WHERE code = '$hash'";
+		try {
+			$user_row = $this->db->getDataRow($query);
+		} catch (DatabaseException $e) {
+			return $this->handleDbException($e);
+		}
+		if (!$user_row) {
+			return null;
+		}
+
+		$user = call_user_func($this->_callable_get_user, $user_row->guid);
+		return $user ? $user : null;
+	}
+
+	/**
+	 * Store a hash in the DB
+	 *
+	 * @param ElggUser $user The user for whom we're storing the hash
+	 * @param string   $hash The hashed token
+	 * @return void
+	 */
+	protected function storeHash(ElggUser $user, $hash) {
+		$time = time();
+		$hash = $this->db->sanitizeString($hash);
+
+		$query = "
+			INSERT INTO {$this->table} (code, guid, timestamp)
+		    VALUES ('$hash', {$user->guid}, $time)
+		";
+		try {
+			$this->db->insertData($query);
+		} catch (DatabaseException $e) {
+			$this->handleDbException($e);
+		}
+	}
+
+	/**
+	 * Remove a hash from the DB
+	 *
+	 * @param string $hash The hashed token to remove (unused before 1.9)
+	 * @return void
+	 */
+	protected function removeHash($hash) {
+		$hash = $this->db->sanitizeString($hash);
+
+		$query = "DELETE FROM {$this->table} WHERE code = '$hash'";
+		try {
+			$this->db->deleteData($query);
+		} catch (DatabaseException $e) {
+			$this->handleDbException($e);
+		}
+	}
+
+	/**
+	 * Swallow a schema not upgraded exception, otherwise rethrow it
+	 *
+	 * @param DatabaseException $exception The exception to handle
+	 * @param string            $default   The value to return if the table doesn't exist yet
+	 * @return mixed
+	 *
+	 * @throws DatabaseException
+	 */
+	protected function handleDbException(DatabaseException $exception, $default = null) {
+		if (false !== strpos($exception->getMessage(), "users_remember_me_cookies' doesn't exist")) {
+			// schema has not been updated so we swallow this exception
+			return $default;
+		} else {
+			throw $exception;
+		}
+	}
+
+	/**
+	 * Remove all the hashes associated with a user
+	 *
+	 * @param ElggUser $user The user for whom we're removing hashes
+	 * @return void
+	 */
+	protected function removeAllHashes(ElggUser $user) {
+		$query = "DELETE FROM {$this->table} WHERE guid = '{$user->guid}'";
+		try {
+			$this->db->deleteData($query);
+		} catch (DatabaseException $e) {
+			$this->handleDbException($e);
+		}
+	}
+
+	/**
+	 * Create a hash from the token
+	 *
+	 * @param string $token The token to hash
+	 * @return string
+	 */
+	protected function hashToken($token) {
+		// note: with user passwords, you'd want legit password hashing, but since these are randomly
+		// generated and long tokens, rainbow tables aren't any help.
+		return md5($token);
+	}
+
+	/**
+	 * Store the token in the client cookie (or remove the cookie)
+	 *
+	 * @param string $token Empty string to remove cookie
+	 * @return void
+	 */
+	protected function setCookie($token) {
+		$cookie = new ElggCookie($this->cookie_config['name']);
+		foreach (array('expire', 'path', 'domain', 'secure', 'httponly') as $key) {
+			$cookie->$key = $this->cookie_config[$key];
+		}
+		$cookie->value = $token;
+		if (!$token) {
+			$cookie->setExpiresTime("-30 days");
+		}
+		call_user_func($this->_callable_elgg_set_cookie, $cookie);
+	}
+
+	/**
+	 * Store the token in the session (or remove it from the session)
+	 *
+	 * @param string $token The token to store in session. Empty string to remove.
+	 * @return void
+	 */
+	protected function setSession($token) {
+		if ($token) {
+			$this->session->set('code', $token);
+		} else {
+			$this->session->remove('code');
+		}
+	}
+
+	/**
+	 * Generate a random token (base 64 URL)
+	 *
+	 * The first char is always "z" to indicate the value has more entropy than the
+	 * previously generated ones.
+	 *
+	 * @return string
+	 */
+	protected function generateToken() {
+		return 'z' . $this->crypto->getRandomString(31);
+	}
+
+	/**
+	 * Is the given token a legacy MD5 hash?
+	 *
+	 * @param string $token The token to analyze
+	 * @return bool
+	 */
+	protected function isLegacyToken($token) {
+		return (isset($token[0]) && $token[0] !== 'z');
+	}
+
+	/**
+	 * @var Elgg_Database
+	 */
+	protected $db;
+
+	/**
+	 * @var string
+	 */
+	protected $table;
+
+	/**
+	 * @var array
+	 */
+	protected $cookie_config;
+
+	/**
+	 * @var string
+	 */
+	protected $cookie_token;
+
+	/**
+	 * @var ElggSession
+	 */
+	protected $session;
+
+	/**
+	 * @var ElggCrypto
+	 */
+	protected $crypto;
+
+	/**
+	 * DO NOT USE. For unit test mocking
+	 * @access private
+	 */
+	public $_callable_get_user = 'get_user';
+
+	/**
+	 * DO NOT USE. For unit test mocking
+	 * @access private
+	 */
+	public $_callable_elgg_set_cookie = 'elgg_set_cookie';
+
+	/**
+	 * DO NOT USE. For unit test mocking
+	 * @access private
+	 */
+	public $_callable_sleep = 'sleep';
+}

--- a/engine/lib/user_settings.php
+++ b/engine/lib/user_settings.php
@@ -72,19 +72,7 @@ function _elgg_set_user_password() {
 			if ($password == $password2) {
 				$user->salt = _elgg_generate_password_salt();
 				$user->password = generate_user_password($user, $password);
-
-				// don't allow others to authenticate via tokens
-				_elgg_delete_users_remember_me_hashes($user);
-
-				$cookie_token = _elgg_get_remember_me_token_from_cookie();
-				if ($user->guid == elgg_get_logged_in_user_guid() && $cookie_token) {
-					// user has a persistent cookie. set this back up
-					$token = _elgg_generate_remember_me_token();
-					$hash = md5($token);
-					elgg_get_session()->set('code', $token);
-					_elgg_add_remember_me_cookie($user, $hash);
-					_elgg_set_remember_me_cookie($token);
-				}
+				_elgg_services()->persistentLogin->handlePasswordChange($user, elgg_get_logged_in_user_entity());
 				if ($user->save()) {
 					system_message(elgg_echo('user:password:success'));
 					return true;

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -275,39 +275,14 @@ function get_user_by_username($username) {
 }
 
 /**
- * Get user by remember me code
+ * Get user by persistent login password
  *
- * @param string $code The remember me code
+ * @param string $hash Hash of the persistent login password
  *
  * @return ElggUser
  */
-function get_user_by_code($code) {
-	if (!$code) {
-		return null;
-	}
-
-	$db = _elgg_services()->db;	
-	$prefix = $db->getTablePrefix();
-	$code = $db->sanitizeString($code);
-
-	$query = "SELECT guid FROM {$prefix}users_remember_me_cookies
-		WHERE code = '$code'";
-	try {
-		$result = $db->getDataRow($query);
-	} catch (DatabaseException $e) {
-		if (false !== strpos($e->getMessage(), "users_remember_me_cookies' doesn't exist")) {
-			// schema has not been updated so we swallow this exception
-			return null;
-		} else {
-			throw $e;
-		}
-	}
-
-	if ($result) {
-		return get_user($result->guid);
-	}
-
-	return null;
+function get_user_by_code($hash) {
+	_elgg_services()->persistentLogin->getUserFromHash($hash);
 }
 
 /**

--- a/engine/tests/phpunit/Elgg/PersistentLoginTest.php
+++ b/engine/tests/phpunit/Elgg/PersistentLoginTest.php
@@ -1,0 +1,346 @@
+<?php
+
+class Elgg_PersistentLoginTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * @var ElggSession
+	 */
+	protected $session;
+
+	/**
+	 * @var PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected $dbMock;
+
+	/**
+	 * @var PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected $cryptoMock;
+
+	/**
+	 * @var Elgg_PersistentLoginService
+	 */
+	protected $svc;
+
+	/**
+	 * @var PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected $user123;
+
+	/**
+	 * @var ElggCookie
+	 */
+	protected $lastCookieSet;
+
+	/**
+	 * @var string
+	 */
+	protected $mockToken;
+
+	/**
+	 * @var string
+	 */
+	protected $mockHash;
+
+	/**
+	 * @var int
+	 */
+	protected $timeSlept;
+
+	function setUp() {
+		$this->mockToken = 'z' . str_repeat('a', 31);
+
+		$this->mockHash = md5($this->mockToken);
+
+		$this->user123 = $this->getMockElggUser(123);
+
+		$this->session = new ElggSession(new Elgg_Http_MockSessionStorage());
+
+		// mock DB
+		$this->dbMock = $this->getMockBuilder('Elgg_Database')
+			->disableOriginalConstructor()
+			->getMock();
+		// use addslashes as ->sanitizeString (my local CLI doesn't have MySQL)
+		$this->dbMock->expects($this->any())
+			->method('sanitizeString')
+			->will($this->returnCallback(array($this, 'mock_sanitizeString')));
+
+		$this->cryptoMock = $this->getMockBuilder('ElggCrypto')->getMock();
+		$this->cryptoMock->expects($this->any())
+			->method('getRandomString')
+			->will($this->returnValue(str_repeat('a', 31)));
+
+		$this->svc = $this->getSvcWithCookie("");
+	}
+
+	function testLoginSavesHashAndPutsTokenInCookieAndSession() {
+		$this->dbMock->expects($this->once())
+			->method('insertData')
+			->will($this->returnCallback(array($this, 'mock_insertData')));
+
+		$this->svc->makeLoginPersistent($this->user123);
+
+		$this->assertSame($this->mockToken, $this->lastCookieSet->value);
+		$this->assertSame($this->mockToken, $this->session->get('code'));
+	}
+
+	function testRemoveDeletesHashAndDeletesTokenFromCookieAndSession() {
+		$this->svc = $this->getSvcWithCookie($this->mockToken);
+
+		$this->dbMock->expects($this->once())
+			->method('deleteData')
+			->will($this->returnCallback(array($this, 'mock_deleteData')));
+
+		$this->svc->removePersistentLogin();
+
+		$this->assertSame('', $this->lastCookieSet->value);
+		$this->assertSame(strtotime("-30 days"), $this->lastCookieSet->expire);
+		$this->assertNull($this->session->get('code'));
+	}
+
+	function testRemoveWithoutCookieCantDeleteHash() {
+		$this->dbMock->expects($this->never())
+			->method('deleteData');
+
+		$this->svc->removePersistentLogin();
+
+		$this->assertSame('', $this->lastCookieSet->value);
+		$this->assertSame(strtotime("-30 days"), $this->lastCookieSet->expire);
+		$this->assertNull($this->session->get('code'));
+	}
+
+	function testGettingUserFromKnownHashReturnsUser() {
+		$this->dbMock->expects($this->once())
+			->method('getDataRow')
+			->will($this->returnCallback(array($this, 'mock_getDataRow')));
+
+		$user = $this->svc->getUserFromHash($this->mockHash);
+
+		$this->assertSame($this->user123, $user);
+	}
+
+	function testGettingUserFromMissingHashReturnsNull() {
+		$this->dbMock->expects($this->once())
+			->method('getDataRow')
+			->will($this->returnValue(array()));
+
+		$user = $this->svc->getUserFromHash($this->mockHash);
+
+		$this->assertNull($user);
+	}
+
+	function testGettingMissingUserFromKnownHashReturnsNull() {
+		$this->dbMock->expects($this->once())
+			->method('getDataRow')
+			->will($this->returnValue((object)array('guid' => 234)));
+
+		$user = $this->svc->getUserFromHash($this->mockHash);
+
+		$this->assertNull($user);
+	}
+
+	function testChangingOwnPasswordDeletesAllHashesAndMakesPersistent() {
+		$subject = $this->user123;
+		$modifier = $this->user123;
+
+		$this->dbMock->expects($this->once())
+			->method('deleteData')
+			->will($this->returnCallback(array($this, 'mock_deleteAll')));
+		$this->dbMock->expects($this->once())
+			->method('insertData')
+			->will($this->returnCallback(array($this, 'mock_insertData')));
+
+		$this->svc = $this->getSvcWithCookie('notempty');
+		$this->svc->handlePasswordChange($subject, $modifier);
+
+		$this->assertSame($this->mockToken, $this->lastCookieSet->value);
+		$this->assertSame($this->mockToken, $this->session->get('code'));
+	}
+
+	function testChangingOwnPasswordWithNoCookieDoesntMakePersistent() {
+		$subject = $this->user123;
+		$modifier = $this->user123;
+
+		$this->dbMock->expects($this->once())
+			->method('deleteData')
+			->will($this->returnCallback(array($this, 'mock_deleteAll')));
+		$this->dbMock->expects($this->never())
+			->method('insertData');
+
+		$this->svc->handlePasswordChange($subject, $modifier);
+
+		$this->assertNull($this->lastCookieSet);
+		$this->assertNull($this->session->get('code'));
+	}
+
+	function testChangingSomeoneElsesPasswordDoesntMakePersistent() {
+		$subject = $this->user123;
+		$modifier = $this->getMockElggUser(234);
+
+		$this->dbMock->expects($this->once())
+			->method('deleteData')
+			->will($this->returnCallback(array($this, 'mock_deleteAll')));
+		$this->dbMock->expects($this->never())
+			->method('insertData');
+
+		$this->svc->handlePasswordChange($subject, $modifier);
+
+		$this->assertNull($this->lastCookieSet);
+		$this->assertNull($this->session->get('code'));
+	}
+
+	function testGettingUserFromValidClientReturnsUser() {
+		$this->dbMock->expects($this->once())
+			->method('getDataRow')
+			->will($this->returnValue((object)array('guid' => 123)));
+
+		$this->svc = $this->getSvcWithCookie($this->mockToken);
+
+		$user = $this->svc->bootSession();
+
+		$this->assertSame($this->user123, $user);
+	}
+
+	function testGetPersistedUser_invalidModernToken() {
+		$this->dbMock->expects($this->once())
+			->method('getDataRow')
+			->will($this->returnValue(array()));
+
+		$this->svc = $this->getSvcWithCookie('z' . str_repeat('b', 31));
+
+		$user = $this->svc->bootSession();
+
+		$this->assertNull($this->timeSlept);
+		$this->assertSame('', $this->lastCookieSet->value);
+		$this->assertSame(strtotime("-30 days"), $this->lastCookieSet->expire);
+		$this->assertNull($user);
+	}
+
+	function testBootSessionWithInvalidLegacyTokenCausesDelayAndFailure() {
+		$this->dbMock->expects($this->once())
+			->method('getDataRow')
+			->will($this->returnValue(array()));
+
+		$this->svc = $this->getSvcWithCookie(str_repeat('b', 32));
+
+		$user = $this->svc->bootSession();
+
+		$this->assertSame(1, $this->timeSlept);
+		$this->assertSame('', $this->lastCookieSet->value);
+		$this->assertSame(strtotime("-30 days"), $this->lastCookieSet->expire);
+		$this->assertNull($user);
+	}
+
+	function testReplaceLegacyTokenWithNoCookieDoesNothing() {
+		$this->svc = $this->getSvcWithCookie('');
+
+		$this->dbMock->expects($this->never())
+			->method('deleteData');
+
+		$this->svc->replaceLegacyToken($this->user123);
+
+		$this->assertNull($this->lastCookieSet);
+		$this->assertNull($this->session->get('code'));
+	}
+
+	function testModernTokenCookiesAreNotReplaced() {
+		$this->dbMock->expects($this->never())
+			->method('deleteData');
+
+		$this->svc->replaceLegacyToken($this->user123);
+
+		$this->assertNull($this->lastCookieSet);
+		$this->assertNull($this->session->get('code'));
+	}
+
+	function testLegacyCookiesAreReplacedInDbCookieAndSession() {
+		$this->svc = $this->getSvcWithCookie(str_repeat('a', 32));
+
+		$this->dbMock->expects($this->once())
+			->method('deleteData');
+		$this->dbMock->expects($this->once())
+			->method('insertData');
+
+		$this->svc->replaceLegacyToken($this->user123);
+
+		$this->assertSame($this->mockToken, $this->lastCookieSet->value);
+		$this->assertSame($this->mockToken, $this->session->get('code'));
+	}
+
+	// mock ElggUser which will return the GUID on ->guid reads
+	function getMockElggUser($guid) {
+		$user = $this->getMockBuilder('ElggUser')
+			->disableOriginalConstructor()
+			->getMock();
+		$user->expects($this->any())
+			->method('__get')
+			->with('guid')
+			->will($this->returnValue((int)$guid));
+		return $user;
+	}
+
+	function mock_get_user($guid) {
+		if ((int)$guid === 123) {
+			return $this->user123;
+		}
+		return null;
+	}
+
+	function mock_elgg_set_cookie(ElggCookie $cookie) {
+		$this->lastCookieSet = $cookie;
+	}
+
+	function mock_sleep($seconds) {
+		$this->timeSlept = $seconds;
+	}
+
+	function mock_sanitizeString($string) {
+		// no need for dependence on MySQL here
+		return addslashes($string);
+	}
+
+	/**
+	 * @param string $cookie_token
+	 * @return Elgg_PersistentLoginService
+	 */
+	protected function getSvcWithCookie($cookie_token = '') {
+		$cookie_config = array(
+			'lifetime' => 0,
+			'path' => '/',
+			'domain' => '',
+			'secure' => false,
+			'httponly' => false,
+			'name' => 'elggperm',
+			'expire' => time() + (30 * 86400),
+		);
+		$svc = new Elgg_PersistentLoginService($this->dbMock, $this->session, $this->cryptoMock, $cookie_config, $cookie_token);
+
+		$svc->_callable_get_user = array($this, 'mock_get_user');
+		$svc->_callable_generateToken = array($this, 'mock_generateToken');
+		$svc->_callable_elgg_set_cookie = array($this, 'mock_elgg_set_cookie');
+		$svc->_callable_sleep = array($this, 'mock_sleep');
+		return $svc;
+	}
+
+	function mock_insertData($sql) {
+		$this->assertContains("INSERT INTO users_remember_me_cookies", $sql);
+		$this->assertContains("VALUES ('{$this->mockHash}', 123,", $sql);
+	}
+
+	function mock_deleteData($sql) {
+		$pattern = "~DELETE FROM users_remember_me_cookies\\s+WHERE code = '{$this->mockHash}'~";
+		$this->assertSame(1, preg_match($pattern, $sql));
+	}
+
+	function mock_getDataRow($sql) {
+		$pattern = "~SELECT guid FROM users_remember_me_cookies\\s+WHERE code = '{$this->mockHash}'~";
+		$this->assertSame(1, preg_match($pattern, $sql));
+
+		return (object)array('guid' => 123);
+	}
+
+	function mock_deleteAll($sql) {
+		$pattern = "~DELETE FROM users_remember_me_cookies\\s+WHERE guid = '123'+~";
+		$this->assertSame(1, preg_match($pattern, $sql));
+	}
+}


### PR DESCRIPTION
This adds a persistent login service, which centralizes this logic and
documents the processes and legacy information.

Fixes #6631
