### PR TITLE
fix(autocomplete): use group summary instead of profile view

### DIFF
--- a/engine/lib/input.php
+++ b/engine/lib/input.php
@@ -392,6 +392,7 @@ function input_livesearch_page_handler($page) {
 						$output = elgg_view_list_item($entity, array(
 							'use_hover' => false,
 							'class' => 'elgg-autocomplete-item',
+							'full_view' => false,
 						));
 
 						$icon = elgg_view_entity_icon($entity, 'tiny', array(


### PR DESCRIPTION
Before:

![livesearch-groups-before](https://cloud.githubusercontent.com/assets/356564/2748062/90902e24-c7a3-11e3-8d53-8f3751657f2a.png)

After:

![livesearch-groups-after](https://cloud.githubusercontent.com/assets/356564/2748063/9850d35c-c7a3-11e3-9ebf-429e912407cb.png)
