### PR TITLE
conventional-changelog support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /.htaccess
 /mod/*
 
+# Ignore third party code
+node_modules
+
 # don't ignore bundled plugins
 !/mod/aalborg_theme/
 !/mod/blog/

--- a/.scripts/write-changelog.js
+++ b/.scripts/write-changelog.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+var pkg = require('../composer.json');
+var fs = require('fs');
+var changelog = require('elgg-conventional-changelog');
+
+changelog({
+  version: pkg.version,
+  repository: 'https://github.com/Elgg/Elgg',
+  types: {
+      feature: 'Features',
+      perf: 'Performance',
+      docs: 'Documentation',
+      fix: 'Bug Fixes',
+      deprecate: 'Deprecations',
+      breaks: 'Breaking Changes',
+  }
+}, function(err, log) {
+  if (err) throw new Error(err);
+  fs.writeFileSync('CHANGELOG.md', log);
+});
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -918,3 +918,4 @@ core. The original dashboard can be restored by the new Dashboard plugin.
 
 Elgg 1.8.0.1 was released immediately after 1.8.0 to correct a problem in
 installation.
+

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+	"name": "elgg/elgg",
+	"version": "1.9.0-dev",
+	"type": "project"
+}

--- a/docs/contribute/releases.rst
+++ b/docs/contribute/releases.rst
@@ -15,39 +15,38 @@ Requirements
  * Author access to http://blog.elgg.org
  * Access to `Twitter account`_
  * Access to `G+ page`_
+ * NPM installed
  
 1. Prepare and tag the release
 ==============================
 
-Merge latest commits up from lowest supported branch
+Make sure your local git clone is up to date!
+
+Merge latest commits up from lowest supported branch.
+Visit https://github.com/Elgg/Elgg/compare/new...old and submit the PR
+if there is anything that needs to be merged up.
+
+Update `version` in composer.json.
+
+Update CHANGELOG.md:
 
 .. code:: sh
 
-	git checkout <branch>
-	git merge <lower-branch>
-
-Update CHANGES.txt + version.php
- * List of contributors
- * List of enhancements
- * List of bugfixes
-
-To figure out the commit hash of the last release:
- 
-.. code:: sh
-
-    git tag -v <version>
-
+   .scripts/write-changelog.js
+   
 Get list of contributors since last release:
 
 .. code:: sh
 
-    git log <commit>..HEAD | grep ^Author: | sed 's/ <.*//; s/^Author: //' | sort | uniq -c | sort -nr
+    git shortlog <tag>..HEAD -summary --numbered --no-merges
 
-To get a list of commit messages since the last release:
+Add these people to the release in CHANGELOG.md
+
+Commit your changes:
 
 .. code:: sh
 
-	git log --format=oneline <commit>..HEAD | grep \ .* -o | sed 's/^ /  * /' | sort
+   git commit -am "chore(release): vX.Y.Z"
 
 Tag the branch with next release
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "elgg-conventional-changelog": "0.0.1"
+  }
+}

--- a/version.php
+++ b/version.php
@@ -13,5 +13,19 @@
 // XX = Interim incrementer
 $version = 2014042500;
 
+$composerJson = file_get_contents(dirname(__FILE__) . "/composer.json");
+if ($composerJson === false) {
+	throw new Exception("Unable to read composer.json file!");
+}
+
+$composer = json_decode($composerJson);
+if ($composer === null) {
+	throw new Exception("JSON parse error while reading composer.json!");
+}
+
 // Human-friendly version name
-$release = '1.9.0-dev';
+if (!isset($composer->version)) {
+	throw new Exception("Version field must be set in composer.json!");
+}
+$release = $composer->version;
+


### PR DESCRIPTION
For your consideration.

I had to fork the original project in order to get support for arbitrary sections without waiting on the PR getting reviewed and accepted. We now have a repo at Elgg/conventional-changelog for our customizations. We may just continue rolling like this for a while since I want to add contributor acknowledgments soon, too.
