### PR TITLE
fix(river): add enabled col to river table, update on enable/disable of ...

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1882,6 +1882,7 @@ abstract class ElggEntity extends ElggData implements
 
 		if ($res) {
 			$this->attributes['enabled'] = 'no';
+			elgg_trigger_event('disable:after', $this->type, $this);
 		}
 
 		return $res;
@@ -1943,6 +1944,7 @@ abstract class ElggEntity extends ElggData implements
 	
 		if ($result) {
 			$this->attributes['enabled'] = 'yes';
+			elgg_trigger_event('enable:after', $this->type, $this);
 		}
 
 		return $result;

--- a/engine/classes/ElggRiverItem.php
+++ b/engine/classes/ElggRiverItem.php
@@ -5,17 +5,18 @@
  * @package    Elgg.Core
  * @subpackage Core
  * 
- * @property int    $id            The unique identifier (read-only)
- * @property int    $subject_guid  The GUID of the actor
- * @property int    $object_guid   The GUID of the object
- * @property int    $target_guid   The GUID of the object's container
- * @property int    $annotation_id The ID of the annotation involved in the action
- * @property string $type          The type of one of the entities involved in the action
- * @property string $subtype       The subtype of one of the entities involved in the action
- * @property string $action_type   The name of the action
- * @property string $view          The view for displaying this river item
- * @property int    $access_id     The visibility of the river item
- * @property int    $posted        UNIX timestamp when the action occurred
+ * @property-read int    $id            The unique identifier (read-only)
+ * @property-read int    $subject_guid  The GUID of the actor
+ * @property-read int    $object_guid   The GUID of the object
+ * @property-read int    $target_guid   The GUID of the object's container
+ * @property-read int    $annotation_id The ID of the annotation involved in the action
+ * @property-read string $type          The type of one of the entities involved in the action
+ * @property-read string $subtype       The subtype of one of the entities involved in the action
+ * @property-read string $action_type   The name of the action
+ * @property-read string $view          The view for displaying this river item
+ * @property-read int    $access_id     The visibility of the river item
+ * @property-read int    $posted        UNIX timestamp when the action occurred
+ * @property-read string $enabled       Is the river item enabled yes|no
  */
 class ElggRiverItem {
 	public $id;
@@ -29,6 +30,7 @@ class ElggRiverItem {
 	public $access_id;
 	public $view;
 	public $posted;
+	public $enabled;
 
 	/**
 	 * Construct a river item object given a database row.
@@ -153,6 +155,7 @@ class ElggRiverItem {
 		$object->read_access = $this->access_id;
 		$object->action = $this->action_type;
 		$object->time_posted = date('c', $this->getTimePosted());
+		$object->enabled = $this->enabled;
 		$params = array('item' => $this);
 		return elgg_trigger_plugin_hook('to:object', 'river_item', $params, $object);
 	}

--- a/engine/lib/upgrades/2014070600-1.9.0_rc.3-river_enabled_col-bef9e6f0533ac338.php
+++ b/engine/lib/upgrades/2014070600-1.9.0_rc.3-river_enabled_col-bef9e6f0533ac338.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Elgg 1.9.0-rc.3 upgrade 2014070600
+ * river_enabled_col
+ *
+ * Add an 'enabled' column to the river table
+ */
+
+$dbprefix = elgg_get_config('dbprefix');
+
+$q1 = "ALTER TABLE  {$dbprefix}river ADD  enabled ENUM(  'yes',  'no' ) NOT NULL DEFAULT  'yes';";
+update_data($q1);
+
+// update any river entries that need to be disabled
+$q2 = <<<Q2
+	UPDATE {$dbprefix}river AS rv
+	LEFT JOIN elgg_entities AS se ON se.guid = rv.subject_guid
+	LEFT JOIN elgg_entities AS te ON te.guid = rv.target_guid
+	LEFT JOIN elgg_entities AS oe ON oe.guid = rv.object_guid
+	SET rv.enabled = 'no'
+	WHERE (se.enabled = 'no' OR te.enabled = 'no' OR oe.enabled = 'no');
+Q2;
+		
+update_data($q2);

--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -214,6 +214,7 @@ CREATE TABLE `prefix_river` (
   `target_guid` int(11) NOT NULL,
   `annotation_id` int(11) NOT NULL,
   `posted` int(11) NOT NULL,
+  `enabled` enum('yes','no') NOT NULL DEFAULT 'yes',
   PRIMARY KEY (`id`),
   KEY `type` (`type`),
   KEY `action_type` (`action_type`),

--- a/engine/tests/ElggCoreRiverAPITest.php
+++ b/engine/tests/ElggCoreRiverAPITest.php
@@ -98,4 +98,44 @@ class ElggCoreRiverAPITest extends ElggCoreUnitTest {
 		$result = _elgg_get_river_type_subtype_where_sql('rv', $types, $subtypes, null);
 		$this->assertIdentical($result, "((rv.type = 'object') AND ((rv.subtype = 'blog') OR (rv.subtype = 'file')))");
 	}
+	
+	public function testElggRiverDisableEnable() {
+		$user = new ElggUser();
+		$user->save();
+		
+		$entity = new ElggObject();
+		$entity->save();
+		
+		$params = array(
+			'view' => 'river/relationship/friend/create',
+			'action_type' => 'create',
+			'subject_guid' => $user->guid,
+			'object_guid' => $entity->guid,
+		);
+
+		$id = elgg_create_river_item($params);
+
+		$river = elgg_get_river(array('ids' => array($id)));
+
+		$this->assertIdentical($river[0]->enabled, 'yes');
+		
+		$user->disable();
+		
+		// should no longer be able to get the river
+		$river = elgg_get_river(array('ids' => array($id)));
+		
+		$this->assertIdentical($river, array());
+		
+		// renabling the user should re-enable the river
+		access_show_hidden_entities(true);
+		$user->enable();
+		access_show_hidden_entities(false);
+		
+		$river = elgg_get_river(array('ids' => array($id)));
+		
+		$this->assertIdentical($river[0]->enabled, 'yes');
+		
+		$user->delete();
+		$entity->delete();
+	}
 }


### PR DESCRIPTION
...referenced entities

Fixes #6022 - empty river items fetched when referenced entities are disabled

TODO:
- [x] Make events private API
- [x] Fix Comments for Travis
- [x] Manual Testing
- [x] Automated Tests
- [x] Add the column to the install schema
- [x] Add documentation for property to model class
- [x] Export property value in toObject
- [x] Address @mrclay docblock comments
