### PR TITLE
perf(entities): preloads owners when drawing lists of entities/likes

### DIFF
--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -19,6 +19,7 @@
  * @property-read ElggVolatileMetadataCache               $metadataCache
  * @property-read Elgg_Notifications_NotificationsService $notifications
  * @property-read Elgg_PersistentLoginService             $persistentLogin
+ * @property-read Elgg_EntityPreloader                    $ownerPreloader
  * @property-read Elgg_Database_QueryCounter              $queryCounter
  * @property-read Elgg_Http_Request                       $request
  * @property-read Elgg_Router                             $router
@@ -49,6 +50,7 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 		$this->setFactory('logger', array($this, 'getLogger'));
 		$this->setClassName('metadataCache', 'ElggVolatileMetadataCache');
 		$this->setFactory('persistentLogin', array($this, 'getPersistentLogin'));
+		$this->setFactory('ownerPreloader', array($this, 'getOwnerPreloader'));
 		$this->setFactory('queryCounter', array($this, 'getQueryCounter'), false);
 		$this->setFactory('request', array($this, 'getRequest'));
 		$this->setFactory('router', array($this, 'getRouter'));
@@ -213,6 +215,16 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 		$cookie_name = $remember_me_cookies_config['name'];
 		$cookie_token = $c->request->cookies->get($cookie_name, '');
 		return new Elgg_PersistentLoginService($c->db, $c->session, $c->crypto, $remember_me_cookies_config, $cookie_token);
+	}
+
+	/**
+	 * Owner preloader factory
+	 *
+	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
+	 * @return Elgg_EntityPreloader
+	 */
+	protected function getOwnerPreloader(Elgg_Di_ServiceProvider $c) {
+		return new Elgg_EntityPreloader(array('owner_guid'));
 	}
 
 	/**

--- a/engine/classes/Elgg/EntityPreloader.php
+++ b/engine/classes/Elgg/EntityPreloader.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Preload entities based on properties of fetched objects
+ *
+ * @access private
+ *
+ * @package Elgg.Core
+ * @since   1.9.0
+ */
+class Elgg_EntityPreloader {
+
+	/**
+	 * @var string
+	 */
+	protected $properties;
+
+	/**
+	 * Configure the preloader to check these properties of fetched objects for GUIDs.
+	 *
+	 * @param array $guid_properties e.g. array("owner_guid")
+	 */
+	public function __construct(array $guid_properties) {
+		$this->properties = $guid_properties;
+	}
+
+	/**
+	 * Preload entities based on the given objects
+	 *
+	 * @param object[] $objects objects loaded from an Elgg query
+	 *
+	 * @return void
+	 * @throws RuntimeException
+	 */
+	public function preload($objects) {
+		$guids = $this->getGuidsToLoad($objects);
+		// If only 1 to load, not worth the overhead of elgg_get_entities(),
+		// get_entity() will handle it later.
+		if (count($guids) > 1) {
+			elgg_get_entities(array(
+				'guids' => $guids,
+			));
+		}
+	}
+
+	/**
+	 * Get GUIDs that need to be loaded
+	 *
+	 * To simplify the user API, this function accepts non-arrays and arrays containing non-objects
+	 *
+	 * @param mixed $objects objects loaded from an Elgg query
+	 * @return int[]
+	 */
+	public function getGuidsToLoad($objects) {
+		if (!is_array($objects) || count($objects) < 2) {
+			return array();
+		}
+		$preload_guids = array();
+		foreach ($objects as $object) {
+			if (is_object($object)) {
+				foreach ($this->properties as $property) {
+					$guid = $object->{$property};
+					if ($guid && !_elgg_retrieve_cached_entity($guid)) {
+						$preload_guids[] = $guid;
+					}
+				}
+			}
+		}
+		return array_unique($preload_guids);
+	}
+}

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -764,6 +764,10 @@ function elgg_enable_entity($guid, $recursive = true) {
  *
  * 	joins => array() Additional joins
  *
+ * 	preload_owners => bool (false) If set to true, this function will preload
+ * 					  all the owners of the returned entities resulting in better
+ * 					  performance when displaying entities owned by several users
+ *
  * 	callback => string A callback function to pass each row through
  *
  * @return mixed If count, int. If not count, array. false on errors.
@@ -802,8 +806,10 @@ function elgg_get_entities(array $options = array()) {
 		'wheres'				=>	array(),
 		'joins'					=>	array(),
 
+		'preload_owners'		=> false,
 		'callback'				=> 'entity_row_to_elggstar',
 
+		// private API
 		'__ElggBatch'			=> null,
 	);
 
@@ -928,7 +934,7 @@ function elgg_get_entities(array $options = array()) {
 		}
 
 		if ($dt) {
-			// populate entity and metadata caches
+			// populate entity and metadata caches, and prepare $entities for preloader
 			$guids = array();
 			foreach ($dt as $item) {
 				// A custom callback could result in items that aren't ElggEntity's, so check for them
@@ -945,6 +951,10 @@ function elgg_get_entities(array $options = array()) {
 
 			if ($guids) {
 				_elgg_get_metadata_cache()->populateFromEntities($guids);
+			}
+
+			if ($options['preload_owners'] && count($dt) > 1) {
+				_elgg_services()->ownerPreloader->preload($dt);
 			}
 		}
 		return $dt;

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -248,6 +248,7 @@ function _elgg_get_metastring_based_objects($options) {
 		'wheres' => array(),
 		'joins' => array(),
 
+		'preload_owners' => false,
 		'callback' => $callback,
 	);
 
@@ -432,6 +433,11 @@ function _elgg_get_metastring_based_objects($options) {
 		}
 
 		$dt = get_data($query, $options['callback']);
+
+		if ($options['preload_owners'] && is_array($dt) && count($dt) > 1) {
+			_elgg_services()->ownerPreloader->preload($dt);
+		}
+
 		return $dt;
 	} else {
 		$result = get_data_row($query);

--- a/mod/blog/lib/blog.php
+++ b/mod/blog/lib/blog.php
@@ -64,6 +64,7 @@ function blog_get_page_content_list($container_guid = NULL) {
 		'subtype' => 'blog',
 		'full_view' => false,
 		'no_results' => elgg_echo('blog:none'),
+		'preload_owners' => true,
 	);
 
 	$current_user = elgg_get_logged_in_user_entity();
@@ -136,6 +137,7 @@ function blog_get_page_content_friends($user_guid) {
 		'relationship_guid' => $user_guid,
 		'relationship_join_on' => 'container_guid',
 		'no_results' => elgg_echo('blog:none'),
+		'preload_owners' => true,
 	);
 
 	$return['content'] = elgg_list_entities_from_relationship($options);
@@ -178,6 +180,7 @@ function blog_get_page_content_archive($owner_guid, $lower = 0, $upper = 0) {
 		'subtype' => 'blog',
 		'full_view' => false,
 		'no_results' => elgg_echo('blog:none'),
+		'preload_owners' => true,
 	);
 
 	if ($owner_guid) {

--- a/mod/bookmarks/pages/bookmarks/all.php
+++ b/mod/bookmarks/pages/bookmarks/all.php
@@ -16,6 +16,7 @@ $content = elgg_list_entities(array(
 	'full_view' => false,
 	'view_toggle_type' => false,
 	'no_results' => elgg_echo('bookmarks:none'),
+	'preload_owners' => true,
 ));
 
 $title = elgg_echo('bookmarks:everyone');

--- a/mod/bookmarks/pages/bookmarks/friends.php
+++ b/mod/bookmarks/pages/bookmarks/friends.php
@@ -25,6 +25,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_guid' => $page_owner->guid,
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo('bookmarks:none'),
+	'preload_owners' => true,
 ));
 
 $params = array(

--- a/mod/bookmarks/pages/bookmarks/owner.php
+++ b/mod/bookmarks/pages/bookmarks/owner.php
@@ -21,6 +21,7 @@ $content .= elgg_list_entities(array(
 	'full_view' => false,
 	'view_toggle_type' => false,
 	'no_results' => elgg_echo('bookmarks:none'),
+	'preload_owners' => true,
 ));
 
 $title = elgg_echo('bookmarks:owner', array($page_owner->name));

--- a/mod/file/pages/file/friends.php
+++ b/mod/file/pages/file/friends.php
@@ -26,6 +26,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_guid' => $owner->guid,
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo("file:none"),
+	'preload_owners' => true,
 ));
 
 $sidebar = file_get_type_cloud($owner->guid, true);

--- a/mod/file/pages/file/owner.php
+++ b/mod/file/pages/file/owner.php
@@ -41,6 +41,7 @@ $content = elgg_list_entities(array(
 	'container_guid' => $owner->guid,
 	'full_view' => false,
 	'no_results' => elgg_echo("file:none"),
+	'preload_owners' => true,
 ));
 
 $sidebar = file_get_type_cloud(elgg_get_page_owner_guid());

--- a/mod/file/pages/file/search.php
+++ b/mod/file/pages/file/search.php
@@ -80,6 +80,7 @@ $params = array(
 	'container_guid' => $page_owner_guid,
 	'limit' => $limit,
 	'full_view' => false,
+	'preload_owners' => true,
 );
 
 if ($file_type) {

--- a/mod/file/pages/file/world.php
+++ b/mod/file/pages/file/world.php
@@ -16,6 +16,7 @@ $content = elgg_list_entities(array(
 	'subtype' => 'file',
 	'full_view' => false,
 	'no_results' => elgg_echo("file:none"),
+	'preload_owners' => true,
 ));
 
 $sidebar = file_get_type_cloud();

--- a/mod/groups/lib/discussion.php
+++ b/mod/groups/lib/discussion.php
@@ -18,6 +18,7 @@ function discussion_handle_all_page() {
 		'limit' => 20,
 		'full_view' => false,
 		'no_results' => elgg_echo('discussion:none'),
+		'preload_owners' => true,
 	));
 
 	$title = elgg_echo('discussion:latest');
@@ -62,6 +63,7 @@ function discussion_handle_list_page($guid) {
 		'container_guid' => $guid,
 		'full_view' => false,
 		'no_results' => elgg_echo('discussion:none'),
+		'preload_owners' => true,
 	);
 	$content = elgg_list_entities($options);
 

--- a/mod/likes/views/default/likes/count.php
+++ b/mod/likes/views/default/likes/count.php
@@ -30,7 +30,8 @@ if ($num_of_likes) {
 		'guid' => $guid,
 		'annotation_name' => 'likes',
 		'limit' => 99,
-		'list_class' => 'elgg-list-likes'
+		'list_class' => 'elgg-list-likes',
+		'preload_owners' => true,
 	));
 	$list .= "</div>";
 	echo $list;

--- a/mod/messageboard/pages/messageboard/owner.php
+++ b/mod/messageboard/pages/messageboard/owner.php
@@ -17,6 +17,7 @@ $options = array(
 	'annotations_name' => 'messageboard',
 	'guid' => $page_owner_guid,
 	'reverse_order_by' => true,
+	'preload_owners' => true,
 );
 
 if ($history_user) {

--- a/mod/messages/pages/messages/inbox.php
+++ b/mod/messages/pages/messages/inbox.php
@@ -31,6 +31,7 @@ $list = elgg_list_entities_from_metadata(array(
 	'metadata_value' => elgg_get_page_owner_guid(),
 	'owner_guid' => elgg_get_page_owner_guid(),
 	'full_view' => false,
+	'preload_owners' => true,
 ));
 
 $body_vars = array(

--- a/mod/pages/pages/pages/friends.php
+++ b/mod/pages/pages/pages/friends.php
@@ -25,6 +25,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_guid' => $owner->guid,
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo('pages:none'),
+	'preload_owners' => true,
 ));
 
 $params = array(

--- a/mod/pages/pages/pages/owner.php
+++ b/mod/pages/pages/pages/owner.php
@@ -25,6 +25,7 @@ $content = elgg_list_entities(array(
 	'container_guid' => elgg_get_page_owner_guid(),
 	'full_view' => false,
 	'no_results' => elgg_echo('pages:none'),
+	'preload_owners' => true,
 ));
 
 $filter_context = '';

--- a/mod/pages/pages/pages/world.php
+++ b/mod/pages/pages/pages/world.php
@@ -17,6 +17,7 @@ $content = elgg_list_entities(array(
 	'subtype' => 'page_top',
 	'full_view' => false,
 	'no_results' => elgg_echo('pages:none'),
+	'preload_owners' => true,
 ));
 
 $body = elgg_view_layout('content', array(

--- a/mod/search/search_hooks.php
+++ b/mod/search/search_hooks.php
@@ -36,6 +36,7 @@ function search_objects_hook($hook, $type, $value, $params) {
 	
 	$params['count'] = FALSE;
 	$params['order_by'] = search_get_order_by_sql('e', 'oe', $params['sort'], $params['order']);
+	$params['preload_owners'] = true;
 	$entities = elgg_get_entities($params);
 
 	// add the volatile data for why these entities have been returned.

--- a/mod/thewire/pages/thewire/everyone.php
+++ b/mod/thewire/pages/thewire/everyone.php
@@ -19,6 +19,7 @@ $content .= elgg_list_entities(array(
 	'type' => 'object',
 	'subtype' => 'thewire',
 	'limit' => get_input('limit', 15),
+	'preload_owners' => true,
 ));
 
 $body = elgg_view_layout('content', array(

--- a/mod/thewire/pages/thewire/friends.php
+++ b/mod/thewire/pages/thewire/friends.php
@@ -27,6 +27,7 @@ $content .= elgg_list_entities_from_relationship(array(
 	'relationship' => 'friend',
 	'relationship_guid' => $owner->guid,
 	'relationship_join_on' => 'container_guid',
+	'preload_owners' => true,
 ));
 
 $body = elgg_view_layout('content', array(

--- a/mod/thewire/pages/thewire/thread.php
+++ b/mod/thewire/pages/thewire/thread.php
@@ -16,6 +16,7 @@ $content = elgg_list_entities_from_metadata(array(
 	"type" => "object",
 	"subtype" => "thewire",
 	"limit" => 20,
+	'preload_owners' => true,
 ));
 
 $body = elgg_view_layout('content', array(

--- a/views/default/page/elements/comments.php
+++ b/views/default/page/elements/comments.php
@@ -38,6 +38,7 @@ $html = elgg_list_entities(array(
 	'reverse_order_by' => true,
 	'full_view' => true,
 	'limit' => $limit,
+	'preload_owners' => true,
 ));
 
 if ($html) {

--- a/views/default/page/elements/comments_block.php
+++ b/views/default/page/elements/comments_block.php
@@ -13,7 +13,8 @@ $options = array(
 	'type' => 'object',
 	'subtype' => 'comment',
 	'limit' => elgg_extract('limit', $vars, 4),
-	'wheres' => array()
+	'wheres' => array(),
+	'preload_owners' => true,
 );
 
 $owner_guid = elgg_extract('owner_guid', $vars);


### PR DESCRIPTION
When drawing lists of entities/likes with a variety of owners, many owners
end up being loaded one by one (ineffecient). This adds a component that
walks the list and preloads all the owners into the cache in one shot.

Fixes #5949

This PR replaces #5950.
- [ ] resubmit to 1.x
