### PR TITLE
fix(upgrade): test for ability to connect to localhost if rewrite test fails

### DIFF
--- a/install/ElggRewriteTester.php
+++ b/install/ElggRewriteTester.php
@@ -121,6 +121,29 @@ class ElggRewriteTester {
 
 		return true;
 	}
+	
+	public function runLocalhostAccessTest() {
+		$url = elgg_get_site_url();
+		if (ini_get('allow_url_fopen')) {
+			$ctx = stream_context_create(array(
+				'http' => array(
+					'follow_location' => 0,
+					'timeout' => 5,
+				),
+			));
+			$response = file_get_contents($url, null, $ctx);
+		} elseif (function_exists('curl_init')) {
+			// try curl if installed
+			$ch = curl_init();
+			curl_setopt($ch, CURLOPT_URL, $url);
+			curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			$response = curl_exec($ch);
+			curl_close($ch);
+		}
+		
+		return $response !== false;
+	}
 
 	/**
 	 * Create Elgg's .htaccess file or confirm that it exists

--- a/languages/en.php
+++ b/languages/en.php
@@ -1067,7 +1067,8 @@ Once you have logged in, we highly recommend that you change your password.
 	'installation:minify_css:label' => "Compress CSS (recommended)",
 
 	'installation:htaccess:needs_upgrade' => "You must update your .htaccess file so that the path is injected into the GET parameter __elgg_uri (you can use htaccess_dist as a guide).",
-
+	'installation:htaccess:localhost:connectionfailed' => "Elgg cannot connect to itself to test rewrite rules properly. Check that curl is working and there are no IP restrictions preventing localhost connections.",
+	
 	'installation:systemcache:description' => "The system cache decreases the loading time of Elgg by caching data to files.",
 	'installation:systemcache:label' => "Use system cache (recommended)",
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -51,6 +51,20 @@ if (get_input('upgrade') == 'upgrade') {
 	$rewriteTester = new ElggRewriteTester();
 	$url = elgg_get_site_url() . "__testing_rewrite?__testing_rewrite=1";
 	if (!$rewriteTester->runRewriteTest($url)) {
+		// see if there is a problem accessing the site at all
+		// due to ip restrictions for example
+		if (!$rewriteTester->runLocalhostAccessTest()) {
+			// note: translation may not be available until after upgrade
+			$msg = elgg_echo("installation:htaccess:localhost:connectionfailed");
+			if ($msg === "installation:htaccess:localhost:connectionfailed") {
+				$msg = "Elgg cannot connect to itself to test rewrite rules properly. Check "
+						. "that curl is working and there are no IP restrictions preventing "
+						. "localhost connections.";
+			}
+			echo $msg;
+			exit;
+		}
+		
 		// note: translation may not be available until after upgrade
 		$msg = elgg_echo("installation:htaccess:needs_upgrade");
 		if ($msg === "installation:htaccess:needs_upgrade") {


### PR DESCRIPTION
Tested on community-test

Method:
lock out all but my IP address, run upgrade -> get localhost connection test error message
add exception for localhost IP address -> upgrade runs ok
remove rewrite rules and run upgrade -> get htaccess rewrite rule error message
- [ ] Move `Refs #...` out of the subject onto its own line
