### PR TITLE
fix(groups): ACCESS_PUBLIC not available as visibility in walled garden

### DIFF
--- a/mod/groups/views/default/groups/edit/access.php
+++ b/mod/groups/views/default/groups/edit/access.php
@@ -33,15 +33,21 @@ $content_access_mode = elgg_extract("content_access_mode", $vars);
 <?php if (elgg_get_plugin_setting("hidden_groups", "groups") == "yes"): ?>
 	<div>
 		<label for="groups-vis"><?php echo elgg_echo("groups:visibility"); ?></label><br />
-		<?php echo elgg_view("input/access", array(
+		<?php
+		$visibility_options =  array(
+			ACCESS_PRIVATE => elgg_echo("groups:access:group"),
+			ACCESS_LOGGED_IN => elgg_echo("LOGGED_IN"),
+			ACCESS_PUBLIC => elgg_echo("PUBLIC"),
+		);
+		if (elgg_get_config("walled_garden")) {
+			unset($visibility_options[ACCESS_PUBLIC]);
+		}
+		
+		echo elgg_view("input/access", array(
 			"name" => "vis",
 			"id" => "groups-vis",
 			"value" => $visibility,
-			"options_values" => array(
-				ACCESS_PRIVATE => elgg_echo("groups:access:group"),
-				ACCESS_LOGGED_IN => elgg_echo("LOGGED_IN"),
-				ACCESS_PUBLIC => elgg_echo("PUBLIC"),
-			)
+			"options_values" => $visibility_options
 		));
 		?>
 	</div>


### PR DESCRIPTION
In a walled garden site nothing is allowed to be public, this also
applies to the visibility of groups
