### PR TITLE
perf(upgrade): ajaxifies data directory migration

### DIFF
--- a/actions/admin/upgrades/upgrade_datadirs.php
+++ b/actions/admin/upgrades/upgrade_datadirs.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Move user data directories
+ * 
+ * Run for 2 seconds per request as set by $batch_run_time_in_secs. This includes
+ * the engine loading time.
+ */
+
+// Migrate also directories that belong to hidden users
+$access_status = access_get_show_hidden_status();
+access_show_hidden_entities(true);
+
+$helper = new Elgg_Upgrades_Helper2013022000(
+	elgg_get_site_entity()->guid,
+	elgg_get_config('dbprefix')
+);
+
+// from engine/start.php
+global $START_MICROTIME;
+$batch_run_time_in_secs = 2;
+
+$data_root = elgg_get_config('dataroot');
+$cleanup_years = array();
+$num_successes = 0;
+$num_errors = 0;
+$is_complete = true;
+
+_elgg_services()->db->disableQueryCache();
+
+$batch = new ElggBatch('elgg_get_entities', $helper->getBatchOptions(), null, 50, false);
+
+foreach ($batch as $user_row) {
+	if ((microtime(true) - $START_MICROTIME) > $batch_run_time_in_secs) {
+		$is_complete = false;
+		break;
+	}
+
+	$guid = $user_row->guid;
+	$from = $data_root . $helper->makeMatrix($user_row);
+	$bucket_dir = $data_root . $helper->getLowerBucketBound($guid);
+	$to = "$bucket_dir/$guid";
+
+	if (!is_dir($from)) {
+		$num_successes += 1;
+		$helper->markSuccess($guid);
+		continue;
+	}
+
+	// make sure bucket dir exists
+	if (!is_dir($bucket_dir)) {
+		// same perms as ElggDiskFilestore.
+		if (!mkdir($bucket_dir, 0700, true)) {
+			elgg_register_error("[$guid] Failed creating `$bucket_dir`");
+			$num_errors += 1;
+			$helper->markFailure($guid);
+			continue;
+		}
+	}
+
+	if (!rename($from, $to)) {
+		elgg_register_error("[$guid] Failed moving `$from` to `$to`");
+		$num_errors += 1;
+		$helper->markFailure($guid);
+	} else {
+		$num_successes += 1;
+		$helper->markSuccess($guid);
+	}
+
+	// store the year for cleanup
+	$year = date('Y', $user_row->time_created);
+	if (!in_array($year, $cleanup_years)) {
+		$cleanup_years[] = $year;
+	}
+}
+
+// remove all dirs that are empty.
+// @todo this could take some time, so we may want to lower the batch run time to compensate.
+foreach ($cleanup_years as $year) {
+	$helper->removeDirIfEmpty($data_root . $year);
+}
+
+if ($is_complete && !$helper->hasFailures()) {
+	// migration has completed, lets clean up
+	$helper->forgetSuccesses();
+
+	// set the upgrade as completed
+	$factory = new ElggUpgrade();
+	$upgrade = $factory->getUpgradeFromURL('admin/upgrades/datadirs');
+	if ($upgrade instanceof ElggUpgrade) {
+		$upgrade->setCompleted();
+	}
+}
+
+access_show_hidden_entities($access_status);
+
+_elgg_services()->db->enableQueryCache();
+
+echo json_encode(array(
+	'numSuccess' => $num_successes,
+	'numErrors' => $num_errors,
+));

--- a/engine/classes/Elgg/Upgrades/Helper2013022000.php
+++ b/engine/classes/Elgg/Upgrades/Helper2013022000.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * Helper for data directory upgrade
+ *
+ * @access private
+ */
+class Elgg_Upgrades_Helper2013022000 {
+	const RELATIONSHIP_SUCCESS = '2013022000';
+	const RELATIONSHIP_FAILURE = '2013022000_fail';
+
+	/**
+	 * @var int Site GUID
+	 */
+	protected $siteGuid;
+
+	/**
+	 * @var string DB table prefix
+	 */
+	protected $dbPrefix;
+
+	/**
+	 * @param int    $siteGuid Site GUID
+	 * @param string $dbPrefix DB table prefix
+	 */
+	public function __construct($siteGuid, $dbPrefix) {
+		$this->siteGuid = $siteGuid;
+		$this->dbPrefix = $dbPrefix;
+	}
+
+	/**
+	 * Get elgg_get_entities() options for fetching users who need data migration
+	 *
+	 * @return array
+	 */
+	public function getBatchOptions() {
+		$relationship1 = sanitise_string(self::RELATIONSHIP_SUCCESS);
+		$relationship2 = sanitise_string(self::RELATIONSHIP_FAILURE);
+		// find users without either relationship
+		return array(
+			'type' => 'user',
+			'callback' => '',
+			'order_by' => 'e.guid',
+			'joins' => array(
+				"LEFT JOIN {$this->dbPrefix}entity_relationships er1
+				ON (e.guid = er1.guid_one
+					AND er1.guid_two = {$this->siteGuid}
+					AND er1.relationship = '$relationship1')
+				",
+				"LEFT JOIN {$this->dbPrefix}entity_relationships er2
+				ON (e.guid = er2.guid_one
+					AND er2.guid_two = {$this->siteGuid}
+					AND er2.relationship = '$relationship2')
+				",
+			),
+			'wheres' => array("er1.guid_one IS NULL AND er2.guid_one IS NULL"),
+			'limit' => false,
+		);
+	}
+
+	/**
+	 * Get number of users who need data migration
+	 *
+	 * @return int
+	 */
+	public function countUnmigratedUsers() {
+		$opts = $this->getBatchOptions();
+		$opts['count'] = true;
+		return elgg_get_entities($opts);
+	}
+
+	/**
+	 * Get the old directory location
+	 *
+	 * @param stdClass $user_row
+	 * @return string
+	 */
+	public function makeMatrix($user_row) {
+		$time_created = date('Y/m/d', $user_row->time_created);
+		return "$time_created/$user_row->guid/";
+	}
+
+	/**
+	 * Remove directory if all users moved out of it
+	 *
+	 * @param string $dir
+	 * @return bool
+	 */
+	public function removeDirIfEmpty($dir) {
+		$files = scandir($dir);
+
+		foreach ($files as $file) {
+			if ($file == '..' || $file == '.') {
+				continue;
+			}
+
+			// not empty.
+			if (is_file("$dir/$file")) {
+				return false;
+			}
+
+			// subdir not empty
+			if (is_dir("$dir/$file") && !$this->removeDirIfEmpty("$dir/$file")) {
+				return false;
+			}
+		}
+
+		// only contains empty subdirs
+		return rmdir($dir);
+	}
+
+	/**
+	 * Get the base directory name as int
+	 *
+	 * @param int $guid GUID of the user
+	 * @return int
+	 */
+	public function getLowerBucketBound($guid) {
+		$bucket_size = Elgg_EntityDirLocator::BUCKET_SIZE;
+		if ($guid < 1) {
+			return false;
+		}
+		return (int) max(floor($guid / $bucket_size) * $bucket_size, 1);
+	}
+
+	/**
+	 * Mark the user as a successful data migration
+	 *
+	 * @param int $guid
+	 */
+	public function markSuccess($guid) {
+		add_entity_relationship($guid, self::RELATIONSHIP_SUCCESS, $this->siteGuid);
+	}
+
+	/**
+	 * Mark the user as having failed data migration
+	 *
+	 * @param int $guid
+	 */
+	public function markFailure($guid) {
+		add_entity_relationship($guid, self::RELATIONSHIP_FAILURE, $this->siteGuid);
+	}
+
+	/**
+	 * Remove the records for failed migrations
+	 */
+	public function forgetFailures() {
+		$relationship = sanitise_string(self::RELATIONSHIP_FAILURE);
+		update_data("
+			DELETE FROM {$this->dbPrefix}entity_relationships
+			WHERE relationship = '$relationship'
+			  AND guid_two = {$this->siteGuid}
+		");
+	}
+
+	/**
+	 * Remove the records for successful migrations
+	 */
+	public function forgetSuccesses() {
+		$relationship = sanitise_string(self::RELATIONSHIP_SUCCESS);
+		update_data("
+			DELETE FROM {$this->dbPrefix}entity_relationships
+			WHERE relationship = '$relationship'
+			  AND guid_two = {$this->siteGuid}
+		");
+	}
+
+	/**
+	 * Are there any failures on record?
+	 *
+	 * @return bool
+	 */
+	public function hasFailures() {
+		$relationship = sanitise_string(self::RELATIONSHIP_FAILURE);
+		$sql = "
+			SELECT COUNT(*) AS cnt FROM {$this->dbPrefix}entity_relationships
+			WHERE relationship = '$relationship'
+			  AND guid_two = {$this->siteGuid}
+		";
+		$row = get_data_row($sql);
+		return ($row->cnt > 0);
+	}
+}

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -279,6 +279,7 @@ function _elgg_admin_init() {
 	elgg_register_action('admin/site/set_maintenance_mode', '', 'admin');
 
 	elgg_register_action('admin/upgrades/upgrade_comments', '', 'admin');
+	elgg_register_action('admin/upgrades/upgrade_datadirs', '', 'admin');
 	elgg_register_action('admin/site/regenerate_secret', '', 'admin');
 
 	elgg_register_action('admin/menu/save', '', 'admin');

--- a/engine/lib/upgrades/2013022000-1.9.0-datadir_dates_to_guids-efb02ff11b9d6444.php
+++ b/engine/lib/upgrades/2013022000-1.9.0-datadir_dates_to_guids-efb02ff11b9d6444.php
@@ -3,126 +3,15 @@
  * Elgg 1.9.0 upgrade 2013022000
  * datadir_dates_to_guids
  *
- * Rewrites user directories in data directory to use guids instead of creation dates
- */
-
-_elgg_services()->db->disableQueryCache();
-
-$data_root = elgg_get_config('dataroot');
-
-$failed = array();
-$existing_bucket_dirs = array();
-$cleanup_years = array();
-$users = new ElggBatch('elgg_get_entities', array('type' => 'user', 'limit' => 0, 'callback' => ''), null, 100);
-foreach ($users as $user_row) {
-	$from = $data_root . make_matrix_2013022000($user_row);
-	$bucket_dir = $data_root . getLowerBucketBound_2013022000($user_row->guid);
-	$to =  "$bucket_dir/" . $user_row->guid;
-
-	if (!is_dir($from)) {
-		continue;
-	}
-
-	// make sure bucket dir exists
-	if (!in_array($bucket_dir, $existing_bucket_dirs)) {
-		// for some reason this dir already exists.
-		if (is_dir($bucket_dir)) {
-			$existing_bucket_dirs[] = $bucket_dir;
-		} else {
-			// same perms as ElggDiskFilestore.
-			if (!mkdir($bucket_dir, 0700, true)) {
-				$failed[] = "[$user_row->guid] Failed creating `$bucket_dir`";
-				continue;
-			}
-			$existing_bucket_dirs[] = $bucket_dir;
-		}
-	}
-	
-	if (!rename($from, $to)) {
-		$failed[] = "[$user_row->guid] Failed moving `$from` to `$to`";
-	}
-
-	// store the year for cleanup
-	$year = date('Y', $user_row->time_created);
-	if (!in_array($year, $cleanup_years)) {
-		$cleanup_years[] = $year;
-	}
-}
-
-// remove all dirs that are empty.
-foreach ($cleanup_years as $year) {
-	remove_dir_if_empty_2013022000($data_root . $year);
-}
-
-if ($failed) {
-	$h = fopen("$data_root/2013022000_data_migration.log", 'w');
-	fwrite($h, implode("\n", $failed));
-	fclose($h);
-	register_error("Problems migrating user data. See the admin area for more information.");
-	elgg_add_admin_notice('2013022000_data_migration',
-			"There were problems migrating some users' data. See the log file at
-		{$data_root}2013022000_data_migration.log for a list of users who were affected.");
-}
-
-_elgg_services()->db->enableQueryCache();
-
-
-/**
- * End of script. Utility functions below
- */
-
-
-/**
- * Get the old directory location
+ * Registers an upgrade object that will be used to rewrite the structure of
+ * the Elgg data directory. The new structure will have the directories named
+ * by GUIDs instead of creation dates.
  *
- * @param stdClass $user_row
- * @return string
+ * See file actions/admin/upgrades/upgrade_comments.php for details.
  */
-function make_matrix_2013022000($user_row) {
-	$time_created = date('Y/m/d', $user_row->time_created);
 
-	return "$time_created/$user_row->guid/";
-}
-
-/**
- * Remove directory if all users moved out of it
- *
- * @param string $dir
- * @return bool
- */
-function remove_dir_if_empty_2013022000($dir) {
-	$files = scandir($dir);
-
-	foreach ($files as $file) {
-		if ($file == '..' || $file == '.') {
-			continue;
-		}
-
-		// not empty.
-		if (is_file("$dir/$file")) {
-			return false;
-		}
-
-		// subdir not empty
-		if (is_dir("$dir/$file") && !remove_dir_if_empty_2013022000("$dir/$file")) {
-			return false;
-		}
-	}
-
-	// only contains empty subdirs
-	return rmdir($dir);
-}
-
-/**
- * Get the base directory name as int
- *
- * @param int $guid GUID of the user
- * @return int
- */
-function getLowerBucketBound_2013022000($guid) {
-	$bucket_size = Elgg_EntityDirLocator::BUCKET_SIZE;
-	if ($guid < 1) {
-		return false;
-	}
-	return (int) max(floor($guid / $bucket_size) * $bucket_size, 1);
-}
+$upgrade = new ElggUpgrade();
+$upgrade->setURL("admin/upgrades/datadirs");
+$upgrade->title = 'Data directory upgrade';
+$upgrade->description = 'Data directory structure has been improved in Elgg 1.9 and it requires a migration. Run this upgrade to complete the migration.';
+$upgrade->save();

--- a/languages/en.php
+++ b/languages/en.php
@@ -1125,6 +1125,9 @@ Once you have logged in, we highly recommend that you change your password.
 	'admin:upgrades:comments' => 'Comments upgrade',
 	'upgrade:comment:create_failed' => 'Failed to convert comment id %s to an entity.',
 
+	// Strings specific for the datadir upgrade
+	'admin:upgrades:datadirs' => 'Data directory upgrade',
+
 /**
  * Welcome
  */

--- a/views/default/admin/upgrades/datadirs.php
+++ b/views/default/admin/upgrades/datadirs.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Data dirs upgrade page
+ */
+
+// Upgrade also possible hidden users. This feature get run
+// by an administrator so there's no need to ignore access.
+$access_status = access_get_show_hidden_status();
+access_show_hidden_entities(true);
+
+$factory = new ElggUpgrade();
+$upgrade = $factory->getUpgradeFromURL('/admin/upgrades/datadirs');
+
+if ($upgrade->isCompleted()) {
+	$count = 0;
+} else {
+	$helper = new Elgg_Upgrades_Helper2013022000(
+		elgg_get_site_entity()->guid,
+		elgg_get_config('dbprefix')
+	);
+
+	$helper->forgetFailures();
+	$count = $helper->countUnmigratedUsers();
+}
+
+echo elgg_view('admin/upgrades/view', array(
+	'count' => $count,
+	'action' => 'action/admin/upgrades/upgrade_datadirs',
+));
+
+access_show_hidden_entities($access_status);


### PR DESCRIPTION
This allows upgrade.php to complete more quickly by moving the user data directory migrations to a separate page with an ajax process.

Fixes #6202
Replaces #6336

Changes to Steve's original PR:
- Uses the generic XHR upgrade view and js
- Uses the ElggUpgrade object
- Fixes a bug that made it upgrade only the first ten users
- Rebased with latest master
