### PR TITLE
fix(walled_garden): ACCESS_PUBLIC no longer available in group context

### DIFF
--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -493,8 +493,9 @@ class ElggSite extends ElggEntity {
 			}
 			elgg_register_plugin_hook_handler(
 					'access:collections:write',
-					'user',
-					'_elgg_walled_garden_remove_public_access');
+					'all',
+					'_elgg_walled_garden_remove_public_access',
+					9999);
 
 			if (!elgg_is_logged_in()) {
 				// override the front page


### PR DESCRIPTION
When walled garden is enabled ACCESS_PUBLIC is removed from the access
options, except in the group context. This fix also removes it for the
group context.
