### PR TITLE
fix(a11y): keep focus outlines by default

### DIFF
--- a/mod/aalborg_theme/views/default/notifications/css.php
+++ b/mod/aalborg_theme/views/default/notifications/css.php
@@ -48,7 +48,6 @@
 	height:24px;
 	cursor: pointer;
 	display: block;
-	outline: none;
 }
 #notificationstable td.sitetogglefield {
 	width:50px;
@@ -64,7 +63,6 @@
 	height:24px;
 	cursor: pointer;
 	display: block;
-	outline: none;
 }
 #notificationstable td.emailtogglefield a.emailtoggleOff {
 	background: url(<?php echo elgg_get_site_url(); ?>mod/notifications/graphics/icon_notifications_email.gif) no-repeat right 2px;

--- a/mod/notifications/views/default/notifications/css.php
+++ b/mod/notifications/views/default/notifications/css.php
@@ -47,7 +47,6 @@
 	height:24px;
 	cursor: pointer;
 	display: block;
-	outline: none;
 }
 #notificationstable td.sitetogglefield {
 	width:50px;
@@ -63,7 +62,6 @@
 	height:24px;
 	cursor: pointer;
 	display: block;
-	outline: none;
 }
 #notificationstable td.emailtogglefield a.emailtoggleOff {
 	background: url(<?php echo elgg_get_site_url(); ?>mod/notifications/graphics/icon_notifications_email.gif) no-repeat right 2px;

--- a/views/default/css/elements/buttons.php
+++ b/views/default/css/elements/buttons.php
@@ -20,7 +20,6 @@
 	width: auto;
 	padding: 2px 4px;
 	cursor: pointer;
-	outline: none;
 	box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.40);
 	background-color: #ccc;
 }

--- a/views/default/css/elements/reset.php
+++ b/views/default/css/elements/reset.php
@@ -22,7 +22,6 @@ table, caption, tbody, tfoot, thead, tr, th, td {
 	margin: 0;
 	padding: 0;
 	border: 0;
-	outline: 0;
 	font-weight: inherit;
 	font-style: inherit;
 	font-size: 100%;

--- a/views/default/css/maintenance.php
+++ b/views/default/css/maintenance.php
@@ -186,7 +186,6 @@ input[type="radio"] {
 	width: auto;
 	padding: 2px 4px;
 	cursor: pointer;
-	outline: none;
 	box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.40);
 }
 .elgg-button-submit {


### PR DESCRIPTION
Defaulting outlines to "none" makes it virtually impossible to navigate Elgg with only a keyboard.

Fixes #6319
