### PR TITLE
chore(docs): Let readthedocs.org handle our theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinxdoc'
+html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Fixes #6698

Easier than I thought. Read the docs claims they'll just take over theming if you set html_theme to "default"

http://read-the-docs.readthedocs.org/en/latest/theme.html
