### PR TITLE
fix(gatekeeper): stop treating being logged out as an error state

### DIFF
--- a/engine/lib/pagehandler.php
+++ b/engine/lib/pagehandler.php
@@ -58,8 +58,8 @@ function elgg_unregister_page_handler($identifier) {
 function elgg_gatekeeper() {
 	if (!elgg_is_logged_in()) {
 		_elgg_services()->session->set('last_forward_from', current_page_url());
-		register_error(elgg_echo('loggedinrequired'));
-		forward('', 'login');
+		system_message(elgg_echo('loggedinrequired'));
+		forward('/login', 'login');
 	}
 }
 


### PR DESCRIPTION
It's quite frequent that someone may get a link to a page or entity that requires being logged in to view it. Instead of treating this as an error, this change gently forwards the user to the login page, giving them a chance to authenticate, after which they are taken to their original destination.
