### PR TITLE
fix(comments): give comment authors edit privileges

### DIFF
--- a/engine/classes/ElggComment.php
+++ b/engine/classes/ElggComment.php
@@ -34,30 +34,6 @@ class ElggComment extends ElggObject {
 	}
 
 	/**
-	 * Can a user edit this comment?
-	 *
-	 * @tip Can be overridden by registering for the permissions_check plugin hook.
-	 *
-	 * @param int $user_guid The user GUID, optionally (default: logged in user)
-	 *
-	 * @return bool Whether this comment is editable by the given user.
-	 * @see elgg_set_ignore_access()
-	 */
-	public function canEdit($user_guid = 0) {
-		$user_guid = (int)$user_guid;
-		$user = get_entity($user_guid);
-		if (!$user) {
-			$user = elgg_get_logged_in_user_entity();
-		}
-
-		// default is to only allow admins to edit.
-		$return = ($user && $user->isAdmin());
-
-		$params = array('entity' => $this, 'user' => $user);
-		return elgg_trigger_plugin_hook('permissions_check', $this->type, $params, $return);
-	}
-
-	/**
 	 * Update container entity last action on successful save.
 	 *
 	 * @param bool $update_last_action Update the container entity's last_action field

--- a/engine/lib/comments.php
+++ b/engine/lib/comments.php
@@ -20,6 +20,7 @@ function _elgg_comments_init() {
 	elgg_register_plugin_hook_handler('register', 'menu:entity', '_elgg_comment_setup_entity_menu', 900);
 	elgg_register_plugin_hook_handler('entity:url', 'object', '_elgg_comment_url_handler');
 	elgg_register_plugin_hook_handler('container_permissions_check', 'object', '_elgg_comments_container_permissions_override');
+	elgg_register_plugin_hook_handler('permissions_check', 'object', '_elgg_comments_permissions_override');
 
 	elgg_register_page_handler('comment', '_elgg_comments_page_handler');
 
@@ -169,5 +170,26 @@ function _elgg_comments_container_permissions_override($hook, $type, $return, $p
 		return true;
 	}
 
+	return $return;
+}
+
+/**
+ * By default, only authors can edit their comments.
+ * 
+ * @param string  $hook   'permissions_check'
+ * @param string  $type   'object'
+ * @param boolean $return Can the given user edit the given entity?
+ * @param array   $params Array of parameters (entity, user)
+ *
+ * @return boolean Whether the given user is allowed to edit the given comment.
+ */
+function _elgg_comments_permissions_override($hook, $type, $return, $params) {
+	$entity = $params['entity'];
+	$user = $params['user'];
+	
+	if (elgg_instanceof($entity, 'object', 'comment') && $user) {
+		return $entity->getOwnerGUID() == $user->getGUID();
+	}
+	
 	return $return;
 }

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -1120,6 +1120,10 @@ function discussion_can_edit_reply($hook, $type, $return, $params) {
 	if (!elgg_instanceof($reply, 'object', 'discussion_reply', 'ElggDiscussionReply')) {
 		return $return;
 	}
+	
+	if ($reply->owner_guid == $user->guid) {
+	    return true;
+	}
 
 	$discussion = $reply->getContainerEntity();
 	if ($discussion->owner_guid == $user->guid) {


### PR DESCRIPTION
It's pretty typical for other networks to allow comment authors to edit their comments after posting. Also, discussion replies used to be editable, so we are restoring the logic to match the old behavior.

Fixes #6724
