### PR TITLE
fix(pages): Stop registering undefined upgrade event callback

### DIFF
--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -86,8 +86,6 @@ function pages_init() {
 
 	// register ecml views to parse
 	elgg_register_plugin_hook_handler('get_views', 'ecml', 'pages_ecml_views_hook');
-	
-	elgg_register_event_handler('upgrade', 'system', 'pages_run_upgrades');
 }
 
 /**


### PR DESCRIPTION
Fixes #6780
