### PR TITLE
fix(tests): persistent login tests are no longer fragile

### DIFF
--- a/engine/classes/Elgg/PersistentLoginService.php
+++ b/engine/classes/Elgg/PersistentLoginService.php
@@ -32,13 +32,15 @@ class Elgg_PersistentLoginService {
 	 * @param ElggCrypto    $crypto        The cryptography service
 	 * @param array         $cookie_config The persistent login cookie settings
 	 * @param string        $cookie_token  The token from the request cookie
+	 * @param int           $time          The current time
 	 */
 	public function __construct(
 			Elgg_Database $db,
 			ElggSession $session,
 			ElggCrypto $crypto,
 			array $cookie_config,
-			$cookie_token) {
+			$cookie_token,
+			$time = null) {
 		$this->db = $db;
 		$this->session = $session;
 		$this->crypto = $crypto;
@@ -47,6 +49,7 @@ class Elgg_PersistentLoginService {
 
 		$prefix = $this->db->getTablePrefix();
 		$this->table = "{$prefix}users_remember_me_cookies";
+		$this->time = is_numeric($time) ? (int)$time : time();
 	}
 
 	/**
@@ -261,7 +264,7 @@ class Elgg_PersistentLoginService {
 		}
 		$cookie->value = $token;
 		if (!$token) {
-			$cookie->setExpiresTime("-30 days");
+			$cookie->expire = $this->time - (86400 * 30);
 		}
 		call_user_func($this->_callable_elgg_set_cookie, $cookie);
 	}
@@ -331,6 +334,11 @@ class Elgg_PersistentLoginService {
 	 * @var ElggCrypto
 	 */
 	protected $crypto;
+
+	/**
+	 * @var int
+	 */
+	protected $time;
 
 	/**
 	 * DO NOT USE. For unit test mocking

--- a/engine/tests/phpunit/Elgg/PersistentLoginTest.php
+++ b/engine/tests/phpunit/Elgg/PersistentLoginTest.php
@@ -47,7 +47,14 @@ class Elgg_PersistentLoginTest extends PHPUnit_Framework_TestCase {
 	 */
 	protected $timeSlept;
 
+	/**
+	 * @var int
+	 */
+	protected $thirtyDaysAgo;
+
 	function setUp() {
+		$this->thirtyDaysAgo = strtotime("-30 days");
+
 		$this->mockToken = 'z' . str_repeat('a', 31);
 
 		$this->mockHash = md5($this->mockToken);
@@ -94,7 +101,7 @@ class Elgg_PersistentLoginTest extends PHPUnit_Framework_TestCase {
 		$this->svc->removePersistentLogin();
 
 		$this->assertSame('', $this->lastCookieSet->value);
-		$this->assertSame(strtotime("-30 days"), $this->lastCookieSet->expire);
+		$this->assertSame($this->thirtyDaysAgo, $this->lastCookieSet->expire);
 		$this->assertNull($this->session->get('code'));
 	}
 
@@ -105,7 +112,7 @@ class Elgg_PersistentLoginTest extends PHPUnit_Framework_TestCase {
 		$this->svc->removePersistentLogin();
 
 		$this->assertSame('', $this->lastCookieSet->value);
-		$this->assertSame(strtotime("-30 days"), $this->lastCookieSet->expire);
+		$this->assertSame($this->thirtyDaysAgo, $this->lastCookieSet->expire);
 		$this->assertNull($this->session->get('code'));
 	}
 
@@ -212,7 +219,7 @@ class Elgg_PersistentLoginTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertNull($this->timeSlept);
 		$this->assertSame('', $this->lastCookieSet->value);
-		$this->assertSame(strtotime("-30 days"), $this->lastCookieSet->expire);
+		$this->assertSame($this->thirtyDaysAgo, $this->lastCookieSet->expire);
 		$this->assertNull($user);
 	}
 
@@ -227,7 +234,7 @@ class Elgg_PersistentLoginTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertSame(1, $this->timeSlept);
 		$this->assertSame('', $this->lastCookieSet->value);
-		$this->assertSame(strtotime("-30 days"), $this->lastCookieSet->expire);
+		$this->assertSame($this->thirtyDaysAgo, $this->lastCookieSet->expire);
 		$this->assertNull($user);
 	}
 
@@ -313,7 +320,10 @@ class Elgg_PersistentLoginTest extends PHPUnit_Framework_TestCase {
 			'name' => 'elggperm',
 			'expire' => time() + (30 * 86400),
 		);
-		$svc = new Elgg_PersistentLoginService($this->dbMock, $this->session, $this->cryptoMock, $cookie_config, $cookie_token);
+		$time = $this->thirtyDaysAgo + (30 * 86400);
+		$svc = new Elgg_PersistentLoginService(
+			$this->dbMock, $this->session, $this->cryptoMock,
+			$cookie_config, $cookie_token, $time);
 
 		$svc->_callable_get_user = array($this, 'mock_get_user');
 		$svc->_callable_generateToken = array($this, 'mock_generateToken');


### PR DESCRIPTION
The persistent login component unit tests were failing when run close to
the border between seconds on the clock because ElggCookie::setExpiresTime
depends on the current time. I refactored to allow injecting the current
time into the persistent login component.

Fixes #6829
