### PR TITLE
fix(session): session unavailable in shutdown functions

### DIFF
--- a/engine/classes/Elgg/Http/DatabaseSessionHandler.php
+++ b/engine/classes/Elgg/Http/DatabaseSessionHandler.php
@@ -33,10 +33,9 @@ class Elgg_Http_DatabaseSessionHandler implements Elgg_Http_SessionHandler {
 	 * {@inheritDoc}
 	 */
 	public function read($session_id) {
-		global $CONFIG;
-
+		
 		$id = sanitize_string($session_id);
-		$query = "SELECT * FROM {$CONFIG->dbprefix}users_sessions WHERE session='$id'";
+		$query = "SELECT * FROM {$this->db->getTablePrefix()}users_sessions WHERE session='$id'";
 		$result = $this->db->getDataRow($query);
 		if ($result) {
 			return (string) $result->data;
@@ -49,13 +48,11 @@ class Elgg_Http_DatabaseSessionHandler implements Elgg_Http_SessionHandler {
 	 * {@inheritDoc}
 	 */
 	public function write($session_id, $session_data) {
-		global $CONFIG;
-
 		$id = sanitize_string($session_id);
 		$time = time();
 		$sess_data_sanitised = sanitize_string($session_data);
 
-		$query = "REPLACE INTO {$CONFIG->dbprefix}users_sessions
+		$query = "REPLACE INTO {$this->db->getTablePrefix()}users_sessions
 			(session, ts, data) VALUES
 			('$id', '$time', '$sess_data_sanitised')";
 
@@ -77,10 +74,9 @@ class Elgg_Http_DatabaseSessionHandler implements Elgg_Http_SessionHandler {
 	 * {@inheritDoc}
 	 */
 	public function destroy($session_id) {
-		global $CONFIG;
-
+		
 		$id = sanitize_string($session_id);
-		$query = "DELETE FROM {$CONFIG->dbprefix}users_sessions WHERE session='$id'";
+		$query = "DELETE FROM {$this->db->getTablePrefix()}users_sessions WHERE session='$id'";
 		return (bool) $this->db->deleteData($query);
 	}
 
@@ -88,10 +84,9 @@ class Elgg_Http_DatabaseSessionHandler implements Elgg_Http_SessionHandler {
 	 * {@inheritDoc}
 	 */
 	public function gc($max_lifetime) {
-		global $CONFIG;
-
+		
 		$life = time() - $max_lifetime;
-		$query = "DELETE FROM {$CONFIG->dbprefix}users_sessions WHERE ts < '$life'";
+		$query = "DELETE FROM {$this->db->getTablePrefix()}users_sessions WHERE ts < '$life'";
 		return (bool) $this->db->deleteData($query);
 	}
 

--- a/engine/classes/Elgg/Http/NativeSessionStorage.php
+++ b/engine/classes/Elgg/Http/NativeSessionStorage.php
@@ -281,7 +281,6 @@ class Elgg_Http_NativeSessionStorage implements Elgg_Http_SessionStorage {
 	 * @return void
 	 */
 	protected function setHandler($handler) {
-		register_shutdown_function('session_write_close');
 		session_set_save_handler(
 			array($handler, 'open'),
 			array($handler, 'close'),


### PR DESCRIPTION
Shutdown functions defined in plugin can't access information in session
because this was already closed.

Because of the `register_shutdown_function('session_write_close');` the session was closed as one of the first shutdown functions. If a plugin wanted to get/set some information during a shutdown functions this was unavailable.

The shutdown function was registered (I think) because it needed access to `$CONFIG->dbprefix`, this was however also available by using `$this->db->getTablePrefix()`.

Now the session is available for all shutdown functions.

TODO:
- [x] Switch back to curly-brace notation instead of string-concatenation
- [ ] Add tests (if possible)
