### PR TITLE
feature(core): better registration of usersettings handlers

### DIFF
--- a/engine/lib/user_settings.php
+++ b/engine/lib/user_settings.php
@@ -8,25 +8,6 @@
  */
 
 /**
- * Saves user settings.
- *
- * @todo all the functions called by this function assume settings are coming
- * in on a GET/POST request
- *
- * @note This is a handler for the 'usersettings:save', 'user' plugin hook
- *
- * @return void
- * @access private
- */
-function _elgg_user_settings_save() {
-	_elgg_set_user_language();
-	_elgg_set_user_password();
-	_elgg_set_user_default_access();
-	_elgg_set_user_name();
-	_elgg_set_user_email();
-}
-
-/**
  * Set a user's password
  * 
  * @return bool
@@ -356,8 +337,12 @@ function _elgg_user_settings_init() {
 
 	elgg_register_event_handler('pagesetup', 'system', '_elgg_user_settings_menu_setup');
 
-	elgg_register_plugin_hook_handler('usersettings:save', 'user', '_elgg_user_settings_save');
-
+	elgg_register_plugin_hook_handler('usersettings:save', 'user', '_elgg_set_user_language');
+	elgg_register_plugin_hook_handler('usersettings:save', 'user', '_elgg_set_user_password');
+	elgg_register_plugin_hook_handler('usersettings:save', 'user', '_elgg_set_user_default_access');
+	elgg_register_plugin_hook_handler('usersettings:save', 'user', '_elgg_set_user_name');
+	elgg_register_plugin_hook_handler('usersettings:save', 'user', '_elgg_set_user_email');
+	
 	elgg_register_action("usersettings/save");
 
 	// extend the account settings form


### PR DESCRIPTION
This will allow plugin developers to replace specific parts of the user
settings action without redoing part of the core actions.

For example:
If I wanted to change the password policies. I had to unregister the default save handler and re-register all but the password handler.

This way I only have to unregister the password handler
- [x] Commit message is in standard format
- [x] Has LGTM
