### PR TITLE
perf(entities): preloads owners when drawing lists of entities/likes

### DIFF
--- a/docs/guides/views.rst
+++ b/docs/guides/views.rst
@@ -225,6 +225,18 @@ This function checks to see if there are any entities; if there are, it first di
 
 Because it does this, Elgg knows that it can automatically supply an RSS feed - it extends the ``metatags`` view (which is called by the header) in order to provide RSS autodiscovery, which is why you can see the orange RSS icon on those pages.
 
+If your entity list will display the entity owners, you can improve performance a bit by preloading all owner entities:
+
+.. code-block:: php
+
+	echo elgg_list_entities(array(
+	    'type' => 'object',
+	    'subtype' => 'blog',
+
+	    // enable owner preloading
+	    'preload_owners' => true,
+	));
+
 See also :doc:`check this page out first </design/database>`.
 
 Using a different templating system

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -19,6 +19,7 @@ namespace Elgg\Di;
  * @property-read \Elgg\Logger                             $logger
  * @property-read \ElggVolatileMetadataCache               $metadataCache
  * @property-read \Elgg\Notifications\NotificationsService $notifications
+ * @property-read \Elgg\EntityPreloader                    $ownerPreloader
  * @property-read \Elgg\PersistentLoginService             $persistentLogin
  * @property-read \Elgg\Database\QueryCounter              $queryCounter
  * @property-read \Elgg\Http\Request                       $request
@@ -51,6 +52,7 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setFactory('logger', array($this, 'getLogger'));
 		$this->setClassName('metadataCache', '\ElggVolatileMetadataCache');
 		$this->setFactory('persistentLogin', array($this, 'getPersistentLogin'));
+		$this->setFactory('ownerPreloader', array($this, 'getOwnerPreloader'));
 		$this->setFactory('queryCounter', array($this, 'getQueryCounter'), false);
 		$this->setFactory('request', array($this, 'getRequest'));
 		$this->setFactory('router', array($this, 'getRouter'));
@@ -215,6 +217,16 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$cookie_name = $remember_me_cookies_config['name'];
 		$cookie_token = $c->request->cookies->get($cookie_name, '');
 		return new \Elgg\PersistentLoginService($c->db, $c->session, $c->crypto, $remember_me_cookies_config, $cookie_token);
+	}
+
+	/**
+	 * Owner preloader factory
+	 *
+	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
+	 * @return \Elgg\EntityPreloader
+	 */
+	protected function getOwnerPreloader(\Elgg\Di\ServiceProvider $c) {
+		return new \Elgg\EntityPreloader(array('owner_guid'));
 	}
 
 	/**

--- a/engine/classes/Elgg/EntityPreloader.php
+++ b/engine/classes/Elgg/EntityPreloader.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Elgg;
+
+/**
+ * Preload entities based on properties of fetched objects
+ *
+ * @access private
+ *
+ * @package Elgg.Core
+ */
+class EntityPreloader {
+
+	/**
+	 * @var string[]
+	 */
+	protected $properties;
+
+	/**
+	 * Configure the preloader to check these properties of fetched objects for GUIDs.
+	 *
+	 * @param array $guid_properties e.g. array("owner_guid")
+	 */
+	public function __construct(array $guid_properties) {
+		$this->properties = $guid_properties;
+	}
+
+	/**
+	 * Preload entities based on the given objects
+	 *
+	 * @param object[] $objects Objects--e.g. loaded from an Elgg query--from which we can pluck GUIDs to preload
+	 *
+	 * @return void
+	 */
+	public function preload($objects) {
+		$guids = $this->getGuidsToLoad($objects);
+		// If only 1 to load, not worth the overhead of elgg_get_entities(),
+		// get_entity() will handle it later.
+		if (count($guids) > 1) {
+			call_user_func($this->_callable_entity_loader, array(
+				'guids' => $guids,
+			));
+		}
+	}
+
+	/**
+	 * Get GUIDs that need to be loaded
+	 *
+	 * To simplify the user API, this function accepts non-arrays and arrays containing non-objects
+	 *
+	 * @param object[] $objects Objects from which to pluck GUIDs
+	 * @return int[]
+	 */
+	protected function getGuidsToLoad($objects) {
+		if (!is_array($objects) || count($objects) < 2) {
+			return array();
+		}
+		$preload_guids = array();
+		foreach ($objects as $object) {
+			if (is_object($object)) {
+				foreach ($this->properties as $property) {
+					if (empty($object->{$property})) {
+						continue;
+					}
+					$guid = $object->{$property};
+					if ($guid && !call_user_func($this->_callable_cache_checker, $guid)) {
+						$preload_guids[] = $guid;
+					}
+				}
+			}
+		}
+		return array_unique($preload_guids);
+	}
+
+	/**
+	 * DO NOT USE. For unit test mocking
+	 * @access private
+	 */
+	public $_callable_cache_checker = '_elgg_retrieve_cached_entity';
+
+	/**
+	 * DO NOT USE. For unit test mocking
+	 * @access private
+	 */
+	public $_callable_entity_loader = 'elgg_get_entities';
+}

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -248,6 +248,7 @@ function _elgg_get_metastring_based_objects($options) {
 		'wheres' => array(),
 		'joins' => array(),
 
+		'preload_owners' => false,
 		'callback' => $callback,
 	);
 
@@ -432,6 +433,11 @@ function _elgg_get_metastring_based_objects($options) {
 		}
 
 		$dt = get_data($query, $options['callback']);
+
+		if ($options['preload_owners'] && is_array($dt) && count($dt) > 1) {
+			_elgg_services()->ownerPreloader->preload($dt);
+		}
+
 		return $dt;
 	} else {
 		$result = get_data_row($query);

--- a/engine/tests/ElggOwnerPreloaderIntegrationTest.php
+++ b/engine/tests/ElggOwnerPreloaderIntegrationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+class ElggOwnerPreloaderIntegrationTest extends ElggCoreUnitTest {
+
+	protected $realPreloader;
+
+	/**
+	 * @var MockEntityPreloader20140623
+	 */
+	protected $mockPreloader;
+
+	public function setUp() {
+		$this->realPreloader = _elgg_services()->ownerPreloader;
+
+		$this->mockPreloader = new MockEntityPreloader20140623(array('owner_guid'));
+		_elgg_services()->setValue('ownerPreloader', $this->mockPreloader);
+	}
+
+	public function tearDown() {
+		_elgg_services()->setValue('ownerPreloader', $this->realPreloader);
+	}
+
+	public function testEGECanUsePreloader() {
+		$options = array(
+			'limit' => 3,
+		);
+
+		elgg_get_entities($options);
+		$this->assertNull($this->mockPreloader->preloaded);
+
+		$options['preload_owners'] = true;
+		elgg_get_entities($options);
+		$this->assertEqual(3, count($this->mockPreloader->preloaded));
+	}
+
+	public function testEGMCanUsePreloader() {
+		$options = array(
+			'limit' => 3,
+		);
+
+		elgg_get_metadata($options);
+		$this->assertNull($this->mockPreloader->preloaded);
+
+		$options['preload_owners'] = true;
+		elgg_get_metadata($options);
+		$this->assertEqual(3, count($this->mockPreloader->preloaded));
+	}
+}
+
+class MockEntityPreloader20140623 extends Elgg\EntityPreloader {
+	public $preloaded;
+
+	public function preload($objects) {
+		$this->preloaded = $objects;
+	}
+}

--- a/engine/tests/phpunit/Elgg/EntityPreloaderTest.php
+++ b/engine/tests/phpunit/Elgg/EntityPreloaderTest.php
@@ -1,0 +1,76 @@
+<?php
+namespace Elgg;
+
+class EntityPreloaderTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @var \PHPUnit_Framework_MockObject_MockObject
+	 */
+	public $mock;
+
+	/**
+	 * @var EntityPreloader
+	 */
+	public $obj;
+
+	public function setup() {
+		$this->obj = new EntityPreloader(array('foo', 'bar'));
+		$dependency = new PreloaderMock_20140623();
+		$this->obj->_callable_cache_checker = array($dependency, 'isCached');
+		$this->obj->_callable_entity_loader = array($dependency, 'load');
+
+		$this->mock = $this->getMock('Elgg\\PreloaderMock_20140623');
+	}
+
+	public function testAcceptsOnlyArraysOfObjects() {
+		$inputs = array(
+			'foo',
+			array('0', array()),
+			array(
+				(object)array('foo' => 123),
+				array('bar' => 234),
+			),
+		);
+		$this->obj->_callable_cache_checker = array($this->mock, 'isCached');
+		$this->mock->expects($this->once())->method('isCached')->with(123);
+		foreach ($inputs as $input) {
+			$this->obj->preload($input);
+		}
+	}
+
+	public function testOnlyLoadsIfNotCached() {
+		$this->obj->_callable_entity_loader = array($this->mock, 'load');
+		$this->mock->expects($this->once())->method('load')->with(array('guids' => array(234, 345)));
+		$this->obj->preload(array(
+			(object)array('foo' => 23,),
+			(object)array('bar' => 234,),
+			(object)array('bar' => 345,),
+		));
+	}
+
+	public function testOnlyLoadsIfMoreThanOne() {
+		$this->obj->_callable_entity_loader = array($this->mock, 'load');
+		$this->mock->expects($this->never())->method('load');
+		$this->obj->preload(array(
+			(object)array('foo' => 23,),
+			(object)array('bar' => 234,),
+		));
+	}
+
+	public function testQuietlyIgnoresMissingProperty() {
+		$this->obj->_callable_entity_loader = array($this->mock, 'load');
+		$this->mock->expects($this->once())->method('load')->with(array('guids' => array(234, 345)));
+		$this->obj->preload(array(
+			(object)array('foo' => 234),
+			(object)array(),
+			(object)array('bar' => 345)
+		));
+	}
+}
+
+class PreloaderMock_20140623 {
+	function isCached($guid) {
+		return $guid < 100;
+	}
+	function load($opts) {}
+}

--- a/mod/blog/lib/blog.php
+++ b/mod/blog/lib/blog.php
@@ -64,6 +64,7 @@ function blog_get_page_content_list($container_guid = NULL) {
 		'subtype' => 'blog',
 		'full_view' => false,
 		'no_results' => elgg_echo('blog:none'),
+		'preload_owners' => true,
 	);
 
 	$current_user = elgg_get_logged_in_user_entity();
@@ -136,6 +137,7 @@ function blog_get_page_content_friends($user_guid) {
 		'relationship_guid' => $user_guid,
 		'relationship_join_on' => 'container_guid',
 		'no_results' => elgg_echo('blog:none'),
+		'preload_owners' => true,
 	);
 
 	$return['content'] = elgg_list_entities_from_relationship($options);
@@ -178,6 +180,7 @@ function blog_get_page_content_archive($owner_guid, $lower = 0, $upper = 0) {
 		'subtype' => 'blog',
 		'full_view' => false,
 		'no_results' => elgg_echo('blog:none'),
+		'preload_owners' => true,
 	);
 
 	if ($owner_guid) {

--- a/mod/bookmarks/pages/bookmarks/all.php
+++ b/mod/bookmarks/pages/bookmarks/all.php
@@ -16,6 +16,7 @@ $content = elgg_list_entities(array(
 	'full_view' => false,
 	'view_toggle_type' => false,
 	'no_results' => elgg_echo('bookmarks:none'),
+	'preload_owners' => true,
 ));
 
 $title = elgg_echo('bookmarks:everyone');

--- a/mod/bookmarks/pages/bookmarks/friends.php
+++ b/mod/bookmarks/pages/bookmarks/friends.php
@@ -25,6 +25,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_guid' => $page_owner->guid,
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo('bookmarks:none'),
+	'preload_owners' => true,
 ));
 
 $params = array(

--- a/mod/bookmarks/pages/bookmarks/owner.php
+++ b/mod/bookmarks/pages/bookmarks/owner.php
@@ -21,6 +21,7 @@ $content .= elgg_list_entities(array(
 	'full_view' => false,
 	'view_toggle_type' => false,
 	'no_results' => elgg_echo('bookmarks:none'),
+	'preload_owners' => true,
 ));
 
 $title = elgg_echo('bookmarks:owner', array($page_owner->name));

--- a/mod/file/pages/file/friends.php
+++ b/mod/file/pages/file/friends.php
@@ -26,6 +26,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_guid' => $owner->guid,
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo("file:none"),
+	'preload_owners' => true,
 ));
 
 $sidebar = file_get_type_cloud($owner->guid, true);

--- a/mod/file/pages/file/owner.php
+++ b/mod/file/pages/file/owner.php
@@ -41,6 +41,7 @@ $content = elgg_list_entities(array(
 	'container_guid' => $owner->guid,
 	'full_view' => false,
 	'no_results' => elgg_echo("file:none"),
+	'preload_owners' => true,
 ));
 
 $sidebar = file_get_type_cloud(elgg_get_page_owner_guid());

--- a/mod/file/pages/file/search.php
+++ b/mod/file/pages/file/search.php
@@ -80,6 +80,7 @@ $params = array(
 	'container_guid' => $page_owner_guid,
 	'limit' => $limit,
 	'full_view' => false,
+	'preload_owners' => true,
 );
 
 if ($file_type) {

--- a/mod/file/pages/file/world.php
+++ b/mod/file/pages/file/world.php
@@ -16,6 +16,7 @@ $content = elgg_list_entities(array(
 	'subtype' => 'file',
 	'full_view' => false,
 	'no_results' => elgg_echo("file:none"),
+	'preload_owners' => true,
 ));
 
 $sidebar = file_get_type_cloud();

--- a/mod/groups/lib/discussion.php
+++ b/mod/groups/lib/discussion.php
@@ -18,6 +18,7 @@ function discussion_handle_all_page() {
 		'limit' => 20,
 		'full_view' => false,
 		'no_results' => elgg_echo('discussion:none'),
+		'preload_owners' => true,
 	));
 
 	$title = elgg_echo('discussion:latest');
@@ -63,6 +64,7 @@ function discussion_handle_list_page($guid) {
 		'container_guid' => $guid,
 		'full_view' => false,
 		'no_results' => elgg_echo('discussion:none'),
+		'preload_owners' => true,
 	);
 	$content = elgg_list_entities($options);
 

--- a/mod/likes/views/default/likes/count.php
+++ b/mod/likes/views/default/likes/count.php
@@ -30,7 +30,8 @@ if ($num_of_likes) {
 		'guid' => $guid,
 		'annotation_name' => 'likes',
 		'limit' => 99,
-		'list_class' => 'elgg-list-likes'
+		'list_class' => 'elgg-list-likes',
+		'preload_owners' => true,
 	));
 	$list .= "</div>";
 	echo $list;

--- a/mod/messageboard/pages/messageboard/owner.php
+++ b/mod/messageboard/pages/messageboard/owner.php
@@ -17,6 +17,7 @@ $options = array(
 	'annotations_name' => 'messageboard',
 	'guid' => $page_owner_guid,
 	'reverse_order_by' => true,
+	'preload_owners' => true,
 );
 
 if ($history_user) {

--- a/mod/messages/pages/messages/inbox.php
+++ b/mod/messages/pages/messages/inbox.php
@@ -31,6 +31,7 @@ $list = elgg_list_entities_from_metadata(array(
 	'metadata_value' => elgg_get_page_owner_guid(),
 	'owner_guid' => elgg_get_page_owner_guid(),
 	'full_view' => false,
+	'preload_owners' => true,
 ));
 
 $body_vars = array(

--- a/mod/pages/pages/pages/friends.php
+++ b/mod/pages/pages/pages/friends.php
@@ -25,6 +25,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_guid' => $owner->guid,
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo('pages:none'),
+	'preload_owners' => true,
 ));
 
 $params = array(

--- a/mod/pages/pages/pages/owner.php
+++ b/mod/pages/pages/pages/owner.php
@@ -25,6 +25,7 @@ $content = elgg_list_entities(array(
 	'container_guid' => elgg_get_page_owner_guid(),
 	'full_view' => false,
 	'no_results' => elgg_echo('pages:none'),
+	'preload_owners' => true,
 ));
 
 $filter_context = '';

--- a/mod/pages/pages/pages/world.php
+++ b/mod/pages/pages/pages/world.php
@@ -17,6 +17,7 @@ $content = elgg_list_entities(array(
 	'subtype' => 'page_top',
 	'full_view' => false,
 	'no_results' => elgg_echo('pages:none'),
+	'preload_owners' => true,
 ));
 
 $body = elgg_view_layout('content', array(

--- a/mod/search/search_hooks.php
+++ b/mod/search/search_hooks.php
@@ -36,6 +36,7 @@ function search_objects_hook($hook, $type, $value, $params) {
 	
 	$params['count'] = FALSE;
 	$params['order_by'] = search_get_order_by_sql('e', 'oe', $params['sort'], $params['order']);
+	$params['preload_owners'] = true;
 	$entities = elgg_get_entities($params);
 
 	// add the volatile data for why these entities have been returned.

--- a/mod/thewire/pages/thewire/everyone.php
+++ b/mod/thewire/pages/thewire/everyone.php
@@ -19,6 +19,7 @@ $content .= elgg_list_entities(array(
 	'type' => 'object',
 	'subtype' => 'thewire',
 	'limit' => get_input('limit', 15),
+	'preload_owners' => true,
 ));
 
 $body = elgg_view_layout('content', array(

--- a/mod/thewire/pages/thewire/friends.php
+++ b/mod/thewire/pages/thewire/friends.php
@@ -27,6 +27,7 @@ $content .= elgg_list_entities_from_relationship(array(
 	'relationship' => 'friend',
 	'relationship_guid' => $owner->guid,
 	'relationship_join_on' => 'container_guid',
+	'preload_owners' => true,
 ));
 
 $body = elgg_view_layout('content', array(

--- a/mod/thewire/pages/thewire/thread.php
+++ b/mod/thewire/pages/thewire/thread.php
@@ -16,6 +16,7 @@ $content = elgg_list_entities_from_metadata(array(
 	"type" => "object",
 	"subtype" => "thewire",
 	"limit" => 20,
+	'preload_owners' => true,
 ));
 
 $body = elgg_view_layout('content', array(

--- a/views/default/page/elements/comments.php
+++ b/views/default/page/elements/comments.php
@@ -38,6 +38,7 @@ $html = elgg_list_entities(array(
 	'reverse_order_by' => true,
 	'full_view' => true,
 	'limit' => $limit,
+	'preload_owners' => true,
 ));
 
 echo $html;

--- a/views/default/page/elements/comments_block.php
+++ b/views/default/page/elements/comments_block.php
@@ -13,7 +13,8 @@ $options = array(
 	'type' => 'object',
 	'subtype' => 'comment',
 	'limit' => elgg_extract('limit', $vars, 4),
-	'wheres' => array()
+	'wheres' => array(),
+	'preload_owners' => true,
 );
 
 $owner_guid = elgg_extract('owner_guid', $vars);


### PR DESCRIPTION
When drawing lists of entities/likes with a variety of owners, many owners
end up being loaded one by one (ineffeciently). This adds a component that
walks the list and preloads all the owners into the cache in one shot.

Fixes #5949

(This PR replaces #5950.)
