### PR TITLE
chore(composer): pull version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+	"name": "elgg/elgg",
+	"version": "1.9.0-dev",
+	"type": "project"
+}

--- a/version.php
+++ b/version.php
@@ -13,5 +13,19 @@
 // XX = Interim incrementer
 $version = 2014032200;
 
+$composerJson = file_get_contents(dirname(__FILE__) . "/composer.json");
+if ($composerJson === false) {
+	throw new Exception("Unable to read composer.json file!");
+}
+
+$composer = json_decode($composerJson);
+if ($composer === null) {
+	throw new Exception("JSON parse error while reading composer.json!");
+}
+
 // Human-friendly version name
-$release = '1.9.0-dev';
+if (!isset($composer->version)) {
+	throw new Exception("Version field must be set in composer.json!");
+}
+$release = $composer->version;
+


### PR DESCRIPTION
Replaces #6766

Added error handling and apparently missing file_get_contents call.

TODOs:
- [x] Don't move `$version` definition to composer
