### PR TITLE
chore(upgrade): enable site_notifications

### DIFF
--- a/engine/lib/upgrades/2014042500-1.9.0_dev-site-notifications-0aae171afb7a00d8.php
+++ b/engine/lib/upgrades/2014042500-1.9.0_dev-site-notifications-0aae171afb7a00d8.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Elgg 1.9.0-dev upgrade 2014042500
+ * site-notifications
+ *
+ * When upgrading from Elgg 1.8.x to Elgg 1.9 and you have the messages plugin enabled
+ * also enable the site_notifications plugin as it takes over the 'site' notification part
+ */
+
+// is the messages plugin enabled
+if (elgg_is_active_plugin('messages')) {
+	// get the site_notifications plugin
+	$site_notifications = elgg_get_plugin_from_id('site_notifications');
+	
+	if (!empty($site_notifications)) {
+		$site_notifications->activate();
+	}
+}

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2014032200;
+$version = 2014042500;
 
 // Human-friendly version name
 $release = '1.9.0-dev';


### PR DESCRIPTION
when upgrading from elgg 1.8 to elgg 1.9 the site_notifications plugin
takes over the 'site' notification from the messages plugin. So enable
this new plugin if the messages plugin was enabled

Fixes #6468
- [x] LGTM ewinslow
