### PR TITLE
fix(views): respect icon_sizes config values when rendering icons

### DIFF
--- a/views/default/icon/default.php
+++ b/views/default/icon/default.php
@@ -14,11 +14,13 @@
 
 $entity = $vars['entity'];
 
-$sizes = array('small', 'medium', 'large', 'tiny', 'master', 'topbar');
+$icon_sizes = elgg_get_config('icon_sizes');
 // Get size
-if (!in_array($vars['size'], $sizes)) {
-	$vars['size'] = "medium";
+$size = elgg_extract('size', $vars, 'medium');
+if (!array_key_exists($size, $icon_sizes)) {
+	$size = "medium";
 }
+$vars['size'] = $size;
 
 $class = elgg_extract('img_class', $vars, '');
 
@@ -34,9 +36,6 @@ if (isset($vars['href'])) {
 	$url = $vars['href'];
 }
 
-$icon_sizes = elgg_get_config('icon_sizes');
-$size = $vars['size'];
-
 if (!isset($vars['width'])) {
 	$vars['width'] = $size != 'master' ? $icon_sizes[$size]['w'] : null;
 }
@@ -45,7 +44,7 @@ if (!isset($vars['height'])) {
 }
 
 $img_params = array(
-	'src' => $entity->getIconURL($vars['size']),
+	'src' => $entity->getIconURL($size),
 	'alt' => $title,	
 );
 

--- a/views/default/icon/user/default.php
+++ b/views/default/icon/user/default.php
@@ -17,7 +17,8 @@
 
 $user = elgg_extract('entity', $vars, elgg_get_logged_in_user_entity());
 $size = elgg_extract('size', $vars, 'medium');
-if (!in_array($size, array('topbar', 'tiny', 'small', 'medium', 'large', 'master'))) {
+$icon_sizes = elgg_get_config('icon_sizes');
+if (!array_key_exists($size, $icon_sizes)) {
 	$size = 'medium';
 }
 


### PR DESCRIPTION
Remove hard-coded references to available icons sizes and use global icon_sizes config values and keys instead

Replaces #6765
