### PR TITLE
fix(views): removes notices from views used in theme sandbox

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -98,6 +98,7 @@ return array(
 
 	'pageownerunavailable' => 'Warning: The page owner %d is not accessible!',
 	'viewfailure' => 'There was an internal failure in the view %s',
+	'view:missing_param' => "The required parameter '%s' is missing in the view %s",
 	'changebookmark' => 'Please change your bookmark for this page',
 	'noaccess' => 'The content you were trying to view has been removed or you do not have permission to view it.',
 	'error:missing_data' => 'There was some data missing in your request',

--- a/mod/developers/classes/ThemeSandboxObject.php
+++ b/mod/developers/classes/ThemeSandboxObject.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * @access private
+ */
+class ThemeSandboxObject extends ElggObject {
+	public function getTimeCreated() {
+		return time();
+	}
+}

--- a/mod/developers/views/default/theme_sandbox/components/list.php
+++ b/mod/developers/views/default/theme_sandbox/components/list.php
@@ -3,11 +3,7 @@
  * List of objects
  */
 
-class ThemeSandboxObject extends ElggObject {
-	public function getTimeCreated() {
-		return time();
-	}
-}
+$ipsum = elgg_view('developers/ipsum');
 
 $obj1 = new ThemeSandboxObject();
 $obj1->title = "Object 1";

--- a/mod/developers/views/default/theme_sandbox/forms.php
+++ b/mod/developers/views/default/theme_sandbox/forms.php
@@ -1,4 +1,8 @@
-<form action="#">
+<?php
+
+$ipsum = elgg_view('developers/ipsum');
+
+?><form action="#">
 	<fieldset>
 		<legend>Fieldset Legend</legend>
 		<div>

--- a/mod/developers/views/default/theme_sandbox/navigation/page.php
+++ b/mod/developers/views/default/theme_sandbox/navigation/page.php
@@ -1,9 +1,10 @@
 <?php
 
 $params = array();
+$params['name'] = 'sandbox_page';
 $params['menu'] = array();
 $params['menu']['default'] = array();
-for ($i=1; $i<=5; $i++) {
+for ($i = 1; $i <= 5; $i++) {
 	$params['menu']['default'][] = new ElggMenuItem($i, "Page $i", "#");
 }
 $params['menu']['default'][2]->setSelected(true);

--- a/mod/developers/views/default/theme_sandbox/typography/misc.php
+++ b/mod/developers/views/default/theme_sandbox/typography/misc.php
@@ -9,7 +9,7 @@
 	<li>I am <i>the i tag</i> example</li>
 	<li>I am <strong>the strong tag</strong> example</li>
 </ul>
-<blockquote><p>Paragraph inside Blockquote: <?php echo $ipsum; ?></p></blockquote>
+<blockquote><p>Paragraph inside Blockquote: <?php echo elgg_view('developers/ipsum'); ?></p></blockquote>
 <pre>
 	<strong>Preformated:</strong>Testing one row
 	and another

--- a/views/default/input/userpicker.php
+++ b/views/default/input/userpicker.php
@@ -5,7 +5,7 @@
  * @package Elgg
  * @subpackage Core
  *
- * @uses $vars['value'] Array of user guids for already selected users or null
+ * @uses $vars['values'] Array of user guids for already selected users or null
  * @uses $vars['limit'] Limit number of users (default 0 = no limit)
  * @uses $vars['name'] Name of the returned data array (default "members")
  * @uses $vars['handler'] Name of page handler used to power search (default "livesearch")
@@ -25,7 +25,7 @@ if (empty($vars['name'])) {
 $name = $vars['name'];
 $name = htmlspecialchars($name, ENT_QUOTES, 'UTF-8');
 
-$guids = (array)$vars['values'];
+$guids = (array)elgg_extract('values', $vars, array());
 
 $handler = elgg_extract('handler', $vars, 'livesearch');
 $handler = htmlspecialchars($handler, ENT_QUOTES, 'UTF-8');

--- a/views/default/navigation/menu/page.php
+++ b/views/default/navigation/menu/page.php
@@ -11,6 +11,12 @@
 
 $headers = elgg_extract('show_section_headers', $vars, false);
 
+if (empty($vars['name'])) {
+	$msg = elgg_echo('view:missing_param', array('name', 'navigation/menu/page'));
+	elgg_log($msg, 'WARNING');
+	$vars['name'] = '';
+}
+
 $class = 'elgg-menu elgg-menu-page';
 if (isset($vars['class'])) {
 	$class = "$class {$vars['class']}";


### PR DESCRIPTION
This handles missing parameters in some input views; fixes the @uses 
statement within the user picker view the the values; adds the missing 
developers/ispum text in developers views; and moves the ThemeSandboxObject
class to its own file.
- [x] MenuItem names should be required
