### PR TITLE
Prevents upgrade scripts from attempting to create the same ElggUpgrade more than once

### DIFF
--- a/engine/lib/upgrades/2013010400-1.9.0_dev-comments_to_entities-faba94768b055b08.php
+++ b/engine/lib/upgrades/2013010400-1.9.0_dev-comments_to_entities-faba94768b055b08.php
@@ -30,11 +30,16 @@ $options = array(
 );
 
 if (elgg_get_annotations($options)) {
+	$url = "admin/upgrades/comments";
 	$upgrade = new ElggUpgrade();
-	$upgrade->setURL("admin/upgrades/comments");
-	$upgrade->title = 'Comments Upgrade';
-	$upgrade->description = 'Comments have been improved in Elgg 1.9 and require a migration. Run this upgrade to complete the migration.';
-	$upgrade->save();
+
+	// Create the upgrade if one with the same URL doesn't already exist
+	if (!$upgrade->getUpgradeFromURL($url)) {
+		$upgrade->setURL($url);
+		$upgrade->title = 'Comments Upgrade';
+		$upgrade->description = 'Comments have been improved in Elgg 1.9 and require a migration. Run this upgrade to complete the migration.';
+		$upgrade->save();
+	}
 }
 
 elgg_set_ignore_access($ia);

--- a/engine/lib/upgrades/2013022000-1.9.0-datadir_dates_to_guids-efb02ff11b9d6444.php
+++ b/engine/lib/upgrades/2013022000-1.9.0-datadir_dates_to_guids-efb02ff11b9d6444.php
@@ -11,7 +11,12 @@
  */
 
 $upgrade = new ElggUpgrade();
-$upgrade->setURL("admin/upgrades/datadirs");
-$upgrade->title = 'Data directory upgrade';
-$upgrade->description = 'Data directory structure has been improved in Elgg 1.9 and it requires a migration. Run this upgrade to complete the migration.';
-$upgrade->save();
+$url = "admin/upgrades/datadirs";
+
+// Create the upgrade if one with the same URL doesn't already exist
+if (!$upgrade->getUpgradeFromURL($url)) {
+	$upgrade->setURL($url);
+	$upgrade->title = 'Data directory upgrade';
+	$upgrade->description = 'Data directory structure has been improved in Elgg 1.9 and it requires a migration. Run this upgrade to complete the migration.';
+	$upgrade->save();
+}

--- a/engine/lib/upgrades/2014050600-1.9.0_dev-replies_to_entities-094ea0e36bc027d3.php
+++ b/engine/lib/upgrades/2014050600-1.9.0_dev-replies_to_entities-094ea0e36bc027d3.php
@@ -32,11 +32,16 @@ $discussion_replies = elgg_get_annotations(array(
 
 // Notify administrator only if there are existing discussion replies
 if ($discussion_replies) {
+	$url = "admin/upgrades/discussion_replies";
 	$upgrade = new ElggUpgrade();
-	$upgrade->setURL("admin/upgrades/discussion_replies");
-	$upgrade->title = 'Group Discussions Upgrade';
-	$upgrade->description = 'Group discussions have been improved in Elgg 1.9 and require a migration. Run this upgrade to complete the migration.';
-	$upgrade->save();
+
+	// Create the upgrade if one with the same URL doesn't already exist
+	if (!$upgrade->getUpgradeFromURL($url)) {
+		$upgrade->setURL($url);
+		$upgrade->title = 'Group Discussions Upgrade';
+		$upgrade->description = 'Group discussions have been improved in Elgg 1.9 and require a migration. Run this upgrade to complete the migration.';
+		$upgrade->save();
+	}
 }
 
 elgg_set_ignore_access($ia);


### PR DESCRIPTION
Attempting to create two ElggUpgrade objects with the same URL causes a fatal error. Now the
scripts check whether the ElggUpgrade already exists.
