### PR TITLE
Fix: Group blogs that are drafts aren't accessible

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -538,6 +538,9 @@ function elgg_view($view, $vars = array(), $bypass = false, $ignored = false, $v
  * The default action is to append a view.  If the priority is less than 500,
  * the output of the extended view will be appended to the original view.
  *
+ * Views can be extended multiple times, and extensions are not checked for
+ * uniqueness. Use {@see elgg_unextend_view()} to help manage duplicates.
+ *
  * Priority can be specified and affects the order in which extensions
  * are appended or prepended.
  *


### PR DESCRIPTION
Fix issue 6682 : Drafted group blogs are not viewable within group (even by author)
https://github.com/Elgg/Elgg/issues/6682
