### PR TITLE
fix(install): Better accessibility for installation flow

### DIFF
--- a/install/ElggInstaller.php
+++ b/install/ElggInstaller.php
@@ -398,12 +398,12 @@ class ElggInstaller {
 				'required' => TRUE,
 				),
 			'siteemail' => array(
-				'type' => 'text',
+				'type' => 'email',
 				'value' => '',
 				'required' => FALSE,
 				),
 			'wwwroot' => array(
-				'type' => 'text',
+				'type' => 'url',
 				'value' => elgg_get_site_url(),
 				'required' => TRUE,
 				),
@@ -474,7 +474,7 @@ class ElggInstaller {
 				'required' => TRUE,
 				),
 			'email' => array(
-				'type' => 'text',
+				'type' => 'email',
 				'value' => '',
 				'required' => TRUE,
 				),

--- a/install/css/install.css
+++ b/install/css/install.css
@@ -169,7 +169,9 @@ h3 {
 }
 
 input[type="text"],
-input[type="password"]  {
+input[type="password"],
+input[type="email"],
+input[type="url"] {
 	font: 120% Arial, Helvetica, sans-serif;
 	padding: 5px;
 	border: 1px solid #cccccc;

--- a/install/css/install.css
+++ b/install/css/install.css
@@ -149,17 +149,25 @@ h3 {
 	margin: 15px 0 5px;
 }
 
-form > div {
-	margin-bottom: 15px;
+.elgg-form-field {
+	display: block;
 }
-label {
-	font-weight: bold;
+
+* + .elgg-form-field {
+	margin-top: 15px;
+}
+
+.elgg-form-field-label {
 	color: #333333;
+	display: block;
 	font-size: 140%;
+	font-weight: bold;
 }
-.elgg-combo-label {
-	font-size: 120%;
+
+.elgg-form-field-help {
+	display: block;
 }
+
 input[type="text"],
 input[type="password"]  {
 	font: 120% Arial, Helvetica, sans-serif;

--- a/views/installation/forms/install/template.php
+++ b/views/installation/forms/install/template.php
@@ -9,22 +9,26 @@
 $variables = $vars['variables'];
 $type = $vars['type'];
 
-$form_body = '';
-foreach ($variables as $field => $params) {
-	$label = elgg_echo("install:$type:label:$field");
-	$help = elgg_echo("install:$type:help:$field");
-	$params['name'] = $field;
+foreach ($variables as $name => $params) {
+	$label = elgg_echo("install:$type:label:$name");
+	$help = elgg_echo("install:$type:help:$name");
+	$params['name'] = $name;
+	
+	$input = elgg_view("input/{$params['type']}", $params);
 
-	$form_body .= '<div>';
-	$form_body .= "<label>$label</label>";
-	$form_body .= elgg_view("input/{$params['type']}", $params);
-	$form_body .= "<span class=\"install-help\">$help</span>";
-	$form_body .= '</div>';
+	$field = <<<FIELD
+<label class="elgg-form-field">
+	<span class="elgg-form-field-label">$label</span>
+	<span class="elgg-form-field-help">$help</span>
+	$input
+</label>
+FIELD;
+
+	$form_body .= $field;
 }
 
-$submit_params = array(
+$form_body .= elgg_view('input/submit', array(
 	'value' => elgg_echo('install:next'),
-);
-$form_body .= elgg_view('input/submit', $submit_params);
+));
 
 echo $form_body;

--- a/views/installation/input/email.php
+++ b/views/installation/input/email.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Displays an email input field
+ */
+
+$vars['class'] = 'elgg-input-email';
+$vars['type'] = 'email';
+
+$attrs = elgg_format_attributes($vars);
+
+echo "<input $attrs>";

--- a/views/installation/input/password.php
+++ b/views/installation/input/password.php
@@ -1,17 +1,11 @@
 <?php
 /**
- * Elgg password input
  * Displays a password input field
- *
- * @uses $vars['value'] The current value, if any
- * @uses $vars['name'] The name of the input field
- *
  */
 
-$class = "input-password";
+$vars['class'] = 'elgg-input-password';
+$vars['type'] = 'password';
 
-$value = htmlentities($vars['value'], ENT_QUOTES, 'UTF-8');
+$attrs = elgg_format_attributes($vars);
 
-?>
-
-<input type="password" name="<?php echo $vars['name']; ?>" value="<?php echo $value; ?>" class="<?php echo $class; ?>" />
+echo "<input $attrs>";

--- a/views/installation/input/text.php
+++ b/views/installation/input/text.php
@@ -1,20 +1,11 @@
 <?php
 /**
- * Elgg text input
  * Displays a text input field
- *
- * @uses $vars['value'] The current value, if any
- * @uses $vars['name']  The name of the input field
- * @uses $vars['class'] CSS class
  */
 
-if (isset($vars['class'])) {
-	$class = "class=\"{$vars['class']}\"";
-} else {
-	$class = "elgg-input-text";
-}
+$vars['class'] = 'elgg-input-text';
+$vars['type'] = 'text';
 
-$value = htmlentities($vars['value'], ENT_QUOTES, 'UTF-8');
+$attrs = elgg_format_attributes($vars);
 
-?>
-<input type="text" name="<?php echo $vars['name']; ?>" value="<?php echo $value; ?>" <?php echo $class; ?> />
+echo "<input $attrs>";

--- a/views/installation/input/url.php
+++ b/views/installation/input/url.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Displays a url input field
+ */
+
+$vars['class'] = 'elgg-input-url';
+$vars['type'] = 'url';
+
+$attrs = elgg_format_attributes($vars);
+
+echo "<input $attrs>";

--- a/views/installation/page/default.php
+++ b/views/installation/page/default.php
@@ -34,24 +34,24 @@ header('Expires: Fri, 05 Feb 1982 00:00:00 -0500', TRUE);
 	</head>
 	<body>
 		<div class="elgg-page">
-			<div class="elgg-page-header">
+			<header class="elgg-page-header" role="banner">
 				<?php echo elgg_view('page/elements/header', $vars); ?>
-			</div>
+			</header>
 			<div class="elgg-page-body">
 				<div class="elgg-layout">
-					<div class="elgg-sidebar">
+					<aside class="elgg-sidebar" role="complementary">
 						<?php echo elgg_view('page/elements/sidebar', $vars); ?>
-					</div>
-					<div class="elgg-body">
-						<h2><?php echo $vars['title']; ?></h2>
+					</aside>
+					<main class="elgg-body" role="main">
+						<h1><?php echo $vars['title']; ?></h1>
 						<?php echo elgg_view('page/elements/messages', array('object' => $vars['sysmessages'])); ?>
 						<?php echo $vars['body']; ?>
-					</div>
+					</main>
 				</div>
 			</div>
-			<div class="elgg-page-footer">
+			<footer class="elgg-page-footer" role="contentinfo">
 				<?php echo elgg_view('page/elements/footer'); ?>
-			</div>
+			</footer>
 		</div>
 	</body>
 </html>


### PR DESCRIPTION
I'm pretty excited about this. This was actually really easy to do and noticeably improved the experience of getting through the installer with assistive technology (I tested using ChromeVox on ChromeOS by hitting Ctrl + Alt + Z to turn it on).

I also like the form markup a lot better than what we were using. I took the liberty of just adding it to the installer since themes don't really affect the installer. Let me know what you think and we can talk about adding it for 1.10. See #6356
