### PR TITLE
chore(travis): run tests on PHP 5.3.3 and 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: php
 php:
  - 5.3
+ - 5.3.3
  - 5.4
  - 5.5
+ - 5.6
 
 branches:
   except:


### PR DESCRIPTION
5.3.3 is the lowest supported version, so we should test explicitly on that.

PHP 5.6 isn't stable yet, but we want to be ready for it.
