### PR TITLE
perf(likes): reduces number of queries when showing likes in lists

### DIFF
--- a/mod/likes/classes/Elgg/Likes/DataService.php
+++ b/mod/likes/classes/Elgg/Likes/DataService.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Elgg\Likes;
+
+/**
+ * @access private
+ */
+class DataService {
+
+	/**
+	 * @var array [GUID => boolean]
+	 */
+	protected $current_user_likes = array();
+
+	/**
+	 * @var array [GUID => int]
+	 */
+	protected $num_likes = array();
+
+	/**
+	 * @param int $guid
+	 * @param int $num
+	 */
+	public function setNumLikes($guid, $num) {
+		$this->num_likes[$guid] = (int)$num;
+	}
+
+	/**
+	 * @param int  $guid
+	 * @param bool $is_liked
+	 */
+	public function setLikedByCurrentUser($guid, $is_liked) {
+		$this->current_user_likes[$guid] = (bool)$is_liked;
+	}
+
+	/**
+	 * @param int $entity_guid
+	 * @return bool
+	 */
+	public function currentUserLikesEntity($entity_guid) {
+		if (!isset($this->current_user_likes[$entity_guid])) {
+			$this->current_user_likes[$entity_guid] = elgg_annotation_exists($entity_guid, 'likes');
+		}
+		return $this->current_user_likes[$entity_guid];
+	}
+
+	/**
+	 * @param \ElggEntity $entity
+	 * @return int
+	 */
+	public function getNumLikes(\ElggEntity $entity) {
+		$guid = $entity->guid;
+		if (!isset($this->num_likes[$guid])) {
+			$this->num_likes[$guid] = likes_count($entity);
+		}
+		return $this->num_likes[$guid];
+	}
+
+	/**
+	 * @return DataService
+	 */
+	public static function instance() {
+		static $inst;
+		if ($inst === null) {
+			$inst = new self();
+		}
+		return $inst;
+	}
+}

--- a/mod/likes/classes/Elgg/Likes/Preloader.php
+++ b/mod/likes/classes/Elgg/Likes/Preloader.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Elgg\Likes;
+
+class Preloader {
+
+	/**
+	 * @var DataService
+	 */
+	protected $data;
+
+	public function __construct(DataService $data) {
+		$this->data = $data;
+	}
+
+	/**
+	 * @param \ElggRiverItem[]|\ElggEntity[] $items
+	 * @return void
+	 */
+	public function preloadForList(array $items) {
+		$guids = $this->getGuidsToPreload($items);
+		if (count($guids) < 2) {
+			return;
+		}
+
+		$this->preloadCurrentUserLikes($guids);
+
+		$guids_remaining = $this->preloadCountsFromHook($this->getEntities($guids));
+		if ($guids_remaining) {
+			$this->preloadCountsFromQuery($guids_remaining);
+		}
+	}
+
+	/**
+	 * @param int[] $guids
+	 */
+	protected function preloadCountsFromQuery(array $guids) {
+		$count_rows = elgg_get_annotations(array(
+			'annotation_names' => 'likes',
+			'guids' => $guids,
+			'selects' => array('e.guid', 'COUNT(*) AS cnt'),
+			'group_by' => 'e.guid',
+			'callback' => false,
+		));
+		foreach ($guids as $guid) {
+			$this->data->setNumLikes($guid, 0);
+		}
+		foreach ($count_rows as $row) {
+			$this->data->setNumLikes($row->guid, $row->cnt);
+		}
+	}
+
+	/**
+	 * @param \ElggEntity[] $entities
+	 * @return int[]
+	 */
+	protected function preloadCountsFromHook(array $entities) {
+		$guids_not_loaded = array();
+
+		foreach ($entities as $entity) {
+			// BC with likes_count(). If this hook is used this preloader may not be of much help.
+			$type = $entity->getType();
+			$params = array('entity' => $entity);
+
+			$num_likes = elgg_trigger_plugin_hook('likes:count', $type, $params, false);
+			if ($num_likes) {
+				$this->data->setNumLikes($entity->guid, $num_likes);
+			} else {
+				$guids_not_loaded[] = $entity->guid;
+			}
+		}
+
+		return $guids_not_loaded;
+	}
+
+	/**
+	 * @param int[] $guids
+	 */
+	protected function preloadCurrentUserLikes(array $guids) {
+		$owner_guid = elgg_get_logged_in_user_guid();
+		if (!$owner_guid) {
+			return;
+		}
+
+		$annotation_rows = elgg_get_annotations(array(
+			'annotation_names' => 'likes',
+			'annotation_owner_guids' => $owner_guid,
+			'guids' => $guids,
+			'callback' => false,
+		));
+
+		foreach ($guids as $guid) {
+			$this->data->setLikedByCurrentUser($guid, false);
+		}
+		foreach ($annotation_rows as $row) {
+			$this->data->setLikedByCurrentUser($row->entity_guid, true);
+		}
+	}
+
+	/**
+	 * @param \ElggRiverItem[]|\ElggEntity[] $items
+	 * @return int[]
+	 */
+	protected function getGuidsToPreload(array $items) {
+		$guids = array();
+
+		foreach ($items as $item) {
+			// TODO remove duplication of @link likes_river_menu_setup()
+
+			if ($item instanceof \ElggRiverItem) {
+				// only like group creation #3958
+				if ($item->type == "group" && $item->view != "river/group/create") {
+					continue;
+				}
+
+				// don't like users #4116
+				if ($item->type == "user") {
+					continue;
+				}
+
+				if ($item->annotation_id != 0) {
+					continue;
+				}
+
+				if ($item->object_guid) {
+					$guids[$item->object_guid] = true;
+				}
+			} elseif ($item instanceof \ElggEntity) {
+
+				if (!$item instanceof \ElggUser) {
+					continue;
+				}
+
+				$guids[$item->guid] = true;
+			}
+		}
+		return array_keys($guids);
+	}
+
+	/**
+	 * Get entities in any order checking cache first
+	 *
+	 * @param int[] $guids
+	 * @return \ElggEntity[]
+	 */
+	protected function getEntities(array $guids) {
+		// most objects are already preloaded
+		$entities = array();
+		$fetch_guids = array();
+
+		foreach ($guids as $guid) {
+			$entity = _elgg_retrieve_cached_entity($guid);
+			if ($entity) {
+				$entities[] = $entity;
+			} else {
+				$fetch_guids[] = $guid;
+			}
+		}
+		if ($fetch_guids) {
+			$fetched = elgg_get_entities(array(
+				'guids' => $fetch_guids,
+			));
+			array_splice($entities, count($entities), 0, $fetched);
+		}
+		return $entities;
+	}
+}

--- a/mod/likes/start.php
+++ b/mod/likes/start.php
@@ -11,6 +11,9 @@ function likes_init() {
 	elgg_extend_view('css/elgg', 'likes/css');
 	elgg_extend_view('js/elgg', 'likes/js');
 
+	// used to preload likes data before rendering river
+	elgg_extend_view('page/components/list', 'likes/before_lists', 1);
+
 	// registered with priority < 500 so other plugins can remove likes
 	elgg_register_plugin_hook_handler('register', 'menu:river', 'likes_river_menu_setup', 400);
 	elgg_register_plugin_hook_handler('register', 'menu:entity', 'likes_entity_menu_setup', 400);
@@ -29,9 +32,10 @@ function likes_entity_menu_setup($hook, $type, $return, $params) {
 	}
 
 	$entity = $params['entity'];
+	/* @var ElggEntity $entity */
 
 	if ($entity->canAnnotate(0, 'likes')) {
-		$hasLiked = elgg_annotation_exists($entity->guid, 'likes');
+		$hasLiked = \Elgg\Likes\DataService::instance()->currentUserLikesEntity($entity->guid);
 		
 		// Always register both. That makes it super easy to toggle with javascript
 		$return[] = ElggMenuItem::factory(array(
@@ -71,54 +75,61 @@ function likes_entity_menu_setup($hook, $type, $return, $params) {
  * Add a like button to river actions
  */
 function likes_river_menu_setup($hook, $type, $return, $params) {
-	if (elgg_is_logged_in()) {
-		$item = $params['item'];
+	if (!elgg_is_logged_in() || elgg_in_context('widgets')) {
+		return;
+	}
 
-		// only like group creation #3958
-		if ($item->type == "group" && $item->view != "river/group/create") {
-			return $return;
-		}
+	$item = $params['item'];
+	/* @var ElggRiverItem $item */
 
-		// don't like users #4116
-		if ($item->type == "user") {
-			return $return;
-		}
-		
-		$object = $item->getObjectEntity();
-		if (!elgg_in_context('widgets') && $item->annotation_id == 0) {
-			if ($object->canAnnotate(0, 'likes')) {
-				$hasLiked = elgg_annotation_exists($object->guid, 'likes');
-				
-				// Always register both. That makes it super easy to toggle with javascript
-				$return[] = ElggMenuItem::factory(array(
-					'name' => 'like',
-					'href' => elgg_add_action_tokens_to_url("/action/likes/add?guid={$object->guid}"),
-					'text' => elgg_view_icon('thumbs-up'),
-					'title' => elgg_echo('likes:likethis'),
-					'item_class' => $hasLiked ? 'hidden' : '',
-					'priority' => 100,
-				));
-				$return[] = ElggMenuItem::factory(array(
-					'name' => 'unlike',
-					'href' => elgg_add_action_tokens_to_url("/action/likes/delete?guid={$object->guid}"),
-					'text' => elgg_view_icon('thumbs-up-alt'),
-					'title' => elgg_echo('likes:remove'),
-					'item_class' => $hasLiked ? '' : 'hidden',
-					'priority' => 100,
-				));
+	// only like group creation #3958
+	if ($item->type == "group" && $item->view != "river/group/create") {
+		return;
+	}
 
-				// likes count
-				$count = elgg_view('likes/count', array('entity' => $object));
-				if ($count) {
-					$return[] = ElggMenuItem::factory(array(
-						'name' => 'likes_count',
-						'text' => $count,
-						'href' => false,
-						'priority' => 101,
-					));
-				}
-			}
-		}
+	// don't like users #4116
+	if ($item->type == "user") {
+		return;
+	}
+
+	if ($item->annotation_id != 0) {
+		return;
+	}
+
+	$object = $item->getObjectEntity();
+	if (!$object || !$object->canAnnotate(0, 'likes')) {
+		return;
+	}
+
+	$hasLiked = \Elgg\Likes\DataService::instance()->currentUserLikesEntity($object->guid);
+
+	// Always register both. That makes it super easy to toggle with javascript
+	$return[] = ElggMenuItem::factory(array(
+		'name' => 'like',
+		'href' => elgg_add_action_tokens_to_url("/action/likes/add?guid={$object->guid}"),
+		'text' => elgg_view_icon('thumbs-up'),
+		'title' => elgg_echo('likes:likethis'),
+		'item_class' => $hasLiked ? 'hidden' : '',
+		'priority' => 100,
+	));
+	$return[] = ElggMenuItem::factory(array(
+		'name' => 'unlike',
+		'href' => elgg_add_action_tokens_to_url("/action/likes/delete?guid={$object->guid}"),
+		'text' => elgg_view_icon('thumbs-up-alt'),
+		'title' => elgg_echo('likes:remove'),
+		'item_class' => $hasLiked ? '' : 'hidden',
+		'priority' => 100,
+	));
+
+	// likes count
+	$count = elgg_view('likes/count', array('entity' => $object));
+	if ($count) {
+		$return[] = ElggMenuItem::factory(array(
+			'name' => 'likes_count',
+			'text' => $count,
+			'href' => false,
+			'priority' => 101,
+		));
 	}
 
 	return $return;
@@ -127,11 +138,11 @@ function likes_river_menu_setup($hook, $type, $return, $params) {
 /**
  * Count how many people have liked an entity.
  *
- * @param  ElggEntity $entity
+ * @param ElggEntity $entity
  *
  * @return int Number of likes
  */
-function likes_count($entity) {
+function likes_count(ElggEntity $entity) {
 	$type = $entity->getType();
 	$params = array('entity' => $entity);
 	$number = elgg_trigger_plugin_hook('likes:count', $type, $params, false);

--- a/mod/likes/views/default/annotation/likes.php
+++ b/mod/likes/views/default/annotation/likes.php
@@ -10,6 +10,7 @@ if (!isset($vars['annotation'])) {
 }
 
 $like = $vars['annotation'];
+/* @var ElggAnnotation $like */
 
 $user = $like->getOwnerEntity();
 if (!$user) {

--- a/mod/likes/views/default/likes/before_lists.php
+++ b/mod/likes/views/default/likes/before_lists.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Elgg likes river preloader (extends page/components/list)
+ *
+ * @uses $vars['items']       Array of ElggEntity or ElggAnnotation objects
+ * @uses $vars['list_class']  Additional CSS class for the <ul> element
+ */
+
+$user = elgg_get_logged_in_user_entity();
+if ($user
+		&& !elgg_in_context('widgets')
+		&& ($vars['list_class'] === 'elgg-list-river' || $vars['list_class'] === 'elgg-list-entity')
+		&& (count($vars['items']) > 2)) {
+	$preloader = new \Elgg\Likes\Preloader(\Elgg\Likes\DataService::instance());
+	$preloader->preloadForList($vars['items']);
+}

--- a/mod/likes/views/default/likes/button.php
+++ b/mod/likes/views/default/likes/button.php
@@ -9,10 +9,13 @@ if (!isset($vars['entity'])) {
 	return true;
 }
 
-$guid = $vars['entity']->getGUID();
+$entity = $vars['entity'];
+/* @var ElggEntity $entity */
+
+$guid = $entity->getGUID();
 
 // check to see if the user has already liked this
-if (elgg_is_logged_in() && $vars['entity']->canAnnotate(0, 'likes')) {
+if (elgg_is_logged_in() && $entity->canAnnotate(0, 'likes')) {
 	if (!elgg_annotation_exists($guid, 'likes')) {
 		$url = elgg_get_site_url() . "action/likes/add?guid={$guid}";
 		$params = array(
@@ -34,6 +37,6 @@ if (elgg_is_logged_in() && $vars['entity']->canAnnotate(0, 'likes')) {
 		);
 		$likes_button = elgg_view('output/url', $params);
 	}
-}
 
-echo $likes_button;
+	echo $likes_button;
+}

--- a/mod/likes/views/default/likes/count.php
+++ b/mod/likes/views/default/likes/count.php
@@ -5,10 +5,9 @@
  *  @uses $vars['entity']
  */
 
-
 $list = '';
-$num_of_likes = likes_count($vars['entity']);
-$guid = $vars['entity']->getGUID();
+$num_of_likes = \Elgg\Likes\DataService::instance()->getNumLikes($vars['entity']);
+$guid = $vars['entity']->guid;
 
 if ($num_of_likes) {
 	// display the number of likes


### PR DESCRIPTION
For each entity in a list, this preloads the total # of likes and whether or not the current user likes it in as few queries as possible.

For a list of N like-able entities this would remove about 2N-2 queries.

Fixes #6941
