### PR TITLE
chore(ci): Encrypted notification email

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,4 @@ script:
  
 notifications:
   email:
-    - team@elgg.org
+    secure: exC/ws07lLOj3Y43C89jiaKpyB8Yt7DPGSCShV4R3Wkw/hVVzjxt1BinPxzsyL5DC7APUMcTHGOhDB2oCE4ynDE6o6L9bH79fc+V8IYAiNaEIGL0AOuHdnRdGN9GMrr2jv78cZ5MctuUTkeYLaoOEyDGHmkMhqa6SufIDAY8b58=


### PR DESCRIPTION
This is to avoid receiving notification from forks. See http://docs.travis-ci.com/user/encryption-keys/

I hope that it will solve the problem of notifications from forks as every repository is supposed to have different encryption key (my fork has different from Elgg/Elgg one).

Side effect with notifications not being sent on failed PRs is a non issue IMHO. We only need info on failed tests after merges as we see test results before merge anyway.
