### PR TITLE
fix(thewire): Restores functionality of JS max length limit parametrization

### DIFF
--- a/mod/thewire/views/default/forms/thewire/add.php
+++ b/mod/thewire/views/default/forms/thewire/add.php
@@ -38,6 +38,7 @@ $post_input = elgg_view('input/plaintext', array(
 	'class' => 'mtm',
 	'id' => 'thewire-textarea',
 	'rows' => $num_lines,
+	'data-max-length' => $char_limit,
 ));
 
 $submit_button = elgg_view('input/submit', array(

--- a/mod/thewire/views/default/js/thewire.php
+++ b/mod/thewire/views/default/js/thewire.php
@@ -8,7 +8,10 @@ elgg.provide('elgg.thewire');
 
 elgg.thewire.init = function() {
 	var callback = function() {
-		elgg.thewire.textCounter(this, $("#thewire-characters-remaining span"), 140);
+		var maxLength = $(this).data('max-length');
+		if (maxLength) {
+			elgg.thewire.textCounter(this, $("#thewire-characters-remaining span"), maxLength);
+		}
 	};
 
 	$("#thewire-textarea").live({


### PR DESCRIPTION
Just fixed it instead of tracking down who exactly broke it. Current 1.8 branch has hardcoded 140 chars, and master branch was using non existing variable.
