### PR TITLE
perf(db): produces more readable DB logs

### DIFF
--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -314,7 +314,7 @@ class Elgg_Database {
 		// Is cached?
 		if ($this->queryCache) {
 			if (isset($this->queryCache[$hash])) {
-				$this->logger->log("DB query $query results returned from cache (hash: $hash)", Elgg_Logger::INFO);
+				$this->logger->log("DB cache hit as $hash. $query", Elgg_Logger::INFO);
 				return $this->queryCache[$hash];
 			}
 		}
@@ -324,10 +324,8 @@ class Elgg_Database {
 
 		if ($result = $this->executeQuery("$query", $dblink)) {
 
-			// test for callback once instead of on each iteration.
-			// @todo check profiling to see if this needs to be broken out into
-			// explicit cases instead of checking in the interation.
 			$is_callable = is_callable($callback);
+
 			while ($row = mysql_fetch_object($result)) {
 				if ($is_callable) {
 					$row = call_user_func($callback, $row);
@@ -342,14 +340,10 @@ class Elgg_Database {
 			}
 		}
 
-		if (empty($return)) {
-			$this->logger->log("DB query $query returned no results.", Elgg_Logger::INFO);
-		}
-
 		// Cache result
 		if ($this->queryCache) {
 			$this->queryCache[$hash] = $return;
-			$this->logger->log("DB query $query results cached (hash: $hash)", Elgg_Logger::INFO);
+			$this->logger->log("DB query. cached as $hash. $query", Elgg_Logger::INFO);
 		}
 
 		return $return;

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -87,6 +87,11 @@ function elgg_is_admin_user($user_guid) {
 
 	$user_guid = (int)$user_guid;
 
+	$current_user = elgg_get_logged_in_user_entity();
+	if ($current_user && $current_user->guid == $user_guid) {
+		return $current_user->isAdmin();
+	}
+
 	// cannot use magic metadata here because of recursion
 
 	// must support the old way of getting admin from metadata
@@ -98,7 +103,7 @@ function elgg_is_admin_user($user_guid) {
 		$yes = elgg_get_metastring_id('yes');
 		$one = elgg_get_metastring_id('1');
 
-		$query = "SELECT * FROM {$CONFIG->dbprefix}users_entity as e,
+		$query = "SELECT 1 FROM {$CONFIG->dbprefix}users_entity as e,
 			{$CONFIG->dbprefix}metadata as md
 			WHERE (
 				md.name_id = '$admin'
@@ -108,7 +113,7 @@ function elgg_is_admin_user($user_guid) {
 				AND e.banned = 'no'
 			)";
 	} else {
-		$query = "SELECT * FROM {$CONFIG->dbprefix}users_entity as e
+		$query = "SELECT 1 FROM {$CONFIG->dbprefix}users_entity as e
 			WHERE (
 				e.guid = {$user_guid}
 				AND e.admin = 'yes'

--- a/mod/messages/actions/messages/delete.php
+++ b/mod/messages/actions/messages/delete.php
@@ -11,6 +11,8 @@ if (!elgg_instanceof($message, 'object', 'messages') || !$message->canEdit()) {
 	forward(REFERER);
 }
 
+messages_invalidate_unread_cache($message);
+
 if (!$message->delete()) {
 	register_error(elgg_echo('messages:error:delete:single'));
 } else {

--- a/mod/messages/actions/messages/process.php
+++ b/mod/messages/actions/messages/process.php
@@ -19,6 +19,7 @@ if ($delete_flag) {
 		$message = get_entity($guid);
 		if (elgg_instanceof($message, 'object', 'messages') && $message->canEdit()) {
 			$message->delete();
+			messages_invalidate_unread_cache($message);
 		}
 	}
 } else {
@@ -27,6 +28,7 @@ if ($delete_flag) {
 		$message = get_entity($guid);
 		if (elgg_instanceof($message, 'object', 'messages') && $message->canEdit()) {
 			$message->readYet = 1;
+			messages_invalidate_unread_cache($message);
 		}
 	}
 }

--- a/mod/messages/pages/messages/read.php
+++ b/mod/messages/pages/messages/read.php
@@ -14,7 +14,8 @@ elgg_entity_gatekeeper($guid, 'object', 'messages');
 $message = get_entity($guid);
 
 // mark the message as read
-$message->readYet = true;
+$message->readYet = 1;
+messages_invalidate_unread_cache($message);
 
 elgg_set_page_owner_guid($message->getOwnerGUID());
 $page_owner = elgg_get_page_owner_entity();


### PR DESCRIPTION
unnecessarily left for each GUID removed from cache. This instead
 entire key for the GUID.
 set_input('page', $page[1]);
 to the embed_page_handler function fixes this
