### PR TITLE
fix(pages): can delete comments if canEdit page container

### DIFF
--- a/mod/pages/actions/pages/delete.php
+++ b/mod/pages/actions/pages/delete.php
@@ -11,9 +11,8 @@ $guid = get_input('guid');
 $page = get_entity($guid);
 if (pages_is_page($page)) {
 	// only allow owners and admin to delete
-	if (elgg_is_admin_logged_in() || elgg_get_logged_in_user_guid() == $page->getOwnerGuid()) {
-		$container = get_entity($page->container_guid);
-
+	$container = get_entity($page->container_guid);
+	if (elgg_is_admin_logged_in() || elgg_get_logged_in_user_guid() == $page->getOwnerGuid()||(elgg_instanceof($container, 'group')&& $container->canEdit())) {
 		// Bring all child elements forward
 		$parent = $page->parent_guid;
 		$children = elgg_get_entities_from_metadata(array(


### PR DESCRIPTION
Fixes #7007 

TODO:
- [ ] Fix commit message according to #5976 
- [ ] Pull out logic into `_pages_can_delete_page()` function (mark `@access private`)
- [ ] Check for container existence before checking edit permissions
- [ ] Remove check for container type as 'group'
