### PR TITLE
fix(thewire): return the thread url for a wire post as documented

### DIFF
--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -154,9 +154,9 @@ function thewire_page_handler($page) {
  * @return string
  */
 function thewire_set_url($hook, $type, $url, $params) {
-	$entity = $params['entity'];
+	$entity = elgg_extract('entity', $params);
 	if (elgg_instanceof($entity, 'object', 'thewire')) {
-		return "thewire/view/" . $entity->guid;
+		return "thewire/thread/" . $entity->wire_thread;
 	}
 }
 


### PR DESCRIPTION
The ->getURL() result should return the thread url of a wire post as
stated in the function documentation.
