### PR TITLE
chore(travis): Switched to blacklisting not-tested branches instead of whitelisting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,12 @@ php:
  - 5.5
 
 branches:
-  only:
-    - master
+  except:
+    - 1.0
+    - 1.5
+    - 1.6
+    - 1.7
+    - 1.8
 
 matrix:
   include:


### PR DESCRIPTION
For details see: http://docs.travis-ci.com/user/build-configuration/#Specify-branches-to-build

Fixes: #6851

I've just thrown all branches for clarity, despite not expecting any commits ever to branches below 1.8 and despite that they have custom .travis.yml files.
