### PR TITLE
fix(aalborg_theme): only pass body_attrs if they are set

### DIFF
--- a/mod/aalborg_theme/views/default/page/default.php
+++ b/mod/aalborg_theme/views/default/page/default.php
@@ -7,6 +7,7 @@
  * @subpackage Core
  *
  * @uses $vars['head']        Parameters for the <head> element
+ * @uses $vars['body_attrs']  Attributes of the <body> tag
  * @uses $vars['body']        The main content of the page
  * @uses $vars['sysmessages'] A 2d array of various message registers, passed from system_messages()
  */
@@ -78,4 +79,13 @@ $body .= elgg_view('page/elements/foot');
 
 $head = elgg_view('page/elements/head', $vars['head']);
 
-echo elgg_view("page/elements/html", array("head" => $head, "body" => $body));
+$params = array(
+	'head' => $head,
+	'body' => $body,
+);
+
+if (isset($vars['body_attrs'])) {
+	$params['body_attrs'] = $vars['body_attrs'];
+}
+
+echo elgg_view("page/elements/html", $params);


### PR DESCRIPTION
Follow-up of #6479
