### PR TITLE
fix(config): path is derived from PHP, not database

### DIFF
--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -633,11 +633,6 @@ function _elgg_load_application_config() {
 		}
 	}
 
-	$path = datalist_get('path');
-	if (!empty($path)) {
-		$CONFIG->path = $path;
-	}
-
 	// allow sites to set dataroot and simplecache_enabled in settings.php
 	if (isset($CONFIG->dataroot)) {
 		$CONFIG->dataroot = sanitise_filepath($CONFIG->dataroot);

--- a/install/ElggInstaller.php
+++ b/install/ElggInstaller.php
@@ -141,7 +141,6 @@ class ElggInstaller {
 		$defaults = array(
 			'dbhost' => 'localhost',
 			'dbprefix' => 'elgg_',
-			'path' => $CONFIG->path,
 			'language' => 'en',
 			'siteaccess' => ACCESS_PUBLIC,
 		);
@@ -405,11 +404,6 @@ class ElggInstaller {
 			'wwwroot' => array(
 				'type' => 'url',
 				'value' => elgg_get_site_url(),
-				'required' => TRUE,
-				),
-			'path' => array(
-				'type' => 'text',
-				'value' => $CONFIG->path,
 				'required' => TRUE,
 				),
 			'dataroot' => array(


### PR DESCRIPTION
Elgg falls apart if `$CONFIG->path` is set to anything but the Elgg root,
so there is no point in saving a different value to the DB
or in respecting any value already saved to the DB.

Refs #2316
