### PR TITLE
chore(context): Expose `elgg_*_context` functions as a service

### DIFF
--- a/engine/classes/Elgg/Context.php
+++ b/engine/classes/Elgg/Context.php
@@ -1,0 +1,101 @@
+<?php
+namespace Elgg;
+
+/**
+ * PRIVATE CLASS. API IN FLUX. DO NOT USE DIRECTLY.
+ * 
+ * PLUGIN DEVELOPERS SHOULD USE elgg_*_context FUNCTIONS INSTEAD.
+ * 
+ * Views can modify their output based on the local context. You may want to
+ * display a list of blogs on a blog page or in a small widget. The rendered
+ * output could be different for those two contexts ('blog' vs 'widget').
+ *
+ * Pages that pass through the page handling system set the context to the
+ * first string after the root url. Example: http://example.org/elgg/bookmarks/ 
+ * results in the initial context being set to 'bookmarks'.
+ *
+ * The context is a stack so that for a widget on a profile, the context stack
+ * may contain first 'profile' and then 'widget'.
+ *
+ * @warning The context is not available until the page_handler runs (after
+ * the 'init, system' event processing has completed).
+ * 
+ * @package Elgg.Core
+ * @access  private
+ * @since   1.10.0
+ */
+final class Context {
+	
+	private $stack = array();
+	
+	/**
+	 * Get the most recently pushed context value.
+	 *
+	 * @return string|null
+	 */
+	public function peek() {
+		$topPos = count($this->stack) - 1;
+		
+		if ($topPos >= 0) {
+			return $this->stack[$topPos];
+		} else {
+			return NULL;
+		}
+
+	}
+	
+	/**
+	 * Push a context onto the top of the stack
+	 *
+	 * @param string $context The context string to add to the context stack
+	 * @return void
+	 */
+	public function push($context) {
+		array_push($this->stack, $context);
+	}
+	
+	/**
+	 * Removes and returns the top context string from the stack
+	 *
+	 * @return string|null
+	 */
+	public function pop() {
+		return array_pop($this->stack);
+	}
+	
+	/**
+	 * Sets the page context
+	 *
+	 * @param string $context The context of the page
+	 * @return bool
+	 */
+	public function set($context) {
+		$context = trim($context);
+
+		if (empty($context)) {
+			return false;
+		}
+
+		$context = strtolower($context);
+
+		$this->pop();
+		$this->push($context);
+
+		return true;
+	}
+
+	/**
+	 * Check if this context exists anywhere in the stack
+	 *
+	 * This is useful for situations with more than one element in the stack. For
+	 * example, a widget has a context of 'widget'. If a widget view needs to render
+	 * itself differently based on being on the dashboard or profile pages, it
+	 * can check the stack.
+	 *
+	 * @param string $context The context string to check for
+	 * @return bool
+	 */
+	public function contains($context) {
+		return in_array($context, $this->stack);
+	}
+}

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -42,6 +42,7 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 		$this->setClassName('actions', 'Elgg_ActionsService');
 		$this->setFactory('amdConfig', array($this, 'getAmdConfig'));
 		$this->setClassName('autoP', 'ElggAutoP');
+		$this->setValue('context', new \Elgg\Context());
 		$this->setClassName('crypto', 'ElggCrypto');
 		$this->setFactory('db', array($this, 'getDatabase'));
 		$this->setFactory('events', array($this, 'getEvents'));

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -663,9 +663,6 @@ function _elgg_load_application_config() {
 		$CONFIG->system_cache_enabled = 1;
 	}
 
-	// initialize context here so it is set before the first get_input call
-	$CONFIG->context = array();
-
 	// needs to be set before system, init for links in html head
 	$CONFIG->lastcache = (int)datalist_get("simplecache_lastupdate");
 

--- a/engine/lib/pageowner.php
+++ b/engine/lib/pageowner.php
@@ -194,20 +194,7 @@ function default_page_owner_handler($hook, $entity_type, $returnvalue, $params) 
  * @since 1.8.0
  */
 function elgg_set_context($context) {
-	global $CONFIG;
-
-	$context = trim($context);
-
-	if (empty($context)) {
-		return false;
-	}
-
-	$context = strtolower($context);
-
-	array_pop($CONFIG->context);
-	array_push($CONFIG->context, $context);
-
-	return true;
+	return _elgg_services()->context->set($context);
 }
 
 /**
@@ -219,13 +206,7 @@ function elgg_set_context($context) {
  * @since 1.8.0
  */
 function elgg_get_context() {
-	global $CONFIG;
-
-	if (!$CONFIG->context) {
-		return null;
-	}
-
-	return $CONFIG->context[count($CONFIG->context) - 1];
+	return _elgg_services()->context->peek();
 }
 
 /**
@@ -236,9 +217,7 @@ function elgg_get_context() {
  * @since 1.8.0
  */
 function elgg_push_context($context) {
-	global $CONFIG;
-
-	array_push($CONFIG->context, $context);
+	return _elgg_services()->context->push($context);
 }
 
 /**
@@ -248,9 +227,7 @@ function elgg_push_context($context) {
  * @since 1.8.0
  */
 function elgg_pop_context() {
-	global $CONFIG;
-
-	return array_pop($CONFIG->context);
+	return _elgg_services()->context->pop();
 }
 
 /**
@@ -266,9 +243,7 @@ function elgg_pop_context() {
  * @since 1.8.0
  */
 function elgg_in_context($context) {
-	global $CONFIG;
-
-	return in_array($context, $CONFIG->context);
+	return _elgg_services()->context->contains($context);
 }
 
 /**

--- a/engine/tests/phpunit/Elgg/ContextTest.php
+++ b/engine/tests/phpunit/Elgg/ContextTest.php
@@ -1,0 +1,109 @@
+<?php
+namespace Elgg;
+
+class ContextTest extends \PHPUnit_Framework_TestCase {
+	public function testPeekAndPopReturnNullByDefault() {
+		$context = new Context();
+		
+		$this->assertNull($context->peek());
+		$this->assertNull($context->pop());
+		
+		// TODO: remove once global state is fully deprecated (2.0)
+		_elgg_services()->setValue('context', new Context());
+		
+		$this->assertNull(elgg_get_context());
+		$this->assertNull(elgg_pop_context());
+	}
+	
+	public function testPopReturnsAndRemovesTheMostRecentlyPushedContext() {
+		$context = new Context();
+
+		$context->push('foo');
+		$context->push('bar');
+		
+		$this->assertEquals('bar', $context->pop());
+		$this->assertEquals('foo', $context->pop());
+		
+		// TODO: remove once global state is fully deprecated (2.0)
+		_elgg_services()->setValue('context', new Context());
+
+		elgg_push_context('foo');
+		elgg_push_context('bar');
+		
+		$this->assertEquals('bar', elgg_pop_context());
+		$this->assertEquals('foo', elgg_pop_context());
+	}
+	
+	public function testSetReplacesTheMostRecentlyPushedContext() {
+		$context = new Context();
+		
+		$context->push('foo');
+		$context->set('bar');
+		
+		$this->assertNotTrue($context->contains('foo'));
+		$this->assertEquals('bar', $context->pop());
+		$this->assertNotEquals('foo', $context->pop());
+		
+		// TODO: remove once global state is fully deprecated (2.0)
+		_elgg_services()->setValue('context', new Context());
+
+		elgg_push_context('foo');
+		elgg_set_context('bar');
+		
+		$this->assertNotTrue(elgg_in_context('foo'));
+		$this->assertEquals('bar', elgg_pop_context());
+		$this->assertNotEquals('foo', elgg_pop_context());
+	}
+	
+	public function testPeekReturnsTheMostRecentlyPushedContext() {
+		$context = new Context();
+		
+		$context->push('foo');
+		$this->assertEquals('foo', $context->peek());
+		$context->push('bar');
+		$this->assertEquals('bar', $context->peek());
+		$context->pop();
+		$this->assertEquals('foo', $context->peek());
+
+		// TODO: remove once global state is fully deprecated (2.0)
+		_elgg_services()->setValue('context', new Context());
+		
+		elgg_push_context('foo');
+		$this->assertEquals('foo', elgg_get_context());
+		elgg_push_context('bar');
+		$this->assertEquals('bar', elgg_get_context());
+		elgg_pop_context();
+		$this->assertEquals('foo', elgg_get_context());
+	}
+	
+	public function testContainsTellsYouIfAGivenContextIsInTheCurrentStack() {
+		$context = new Context();
+		
+		$context->push('foo');
+		$context->push('bar');
+		$context->push('baz');
+		
+		$this->assertTrue($context->contains('foo'));
+		$this->assertTrue($context->contains('bar'));
+		$this->assertTrue($context->contains('baz'));
+		
+		$popped = $context->pop();
+		
+		$this->assertFalse($context->contains($popped));
+
+		// TODO: remove once global state is fully deprecated (2.0)
+		_elgg_services()->setValue('context', new Context());
+		
+		elgg_push_context('foo');
+		elgg_push_context('bar');
+		elgg_push_context('baz');
+		
+		$this->assertTrue(elgg_in_context('foo'));
+		$this->assertTrue(elgg_in_context('bar'));
+		$this->assertTrue(elgg_in_context('baz'));
+		
+		$popped = elgg_pop_context();
+		
+		$this->assertFalse(elgg_in_context($popped));
+	}
+}

--- a/engine/tests/phpunit/ElggCoreViewtypeTest.php
+++ b/engine/tests/phpunit/ElggCoreViewtypeTest.php
@@ -5,10 +5,6 @@ require_once "$engine/lib/views.php";
 require_once "$engine/lib/input.php";
 require_once "$engine/lib/pageowner.php";
 
-global $CONFIG;
-$CONFIG->context = array();
-
-
 class ElggCoreViewtypeTest extends PHPUnit_Framework_TestCase {
 
 	protected function setUp() {

--- a/install/ElggInstaller.php
+++ b/install/ElggInstaller.php
@@ -859,7 +859,6 @@ class ElggInstaller {
 		$CONFIG->path = dirname(dirname(__FILE__)) . '/';
 		$CONFIG->viewpath =	$CONFIG->path . 'views/';
 		$CONFIG->pluginspath = $CONFIG->path . 'mod/';
-		$CONFIG->context = array();
 		$CONFIG->entity_types = array('group', 'object', 'site', 'user');
 		// required by elgg_view_page()
 		$CONFIG->sitename = '';


### PR DESCRIPTION
TODO:
- [x] Expose the `context` service in our service provider
- [x] Update the `@since` annotations
- [x] Fill out tests, includes tests for the global wrappers
- [x] Rename `get` to `peek` since that's what it does
- [x] Incorporate Elgg\Context service (https://github.com/Elgg/Elgg/pull/7101)
- [x] Switch to namespaces (https://github.com/Elgg/Elgg/pull/7104)
