### PR TITLE
Fix word count (thewire)

### DIFF
--- a/mod/thewire/views/default/js/thewire.php
+++ b/mod/thewire/views/default/js/thewire.php
@@ -8,10 +8,14 @@
 elgg.provide('elgg.thewire');
 
 elgg.thewire.init = function() {
-	$("#thewire-textarea").live(['keydown', 'keyup'], function() {
-		elgg.thewire.textCounter(this, $("#thewire-characters-remaining span"), 140);
-	});
-
+ $("#thewire-textarea").live({
+   keydown: function() {
+    elgg.thewire.textCounter(this, $("#thewire-characters-remaining span"), 140);
+   },
+   keyup: function() {
+    elgg.thewire.textCounter(this, $("#thewire-characters-remaining span"), 140);
+  }
+});
 	$(".thewire-previous").live('click', elgg.thewire.viewPrevious);
 };
 


### PR DESCRIPTION
ref #6644
What cause problem?
Arrays not gonna work like that ( live(['keydown', 'keyup'])  for live() it must be like this 
live(
   keydown: function() {},
   keyup: function() {}
);
