### PR TITLE
fix(router): Can return 'handler' param in `'route', $identifier` hook again

### DIFF
--- a/engine/classes/Elgg/Router.php
+++ b/engine/classes/Elgg/Router.php
@@ -65,7 +65,12 @@ class Elgg_Router {
 			return true;
 		}
 
-		$identifier = $result['identifier'];
+		if ($identifier != $result['identifier']) {
+			$identifier = $result['identifier'];
+		} else if ($identifier != $result['handler']) {
+			$identifier = $result['handler'];
+		}
+
 		$segments = $result['segments'];
 
 		$handled = false;

--- a/engine/tests/phpunit/Elgg/RouterTest.php
+++ b/engine/tests/phpunit/Elgg/RouterTest.php
@@ -11,6 +11,7 @@ class Elgg_RouterTest extends PHPUnit_Framework_TestCase {
 		$this->hooks = new Elgg_PluginHooksService();
 		$this->router = new Elgg_Router($this->hooks);
 		$this->pages = dirname(dirname(__FILE__)) . '/test_files/pages';
+		$this->fooHandlerCalls = 0;
 	}
 
 	function hello_page_handler($segments, $identifier) {
@@ -52,5 +53,35 @@ class Elgg_RouterTest extends PHPUnit_Framework_TestCase {
 		// that the output we buffered is empty.
 		// $this->assertFalse($handled);
 		$this->assertEmpty($output);
+	}
+
+	/**
+	 * 1. Register a page handler for `/foo`
+	 * 2. Register a plugin hook that uses the "handler" result param
+	 *    to route all `/bar/*` requests to the `/foo` handler.
+	 * 3. Route a request for a `/bar` page.
+	 * 4. Check that the `/foo` handler was called.
+	 */
+	function testRouteSupportsSettingHandlerInHookResultForBackwardsCompatibility() {
+		$this->router->registerPageHandler('foo', array($this, 'foo_page_handler'));
+		$this->hooks->registerHandler('route', 'bar', array($this, 'bar_route_handler'));
+		
+		$query = http_build_query(array('__elgg_uri' => 'bar/baz'));
+
+		ob_start();
+		$handled = $this->router->route(Elgg_Http_Request::create("http://localhost/?$query"));
+		$output = ob_get_clean();
+		
+		$this->assertEquals(1, $this->fooHandlerCalls);
+	}
+	
+	function foo_page_handler() {
+		$this->fooHandlerCalls++;
+		return true;
+	}
+	
+	function bar_route_handler($hook, $type, $value, $params) {
+		$value['handler'] = 'foo';
+		return $value;
 	}
 }


### PR DESCRIPTION
In 1.8, it was possible to delegate to a different page handler by registering
a callback for the `'route', $identifier` plugin hook that looks like so:

``` php
$result['handler'] = 'other';
return $result;
```

Then during 1.9 it was changed to expect the key to be 'identifier':

``` php
$result['identifier'] = 'other';
return $result;
```

This change makes it so that both approaches will work as intended.

Fixes #6696
