### PR TITLE
chore(security): converts ElggCrypto to service

### DIFF
--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -11,6 +11,7 @@
  * @property-read Elgg_Amd_Config                         $amdConfig
  * @property-read ElggAutoP                               $autoP
  * @property-read Elgg_AutoloadManager                    $autoloadManager
+ * @property-read ElggCrypto                              $crypto
  * @property-read Elgg_Database                           $db
  * @property-read Elgg_EventsService                      $events
  * @property-read Elgg_PluginHooksService                 $hooks
@@ -40,6 +41,7 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 		$this->setClassName('actions', 'Elgg_ActionsService');
 		$this->setFactory('amdConfig', array($this, 'getAmdConfig'));
 		$this->setClassName('autoP', 'ElggAutoP');
+		$this->setClassName('crypto', 'ElggCrypto');
 		$this->setFactory('db', array($this, 'getDatabase'));
 		$this->setFactory('events', array($this, 'getEvents'));
 		$this->setFactory('hooks', array($this, 'getHooks'));

--- a/engine/classes/ElggCrypto.php
+++ b/engine/classes/ElggCrypto.php
@@ -52,7 +52,7 @@ class ElggCrypto {
 	 * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 	 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	 */
-	public static function getRandomBytes($length) {
+	public function getRandomBytes($length) {
 		/**
 		 * Our primary choice for a cryptographic strong randomness function is
 		 * openssl_random_pseudo_bytes.
@@ -180,14 +180,14 @@ class ElggCrypto {
 	 *
 	 * @see https://github.com/zendframework/zf2/blob/master/library/Zend/Math/Rand.php#L179
 	 */
-	public static function getRandomString($length, $chars = null) {
+	public function getRandomString($length, $chars = null) {
 		if ($length < 1) {
 			throw new InvalidArgumentException('Length should be >= 1');
 		}
 
 		if (empty($chars)) {
 			$numBytes = ceil($length * 0.75);
-			$bytes    = self::getRandomBytes($numBytes);
+			$bytes    = $this->getRandomBytes($numBytes);
 			$string = substr(rtrim(base64_encode($bytes), '='), 0, $length);
 
 			// Base64 URL
@@ -196,7 +196,7 @@ class ElggCrypto {
 
 		if ($chars == self::CHARS_HEX) {
 			// hex is easy
-			$bytes = self::getRandomBytes(ceil($length / 2));
+			$bytes = $this->getRandomBytes(ceil($length / 2));
 			return substr(bin2hex($bytes), 0, $length);
 		}
 
@@ -206,7 +206,7 @@ class ElggCrypto {
 			return str_repeat($chars, $length);
 		}
 
-		$bytes  = self::getRandomBytes($length);
+		$bytes  = $this->getRandomBytes($length);
 		$pos    = 0;
 		$result = '';
 		for ($i = 0; $i < $length; $i++) {

--- a/engine/lib/actions.php
+++ b/engine/lib/actions.php
@@ -191,7 +191,7 @@ function generate_action_token($timestamp) {
  * @todo Move to better file.
  */
 function init_site_secret() {
-	$secret = 'z' . ElggCrypto::getRandomString(31);
+	$secret = 'z' . _elgg_services()->crypto->getRandomString(31);
 
 	if (datalist_set('__site_secret__', $secret)) {
 		return $secret;

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -416,7 +416,7 @@ function _elgg_get_remember_me_token_from_cookie() {
  * @return string
  */
 function _elgg_generate_remember_me_token() {
-	return 'z' . ElggCrypto::getRandomString(31);
+	return 'z' . _elgg_services()->crypto->getRandomString(31);
 }
 
 /**

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -523,7 +523,7 @@ function execute_new_password_request($user_guid, $conf_code, $password = null) 
  * @return string
  */
 function generate_random_cleartext_password() {
-	return ElggCrypto::getRandomString(12, ElggCrypto::CHARS_PASSWORD);
+	return _elgg_services()->crypto->getRandomString(12, ElggCrypto::CHARS_PASSWORD);
 }
 
 /**
@@ -533,7 +533,7 @@ function generate_random_cleartext_password() {
  * @access private
  */
 function _elgg_generate_password_salt() {
-	return ElggCrypto::getRandomString(8);
+	return _elgg_services()->crypto->getRandomString(8);
 }
 
 /**

--- a/engine/tests/phpunit/ElggCryptoTest.php
+++ b/engine/tests/phpunit/ElggCryptoTest.php
@@ -1,0 +1,44 @@
+<?php
+
+class ElggCryptoTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * @var PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected $stub;
+
+	protected function setUp() {
+		$this->stub = $this->getMockBuilder('ElggCrypto')
+			->setMethods(array('getRandomBytes'))
+			->getMock();
+
+		$this->stub->expects($this->any())
+			->method('getRandomBytes')
+			->will($this->returnCallback(array($this, 'mock_getRandomBytes')));
+	}
+
+	function mock_getRandomBytes($length) {
+		mt_srand(1);
+		$bytes = '';
+		for ($i = 0; $i < $length; $i++) {
+			$bytes .= chr(mt_rand(0, 254));
+		}
+		return $bytes;
+	}
+
+	function provider() {
+		return array(
+			array(32, null, 'kwG37f3ds_7awuiaL52mVWXud9dqT1GF'),
+			array(32, ElggCrypto::CHARS_HEX, '9301b7edfdddb3fedac2e89a2f9da655'),
+			array(32, ElggCrypto::CHARS_PASSWORD, 'kl4lmjwyrpyh6rpqct3rkd9zvxwvqww8'),
+			array(32, "0123456789", "78181215379307389761767024720714"),
+		);
+	}
+
+	/**
+	 * @dataProvider provider
+	 */
+	function testGetRandomString($length, $chars, $expected) {
+		$this->assertSame($expected, $this->stub->getRandomString($length, $chars));
+	}
+}


### PR DESCRIPTION
This makes these methods possible to override in unit tests.

Fixes #6635
