### PR TITLE
fix(comments): makes ElggComment E_STRICT compliant

### DIFF
--- a/engine/classes/ElggComment.php
+++ b/engine/classes/ElggComment.php
@@ -20,11 +20,16 @@ class ElggComment extends ElggObject {
 	}
 
 	/**
-	 * Not supporting threaded comments yet
-	 * 
-	 * @return bool
+	 * Can a user comment on this object? Always returns false (threaded comments
+	 * not yet supported)
+	 *
+	 * @see ElggEntity::canComment()
+	 *
+	 * @param int $user_guid User guid (default is logged in user)
+	 * @return bool False
+	 * @since 1.9.0
 	 */
-	public function canComment() {
+	public function canComment($user_guid = 0) {
 		return false;
 	}
 


### PR DESCRIPTION
Gives ElggComment::canComment the same signature as the method in its parent class.

(Noticed this in SimpleTests)
