### PR TITLE
feature(elgg_require_js): add fallback for require.js configured with CDN.

### DIFF
--- a/engine/classes/Elgg/Amd/Config.php
+++ b/engine/classes/Elgg/Amd/Config.php
@@ -34,8 +34,14 @@ class Elgg_Amd_Config {
 	 * @return void
 	 */
 	public function setPath($module, $path) {
-		if (preg_match("/\.js$/", $path)) {
-			$path = preg_replace("/\.js$/", '', $path);
+		if (!is_array($path)) {
+			$path = array($path);
+		}
+
+		foreach ($path as $key => $url) {
+			if (preg_match("/\.js$/", $url)) {
+				$path[$key] = preg_replace("/\.js$/", '', elgg_normalize_url($url));
+			}
 		}
 
 		$this->paths[$module] = $path;

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -149,7 +149,7 @@ function elgg_register_js($name, $url, $location = 'head', $priority = null) {
 			_elgg_services()->amdConfig->addDependency($name);
 		}
 		_elgg_services()->amdConfig->setShim($name, $config);
-		_elgg_services()->amdConfig->setPath($name, elgg_normalize_url($url));
+		_elgg_services()->amdConfig->setPath($name, $url);
 		return true;
 	}
 


### PR DESCRIPTION
There is a fallback with require.js. It could be useful to use it when we want to register a CDN and improve performance. `elgg_register_js` actually not provide it.  
They talk about how to do it [in the wiki](https://github.com/jrburke/requirejs/wiki/Upgrading-to-RequireJS-2.0#wiki-pathsfallbacks).

With this feature, we can add a second source like that:

```
elgg_register_js('chart', array(
    'src' => array(
        '//cdnjs.cloudflare.com/ajax/libs/Chart.js/0.2.0/Chart.min.js', // cloudfare CDN
        '/mod/myPlugin/vendors/Chart.min.js' // local fallback
    ),
    'deps' => array('jquery')
));
```

**Old method still works!**

```
elgg_register_js('chart', array(
    'src' => '/mod/myPlugin/vendors/Chart.min.js',
    'deps' => array('jquery')
));
```
