### PR TITLE
fix(core): output/iframe made to the w3c standard

### DIFF
--- a/views/default/output/iframe.php
+++ b/views/default/output/iframe.php
@@ -12,11 +12,11 @@ if (!isset($vars['src']) && isset($vars['value'])) {
 	elgg_deprecated_notice('$vars[\'src\'] deprecated in output/iframe for $vars[\'src\']', 1.9);
 	$src = $vars['value'];
 } else {
-	$src = elgg_extract('src', $vars);	
+	$src = elgg_extract('src', $vars);
 }
 
 $src = elgg_normalize_url($src);
 $vars['src'] = elgg_format_url($src);
 
 $attributes = elgg_format_attributes($vars);
-echo "<iframe $attributes/>";
+echo "<iframe $attributes></iframe>";


### PR DESCRIPTION
Not all browsers support the self closing iframe tag, according to the
w3c standard it's not self closing.
