### PR TITLE
chore(twitter): cleans up Twitter API to work with 1.9 session

### DIFF
--- a/engine/classes/ElggSession.php
+++ b/engine/classes/ElggSession.php
@@ -239,6 +239,7 @@ class ElggSession implements ArrayAccess {
 	 */
 	public function __isset($key) {
 		elgg_deprecated_notice(__METHOD__ . " has been deprecated.", 1.9);
+		// Note: We use offsetExists() for BC
 		return $this->offsetExists($key);
 	}
 
@@ -253,7 +254,7 @@ class ElggSession implements ArrayAccess {
 	 */
 	public function offsetSet($key, $value) {
 		elgg_deprecated_notice(__METHOD__ . " has been deprecated.", 1.9);
-		$_SESSION[$key] = $value;
+		$this->set($key, $value);
 	}
 
 	/**
@@ -290,8 +291,8 @@ class ElggSession implements ArrayAccess {
 			}
 		}
 
-		if (isset($_SESSION[$key])) {
-			return $_SESSION[$key];
+		if ($this->has($key)) {
+			return $this->get($key);
 		}
 
 		$orig_value = null;
@@ -300,7 +301,7 @@ class ElggSession implements ArrayAccess {
 			elgg_deprecated_notice("Plugin hook session:get has been deprecated.", 1.9);
 		}
 
-		$_SESSION[$key] = $value;
+		$this->set($key, $value);
 		return $value;
 	}
 
@@ -316,7 +317,7 @@ class ElggSession implements ArrayAccess {
 	 */
 	public function offsetUnset($key) {
 		elgg_deprecated_notice(__METHOD__ . " has been deprecated.", 1.9);
-		unset($_SESSION[$key]);
+		$this->remove($key);
 	}
 
 	/**
@@ -337,10 +338,11 @@ class ElggSession implements ArrayAccess {
 			return (bool)$this->loggedInUser;
 		}
 
-		if (isset($_SESSION[$offset])) {
+		if ($this->has($offset)) {
 			return true;
 		}
 
+		// Note: We use offsetGet() for BC
 		if ($this->offsetGet($offset)) {
 			return true;
 		}

--- a/mod/twitter_api/start.php
+++ b/mod/twitter_api/start.php
@@ -111,7 +111,7 @@ function twitter_api_pagehandler($page) {
  */
 function twitter_api_tweet($hook, $type, $returnvalue, $params) {
 
-	if (!elgg_instanceof($params['user'])) {
+	if (!$params['user'] instanceof ElggUser) {
 		return;
 	}
 


### PR DESCRIPTION
This updates the session handling to use the new elgg_get_session and set/get/remove rather than the deprecated array access. Also cleans up ElggSession a bit.
