### PR TITLE
Documentation fix - for inline refs use @link instead of @see

### DIFF
--- a/engine/classes/ElggBatch.php
+++ b/engine/classes/ElggBatch.php
@@ -182,7 +182,7 @@ class ElggBatch
 	 *                           and hitting the db server too often.
 	 * @param bool   $inc_offset Increment the offset on each fetch. This must be false for
 	 *                           callbacks that delete rows. You can set this after the
-	 *                           object is created with {@see ElggBatch::setIncrementOffset()}.
+	 *                           object is created with {@link ElggBatch::setIncrementOffset()}.
 	 */
 	public function __construct($getter, $options, $callback = null, $chunk_size = 25,
 			$inc_offset = true) {

--- a/engine/lib/access.php
+++ b/engine/lib/access.php
@@ -538,7 +538,7 @@ function get_write_access_array($user_guid = 0, $site_guid = 0, $flush = false) 
  * Use the plugin hook of 'access:collections:write', 'user' to change this.
  * @see get_write_access_array() for details on the hook.
  *
- * Respects access control disabling for admin users and {@see elgg_set_ignore_access()}
+ * Respects access control disabling for admin users and {@link elgg_set_ignore_access()}
  *
  * @see get_write_access_array()
  *

--- a/engine/lib/annotations.php
+++ b/engine/lib/annotations.php
@@ -224,7 +224,7 @@ function elgg_get_annotations(array $options = array()) {
  * Returns a rendered list of annotations with pagination.
  *
  * @param array $options Annotation getter and display options.
- * {@see elgg_get_annotations()} and {@see elgg_list_entities()}.
+ * {@link elgg_get_annotations()} and {@link elgg_list_entities()}.
  *
  * @return string The list of entities
  * @since 1.8.0

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1487,9 +1487,9 @@ function elgg_extract($key, array $array, $default = null, $strict = true) {
  * @param array  &$array     Array to sort
  * @param string $element    Element to sort by
  * @param int    $sort_order PHP sort order
- *                           {@see http://us2.php.net/array_multisort}
+ *                           {@link http://us2.php.net/array_multisort}
  * @param int    $sort_type  PHP sort type
- *                           {@see http://us2.php.net/sort}
+ *                           {@link http://us2.php.net/sort}
  *
  * @return bool
  */

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -1766,7 +1766,7 @@ function get_registered_entity_types($type = null) {
 }
 
 /**
- * Returns if the entity type and subtype have been registered with {@see elgg_register_entity_type()}.
+ * Returns if the entity type and subtype have been registered with {@link elgg_register_entity_type()}.
  *
  * @param string $type    The type of entity (object, site, user, group)
  * @param string $subtype The subtype (may be blank)

--- a/engine/lib/metadata.php
+++ b/engine/lib/metadata.php
@@ -299,7 +299,7 @@ function elgg_get_metadata(array $options = array()) {
  *          This requires at least one constraint: metadata_owner_guid(s),
  *          metadata_name(s), metadata_value(s), or guid(s) must be set.
  *
- * @param array $options An options array. {@see elgg_get_metadata()}
+ * @param array $options An options array. {@link elgg_get_metadata()}
  * @return bool|null true on success, false on failure, null if no metadata to delete.
  * @since 1.8.0
  */

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -662,7 +662,7 @@ function _elgg_set_metastring_based_object_enabled_by_id($id, $enabled, $type) {
  *
  * @warning This returns null on no ops.
  *
- * @param array  $options    An options array. {@see _elgg_get_metastring_based_objects()}
+ * @param array  $options    An options array. {@link _elgg_get_metastring_based_objects()}
  * @param string $callback   The callback to pass each result through
  * @param bool   $inc_offset Increment the offset? Pass false for callbacks that delete / disable
  *

--- a/engine/lib/plugins.php
+++ b/engine/lib/plugins.php
@@ -1017,7 +1017,7 @@ function elgg_unset_all_plugin_settings($plugin_id = null) {
 
 /**
  * Returns entities based upon plugin user settings.
- * Takes all the options for {@see elgg_get_entities_from_private_settings()}
+ * Takes all the options for {@link elgg_get_entities_from_private_settings()}
  * in addition to the ones below.
  *
  * @param array $options Array in the format:

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -381,7 +381,7 @@ function elgg_view_deprecated($view, array $vars, $suggestion, $version) {
  * the output of the extended view will be appended to the original view.
  *
  * Views can be extended multiple times, and extensions are not checked for
- * uniqueness. Use {@see elgg_unextend_view()} to help manage duplicates.
+ * uniqueness. Use {@link elgg_unextend_view()} to help manage duplicates.
  *
  * Priority can be specified and affects the order in which extensions
  * are appended or prepended.
@@ -763,7 +763,7 @@ function elgg_view_menu_item(ElggMenuItem $item, array $vars = array()) {
  * @param array      $vars   Array of variables to pass to the entity view.
  *                           In Elgg 1.7 and earlier it was the boolean $full_view
  * @param boolean    $bypass If true, will not pass to a custom template handler.
- *                           {@see set_template_handler()}
+ *                           {@link set_template_handler()}
  * @param boolean    $debug  Complain if views are missing
  *
  * @return string HTML to display or false
@@ -887,7 +887,7 @@ function elgg_view_entity_icon(ElggEntity $entity, $size = 'medium', $vars = arr
  * @param ElggAnnotation $annotation The annotation to display
  * @param array          $vars       Variable array for view.
  * @param bool           $bypass     If true, will not pass to a custom
- *                                   template handler. {@see set_template_handler()}
+ *                                   template handler. {@link set_template_handler()}
  * @param bool           $debug      Complain if views are missing
  *
  * @return string/false Rendered annotation


### PR DESCRIPTION
Inline references in documentation should use {@link ...} not {@see ...}
