### PR TITLE
fix(rss): River entries include their full correct summaries again

### DIFF
--- a/views/rss/river/elements/layout.php
+++ b/views/rss/river/elements/layout.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * RSS river view
+ *
+ * @uses $vars['item']
+ */
+$item = $vars['item'];
+
+$name = $item->getSubjectEntity()->name;
+$name = htmlspecialchars($name, ENT_NOQUOTES, 'UTF-8');
+$title = elgg_echo('river:update', array($name));
+
+$timestamp = date('r', $item->getTimePosted());
+$summary = elgg_view('river/elements/summary', $vars, false, false, 'default');
+$body = elgg_extract('summary', $vars, $summary);
+
+
+$object = $item->getObjectEntity();
+if ($object) {
+	$url = htmlspecialchars($object->getURL());
+} else {
+	$url = elgg_normalize_url('activity');
+}
+
+$site_url = parse_url(elgg_get_site_url());
+$domain = htmlspecialchars($site_url['host'], ENT_NOQUOTES, 'UTF-8');
+
+$html = <<<__HTML
+	<guid isPermaLink="false">$domain::river::$item->id</guid>
+	<pubDate>$timestamp</pubDate>
+	<link>$url</link>
+	<title><![CDATA[$title]]></title>
+	<description><![CDATA[$body]]></description>
+__HTML;
+
+echo $html;

--- a/views/rss/river/item.php
+++ b/views/rss/river/item.php
@@ -4,35 +4,19 @@
  *
  * @uses $vars['item']
  */
+
 $item = $vars['item'];
 
-$name = $item->getSubjectEntity()->name;
-$name = htmlspecialchars($name, ENT_NOQUOTES, 'UTF-8');
-$title = elgg_echo('river:update', array($name));
+$output = elgg_view($item->getView(), $vars);
 
-$timestamp = date('r', $item->getTimePosted());
-$body = elgg_view('river/elements/summary', $vars, false, false, 'default');
-
-
-$object = $item->getObjectEntity();
-if ($object) {
-	$url = htmlspecialchars($object->getURL());
-} else {
-	$url = elgg_normalize_url('activity');
+if (empty($output)) {
+	$output = elgg_view($item->getView(), $vars, false, false, 'default');
 }
 
-$site_url = parse_url(elgg_get_site_url());
-$domain = htmlspecialchars($site_url['host'], ENT_NOQUOTES, 'UTF-8');
-
-$html = <<<__HTML
+$rss_item = <<<__ITEM
 <item>
-	<guid isPermaLink="false">$domain::river::$item->id</guid>
-	<pubDate>$timestamp</pubDate>
-	<link>$url</link>
-	<title><![CDATA[$title]]></title>
-	<description><![CDATA[$body]]></description>
+	$output
 </item>
+__ITEM;
 
-__HTML;
-
-echo $html;
+echo $rss_item;


### PR DESCRIPTION
This causes the rss viewtype's river/item view to fall back to the
item's default viewtype in order to capture custom logic that
determines what the summaries should be, since the river's summary
view (`river/elements/summary`) doesn't know how to handle all
possible river items, especially now that we have a `target` field
in the river.

Fixes #6901
