### PR TITLE
fix(router): Can return 'handler' param in `'route', $identifier` hook again

### DIFF
--- a/engine/classes/Elgg/Router.php
+++ b/engine/classes/Elgg/Router.php
@@ -65,7 +65,12 @@ class Elgg_Router {
 			return true;
 		}
 
-		$identifier = $result['identifier'];
+		if ($identifier != $result['identifier']) {
+			$identifier = $result['identifier'];
+		} else if ($identifier != $result['handler']) {
+			$identifier = $result['handler'];
+		}
+
 		$segments = $result['segments'];
 
 		$handled = false;


### PR DESCRIPTION
This PR replaces #6971

In 1.8, it was possible to delegate to a different page handler by registering
a callback for the `'route', $identifier` plugin hook that looks like so:

``` php
$result['handler'] = 'other';
return $result;
```

Then during 1.9 it was changed to expect the key to be 'identifier':

``` php
$result['identifier'] = 'other';
return $result;
```

This change makes it so that both approaches will work as intended.

Fixes #6696
