### PR TITLE
feature:js(unregister_hook_handler) Provide a function to unregister a hook handler.

### DIFF
--- a/js/lib/hooks.js
+++ b/js/lib/hooks.js
@@ -47,6 +47,22 @@ elgg.register_hook_handler = function(name, type, handler, priority) {
 };
 
 /**
+ * Unregister a hook handler.
+ *
+ * @param {String}   name     Name of the plugin hook
+ * @param {String}   type     Type of the event
+ * @param {Function} handler  Handle to remove
+ * @return {bool}
+ */
+elgg.unregister_hook_handler = function(name, type, handler) {
+	var priorities =  elgg.config.hooks;
+
+	if (priorities[name][type] instanceof elgg.ElggPriorityList) {
+		priorities[name][type].remove(handler);
+	}
+};
+
+/**
  * Emits a hook.
  *
  * Loops through all registered hooks and calls the handler functions in order.


### PR DESCRIPTION
A simple function to unregister a javascript hook handler.
Remove handler in priorities list if exist.
- [ ] fix build errors
- [ ] write tests
- [ ] write developer docs
- [ ] Change commit message to `feature(js): ...`
- [ ] resubmit to 1.x branch
