### PR TITLE
chore(travis): add 'deprecate' commit type

### DIFF
--- a/.scripts/ElggCommitMessage.php
+++ b/.scripts/ElggCommitMessage.php
@@ -73,7 +73,8 @@ class ElggCommitMessage {
 		'docs',
 		'chore',
 		'perf',
-		'security'
+		'security',
+		'deprecate',
 	);
 
 	/**

--- a/docs/contribute/code.rst
+++ b/docs/contribute/code.rst
@@ -94,6 +94,7 @@ Where ``type`` is one of:
 * chore (refactoring, style changes, add missing tests, Travis stuff, etc.)
 * perf (when primary purpose of change is to improve performance)
 * security (any change affecting a security issue)
+* deprecate (any change that deprecates any part of the API)
 
 And ``component`` is one of:
 

--- a/engine/tests/phpunit/ElggCommitMessageTest.php
+++ b/engine/tests/phpunit/ElggCommitMessageTest.php
@@ -133,6 +133,7 @@ ___MSG;
 			'chore',
 			'perf',
 			'security',
+			'deprecate',
 		);
 
 		// make sure we have all the types


### PR DESCRIPTION
This type will allow us to easily call out deprecations in changelogs

Fixes #6785
- [x] fix tests
- [x] add docs
