### PR TITLE
docs(js): use proper title markup

### DIFF
--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -1,5 +1,5 @@
 Javascript
-==========
+##########
 
 This guide assumes basic familiarity with:
 


### PR DESCRIPTION
The previous markup matched other heading levels within the
document itself, so sphinx was getting confused and putting
the sub-headings into the top-level table of contents.
