### PR TITLE
fix(core): no longer strip slashes on $_FILES and $_SERVER

### DIFF
--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -115,8 +115,8 @@ class Elgg_Http_Request {
 		$this->request = new Elgg_Http_ParameterBag($this->stripSlashesIfMagicQuotes($request));
 		$this->cookies = new Elgg_Http_ParameterBag($this->stripSlashesIfMagicQuotes($cookies));
 		// Symfony uses FileBag so this will change in next Elgg version
-		$this->files = new Elgg_Http_ParameterBag($this->stripSlashesIfMagicQuotes($files));
-		$this->server = new Elgg_Http_ParameterBag($this->stripSlashesIfMagicQuotes($server));
+		$this->files = new Elgg_Http_ParameterBag($files);
+		$this->server = new Elgg_Http_ParameterBag($server);
 	
 		$headers = $this->prepareHeaders();
 		// Symfony uses HeaderBag so this will change in next Elgg version


### PR DESCRIPTION
When magic_quotes_gpc is enabled on your server file uploads would fail.

The Elgg_HTTP_Request class should only undo the magic quotes on the GPC
(GET, POST and COOKIES) super global not on other super globals (SERVER
and FILES)

Fixes #6777
