### PR TITLE
chore(php): convert class underscores to namespaces

### DIFF
--- a/.scripts/move_namespaces_to_top.php
+++ b/.scripts/move_namespaces_to_top.php
@@ -1,0 +1,57 @@
+<?php
+
+// for each file that has a namespace declaration
+$dir = __DIR__;
+$filesWithNamespaceDeclaration = explode("\n", `grep -r '^namespace' $dir --include=*.php --exclude=vendor -l`);
+
+// echo implode("\n", $filesWithNamespaceDeclaration);
+
+foreach ($filesWithNamespaceDeclaration as $file) {
+	moveNamespaceToTop($file);
+}
+
+function moveNamespaceToTop($file) {
+	if (!is_file($file)) {
+		return;
+	}
+	
+	$contents = file_get_contents($file);
+	$lines = explode("\n", $contents);
+	
+	$nsDeclarationPosition = findPositionOfNamespaceDeclaration($lines);
+	
+	if ($nsDeclarationPosition == -1) {
+		return;
+	}
+	
+	$declaration = $lines[$nsDeclarationPosition];
+	
+	// echo "$declaration\n";
+	
+	unset($lines[$nsDeclarationPosition]);
+	
+	array_splice($lines, 1, 0, $declaration);
+	
+	$newContents = implode("\n", $lines) . "\n";
+	
+	file_put_contents($file, $newContents);
+}
+
+function findPositionOfNamespaceDeclaration($lines) {
+	$position = -1;
+	foreach ($lines as $pos => $lineContent) {
+		if (isNamespaceDeclaration($lineContent)) {
+			$position = $pos;
+		}
+	}
+	
+	return $position;
+}
+
+function isNamespaceDeclaration($lineContent) {
+	return strpos($lineContent, "namespace ") === 0;
+}
+// get the contents of that file and split into lines
+// find the line with the namespace declaration and remove it
+// insert it into the second position
+// write all the lines back to the file

--- a/actions/admin/site/unlock_upgrade.php
+++ b/actions/admin/site/unlock_upgrade.php
@@ -3,7 +3,7 @@
  * Unlocks the upgrade script 
  */
 
-$upgrader = new Elgg_UpgradeService();
+$upgrader = new Elgg\UpgradeService();
 
 if ($upgrader->isUpgradeLocked()) {
 	$upgrader->releaseUpgradeMutex();

--- a/actions/admin/upgrades/upgrade_comments.php
+++ b/actions/admin/upgrades/upgrade_comments.php
@@ -33,8 +33,8 @@ access_show_hidden_entities(true);
 // don't want any event or plugin hook handlers from plugins to run
 $original_events = _elgg_services()->events;
 $original_hooks = _elgg_services()->hooks;
-_elgg_services()->events = new Elgg_EventsService();
-_elgg_services()->hooks = new Elgg_PluginHooksService();
+_elgg_services()->events = new Elgg\EventsService();
+_elgg_services()->hooks = new Elgg\PluginHooksService();
 elgg_register_plugin_hook_handler('permissions_check', 'all', 'elgg_override_permissions');
 elgg_register_plugin_hook_handler('container_permissions_check', 'all', 'elgg_override_permissions');
 

--- a/actions/admin/upgrades/upgrade_datadirs.php
+++ b/actions/admin/upgrades/upgrade_datadirs.php
@@ -10,7 +10,7 @@
 $access_status = access_get_show_hidden_status();
 access_show_hidden_entities(true);
 
-$helper = new Elgg_Upgrades_Helper2013022000(
+$helper = new Elgg\Upgrades\Helper2013022000(
 	elgg_get_site_entity()->guid,
 	elgg_get_config('dbprefix')
 );

--- a/actions/admin/upgrades/upgrade_discussion_replies.php
+++ b/actions/admin/upgrades/upgrade_discussion_replies.php
@@ -32,8 +32,8 @@ access_show_hidden_entities(true);
 // don't want any event or plugin hook handlers from plugins to run
 $original_events = _elgg_services()->events;
 $original_hooks = _elgg_services()->hooks;
-_elgg_services()->events = new Elgg_EventsService();
-_elgg_services()->hooks = new Elgg_PluginHooksService();
+_elgg_services()->events = new Elgg\EventsService();
+_elgg_services()->hooks = new Elgg\PluginHooksService();
 elgg_register_plugin_hook_handler('permissions_check', 'all', 'elgg_override_permissions');
 elgg_register_plugin_hook_handler('container_permissions_check', 'all', 'elgg_override_permissions');
 

--- a/docs/contribute/code.rst
+++ b/docs/contribute/code.rst
@@ -377,9 +377,6 @@ Naming
   
 * All other function names must begin with ``_elgg_``.
 
-* The names of all classes and interfaces must use underscores as namespace
-  separators and be within the Elgg namespace. (``Elgg_Cache_LRUCache``)
-
 * Name globals and constants in ``ALL_CAPS`` (``ACCESS_FRIENDS``, ``$CONFIG``).
 
 Miscellaneous

--- a/engine/classes/CallException.php
+++ b/engine/classes/CallException.php
@@ -7,4 +7,4 @@
  * @package    Elgg.Core
  * @subpackage Exceptions.Stub
  */
-class CallException extends Exception {}
+class CallException extends \Exception {}

--- a/engine/classes/ClassException.php
+++ b/engine/classes/ClassException.php
@@ -7,4 +7,4 @@
  * @package    Elgg.Core
  * @subpackage Exceptions.Stub
  */
-class ClassException extends Exception {}
+class ClassException extends \Exception {}

--- a/engine/classes/ClassNotFoundException.php
+++ b/engine/classes/ClassNotFoundException.php
@@ -7,4 +7,4 @@
  * @package    Elgg.Core
  * @subpackage Exceptions
  */
-class ClassNotFoundException extends ClassException {}
+class ClassNotFoundException extends \ClassException {}

--- a/engine/classes/ConfigurationException.php
+++ b/engine/classes/ConfigurationException.php
@@ -7,4 +7,4 @@
  * @package    Elgg
  * @subpackage Exceptions.Stub
  */
-class ConfigurationException extends Exception {}
+class ConfigurationException extends \Exception {}

--- a/engine/classes/CronException.php
+++ b/engine/classes/CronException.php
@@ -7,4 +7,4 @@
  * @package    Elgg
  * @subpackage Exceptions.Stub
  */
-class CronException extends Exception {}
+class CronException extends \Exception {}

--- a/engine/classes/DataFormatException.php
+++ b/engine/classes/DataFormatException.php
@@ -6,4 +6,4 @@
  * @package    Elgg.Core
  * @subpackage Exceptions.Stub
  */
-class DataFormatException extends Exception {}
+class DataFormatException extends \Exception {}

--- a/engine/classes/DatabaseException.php
+++ b/engine/classes/DatabaseException.php
@@ -7,4 +7,4 @@
  * @package    Elgg.Core
  * @subpackage Exceptions.Stub
  */
-class DatabaseException extends Exception {}
+class DatabaseException extends \Exception {}

--- a/engine/classes/Elgg/Access.php
+++ b/engine/classes/Elgg/Access.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 /**
  * Class used to determine if access is being ignored.
  *
@@ -9,7 +10,7 @@
  *
  * @todo       I don't remember why this was required beyond scope concerns.
  */
-class Elgg_Access {
+class Access {
 	/**
 	 * Bypass Elgg's access control if true.
 	 * @var bool
@@ -21,10 +22,10 @@ class Elgg_Access {
 	 * Get current ignore access setting.
 	 *
 	 * @return bool
-	 * @deprecated 1.8 Use Elgg_Access::getIgnoreAccess()
+	 * @deprecated 1.8 Use \Elgg\Access::getIgnoreAccess()
 	 */
 	public function get_ignore_access() {
-		elgg_deprecated_notice('Elgg_Access::get_ignore_access() is deprecated by Elgg_Access::getIgnoreAccess()', 1.8);
+		elgg_deprecated_notice('\Elgg\Access::get_ignore_access() is deprecated by \Elgg\Access::getIgnoreAccess()', 1.8);
 		return $this->getIgnoreAccess();
 	}
 	// @codingStandardsIgnoreEnd
@@ -46,10 +47,10 @@ class Elgg_Access {
 	 *
 	 * @return bool Previous setting
 	 *
-	 * @deprecated 1.8 Use Elgg_Access:setIgnoreAccess()
+	 * @deprecated 1.8 Use \Elgg\Access:setIgnoreAccess()
 	 */
 	public function set_ignore_access($ignore = true) {
-		elgg_deprecated_notice('Elgg_Access::set_ignore_access() is deprecated by Elgg_Access::setIgnoreAccess()', 1.8);
+		elgg_deprecated_notice('\Elgg\Access::set_ignore_access() is deprecated by \Elgg\Access::setIgnoreAccess()', 1.8);
 		return $this->setIgnoreAccess($ignore);
 	}
 	// @codingStandardsIgnoreEnd
@@ -68,3 +69,4 @@ class Elgg_Access {
 		return $prev;
 	}
 }
+

--- a/engine/classes/Elgg/ActionsService.php
+++ b/engine/classes/Elgg/ActionsService.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -11,7 +12,7 @@
  * @subpackage Actions
  * @since      1.9.0
  */
-class Elgg_ActionsService {
+class ActionsService {
 	
 	/**
 	 * Registered actions storage
@@ -200,7 +201,7 @@ class Elgg_ActionsService {
 	}
 
 	/**
-	 * @see Elgg_ActionsService::validateActionToken
+	 * @see \Elgg\ActionsService::validateActionToken
 	 * @access private
 	 * @since 1.9.0
 	 * @return int number of seconds that action token is valid
@@ -345,3 +346,4 @@ class Elgg_ActionsService {
 		return $this->actions;
 	}
 }
+

--- a/engine/classes/Elgg/Amd/Config.php
+++ b/engine/classes/Elgg/Amd/Config.php
@@ -1,14 +1,15 @@
 <?php
+namespace Elgg\Amd;
 
 /**
  * Control configuration of RequireJS
  *
- * @access private
- *
  * @package    Elgg.Core
  * @subpackage JavaScript
+ * 
+ * @access private
  */
-class Elgg_Amd_Config {
+class Config {
 	private $baseUrl = '';
 	private $paths = array();
 	private $shim = array();
@@ -74,7 +75,7 @@ class Elgg_Amd_Config {
 		$exports = elgg_extract('exports', $config);
 
 		if (empty($deps) && empty($exports)) {
-			throw new InvalidParameterException("Shimmed modules must have deps or exports");
+			throw new \InvalidParameterException("Shimmed modules must have deps or exports");
 		}
 
 		$this->shim[$name] = array();
@@ -180,7 +181,7 @@ class Elgg_Amd_Config {
 	/**
 	 * Removes all config for a module
 	 *
-	 * @param type $name The module name
+	 * @param string $name The module name
 	 * @return bool
 	 */
 	public function removeModule($name) {

--- a/engine/classes/Elgg/Amd/ViewFilter.php
+++ b/engine/classes/Elgg/Amd/ViewFilter.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Amd;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -11,7 +12,7 @@
  * 
  * @access private
  */
-class Elgg_Amd_ViewFilter {
+class ViewFilter {
 	/**
 	 * Given the view name, returns the AMD name.
 	 * 
@@ -50,3 +51,4 @@ class Elgg_Amd_ViewFilter {
 		return $content;
 	}
 }
+

--- a/engine/classes/Elgg/AttributeLoader.php
+++ b/engine/classes/Elgg/AttributeLoader.php
@@ -1,19 +1,20 @@
 <?php
+namespace Elgg;
 
 /**
- * Loads ElggEntity attributes from DB or validates those passed in via constructor
+ * Loads \ElggEntity attributes from DB or validates those passed in via constructor
  *
  * @access private
  *
  * @package    Elgg.Core
  * @subpackage DataModel
  */
-class Elgg_AttributeLoader {
+class AttributeLoader {
 
 	/**
 	 * @var array names of attributes in all entities
 	 *
-	 * @todo require this to be injected and get it from ElggEntity
+	 * @todo require this to be injected and get it from \ElggEntity
 	 */
 	protected static $primary_attr_names = array(
 		'guid',
@@ -41,7 +42,7 @@ class Elgg_AttributeLoader {
 		'time_created',
 		'time_updated',
 		'last_action',
-		// ElggUser
+		// \ElggUser
 		'prev_last_action',
 		'last_login',
 		'prev_last_login'
@@ -108,16 +109,16 @@ class Elgg_AttributeLoader {
 	 * @param string $class             class of object being loaded
 	 * @param string $required_type     entity type this is being used to populate
 	 * @param array  $initialized_attrs attributes after initializeAttributes() has been run
-	 * @throws InvalidArgumentException
+	 * @throws \InvalidArgumentException
 	 */
 	public function __construct($class, $required_type, array $initialized_attrs) {
 		if (!is_string($class)) {
-			throw new InvalidArgumentException('$class must be a class name.');
+			throw new \InvalidArgumentException('$class must be a class name.');
 		}
 		$this->class = $class;
 
 		if (!is_string($required_type)) {
-			throw new InvalidArgumentException('$requiredType must be a system entity type.');
+			throw new \InvalidArgumentException('$requiredType must be a system entity type.');
 		}
 		$this->required_type = $required_type;
 
@@ -129,7 +130,7 @@ class Elgg_AttributeLoader {
 	/**
 	 * Get primary attributes missing that are missing
 	 *
-	 * @param stdClass $row Database row
+	 * @param \stdClass $row Database row
 	 * @return array
 	 */
 	protected function isMissingPrimaries($row) {
@@ -139,7 +140,7 @@ class Elgg_AttributeLoader {
 	/**
 	 * Get secondary attributes that are missing
 	 *
-	 * @param stdClass $row Database row
+	 * @param \stdClass $row Database row
 	 * @return array
 	 */
 	protected function isMissingSecondaries($row) {
@@ -149,14 +150,14 @@ class Elgg_AttributeLoader {
 	/**
 	 * Check that the type is correct
 	 *
-	 * @param stdClass $row Database row
+	 * @param \stdClass $row Database row
 	 * @return void
-	 * @throws InvalidClassException
+	 * @throws \InvalidClassException
 	 */
 	protected function checkType($row) {
 		if ($row['type'] !== $this->required_type) {
 			$msg = "GUID:" . $row['guid'] . " is not a valid " . $this->class;
-			throw new InvalidClassException($msg);
+			throw new \InvalidClassException($msg);
 		}
 	}
 
@@ -177,19 +178,19 @@ class Elgg_AttributeLoader {
 	 * "secondary" attributes (e.g. those in {prefix}objects_entity), but can load all at once if a
 	 * combined loader is available.
 	 *
-	 * @param mixed $row a row loaded from DB (array or stdClass) or a GUID
+	 * @param mixed $row a row loaded from DB (array or \stdClass) or a GUID
 	 * @return array will be empty if failed to load all attributes (access control or entity doesn't exist)
 	 *
-	 * @throws InvalidArgumentException|LogicException|IncompleteEntityException
+	 * @throws \InvalidArgumentException|\LogicException|\IncompleteEntityException
 	 */
 	public function getRequiredAttributes($row) {
-		if (!is_array($row) && !($row instanceof stdClass)) {
+		if (!is_array($row) && !($row instanceof \stdClass)) {
 			// assume row is the GUID
 			$row = array('guid' => $row);
 		}
 		$row = (array) $row;
 		if (empty($row['guid'])) {
-			throw new InvalidArgumentException('$row must be or contain a GUID');
+			throw new \InvalidArgumentException('$row must be or contain a GUID');
 		}
 
 		$was_missing_primaries = $this->isMissingPrimaries($row);
@@ -206,7 +207,7 @@ class Elgg_AttributeLoader {
 		} else {
 			if ($was_missing_primaries) {
 				if (!is_callable($this->primary_loader)) {
-					throw new LogicException('Primary attribute loader must be callable');
+					throw new \LogicException('Primary attribute loader must be callable');
 				}
 				if ($this->requires_access_control) {
 					$fetched = (array) call_user_func($this->primary_loader, $row['guid']);
@@ -227,11 +228,11 @@ class Elgg_AttributeLoader {
 
 			if ($was_missing_secondaries) {
 				if (!is_callable($this->secondary_loader)) {
-					throw new LogicException('Secondary attribute loader must be callable');
+					throw new \LogicException('Secondary attribute loader must be callable');
 				}
 				$fetched = (array) call_user_func($this->secondary_loader, $row['guid']);
 				if (!$fetched) {
-					throw new IncompleteEntityException("Secondary loader failed to return row for {$row['guid']}");
+					throw new \IncompleteEntityException("Secondary loader failed to return row for {$row['guid']}");
 				}
 				$row = array_merge($row, $fetched);
 			}
@@ -281,3 +282,4 @@ class Elgg_AttributeLoader {
 		return $row;
 	}
 }
+

--- a/engine/classes/Elgg/AutoloadManager.php
+++ b/engine/classes/Elgg/AutoloadManager.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 /**
  * Manages core autoloading and caching of class maps
  *
@@ -7,14 +8,14 @@
  * @package    Elgg.Core
  * @subpackage Autoloader
  */
-class Elgg_AutoloadManager {
+class AutoloadManager {
 
 	const FILENAME = 'autoload_data.php';
 	const KEY_CLASSES = 'classes';
 	const KEY_SCANNED_DIRS = 'scannedDirs';
 
 	/**
-	 * @var Elgg_ClassLoader
+	 * @var \Elgg\ClassLoader
 	 */
 	protected $loader;
 
@@ -29,16 +30,16 @@ class Elgg_AutoloadManager {
 	protected $altered = false;
 
 	/**
-	 * @var ElggCache
+	 * @var \ElggCache
 	 */
 	protected $storage = null;
 
 	/**
 	 * Constructor
 	 * 
-	 * @param Elgg_ClassLoader $loader Class loader object
+	 * @param \Elgg\ClassLoader $loader Class loader object
 	 */
-	public function __construct(Elgg_ClassLoader $loader) {
+	public function __construct(\Elgg\ClassLoader $loader) {
 		$this->loader = $loader;
 	}
 
@@ -50,7 +51,7 @@ class Elgg_AutoloadManager {
 	 * rescan unless the cache is emptied.
 	 *
 	 * @param string $dir Directory of classes
-	 * @return Elgg_AutoloadManager
+	 * @return \Elgg\AutoloadManager
 	 */
 	public function addClasses($dir) {
 		if (!in_array($dir, $this->scannedDirs)) {
@@ -73,11 +74,11 @@ class Elgg_AutoloadManager {
 	 * @return array
 	 */
 	protected function scanClassesDir($dir) {
-		$dir = new DirectoryIterator($dir);
+		$dir = new \DirectoryIterator($dir);
 		$map = array();
 
 		foreach ($dir as $file) {
-			/* @var SplFileInfo $file */
+			/* @var \SplFileInfo $file */
 			if (!$file->isFile() || !$file->isReadable()) {
 				continue;
 			}
@@ -99,7 +100,7 @@ class Elgg_AutoloadManager {
 	 *
 	 * @param string $class Class name
 	 * @param string $path  Path of class file
-	 * @return Elgg_AutoloadManager
+	 * @return \Elgg\AutoloadManager
 	 */
 	public function setClassPath($class, $path) {
 		$this->loader->getClassMap()->setPath($class, $path);
@@ -109,7 +110,7 @@ class Elgg_AutoloadManager {
 	/**
 	 * If necessary, save necessary state details
 	 *
-	 * @return Elgg_AutoloadManager
+	 * @return \Elgg\AutoloadManager
 	 */
 	public function saveCache() {
 		if ($this->storage) {
@@ -165,7 +166,7 @@ class Elgg_AutoloadManager {
 	/**
 	 * Delete the cache file
 	 *
-	 * @return Elgg_AutoloadManager
+	 * @return \Elgg\AutoloadManager
 	 */
 	public function deleteCache() {
 		if ($this->storage) {
@@ -177,7 +178,7 @@ class Elgg_AutoloadManager {
 	/**
 	 * Get the class loader
 	 * 
-	 * @return Elgg_ClassLoader
+	 * @return \Elgg\ClassLoader
 	 */
 	public function getLoader() {
 		return $this->loader;
@@ -186,10 +187,11 @@ class Elgg_AutoloadManager {
 	/**
 	 * Set the cache storage object
 	 * 
-	 * @param ElggCache $storage Cache object
+	 * @param \ElggCache $storage Cache object
 	 * @return void
 	 */
-	public function setStorage(ElggCache $storage) {
+	public function setStorage(\ElggCache $storage) {
 		$this->storage = $storage;
 	}
 }
+

--- a/engine/classes/Elgg/Cache/LRUCache.php
+++ b/engine/classes/Elgg/Cache/LRUCache.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Cache;
 
 /**
  * Least Recently Used Cache
@@ -13,7 +14,7 @@
  * @package    Elgg.Core
  * @subpackage Cache
  */
-class Elgg_Cache_LRUCache implements ArrayAccess {
+class LRUCache implements \ArrayAccess {
 	/** @var int */
 	protected $maximumSize;
 
@@ -28,11 +29,11 @@ class Elgg_Cache_LRUCache implements ArrayAccess {
 	 * Create a LRU Cache
 	 *
 	 * @param int $size The size of the cache
-	 * @throws InvalidArgumentException
+	 * @throws \InvalidArgumentException
 	 */
 	public function __construct($size) {
 		if (!is_int($size) || $size <= 0) {
-			throw new InvalidArgumentException();
+			throw new \InvalidArgumentException();
 		}
 		$this->maximumSize = $size;
 	}
@@ -133,7 +134,7 @@ class Elgg_Cache_LRUCache implements ArrayAccess {
 	/**
 	 * Assigns a value for the specified key
 	 *
-	 * @see ArrayAccess::offsetSet()
+	 * @see \ArrayAccess::offsetSet()
 	 *
 	 * @param int|string $key   The key to assign the value to.
 	 * @param mixed      $value The value to set.
@@ -146,7 +147,7 @@ class Elgg_Cache_LRUCache implements ArrayAccess {
 	/**
 	 * Get the value for specified key
 	 *
-	 * @see ArrayAccess::offsetGet()
+	 * @see \ArrayAccess::offsetGet()
 	 *
 	 * @param int|string $key The key to retrieve.
 	 * @return mixed
@@ -158,7 +159,7 @@ class Elgg_Cache_LRUCache implements ArrayAccess {
 	/**
 	 * Unsets a key.
 	 *
-	 * @see ArrayAccess::offsetUnset()
+	 * @see \ArrayAccess::offsetUnset()
 	 *
 	 * @param int|string $key The key to unset.
 	 * @return void
@@ -170,7 +171,7 @@ class Elgg_Cache_LRUCache implements ArrayAccess {
 	/**
 	 * Does key exist?
 	 *
-	 * @see ArrayAccess::offsetExists()
+	 * @see \ArrayAccess::offsetExists()
 	 *
 	 * @param int|string $key A key to check for.
 	 * @return boolean
@@ -179,3 +180,4 @@ class Elgg_Cache_LRUCache implements ArrayAccess {
 		return $this->containsKey($key);
 	}
 }
+

--- a/engine/classes/Elgg/CacheHandler.php
+++ b/engine/classes/Elgg/CacheHandler.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 
 /**
  * Simplecache handler
@@ -7,14 +8,14 @@
  *
  * @package Elgg.Core
  */
-class Elgg_CacheHandler {
+class CacheHandler {
 
 	protected $config;
 
 	/**
 	 * Constructor
 	 *
-	 * @param stdClass $config Elgg config object
+	 * @param \stdClass $config Elgg config object
 	 */
 	public function __construct($config) {
 		$this->config = $config;
@@ -263,3 +264,4 @@ class Elgg_CacheHandler {
 		exit;
 	}
 }
+

--- a/engine/classes/Elgg/ClassLoader.php
+++ b/engine/classes/Elgg/ClassLoader.php
@@ -1,4 +1,6 @@
 <?php
+namespace Elgg;
+
 /**
  * A class/interface/trait autoloader for PHP
  *
@@ -44,30 +46,30 @@
  * @subpackage Autoloader
  * @author     Fabien Potencier <fabien@symfony.com>
  */
-class Elgg_ClassLoader {
+class ClassLoader {
 
 	protected $namespaces = array();
 	protected $prefixes = array();
 	protected $fallbacks = array();
 
 	/**
-	 * @var Elgg_ClassMap Map of classes to files
+	 * @var \Elgg\ClassMap Map of classes to files
 	 */
 	protected $map;
 
 	/**
 	 * Constructor
 	 * 
-	 * @param Elgg_ClassMap $map Class map
+	 * @param \Elgg\ClassMap $map Class map
 	 */
-	public function __construct(Elgg_ClassMap $map) {
+	public function __construct(\Elgg\ClassMap $map) {
 		$this->map = $map;
 	}
 
 	/**
 	 * Get the class map
 	 * 
-	 * @return Elgg_ClassMap
+	 * @return \Elgg\ClassMap
 	 */
 	public function getClassMap() {
 		return $this->map;
@@ -235,3 +237,4 @@ class Elgg_ClassLoader {
 		}
 	}
 }
+

--- a/engine/classes/Elgg/ClassMap.php
+++ b/engine/classes/Elgg/ClassMap.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 /**
  * A map of class names to absolute file paths
  *
@@ -7,7 +8,7 @@
  * @package    Elgg.Core
  * @subpackage Autoloader
  */
-class Elgg_ClassMap {
+class ClassMap {
 
 	/**
 	 * @var array
@@ -37,7 +38,7 @@ class Elgg_ClassMap {
 	 *
 	 * @param string $class a class/interface/trait name
 	 * @param string $path  absolute file path
-	 * @return Elgg_ClassMap
+	 * @return \Elgg\ClassMap
 	 */
 	public function setPath($class, $path) {
 		if ('\\' === $class[0]) {
@@ -61,7 +62,7 @@ class Elgg_ClassMap {
 	 * Set the altered flag
 	 * 
 	 * @param bool $altered Whether the class map has been altered
-	 * @return Elgg_ClassMap
+	 * @return \Elgg\ClassMap
 	 */
 	public function setAltered($altered) {
 		$this->altered = (bool) $altered;
@@ -82,7 +83,7 @@ class Elgg_ClassMap {
 	 *
 	 * @param array $map array with keys being class/interface/trait names and
 	 *                   values the absolute file paths that define them
-	 * @return Elgg_ClassMap
+	 * @return \Elgg\ClassMap
 	 */
 	public function setMap(array $map) {
 		$this->map = $map;
@@ -94,10 +95,11 @@ class Elgg_ClassMap {
 	 * 
 	 * @param array $map array with keys being class/interface/trait names and
 	 *                   values the absolute file paths that define them
-	 * @return Elgg_ClassMap
+	 * @return \Elgg\ClassMap
 	 */
 	public function mergeMap(array $map) {
 		$this->map = array_merge($this->map, $map);
 		return $this;
 	}
 }
+

--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 
 /**
  * An object representing a single Elgg database.
@@ -10,7 +11,7 @@
  * @package    Elgg.Core
  * @subpackage Database
  */
-class Elgg_Database {
+class Database {
 
 	/** @var string $tablePrefix Prefix for database tables */
 	private $tablePrefix;
@@ -28,9 +29,9 @@ class Elgg_Database {
 	 * <code>
 	 * $DB_QUERY_CACHE[query hash] => array(result1, result2, ... resultN)
 	 * </code>
-	 * @see Elgg_Database::getResults() for details on the hash.
+	 * @see \Elgg\Database::getResults() for details on the hash.
 	 *
-	 * @var Elgg_Cache_LRUCache $queryCache The cache
+	 * @var \Elgg\Cache\LRUCache $queryCache The cache
 	 */
 	private $queryCache = null;
 
@@ -59,19 +60,19 @@ class Elgg_Database {
 	/** @var bool $installed Is the database installed? */
 	private $installed = false;
 
-	/** @var Elgg_Database_Config $config Database configuration */
+	/** @var \Elgg\Database\Config $config Database configuration */
 	private $config;
 
-	/** @var Elgg_Logger $logger The logger */
+	/** @var \Elgg\Logger $logger The logger */
 	private $logger;
 
 	/**
 	 * Constructor
 	 *
-	 * @param Elgg_Database_Config $config Database configuration
-	 * @param Elgg_Logger          $logger The logger
+	 * @param \Elgg\Database\Config $config Database configuration
+	 * @param \Elgg\Logger          $logger The logger
 	 */
-	public function __construct(Elgg_Database_Config $config, Elgg_Logger $logger) {
+	public function __construct(\Elgg\Database\Config $config, \Elgg\Logger $logger) {
 
 		$this->logger = $logger;
 		$this->config = $config;
@@ -85,12 +86,12 @@ class Elgg_Database {
 	 * Gets (if required, also creates) a database link resource.
 	 *
 	 * The database link resources are created by
-	 * {@link Elgg_Database::setupConnections()}, which is called if no links exist.
+	 * {@link \Elgg\Database::setupConnections()}, which is called if no links exist.
 	 *
 	 * @param string $type The type of link we want: "read", "write" or "readwrite".
 	 *
 	 * @return resource Database link
-	 * @throws DatabaseException
+	 * @throws \DatabaseException
 	 * @todo make protected once we get rid of get_db_link()
 	 */
 	public function getLink($type) {
@@ -111,7 +112,7 @@ class Elgg_Database {
 	 * links up separately; otherwise just create the one database link.
 	 *
 	 * @return void
-	 * @throws DatabaseException
+	 * @throws \DatabaseException
 	 */
 	public function setupConnections() {
 		if ($this->config->isDatabaseSplit()) {
@@ -132,7 +133,7 @@ class Elgg_Database {
 	 * resource: "read", "write", or "readwrite".
 	 *
 	 * @return void
-	 * @throws DatabaseException
+	 * @throws \DatabaseException
 	 */
 	public function establishLink($dblinkname = "readwrite") {
 
@@ -142,12 +143,12 @@ class Elgg_Database {
 		$this->dbLinks[$dblinkname] = mysql_connect($conf['host'], $conf['user'], $conf['password'], true);
 		if (!$this->dbLinks[$dblinkname]) {
 			$msg = "Elgg couldn't connect to the database using the given credentials. Check the settings file.";
-			throw new DatabaseException($msg);
+			throw new \DatabaseException($msg);
 		}
 
 		if (!mysql_select_db($conf['database'], $this->dbLinks[$dblinkname])) {
 			$msg = "Elgg couldn't select the database '{$conf['database']}'. Please check that the database is created and you have access to it.";
-			throw new DatabaseException($msg);
+			throw new \DatabaseException($msg);
 		}
 
 		// Set DB for UTF8
@@ -157,7 +158,7 @@ class Elgg_Database {
 	/**
 	 * Retrieve rows from the database.
 	 *
-	 * Queries are executed with {@link Elgg_Database::executeQuery()} and results
+	 * Queries are executed with {@link \Elgg\Database::executeQuery()} and results
 	 * are retrieved with {@link mysql_fetch_object()}.  If a callback
 	 * function $callback is defined, each row will be passed as a single
 	 * argument to $callback.  If no callback function is defined, the
@@ -168,7 +169,7 @@ class Elgg_Database {
 	 *
 	 * @return array An array of database result objects or callback function results. If the query
 	 *               returned nothing, an empty array.
-	 * @throws DatabaseException
+	 * @throws \DatabaseException
 	 */
 	public function getData($query, $callback = '') {
 		return $this->getResults($query, $callback, false);
@@ -177,7 +178,7 @@ class Elgg_Database {
 	/**
 	 * Retrieve a single row from the database.
 	 *
-	 * Similar to {@link Elgg_Database::getData()} but returns only the first row
+	 * Similar to {@link \Elgg\Database::getData()} but returns only the first row
 	 * matched.  If a callback function $callback is specified, the row will be passed
 	 * as the only argument to $callback.
 	 *
@@ -185,7 +186,7 @@ class Elgg_Database {
 	 * @param string $callback A callback function
 	 *
 	 * @return mixed A single database result object or the result of the callback function.
-	 * @throws DatabaseException
+	 * @throws \DatabaseException
 	 */
 	public function getDataRow($query, $callback = '') {
 		return $this->getResults($query, $callback, true);
@@ -200,11 +201,11 @@ class Elgg_Database {
 	 *
 	 * @return int|false The database id of the inserted row if a AUTO_INCREMENT field is
 	 *                   defined, 0 if not, and false on failure.
-	 * @throws DatabaseException
+	 * @throws \DatabaseException
 	 */
 	public function insertData($query) {
 
-		$this->logger->log("DB query $query", Elgg_Logger::INFO);
+		$this->logger->log("DB query $query", \Elgg\Logger::INFO);
 
 		$dblink = $this->getLink('write');
 
@@ -226,11 +227,11 @@ class Elgg_Database {
 	 * @param bool   $getNumRows Return the number of rows affected (default: false)
 	 *
 	 * @return bool|int
-	 * @throws DatabaseException
+	 * @throws \DatabaseException
 	 */
 	public function updateData($query, $getNumRows = false) {
 
-		$this->logger->log("DB query $query", Elgg_Logger::INFO);
+		$this->logger->log("DB query $query", \Elgg\Logger::INFO);
 
 		$dblink = $this->getLink('write');
 
@@ -255,11 +256,11 @@ class Elgg_Database {
 	 * @param string $query The SQL query to run
 	 *
 	 * @return int|false The number of affected rows or false on failure
-	 * @throws DatabaseException
+	 * @throws \DatabaseException
 	 */
 	public function deleteData($query) {
 
-		$this->logger->log("DB query $query", Elgg_Logger::INFO);
+		$this->logger->log("DB query $query", \Elgg\Logger::INFO);
 
 		$dblink = $this->getLink('write');
 
@@ -282,7 +283,7 @@ class Elgg_Database {
 	 *
 	 * @return array An array of database result objects or callback function results. If the query
 	 *               returned nothing, an empty array.
-	 * @throws DatabaseException
+	 * @throws \DatabaseException
 	 */
 	protected function getResults($query, $callback = null, $single = false) {
 
@@ -295,7 +296,7 @@ class Elgg_Database {
 		// Is cached?
 		if ($this->queryCache) {
 			if (isset($this->queryCache[$hash])) {
-				$this->logger->log("DB query $query results returned from cache (hash: $hash)", Elgg_Logger::INFO);
+				$this->logger->log("DB query $query results returned from cache (hash: $hash)", \Elgg\Logger::INFO);
 				return $this->queryCache[$hash];
 			}
 		}
@@ -324,13 +325,13 @@ class Elgg_Database {
 		}
 
 		if (empty($return)) {
-			$this->logger->log("DB query $query returned no results.", Elgg_Logger::INFO);
+			$this->logger->log("DB query $query returned no results.", \Elgg\Logger::INFO);
 		}
 
 		// Cache result
 		if ($this->queryCache) {
 			$this->queryCache[$hash] = $return;
-			$this->logger->log("DB query $query results cached (hash: $hash)", Elgg_Logger::INFO);
+			$this->logger->log("DB query $query results cached (hash: $hash)", \Elgg\Logger::INFO);
 		}
 
 		return $return;
@@ -346,17 +347,17 @@ class Elgg_Database {
 	 * @param resource $dblink The DB link
 	 *
 	 * @return resource|bool The result of mysql_query()
-	 * @throws DatabaseException
+	 * @throws \DatabaseException
 	 * @todo should this be public?
 	 */
 	public function executeQuery($query, $dblink) {
 
 		if ($query == null) {
-			throw new DatabaseException("Query cannot be null");
+			throw new \DatabaseException("Query cannot be null");
 		}
 
 		if (!is_resource($dblink)) {
-			throw new DatabaseException("Connection to database was lost.");
+			throw new \DatabaseException("Connection to database was lost.");
 		}
 
 		$this->queryCount++;
@@ -364,7 +365,7 @@ class Elgg_Database {
 		$result = mysql_query($query, $dblink);
 
 		if (mysql_errno($dblink)) {
-			throw new DatabaseException(mysql_error($dblink) . "\n\n QUERY: $query");
+			throw new \DatabaseException(mysql_error($dblink) . "\n\n QUERY: $query");
 		}
 
 		return $result;
@@ -388,7 +389,7 @@ class Elgg_Database {
 	 * @param string $scriptlocation The full path to the script
 	 *
 	 * @return void
-	 * @throws DatabaseException
+	 * @throws \DatabaseException
 	 */
 	public function runSqlScript($scriptlocation) {
 		$script = file_get_contents($scriptlocation);
@@ -408,7 +409,7 @@ class Elgg_Database {
 				if (!empty($statement)) {
 					try {
 						$this->updateData($statement);
-					} catch (DatabaseException $e) {
+					} catch (\DatabaseException $e) {
 						$errors[] = $e->getMessage();
 					}
 				}
@@ -420,11 +421,11 @@ class Elgg_Database {
 				}
 
 				$msg = "There were a number of issues: " . $errortxt;
-				throw new DatabaseException($msg);
+				throw new \DatabaseException($msg);
 			}
 		} else {
 			$msg = "Elgg couldn't find the requested database script at " . $scriptlocation . ".";
-			throw new DatabaseException($msg);
+			throw new \DatabaseException($msg);
 		}
 	}
 
@@ -477,7 +478,7 @@ class Elgg_Database {
 					$link = $this->getLink($link);
 				} elseif (!is_resource($link)) {
 					$msg = "Link for delayed query not valid resource or db_link type. Query: {$query_details['q']}";
-					$this->logger->log($msg, Elgg_Logger::WARNING);
+					$this->logger->log($msg, \Elgg\Logger::WARNING);
 				}
 
 				$result = $this->executeQuery($query_details['q'], $link);
@@ -485,9 +486,9 @@ class Elgg_Database {
 				if ((isset($query_details['h'])) && (is_callable($query_details['h']))) {
 					$query_details['h']($result);
 				}
-			} catch (DatabaseException $e) {
+			} catch (\DatabaseException $e) {
 				// Suppress all exceptions since page already sent to requestor
-				$this->logger->log($e, Elgg_Logger::ERROR);
+				$this->logger->log($e, \Elgg\Logger::ERROR);
 			}
 		}
 	}
@@ -495,14 +496,14 @@ class Elgg_Database {
 	/**
 	 * Enable the query cache
 	 * 
-	 * This does not take precedence over the Elgg_Database_Config setting.
+	 * This does not take precedence over the \Elgg\Database\Config setting.
 	 * 
 	 * @return void
 	 */
 	public function enableQueryCache() {
 		if ($this->config->isQueryCacheEnabled() && $this->queryCache === null) {
 			// @todo if we keep this cache, expose the size as a config parameter
-			$this->queryCache = new Elgg_Cache_LRUCache($this->queryCacheSize);
+			$this->queryCache = new \Elgg\Cache\LRUCache($this->queryCacheSize);
 		}
 	}
 
@@ -526,7 +527,7 @@ class Elgg_Database {
 	protected function invalidateQueryCache() {
 		if ($this->queryCache) {
 			$this->queryCache->clear();
-			$this->logger->log("Query cache invalidated", Elgg_Logger::INFO);
+			$this->logger->log("Query cache invalidated", \Elgg\Logger::INFO);
 		}
 	}
 
@@ -534,7 +535,7 @@ class Elgg_Database {
 	 * Test that the Elgg database is installed
 	 *
 	 * @return void
-	 * @throws InstallationException
+	 * @throws \InstallationException
 	 */
 	public function assertInstalled() {
 
@@ -546,10 +547,10 @@ class Elgg_Database {
 			$dblink = $this->getLink('read');
 			mysql_query("SELECT value FROM {$this->tablePrefix}datalists WHERE name = 'installed'", $dblink);
 			if (mysql_errno($dblink) > 0) {
-				throw new DatabaseException();
+				throw new \DatabaseException();
 			}
-		} catch (DatabaseException $e) {
-			throw new InstallationException("Unable to handle this request. This site is not configured or the database is down.");
+		} catch (\DatabaseException $e) {
+			throw new \InstallationException("Unable to handle this request. This site is not configured or the database is down.");
 		}
 
 		$this->installed = true;
@@ -602,3 +603,4 @@ class Elgg_Database {
 		return mysql_real_escape_string($value);
 	}
 }
+

--- a/engine/classes/Elgg/Database/Config.php
+++ b/engine/classes/Elgg/Database/Config.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Database;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -9,21 +10,21 @@
  * @subpackage Database
  * @since      1.9.0
  */
-class Elgg_Database_Config {
+class Config {
 
 	const READ = 'read';
 	const WRITE = 'write';
 	const READ_WRITE = 'readwrite';
 
-	/** @var stdClass $config Elgg's config object */
+	/** @var \stdClass $config Elgg's config object */
 	protected $config;
 
 	/**
 	 * Constructor
 	 *
-	 * @param stdClass $config Elgg's $CONFIG object
+	 * @param \stdClass $config Elgg's $CONFIG object
 	 */
-	public function __construct(stdClass $config) {
+	public function __construct(\stdClass $config) {
 		$this->config = $config;
 	}
 
@@ -156,3 +157,4 @@ class Elgg_Database_Config {
 		return $config;
 	}
 }
+

--- a/engine/classes/Elgg/Database/QueryCounter.php
+++ b/engine/classes/Elgg/Database/QueryCounter.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Database;
 
 /**
  * Count queries performed
@@ -11,7 +12,7 @@
  * @subpackage Database
  * @since      1.9.0
  */
-class Elgg_Database_QueryCounter {
+class QueryCounter {
 
 	/**
 	 * @var int
@@ -19,16 +20,16 @@ class Elgg_Database_QueryCounter {
 	protected $initial;
 
 	/**
-	 * @var Elgg_Database
+	 * @var \Elgg\Database
 	 */
 	protected $db;
 
 	/**
 	 * Constructor
 	 *
-	 * @param Elgg_Database $db Elgg's database
+	 * @param \Elgg\Database $db Elgg's database
 	 */
-	public function __construct(Elgg_Database $db) {
+	public function __construct(\Elgg\Database $db) {
 		$this->db = $db;
 		$this->initial = $db->getQueryCount();
 	}
@@ -73,3 +74,4 @@ class Elgg_Database_QueryCounter {
 		return "<script>console.log($msg)</script>";
 	}
 }
+

--- a/engine/classes/Elgg/DeprecationWrapper.php
+++ b/engine/classes/Elgg/DeprecationWrapper.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 /**
  * Wrap an object and display warnings whenever the object's variables are
  * accessed or a method is used. It can also be used to wrap a string.
@@ -20,7 +21,7 @@
  * 
  * @package Elgg.Core
  */
-class Elgg_DeprecationWrapper implements ArrayAccess {
+class DeprecationWrapper implements \ArrayAccess {
 	/** @var object */
 	protected $object;
 
@@ -120,7 +121,7 @@ class Elgg_DeprecationWrapper implements ArrayAccess {
 	/**
 	 * Array access interface
 	 *
-	 * @see ArrayAccess::offsetSet()
+	 * @see \ArrayAccess::offsetSet()
 	 *
 	 * @param mixed $key   Name
 	 * @param mixed $value Value
@@ -129,7 +130,7 @@ class Elgg_DeprecationWrapper implements ArrayAccess {
 	 */
 	public function offsetSet($key, $value) {
 		$this->displayWarning();
-		if (is_object($this->object) && !$this->object instanceof ArrayAccess) {
+		if (is_object($this->object) && !$this->object instanceof \ArrayAccess) {
 			$this->object->$key = $value;
 		} else {
 			if ($key === null) {
@@ -144,7 +145,7 @@ class Elgg_DeprecationWrapper implements ArrayAccess {
 	/**
 	 * Array access interface
 	 *
-	 * @see ArrayAccess::offsetGet()
+	 * @see \ArrayAccess::offsetGet()
 	 *
 	 * @param mixed $key Name
 	 *
@@ -152,7 +153,7 @@ class Elgg_DeprecationWrapper implements ArrayAccess {
 	 */
 	public function offsetGet($key) {
 		$this->displayWarning();
-		if (is_object($this->object) && !$this->object instanceof ArrayAccess) {
+		if (is_object($this->object) && !$this->object instanceof \ArrayAccess) {
 			return $this->object->$key;
 		} else {
 			return $this->object[$key];
@@ -162,7 +163,7 @@ class Elgg_DeprecationWrapper implements ArrayAccess {
 	/**
 	 * Array access interface
 	 *
-	 * @see ArrayAccess::offsetUnset()
+	 * @see \ArrayAccess::offsetUnset()
 	 *
 	 * @param mixed $key Name
 	 *
@@ -170,7 +171,7 @@ class Elgg_DeprecationWrapper implements ArrayAccess {
 	 */
 	public function offsetUnset($key) {
 		$this->displayWarning();
-		if (is_object($this->object) && !$this->object instanceof ArrayAccess) {
+		if (is_object($this->object) && !$this->object instanceof \ArrayAccess) {
 			unset($this->object->$key);
 		} else {
 			unset($this->object[$key]);
@@ -180,7 +181,7 @@ class Elgg_DeprecationWrapper implements ArrayAccess {
 	/**
 	 * Array access interface
 	 *
-	 * @see ArrayAccess::offsetExists()
+	 * @see \ArrayAccess::offsetExists()
 	 *
 	 * @param mixed $offset Offset
 	 *
@@ -188,10 +189,11 @@ class Elgg_DeprecationWrapper implements ArrayAccess {
 	 */
 	public function offsetExists($offset) {
 		$this->displayWarning();
-		if (is_object($this->object) && !$this->object instanceof ArrayAccess) {
+		if (is_object($this->object) && !$this->object instanceof \ArrayAccess) {
 			return isset($this->object->$offset);
 		} else {
 			return array_key_exists($offset, $this->object);
 		}
 	}
 }
+

--- a/engine/classes/Elgg/Di/DiContainer.php
+++ b/engine/classes/Elgg/Di/DiContainer.php
@@ -1,11 +1,12 @@
 <?php
+namespace Elgg\Di;
 
 /**
  * Container holding values which can be resolved upon reading and optionally stored and shared
  * across reads.
  *
  * <code>
- * $c = new Elgg_Di_DiContainer();
+ * $c = new \Elgg\Di\DiContainer();
  *
  * $c->setFactory('foo', 'Foo_factory'); // $c will be passed to Foo_factory()
  * $c->foo; // new Foo instance
@@ -24,7 +25,7 @@
  * @package Elgg.Core
  * @since   1.9
  */
-class Elgg_Di_DiContainer {
+class DiContainer {
 
 	/**
 	 * @var array each element is an array: ['callable' => mixed $factory, 'shared' => bool $isShared]
@@ -44,14 +45,14 @@ class Elgg_Di_DiContainer {
 	 *
 	 * @param string $name The name of the value to fetch
 	 * @return mixed
-	 * @throws Elgg_Di_MissingValueException
+	 * @throws \Elgg\Di\MissingValueException
 	 */
 	public function __get($name) {
 		if (array_key_exists($name, $this->cache)) {
 			return $this->cache[$name];
 		}
 		if (!isset($this->factories[$name])) {
-			throw new Elgg_Di_MissingValueException("Value or factory was not set for: $name");
+			throw new \Elgg\Di\MissingValueException("Value or factory was not set for: $name");
 		}
 		$value = $this->build($this->factories[$name]['callable'], $name);
 
@@ -69,7 +70,7 @@ class Elgg_Di_DiContainer {
 	 * @param mixed  $factory The factory for the value
 	 * @param string $name    The name of the value
 	 * @return mixed
-	 * @throws Elgg_Di_FactoryUncallableException
+	 * @throws \Elgg\Di\FactoryUncallableException
 	 */
 	protected function build($factory, $name) {
 		if (is_callable($factory)) {
@@ -85,7 +86,7 @@ class Elgg_Di_DiContainer {
 				$msg .= ": " . get_class($factory[0]) . "->{$factory[1]}";
 			}
 		}
-		throw new Elgg_Di_FactoryUncallableException($msg);
+		throw new \Elgg\Di\FactoryUncallableException($msg);
 	}
 
 	/**
@@ -93,8 +94,8 @@ class Elgg_Di_DiContainer {
 	 *
 	 * @param string $name  The name of the value
 	 * @param mixed  $value The value
-	 * @return Elgg_Di_DiContainer
-	 * @throws InvalidArgumentException
+	 * @return \Elgg\Di\DiContainer
+	 * @throws \InvalidArgumentException
 	 */
 	public function setValue($name, $value) {
 		$this->remove($name);
@@ -108,12 +109,12 @@ class Elgg_Di_DiContainer {
 	 * @param string   $name     The name of the value
 	 * @param callable $callable Factory for the value
 	 * @param bool     $shared   Whether the same value should be returned for every request
-	 * @return Elgg_Di_DiContainer
-	 * @throws InvalidArgumentException
+	 * @return \Elgg\Di\DiContainer
+	 * @throws \InvalidArgumentException
 	 */
 	public function setFactory($name, $callable, $shared = true) {
 		if (!is_callable($callable, true)) {
-			throw new InvalidArgumentException('$factory must appear callable');
+			throw new \InvalidArgumentException('$factory must appear callable');
 		}
 		$this->remove($name);
 		$this->factories[$name] = array(
@@ -129,13 +130,13 @@ class Elgg_Di_DiContainer {
 	 * @param string $name       Name of the value
 	 * @param string $class_name Class name to be instantiated
 	 * @param bool   $shared     Whether the same value should be returned for every request
-	 * @return Elgg_Di_DiContainer
-	 * @throws InvalidArgumentException
+	 * @return \Elgg\Di\DiContainer
+	 * @throws \InvalidArgumentException
 	 */
 	public function setClassName($name, $class_name, $shared = true) {
 		$classname_pattern = version_compare(PHP_VERSION, '5.3', '<') ? self::CLASS_NAME_PATTERN_52 : self::CLASS_NAME_PATTERN_53;
 		if (!is_string($class_name) || !preg_match($classname_pattern, $class_name)) {
-			throw new InvalidArgumentException('Class names must be valid PHP class names');
+			throw new \InvalidArgumentException('Class names must be valid PHP class names');
 		}
 		$func = create_function('', "return new $class_name();");
 		return $this->setFactory($name, $func, $shared);
@@ -145,7 +146,7 @@ class Elgg_Di_DiContainer {
 	 * Remove a value from the container
 	 * 
 	 * @param string $name The name of the value
-	 * @return Elgg_Di_DiContainer
+	 * @return \Elgg\Di\DiContainer
 	 */
 	public function remove($name) {
 		unset($this->cache[$name]);
@@ -163,3 +164,4 @@ class Elgg_Di_DiContainer {
 		return isset($this->factories[$name]) || array_key_exists($name, $this->cache);
 	}
 }
+

--- a/engine/classes/Elgg/Di/FactoryUncallableException.php
+++ b/engine/classes/Elgg/Di/FactoryUncallableException.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Di;
 
 /**
  * Factory uncallable exception
@@ -7,4 +8,5 @@
  * 
  * @package Elgg.Core
  */
-class Elgg_Di_FactoryUncallableException extends Exception {}
+class FactoryUncallableException extends \Exception {}
+

--- a/engine/classes/Elgg/Di/MissingValueException.php
+++ b/engine/classes/Elgg/Di/MissingValueException.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Di;
 
 /**
  * Missing value exception
@@ -7,4 +8,5 @@
  * 
  * @package Elgg.Core
  */
-class Elgg_Di_MissingValueException extends Exception {}
+class MissingValueException extends \Exception {}
+

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Di;
 
 /**
  * Provides common Elgg services.
@@ -7,96 +8,96 @@
  * IDEs to auto-complete properties and understand the types returned. Extension allows us to keep
  * the container generic.
  * 
- * @property-read Elgg_ActionsService                     $actions
- * @property-read Elgg_Amd_Config                         $amdConfig
- * @property-read ElggAutoP                               $autoP
- * @property-read Elgg_AutoloadManager                    $autoloadManager
- * @property-read ElggCrypto                              $crypto
- * @property-read Elgg_Database                           $db
- * @property-read Elgg_EventsService                      $events
- * @property-read Elgg_PluginHooksService                 $hooks
- * @property-read Elgg_Logger                             $logger
- * @property-read ElggVolatileMetadataCache               $metadataCache
- * @property-read Elgg_Notifications_NotificationsService $notifications
- * @property-read Elgg_PersistentLoginService             $persistentLogin
- * @property-read Elgg_Database_QueryCounter              $queryCounter
- * @property-read Elgg_Http_Request                       $request
- * @property-read Elgg_Router                             $router
- * @property-read ElggSession                             $session
- * @property-read Elgg_ViewsService                       $views
- * @property-read Elgg_WidgetsService                     $widgets
+ * @property-read \Elgg\ActionsService                     $actions
+ * @property-read \Elgg\Amd\Config                         $amdConfig
+ * @property-read \ElggAutoP                               $autoP
+ * @property-read \Elgg\AutoloadManager                    $autoloadManager
+ * @property-read \ElggCrypto                              $crypto
+ * @property-read \Elgg\Database                           $db
+ * @property-read \Elgg\EventsService                      $events
+ * @property-read \Elgg\PluginHooksService                 $hooks
+ * @property-read \Elgg\Logger                             $logger
+ * @property-read \ElggVolatileMetadataCache               $metadataCache
+ * @property-read \Elgg\Notifications\NotificationsService $notifications
+ * @property-read \Elgg\PersistentLoginService             $persistentLogin
+ * @property-read \Elgg\Database\QueryCounter              $queryCounter
+ * @property-read \Elgg\Http\Request                       $request
+ * @property-read \Elgg\Router                             $router
+ * @property-read \ElggSession                             $session
+ * @property-read \Elgg\ViewsService                       $views
+ * @property-read \Elgg\WidgetsService                     $widgets
  * 
  * @package Elgg.Core
  * @access private
  */
-class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
+class ServiceProvider extends \Elgg\Di\DiContainer {
 
 	/**
 	 * Constructor
 	 * 
-	 * @param Elgg_AutoloadManager $autoload_manager Class autoloader
+	 * @param \Elgg\AutoloadManager $autoload_manager Class autoloader
 	 */
-	public function __construct(Elgg_AutoloadManager $autoload_manager) {
+	public function __construct(\Elgg\AutoloadManager $autoload_manager) {
 		$this->setValue('autoloadManager', $autoload_manager);
 
-		$this->setClassName('actions', 'Elgg_ActionsService');
+		$this->setClassName('actions', '\Elgg\ActionsService');
 		$this->setFactory('amdConfig', array($this, 'getAmdConfig'));
-		$this->setClassName('autoP', 'ElggAutoP');
+		$this->setClassName('autoP', '\ElggAutoP');
 		$this->setValue('context', new \Elgg\Context());
-		$this->setClassName('crypto', 'ElggCrypto');
+		$this->setClassName('crypto', '\ElggCrypto');
 		$this->setFactory('db', array($this, 'getDatabase'));
 		$this->setFactory('events', array($this, 'getEvents'));
 		$this->setFactory('hooks', array($this, 'getHooks'));
 		$this->setFactory('logger', array($this, 'getLogger'));
-		$this->setClassName('metadataCache', 'ElggVolatileMetadataCache');
+		$this->setClassName('metadataCache', '\ElggVolatileMetadataCache');
 		$this->setFactory('persistentLogin', array($this, 'getPersistentLogin'));
 		$this->setFactory('queryCounter', array($this, 'getQueryCounter'), false);
 		$this->setFactory('request', array($this, 'getRequest'));
 		$this->setFactory('router', array($this, 'getRouter'));
 		$this->setFactory('session', array($this, 'getSession'));
 		$this->setFactory('views', array($this, 'getViews'));
-		$this->setClassName('widgets', 'Elgg_WidgetsService');
+		$this->setClassName('widgets', '\Elgg\WidgetsService');
 		$this->setFactory('notifications', array($this, 'getNotifications'));
 	}
 
 	/**
 	 * Database factory
 	 *
-	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
-	 * @return Elgg_Database
+	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
+	 * @return \Elgg\Database
 	 */
-	protected function getDatabase(Elgg_Di_ServiceProvider $c) {
+	protected function getDatabase(\Elgg\Di\ServiceProvider $c) {
 		global $CONFIG;
-		return new Elgg_Database(new Elgg_Database_Config($CONFIG), $c->logger);
+		return new \Elgg\Database(new \Elgg\Database\Config($CONFIG), $c->logger);
 	}
 
 	/**
 	 * Events service factory
 	 *
-	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
-	 * @return Elgg_EventsService
+	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
+	 * @return \Elgg\EventsService
 	 */
-	protected function getEvents(Elgg_Di_ServiceProvider $c) {
+	protected function getEvents(\Elgg\Di\ServiceProvider $c) {
 		return $this->resolveLoggerDependencies('events');
 	}
 
 	/**
 	 * Logger factory
 	 * 
-	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
-	 * @return Elgg_Logger
+	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
+	 * @return \Elgg\Logger
 	 */
-	protected function getLogger(Elgg_Di_ServiceProvider $c) {
+	protected function getLogger(\Elgg\Di\ServiceProvider $c) {
 		return $this->resolveLoggerDependencies('logger');
 	}
 
 	/**
 	 * Plugin hooks service factory
 	 *
-	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
-	 * @return Elgg_PluginHooksService
+	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
+	 * @return \Elgg\PluginHooksService
 	 */
-	protected function getHooks(Elgg_Di_ServiceProvider $c) {
+	protected function getHooks(\Elgg\Di\ServiceProvider $c) {
 		return $this->resolveLoggerDependencies('hooks');
 	}
 
@@ -108,10 +109,10 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 	 * @return mixed
 	 */
 	protected function resolveLoggerDependencies($service_needed) {
-		$svcs['hooks'] = new Elgg_PluginHooksService();
-		$svcs['logger'] = new Elgg_Logger($svcs['hooks']);
+		$svcs['hooks'] = new \Elgg\PluginHooksService();
+		$svcs['logger'] = new \Elgg\Logger($svcs['hooks']);
 		$svcs['hooks']->setLogger($svcs['logger']);
-		$svcs['events'] = new Elgg_EventsService();
+		$svcs['events'] = new \Elgg\EventsService();
 		$svcs['events']->setLogger($svcs['logger']);
 
 		foreach ($svcs as $key => $service) {
@@ -123,21 +124,21 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 	/**
 	 * Views service factory
 	 * 
-	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
-	 * @return Elgg_ViewsService
+	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
+	 * @return \Elgg\ViewsService
 	 */
-	protected function getViews(Elgg_Di_ServiceProvider $c) {
-		return new Elgg_ViewsService($c->hooks, $c->logger);
+	protected function getViews(\Elgg\Di\ServiceProvider $c) {
+		return new \Elgg\ViewsService($c->hooks, $c->logger);
 	}
 
 	/**
 	 * AMD Config factory
 	 * 
-	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
-	 * @return Elgg_Amd_Config
+	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
+	 * @return \Elgg\Amd\Config
 	 */
-	protected function getAmdConfig(Elgg_Di_ServiceProvider $c) {
-		$obj = new Elgg_Amd_Config();
+	protected function getAmdConfig(\Elgg\Di\ServiceProvider $c) {
+		$obj = new \Elgg\Amd\Config();
 		$obj->setBaseUrl(_elgg_get_simplecache_root() . "js/");
 		return $obj;
 	}
@@ -145,10 +146,10 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 	/**
 	 * Session factory
 	 * 
-	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
-	 * @return ElggSession
+	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
+	 * @return \ElggSession
 	 */
-	protected function getSession(Elgg_Di_ServiceProvider $c) {
+	protected function getSession(\Elgg\Di\ServiceProvider $c) {
 		global $CONFIG;
 
 		// account for difference of session_get_cookie_params() and ini key names
@@ -160,9 +161,9 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 			}
 		}
 
-		$handler = new Elgg_Http_DatabaseSessionHandler($c->db);
-		$storage = new Elgg_Http_NativeSessionStorage($params, $handler);
-		$session = new ElggSession($storage);
+		$handler = new \Elgg\Http\DatabaseSessionHandler($c->db);
+		$storage = new \Elgg\Http\NativeSessionStorage($params, $handler);
+		$session = new \ElggSession($storage);
 
 		return $session;
 	}
@@ -170,59 +171,60 @@ class Elgg_Di_ServiceProvider extends Elgg_Di_DiContainer {
 	/**
 	 * Request factory
 	 * 
-	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
-	 * @return Elgg_Http_Request
+	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
+	 * @return \Elgg\Http\Request
 	 */
-	protected function getRequest(Elgg_Di_ServiceProvider $c) {
-		return Elgg_Http_Request::createFromGlobals();
+	protected function getRequest(\Elgg\Di\ServiceProvider $c) {
+		return \Elgg\Http\Request::createFromGlobals();
 	}
 
 	/**
 	 * Router factory
 	 * 
-	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
-	 * @return Elgg_Router
+	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
+	 * @return \Elgg\Router
 	 */
-	protected function getRouter(Elgg_Di_ServiceProvider $c) {
+	protected function getRouter(\Elgg\Di\ServiceProvider $c) {
 		// TODO(evan): Init routes from plugins or cache
-		return new Elgg_Router($c->hooks);
+		return new \Elgg\Router($c->hooks);
 	}
 
 	/**
 	 * Notification service factory
 	 * 
-	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
-	 * @return Elgg_Notifications_NotificationsService
+	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
+	 * @return \Elgg\Notifications\NotificationsService
 	 */
-	protected function getNotifications(Elgg_Di_ServiceProvider $c) {
+	protected function getNotifications(\Elgg\Di\ServiceProvider $c) {
 		// @todo move queue in service provider
-		$queue = new Elgg_Queue_DatabaseQueue(Elgg_Notifications_NotificationsService::QUEUE_NAME, $c->db);
-		$sub = new Elgg_Notifications_SubscriptionsService($c->db);
+		$queue = new \Elgg\Queue\DatabaseQueue(\Elgg\Notifications\NotificationsService::QUEUE_NAME, $c->db);
+		$sub = new \Elgg\Notifications\SubscriptionsService($c->db);
 		$access = elgg_get_access_object();
-		return new Elgg_Notifications_NotificationsService($sub, $queue, $c->hooks, $access);
+		return new \Elgg\Notifications\NotificationsService($sub, $queue, $c->hooks, $access);
 	}
 
 	/**
 	 * Persistent login service factory
 	 *
-	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
-	 * @return Elgg_PersistentLoginService
+	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
+	 * @return \Elgg\PersistentLoginService
 	 */
-	protected function getPersistentLogin(Elgg_Di_ServiceProvider $c) {
+	protected function getPersistentLogin(\Elgg\Di\ServiceProvider $c) {
 		$cookies_config = elgg_get_config('cookies');
 		$remember_me_cookies_config = $cookies_config['remember_me'];
 		$cookie_name = $remember_me_cookies_config['name'];
 		$cookie_token = $c->request->cookies->get($cookie_name, '');
-		return new Elgg_PersistentLoginService($c->db, $c->session, $c->crypto, $remember_me_cookies_config, $cookie_token);
+		return new \Elgg\PersistentLoginService($c->db, $c->session, $c->crypto, $remember_me_cookies_config, $cookie_token);
 	}
 
 	/**
 	 * Query counter factory
 	 *
-	 * @param Elgg_Di_ServiceProvider $c Dependency injection container
-	 * @return Elgg_Database_QueryCounter
+	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
+	 * @return \Elgg\Database\QueryCounter
 	 */
-	protected function getQueryCounter(Elgg_Di_ServiceProvider $c) {
-		return new Elgg_Database_QueryCounter($c->db);
+	protected function getQueryCounter(\Elgg\Di\ServiceProvider $c) {
+		return new \Elgg\Database\QueryCounter($c->db);
 	}
 }
+

--- a/engine/classes/Elgg/EntityDirLocator.php
+++ b/engine/classes/Elgg/EntityDirLocator.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 
 /**
  * Locate the relative path of an entity's data dir.
@@ -12,7 +13,7 @@
  * 
  * @package Elgg.Core
  */
-class Elgg_EntityDirLocator {
+class EntityDirLocator {
 
 	/**
 	 * Number of entries per matrix dir. DO NOT CHANGE!
@@ -24,14 +25,14 @@ class Elgg_EntityDirLocator {
 	 * 
 	 * @param int $guid GUID of the entity.
 	 *
-	 * @throws InvalidArgumentException
+	 * @throws \InvalidArgumentException
 	 */
 	public function __construct($guid) {
 		$guid = (int) $guid;
 
 		if (!$guid || $guid < 1) {
 			// Don't throw a ClassException to keep this class completely atomic.
-			throw new InvalidArgumentException("GUIDs must be integers > 0.");
+			throw new \InvalidArgumentException("GUIDs must be integers > 0.");
 		}
 
 		$this->guid = $guid;

--- a/engine/classes/Elgg/EventsService.php
+++ b/engine/classes/Elgg/EventsService.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 
 /**
  * Service for Events
@@ -9,7 +10,7 @@
  * @subpackage Hooks
  * @since      1.9.0
  */
-class Elgg_EventsService extends Elgg_HooksRegistrationService {
+class EventsService extends \Elgg\HooksRegistrationService {
 
 	const OPTION_STOPPABLE = 'stoppable';
 	const OPTION_DEPRECATION_MESSAGE = 'deprecation_message';

--- a/engine/classes/Elgg/GroupItemVisibility.php
+++ b/engine/classes/Elgg/GroupItemVisibility.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 
 /**
  * Determines if otherwise visible items should be hidden from a user due to group
@@ -9,7 +10,7 @@
  *
  * @access private
  */
-class Elgg_GroupItemVisibility {
+class GroupItemVisibility {
 
 	const REASON_NON_MEMBER = 'non_member';
 	const REASON_LOGGED_OUT = 'logged_out';
@@ -31,7 +32,7 @@ class Elgg_GroupItemVisibility {
 	 * @param int  $container_guid GUID of a container (may/may not be a group)
 	 * @param bool $use_cache      Use the cached result of
 	 *
-	 * @return Elgg_GroupItemVisibility
+	 * @return \Elgg\GroupItemVisibility
 	 *
 	 * @todo Make this faster, considering it must run for every river item.
 	 */
@@ -42,7 +43,7 @@ class Elgg_GroupItemVisibility {
 		static $cache = array();
 
 		if (!$container_guid) {
-			return new Elgg_GroupItemVisibility();
+			return new \Elgg\GroupItemVisibility();
 		}
 
 		$user = elgg_get_logged_in_user_entity();
@@ -64,13 +65,13 @@ class Elgg_GroupItemVisibility {
 				elgg_set_ignore_access($prev_access);
 			}
 
-			$ret = new Elgg_GroupItemVisibility();
+			$ret = new \Elgg\GroupItemVisibility();
 
-			if ($container && $container instanceof ElggGroup) {
-				/* @var ElggGroup $container */
+			if ($container && $container instanceof \ElggGroup) {
+				/* @var \ElggGroup $container */
 
 				if ($is_visible) {
-					if ($container->getContentAccessMode() === ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY) {
+					if ($container->getContentAccessMode() === \ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY) {
 						if ($user) {
 							if (!$container->isMember($user) && !$user->isAdmin()) {
 								$ret->shouldHideItems = true;
@@ -100,3 +101,4 @@ class Elgg_GroupItemVisibility {
 		return $return;
 	}
 }
+

--- a/engine/classes/Elgg/HooksRegistrationService.php
+++ b/engine/classes/Elgg/HooksRegistrationService.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -11,22 +12,22 @@
  * @subpackage Hooks
  * @since      1.9.0
  */
-abstract class Elgg_HooksRegistrationService {
+abstract class HooksRegistrationService {
 	
 	private $handlers = array();
 
 	/**
-	 * @var Elgg_Logger
+	 * @var \Elgg\Logger
 	 */
 	protected $logger;
 
 	/**
 	 * Set a logger instance, e.g. for reporting uncallable handlers
 	 *
-	 * @param Elgg_Logger $logger The logger
+	 * @param \Elgg\Logger $logger The logger
 	 * @return self
 	 */
-	public function setLogger(Elgg_Logger $logger = null) {
+	public function setLogger(\Elgg\Logger $logger = null) {
 		$this->logger = $logger;
 		return $this;
 	}
@@ -120,7 +121,7 @@ abstract class Elgg_HooksRegistrationService {
 	 * @param string $name The name of the hook
 	 * @param string $type The type of the hook
 	 * @return array
-	 * @see Elgg_HooksRegistrationService::getAllHandlers()
+	 * @see \Elgg\HooksRegistrationService::getAllHandlers()
 	 */
 	protected function getOrderedHandlers($name, $type) {
 		$handlers = array();
@@ -165,8 +166,8 @@ abstract class Elgg_HooksRegistrationService {
 			}
 			return "(" . get_class($callable[0]) . ")->{$callable[1]}";
 		}
-		if ($callable instanceof Closure) {
-			$ref = new ReflectionFunction($callable);
+		if ($callable instanceof \Closure) {
+			$ref = new \ReflectionFunction($callable);
 			$file = $ref->getFileName();
 			$line = $ref->getStartLine();
 			return "(Closure {$file}:{$line})";
@@ -177,3 +178,4 @@ abstract class Elgg_HooksRegistrationService {
 		return "(unknown)";
 	}
 }
+

--- a/engine/classes/Elgg/Http/DatabaseSessionHandler.php
+++ b/engine/classes/Elgg/Http/DatabaseSessionHandler.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Http;
 
 /**
  * Database session handler
@@ -8,17 +9,17 @@
  * @package    Elgg.Core
  * @subpackage Http
  */
-class Elgg_Http_DatabaseSessionHandler implements Elgg_Http_SessionHandler {
+class DatabaseSessionHandler implements \Elgg\Http\SessionHandler {
 
-	/** @var Elgg_Database $db */
+	/** @var \Elgg\Database $db */
 	protected $db;
 
 	/**
 	 * Constructor
 	 *
-	 * @param Elgg_Database $db The database
+	 * @param \Elgg\Database $db The database
 	 */
-	public function __construct(Elgg_Database $db) {
+	public function __construct(\Elgg\Database $db) {
 		$this->db = $db;
 	}
 
@@ -91,3 +92,4 @@ class Elgg_Http_DatabaseSessionHandler implements Elgg_Http_SessionHandler {
 	}
 
 }
+

--- a/engine/classes/Elgg/Http/MockSessionHandler.php
+++ b/engine/classes/Elgg/Http/MockSessionHandler.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Http;
 
 /**
  * Mock session handler
@@ -8,7 +9,7 @@
  * @package    Elgg.Core
  * @subpackage Http
  */
-class Elgg_Http_MockSessionHandler implements Elgg_Http_SessionHandler {
+class MockSessionHandler implements \Elgg\Http\SessionHandler {
 
 	/**
 	 * {@inheritDoc}
@@ -53,3 +54,4 @@ class Elgg_Http_MockSessionHandler implements Elgg_Http_SessionHandler {
 	}
 
 }
+

--- a/engine/classes/Elgg/Http/MockSessionStorage.php
+++ b/engine/classes/Elgg/Http/MockSessionStorage.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Http;
 
 /**
  * Based on Symfony2's NativeSessionStorage.
@@ -32,7 +33,7 @@
  * @package    Elgg.Core
  * @subpackage Http
  */
-class Elgg_Http_MockSessionStorage implements Elgg_Http_SessionStorage {
+class MockSessionStorage implements \Elgg\Http\SessionStorage {
 
 	/** @var boolean */
 	protected $started = false;
@@ -94,7 +95,7 @@ class Elgg_Http_MockSessionStorage implements Elgg_Http_SessionStorage {
 	 */
 	public function save() {
 		if (!$this->started || $this->closed) {
-			throw new RuntimeException("Trying to save a session that was not started yet or was already closed");
+			throw new \RuntimeException("Trying to save a session that was not started yet or was already closed");
 		}
 		$this->closed = false;
 	}
@@ -118,7 +119,7 @@ class Elgg_Http_MockSessionStorage implements Elgg_Http_SessionStorage {
 	 */
 	public function setId($id) {
 		if ($this->started) {
-			throw new RuntimeException('Cannot change the ID of an active session');
+			throw new \RuntimeException('Cannot change the ID of an active session');
 		}
 
 		$this->id = $id;
@@ -230,3 +231,4 @@ class Elgg_Http_MockSessionStorage implements Elgg_Http_SessionStorage {
 	}
 
 }
+

--- a/engine/classes/Elgg/Http/NativeSessionStorage.php
+++ b/engine/classes/Elgg/Http/NativeSessionStorage.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Http;
 
 /**
  * Based on Symfony2's NativeSessionStorage.
@@ -32,7 +33,7 @@
  * @package    Elgg.Core
  * @subpackage Http
  */
-class Elgg_Http_NativeSessionStorage implements Elgg_Http_SessionStorage {
+class NativeSessionStorage implements \Elgg\Http\SessionStorage {
 
 	/** @var boolean */
 	protected $started = false;
@@ -75,10 +76,10 @@ class Elgg_Http_NativeSessionStorage implements Elgg_Http_SessionStorage {
 	 * upload_progress.freq, "1%"
 	 * upload_progress.min-freq, "1"
 	 * 
-	 * @param array                    $options Session config options
-	 * @param Elgg_Http_SessionHandler $handler Session handler
+	 * @param array                     $options Session config options
+	 * @param \Elgg\Http\SessionHandler $handler Session handler
 	 */
-	public function __construct(array $options = array(), Elgg_Http_SessionHandler $handler = null) {
+	public function __construct(array $options = array(), \Elgg\Http\SessionHandler $handler = null) {
 		$this->setOptions($options);
 		$this->setHandler($handler);
 	}
@@ -92,7 +93,7 @@ class Elgg_Http_NativeSessionStorage implements Elgg_Http_SessionStorage {
 		}
 
 		if (!session_start()) {
-			throw new RuntimeException('Failed to start the session');
+			throw new \RuntimeException('Failed to start the session');
 		}
 
 		$this->started = true;
@@ -144,7 +145,7 @@ class Elgg_Http_NativeSessionStorage implements Elgg_Http_SessionStorage {
 	 */
 	public function setId($id) {
 		if ($this->started) {
-			throw new RuntimeException('Cannot change the ID of an active session');
+			throw new \RuntimeException('Cannot change the ID of an active session');
 		}
 
 		session_id($id);
@@ -277,7 +278,7 @@ class Elgg_Http_NativeSessionStorage implements Elgg_Http_SessionStorage {
 	/**
 	 * Set the session handler class with PHP
 	 * 
-	 * @param Elgg_Http_SessionHandler $handler Handler object
+	 * @param \Elgg\Http\SessionHandler $handler Handler object
 	 * @return void
 	 */
 	protected function setHandler($handler) {
@@ -291,3 +292,4 @@ class Elgg_Http_NativeSessionStorage implements Elgg_Http_SessionStorage {
 	}
 
 }
+

--- a/engine/classes/Elgg/Http/ParameterBag.php
+++ b/engine/classes/Elgg/Http/ParameterBag.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Http;
 
 /**
  * Based on Symfony2's ParameterBag.
@@ -32,7 +33,7 @@
  * @package    Elgg.Core
  * @subpackage Http
  */
-class Elgg_Http_ParameterBag implements IteratorAggregate, Countable {
+class ParameterBag implements \IteratorAggregate, \Countable {
 
 	/**
 	 * Parameter storage.
@@ -98,7 +99,7 @@ class Elgg_Http_ParameterBag implements IteratorAggregate, Countable {
 	 *
 	 * @return mixed
 	 *
-	 * @throws InvalidArgumentException
+	 * @throws \InvalidArgumentException
 	 */
 	public function get($path, $default = null, $deep = false) {
 		if (!$deep || false === $pos = strpos($path, '[')) {
@@ -117,13 +118,13 @@ class Elgg_Http_ParameterBag implements IteratorAggregate, Countable {
 
 			if ('[' === $char) {
 				if (null !== $currentKey) {
-					throw new InvalidArgumentException(sprintf('Malformed path. Unexpected "[" at position %d.', $i));
+					throw new \InvalidArgumentException(sprintf('Malformed path. Unexpected "[" at position %d.', $i));
 				}
 
 				$currentKey = '';
 			} elseif (']' === $char) {
 				if (null === $currentKey) {
-					throw new InvalidArgumentException(sprintf('Malformed path. Unexpected "]" at position %d.', $i));
+					throw new \InvalidArgumentException(sprintf('Malformed path. Unexpected "]" at position %d.', $i));
 				}
 
 				if (!is_array($value) || !array_key_exists($currentKey, $value)) {
@@ -134,7 +135,7 @@ class Elgg_Http_ParameterBag implements IteratorAggregate, Countable {
 				$currentKey = null;
 			} else {
 				if (null === $currentKey) {
-					throw new InvalidArgumentException(sprintf('Malformed path. Unexpected "%s" at position %d.', $char, $i));
+					throw new \InvalidArgumentException(sprintf('Malformed path. Unexpected "%s" at position %d.', $char, $i));
 				}
 
 				$currentKey .= $char;
@@ -142,7 +143,7 @@ class Elgg_Http_ParameterBag implements IteratorAggregate, Countable {
 		}
 
 		if (null !== $currentKey) {
-			throw new InvalidArgumentException(sprintf('Malformed path. Path must end with "]".'));
+			throw new \InvalidArgumentException(sprintf('Malformed path. Path must end with "]".'));
 		}
 
 		return $value;
@@ -265,10 +266,10 @@ class Elgg_Http_ParameterBag implements IteratorAggregate, Countable {
 	/**
 	 * Returns an iterator for parameters.
 	 *
-	 * @return ArrayIterator
+	 * @return \ArrayIterator
 	 */
 	public function getIterator() {
-		return new ArrayIterator($this->parameters);
+		return new \ArrayIterator($this->parameters);
 	}
 
 	/**
@@ -281,3 +282,4 @@ class Elgg_Http_ParameterBag implements IteratorAggregate, Countable {
 	}
 
 }
+

--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Http;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -34,39 +35,39 @@
  * @since      1.9.0
  * @access private
  */
-class Elgg_Http_Request {
+class Request {
 	/**
-	 * @var Elgg_Http_ParameterBag GET parameters
+	 * @var \Elgg\Http\ParameterBag GET parameters
 	 */
 	public $query;
 
 	/**
 	 *
-	 * @var Elgg_Http_ParameterBag POST parameters
+	 * @var \Elgg\Http\ParameterBag POST parameters
 	 */
 	public $request;
 
 	/**
 	 *
-	 * @var Elgg_Http_ParameterBag COOKIE parameters
+	 * @var \Elgg\Http\ParameterBag COOKIE parameters
 	 */
 	public $cookies;
 
 	/**
 	 *
-	 * @var Elgg_Http_ParameterBag FILES parameters
+	 * @var \Elgg\Http\ParameterBag FILES parameters
 	 */
 	public $files;
 
 	/**
 	 *
-	 * @var Elgg_Http_ParameterBag SERVER parameters
+	 * @var \Elgg\Http\ParameterBag SERVER parameters
 	 */
 	public $server;
 
 	/**
 	 *
-	 * @var Elgg_Http_ParameterBag Header parameters
+	 * @var \Elgg\Http\ParameterBag Header parameters
 	 */
 	public $headers;
 
@@ -111,25 +112,25 @@ class Elgg_Http_Request {
 	 */
 	protected function initialize(array $query = array(), array $request = array(),
 			array $cookies = array(), array $files = array(), array $server = array()) {
-		$this->query = new Elgg_Http_ParameterBag($this->stripSlashesIfMagicQuotes($query));
-		$this->request = new Elgg_Http_ParameterBag($this->stripSlashesIfMagicQuotes($request));
-		$this->cookies = new Elgg_Http_ParameterBag($this->stripSlashesIfMagicQuotes($cookies));
+		$this->query = new \Elgg\Http\ParameterBag($this->stripSlashesIfMagicQuotes($query));
+		$this->request = new \Elgg\Http\ParameterBag($this->stripSlashesIfMagicQuotes($request));
+		$this->cookies = new \Elgg\Http\ParameterBag($this->stripSlashesIfMagicQuotes($cookies));
 		// Symfony uses FileBag so this will change in next Elgg version
-		$this->files = new Elgg_Http_ParameterBag($files);
-		$this->server = new Elgg_Http_ParameterBag($server);
+		$this->files = new \Elgg\Http\ParameterBag($files);
+		$this->server = new \Elgg\Http\ParameterBag($server);
 	
 		$headers = $this->prepareHeaders();
 		// Symfony uses HeaderBag so this will change in next Elgg version
-		$this->headers = new Elgg_Http_ParameterBag($headers);
+		$this->headers = new \Elgg\Http\ParameterBag($headers);
 	}
 
 	/**
 	 * Creates a request from PHP's globals
 	 *
-	 * @return Elgg_Http_Request
+	 * @return \Elgg\Http\Request
 	 */
 	public static function createFromGlobals() {
-		return new Elgg_Http_Request($_GET, $_POST, $_COOKIE, $_FILES, $_SERVER);
+		return new \Elgg\Http\Request($_GET, $_POST, $_COOKIE, $_FILES, $_SERVER);
 	}
 
 	/**
@@ -145,7 +146,7 @@ class Elgg_Http_Request {
 	 * @param array  $files      The request files ($_FILES)
 	 * @param array  $server     The server parameters ($_SERVER)
 	 *
-	 * @return Elgg_Http_Request
+	 * @return \Elgg\Http\Request
 	 */
 	public static function create($uri, $method = 'GET', $parameters = array(), $cookies = array(), $files = array(), $server = array()) {
 		$server = array_merge(array(
@@ -218,7 +219,7 @@ class Elgg_Http_Request {
 		$server['REQUEST_URI'] = $components['path'] . ('' !== $queryString ? '?' . $queryString : '');
 		$server['QUERY_STRING'] = $queryString;
 
-		return new Elgg_Http_Request($query, $request, $cookies, $files, $server);
+		return new \Elgg\Http\Request($query, $request, $cookies, $files, $server);
 	}
 
 	/**
@@ -355,7 +356,7 @@ class Elgg_Http_Request {
 	 *
 	 * @return string
 	 *
-	 * @throws UnexpectedValueException when the host name is invalid
+	 * @throws \UnexpectedValueException when the host name is invalid
 	 */
 	public function getHost() {
 		if (!$host = $this->headers->get('HOST')) {
@@ -372,7 +373,7 @@ class Elgg_Http_Request {
 		// SERVER_NAME too can come from the user)
 		// check that it does not contain forbidden characters (see RFC 952 and RFC 2181)
 		if ($host && !preg_match('/^\[?(?:[a-zA-Z0-9-:\]_]+\.?)+$/', $host)) {
-			throw new UnexpectedValueException('Invalid Host');
+			throw new \UnexpectedValueException('Invalid Host');
 		}
 
 		return $host;
@@ -449,7 +450,7 @@ class Elgg_Http_Request {
 	 * @return string|null A normalized query string for the Request
 	 */
 	public function getQueryString() {
-		$qs = Elgg_Http_Request::normalizeQueryString($this->server->get('QUERY_STRING'));
+		$qs = \Elgg\Http\Request::normalizeQueryString($this->server->get('QUERY_STRING'));
 
 		return '' === $qs ? null : $qs;
 	}
@@ -457,7 +458,7 @@ class Elgg_Http_Request {
 	/**
 	 * Get URL segments from the path info
 	 *
-	 * @see Elgg_Http_Request::getPathInfo()
+	 * @see \Elgg\Http\Request::getPathInfo()
 	 *
 	 * @return array
 	 */
@@ -473,7 +474,7 @@ class Elgg_Http_Request {
 	/**
 	 * Get first URL segment from the path info
 	 *
-	 * @see Elgg_Http_Request::getUrlSegments()
+	 * @see \Elgg\Http\Request::getUrlSegments()
 	 *
 	 * @return string
 	 */
@@ -684,3 +685,4 @@ class Elgg_Http_Request {
 	}
 
 }
+

--- a/engine/classes/Elgg/Http/SessionHandler.php
+++ b/engine/classes/Elgg/Http/SessionHandler.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Http;
 
 /**
  * Session handler interface
@@ -10,7 +11,7 @@
  * @package    Elgg.Core
  * @subpackage Http
  */
-interface Elgg_Http_SessionHandler {
+interface SessionHandler {
 
 	/**
 	 * Re-initialize existing session, or creates a new one.

--- a/engine/classes/Elgg/Http/SessionStorage.php
+++ b/engine/classes/Elgg/Http/SessionStorage.php
@@ -1,4 +1,6 @@
 <?php
+namespace Elgg\Http;
+
 /**
  * Based on Symfony2's SessionStorageInterface and AttributeBagInterface.
  *
@@ -31,13 +33,13 @@
  * @package    Elgg.Core
  * @subpackage Http
  */
-interface Elgg_Http_SessionStorage {
+interface SessionStorage {
 
 	/**
 	 * Starts the session.
 	 *
 	 * @return boolean True if started.
-	 * @throws RuntimeException If something goes wrong starting the session.
+	 * @throws \RuntimeException If something goes wrong starting the session.
 	 */
 	public function start();
 
@@ -97,7 +99,7 @@ interface Elgg_Http_SessionStorage {
 	 *
 	 * @return boolean True if session regenerated, false if error
 	 *
-	 * @throws RuntimeException If an error occurs while regenerating this storage
+	 * @throws \RuntimeException If an error occurs while regenerating this storage
 	 */
 	public function regenerate($destroy = false, $lifetime = null);
 
@@ -110,7 +112,7 @@ interface Elgg_Http_SessionStorage {
 	 * it should actually persist the session data if required.
 	 *
 	 * @return void
-	 * @throws RuntimeException If the session is saved without being started,
+	 * @throws \RuntimeException If the session is saved without being started,
 	 *                          or if the session is already closed.
 	 */
 	public function save();

--- a/engine/classes/Elgg/Logger.php
+++ b/engine/classes/Elgg/Logger.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -11,7 +12,7 @@
  * @subpackage Logging
  * @since      1.9.0
  */
-class Elgg_Logger {
+class Logger {
 
 	const OFF = 0;
 	const ERROR = 400;
@@ -33,15 +34,15 @@ class Elgg_Logger {
 	/** @var bool $display Display to user? */
 	protected $display = false;
 
-	/** @var Elgg_PluginHooksService $hooks */
+	/** @var \Elgg\PluginHooksService $hooks */
 	protected $hooks;
 
 	/**
 	 * Constructor
 	 *
-	 * @param Elgg_PluginHooksService $hooks Hooks service
+	 * @param \Elgg\PluginHooksService $hooks Hooks service
 	 */
-	public function __construct(Elgg_PluginHooksService $hooks) {
+	public function __construct(\Elgg\PluginHooksService $hooks) {
 		$this->hooks = $hooks;
 	}
 
@@ -204,3 +205,4 @@ class Elgg_Logger {
 		}
 	}
 }
+

--- a/engine/classes/Elgg/Notifications/Event.php
+++ b/engine/classes/Elgg/Notifications/Event.php
@@ -1,12 +1,12 @@
 <?php
+namespace Elgg\Notifications;
 /**
  * Notification event
  * 
  * @package    Elgg.Core
  * @subpackage Notifications
- * @since      1.9.0
  */
-class Elgg_Notifications_Event {
+class Event {
 	/* @var string The name of the action/event */
 	protected $action;
 
@@ -26,12 +26,13 @@ class Elgg_Notifications_Event {
 	/**
 	 * Create a notification event
 	 *
-	 * @param ElggData $object The object of the event (ElggEntity)
-	 * @param string   $action The name of the action (default: create)
-	 * @param ElggUser $actor  The user that caused the event (default: logged in user)
-	 * @throws InvalidArgumentException
+	 * @param \ElggData $object The object of the event (\ElggEntity)
+	 * @param string    $action The name of the action (default: create)
+	 * @param \ElggUser $actor  The user that caused the event (default: logged in user)
+	 * 
+	 * @throws \InvalidArgumentException
 	 */
-	public function __construct(ElggData $object, $action, ElggUser $actor = null) {
+	public function __construct(\ElggData $object, $action, \ElggUser $actor = null) {
 		if (elgg_instanceof($object)) {
 			$this->object_type = $object->getType();
 			$this->object_subtype = $object->getSubtype();
@@ -54,7 +55,7 @@ class Elgg_Notifications_Event {
 	/**
 	 * Get the actor of the event
 	 *
-	 * @return ElggUser
+	 * @return \ElggUser
 	 */
 	public function getActor() {
 		return get_entity($this->actor_guid);
@@ -72,7 +73,7 @@ class Elgg_Notifications_Event {
 	/**
 	 * Get the object of the event
 	 *
-	 * @return ElggData
+	 * @return \ElggData
 	 */
 	public function getObject() {
 		switch ($this->object_type) {
@@ -110,3 +111,13 @@ class Elgg_Notifications_Event {
 		return "{$this->action}:{$this->object_type}:{$this->object_subtype}";
 	}
 }
+
+/**
+ * Notification event
+ * 
+ * @package    Elgg.Core
+ * @subpackage Notifications
+ * @since      1.9.0
+ */
+class Elgg_Notifications_Event extends \Elgg\Notifications\Event {}
+

--- a/engine/classes/Elgg/Notifications/Notification.php
+++ b/engine/classes/Elgg/Notifications/Notification.php
@@ -1,16 +1,18 @@
 <?php
+namespace Elgg\Notifications;
+
 /**
  * Notification container
  * 
  * @package    Elgg.Core
  * @subpackage Notifications
- * @since      1.9.0
+ * @since      1.10
  */
-class Elgg_Notifications_Notification {
-	/** @var ElggEntity The entity causing or creating the notification */
+class Notification {
+	/** @var \ElggEntity The entity causing or creating the notification */
 	protected $from;
 
-	/** @var ElggUser The user receiving the notification */
+	/** @var \ElggUser The user receiving the notification */
 	protected $to;
 
 	/** @var string A single sentence summary string */
@@ -31,21 +33,21 @@ class Elgg_Notifications_Notification {
 	/**
 	 * Create a notification
 	 *
-	 * @param ElggEntity $from     The entity sending the notification (usually the site)
-	 * @param ElggEntity $to       The entity receiving the notification
-	 * @param string     $language The language code for the notification
-	 * @param string     $subject  The subject of the notification
-	 * @param string     $body     The body of the notification
-	 * @param string     $summary  Optional summary of the notification
-	 * @param array      $params   Optional array of parameters
-	 * @throws InvalidArgumentException
+	 * @param \ElggEntity $from     The entity sending the notification (usually the site)
+	 * @param \ElggEntity $to       The entity receiving the notification
+	 * @param string      $language The language code for the notification
+	 * @param string      $subject  The subject of the notification
+	 * @param string      $body     The body of the notification
+	 * @param string      $summary  Optional summary of the notification
+	 * @param array       $params   Optional array of parameters
+	 * @throws \InvalidArgumentException
 	 */
-	public function __construct(ElggEntity $from, ElggEntity $to, $language, $subject, $body, $summary = '', array $params = array()) {
+	public function __construct(\ElggEntity $from, \ElggEntity $to, $language, $subject, $body, $summary = '', array $params = array()) {
 		if (!$from) {
-			throw new InvalidArgumentException('$from is not a valid ElggEntity');
+			throw new \InvalidArgumentException('$from is not a valid \ElggEntity');
 		}
 		if (!$to) {
-			throw new InvalidArgumentException('$to is not a valid ElggEntity');
+			throw new \InvalidArgumentException('$to is not a valid \ElggEntity');
 		}
 		$this->from = $from;
 		$this->to = $to;
@@ -59,7 +61,7 @@ class Elgg_Notifications_Notification {
 	/**
 	 * Get the sender entity
 	 *
-	 * @return ElggEntity
+	 * @return \ElggEntity
 	 */
 	public function getSender() {
 		return $this->from;
@@ -77,7 +79,7 @@ class Elgg_Notifications_Notification {
 	/**
 	 * Get the recipient entity
 	 *
-	 * @return ElggEntity
+	 * @return \ElggEntity
 	 */
 	public function getRecipient() {
 		return $this->to;
@@ -92,3 +94,14 @@ class Elgg_Notifications_Notification {
 		return $this->to->guid;
 	}
 }
+
+/**
+ * Notification container
+ * 
+ * @package    Elgg.Core
+ * @subpackage Notifications
+ * @since      1.9.0
+ * 
+ * @deprecated 1.10 Use \Elgg\Notifications\Notification instead
+ */
+class Elgg_Notifications_Notification extends \Elgg\Notifications\Notification {}

--- a/engine/classes/Elgg/Notifications/NotificationsService.php
+++ b/engine/classes/Elgg/Notifications/NotificationsService.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Notifications;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -9,20 +10,20 @@
  * @subpackage Notifications
  * @since      1.9.0
  */
-class Elgg_Notifications_NotificationsService {
+class NotificationsService {
 
 	const QUEUE_NAME = 'notifications';
 
-	/** @var Elgg_Notifications_SubscriptionsService */
+	/** @var \Elgg\Notifications\SubscriptionsService */
 	protected $subscriptions;
 
-	/** @var Elgg_Queue_Queue */
+	/** @var \Elgg\Queue\Queue */
 	protected $queue;
 
-	/** @var Elgg_PluginHooksService */
+	/** @var \Elgg\PluginHooksService */
 	protected $hooks;
 
-	/** @var Elgg_Access */
+	/** @var \Elgg\Access */
 	protected $access;
 
 	/** @var array Registered notification events */
@@ -40,13 +41,13 @@ class Elgg_Notifications_NotificationsService {
 	/**
 	 * Constructor
 	 *
-	 * @param Elgg_Notifications_SubscriptionsService $subscriptions Subscription service
-	 * @param Elgg_Queue_Queue                        $queue         Queue
-	 * @param Elgg_PluginHooksService                 $hooks         Plugin hook service
-	 * @param Elgg_Access                             $access        Access control service
+	 * @param \Elgg\Notifications\SubscriptionsService $subscriptions Subscription service
+	 * @param \Elgg\Queue\Queue                        $queue         Queue
+	 * @param \Elgg\PluginHooksService                 $hooks         Plugin hook service
+	 * @param \Elgg\Access                             $access        Access control service
 	 */
-	public function __construct(Elgg_Notifications_SubscriptionsService $subscriptions,
-			Elgg_Queue_Queue $queue, Elgg_PluginHooksService $hooks, Elgg_Access $access) {
+	public function __construct(\Elgg\Notifications\SubscriptionsService $subscriptions,
+			\Elgg\Queue\Queue $queue, \Elgg\PluginHooksService $hooks, \Elgg\Access $access) {
 		$this->subscriptions = $subscriptions;
 		$this->queue = $queue;
 		$this->hooks = $hooks;
@@ -128,12 +129,12 @@ class Elgg_Notifications_NotificationsService {
 	 * 
 	 * @param string   $action Action name
 	 * @param string   $type   Type of the object of the action
-	 * @param ElggData $object The object of the action 
+	 * @param \ElggData $object The object of the action 
 	 * @return void
 	 * @access private
 	 */
 	public function enqueueEvent($action, $type, $object) {
-		if ($object instanceof ElggData) {
+		if ($object instanceof \ElggData) {
 			$object_type = $object->getType();
 			$object_subtype = $object->getSubtype();
 
@@ -153,7 +154,7 @@ class Elgg_Notifications_NotificationsService {
 			}
 
 			if ($registered) {
-				$this->queue->enqueue(new Elgg_Notifications_Event($object, $action));
+				$this->queue->enqueue(new \Elgg\Notifications\Event($object, $action));
 			}
 		}
 	}
@@ -208,7 +209,7 @@ class Elgg_Notifications_NotificationsService {
 	/**
 	 * Sends the notifications based on subscriptions
 	 *
-	 * @param Elgg_Notifications_Event $event         Notification event
+	 * @param \Elgg\Notifications\Event $event         Notification event
 	 * @param array                    $subscriptions Subscriptions for this event
 	 * @return int The number of notifications handled
 	 * @access private
@@ -235,13 +236,13 @@ class Elgg_Notifications_NotificationsService {
 	/**
 	 * Send a notification to a subscriber
 	 *
-	 * @param Elgg_Notifications_Event $event  The notification event
+	 * @param \Elgg\Notifications\Event $event  The notification event
 	 * @param int                      $guid   The guid of the subscriber
 	 * @param string                   $method The notification method
 	 * @return bool
 	 * @access private
 	 */
-	protected function sendNotification(Elgg_Notifications_Event $event, $guid, $method) {
+	protected function sendNotification(\Elgg\Notifications\Event $event, $guid, $method) {
 
 		$recipient = get_user($guid);
 		if (!$recipient || $recipient->isBanned()) {
@@ -274,7 +275,7 @@ class Elgg_Notifications_NotificationsService {
 
 		$subject = elgg_echo('notification:subject', array($actor->name), $language);
 		$body = elgg_echo('notification:body', array($object->getURL()), $language);
-		$notification = new Elgg_Notifications_Notification($event->getActor(), $recipient, $language, $subject, $body, '', $params);
+		$notification = new \Elgg\Notifications\Notification($event->getActor(), $recipient, $language, $subject, $body, '', $params);
 
 		$type = 'notification:' . $event->getDescription();
 		if ($this->hooks->hasHandler('prepare', $type)) {
@@ -344,12 +345,12 @@ class Elgg_Notifications_NotificationsService {
 	/**
 	 * Get the notification body using a pre-Elgg 1.9 plugin hook
 	 * 
-	 * @param Elgg_Notifications_Notification $notification Notification
-	 * @param Elgg_Notifications_Event        $event        Event
-	 * @param string                          $method       Method
-	 * @return Elgg_Notifications_Notification
+	 * @param \Elgg\Notifications\Notification $notification Notification
+	 * @param \Elgg\Notifications\Event        $event        Event
+	 * @param string                           $method       Method
+	 * @return \Elgg\Notifications\Notification
 	 */
-	protected function getDeprecatedNotificationBody(Elgg_Notifications_Notification $notification, Elgg_Notifications_Event $event, $method) {
+	protected function getDeprecatedNotificationBody(\Elgg\Notifications\Notification $notification, \Elgg\Notifications\Event $event, $method) {
 		$entity = $event->getObject();
 		$params = array(
 			'entity' => $entity,
@@ -420,10 +421,10 @@ class Elgg_Notifications_NotificationsService {
 	/**
 	 * Is someone using the deprecated override
 	 * 
-	 * @param Elgg_Notifications_Event $event Event
+	 * @param \Elgg\Notifications\Event $event Event
 	 * @return boolean
 	 */
-	protected function existsDeprecatedNotificationOverride(Elgg_Notifications_Event $event) {
+	protected function existsDeprecatedNotificationOverride(\Elgg\Notifications\Event $event) {
 		$entity = $event->getObject();
 		if (!elgg_instanceof($entity)) {
 			return false;

--- a/engine/classes/Elgg/Notifications/SubscriptionsService.php
+++ b/engine/classes/Elgg/Notifications/SubscriptionsService.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Notifications;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -9,7 +10,7 @@
  * @subpackage Notifications
  * @since      1.9.0
  */
-class Elgg_Notifications_SubscriptionsService {
+class SubscriptionsService {
 
 	/**
 	 *  Elgg has historically stored subscriptions as relationships with the prefix 'notify'
@@ -22,16 +23,16 @@ class Elgg_Notifications_SubscriptionsService {
 	 */
 	public $methods;
 
-	/** @var Elgg_Database */
+	/** @var \Elgg\Database */
 	protected $db;
 
 	/**
 	 * Constructor
 	 *
-	 * @param Elgg_Database $db      Database object
-	 * @param array         $methods Notification delivery method names
+	 * @param \Elgg\Database $db      Database object
+	 * @param array          $methods Notification delivery method names
 	 */
-	public function __construct(Elgg_Database $db, array $methods = array()) {
+	public function __construct(\Elgg\Database $db, array $methods = array()) {
 		$this->db = $db;
 		$this->methods = $methods;
 	}
@@ -45,10 +46,10 @@ class Elgg_Notifications_SubscriptionsService {
 	 *     <user guid> => array('email', 'sms', 'ajax'),
 	 * );
 	 *
-	 * @param Elgg_Notifications_Event $event Notification event
+	 * @param \Elgg\Notifications\Event $event Notification event
 	 * @return array
 	 */
-	public function getSubscriptions(Elgg_Notifications_Event $event) {
+	public function getSubscriptions(\Elgg\Notifications\Event $event) {
 
 		$subscriptions = array();
 
@@ -176,3 +177,4 @@ class Elgg_Notifications_SubscriptionsService {
 		return $names;
 	}
 }
+

--- a/engine/classes/Elgg/PersistentLoginService.php
+++ b/engine/classes/Elgg/PersistentLoginService.php
@@ -1,6 +1,7 @@
 <?php
+namespace Elgg;
 /**
- * Elgg_PersistentLoginService
+ * \Elgg\PersistentLoginService
  *
  * If a user selects a persistent login, a long, random token is generated and stored in the cookie
  * called "elggperm", and a hash of the token is stored in the DB. If the user's PHP session expires,
@@ -22,22 +23,22 @@
  *
  * @access private
  */
-class Elgg_PersistentLoginService {
+class PersistentLoginService {
 
 	/**
 	 * Constructor
 	 *
-	 * @param Elgg_Database $db            The DB service
-	 * @param ElggSession   $session       The Elgg session
-	 * @param ElggCrypto    $crypto        The cryptography service
-	 * @param array         $cookie_config The persistent login cookie settings
-	 * @param string        $cookie_token  The token from the request cookie
-	 * @param int           $time          The current time
+	 * @param Database     $db            The DB service
+	 * @param \ElggSession $session       The Elgg session
+	 * @param \ElggCrypto  $crypto        The cryptography service
+	 * @param array        $cookie_config The persistent login cookie settings
+	 * @param string       $cookie_token  The token from the request cookie
+	 * @param int          $time          The current time
 	 */
 	public function __construct(
-			Elgg_Database $db,
-			ElggSession $session,
-			ElggCrypto $crypto,
+			Database $db,
+			\ElggSession $session,
+			\ElggCrypto $crypto,
 			array $cookie_config,
 			$cookie_token,
 			$time = null) {
@@ -55,10 +56,11 @@ class Elgg_PersistentLoginService {
 	/**
 	 * Make the user's login persistent
 	 *
-	 * @param ElggUser $user The user who logged in
+	 * @param \ElggUser $user The user who logged in
+	 * 
 	 * @return void
 	 */
-	public function makeLoginPersistent(ElggUser $user) {
+	public function makeLoginPersistent(\ElggUser $user) {
 		$token = $this->generateToken();
 		$hash = $this->hashToken($token);
 
@@ -69,6 +71,7 @@ class Elgg_PersistentLoginService {
 
 	/**
 	 * Remove the persisted login token from client and server
+	 * 
 	 * @return void
 	 */
 	public function removePersistentLogin() {
@@ -84,11 +87,12 @@ class Elgg_PersistentLoginService {
 	/**
 	 * Handle a password change
 	 *
-	 * @param ElggUser $subject  The user whose password changed
-	 * @param ElggUser $modifier The user who changed the password
+	 * @param \ElggUser $subject  The user whose password changed
+	 * @param \ElggUser $modifier The user who changed the password
+	 * 
 	 * @return void
 	 */
-	public function handlePasswordChange(ElggUser $subject, ElggUser $modifier = null) {
+	public function handlePasswordChange(\ElggUser $subject, \ElggUser $modifier = null) {
 		$this->removeAllHashes($subject);
 		if (!$modifier || ($modifier->guid !== $subject->guid) || !$this->cookie_token) {
 			return;
@@ -101,7 +105,7 @@ class Elgg_PersistentLoginService {
 	 * Boot the persistent login session, possibly returning the user who should be
 	 * silently logged in.
 	 *
-	 * @return ElggUser|null
+	 * @return \ElggUser|null
 	 */
 	public function bootSession() {
 		if (!$this->cookie_token) {
@@ -128,10 +132,11 @@ class Elgg_PersistentLoginService {
 	/**
 	 * Replace the user's token if it's a legacy hexadecimal token
 	 *
-	 * @param ElggUser $logged_in_user The logged in user
+	 * @param \ElggUser $logged_in_user The logged in user
+	 * 
 	 * @return void
 	 */
-	public function replaceLegacyToken(ElggUser $logged_in_user) {
+	public function replaceLegacyToken(\ElggUser $logged_in_user) {
 		if (!$this->cookie_token || !$this->isLegacyToken($this->cookie_token)) {
 			return;
 		}
@@ -145,7 +150,8 @@ class Elgg_PersistentLoginService {
 	 * Find a user with the given hash
 	 *
 	 * @param string $hash The hashed token
-	 * @return ElggUser|null
+	 * 
+	 * @return \ElggUser|null
 	 */
 	public function getUserFromHash($hash) {
 		if (!$hash) {
@@ -156,7 +162,7 @@ class Elgg_PersistentLoginService {
 		$query = "SELECT guid FROM {$this->table} WHERE code = '$hash'";
 		try {
 			$user_row = $this->db->getDataRow($query);
-		} catch (DatabaseException $e) {
+		} catch (\DatabaseException $e) {
 			return $this->handleDbException($e);
 		}
 		if (!$user_row) {
@@ -170,11 +176,12 @@ class Elgg_PersistentLoginService {
 	/**
 	 * Store a hash in the DB
 	 *
-	 * @param ElggUser $user The user for whom we're storing the hash
-	 * @param string   $hash The hashed token
+	 * @param \ElggUser $user The user for whom we're storing the hash
+	 * @param string    $hash The hashed token
+	 * 
 	 * @return void
 	 */
-	protected function storeHash(ElggUser $user, $hash) {
+	protected function storeHash(\ElggUser $user, $hash) {
 		$time = time();
 		$hash = $this->db->sanitizeString($hash);
 
@@ -184,7 +191,7 @@ class Elgg_PersistentLoginService {
 		";
 		try {
 			$this->db->insertData($query);
-		} catch (DatabaseException $e) {
+		} catch (\DatabaseException $e) {
 			$this->handleDbException($e);
 		}
 	}
@@ -201,7 +208,7 @@ class Elgg_PersistentLoginService {
 		$query = "DELETE FROM {$this->table} WHERE code = '$hash'";
 		try {
 			$this->db->deleteData($query);
-		} catch (DatabaseException $e) {
+		} catch (\DatabaseException $e) {
 			$this->handleDbException($e);
 		}
 	}
@@ -209,13 +216,14 @@ class Elgg_PersistentLoginService {
 	/**
 	 * Swallow a schema not upgraded exception, otherwise rethrow it
 	 *
-	 * @param DatabaseException $exception The exception to handle
-	 * @param string            $default   The value to return if the table doesn't exist yet
+	 * @param \DatabaseException $exception The exception to handle
+	 * @param string             $default   The value to return if the table doesn't exist yet
+	 * 
 	 * @return mixed
 	 *
-	 * @throws DatabaseException
+	 * @throws \DatabaseException
 	 */
-	protected function handleDbException(DatabaseException $exception, $default = null) {
+	protected function handleDbException(\DatabaseException $exception, $default = null) {
 		if (false !== strpos($exception->getMessage(), "users_remember_me_cookies' doesn't exist")) {
 			// schema has not been updated so we swallow this exception
 			return $default;
@@ -227,14 +235,15 @@ class Elgg_PersistentLoginService {
 	/**
 	 * Remove all the hashes associated with a user
 	 *
-	 * @param ElggUser $user The user for whom we're removing hashes
+	 * @param \ElggUser $user The user for whom we're removing hashes
+	 * 
 	 * @return void
 	 */
-	protected function removeAllHashes(ElggUser $user) {
+	protected function removeAllHashes(\ElggUser $user) {
 		$query = "DELETE FROM {$this->table} WHERE guid = '{$user->guid}'";
 		try {
 			$this->db->deleteData($query);
-		} catch (DatabaseException $e) {
+		} catch (\DatabaseException $e) {
 			$this->handleDbException($e);
 		}
 	}
@@ -243,6 +252,7 @@ class Elgg_PersistentLoginService {
 	 * Create a hash from the token
 	 *
 	 * @param string $token The token to hash
+	 * 
 	 * @return string
 	 */
 	protected function hashToken($token) {
@@ -255,10 +265,11 @@ class Elgg_PersistentLoginService {
 	 * Store the token in the client cookie (or remove the cookie)
 	 *
 	 * @param string $token Empty string to remove cookie
+	 * 
 	 * @return void
 	 */
 	protected function setCookie($token) {
-		$cookie = new ElggCookie($this->cookie_config['name']);
+		$cookie = new \ElggCookie($this->cookie_config['name']);
 		foreach (array('expire', 'path', 'domain', 'secure', 'httponly') as $key) {
 			$cookie->$key = $this->cookie_config[$key];
 		}
@@ -273,6 +284,7 @@ class Elgg_PersistentLoginService {
 	 * Store the token in the session (or remove it from the session)
 	 *
 	 * @param string $token The token to store in session. Empty string to remove.
+	 * 
 	 * @return void
 	 */
 	protected function setSession($token) {
@@ -299,6 +311,7 @@ class Elgg_PersistentLoginService {
 	 * Is the given token a legacy MD5 hash?
 	 *
 	 * @param string $token The token to analyze
+	 * 
 	 * @return bool
 	 */
 	protected function isLegacyToken($token) {
@@ -306,7 +319,7 @@ class Elgg_PersistentLoginService {
 	}
 
 	/**
-	 * @var Elgg_Database
+	 * @var Database
 	 */
 	protected $db;
 
@@ -326,12 +339,12 @@ class Elgg_PersistentLoginService {
 	protected $cookie_token;
 
 	/**
-	 * @var ElggSession
+	 * @var \ElggSession
 	 */
 	protected $session;
 
 	/**
-	 * @var ElggCrypto
+	 * @var \ElggCrypto
 	 */
 	protected $crypto;
 
@@ -358,3 +371,4 @@ class Elgg_PersistentLoginService {
 	 */
 	public $_callable_sleep = 'sleep';
 }
+

--- a/engine/classes/Elgg/PluginHooksService.php
+++ b/engine/classes/Elgg/PluginHooksService.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -11,7 +12,7 @@
  * @subpackage Hooks
  * @since      1.9.0
  */
-class Elgg_PluginHooksService extends Elgg_HooksRegistrationService {
+class PluginHooksService extends \Elgg\HooksRegistrationService {
 
 	/**
 	 * Triggers a plugin hook

--- a/engine/classes/Elgg/Queue/DatabaseQueue.php
+++ b/engine/classes/Elgg/Queue/DatabaseQueue.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Queue;
 
 /**
  * FIFO queue that uses the database for persistence
@@ -11,12 +12,12 @@
  * @subpackage Queue
  * @since      1.9.0
  */
-class Elgg_Queue_DatabaseQueue implements Elgg_Queue_Queue {
+class DatabaseQueue implements \Elgg\Queue\Queue {
 
 	/** @var string Name of the queue */
 	protected $name;
 
-	/** @var Elgg_Database Database adapter */
+	/** @var \Elgg\Database Database adapter */
 	protected $db;
 
 	/** @var string The identifier of the worker pulling from the queue */
@@ -25,10 +26,10 @@ class Elgg_Queue_DatabaseQueue implements Elgg_Queue_Queue {
 	/**
 	 * Create a queue
 	 *
-	 * @param string        $name Name of the queue. Must be less than 256 characters.
-	 * @param Elgg_Database $db   Database adapter
+	 * @param string         $name Name of the queue. Must be less than 256 characters.
+	 * @param \Elgg\Database $db   Database adapter
 	 */
-	public function __construct($name, Elgg_Database $db) {
+	public function __construct($name, \Elgg\Database $db) {
 		$this->db = $db;
 		$this->name = $this->db->sanitizeString($name);
 		$this->workerId = $this->db->sanitizeString(md5(microtime() . getmypid()));
@@ -89,3 +90,4 @@ class Elgg_Queue_DatabaseQueue implements Elgg_Queue_Queue {
 		return (int)$result->total;
 	}
 }
+

--- a/engine/classes/Elgg/Queue/MemoryQueue.php
+++ b/engine/classes/Elgg/Queue/MemoryQueue.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Queue;
 
 /**
  * FIFO queue that is memory based (not persistent)
@@ -11,7 +12,7 @@
  * @subpackage Queue
  * @since      1.9.0
  */
-class Elgg_Queue_MemoryQueue implements Elgg_Queue_Queue {
+class MemoryQueue implements \Elgg\Queue\Queue {
 
 	/* @var array */
 	protected $queue = array();
@@ -51,3 +52,4 @@ class Elgg_Queue_MemoryQueue implements Elgg_Queue_Queue {
 		return count($this->queue);
 	}
 }
+

--- a/engine/classes/Elgg/Queue/Queue.php
+++ b/engine/classes/Elgg/Queue/Queue.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Queue;
 
 /**
  * Queue interface
@@ -11,7 +12,7 @@
  * @subpackage Queue
  * @since      1.9.0
  */
-interface Elgg_Queue_Queue {
+interface Queue {
 	/**
 	 * Add an item to the queue
 	 *

--- a/engine/classes/Elgg/Router.php
+++ b/engine/classes/Elgg/Router.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 
 /**
  * Delegates requests to controllers based on the registered configuration.
@@ -12,16 +13,16 @@
  * @since      1.9.0
  * @access private
  */
-class Elgg_Router {
+class Router {
 	private $handlers = array();
 	private $hooks;
 
 	/**
 	 * Constructor
 	 *
-	 * @param Elgg_PluginHooksService $hooks For customized routing.
+	 * @param \Elgg\PluginHooksService $hooks For customized routing.
 	 */
-	public function __construct(Elgg_PluginHooksService $hooks) {
+	public function __construct(\Elgg\PluginHooksService $hooks) {
 		$this->hooks = $hooks;
 	}
 
@@ -31,11 +32,11 @@ class Elgg_Router {
 	 * This function triggers a plugin hook `'route', $identifier` so that plugins can
 	 * modify the routing or handle a request.
 	 *
-	 * @param Elgg_Http_Request $request The request to handle.
+	 * @param \Elgg\Http\Request $request The request to handle.
 	 * @return boolean Whether the request was routed successfully.
 	 * @access private
 	 */
-	public function route(Elgg_Http_Request $request) {
+	public function route(\Elgg\Http\Request $request) {
 		$segments = $request->getUrlSegments();
 		if ($segments) {
 			$identifier = array_shift($segments);
@@ -120,3 +121,4 @@ class Elgg_Router {
 		return $this->handlers;
 	}
 }
+

--- a/engine/classes/Elgg/Translit.php
+++ b/engine/classes/Elgg/Translit.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 /**
  * Elgg Transliterate
  *
@@ -27,7 +28,7 @@
  *
  * @access private Plugin authors should not use this directly
  */
-class Elgg_Translit {
+class Translit {
 
 	/**
 	 * Create a version of a string for embedding in a URL
@@ -265,3 +266,4 @@ class Elgg_Translit {
 		return $ret;
 	}
 }
+

--- a/engine/classes/Elgg/UpgradeService.php
+++ b/engine/classes/Elgg/UpgradeService.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 
 /**
  * Upgrade service for Elgg
@@ -11,7 +12,7 @@
  * @package    Elgg.Core
  * @subpackage Upgrade
  */
-class Elgg_UpgradeService {
+class UpgradeService {
 
 	/**
 	 * Run the upgrade process
@@ -98,7 +99,7 @@ class Elgg_UpgradeService {
 						$success = false;
 						error_log("Could not include $upgrade_path/$upgrade");
 					}
-				} catch (Exception $e) {
+				} catch (\Exception $e) {
 					$success = false;
 					error_log($e->getMessage());
 				}
@@ -251,7 +252,7 @@ class Elgg_UpgradeService {
 			system_message(elgg_echo('upgrade:core'));
 
 			// Now we trigger an event to give the option for plugins to do something
-			$upgrade_details = new stdClass;
+			$upgrade_details = new \stdClass;
 			$upgrade_details->from = $dbversion;
 			$upgrade_details->to = elgg_get_version();
 
@@ -404,7 +405,7 @@ class Elgg_UpgradeService {
 					if ($quiet) {
 						try {
 							run_sql_script($fromdir . $sqlfile);
-						} catch (DatabaseException $e) {
+						} catch (\DatabaseException $e) {
 							error_log($e->getmessage());
 						}
 					} else {
@@ -419,3 +420,4 @@ class Elgg_UpgradeService {
 	}
 
 }
+

--- a/engine/classes/Elgg/Upgrades/Helper2013022000.php
+++ b/engine/classes/Elgg/Upgrades/Helper2013022000.php
@@ -1,11 +1,12 @@
 <?php
+namespace Elgg\Upgrades;
 
 /**
  * Helper for data directory upgrade
  *
  * @access private
  */
-class Elgg_Upgrades_Helper2013022000 {
+class Helper2013022000 {
 	const RELATIONSHIP_SUCCESS = '2013022000';
 	const RELATIONSHIP_FAILURE = '2013022000_fail';
 
@@ -72,7 +73,7 @@ class Elgg_Upgrades_Helper2013022000 {
 	/**
 	 * Get the old directory location
 	 *
-	 * @param stdClass $user_row
+	 * @param \stdClass $user_row
 	 * @return string
 	 */
 	public function makeMatrix($user_row) {
@@ -116,7 +117,7 @@ class Elgg_Upgrades_Helper2013022000 {
 	 * @return int
 	 */
 	public function getLowerBucketBound($guid) {
-		$bucket_size = Elgg_EntityDirLocator::BUCKET_SIZE;
+		$bucket_size = \Elgg\EntityDirLocator::BUCKET_SIZE;
 		if ($guid < 1) {
 			return false;
 		}
@@ -181,3 +182,4 @@ class Elgg_Upgrades_Helper2013022000 {
 		return ($row->cnt > 0);
 	}
 }
+

--- a/engine/classes/Elgg/ViewsService.php
+++ b/engine/classes/Elgg/ViewsService.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -14,7 +15,7 @@
  * @subpackage Views
  * @since      1.9.0
  */
-class Elgg_ViewsService {
+class ViewsService {
 
 	protected $config_wrapper;
 	protected $site_url_wrapper;
@@ -22,7 +23,7 @@ class Elgg_ViewsService {
 	protected $user_wrapped;
 
 	/**
-	 * @see Elgg_ViewsService::fileExists
+	 * @see \Elgg\ViewsService::fileExists
 	 * @var array
 	 */
 	protected $file_exists_cache = array();
@@ -30,10 +31,10 @@ class Elgg_ViewsService {
 	/**
 	 * Constructor
 	 *
-	 * @param Elgg_PluginHooksService $hooks  The hooks service
-	 * @param Elgg_Logger             $logger Logger
+	 * @param \Elgg\PluginHooksService $hooks  The hooks service
+	 * @param \Elgg\Logger             $logger Logger
 	 */
-	public function __construct(Elgg_PluginHooksService $hooks, Elgg_Logger $logger) {
+	public function __construct(\Elgg\PluginHooksService $hooks, \Elgg\Logger $logger) {
 		$this->hooks = $hooks;
 		$this->logger = $logger;
 	}
@@ -41,7 +42,7 @@ class Elgg_ViewsService {
 	/**
 	 * Get the user object in a wrapper
 	 * 
-	 * @return Elgg_DeprecationWrapper|null
+	 * @return \Elgg\DeprecationWrapper|null
 	 */
 	protected function getUserWrapper() {
 		$user = elgg_get_logged_in_user_entity();
@@ -49,7 +50,7 @@ class Elgg_ViewsService {
 			if ($user !== $this->user_wrapped) {
 				$warning = 'Use elgg_get_logged_in_user_entity() rather than assuming elgg_view() '
 							. 'populates $vars["user"]';
-				$this->user_wrapper = new Elgg_DeprecationWrapper($user, $warning, 1.8);
+				$this->user_wrapper = new \Elgg\DeprecationWrapper($user, $warning, 1.8);
 			}
 			$user = $this->user_wrapper;
 		}
@@ -116,7 +117,7 @@ class Elgg_ViewsService {
 		}
 
 		if (!isset($CONFIG->views)) {
-			$CONFIG->views = new stdClass;
+			$CONFIG->views = new \stdClass;
 		}
 
 		if (!isset($CONFIG->views->locations)) {
@@ -137,7 +138,7 @@ class Elgg_ViewsService {
 		global $CONFIG;
 
 		if (!isset($CONFIG->viewtype)) {
-			$CONFIG->viewtype = new stdClass;
+			$CONFIG->viewtype = new \stdClass;
 		}
 
 		if (!isset($CONFIG->viewtype->fallback)) {
@@ -223,14 +224,14 @@ class Elgg_ViewsService {
 		if (!isset($vars['config'])) {
 			if (!$this->config_wrapper) {
 				$warning = 'Do not rely on $vars["config"] or $CONFIG being available in views';
-				$this->config_wrapper = new Elgg_DeprecationWrapper($CONFIG, $warning, 1.8);
+				$this->config_wrapper = new \Elgg\DeprecationWrapper($CONFIG, $warning, 1.8);
 			}
 			$vars['config'] = $this->config_wrapper;
 		}
 		if (!isset($vars['url'])) {
 			if (!$this->site_url_wrapper) {
 				$warning = 'Do not rely on $vars["url"] being available in views';
-				$this->site_url_wrapper = new Elgg_DeprecationWrapper(elgg_get_site_url(), $warning, 1.8);
+				$this->site_url_wrapper = new \Elgg\DeprecationWrapper(elgg_get_site_url(), $warning, 1.8);
 			}
 			$vars['url'] = $this->site_url_wrapper;
 		}
@@ -471,7 +472,7 @@ class Elgg_ViewsService {
 		global $CONFIG;
 
 		if (!isset($CONFIG->views)) {
-			$CONFIG->views = new stdClass;
+			$CONFIG->views = new \stdClass;
 		}
 
 		if (!isset($CONFIG->views->simplecache)) {
@@ -488,7 +489,7 @@ class Elgg_ViewsService {
 		global $CONFIG;
 
 		if (!isset($CONFIG->views)) {
-			$CONFIG->views = new stdClass;
+			$CONFIG->views = new \stdClass;
 		}
 
 		if (!isset($CONFIG->views->simplecache)) {

--- a/engine/classes/Elgg/WidgetsService.php
+++ b/engine/classes/Elgg/WidgetsService.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -11,15 +12,15 @@
  * @subpackage Widgets
  * @since      1.9.0
  */
-class Elgg_WidgetsService {
+class WidgetsService {
 
 	/**
-	 * @var stdClass
+	 * @var \stdClass
 	 */
 	private $widgets;
 
 	/**
-	 * @see Elgg_WidgetsService::getWidgets()
+	 * @see \Elgg\WidgetsService::getWidgets()
 	 * @var array
 	 */
 	private $widgetCache = array();
@@ -81,7 +82,7 @@ class Elgg_WidgetsService {
 			return false;
 		}
 
-		$widget = new ElggWidget;
+		$widget = new \ElggWidget;
 		$widget->owner_guid = $owner_guid;
 		$widget->container_guid = $owner_guid; // @todo - will this work for group widgets?
 		if (isset($access_id)) {
@@ -94,7 +95,7 @@ class Elgg_WidgetsService {
 			return false;
 		}
 
-		// private settings cannot be set until ElggWidget saved
+		// private settings cannot be set until \ElggWidget saved
 		$widget->handler = $handler;
 		$widget->context = $context;
 
@@ -139,13 +140,13 @@ class Elgg_WidgetsService {
 		}
 
 		if (!isset($this->widgets)) {
-			$this->widgets = new stdClass;
+			$this->widgets = new \stdClass;
 		}
 		if (!isset($this->widgets->handlers)) {
 			$this->widgets->handlers = array();
 		}
 
-		$handlerobj = new stdClass;
+		$handlerobj = new \stdClass;
 		$handlerobj->name = $name;
 		$handlerobj->description = $description;
 		$handlerobj->context = $context;
@@ -260,3 +261,4 @@ class Elgg_WidgetsService {
 		return $widgets;
 	}
 }
+

--- a/engine/classes/ElggAnnotation.php
+++ b/engine/classes/ElggAnnotation.php
@@ -11,12 +11,12 @@
  * @package    Elgg.Core
  * @subpackage DataModel.Annotations
  */
-class ElggAnnotation extends ElggExtender {
+class ElggAnnotation extends \ElggExtender {
 
 	/**
 	 * (non-PHPdoc)
 	 *
-	 * @see ElggData::initializeAttributes()
+	 * @see \ElggData::initializeAttributes()
 	 *
 	 * @return void
 	 */
@@ -30,16 +30,16 @@ class ElggAnnotation extends ElggExtender {
 	 * Construct a new annotation object
 	 *
 	 * Plugin developers will probably never use the constructor.
-	 * See ElggEntity for its API for adding annotations.
+	 * See \ElggEntity for its API for adding annotations.
 	 *
-	 * @param stdClass $row Database row as stdClass object
+	 * @param \stdClass $row Database row as \stdClass object
 	 */
 	public function __construct($row = null) {
 		$this->initializeAttributes();
 
 		if (!empty($row)) {
 			// Create from db row
-			if ($row instanceof stdClass) {
+			if ($row instanceof \stdClass) {
 				$annotation = $row;
 
 				$objarray = (array) $annotation;
@@ -47,7 +47,7 @@ class ElggAnnotation extends ElggExtender {
 					$this->attributes[$key] = $value;
 				}
 			} else {
-				// get an ElggAnnotation object and copy its attributes
+				// get an \ElggAnnotation object and copy its attributes
 				elgg_deprecated_notice('Passing an ID to constructor is deprecated. Use elgg_get_annotation_from_id()', 1.9);
 				$annotation = elgg_get_annotation_from_id($row);
 				$this->attributes = $annotation->attributes;
@@ -71,7 +71,7 @@ class ElggAnnotation extends ElggExtender {
 				$this->value_type, $this->owner_guid, $this->access_id);
 
 			if (!$this->id) {
-				throw new IOException("Unable to save new " . get_class());
+				throw new \IOException("Unable to save new " . get_class());
 			}
 			return $this->id;
 		}
@@ -159,7 +159,7 @@ class ElggAnnotation extends ElggExtender {
 	 *
 	 * @param int $id An annotation ID.
 	 *
-	 * @return ElggAnnotation
+	 * @return \ElggAnnotation
 	 */
 	public function getObjectFromID($id) {
 		return elgg_get_annotation_from_id($id);

--- a/engine/classes/ElggBatch.php
+++ b/engine/classes/ElggBatch.php
@@ -34,7 +34,7 @@
  * @example
  * <code>
  * // using foreach
- * $batch = new ElggBatch('elgg_get_entities', array());
+ * $batch = new \ElggBatch('elgg_get_entities', array());
  * $batch->setIncrementOffset(false);
  *
  * foreach ($batch as $entity) {
@@ -47,7 +47,7 @@
  *  return true;
  * }
  *
- * $batch = new ElggBatch('elgg_get_annotations', array('guid' => 2), $callback);
+ * $batch = new \ElggBatch('elgg_get_annotations', array('guid' => 2), $callback);
  * </code>
  *
  * @package    Elgg.Core
@@ -55,7 +55,7 @@
  * @since      1.8
  */
 class ElggBatch
-	implements Iterator {
+	implements \Iterator {
 
 	/**
 	 * The objects to interator over.
@@ -151,7 +151,7 @@ class ElggBatch
 	/**
 	 * Entities that could not be instantiated during a fetch
 	 *
-	 * @var stdClass[]
+	 * @var \stdClass[]
 	 */
 	private $incompleteEntities = array();
 
@@ -182,7 +182,7 @@ class ElggBatch
 	 *                           and hitting the db server too often.
 	 * @param bool   $inc_offset Increment the offset on each fetch. This must be false for
 	 *                           callbacks that delete rows. You can set this after the
-	 *                           object is created with {@link ElggBatch::setIncrementOffset()}.
+	 *                           object is created with {@link \ElggBatch::setIncrementOffset()}.
 	 */
 	public function __construct($getter, $options, $callback = null, $chunk_size = 25,
 			$inc_offset = true) {
@@ -201,10 +201,10 @@ class ElggBatch
 		$this->offset = elgg_extract('offset', $options, 0);
 		$this->limit = elgg_extract('limit', $options, 10);
 
-		// if passed a callback, create a new ElggBatch with the same options
+		// if passed a callback, create a new \ElggBatch with the same options
 		// and pass each to the callback.
 		if ($callback && is_callable($callback)) {
-			$batch = new ElggBatch($getter, $options, null, $chunk_size, $inc_offset);
+			$batch = new \ElggBatch($getter, $options, null, $chunk_size, $inc_offset);
 
 			$all_results = null;
 
@@ -233,11 +233,11 @@ class ElggBatch
 	/**
 	 * Tell the process that an entity was incomplete during a fetch
 	 *
-	 * @param stdClass $row
+	 * @param \stdClass $row
 	 *
 	 * @access private
 	 */
-	public function reportIncompleteEntity(stdClass $row) {
+	public function reportIncompleteEntity(\stdClass $row) {
 		$this->incompleteEntities[] = $row;
 	}
 

--- a/engine/classes/ElggCache.php
+++ b/engine/classes/ElggCache.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * ElggCache The elgg cache superclass.
+ * \ElggCache The elgg cache superclass.
  * This defines the interface for a cache (wherever that cache is stored).
  *
  * @package    Elgg.Core
  * @subpackage Cache
  */
-abstract class ElggCache implements ArrayAccess {
+abstract class ElggCache implements \ArrayAccess {
 	/**
 	 * Variables for the cache object.
 	 *
@@ -30,10 +30,10 @@ abstract class ElggCache implements ArrayAccess {
 	 *
 	 * @return void
 	 *
-	 * @deprecated 1.8 Use ElggCache:setVariable()
+	 * @deprecated 1.8 Use \ElggCache:setVariable()
 	 */
 	public function set_variable($variable, $value) {
-		elgg_deprecated_notice('ElggCache::set_variable() is deprecated by ElggCache::setVariable()', 1.8);
+		elgg_deprecated_notice('\ElggCache::set_variable() is deprecated by \ElggCache::setVariable()', 1.8);
 		$this->setVariable($variable, $value);
 	}
 	// @codingStandardsIgnoreEnd
@@ -62,10 +62,10 @@ abstract class ElggCache implements ArrayAccess {
 	 *
 	 * @return mixed The value or null;
 	 *
-	 * @deprecated 1.8 Use ElggCache::getVariable()
+	 * @deprecated 1.8 Use \ElggCache::getVariable()
 	 */
 	public function get_variable($variable) {
-		elgg_deprecated_notice('ElggCache::get_variable() is deprecated by ElggCache::getVariable()', 1.8);
+		elgg_deprecated_notice('\ElggCache::get_variable() is deprecated by \ElggCache::getVariable()', 1.8);
 		return $this->getVariable($variable);
 	}
 	// @codingStandardsIgnoreEnd
@@ -144,7 +144,7 @@ abstract class ElggCache implements ArrayAccess {
 	 * Load data from the cache using a given key.
 	 *
 	 * @todo $offset is a horrible variable name because it creates confusion
-	 * with the ArrayAccess methods
+	 * with the \ArrayAccess methods
 	 *
 	 * @param string $key    Name
 	 * @param int    $offset Offset
@@ -193,7 +193,7 @@ abstract class ElggCache implements ArrayAccess {
 	/**
 	 * Assigns a value for the specified key
 	 *
-	 * @see ArrayAccess::offsetSet()
+	 * @see \ArrayAccess::offsetSet()
 	 *
 	 * @param mixed $key   The key (offset) to assign the value to.
 	 * @param mixed $value The value to set.
@@ -207,7 +207,7 @@ abstract class ElggCache implements ArrayAccess {
 	/**
 	 * Get the value for specified key
 	 *
-	 * @see ArrayAccess::offsetGet()
+	 * @see \ArrayAccess::offsetGet()
 	 *
 	 * @param mixed $key The key (offset) to retrieve.
 	 *
@@ -220,7 +220,7 @@ abstract class ElggCache implements ArrayAccess {
 	/**
 	 * Unsets a key.
 	 *
-	 * @see ArrayAccess::offsetUnset()
+	 * @see \ArrayAccess::offsetUnset()
 	 *
 	 * @param mixed $key The key (offset) to unset.
 	 *
@@ -235,7 +235,7 @@ abstract class ElggCache implements ArrayAccess {
 	/**
 	 * Does key exist
 	 *
-	 * @see ArrayAccess::offsetExists()
+	 * @see \ArrayAccess::offsetExists()
 	 *
 	 * @param mixed $key A key (offset) to check for.
 	 *

--- a/engine/classes/ElggComment.php
+++ b/engine/classes/ElggComment.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * ElggComment
+ * \ElggComment
  * 
  * @package    Elgg.Core
  * @subpackage Comments
  * @since      1.9.0
  */
-class ElggComment extends ElggObject {
+class ElggComment extends \ElggObject {
 
 	/**
 	 * Set subtype to comment
@@ -23,7 +23,7 @@ class ElggComment extends ElggObject {
 	 * Can a user comment on this object? Always returns false (threaded comments
 	 * not yet supported)
 	 *
-	 * @see ElggEntity::canComment()
+	 * @see \ElggEntity::canComment()
 	 *
 	 * @param int $user_guid User guid (default is logged in user)
 	 * @return bool False

--- a/engine/classes/ElggCrypto.php
+++ b/engine/classes/ElggCrypto.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ElggCrypto
+ * \ElggCrypto
  *
  * @package    Elgg.Core
  * @subpackage Crypto
@@ -182,7 +182,7 @@ class ElggCrypto {
 	 */
 	public function getRandomString($length, $chars = null) {
 		if ($length < 1) {
-			throw new InvalidArgumentException('Length should be >= 1');
+			throw new \InvalidArgumentException('Length should be >= 1');
 		}
 
 		if (empty($chars)) {

--- a/engine/classes/ElggData.php
+++ b/engine/classes/ElggData.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * A generic class that contains shared code among
- * ElggExtender, ElggEntity, and ElggRelationship
+ * \ElggExtender, \ElggEntity, and \ElggRelationship
  *
  * @package    Elgg.Core
  * @subpackage DataModel
@@ -9,7 +9,7 @@
 abstract class ElggData implements
 	Loggable,    // Can events related to this object class be logged
 	Iterator,    // Override foreach behaviour
-	ArrayAccess, // Override for array access
+	\ArrayAccess, // Override for array access
 	Exportable   // (deprecated 1.9)
 {
 
@@ -62,7 +62,7 @@ abstract class ElggData implements
 	/**
 	 * Provides a pointer to the database object.
 	 *
-	 * @return Elgg_Database The database where this data is (will be) stored.
+	 * @return \Elgg\Database The database where this data is (will be) stored.
 	 */
 	protected function getDatabase() {
 		return _elgg_services()->db;
@@ -135,7 +135,7 @@ abstract class ElggData implements
 	/**
 	 * Get a plain old object copy for public consumption
 	 * 
-	 * @return stdClass
+	 * @return \stdClass
 	 */
 	abstract public function toObject();
 
@@ -233,7 +233,7 @@ abstract class ElggData implements
 	/**
 	 * Array access interface
 	 *
-	 * @see ArrayAccess::offsetSet()
+	 * @see \ArrayAccess::offsetSet()
 	 *
 	 * @param mixed $key   Name
 	 * @param mixed $value Value
@@ -249,7 +249,7 @@ abstract class ElggData implements
 	/**
 	 * Array access interface
 	 *
-	 * @see ArrayAccess::offsetGet()
+	 * @see \ArrayAccess::offsetGet()
 	 *
 	 * @param mixed $key Name
 	 *
@@ -265,7 +265,7 @@ abstract class ElggData implements
 	/**
 	 * Array access interface
 	 *
-	 * @see ArrayAccess::offsetUnset()
+	 * @see \ArrayAccess::offsetUnset()
 	 *
 	 * @param mixed $key Name
 	 *
@@ -281,7 +281,7 @@ abstract class ElggData implements
 	/**
 	 * Array access interface
 	 *
-	 * @see ArrayAccess::offsetExists()
+	 * @see \ArrayAccess::offsetExists()
 	 *
 	 * @param int $offset Offset
 	 *

--- a/engine/classes/ElggDiskFilestore.php
+++ b/engine/classes/ElggDiskFilestore.php
@@ -3,12 +3,12 @@
  * A filestore that uses disk as storage.
  *
  * @warning This should be used by a wrapper class
- * like {@link ElggFile}.
+ * like {@link \ElggFile}.
  *
  * @package    Elgg.Core
  * @subpackage FileStore.Disk
  */
-class ElggDiskFilestore extends ElggFilestore {
+class ElggDiskFilestore extends \ElggFilestore {
 	/**
 	 * Directory root.
 	 */
@@ -42,14 +42,14 @@ class ElggDiskFilestore extends ElggFilestore {
 	 * @note This will try to create the a directory if it doesn't exist and is opened
 	 * in write or append mode.
 	 *
-	 * @param ElggFile $file The file to open
-	 * @param string   $mode read, write, or append.
+	 * @param \ElggFile $file The file to open
+	 * @param string    $mode read, write, or append.
 	 *
 	 * @throws InvalidParameterException
 	 * @return resource File pointer resource
 	 * @todo This really shouldn't try to create directories if not writing.
 	 */
-	public function open(ElggFile $file, $mode) {
+	public function open(\ElggFile $file, $mode) {
 		$fullname = $this->getFilenameOnFilestore($file);
 
 		// Split into path and name
@@ -86,7 +86,7 @@ class ElggDiskFilestore extends ElggFilestore {
 				break;
 			default:
 				$msg = "Unrecognized file mode '" . $mode . "'";
-				throw new InvalidParameterException($msg);
+				throw new \InvalidParameterException($msg);
 		}
 
 		return fopen($fullname, $mode);
@@ -134,13 +134,13 @@ class ElggDiskFilestore extends ElggFilestore {
 	}
 
 	/**
-	 * Delete an ElggFile file.
+	 * Delete an \ElggFile file.
 	 *
-	 * @param ElggFile $file File to delete
+	 * @param \ElggFile $file File to delete
 	 *
 	 * @return bool
 	 */
-	public function delete(ElggFile $file) {
+	public function delete(\ElggFile $file) {
 		$filename = $this->getFilenameOnFilestore($file);
 		if (file_exists($filename)) {
 			return unlink($filename);
@@ -184,27 +184,27 @@ class ElggDiskFilestore extends ElggFilestore {
 	}
 
 	/**
-	 * Returns the file size of an ElggFile file.
+	 * Returns the file size of an \ElggFile file.
 	 *
-	 * @param ElggFile $file File object
+	 * @param \ElggFile $file File object
 	 *
 	 * @return int The file size
 	 */
-	public function getFileSize(ElggFile $file) {
+	public function getFileSize(\ElggFile $file) {
 		return filesize($this->getFilenameOnFilestore($file));
 	}
 
 	/**
-	 * Get the filename as saved on disk for an ElggFile object
+	 * Get the filename as saved on disk for an \ElggFile object
 	 *
 	 * Returns an empty string if no filename set
 	 *
-	 * @param ElggFile $file File object
+	 * @param \ElggFile $file File object
 	 *
 	 * @return string The full path of where the file is stored
 	 * @throws InvalidParameterException
 	 */
-	public function getFilenameOnFilestore(ElggFile $file) {
+	public function getFilenameOnFilestore(\ElggFile $file) {
 		$owner_guid = $file->getOwnerGuid();
 		if (!$owner_guid) {
 			$owner_guid = elgg_get_logged_in_user_guid();
@@ -212,33 +212,33 @@ class ElggDiskFilestore extends ElggFilestore {
 
 		if (!$owner_guid) {
 			$msg = "File " . $file->getFilename() . " (file guid:" . $file->guid . ") is missing an owner!";
-			throw new InvalidParameterException($msg);
+			throw new \InvalidParameterException($msg);
 		}
 
-		$dir = new Elgg_EntityDirLocator($owner_guid);
+		$dir = new \Elgg\EntityDirLocator($owner_guid);
 
 		return $this->dir_root . $dir . $file->getFilename();
 	}
 
 	/**
-	 * Returns the contents of the ElggFile file.
+	 * Returns the contents of the \ElggFile file.
 	 *
-	 * @param ElggFile $file File object
+	 * @param \ElggFile $file File object
 	 *
 	 * @return string
 	 */
-	public function grabFile(ElggFile $file) {
+	public function grabFile(\ElggFile $file) {
 		return file_get_contents($file->getFilenameOnFilestore());
 	}
 
 	/**
-	 * Tests if an ElggFile file exists.
+	 * Tests if an \ElggFile file exists.
 	 *
-	 * @param ElggFile $file File object
+	 * @param \ElggFile $file File object
 	 *
 	 * @return bool
 	 */
-	public function exists(ElggFile $file) {
+	public function exists(\ElggFile $file) {
 		if (!$file->getFilename()) {
 			return false;
 		}
@@ -255,7 +255,7 @@ class ElggDiskFilestore extends ElggFilestore {
 	 */
 	public function getSize($prefix, $container_guid) {
 		if ($container_guid) {
-			$dir = new Elgg_EntityDirLocator($container_guid);
+			$dir = new \Elgg\EntityDirLocator($container_guid);
 			return get_dir_size($this->dir_root . $dir . $prefix);
 		} else {
 			return false;
@@ -270,10 +270,10 @@ class ElggDiskFilestore extends ElggFilestore {
 	 *
 	 * @throws IOException
 	 * @return true
-	 * @deprecated 1.8 Use ElggDiskFilestore::makeDirectoryRoot()
+	 * @deprecated 1.8 Use \ElggDiskFilestore::makeDirectoryRoot()
 	 */
 	protected function make_directory_root($dirroot) {
-		elgg_deprecated_notice('ElggDiskFilestore::make_directory_root() is deprecated by ::makeDirectoryRoot()', 1.8);
+		elgg_deprecated_notice('\ElggDiskFilestore::make_directory_root() is deprecated by ::makeDirectoryRoot()', 1.8);
 
 		return $this->makeDirectoryRoot($dirroot);
 	}
@@ -290,7 +290,7 @@ class ElggDiskFilestore extends ElggFilestore {
 	protected function makeDirectoryRoot($dirroot) {
 		if (!file_exists($dirroot)) {
 			if (!@mkdir($dirroot, 0700, true)) {
-				throw new IOException("Could not make " . $dirroot);
+				throw new \IOException("Could not make " . $dirroot);
 			}
 		}
 
@@ -299,7 +299,7 @@ class ElggDiskFilestore extends ElggFilestore {
 
 	/**
 	 * Returns a list of attributes to save to the database when saving
-	 * the ElggFile object using this file store.
+	 * the \ElggFile object using this file store.
 	 *
 	 * @return array
 	 */
@@ -336,10 +336,10 @@ class ElggDiskFilestore extends ElggFilestore {
 	 * @param int $identifier The guid of the entity to store the data under.
 	 *
 	 * @return string The path where the entity's data will be stored.
-	 * @deprecated 1.8 Use Elgg_EntityDirLocator
+	 * @deprecated 1.8 Use \Elgg\EntityDirLocator
 	 */
 	protected function make_file_matrix($identifier) {
-		elgg_deprecated_notice('ElggDiskFilestore::make_file_matrix() is deprecated by Elgg_EntityDirLocator', 1.8);
+		elgg_deprecated_notice('\ElggDiskFilestore::make_file_matrix() is deprecated by \Elgg\EntityDirLocator', 1.8);
 
 		return $this->makeFileMatrix($identifier);
 	}
@@ -354,11 +354,11 @@ class ElggDiskFilestore extends ElggFilestore {
 	 *
 	 * @param int $guid The entity to contrust a matrix for
 	 *
-	 * @deprecated 1.8 Use ElggDiskFileStore::makeFileMatrix()
-	 * @return str The
+	 * @deprecated 1.8 Use \ElggDiskFileStore::makeFileMatrix()
+	 * @return string The
 	 */
 	protected function user_file_matrix($guid) {
-		elgg_deprecated_notice('ElggDiskFilestore::user_file_matrix() is deprecated by Elgg_EntityDirLocator', 1.8);
+		elgg_deprecated_notice('\ElggDiskFilestore::user_file_matrix() is deprecated by \Elgg\EntityDirLocator', 1.8);
 
 		return $this->makeFileMatrix($guid);
 	}
@@ -378,7 +378,7 @@ class ElggDiskFilestore extends ElggFilestore {
 	 * @deprecated 1.8 Files are stored by date and guid; no need for this.
 	 */
 	private function mb_str_split($string, $charset = 'UTF8') {
-		elgg_deprecated_notice('ElggDiskFilestore::mb_str_split() is deprecated.', 1.8);
+		elgg_deprecated_notice('\ElggDiskFilestore::mb_str_split() is deprecated.', 1.8);
 
 		if (is_callable('mb_substr')) {
 			$length = mb_strlen($string);
@@ -403,18 +403,18 @@ class ElggDiskFilestore extends ElggFilestore {
 	 *
 	 * @param int $guid The guid of the entity to store the data under.
 	 *
-	 * @return str The path where the entity's data will be stored relative to the data dir.
-	 * @deprecated 1.9 Use Elgg_EntityDirLocator()
+	 * @return string The path where the entity's data will be stored relative to the data dir.
+	 * @deprecated 1.9 Use \Elgg\EntityDirLocator()
 	 */
 	protected function makeFileMatrix($guid) {
-		elgg_deprecated_notice('ElggDiskFilestore::makeFileMatrix() is deprecated by Elgg_EntityDirLocator', 1.9);
+		elgg_deprecated_notice('\ElggDiskFilestore::makeFileMatrix() is deprecated by \Elgg\EntityDirLocator', 1.9);
 		$entity = get_entity($guid);
 
-		if (!$entity instanceof ElggEntity) {
+		if (!$entity instanceof \ElggEntity) {
 			return false;
 		}
 
-		$dir = new Elgg_EntityDirLocator($guid);
+		$dir = new \Elgg\EntityDirLocator($guid);
 		return $dir->getPath();
 	}
 }

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -2,24 +2,24 @@
 /**
  * The parent class for all Elgg Entities.
  *
- * An ElggEntity is one of the basic data models in Elgg.  It is the primary
- * means of storing and retrieving data from the database.  An ElggEntity
+ * An \ElggEntity is one of the basic data models in Elgg.  It is the primary
+ * means of storing and retrieving data from the database.  An \ElggEntity
  * represents one row of the entities table.
  *
- * The ElggEntity class handles CRUD operations for the entities table.
- * ElggEntity should always be extended by another class to handle CRUD
+ * The \ElggEntity class handles CRUD operations for the entities table.
+ * \ElggEntity should always be extended by another class to handle CRUD
  * operations on the type-specific table.
  *
- * ElggEntity uses magic methods for get and set, so any property that isn't
+ * \ElggEntity uses magic methods for get and set, so any property that isn't
  * declared will be assumed to be metadata and written to the database
  * as metadata on the object.  All children classes must declare which
  * properties are columns of the type table or they will be assumed
- * to be metadata.  See ElggObject::initializeAttributes() for examples.
+ * to be metadata.  See \ElggObject::initializeAttributes() for examples.
  *
- * Core supports 4 types of entities: ElggObject, ElggUser, ElggGroup, and
- * ElggSite.
+ * Core supports 4 types of entities: \ElggObject, \ElggUser, \ElggGroup, and
+ * \ElggSite.
  *
- * @tip Plugin authors will want to extend the ElggObject class, not this class.
+ * @tip Plugin authors will want to extend the \ElggObject class, not this class.
  *
  * @package    Elgg.Core
  * @subpackage DataModel.Entities
@@ -38,7 +38,7 @@
  * Metadata (the above are attributes)
  * @property       string $location       A location of the entity
  */
-abstract class ElggEntity extends ElggData implements
+abstract class ElggEntity extends \ElggData implements
 	Notable,   // Calendar interface (deprecated 1.9)
 	Locatable, // Geocoding interface
 	Importable // Allow import of data (deprecated 1.9)
@@ -187,12 +187,12 @@ abstract class ElggEntity extends ElggData implements
 	 * Anything that is not an attribute is saved as metadata.
 	 * 
 	 * @warning Metadata set this way will inherit the entity's owner and 
-	 * access ID. If you want more control over metadata, use ElggEntity::setMetadata()
+	 * access ID. If you want more control over metadata, use \ElggEntity::setMetadata()
 	 * 
 	 * @param string $name  Name of the attribute or metadata
 	 * @param mixed  $value The value to be set
 	 * @return void
-	 * @see ElggEntity::setMetadata()
+	 * @see \ElggEntity::setMetadata()
 	 */
 	public function __set($name, $value) {
 		if (array_key_exists($name, $this->attributes)) {
@@ -437,8 +437,8 @@ abstract class ElggEntity extends ElggData implements
 			// getMetaData(), just like pulling from the db.
 
 			if ($owner_guid != 0 || $access_id !== null) {
-				$msg = "owner guid and access id cannot be used in ElggEntity::setMetadata() until entity is saved.";
-				throw new InvalidArgumentException($msg);
+				$msg = "owner guid and access id cannot be used in \ElggEntity::setMetadata() until entity is saved.";
+				throw new \InvalidArgumentException($msg);
 			}
 
 			// if overwrite, delete first
@@ -514,7 +514,7 @@ abstract class ElggEntity extends ElggData implements
 	 * @deprecated 1.8 Use deleteMetadata()
 	 */
 	public function clearMetadata($name = '') {
-		elgg_deprecated_notice('ElggEntity->clearMetadata() is deprecated by ->deleteMetadata()', 1.8);
+		elgg_deprecated_notice('\ElggEntity->clearMetadata() is deprecated by ->deleteMetadata()', 1.8);
 		return $this->deleteMetadata($name);
 	}
 
@@ -603,8 +603,8 @@ abstract class ElggEntity extends ElggData implements
 	 *
 	 * @param null|string $relationship The name of the relationship to remove.
 	 * @return bool
-	 * @see ElggEntity::addRelationship()
-	 * @see ElggEntity::removeRelationship()
+	 * @see \ElggEntity::addRelationship()
+	 * @see \ElggEntity::removeRelationship()
 	 */
 	public function deleteRelationships($relationship = null) {
 		$relationship = (string)$relationship;
@@ -616,12 +616,12 @@ abstract class ElggEntity extends ElggData implements
 	 * Remove all relationships to and from this entity.
 	 *
 	 * @return bool
-	 * @see ElggEntity::addRelationship()
-	 * @see ElggEntity::removeRelationship()
-	 * @deprecated 1.8 Use ElggEntity::deleteRelationships()
+	 * @see \ElggEntity::addRelationship()
+	 * @see \ElggEntity::removeRelationship()
+	 * @deprecated 1.8 Use \ElggEntity::deleteRelationships()
 	 */
 	public function clearRelationships() {
-		elgg_deprecated_notice('ElggEntity->clearRelationships() is deprecated by ->deleteRelationships()', 1.8);
+		elgg_deprecated_notice('\ElggEntity->clearRelationships() is deprecated by ->deleteRelationships()', 1.8);
 		return $this->deleteRelationships();
 	}
 
@@ -634,8 +634,8 @@ abstract class ElggEntity extends ElggData implements
 	 * @param string $relationship The type of relationship.
 	 *
 	 * @return bool
-	 * @see ElggEntity::removeRelationship()
-	 * @see ElggEntity::deleteRelationships()
+	 * @see \ElggEntity::removeRelationship()
+	 * @see \ElggEntity::deleteRelationships()
 	 */
 	public function addRelationship($guid_two, $relationship) {
 		return add_entity_relationship($this->getGUID(), $relationship, $guid_two);
@@ -648,8 +648,8 @@ abstract class ElggEntity extends ElggData implements
 	 * @param string $relationship The type of relationship.
 	 *
 	 * @return bool
-	 * @see ElggEntity::addRelationship()
-	 * @see ElggEntity::deleteRelationships()
+	 * @see \ElggEntity::addRelationship()
+	 * @see \ElggEntity::deleteRelationships()
 	 */
 	public function removeRelationship($guid_two, $relationship) {
 		return remove_entity_relationship($this->getGUID(), $relationship, $guid_two);
@@ -850,7 +850,7 @@ abstract class ElggEntity extends ElggData implements
 	 */
 	public function getAnnotations($options = array(), $limit = 50, $offset = 0, $order = "asc") {
 		if (!is_array($options)) {
-			elgg_deprecated_notice("ElggEntity::getAnnotations() takes an array of options.", 1.9);
+			elgg_deprecated_notice("\ElggEntity::getAnnotations() takes an array of options.", 1.9);
 		}
 
 		if ((int) ($this->guid) > 0) {
@@ -896,7 +896,7 @@ abstract class ElggEntity extends ElggData implements
 	 * @deprecated 1.8 Use ->deleteAnnotations()
 	 */
 	public function clearAnnotations($name = "") {
-		elgg_deprecated_notice('ElggEntity->clearAnnotations() is deprecated by ->deleteAnnotations()', 1.8);
+		elgg_deprecated_notice('\ElggEntity->clearAnnotations() is deprecated by ->deleteAnnotations()', 1.8);
 		return $this->deleteAnnotations($name);
 	}
 
@@ -995,7 +995,7 @@ abstract class ElggEntity extends ElggData implements
 			$options['relationship_guid'] = $this->getGUID();
 			return elgg_get_entities_from_relationship($options);
 		} else {
-			elgg_deprecated_notice("ElggEntity::getEntitiesFromRelationship takes an options array", 1.9);
+			elgg_deprecated_notice("\ElggEntity::getEntitiesFromRelationship takes an options array", 1.9);
 			return elgg_get_entities_from_relationship(array(
 				'relationship' => $options,
 				'relationship_guid' => $this->getGUID(),
@@ -1075,8 +1075,8 @@ abstract class ElggEntity extends ElggData implements
 	 * @tip Can be overridden by by registering for the permissions_check:metadata
 	 * plugin hook.
 	 *
-	 * @param ElggMetadata $metadata  The piece of metadata to specifically check or null for any metadata
-	 * @param int          $user_guid The user GUID, optionally (default: logged in user)
+	 * @param \ElggMetadata $metadata  The piece of metadata to specifically check or null for any metadata
+	 * @param int           $user_guid The user GUID, optionally (default: logged in user)
 	 *
 	 * @return bool
 	 * @see elgg_set_ignore_access()
@@ -1144,7 +1144,7 @@ abstract class ElggEntity extends ElggData implements
 		$user = get_entity($user_guid);
 
 		// By default, we don't take a position of whether commenting is allowed
-		// because it is handled by the subclasses of ElggEntity
+		// because it is handled by the subclasses of \ElggEntity
 		$params = array('entity' => $this, 'user' => $user);
 		return elgg_trigger_plugin_hook('permissions_check:comment', $this->type, $params, null);
 	}
@@ -1238,14 +1238,14 @@ abstract class ElggEntity extends ElggData implements
 	 * @deprecated 1.8 Use getOwnerGUID()
 	 */
 	public function getOwner() {
-		elgg_deprecated_notice("ElggEntity::getOwner deprecated for ElggEntity::getOwnerGUID", 1.8);
+		elgg_deprecated_notice("\ElggEntity::getOwner deprecated for \ElggEntity::getOwnerGUID", 1.8);
 		return $this->getOwnerGUID();
 	}
 
 	/**
-	 * Gets the ElggEntity that owns this entity.
+	 * Gets the \ElggEntity that owns this entity.
 	 *
-	 * @return ElggEntity The owning entity
+	 * @return \ElggEntity The owning entity
 	 */
 	public function getOwnerEntity() {
 		return get_entity($this->owner_guid);
@@ -1271,7 +1271,7 @@ abstract class ElggEntity extends ElggData implements
 	 * @deprecated 1.8 use setContainerGUID()
 	 */
 	public function setContainer($container_guid) {
-		elgg_deprecated_notice("ElggObject::setContainer deprecated for ElggEntity::setContainerGUID", 1.8);
+		elgg_deprecated_notice("\ElggObject::setContainer deprecated for \ElggEntity::setContainerGUID", 1.8);
 		return $this->setContainerGUID('container_guid', $container_guid);
 	}
 
@@ -1291,14 +1291,14 @@ abstract class ElggEntity extends ElggData implements
 	 * @deprecated 1.8 Use getContainerGUID()
 	 */
 	public function getContainer() {
-		elgg_deprecated_notice("ElggObject::getContainer deprecated for ElggEntity::getContainerGUID", 1.8);
+		elgg_deprecated_notice("\ElggObject::getContainer deprecated for \ElggEntity::getContainerGUID", 1.8);
 		return $this->getContainerGUID();
 	}
 
 	/**
 	 * Get the container entity for this object.
 	 *
-	 * @return ElggEntity
+	 * @return \ElggEntity
 	 * @since 1.8.0
 	 */
 	public function getContainerEntity() {
@@ -1355,7 +1355,7 @@ abstract class ElggEntity extends ElggData implements
 		$params = array('entity' => $this);
 		$url = elgg_trigger_plugin_hook('entity:url', $type, $params, $url);
 
-		// @todo remove when ElggEntity::setURL() has been removed
+		// @todo remove when \ElggEntity::setURL() has been removed
 		if (!empty($this->url_override)) {
 			$url = $this->url_override;
 		}
@@ -1371,10 +1371,10 @@ abstract class ElggEntity extends ElggData implements
 	 * @param string $url The new item URL
 	 *
 	 * @return string The URL
-	 * @deprecated 1.9.0 See ElggEntity::getURL() for details on the plugin hook
+	 * @deprecated 1.9.0 See \ElggEntity::getURL() for details on the plugin hook
 	 */
 	public function setURL($url) {
-		elgg_deprecated_notice('ElggEntity::setURL() has been replaced by the "entity:url" plugin hook', 1.9);
+		elgg_deprecated_notice('\ElggEntity::setURL() has been replaced by the "entity:url" plugin hook', 1.9);
 		$this->url_override = $url;
 		return $url;
 	}
@@ -1455,11 +1455,11 @@ abstract class ElggEntity extends ElggData implements
 	 *
 	 * This creates a 'member_of_site' relationship.
 	 *
-	 * @param ElggSite $site The site to add this entity to
+	 * @param \ElggSite $site The site to add this entity to
 	 *
 	 * @return bool
-	 * @todo add ElggSite type hint once we have removed addToSite() from ElggUser
-	 * and ElggObject
+	 * @todo add \ElggSite type hint once we have removed addToSite() from \ElggUser
+	 * and \ElggObject
 	 */
 	public function addToSite($site) {
 		if (!elgg_instanceof($site, 'site')) {
@@ -1474,10 +1474,10 @@ abstract class ElggEntity extends ElggData implements
 	 *
 	 * This deletes the 'member_of_site' relationship.
 	 *
-	 * @param ElggSite $site The site to remove this entity from
+	 * @param \ElggSite $site The site to remove this entity from
 	 *
 	 * @return bool
-	 * @todo add ElggSite type hint once we have removed addToSite() from ElggUser
+	 * @todo add \ElggSite type hint once we have removed addToSite() from \ElggUser
 	 */
 	public function removeFromSite($site) {
 		if (!elgg_instanceof($site, 'site')) {
@@ -1497,7 +1497,7 @@ abstract class ElggEntity extends ElggData implements
 	 *                       'relationship', 'relationship_guid', 'inverse_relationship'
 	 *
 	 * @return array
-	 * @todo add type hint when ElggUser and ElggObject have been updates
+	 * @todo add type hint when \ElggUser and \ElggObject have been updates
 	 */
 	public function getSites($options = array()) {
 		$options['relationship'] = 'member_of_site';
@@ -1566,7 +1566,7 @@ abstract class ElggEntity extends ElggData implements
 		// Using attribute array directly; get function does something special!
 		$type = $this->getDatabase()->sanitizeString($this->attributes['type']);
 		if ($type == "") {
-			throw new InvalidParameterException("Entity type must be set.");
+			throw new \InvalidParameterException("Entity type must be set.");
 		}
 		
 		$subtype = $this->attributes['subtype'];
@@ -1589,7 +1589,7 @@ abstract class ElggEntity extends ElggData implements
 		$container_guid = (int)$container_guid;
 
 		if ($access_id == ACCESS_DEFAULT) {
-			throw new InvalidParameterException('ACCESS_DEFAULT is not a valid access level. See its documentation in elgglib.h');
+			throw new \InvalidParameterException('ACCESS_DEFAULT is not a valid access level. See its documentation in elgglib.h');
 		}
 
 		$owner = $this->getOwnerEntity();
@@ -1612,7 +1612,7 @@ abstract class ElggEntity extends ElggData implements
 				$access_id, $time_created, $now, $now)");
 
 		if (!$result) {
-			throw new IOException("Unable to save new object's base entity information!");
+			throw new \IOException("Unable to save new object's base entity information!");
 		}
 	
 		// for BC with 1.8, ->subtype always returns ID, ->getSubtype() the string
@@ -1698,7 +1698,7 @@ abstract class ElggEntity extends ElggData implements
 		$time = time();
 
 		if ($access_id == ACCESS_DEFAULT) {
-			throw new InvalidParameterException('ACCESS_DEFAULT is not a valid access level. See its documentation in elgglib.php');
+			throw new \InvalidParameterException('ACCESS_DEFAULT is not a valid access level. See its documentation in elgglib.php');
 		}
 		
 		$ret = $this->getDatabase()->updateData("UPDATE {$CONFIG->dbprefix}entities
@@ -1706,15 +1706,15 @@ abstract class ElggEntity extends ElggData implements
 			container_guid='$container_guid', time_created='$time_created',
 			time_updated='$time' WHERE guid=$guid");
 
-		// TODO(evan): Move this to ElggObject?
-		if ($this instanceof ElggObject) {
+		// TODO(evan): Move this to \ElggObject?
+		if ($this instanceof \ElggObject) {
 			update_river_access_by_object($guid, $access_id);
 		}
 
 		// If memcache is available then delete this entry from the cache
 		static $newentity_cache;
 		if ((!$newentity_cache) && (is_memcache_available())) {
-			$newentity_cache = new ElggMemcache('new_entity_cache');
+			$newentity_cache = new \ElggMemcache('new_entity_cache');
 		}
 		if ($newentity_cache) {
 			$newentity_cache->delete($guid);
@@ -1733,12 +1733,12 @@ abstract class ElggEntity extends ElggData implements
 	/**
 	 * Loads attributes from the entities table into the object.
 	 *
-	 * @param mixed $guid GUID of entity or stdClass object from entities table
+	 * @param mixed $guid GUID of entity or \stdClass object from entities table
 	 *
 	 * @return bool
 	 */
 	protected function load($guid) {
-		if ($guid instanceof stdClass) {
+		if ($guid instanceof \stdClass) {
 			$row = $guid;
 		} else {
 			$row = get_entity_as_row($guid);
@@ -1798,12 +1798,12 @@ abstract class ElggEntity extends ElggData implements
 	 * request in case different select clauses were used to load different data
 	 * into volatile data.
 	 * 
-	 * @param stdClass $row DB row with new entity data
+	 * @param \stdClass $row DB row with new entity data
 	 * @return bool
 	 * @access private
 	 */
-	public function refresh(stdClass $row) {
-		if ($row instanceof stdClass) {
+	public function refresh(\stdClass $row) {
+		if ($row instanceof \stdClass) {
 			return $this->load($row);
 		}
 		return false;
@@ -1813,7 +1813,7 @@ abstract class ElggEntity extends ElggData implements
 	 * Disable this entity.
 	 *
 	 * Disabled entities are not returned by getter functions.
-	 * To enable an entity, use {@link ElggEntity::enable()}.
+	 * To enable an entity, use {@link \ElggEntity::enable()}.
 	 *
 	 * Recursively disabling an entity will disable all entities
 	 * owned or contained by the parent entity.
@@ -1826,7 +1826,7 @@ abstract class ElggEntity extends ElggData implements
 	 * @param bool   $recursive Recursively disable all contained entities?
 	 *
 	 * @return bool
-	 * @see ElggEntity::enable()
+	 * @see \ElggEntity::enable()
 	 */
 	public function disable($reason = "", $recursive = true) {
 		if (!$this->guid) {
@@ -1997,7 +1997,7 @@ abstract class ElggEntity extends ElggData implements
 		// If memcache is available then delete this entry from the cache
 		static $newentity_cache;
 		if ((!$newentity_cache) && (is_memcache_available())) {
-			$newentity_cache = new ElggMemcache('new_entity_cache');
+			$newentity_cache = new \ElggMemcache('new_entity_cache');
 		}
 		if ($newentity_cache) {
 			$newentity_cache->delete($guid);
@@ -2017,7 +2017,7 @@ abstract class ElggEntity extends ElggData implements
 
 			// @todo there was logic in the original code that ignored
 			// entities with owner or container guids of themselves.
-			// this should probably be prevented in ElggEntity instead of checked for here
+			// this should probably be prevented in \ElggEntity instead of checked for here
 			$options = array(
 				'wheres' => array(
 					"((container_guid = $guid OR owner_guid = $guid OR site_guid = $guid)"
@@ -2026,7 +2026,7 @@ abstract class ElggEntity extends ElggData implements
 				'limit' => 0
 			);
 
-			$batch = new ElggBatch('elgg_get_entities', $options);
+			$batch = new \ElggBatch('elgg_get_entities', $options);
 			$batch->setIncrementOffset(false);
 
 			foreach ($batch as $e) {
@@ -2089,7 +2089,7 @@ abstract class ElggEntity extends ElggData implements
 	 * {@inheritdoc}
 	 */
 	public function toObject() {
-		$object = $this->prepareObject(new stdClass());
+		$object = $this->prepareObject(new \stdClass());
 		$params = array('entity' => $this);
 		$object = elgg_trigger_plugin_hook('to:object', 'entity', $params, $object);
 		return $object;
@@ -2098,8 +2098,8 @@ abstract class ElggEntity extends ElggData implements
 	/**
 	 * Prepare an object copy for toObject()
 	 * 
-	 * @param stdClass $object Object representation of the entity
-	 * @return stdClass
+	 * @param \stdClass $object Object representation of the entity
+	 * @return \stdClass
 	 */
 	protected function prepareObject($object) {
 		$object->guid = $this->guid;
@@ -2356,7 +2356,7 @@ abstract class ElggEntity extends ElggData implements
 	public function import(ODD $data) {
 		elgg_deprecated_notice(__METHOD__ . ' has been deprecated', 1.9);
 		if (!($data instanceof ODDEntity)) {
-			throw new InvalidParameterException("import() passed an unexpected ODD class");
+			throw new \InvalidParameterException("import() passed an unexpected ODD class");
 		}
 
 		// Set type and subtype

--- a/engine/classes/ElggExtender.php
+++ b/engine/classes/ElggExtender.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * The base class for ElggEntity extenders.
+ * The base class for \ElggEntity extenders.
  *
  * Extenders allow you to attach extended information to an
- * ElggEntity.  Core supports two: ElggAnnotation and ElggMetadata.
+ * \ElggEntity.  Core supports two: \ElggAnnotation and \ElggMetadata.
  *
  * Saving the extender data to database is handled by the child class.
  *
  * @package    Elgg.Core
  * @subpackage DataModel.Extender
- * @see        ElggAnnotation
- * @see        ElggMetadata
+ * @see        \ElggAnnotation
+ * @see        \ElggMetadata
  * 
  * @property string $type         annotation or metadata (read-only after save)
  * @property int    $id           The unique identifier (read-only)
@@ -23,12 +23,12 @@
  * @property string $value_type   'integer' or 'text'
  * @property string $enabled      Is this extender enabled ('yes' or 'no')
  */
-abstract class ElggExtender extends ElggData {
+abstract class ElggExtender extends \ElggData {
 
 	/**
 	 * (non-PHPdoc)
 	 *
-	 * @see ElggData::initializeAttributes()
+	 * @see \ElggData::initializeAttributes()
 	 *
 	 * @return void
 	 */
@@ -108,8 +108,8 @@ abstract class ElggExtender extends ElggData {
 						return $this->attributes['value'];
 						break;
 					default :
-						$msg = "{$this->attributes['value_type']} is not a supported ElggExtender value type.";
-						throw new UnexpectedValueException($msg);
+						$msg = "{$this->attributes['value_type']} is not a supported \ElggExtender value type.";
+						throw new \UnexpectedValueException($msg);
 						break;
 				}
 			}
@@ -148,14 +148,14 @@ abstract class ElggExtender extends ElggData {
 	 * @deprecated 1.8 Use getOwnerGUID
 	 */
 	public function getOwner() {
-		elgg_deprecated_notice("ElggExtender::getOwner deprecated for ElggExtender::getOwnerGUID", 1.8);
+		elgg_deprecated_notice("\ElggExtender::getOwner deprecated for \ElggExtender::getOwnerGUID", 1.8);
 		return $this->getOwnerGUID();
 	}
 
 	/**
 	 * Get the entity that owns this extender
 	 *
-	 * @return ElggEntity
+	 * @return \ElggEntity
 	 */
 	public function getOwnerEntity() {
 		return get_entity($this->owner_guid);
@@ -164,7 +164,7 @@ abstract class ElggExtender extends ElggData {
 	/**
 	 * Get the entity this describes.
 	 *
-	 * @return ElggEntity The entity
+	 * @return \ElggEntity The entity
 	 */
 	public function getEntity() {
 		return get_entity($this->entity_guid);
@@ -185,7 +185,7 @@ abstract class ElggExtender extends ElggData {
 	 * {@inheritdoc}
 	 */
 	public function toObject() {
-		$object = new stdClass();
+		$object = new \stdClass();
 		$object->id = $this->id;
 		$object->entity_guid = $this->entity_guid;
 		$object->owner_guid = $this->owner_guid;

--- a/engine/classes/ElggFile.php
+++ b/engine/classes/ElggFile.php
@@ -3,7 +3,7 @@
 /**
  * This class represents a physical file.
  *
- * Create a new ElggFile object and specify a filename, and optionally a
+ * Create a new \ElggFile object and specify a filename, and optionally a
  * FileStore (if one isn't specified then the default is assumed.)
  *
  * Open the file using the appropriate mode, and you will be able to
@@ -13,13 +13,13 @@
  * turn the file into an entity in the system and permit you to do
  * things like attach tags to the file. If you do not save the file, no
  * entity is created in the database. This is because there are occasions
- * when you may want access to file data on datastores using the ElggFile
+ * when you may want access to file data on datastores using the \ElggFile
  * interface without a need to persist information such as temporary files.
  *
  * @package    Elgg.Core
  * @subpackage DataModel.File
  */
-class ElggFile extends ElggObject {
+class ElggFile extends \ElggObject {
 	/** Filestore */
 	private $filestore;
 
@@ -38,9 +38,9 @@ class ElggFile extends ElggObject {
 	}
 
 	/**
-	 * Loads an ElggFile entity.
+	 * Loads an \ElggFile entity.
 	 *
-	 * @param stdClass $row Database result or null for new ElggFile
+	 * @param \stdClass $row Database result or null for new \ElggFile
 	 */
 	public function __construct($row = null) {
 		parent::__construct($row);
@@ -92,7 +92,7 @@ class ElggFile extends ElggObject {
 			$container_guid = $this->container_guid;
 		}
 		$fs = $this->getFilestore();
-		// @todo add getSize() to ElggFilestore
+		// @todo add getSize() to \ElggFilestore
 		return $fs->getSize($prefix, $container_guid);
 	}
 
@@ -184,7 +184,7 @@ class ElggFile extends ElggObject {
 	 */
 	public function open($mode) {
 		if (!$this->getFilename()) {
-			throw new IOException("You must specify a name before opening a file.");
+			throw new \IOException("You must specify a name before opening a file.");
 		}
 
 		// See if file has already been saved
@@ -197,7 +197,7 @@ class ElggFile extends ElggObject {
 			($mode != "append")
 		) {
 			$msg = "Unrecognized file mode '" . $mode . "'";
-			throw new InvalidParameterException($msg);
+			throw new \InvalidParameterException($msg);
 		}
 
 		// Get the filestore
@@ -293,7 +293,7 @@ class ElggFile extends ElggObject {
 	public function seek($position) {
 		$fs = $this->getFilestore();
 
-		// @todo add seek() to ElggFilestore
+		// @todo add seek() to \ElggFilestore
 		return $fs->seek($this->handle, $position);
 	}
 
@@ -325,7 +325,7 @@ class ElggFile extends ElggObject {
 	 * @deprecated 1.8 Use getSize()
 	 */
 	public function size() {
-		elgg_deprecated_notice("Use ElggFile::getSize() instead of ElggFile::size()", 1.9);
+		elgg_deprecated_notice("Use \ElggFile::getSize() instead of \ElggFile::size()", 1.9);
 		return $this->getSize();
 	}
 
@@ -354,11 +354,11 @@ class ElggFile extends ElggObject {
 	/**
 	 * Set a filestore.
 	 *
-	 * @param ElggFilestore $filestore The file store.
+	 * @param \ElggFilestore $filestore The file store.
 	 *
 	 * @return void
 	 */
-	public function setFilestore(ElggFilestore $filestore) {
+	public function setFilestore(\ElggFilestore $filestore) {
 		$this->filestore = $filestore;
 	}
 
@@ -367,7 +367,7 @@ class ElggFile extends ElggObject {
 	 * This filestore is either a pre-registered filestore,
 	 * a filestore as recorded in metadata or the system default.
 	 *
-	 * @return ElggFilestore
+	 * @return \ElggFilestore
 	 *
 	 * @throws ClassNotFoundException
 	 */
@@ -404,7 +404,7 @@ class ElggFile extends ElggObject {
 		if (isset($filestore)) {
 			if (!class_exists($filestore)) {
 				$msg = "Unable to load filestore class " . $filestore . " for file " . $this->guid;
-				throw new ClassNotFoundException($msg);
+				throw new \ClassNotFoundException($msg);
 			}
 
 			$this->filestore = new $filestore();
@@ -426,7 +426,7 @@ class ElggFile extends ElggObject {
 	 * Write the file's data to the filestore and save
 	 * the corresponding entity.
 	 *
-	 * @see ElggObject::save()
+	 * @see \ElggObject::save()
 	 *
 	 * @return bool
 	 */

--- a/engine/classes/ElggFileCache.php
+++ b/engine/classes/ElggFileCache.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * ElggFileCache
+ * \ElggFileCache
  * Store cached data in a file store.
  *
  * @package    Elgg.Core
  * @subpackage Caches
  */
-class ElggFileCache extends ElggCache {
+class ElggFileCache extends \ElggCache {
 	/**
 	 * Set the Elgg cache.
 	 *
@@ -22,7 +22,7 @@ class ElggFileCache extends ElggCache {
 		$this->setVariable("max_size", $max_size);
 
 		if ($cache_path == "") {
-			throw new ConfigurationException("Cache path set to nothing!");
+			throw new \ConfigurationException("Cache path set to nothing!");
 		}
 	}
 
@@ -30,7 +30,7 @@ class ElggFileCache extends ElggCache {
 	/**
 	 * Create and return a handle to a file.
 	 *
-	 * @deprecated 1.8 Use ElggFileCache::createFile()
+	 * @deprecated 1.8 Use \ElggFileCache::createFile()
 	 *
 	 * @param string $filename Filename to save as
 	 * @param string $rw       Write mode
@@ -38,7 +38,7 @@ class ElggFileCache extends ElggCache {
 	 * @return mixed
 	 */
 	protected function create_file($filename, $rw = "rb") {
-		elgg_deprecated_notice('ElggFileCache::create_file() is deprecated by ::createFile()', 1.8);
+		elgg_deprecated_notice('\ElggFileCache::create_file() is deprecated by ::createFile()', 1.8);
 
 		return $this->createFile($filename, $rw);
 	}
@@ -78,7 +78,7 @@ class ElggFileCache extends ElggCache {
 	/**
 	 * Create a sanitised filename for the file.
 	 *
-	 * @deprecated 1.8 Use ElggFileCache::sanitizeFilename()
+	 * @deprecated 1.8 Use \ElggFileCache::sanitizeFilename()
 	 *
 	 * @param string $filename The filename
 	 *
@@ -207,7 +207,7 @@ class ElggFileCache extends ElggCache {
 
 		$files = scandir($dir);
 		if (!$files) {
-			throw new IOException($dir . " is not a directory.");
+			throw new \IOException($dir . " is not a directory.");
 		}
 
 		// Perform cleanup

--- a/engine/classes/ElggFilestore.php
+++ b/engine/classes/ElggFilestore.php
@@ -4,18 +4,18 @@
  *
  * @package    Elgg.Core
  * @subpackage DataStorage
- * @class   ElggFilestore
+ * @class   \ElggFilestore
  */
 abstract class ElggFilestore {
 	/**
 	 * Attempt to open the file $file for storage or writing.
 	 *
-	 * @param ElggFile $file A file
-	 * @param string   $mode "read", "write", "append"
+	 * @param \ElggFile $file A file
+	 * @param string    $mode "read", "write", "append"
 	 *
 	 * @return mixed A handle to the opened file or false on error.
 	 */
-	abstract public function open(ElggFile $file, $mode);
+	abstract public function open(\ElggFile $file, $mode);
 
 	/**
 	 * Write data to a given file handle.
@@ -78,29 +78,29 @@ abstract class ElggFilestore {
 	/**
 	 * Delete the file associated with a given file handle.
 	 *
-	 * @param ElggFile $file The file
+	 * @param \ElggFile $file The file
 	 *
 	 * @return bool
 	 */
-	abstract public function delete(ElggFile $file);
+	abstract public function delete(\ElggFile $file);
 
 	/**
 	 * Return the size in bytes for a given file.
 	 *
-	 * @param ElggFile $file The file
+	 * @param \ElggFile $file The file
 	 *
 	 * @return int
 	 */
-	abstract public function getFileSize(ElggFile $file);
+	abstract public function getFileSize(\ElggFile $file);
 
 	/**
 	 * Return the filename of a given file as stored on the filestore.
 	 *
-	 * @param ElggFile $file The file
+	 * @param \ElggFile $file The file
 	 *
 	 * @return string
 	 */
-	abstract public function getFilenameOnFilestore(ElggFile $file);
+	abstract public function getFilenameOnFilestore(\ElggFile $file);
 
 	/**
 	 * Get the filestore's creation parameters as an associative array.
@@ -126,14 +126,14 @@ abstract class ElggFilestore {
 	 *
 	 * @return mixed The file contents.
 	 */
-	abstract public function grabFile(ElggFile $file);
+	abstract public function grabFile(\ElggFile $file);
 
 	/**
 	 * Return whether a file physically exists or not.
 	 *
-	 * @param ElggFile $file The file
+	 * @param \ElggFile $file The file
 	 *
 	 * @return bool
 	 */
-	abstract public function exists(ElggFile $file);
+	abstract public function exists(\ElggFile $file);
 }

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -9,7 +9,7 @@
  * @property string $name        A short name that captures the purpose of the group
  * @property string $description A longer body of content that gives more details about the group
  */
-class ElggGroup extends ElggEntity
+class ElggGroup extends \ElggEntity
 	implements Friendable {
 
 	const CONTENT_ACCESS_MODE_UNRESTRICTED = 'unrestricted';
@@ -35,7 +35,7 @@ class ElggGroup extends ElggEntity
 	 * Plugin developers should only use the constructor to create a new entity.
 	 * To retrieve entities, use get_entity() and the elgg_get_entities* functions.
 	 *
-	 * @param stdClass $row Database row result. Default is null to create a new group.
+	 * @param \stdClass $row Database row result. Default is null to create a new group.
 	 *
 	 * @throws IOException|InvalidParameterException if there was a problem creating the group.
 	 */
@@ -47,15 +47,15 @@ class ElggGroup extends ElggEntity
 
 		if (!empty($row)) {
 			// Is $guid is a entity table DB row
-			if ($row instanceof stdClass) {
+			if ($row instanceof \stdClass) {
 				// Load the rest
 				if (!$this->load($row)) {
 					$msg = "Failed to load new " . get_class() . " for GUID:" . $row->guid;
-					throw new IOException($msg);
+					throw new \IOException($msg);
 				}
-			} else if ($row instanceof ElggGroup) {
-				// $row is an ElggGroup so this is a copy constructor
-				elgg_deprecated_notice('This type of usage of the ElggGroup constructor was deprecated. Please use the clone method.', 1.7);
+			} else if ($row instanceof \ElggGroup) {
+				// $row is an \ElggGroup so this is a copy constructor
+				elgg_deprecated_notice('This type of usage of the \ElggGroup constructor was deprecated. Please use the clone method.', 1.7);
 				foreach ($row->attributes as $key => $value) {
 					$this->attributes[$key] = $value;
 				}
@@ -63,10 +63,10 @@ class ElggGroup extends ElggEntity
 				// $row is a GUID so load entity
 				elgg_deprecated_notice('Passing a GUID to constructor is deprecated. Use get_entity()', 1.9);
 				if (!$this->load($row)) {
-					throw new IOException("Failed to load new " . get_class() . " from GUID:" . $row);
+					throw new \IOException("Failed to load new " . get_class() . " from GUID:" . $row);
 				}
 			} else {
-				throw new InvalidParameterException("Unrecognized value passed to constuctor.");
+				throw new \InvalidParameterException("Unrecognized value passed to constuctor.");
 			}
 		}
 	}
@@ -86,13 +86,13 @@ class ElggGroup extends ElggEntity
 	}
 
 	/**
-	 * Add an ElggObject to this group.
+	 * Add an \ElggObject to this group.
 	 *
-	 * @param ElggObject $object The object.
+	 * @param \ElggObject $object The object.
 	 *
 	 * @return bool
 	 */
-	public function addObjectToGroup(ElggObject $object) {
+	public function addObjectToGroup(\ElggObject $object) {
 		$object->container_guid = $this->guid;
 		return $object->save();
 	}
@@ -101,13 +101,13 @@ class ElggGroup extends ElggEntity
 	 * Remove an object from this containing group and sets the container to be
 	 * object's owner
 	 *
-	 * @param ElggObject $object The object.
+	 * @param \ElggObject $object The object.
 	 *
 	 * @return bool
 	 */
 	public function removeObjectFromGroup($object) {
 		if (is_numeric($object)) {
-			elgg_deprecated_notice('ElggGroup::removeObjectFromGroup() takes an ElggObject not a guid.', 1.9);
+			elgg_deprecated_notice('\ElggGroup::removeObjectFromGroup() takes an \ElggObject not a guid.', 1.9);
 			$object = get_entity($object);
 			if (!elgg_instanceof($object, 'object')) {
 				return false;
@@ -119,9 +119,9 @@ class ElggGroup extends ElggEntity
 	}
 
 	/**
-	 * Wrapper around ElggEntity::__get()
+	 * Wrapper around \ElggEntity::__get()
 	 *
-	 * @see ElggEntity::__get()
+	 * @see \ElggEntity::__get()
 	 *
 	 * @param string $name Name
 	 * @return mixed
@@ -136,7 +136,7 @@ class ElggGroup extends ElggEntity
 	}
 
 	/**
-	 * Wrapper around ElggEntity::get()
+	 * Wrapper around \ElggEntity::get()
 	 *
 	 * @param string $name Name
 	 * @return mixed
@@ -165,15 +165,15 @@ class ElggGroup extends ElggEntity
 	/**
 	 * For compatibility with Friendable.
 	 *
-	 * Join a group when you friend ElggGroup.
+	 * Join a group when you friend \ElggGroup.
 	 *
 	 * @param int $friend_guid The GUID of the user joining the group.
 	 *
 	 * @return bool
-	 * @deprecated 1.9 Use ElggGroup::join()
+	 * @deprecated 1.9 Use \ElggGroup::join()
 	 */
 	public function addFriend($friend_guid) {
-		elgg_deprecated_notice("ElggGroup::addFriend() is deprecated. Use ElggGroup::join()", 1.9);
+		elgg_deprecated_notice("\ElggGroup::addFriend() is deprecated. Use \ElggGroup::join()", 1.9);
 		$user = get_user($friend_guid);
 		return $user ? $this->join($user) : false;
 	}
@@ -181,15 +181,15 @@ class ElggGroup extends ElggEntity
 	/**
 	 * For compatibility with Friendable
 	 *
-	 * Leave group when you unfriend ElggGroup.
+	 * Leave group when you unfriend \ElggGroup.
 	 *
 	 * @param int $friend_guid The GUID of the user leaving.
 	 *
 	 * @return bool
-	 * @deprecated 1.9 Use ElggGroup::leave()
+	 * @deprecated 1.9 Use \ElggGroup::leave()
 	 */
 	public function removeFriend($friend_guid) {
-		elgg_deprecated_notice("ElggGroup::removeFriend() is deprecated. Use ElggGroup::leave()", 1.9);
+		elgg_deprecated_notice("\ElggGroup::removeFriend() is deprecated. Use \ElggGroup::leave()", 1.9);
 		$user = get_user($friend_guid);
 		return $user ? $this->leave($user) : false;
 	}
@@ -200,10 +200,10 @@ class ElggGroup extends ElggEntity
 	 * Friending a group adds you as a member
 	 *
 	 * @return bool
-	 * @deprecated 1.9 Use ElggGroup::isMember()
+	 * @deprecated 1.9 Use \ElggGroup::isMember()
 	 */
 	public function isFriend() {
-		elgg_deprecated_notice("ElggGroup::isFriend() is deprecated. Use ElggGroup::isMember()", 1.9);
+		elgg_deprecated_notice("\ElggGroup::isFriend() is deprecated. Use \ElggGroup::isMember()", 1.9);
 		return $this->isMember();
 	}
 
@@ -213,10 +213,10 @@ class ElggGroup extends ElggEntity
 	 * @param int $user_guid The GUID of a user to check.
 	 *
 	 * @return bool
-	 * @deprecated 1.9 Use ElggGroup::isMember()
+	 * @deprecated 1.9 Use \ElggGroup::isMember()
 	 */
 	public function isFriendsWith($user_guid) {
-		elgg_deprecated_notice("ElggGroup::isFriendsWith() is deprecated. Use ElggGroup::isMember()", 1.9);
+		elgg_deprecated_notice("\ElggGroup::isFriendsWith() is deprecated. Use \ElggGroup::isMember()", 1.9);
 		$user = get_user($user_guid);
 		return $user ? $this->isMember($user) : false;
 	}
@@ -227,10 +227,10 @@ class ElggGroup extends ElggEntity
 	 * @param int $user_guid The GUID of a user to check.
 	 *
 	 * @return bool
-	 * @deprecated 1.9 Use ElggGroup::isMember()
+	 * @deprecated 1.9 Use \ElggGroup::isMember()
 	 */
 	public function isFriendOf($user_guid) {
-		elgg_deprecated_notice("ElggGroup::isFriendOf() is deprecated. Use ElggGroup::isMember()", 1.9);
+		elgg_deprecated_notice("\ElggGroup::isFriendOf() is deprecated. Use \ElggGroup::isMember()", 1.9);
 		$user = get_user($user_guid);
 		return $user ? $this->isMember($user) : false;
 	}
@@ -243,10 +243,10 @@ class ElggGroup extends ElggEntity
 	 * @param int    $offset  Offset
 	 *
 	 * @return bool
-	 * @deprecated 1.9 Use ElggGroup::getMembers()
+	 * @deprecated 1.9 Use \ElggGroup::getMembers()
 	 */
 	public function getFriends($subtype = "", $limit = 10, $offset = 0) {
-		elgg_deprecated_notice("ElggGroup::getFriends() is deprecated. Use ElggGroup::getMembers()", 1.9);
+		elgg_deprecated_notice("\ElggGroup::getFriends() is deprecated. Use \ElggGroup::getMembers()", 1.9);
 		return get_group_members($this->getGUID(), $limit, $offset);
 	}
 
@@ -258,10 +258,10 @@ class ElggGroup extends ElggEntity
 	 * @param int    $offset  Offset
 	 *
 	 * @return bool
-	 * @deprecated 1.9 Use ElggGroup::getMembers()
+	 * @deprecated 1.9 Use \ElggGroup::getMembers()
 	 */
 	public function getFriendsOf($subtype = "", $limit = 10, $offset = 0) {
-		elgg_deprecated_notice("ElggGroup::getFriendsOf() is deprecated. Use ElggGroup::getMembers()", 1.9);
+		elgg_deprecated_notice("\ElggGroup::getFriendsOf() is deprecated. Use \ElggGroup::getMembers()", 1.9);
 		return get_group_members($this->getGUID(), $limit, $offset);
 	}
 
@@ -276,7 +276,7 @@ class ElggGroup extends ElggEntity
 	 * @deprecated 1.9 Use elgg_get_entities()
 	 */
 	public function getObjects($subtype = "", $limit = 10, $offset = 0) {
-		elgg_deprecated_notice("ElggGroup::getObjects() is deprecated. Use elgg_get_entities()", 1.9);
+		elgg_deprecated_notice("\ElggGroup::getObjects() is deprecated. Use elgg_get_entities()", 1.9);
 		return get_objects_in_group($this->getGUID(), $subtype, 0, 0, "", $limit, $offset, false);
 	}
 
@@ -291,7 +291,7 @@ class ElggGroup extends ElggEntity
 	 * @deprecated 1.9 Use elgg_get_entities()
 	 */
 	public function getFriendsObjects($subtype = "", $limit = 10, $offset = 0) {
-		elgg_deprecated_notice("ElggGroup::getFriendsObjects() is deprecated. Use elgg_get_entities()", 1.9);
+		elgg_deprecated_notice("\ElggGroup::getFriendsObjects() is deprecated. Use elgg_get_entities()", 1.9);
 		return get_objects_in_group($this->getGUID(), $subtype, 0, 0, "", $limit, $offset, false);
 	}
 
@@ -304,7 +304,7 @@ class ElggGroup extends ElggEntity
 	 * @deprecated 1.9 Use elgg_get_entities()
 	 */
 	public function countObjects($subtype = "") {
-		elgg_deprecated_notice("ElggGroup::countObjects() is deprecated. Use elgg_get_entities()", 1.9);
+		elgg_deprecated_notice("\ElggGroup::countObjects() is deprecated. Use elgg_get_entities()", 1.9);
 		return get_objects_in_group($this->getGUID(), $subtype, 0, 0, "", 10, 0, true);
 	}
 
@@ -327,7 +327,7 @@ class ElggGroup extends ElggEntity
 	 */
 	public function getMembers($options = array(), $offset = 0, $count = false) {
 		if (!is_array($options)) {
-			elgg_deprecated_notice('ElggGroup::getMembers() takes an options array.', 1.9);
+			elgg_deprecated_notice('\ElggGroup::getMembers() takes an options array.', 1.9);
 			$options = array(
 				'relationship' => 'member',
 				'relationship_guid' => $this->getGUID(),
@@ -403,11 +403,11 @@ class ElggGroup extends ElggEntity
 	/**
 	 * Is the given user a member of this group?
 	 *
-	 * @param ElggUser $user The user. Default is logged in user.
+	 * @param \ElggUser $user The user. Default is logged in user.
 	 *
 	 * @return bool
 	 */
-	public function isMember(ElggUser $user = null) {
+	public function isMember(\ElggUser $user = null) {
 		if ($user == null) {
 			$user = elgg_get_logged_in_user_entity();
 		}
@@ -427,11 +427,11 @@ class ElggGroup extends ElggEntity
 	/**
 	 * Join a user to this group.
 	 *
-	 * @param ElggUser $user User joining the group.
+	 * @param \ElggUser $user User joining the group.
 	 *
 	 * @return bool Whether joining was successful.
 	 */
-	public function join(ElggUser $user) {
+	public function join(\ElggUser $user) {
 		$result = add_entity_relationship($user->guid, 'member', $this->guid);
 	
 		if ($result) {
@@ -445,11 +445,11 @@ class ElggGroup extends ElggEntity
 	/**
 	 * Remove a user from the group.
 	 *
-	 * @param ElggUser $user User to remove from the group.
+	 * @param \ElggUser $user User to remove from the group.
 	 *
 	 * @return bool Whether the user was removed from the group.
 	 */
-	public function leave(ElggUser $user) {
+	public function leave(\ElggUser $user) {
 		// event needs to be triggered while user is still member of group to have access to group acl
 		$params = array('group' => $this, 'user' => $user);
 		elgg_trigger_event('leave', 'group', $params);
@@ -458,15 +458,15 @@ class ElggGroup extends ElggEntity
 	}
 
 	/**
-	 * Load the ElggGroup data from the database
+	 * Load the \ElggGroup data from the database
 	 *
-	 * @param mixed $guid GUID of an ElggGroup entity or database row from entity table
+	 * @param mixed $guid GUID of an \ElggGroup entity or database row from entity table
 	 *
 	 * @return bool
 	 */
 	protected function load($guid) {
-		$attr_loader = new Elgg_AttributeLoader(get_class(), 'group', $this->attributes);
-		$attr_loader->requires_access_control = !($this instanceof ElggPlugin);
+		$attr_loader = new \Elgg\AttributeLoader(get_class(), 'group', $this->attributes);
+		$attr_loader->requires_access_control = !($this instanceof \ElggPlugin);
 		$attr_loader->secondary_loader = 'get_group_entity_as_row';
 
 		$attrs = $attr_loader->getRequiredAttributes($guid);
@@ -554,7 +554,7 @@ class ElggGroup extends ElggEntity
 	/**
 	 * Can a user comment on this group?
 	 *
-	 * @see ElggEntity::canComment()
+	 * @see \ElggEntity::canComment()
 	 *
 	 * @param int $user_guid User guid (default is logged in user)
 	 * @return bool

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -59,7 +59,7 @@ class ElggInstaller {
 
 		$this->bootstrapEngine();
 
-		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
+		_elgg_services()->setValue('session', new ElggSession(new Elgg\Http\MockSessionStorage()));
 
 		elgg_set_viewtype('installation');
 
@@ -1625,8 +1625,8 @@ class ElggInstaller {
 		create_metadata($guid, 'validated_method', 'admin_user', '', 0, ACCESS_PUBLIC);
 
 		if ($login) {
-			$handler = new Elgg_Http_DatabaseSessionHandler(_elgg_services()->db);
-			$storage = new Elgg_Http_NativeSessionStorage(array(), $handler);
+			$handler = new Elgg\Http\DatabaseSessionHandler(_elgg_services()->db);
+			$storage = new Elgg\Http\NativeSessionStorage(array(), $handler);
 			$session = new ElggSession($storage);
 			$session->setName('Elgg');
 			_elgg_services()->setValue('session', $session);

--- a/engine/classes/ElggMemcache.php
+++ b/engine/classes/ElggMemcache.php
@@ -5,7 +5,7 @@
  * @package    Elgg.Core
  * @subpackage Memcache
  */
-class ElggMemcache extends ElggSharedMemoryCache {
+class ElggMemcache extends \ElggSharedMemoryCache {
 	/**
 	 * Minimum version of memcached needed to run
 	 *
@@ -42,7 +42,7 @@ class ElggMemcache extends ElggSharedMemoryCache {
 
 		// Do we have memcache?
 		if (!class_exists('Memcache')) {
-			throw new ConfigurationException('PHP memcache module not installed, you must install php5-memcache');
+			throw new \ConfigurationException('PHP memcache module not installed, you must install php5-memcache');
 		}
 
 		// Create memcache object
@@ -50,7 +50,7 @@ class ElggMemcache extends ElggSharedMemoryCache {
 
 		// Now add servers
 		if (!$CONFIG->memcache_servers) {
-			throw new ConfigurationException('No memcache servers defined, please populate the $CONFIG->memcache_servers variable');
+			throw new \ConfigurationException('No memcache servers defined, please populate the $CONFIG->memcache_servers variable');
 		}
 
 		if (is_callable(array($this->memcache, 'addServer'))) {
@@ -86,13 +86,13 @@ class ElggMemcache extends ElggSharedMemoryCache {
 
 		// Get version
 		$this->version = $this->memcache->getVersion();
-		if (version_compare($this->version, ElggMemcache::$MINSERVERVERSION, '<')) {
+		if (version_compare($this->version, \ElggMemcache::$MINSERVERVERSION, '<')) {
 			$msg = vsprintf('Memcache needs at least version %s to run, you are running %s',
-				array(ElggMemcache::$MINSERVERVERSION,
+				array(\ElggMemcache::$MINSERVERVERSION,
 				$this->version
 			));
 
-			throw new ConfigurationException($msg);
+			throw new \ConfigurationException($msg);
 		}
 
 		// Set some defaults

--- a/engine/classes/ElggMenuBuilder.php
+++ b/engine/classes/ElggMenuBuilder.php
@@ -9,16 +9,16 @@
 class ElggMenuBuilder {
 
 	/**
-	 * @var ElggMenuItem[]
+	 * @var \ElggMenuItem[]
 	 */
 	protected $menu = array();
 
 	protected $selected = null;
 
 	/**
-	 * ElggMenuBuilder constructor
+	 * \ElggMenuBuilder constructor
 	 *
-	 * @param ElggMenuItem[] $menu Array of ElggMenuItem objects
+	 * @param \ElggMenuItem[] $menu Array of \ElggMenuItem objects
 	 */
 	public function __construct(array $menu) {
 		$this->menu = $menu;
@@ -27,7 +27,7 @@ class ElggMenuBuilder {
 	/**
 	 * Get a prepared menu array
 	 *
-	 * @param mixed $sort_by Method to sort the menu by. @see ElggMenuBuilder::sort()
+	 * @param mixed $sort_by Method to sort the menu by. @see \ElggMenuBuilder::sort()
 	 * @return array
 	 */
 	public function getMenu($sort_by = 'text') {
@@ -48,7 +48,7 @@ class ElggMenuBuilder {
 	/**
 	 * Get the selected menu item
 	 *
-	 * @return ElggMenuItem
+	 * @return \ElggMenuItem
 	 */
 	public function getSelected() {
 		return $this->selected;
@@ -69,7 +69,7 @@ class ElggMenuBuilder {
 		$selected_menu = array();
 		foreach ($this->menu as $menu_item) {
 			if (!is_object($menu_item)) {
-				elgg_log("A non-object was passed to ElggMenuBuilder", "ERROR");
+				elgg_log("A non-object was passed to \ElggMenuBuilder", "ERROR");
 				continue;
 			}
 			if ($menu_item->inContext()) {
@@ -110,7 +110,7 @@ class ElggMenuBuilder {
 			$children = array();
 			// divide base nodes from children
 			foreach ($section as $menu_item) {
-				/* @var ElggMenuItem $menu_item */
+				/* @var \ElggMenuItem $menu_item */
 				$parent_name = $menu_item->getParentName();
 				if (!$parent_name) {
 					$parents[$menu_item->getName()] = $menu_item;
@@ -151,7 +151,7 @@ class ElggMenuBuilder {
 	/**
 	 * Find the menu item that is currently selected
 	 *
-	 * @return ElggMenuItem
+	 * @return \ElggMenuItem
 	 */
 	protected function findSelected() {
 
@@ -188,13 +188,13 @@ class ElggMenuBuilder {
 
 		switch ($sort_by) {
 			case 'text':
-				$sort_callback = array('ElggMenuBuilder', 'compareByText');
+				$sort_callback = array('\ElggMenuBuilder', 'compareByText');
 				break;
 			case 'name':
-				$sort_callback = array('ElggMenuBuilder', 'compareByName');
+				$sort_callback = array('\ElggMenuBuilder', 'compareByName');
 				break;
 			case 'priority':
-				$sort_callback = array('ElggMenuBuilder', 'compareByPriority');
+				$sort_callback = array('\ElggMenuBuilder', 'compareByPriority');
 				break;
 			case 'register':
 				// use registration order - usort breaks this
@@ -223,7 +223,7 @@ class ElggMenuBuilder {
 				array_push($stack, $root);
 				while (!empty($stack)) {
 					$node = array_pop($stack);
-					/* @var ElggMenuItem $node */
+					/* @var \ElggMenuItem $node */
 					$node->sortChildren($sort_callback);
 					$children = $node->getChildren();
 					if ($children) {
@@ -237,8 +237,8 @@ class ElggMenuBuilder {
 	/**
 	 * Compare two menu items by their display text
 	 *
-	 * @param ElggMenuItem $a Menu item
-	 * @param ElggMenuItem $b Menu item
+	 * @param \ElggMenuItem $a Menu item
+	 * @param \ElggMenuItem $b Menu item
 	 * @return bool
 	 */
 	public static function compareByText($a, $b) {
@@ -255,8 +255,8 @@ class ElggMenuBuilder {
 	/**
 	 * Compare two menu items by their identifiers
 	 *
-	 * @param ElggMenuItem $a Menu item
-	 * @param ElggMenuItem $b Menu item
+	 * @param \ElggMenuItem $a Menu item
+	 * @param \ElggMenuItem $b Menu item
 	 * @return bool
 	 */
 	public static function compareByName($a, $b) {
@@ -273,8 +273,8 @@ class ElggMenuBuilder {
 	/**
 	 * Compare two menu items by their priority
 	 *
-	 * @param ElggMenuItem $a Menu item
-	 * @param ElggMenuItem $b Menu item
+	 * @param \ElggMenuItem $a Menu item
+	 * @param \ElggMenuItem $b Menu item
 	 * @return bool
 	 * @since 1.9.0
 	 */
@@ -291,13 +291,13 @@ class ElggMenuBuilder {
 	/**
 	 * Compare two menu items by their priority
 	 *
-	 * @param ElggMenuItem $a Menu item
-	 * @param ElggMenuItem $b Menu item
+	 * @param \ElggMenuItem $a Menu item
+	 * @param \ElggMenuItem $b Menu item
 	 * @return bool
 	 * @deprecated 1.9 Use compareByPriority()
 	 */
 	public static function compareByWeight($a, $b) {
-		elgg_deprecated_notice("ElggMenuBuilder::compareByWeight() deprecated by ElggMenuBuilder::compareByPriority", 1.9);
+		elgg_deprecated_notice("\ElggMenuBuilder::compareByWeight() deprecated by \ElggMenuBuilder::compareByPriority", 1.9);
 		$aw = $a->getPriority();
 		$bw = $b->getPriority();
 

--- a/engine/classes/ElggMenuItem.php
+++ b/engine/classes/ElggMenuItem.php
@@ -32,7 +32,7 @@ class ElggMenuItem {
 		// string Identifier of this item's parent
 		'parent_name' => '',
 
-		// ElggMenuItem The parent object or null
+		// \ElggMenuItem The parent object or null
 		'parent' => null,
 
 		// array Array of children objects or empty array
@@ -67,7 +67,7 @@ class ElggMenuItem {
 
 
 	/**
-	 * ElggMenuItem constructor
+	 * \ElggMenuItem constructor
 	 *
 	 * @param string $name Identifier of the menu item
 	 * @param string $text Display text of the menu item (HTML)
@@ -85,14 +85,14 @@ class ElggMenuItem {
 	}
 
 	/**
-	 * ElggMenuItem factory method
+	 * \ElggMenuItem factory method
 	 *
-	 * This static method creates an ElggMenuItem from an associative array.
+	 * This static method creates an \ElggMenuItem from an associative array.
 	 * Required keys are name, text, and href.
 	 *
 	 * @param array $options Option array of key value pairs
 	 *
-	 * @return ElggMenuItem or null on error
+	 * @return \ElggMenuItem or null on error
 	 */
 	public static function factory($options) {
 		if (!isset($options['name']) || !isset($options['text'])) {
@@ -102,7 +102,7 @@ class ElggMenuItem {
 			$options['href'] = '';
 		}
 
-		$item = new ElggMenuItem($options['name'], $options['text'], $options['href']);
+		$item = new \ElggMenuItem($options['name'], $options['text'], $options['href']);
 		unset($options['name']);
 		unset($options['text']);
 		unset($options['href']);
@@ -123,7 +123,7 @@ class ElggMenuItem {
 			$item->setLinkClass($options['link_class']);
 			unset($options['link_class']);
 		} elseif (isset($options['class'])) {
-			elgg_deprecated_notice("ElggMenuItem::factory() does not accept 'class' key anymore, use 'link_class' instead", 1.9);
+			elgg_deprecated_notice("\ElggMenuItem::factory() does not accept 'class' key anymore, use 'link_class' instead", 1.9);
 			$item->setLinkClass($options['class']);
 			unset($options['class']);
 		}
@@ -446,7 +446,7 @@ class ElggMenuItem {
 	 * @deprecated 1.9 Use setPriority()
 	 */
 	public function setWeight($priority) {
-		elgg_deprecated_notice("ElggMenuItem::setWeight() deprecated by ElggMenuItem::setPriority()", 1.9);
+		elgg_deprecated_notice("\ElggMenuItem::setWeight() deprecated by \ElggMenuItem::setPriority()", 1.9);
 		$this->data['priority'] = $priority;
 	}
 
@@ -457,7 +457,7 @@ class ElggMenuItem {
 	 * @deprecated 1.9 Use getPriority()
 	 */
 	public function getWeight() {
-		elgg_deprecated_notice("ElggMenuItem::getWeight() deprecated by ElggMenuItem::getPriority()", 1.9);
+		elgg_deprecated_notice("\ElggMenuItem::getWeight() deprecated by \ElggMenuItem::getPriority()", 1.9);
 		return $this->data['priority'];
 	}
 
@@ -502,7 +502,7 @@ class ElggMenuItem {
 	/**
 	 * Set the parent identifier
 	 *
-	 * @param string $name The identifier of the parent ElggMenuItem
+	 * @param string $name The identifier of the parent \ElggMenuItem
 	 * @return void
 	 */
 	public function setParentName($name) {
@@ -521,9 +521,9 @@ class ElggMenuItem {
 	/**
 	 * Set the parent menu item
 	 * 
-	 * This is reserved for the ElggMenuBuilder.
+	 * This is reserved for the \ElggMenuBuilder.
 	 *
-	 * @param ElggMenuItem $parent The parent of this menu item
+	 * @param \ElggMenuItem $parent The parent of this menu item
 	 * @return void
 	 * @access private
 	 */
@@ -534,9 +534,9 @@ class ElggMenuItem {
 	/**
 	 * Get the parent menu item
 	 * 
-	 * This is reserved for the ElggMenuBuilder.
+	 * This is reserved for the \ElggMenuBuilder.
 	 *
-	 * @return ElggMenuItem or null
+	 * @return \ElggMenuItem or null
 	 * @access private
 	 */
 	public function getParent() {
@@ -546,9 +546,9 @@ class ElggMenuItem {
 	/**
 	 * Add a child menu item
 	 * 
-	 * This is reserved for the ElggMenuBuilder.
+	 * This is reserved for the \ElggMenuBuilder.
 	 *
-	 * @param ElggMenuItem $item A child menu item
+	 * @param \ElggMenuItem $item A child menu item
 	 * @return void
 	 * @access private
 	 */
@@ -559,9 +559,9 @@ class ElggMenuItem {
 	/**
 	 * Set the menu item's children
 	 * 
-	 * This is reserved for the ElggMenuBuilder.
+	 * This is reserved for the \ElggMenuBuilder.
 	 *
-	 * @param array $children Array of ElggMenuItems
+	 * @param array $children Array of \ElggMenuItems
 	 * @return void
 	 * @access private
 	 */
@@ -572,7 +572,7 @@ class ElggMenuItem {
 	/**
 	 * Get the children menu items
 	 * 
-	 * This is reserved for the ElggMenuBuilder.
+	 * This is reserved for the \ElggMenuBuilder.
 	 *
 	 * @return array
 	 * @access private
@@ -584,7 +584,7 @@ class ElggMenuItem {
 	/**
 	 * Sort the children
 	 * 
-	 * This is reserved for the ElggMenuBuilder.
+	 * This is reserved for the \ElggMenuBuilder.
 	 *
 	 * @param string $sortFunction A function that is passed to usort()
 	 * @return void
@@ -618,7 +618,7 @@ class ElggMenuItem {
 	 * @deprecated 1.9 Use elgg_view_menu_item()
 	 */
 	public function getContent(array $vars = array()) {
-		elgg_deprecated_notice("ElggMenuItem::getContent() deprecated by elgg_view_menu_item()", 1.9);
+		elgg_deprecated_notice("\ElggMenuItem::getContent() deprecated by elgg_view_menu_item()", 1.9);
 		return elgg_view_menu_item($this, $vars);
 	}
 }

--- a/engine/classes/ElggMetadata.php
+++ b/engine/classes/ElggMetadata.php
@@ -1,22 +1,22 @@
 <?php
 
 /**
- * ElggMetadata
+ * \ElggMetadata
  *
- * This class describes metadata that can be attached to an ElggEntity. It is
+ * This class describes metadata that can be attached to an \ElggEntity. It is
  * rare that a plugin developer needs to use this API for metadata. Almost all
- * interaction with metadata occurs through the methods of ElggEntity. See its
+ * interaction with metadata occurs through the methods of \ElggEntity. See its
  * __set(), __get(), and setMetadata() methods.
  *
  * @package    Elgg.Core
  * @subpackage Metadata
  */
-class ElggMetadata extends ElggExtender {
+class ElggMetadata extends \ElggExtender {
 
 	/**
 	 * (non-PHPdoc)
 	 *
-	 * @see ElggData::initializeAttributes()
+	 * @see \ElggData::initializeAttributes()
 	 *
 	 * @return void
 	 */
@@ -29,17 +29,17 @@ class ElggMetadata extends ElggExtender {
 	/**
 	 * Construct a metadata object
 	 *
-	 * Plugin developers will probably never need to use this API. See ElggEntity
+	 * Plugin developers will probably never need to use this API. See \ElggEntity
 	 * for its API for setting and getting metadata.
 	 *
-	 * @param stdClass $row Database row as stdClass object
+	 * @param \stdClass $row Database row as \stdClass object
 	 */
 	public function __construct($row = null) {
 		$this->initializeAttributes();
 
 		if (!empty($row)) {
 			// Create from db row
-			if ($row instanceof stdClass) {
+			if ($row instanceof \stdClass) {
 				$metadata = $row;
 				
 				$objarray = (array) $metadata;
@@ -47,7 +47,7 @@ class ElggMetadata extends ElggExtender {
 					$this->attributes[$key] = $value;
 				}
 			} else {
-				// get an ElggMetadata object and copy its attributes
+				// get an \ElggMetadata object and copy its attributes
 				elgg_deprecated_notice('Passing an ID to constructor is deprecated. Use elgg_get_metadata_from_id()', 1.9);
 				$metadata = elgg_get_metadata_from_id($row);
 				$this->attributes = $metadata->attributes;
@@ -86,7 +86,7 @@ class ElggMetadata extends ElggExtender {
 				$this->value_type, $this->owner_guid, $this->access_id);
 
 			if (!$this->id) {
-				throw new IOException("Unable to save new " . get_class());
+				throw new \IOException("Unable to save new " . get_class());
 			}
 			return $this->id;
 		}
@@ -146,7 +146,7 @@ class ElggMetadata extends ElggExtender {
 	 *
 	 * @param int $id Metadata ID
 	 *
-	 * @return ElggMetadata
+	 * @return \ElggMetadata
 	 */
 	public function getObjectFromID($id) {
 		return elgg_get_metadata_from_id($id);

--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -3,12 +3,12 @@
  * Elgg Object
  *
  * Elgg objects are the most common means of storing information in the database.
- * They are a child class of ElggEntity, so receive all the benefits of the Entities,
+ * They are a child class of \ElggEntity, so receive all the benefits of the Entities,
  * but also include a title and description field.
  *
- * An ElggObject represents a row from the objects_entity table, as well
+ * An \ElggObject represents a row from the objects_entity table, as well
  * as the related row in the entities table as represented by the parent
- * ElggEntity object.
+ * \ElggEntity object.
  *
  * @internal Title and description are stored in the objects_entity table.
  *
@@ -19,7 +19,7 @@
  * @property string $description The body, description, or content of the object
  * @property array  $tags        Tags that describe the object (metadata)
  */
-class ElggObject extends ElggEntity {
+class ElggObject extends \ElggEntity {
 
 	/**
 	 * Initialize the attributes array to include the type,
@@ -37,16 +37,16 @@ class ElggObject extends ElggEntity {
 	}
 
 	/**
-	 * Create a new ElggObject.
+	 * Create a new \ElggObject.
 	 *
 	 * Plugin developers should only use the constructor to create a new entity.
 	 * To retrieve entities, use get_entity() and the elgg_get_entities* functions.
 	 *
 	 * If no arguments are passed, it creates a new entity.
-	 * If a database result is passed as a stdClass instance, it instantiates
+	 * If a database result is passed as a \stdClass instance, it instantiates
 	 * that entity.
 	 *
-	 * @param stdClass $row Database row result. Default is null to create a new object.
+	 * @param \stdClass $row Database row result. Default is null to create a new object.
 	 *
 	 * @throws IOException If cannot load remaining data from db
 	 * @throws InvalidParameterException If not passed a db row result
@@ -59,15 +59,15 @@ class ElggObject extends ElggEntity {
 
 		if (!empty($row)) {
 			// Is $row is a DB row from the entity table
-			if ($row instanceof stdClass) {
+			if ($row instanceof \stdClass) {
 				// Load the rest
 				if (!$this->load($row)) {
 					$msg = "Failed to load new " . get_class() . " for GUID: " . $row->guid;
-					throw new IOException($msg);
+					throw new \IOException($msg);
 				}
-			} else if ($row instanceof ElggObject) {
-				// $row is an ElggObject so this is a copy constructor
-				elgg_deprecated_notice('This type of usage of the ElggObject constructor was deprecated. Please use the clone method.', 1.7);
+			} else if ($row instanceof \ElggObject) {
+				// $row is an \ElggObject so this is a copy constructor
+				elgg_deprecated_notice('This type of usage of the \ElggObject constructor was deprecated. Please use the clone method.', 1.7);
 				foreach ($row->attributes as $key => $value) {
 					$this->attributes[$key] = $value;
 				}
@@ -75,25 +75,25 @@ class ElggObject extends ElggEntity {
 				// $row is a GUID so load
 				elgg_deprecated_notice('Passing a GUID to constructor is deprecated. Use get_entity()', 1.9);
 				if (!$this->load($row)) {
-					throw new IOException("Failed to load new " . get_class() . " from GUID:" . $row);
+					throw new \IOException("Failed to load new " . get_class() . " from GUID:" . $row);
 				}
 			} else {
-				throw new InvalidParameterException("Unrecognized value passed to constuctor.");
+				throw new \InvalidParameterException("Unrecognized value passed to constuctor.");
 			}
 		}
 	}
 
 	/**
-	 * Loads the full ElggObject when given a guid.
+	 * Loads the full \ElggObject when given a guid.
 	 *
-	 * @param mixed $guid GUID of an ElggObject or the stdClass object from entities table
+	 * @param mixed $guid GUID of an \ElggObject or the \stdClass object from entities table
 	 *
 	 * @return bool
 	 * @throws InvalidClassException
 	 */
 	protected function load($guid) {
-		$attr_loader = new Elgg_AttributeLoader(get_class(), 'object', $this->attributes);
-		$attr_loader->requires_access_control = !($this instanceof ElggPlugin);
+		$attr_loader = new \Elgg\AttributeLoader(get_class(), 'object', $this->attributes);
+		$attr_loader->requires_access_control = !($this instanceof \ElggPlugin);
 		$attr_loader->secondary_loader = 'get_object_entity_as_row';
 
 		$attrs = $attr_loader->getRequiredAttributes($guid);
@@ -175,7 +175,7 @@ class ElggObject extends ElggEntity {
 	 *
 	 * Site membership is determined by relationships and not site_guid.
 	 *
-	 * @todo Moved to ElggEntity so remove this in 2.0
+	 * @todo Moved to \ElggEntity so remove this in 2.0
 	 *
 	 * @param array $options Options array. Used to be $subtype
 	 * @param int   $limit   The number of results to return (deprecated)
@@ -185,7 +185,7 @@ class ElggObject extends ElggEntity {
 	 */
 	public function getSites($options = "", $limit = 10, $offset = 0) {
 		if (is_string($options)) {
-			elgg_deprecated_notice('ElggObject::getSites() takes an options array', 1.9);
+			elgg_deprecated_notice('\ElggObject::getSites() takes an options array', 1.9);
 			return get_site_objects($this->getGUID(), $options, $limit, $offset);
 		}
 
@@ -195,13 +195,13 @@ class ElggObject extends ElggEntity {
 	/**
 	 * Add this object to a site
 	 *
-	 * @param ElggSite $site The site to add this object to. This used to be the
+	 * @param \ElggSite $site The site to add this object to. This used to be the
 	 *                       the site guid (still supported by deprecated)
 	 * @return bool
 	 */
 	public function addToSite($site) {
 		if (is_numeric($site)) {
-			elgg_deprecated_notice('ElggObject::addToSite() takes a site entity', 1.9);
+			elgg_deprecated_notice('\ElggObject::addToSite() takes a site entity', 1.9);
 			return add_site_object($site, $this->getGUID());
 		}
 
@@ -239,7 +239,7 @@ class ElggObject extends ElggEntity {
 	/**
 	 * Can a user comment on this object?
 	 *
-	 * @see ElggEntity::canComment()
+	 * @see \ElggEntity::canComment()
 	 *
 	 * @param int $user_guid User guid (default is logged in user)
 	 * @return bool

--- a/engine/classes/ElggPAM.php
+++ b/engine/classes/ElggPAM.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ElggPAM Pluggable Authentication Module
+ * \ElggPAM Pluggable Authentication Module
  *
  * @package    Elgg.Core
  * @subpackage Authentication
@@ -17,7 +17,7 @@ class ElggPAM {
 	protected $messages;
 
 	/**
-	 * ElggPAM constructor
+	 * \ElggPAM constructor
 	 * 
 	 * @param string $policy PAM policy type: user, api, or plugin-defined policies
 	 */

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -8,7 +8,7 @@
  * @package    Elgg.Core
  * @subpackage Plugins.Settings
  */
-class ElggPlugin extends ElggObject {
+class ElggPlugin extends \ElggObject {
 	private $package;
 	private $manifest;
 
@@ -34,8 +34,8 @@ class ElggPlugin extends ElggObject {
 	 *
 	 * @internal also supports database objects
 	 *
-	 * @warning Unlike other ElggEntity objects, you cannot null instantiate
-	 *          ElggPlugin. You must provide the path to the plugin directory.
+	 * @warning Unlike other \ElggEntity objects, you cannot null instantiate
+	 *          \ElggPlugin. You must provide the path to the plugin directory.
 	 *
 	 * @param string $path The absolute path of the plugin
 	 *
@@ -43,7 +43,7 @@ class ElggPlugin extends ElggObject {
 	 */
 	public function __construct($path) {
 		if (!$path) {
-			throw new PluginException("ElggPlugin cannot be null instantiated. You must pass a full path.");
+			throw new \PluginException("\ElggPlugin cannot be null instantiated. You must pass a full path.");
 		}
 
 		if (is_object($path)) {
@@ -63,7 +63,7 @@ class ElggPlugin extends ElggObject {
 
 			// not a full path, so assume a directory name and use the default path
 			if (strpos($path, $mod_dir) !== 0) {
-				elgg_deprecated_notice("You should pass a full path to ElggPlugin.", 1.9);
+				elgg_deprecated_notice("You should pass a full path to \ElggPlugin.", 1.9);
 				$path = $mod_dir . $path;
 			}
 
@@ -88,7 +88,7 @@ class ElggPlugin extends ElggObject {
 	/**
 	 * Save the plugin object.  Make sure required values exist.
 	 *
-	 * @see ElggObject::save()
+	 * @see \ElggObject::save()
 	 * @return bool
 	 */
 	public function save() {
@@ -385,7 +385,7 @@ class ElggPlugin extends ElggObject {
 			$user = elgg_get_logged_in_user_entity();
 		}
 
-		if (!($user instanceof ElggUser)) {
+		if (!($user instanceof \ElggUser)) {
 			return false;
 		}
 
@@ -410,7 +410,7 @@ class ElggPlugin extends ElggObject {
 			$user = elgg_get_logged_in_user_entity();
 		}
 
-		if (!($user instanceof ElggUser)) {
+		if (!($user instanceof \ElggUser)) {
 			return false;
 		}
 
@@ -458,7 +458,7 @@ class ElggPlugin extends ElggObject {
 			$user = elgg_get_logged_in_user_entity();
 		}
 
-		if (!($user instanceof ElggUser)) {
+		if (!($user instanceof \ElggUser)) {
 			return false;
 		}
 
@@ -494,7 +494,7 @@ class ElggPlugin extends ElggObject {
 			$user = elgg_get_logged_in_user_entity();
 		}
 
-		if (!($user instanceof ElggUser)) {
+		if (!($user instanceof \ElggUser)) {
 			return false;
 		}
 
@@ -552,7 +552,7 @@ class ElggPlugin extends ElggObject {
 	 * Returns if the plugin is complete, meaning has all required files
 	 * and Elgg can read them and they make sense.
 	 *
-	 * @todo bad name? This could be confused with isValid() from ElggPluginPackage.
+	 * @todo bad name? This could be confused with isValid() from \ElggPluginPackage.
 	 *
 	 * @return bool
 	 */
@@ -562,7 +562,7 @@ class ElggPlugin extends ElggObject {
 			return false;
 		}
 
-		if (!$this->getPackage() instanceof ElggPluginPackage) {
+		if (!$this->getPackage() instanceof \ElggPluginPackage) {
 			$this->errorMsg = elgg_echo('ElggPlugin:NoPluginPackagePackage', array($this->getID(), $this->guid));
 			return false;
 		}
@@ -592,7 +592,7 @@ class ElggPlugin extends ElggObject {
 			$site = get_config('site');
 		}
 
-		if (!($site instanceof ElggSite)) {
+		if (!($site instanceof \ElggSite)) {
 			return false;
 		}
 
@@ -765,7 +765,7 @@ class ElggPlugin extends ElggObject {
 		if (!$this->canReadFile($filename)) {
 			$msg = elgg_echo('ElggPlugin:Exception:CannotIncludeFile',
 							array($filename, $this->getID(), $this->guid, $this->path));
-			throw new PluginException($msg);
+			throw new \PluginException($msg);
 		}
 
 		return include $filepath;
@@ -800,7 +800,7 @@ class ElggPlugin extends ElggObject {
 		if (!$handle) {
 			$msg = elgg_echo('ElggPlugin:Exception:CannotRegisterViews',
 							array($this->getID(), $this->guid, $view_dir));
-			throw new PluginException($msg);
+			throw new \PluginException($msg);
 		}
 
 		while (false !== ($view_type = readdir($handle))) {
@@ -812,7 +812,7 @@ class ElggPlugin extends ElggObject {
 				} else {
 					$msg = elgg_echo('ElggPlugin:Exception:CannotRegisterViews',
 									array($this->getID(), $view_type_dir));
-					throw new PluginException($msg);
+					throw new \PluginException($msg);
 				}
 			}
 		}
@@ -838,7 +838,7 @@ class ElggPlugin extends ElggObject {
 		if (!register_translations($languages_path)) {
 			$msg = elgg_echo('ElggPlugin:Exception:CannotRegisterLanguages',
 							array($this->getID(), $this->guid, $languages_path));
-			throw new PluginException($msg);
+			throw new \PluginException($msg);
 		}
 
 		return true;
@@ -869,7 +869,7 @@ class ElggPlugin extends ElggObject {
 	public function __get($name) {
 		// rewrite for old and inaccurate plugin:setting
 		if (strstr($name, 'plugin:setting:')) {
-			$msg = 'Direct access of user settings is deprecated. Use ElggPlugin->getUserSetting()';
+			$msg = 'Direct access of user settings is deprecated. Use \ElggPlugin->getUserSetting()';
 			elgg_deprecated_notice($msg, 1.8);
 			$name = str_replace('plugin:setting:', '', $name);
 			$name = _elgg_namespace_plugin_private_setting('user_setting', $name, $this->getID());
@@ -967,7 +967,7 @@ class ElggPlugin extends ElggObject {
 		if ($site_guid) {
 			$site = get_entity($site_guid);
 
-			if (!($site instanceof ElggSite)) {
+			if (!($site instanceof \ElggSite)) {
 				return false;
 			}
 		} else {
@@ -995,12 +995,12 @@ class ElggPlugin extends ElggObject {
 	}
 
 	/**
-	 * Returns this plugin's ElggPluginManifest object
+	 * Returns this plugin's \ElggPluginManifest object
 	 *
-	 * @return ElggPluginManifest
+	 * @return \ElggPluginManifest
 	 */
 	public function getManifest() {
-		if ($this->manifest instanceof ElggPluginManifest) {
+		if ($this->manifest instanceof \ElggPluginManifest) {
 			return $this->manifest;
 		}
 
@@ -1015,17 +1015,17 @@ class ElggPlugin extends ElggObject {
 	}
 
 	/**
-	 * Returns this plugin's ElggPluginPackage object
+	 * Returns this plugin's \ElggPluginPackage object
 	 *
-	 * @return ElggPluginPackage
+	 * @return \ElggPluginPackage
 	 */
 	public function getPackage() {
-		if ($this->package instanceof ElggPluginPackage) {
+		if ($this->package instanceof \ElggPluginPackage) {
 			return $this->package;
 		}
 
 		try {
-			$this->package = new ElggPluginPackage($this->path, false);
+			$this->package = new \ElggPluginPackage($this->path, false);
 		} catch (Exception $e) {
 			elgg_log("Failed to load package for $this->guid. " . $e->getMessage(), 'WARNING');
 			$this->errorMsg = $e->getmessage();

--- a/engine/classes/ElggPluginManifest.php
+++ b/engine/classes/ElggPluginManifest.php
@@ -2,12 +2,12 @@
 /**
  * Parses Elgg manifest.xml files.
  *
- * Normalizes the values from the ElggManifestParser object.
+ * Normalizes the values from the \ElggManifestParser object.
  *
- * This requires an ElggPluginManifestParser class implementation
+ * This requires an \ElggPluginManifestParser class implementation
  * as $this->parser.
  *
- * To add new parser versions, name them ElggPluginManifestParserXX
+ * To add new parser versions, name them \ElggPluginManifestParserXX
  * where XX is the version specified in the top-level <plugin_manifest>
  * tag's XML namespace.
  *
@@ -20,7 +20,7 @@ class ElggPluginManifest {
 	/**
 	 * The parser object
 	 *
-	 * @var ElggPluginManifestParser18
+	 * @var \ElggPluginManifestParser18
 	 */
 	protected $parser;
 
@@ -154,7 +154,7 @@ class ElggPluginManifest {
 		}
 
 		// see if we need to construct the xml object.
-		if ($manifest instanceof ElggXMLElement) {
+		if ($manifest instanceof \ElggXMLElement) {
 			$manifest_obj = $manifest;
 		} else {
 			$raw_xml = '';
@@ -166,14 +166,14 @@ class ElggPluginManifest {
 				$raw_xml = file_get_contents($manifest);
 			}
 			if ($raw_xml) {
-				$manifest_obj = new ElggXMLElement($raw_xml);
+				$manifest_obj = new \ElggXMLElement($raw_xml);
 			} else {
 				$manifest_obj = null;
 			}
 		}
 
 		if (!$manifest_obj) {
-			throw new PluginException(elgg_echo('PluginException:InvalidManifest',
+			throw new \PluginException(elgg_echo('PluginException:InvalidManifest',
 						array($this->getPluginID())));
 		}
 
@@ -187,7 +187,7 @@ class ElggPluginManifest {
 
 		$this->apiVersion = $version;
 
-		$parser_class_name = 'ElggPluginManifestParser' . str_replace('.', '', $this->apiVersion);
+		$parser_class_name = '\ElggPluginManifestParser' . str_replace('.', '', $this->apiVersion);
 
 		// @todo currently the autoloader freaks out if a class doesn't exist.
 		try {
@@ -199,12 +199,12 @@ class ElggPluginManifest {
 		if ($class_exists) {
 			$this->parser = new $parser_class_name($manifest_obj, $this);
 		} else {
-			throw new PluginException(elgg_echo('PluginException:NoAvailableParser',
+			throw new \PluginException(elgg_echo('PluginException:NoAvailableParser',
 							array($this->apiVersion, $this->getPluginID())));
 		}
 
 		if (!$this->parser->parse()) {
-			throw new PluginException(elgg_echo('PluginException:ParserError',
+			throw new \PluginException(elgg_echo('PluginException:ParserError',
 						array($this->apiVersion, $this->getPluginID())));
 		}
 	}

--- a/engine/classes/ElggPluginManifestParser.php
+++ b/engine/classes/ElggPluginManifestParser.php
@@ -10,7 +10,7 @@
  * This class only parses XML to an XmlEntity object and
  * an array.  The array should be used primarily to extract
  * information since it is quicker to parse once and store
- * values from the ElggXmlElement object than to parse the object
+ * values from the \ElggXmlElement object than to parse the object
  * each time.
  *
  * The array should be an exact representation of the manifest.xml
@@ -23,9 +23,9 @@
  */
 abstract class ElggPluginManifestParser {
 	/**
-	 * The ElggXmlElement object
+	 * The \ElggXmlElement object
 	 *
-	 * @var ElggXmlElement
+	 * @var \ElggXmlElement
 	 */
 	protected $manifestObject;
 
@@ -53,10 +53,10 @@ abstract class ElggPluginManifestParser {
 	/**
 	 * Loads the manifest XML to be parsed.
 	 *
-	 * @param ElggXmlElement $xml    The Manifest XML object to be parsed
-	 * @param object         $caller The object calling this parser.
+	 * @param \ElggXmlElement $xml    The Manifest XML object to be parsed
+	 * @param object          $caller The object calling this parser.
 	 */
-	public function __construct(ElggXMLElement $xml, $caller) {
+	public function __construct(\ElggXMLElement $xml, $caller) {
 		$this->manifestObject = $xml;
 		$this->caller = $caller;
 	}
@@ -64,7 +64,7 @@ abstract class ElggPluginManifestParser {
 	/**
 	 * Returns the manifest XML object
 	 *
-	 * @return ElggXmlElement
+	 * @return \ElggXmlElement
 	 */
 	public function getManifestObject() {
 		return $this->manifestObject;

--- a/engine/classes/ElggPluginManifestParser17.php
+++ b/engine/classes/ElggPluginManifestParser17.php
@@ -6,7 +6,7 @@
  * @subpackage Plugins
  * @since      1.8
  */
-class ElggPluginManifestParser17 extends ElggPluginManifestParser {
+class ElggPluginManifestParser17 extends \ElggPluginManifestParser {
 	/**
 	 * The valid top level attributes and defaults for a 1.7 manifest
 	 */
@@ -66,7 +66,7 @@ class ElggPluginManifestParser17 extends ElggPluginManifestParser {
 	/**
 	 * Return an attribute in the manifest.
 	 *
-	 * Overrides ElggPluginManifestParser::getAttribute() because before 1.8
+	 * Overrides \ElggPluginManifestParser::getAttribute() because before 1.8
 	 * there were no rules...weeeeeeeee!
 	 *
 	 * @param string $name Attribute name

--- a/engine/classes/ElggPluginManifestParser18.php
+++ b/engine/classes/ElggPluginManifestParser18.php
@@ -6,7 +6,7 @@
  * @subpackage Plugins
  * @since      1.8
  */
-class ElggPluginManifestParser18 extends ElggPluginManifestParser {
+class ElggPluginManifestParser18 extends \ElggPluginManifestParser {
 	/**
 	 * The valid top level attributes and defaults for a 1.8 manifest array.
 	 *
@@ -101,7 +101,7 @@ class ElggPluginManifestParser18 extends ElggPluginManifestParser {
 		// check we have all the required fields
 		foreach ($this->requiredAttributes as $attr) {
 			if (!array_key_exists($attr, $parsed)) {
-				throw new PluginException(elgg_echo('PluginException:ParserErrorMissingRequiredAttribute',
+				throw new \PluginException(elgg_echo('PluginException:ParserErrorMissingRequiredAttribute',
 							array($attr, $this->caller->getPluginID())));
 			}
 		}

--- a/engine/classes/ElggPluginPackage.php
+++ b/engine/classes/ElggPluginPackage.php
@@ -2,15 +2,15 @@
 /**
  * Manages plugin packages under mod.
  *
- * @todo This should eventually be merged into ElggPlugin.
- * Currently ElggPlugin objects are only used to get and save
+ * @todo This should eventually be merged into \ElggPlugin.
+ * Currently \ElggPlugin objects are only used to get and save
  * plugin settings and user settings, so not every plugin
- * has an ElggPlugin object.  It's not implemented in ElggPlugin
+ * has an \ElggPlugin object.  It's not implemented in \ElggPlugin
  * right now because of conflicts with at least the constructor,
  * enable(), disable(), and private settings.
  *
  * Around 1.9 or so we should each plugin over to using
- * ElggPlugin and merge ElggPluginPackage and ElggPlugin.
+ * \ElggPlugin and merge \ElggPluginPackage and \ElggPlugin.
  *
  * @package    Elgg.Core
  * @subpackage Plugins
@@ -64,7 +64,7 @@ class ElggPluginPackage {
 	/**
 	 * The plugin's manifest object
 	 *
-	 * @var ElggPluginManifest
+	 * @var \ElggPluginManifest
 	 */
 	protected $manifest;
 
@@ -112,7 +112,7 @@ class ElggPluginPackage {
 			// this is a plugin id
 			// strict plugin names
 			if (preg_match('/[^a-z0-9\.\-_]/i', $plugin)) {
-				throw new PluginException(elgg_echo('PluginException:InvalidID', array($plugin)));
+				throw new \PluginException(elgg_echo('PluginException:InvalidID', array($plugin)));
 			}
 
 			$path = "{$plugin_path}$plugin/";
@@ -120,7 +120,7 @@ class ElggPluginPackage {
 		}
 
 		if (!is_dir($path)) {
-			throw new PluginException(elgg_echo('PluginException:InvalidPath', array($path)));
+			throw new \PluginException(elgg_echo('PluginException:InvalidPath', array($path)));
 		}
 
 		$this->path = $path;
@@ -128,10 +128,10 @@ class ElggPluginPackage {
 
 		if ($validate && !$this->isValid()) {
 			if ($this->errorMsg) {
-				throw new PluginException(elgg_echo('PluginException:InvalidPlugin:Details',
+				throw new \PluginException(elgg_echo('PluginException:InvalidPlugin:Details',
 							array($plugin, $this->errorMsg)));
 			} else {
-				throw new PluginException(elgg_echo('PluginException:InvalidPlugin', array($plugin)));
+				throw new \PluginException(elgg_echo('PluginException:InvalidPlugin', array($plugin)));
 			}
 		}
 	}
@@ -144,12 +144,12 @@ class ElggPluginPackage {
 	 * Checks if this is a valid Elgg plugin.
 	 *
 	 * Checks for requires files as defined at the start of this
-	 * class.  Will check require manifest fields via ElggPluginManifest
+	 * class.  Will check require manifest fields via \ElggPluginManifest
 	 * for Elgg 1.8 plugins.
 	 *
 	 * @note This doesn't check dependencies or conflicts.
-	 * Use {@link ElggPluginPackage::canActivate()} or
-	 * {@link ElggPluginPackage::checkDependencies()} for that.
+	 * Use {@link \ElggPluginPackage::canActivate()} or
+	 * {@link \ElggPluginPackage::checkDependencies()} for that.
 	 *
 	 * @return bool
 	 */
@@ -284,7 +284,7 @@ class ElggPluginPackage {
 	/**
 	 * Returns a parsed manifest file.
 	 *
-	 * @return ElggPluginManifest
+	 * @return \ElggPluginManifest
 	 */
 	public function getManifest() {
 		if (!$this->manifest) {
@@ -298,7 +298,7 @@ class ElggPluginPackage {
 
 	/**
 	 * Loads the manifest into this->manifest as an
-	 * ElggPluginManifest object.
+	 * \ElggPluginManifest object.
 	 *
 	 * @return bool
 	 */
@@ -306,13 +306,13 @@ class ElggPluginPackage {
 		$file = $this->path . 'manifest.xml';
 
 		try {
-			$this->manifest = new ElggPluginManifest($file, $this->id);
+			$this->manifest = new \ElggPluginManifest($file, $this->id);
 		} catch (Exception $e) {
 			$this->errorMsg = $e->getMessage();
 			return false;
 		}
 
-		if ($this->manifest instanceof ElggPluginManifest) {
+		if ($this->manifest instanceof \ElggPluginManifest) {
 			return true;
 		}
 
@@ -365,7 +365,7 @@ class ElggPluginPackage {
 		foreach ($enabled_plugins as $plugin) {
 			$temp_conflicts = array();
 			$temp_manifest = $plugin->getManifest();
-			if ($temp_manifest instanceof ElggPluginManifest) {
+			if ($temp_manifest instanceof \ElggPluginManifest) {
 				$temp_conflicts = $plugin->getManifest()->getConflicts();
 			}
 			foreach ($temp_conflicts as $conflict) {
@@ -501,7 +501,7 @@ class ElggPluginPackage {
 	 * @return bool
 	 */
 	private function checkDepPriority(array $dep, array $plugins, $inverse = false) {
-		// grab the ElggPlugin using this package.
+		// grab the \ElggPlugin using this package.
 		$plugin_package = elgg_get_plugin_from_id($this->getID());
 		$plugin_priority = $plugin_package->getPriority();
 		$test_plugin = elgg_get_plugin_from_id($dep['plugin']);
@@ -655,7 +655,7 @@ class ElggPluginPackage {
 
 		// ini_get() normalizes truthy values to 1 but falsey values to 0 or ''.
 		// version_compare() considers '' < 0, so normalize '' to 0.
-		// ElggPluginManifest normalizes all bool values and '' to 1 or 0.
+		// \ElggPluginManifest normalizes all bool values and '' to 1 or 0.
 		$setting = ini_get($name);
 
 		if ($setting === '') {

--- a/engine/classes/ElggPriorityList.php
+++ b/engine/classes/ElggPriorityList.php
@@ -2,7 +2,7 @@
 /**
  * Iterate over elements in a specific priority.
  *
- * $pl = new ElggPriorityList();
+ * $pl = new \ElggPriorityList();
  * $pl->add('Element 0');
  * $pl->add('Element 10', 10);
  * $pl->add('Element -10', -10);
@@ -19,7 +19,7 @@
  * Collisions on priority are handled by inserting the element at or as close to the
  * requested priority as possible:
  *
- * $pl = new ElggPriorityList();
+ * $pl = new \ElggPriorityList();
  * $pl->add('Element 5', 5);
  * $pl->add('Colliding element 5', 5);
  * $pl->add('Another colliding element 5', 5);
@@ -35,7 +35,7 @@
  *
  * You can do priority lookups by element:
  *
- * $pl = new ElggPriorityList();
+ * $pl = new \ElggPriorityList();
  * $pl->add('Element 0');
  * $pl->add('Element -5', -5);
  * $pl->add('Element 10', 10);
@@ -55,7 +55,7 @@
  * To move an element:
  * $pl->move('Element -5', -3);
  *
- * ElggPriorityList only tracks priority. No checking is done in ElggPriorityList for duplicates or
+ * \ElggPriorityList only tracks priority. No checking is done in \ElggPriorityList for duplicates or
  * updating. If you need to track this use objects and an external map:
  *
  * function elgg_register_something($id, $display_name, $location, $priority = 500) {
@@ -64,7 +64,7 @@
  *	static $list;
  *
  *	if (!$list) {
- *		$list = new ElggPriorityList();
+ *		$list = new \ElggPriorityList();
  *	}
  *
  *	// update if already registered.
@@ -77,7 +77,7 @@
  *		$element->display_name = $display_name;
  *		$element->location = $location;
  *	} else {
- *		$element = new stdClass();
+ *		$element = new \stdClass();
  *		$element->display_name = $display_name;
  *		$element->location = $location;
  *		if (!$list->add($element, $priority)) {
@@ -93,7 +93,7 @@
  * @subpackage Helpers
  */
 class ElggPriorityList
-	implements Iterator, Countable {
+	implements \Iterator, \Countable {
 
 	/**
 	 * The list of elements

--- a/engine/classes/ElggRelationship.php
+++ b/engine/classes/ElggRelationship.php
@@ -11,7 +11,7 @@
  * @property int    $guid_two     The GUID of the target of the relationship
  * @property int    $time_created A UNIX timestamp of when the relationship was created (read-only, set on first save)
  */
-class ElggRelationship extends ElggData implements
+class ElggRelationship extends \ElggData implements
 	Importable // deprecated
 {
 	// database column limit
@@ -20,7 +20,7 @@ class ElggRelationship extends ElggData implements
 	/**
 	 * Create a relationship object
 	 *
-	 * @param stdClass $row Database row or null for new relationship
+	 * @param \stdClass $row Database row or null for new relationship
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct($row = null) {
@@ -31,16 +31,16 @@ class ElggRelationship extends ElggData implements
 			return;
 		}
 
-		if (!($row instanceof stdClass)) {
+		if (!($row instanceof \stdClass)) {
 			if (!is_numeric($row)) {
-				throw new InvalidArgumentException("Constructor accepts only a stdClass or null.");
+				throw new \InvalidArgumentException("Constructor accepts only a \stdClass or null.");
 			}
 
 			$id = (int)$row;
 			elgg_deprecated_notice('Passing an ID to constructor is deprecated. Use get_relationship()', 1.9);
 			$row = _elgg_get_relationship_row($id);
 			if (!$row) {
-				throw new InvalidArgumentException("Relationship not found with ID $id");
+				throw new \InvalidArgumentException("Relationship not found with ID $id");
 			}
 		}
 
@@ -52,7 +52,7 @@ class ElggRelationship extends ElggData implements
 	/**
 	 * (non-PHPdoc)
 	 *
-	 * @see ElggData::initializeAttributes()
+	 * @see \ElggData::initializeAttributes()
 	 *
 	 * @return void
 	 */
@@ -129,7 +129,7 @@ class ElggRelationship extends ElggData implements
 
 		$this->id = add_entity_relationship($this->guid_one, $this->relationship, $this->guid_two);
 		if (!$this->id) {
-			throw new IOException("Unable to save new " . get_class());
+			throw new \IOException("Unable to save new " . get_class());
 		}
 
 		return $this->id;
@@ -188,7 +188,7 @@ class ElggRelationship extends ElggData implements
 	 * {@inheritdoc}
 	 */
 	public function toObject() {
-		$object = new stdClass();
+		$object = new \stdClass();
 		$object->id = $this->id;
 		$object->subject_guid = $this->guid_one;
 		$object->relationship = $this->relationship;
@@ -250,7 +250,7 @@ class ElggRelationship extends ElggData implements
 	public function import(ODD $data) {
 		elgg_deprecated_notice(__METHOD__ . ' has been deprecated', 1.9);
 		if (!($data instanceof ODDRelationship)) {
-			throw new InvalidParameterException("import() passed an unexpected ODD class");
+			throw new \InvalidParameterException("import() passed an unexpected ODD class");
 		}
 
 		$uuid_one = $data->getAttribute('uuid1');
@@ -274,7 +274,7 @@ class ElggRelationship extends ElggData implements
 				// save
 				$result = $this->save();
 				if (!$result) {
-					throw new ImportException("There was a problem saving " . get_class());
+					throw new \ImportException("There was a problem saving " . get_class());
 				}
 
 				return true;
@@ -303,7 +303,7 @@ class ElggRelationship extends ElggData implements
 	 *
 	 * @param int $id ID
 	 *
-	 * @return ElggRelationship
+	 * @return \ElggRelationship
 	 */
 	public function getObjectFromID($id) {
 		return get_relationship($id);

--- a/engine/classes/ElggRewriteTester.php
+++ b/engine/classes/ElggRewriteTester.php
@@ -30,7 +30,7 @@ class ElggRewriteTester {
 	 */
 	public function run($url, $path) {
 
-		$this->webserver = ElggRewriteTester::guessWebServer();
+		$this->webserver = \ElggRewriteTester::guessWebServer();
 
 		$this->rewriteTestPassed = $this->runRewriteTest($url);
 

--- a/engine/classes/ElggRiverItem.php
+++ b/engine/classes/ElggRiverItem.php
@@ -35,11 +35,11 @@ class ElggRiverItem {
 	/**
 	 * Construct a river item object given a database row.
 	 *
-	 * @param stdClass $object Object obtained from database
+	 * @param \stdClass $object Object obtained from database
 	 */
 	public function __construct($object) {
-		if (!($object instanceof stdClass)) {
-			throw new InvalidParameterException("Invalid input to ElggRiverItem constructor");
+		if (!($object instanceof \stdClass)) {
+			throw new \InvalidParameterException("Invalid input to \ElggRiverItem constructor");
 		}
 
 		// the casting is to support typed serialization like json
@@ -56,7 +56,7 @@ class ElggRiverItem {
 	/**
 	 * Get the subject of this river item
 	 * 
-	 * @return ElggEntity
+	 * @return \ElggEntity
 	 */
 	public function getSubjectEntity() {
 		return get_entity($this->subject_guid);
@@ -65,7 +65,7 @@ class ElggRiverItem {
 	/**
 	 * Get the object of this river item
 	 *
-	 * @return ElggEntity
+	 * @return \ElggEntity
 	 */
 	public function getObjectEntity() {
 		return get_entity($this->object_guid);
@@ -74,7 +74,7 @@ class ElggRiverItem {
 	/**
 	 * Get the target of this river item
 	 *
-	 * @return ElggEntity
+	 * @return \ElggEntity
 	 */
 	public function getTargetEntity() {
 		return get_entity($this->target_guid);
@@ -83,7 +83,7 @@ class ElggRiverItem {
 	/**
 	 * Get the Annotation for this river item
 	 * 
-	 * @return ElggAnnotation
+	 * @return \ElggAnnotation
 	 */
 	public function getAnnotation() {
 		return elgg_get_annotation_from_id($this->annotation_id);
@@ -105,7 +105,7 @@ class ElggRiverItem {
 	 * @deprecated 1.9 Use getTimePosted()
 	 */
 	public function getPostedTime() {
-		elgg_deprecated_notice("ElggRiverItem::getPostedTime() deprecated in favor of getTimePosted()", 1.9);
+		elgg_deprecated_notice("\ElggRiverItem::getPostedTime() deprecated in favor of getTimePosted()", 1.9);
 		return (int)$this->posted;
 	}
 
@@ -144,10 +144,10 @@ class ElggRiverItem {
 	/**
 	 * Get a plain old object copy for public consumption
 	 * 
-	 * @return stdClass
+	 * @return \stdClass
 	 */
 	public function toObject() {
-		$object = new stdClass();
+		$object = new \stdClass();
 		$object->id = $this->id;
 		$object->subject_guid = $this->subject_guid;
 		$object->object_guid = $this->object_guid;

--- a/engine/classes/ElggSession.php
+++ b/engine/classes/ElggSession.php
@@ -6,30 +6,30 @@
  * Reserved keys: last_forward_from, msg, sticky_forms, user, guid, id, code, name, username
  * Deprecated keys: user, id, name, username
  * 
- * ArrayAccess was deprecated in Elgg 1.9. This means you should use 
+ * \ArrayAccess was deprecated in Elgg 1.9. This means you should use 
  * $session->get('foo') rather than $session['foo'].
- * Warning: You can not access multidimensional arrays through ArrayAccess like
+ * Warning: You can not access multidimensional arrays through \ArrayAccess like
  * this $session['foo']['bar']
  *
  * @package    Elgg.Core
  * @subpackage Session
  * @see        elgg_get_session()
  */
-class ElggSession implements ArrayAccess {
+class ElggSession implements \ArrayAccess {
 
-	/** @var Elgg_Http_SessionStorage */
+	/** @var \Elgg\Http\SessionStorage */
 	protected $storage;
 
-	/** @var ElggUser */
+	/** @var \ElggUser */
 	protected $loggedInUser;
 
 	/**
 	 * Constructor
 	 *
-	 * @param Elgg_Http_SessionStorage $storage The storage engine
+	 * @param \Elgg\Http\SessionStorage $storage The storage engine
 	 * @access private Use elgg_get_session()
 	 */
-	public function __construct(Elgg_Http_SessionStorage $storage) {
+	public function __construct(\Elgg\Http\SessionStorage $storage) {
 		$this->storage = $storage;
 		$this->loggedInUser = null;
 	}
@@ -185,11 +185,11 @@ class ElggSession implements ArrayAccess {
 	/**
 	 * Sets the logged in user
 	 * 
-	 * @param ElggUser $user The user who is logged in
+	 * @param \ElggUser $user The user who is logged in
 	 * @return void
 	 * @since 1.9
 	 */
-	public function setLoggedInUser(ElggUser $user) {
+	public function setLoggedInUser(\ElggUser $user) {
 		$this->set('guid', $user->guid);
 		$this->loggedInUser = $user;
 	}
@@ -197,7 +197,7 @@ class ElggSession implements ArrayAccess {
 	/**
 	 * Gets the logged in user
 	 * 
-	 * @return ElggUser
+	 * @return \ElggUser
 	 * @since 1.9
 	 */
 	public function getLoggedInUser() {
@@ -261,7 +261,7 @@ class ElggSession implements ArrayAccess {
 	 * Get a variable from either the session, or if its not in the session
 	 * attempt to get it from an api call.
 	 *
-	 * @see ArrayAccess::offsetGet()
+	 * @see \ArrayAccess::offsetGet()
 	 *
 	 * @param mixed $key Name
 	 *
@@ -308,7 +308,7 @@ class ElggSession implements ArrayAccess {
 	/**
 	 * Unset a value from the cache and the session.
 	 *
-	 * @see ArrayAccess::offsetUnset()
+	 * @see \ArrayAccess::offsetUnset()
 	 *
 	 * @param mixed $key Name
 	 *
@@ -323,7 +323,7 @@ class ElggSession implements ArrayAccess {
 	/**
 	 * Return whether the value is set in either the session or the cache.
 	 *
-	 * @see ArrayAccess::offsetExists()
+	 * @see \ArrayAccess::offsetExists()
 	 *
 	 * @param int $offset Offset
 	 *

--- a/engine/classes/ElggSharedMemoryCache.php
+++ b/engine/classes/ElggSharedMemoryCache.php
@@ -1,13 +1,13 @@
 <?php
 /**
  * Shared memory cache description.
- * Extends ElggCache with functions useful to shared memory
+ * Extends \ElggCache with functions useful to shared memory
  * style caches (static variables, memcache etc)
  *
  * @package    Elgg.Core
  * @subpackage Cache
  */
-abstract class ElggSharedMemoryCache extends ElggCache {
+abstract class ElggSharedMemoryCache extends \ElggCache {
 	/**
 	 * Namespace variable used to keep various bits of the cache
 	 * separate.

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -2,18 +2,18 @@
 /**
  * A Site entity.
  *
- * ElggSite represents a single site entity.
+ * \ElggSite represents a single site entity.
  *
- * An ElggSite object is an ElggEntity child class with the subtype
+ * An \ElggSite object is an \ElggEntity child class with the subtype
  * of "site."  It is created upon installation and holds information about a site:
  *  - name
  *  - description
  *  - url
  *
- * Every ElggEntity belongs to a site.
+ * Every \ElggEntity belongs to a site.
  *
- * @internal ElggSite represents a single row from the sites_entity
- * table, as well as the corresponding ElggEntity row from the entities table.
+ * @internal \ElggSite represents a single row from the sites_entity
+ * table, as well as the corresponding \ElggEntity row from the entities table.
  *
  * @warning Multiple site support isn't fully developed.
  *
@@ -25,7 +25,7 @@
  * @property string $description A motto, mission statement, or description of the website
  * @property string $url         The root web address for the site, including trailing slash
  */
-class ElggSite extends ElggEntity {
+class ElggSite extends \ElggEntity {
 
 	/**
 	 * Initialize the attributes array.
@@ -44,12 +44,12 @@ class ElggSite extends ElggEntity {
 	}
 
 	/**
-	 * Create a new ElggSite.
+	 * Create a new \ElggSite.
 	 *
 	 * Plugin developers should only use the constructor to create a new entity.
 	 * To retrieve entities, use get_entity() and the elgg_get_entities* functions.
 	 *
-	 * @param stdClass $row Database row result. Default is null to create a new site.
+	 * @param \stdClass $row Database row result. Default is null to create a new site.
 	 *
 	 * @throws IOException If cannot load remaining data from db
 	 * @throws InvalidParameterException If not passed a db result
@@ -62,15 +62,15 @@ class ElggSite extends ElggEntity {
 
 		if (!empty($row)) {
 			// Is $row is a DB entity table row
-			if ($row instanceof stdClass) {
+			if ($row instanceof \stdClass) {
 				// Load the rest
 				if (!$this->load($row)) {
 					$msg = "Failed to load new " . get_class() . " for GUID:" . $row->guid;
-					throw new IOException($msg);
+					throw new \IOException($msg);
 				}
-			} else if ($row instanceof ElggSite) {
-				// $row is an ElggSite so this is a copy constructor
-				elgg_deprecated_notice('This type of usage of the ElggSite constructor was deprecated. Please use the clone method.', 1.7);
+			} else if ($row instanceof \ElggSite) {
+				// $row is an \ElggSite so this is a copy constructor
+				elgg_deprecated_notice('This type of usage of the \ElggSite constructor was deprecated. Please use the clone method.', 1.7);
 				foreach ($row->attributes as $key => $value) {
 					$this->attributes[$key] = $value;
 				}
@@ -85,25 +85,25 @@ class ElggSite extends ElggEntity {
 				// $row is a GUID so load
 				elgg_deprecated_notice('Passing a GUID to constructor is deprecated. Use get_entity()', 1.9);
 				if (!$this->load($row)) {
-					throw new IOException("Failed to load new " . get_class() . " from GUID:" . $row);
+					throw new \IOException("Failed to load new " . get_class() . " from GUID:" . $row);
 				}
 			} else {
-				throw new InvalidParameterException("Unrecognized value passed to constuctor.");
+				throw new \InvalidParameterException("Unrecognized value passed to constuctor.");
 			}
 		}
 	}
 
 	/**
-	 * Loads the full ElggSite when given a guid.
+	 * Loads the full \ElggSite when given a guid.
 	 *
-	 * @param mixed $guid GUID of ElggSite entity or database row object
+	 * @param mixed $guid GUID of \ElggSite entity or database row object
 	 *
 	 * @return bool
 	 * @throws InvalidClassException
 	 */
 	protected function load($guid) {
-		$attr_loader = new Elgg_AttributeLoader(get_class(), 'site', $this->attributes);
-		$attr_loader->requires_access_control = !($this instanceof ElggPlugin);
+		$attr_loader = new \Elgg\AttributeLoader(get_class(), 'site', $this->attributes);
+		$attr_loader->requires_access_control = !($this instanceof \ElggPlugin);
 		$attr_loader->secondary_loader = 'get_site_entity_as_row';
 
 		$attrs = $attr_loader->getRequiredAttributes($guid);
@@ -182,7 +182,7 @@ class ElggSite extends ElggEntity {
 	public function delete() {
 		global $CONFIG;
 		if ($CONFIG->site->getGUID() == $this->guid) {
-			throw new SecurityException('You cannot delete the current site');
+			throw new \SecurityException('You cannot delete the current site');
 		}
 
 		return parent::delete();
@@ -203,7 +203,7 @@ class ElggSite extends ElggEntity {
 		global $CONFIG;
 
 		if ($CONFIG->site->getGUID() == $this->guid) {
-			throw new SecurityException('You cannot disable the current site');
+			throw new \SecurityException('You cannot disable the current site');
 		}
 
 		return parent::disable($reason, $recursive);
@@ -233,7 +233,7 @@ class ElggSite extends ElggEntity {
 	}
 
 	/**
-	 * Gets an array of ElggUser entities who are members of the site.
+	 * Gets an array of \ElggUser entities who are members of the site.
 	 *
 	 * @param array $options An associative array for key => value parameters
 	 *                       accepted by elgg_get_entities(). Common parameters
@@ -241,13 +241,13 @@ class ElggSite extends ElggEntity {
 	 *                       Note: this was $limit before version 1.8
 	 * @param int   $offset  Offset @deprecated parameter
 	 *
-	 * @return array of ElggUsers
-	 * @deprecated 1.9 Use ElggSite::getEntities()
+	 * @return array of \ElggUsers
+	 * @deprecated 1.9 Use \ElggSite::getEntities()
 	 */
 	public function getMembers($options = array(), $offset = 0) {
-		elgg_deprecated_notice('ElggSite::getMembers() is deprecated. Use ElggSite::getEntities()', 1.9);
+		elgg_deprecated_notice('\ElggSite::getMembers() is deprecated. Use \ElggSite::getEntities()', 1.9);
 		if (!is_array($options)) {
-			elgg_deprecated_notice("ElggSite::getMembers uses different arguments!", 1.8);
+			elgg_deprecated_notice("\ElggSite::getMembers uses different arguments!", 1.8);
 			$options = array(
 				'limit' => $options,
 				'offset' => $offset,
@@ -279,7 +279,7 @@ class ElggSite extends ElggEntity {
 	 * @deprecated 1.9 Use elgg_list_entities_from_relationship()
 	 */
 	public function listMembers($options = array()) {
-		elgg_deprecated_notice('ElggSite::listMembers() is deprecated. Use elgg_list_entities_from_relationship()', 1.9);
+		elgg_deprecated_notice('\ElggSite::listMembers() is deprecated. Use elgg_list_entities_from_relationship()', 1.9);
 		$defaults = array(
 			'site_guids' => ELGG_ENTITIES_ANY_VALUE,
 			'relationship' => 'member_of_site',
@@ -299,11 +299,11 @@ class ElggSite extends ElggEntity {
 	 * This adds a 'member_of_site' relationship between between the entity and
 	 * the site. It does not change the site_guid of the entity.
 	 *
-	 * @param ElggEntity $entity User, group, or object entity
+	 * @param \ElggEntity $entity User, group, or object entity
 	 *
 	 * @return bool
 	 */
-	public function addEntity(ElggEntity $entity) {
+	public function addEntity(\ElggEntity $entity) {
 		if (elgg_instanceof($entity, 'site')) {
 			return false;
 		}
@@ -313,7 +313,7 @@ class ElggSite extends ElggEntity {
 	/**
 	 * Removes an entity from this site
 	 *
-	 * @param ElggEntity $entity User, group, or object entity
+	 * @param \ElggEntity $entity User, group, or object entity
 	 *
 	 * @return bool
 	 */
@@ -352,10 +352,10 @@ class ElggSite extends ElggEntity {
 	 * @param int $user_guid GUID
 	 *
 	 * @return bool
-	 * @deprecated 1.9 Use ElggSite::addEntity()
+	 * @deprecated 1.9 Use \ElggSite::addEntity()
 	 */
 	public function addUser($user_guid) {
-		elgg_deprecated_notice('ElggSite::addUser() is deprecated. Use ElggEntity::addEntity()', 1.9);
+		elgg_deprecated_notice('\ElggSite::addUser() is deprecated. Use \ElggEntity::addEntity()', 1.9);
 		return add_site_user($this->getGUID(), $user_guid);
 	}
 
@@ -365,15 +365,15 @@ class ElggSite extends ElggEntity {
 	 * @param int $user_guid GUID
 	 *
 	 * @return bool
-	 * @deprecated 1.9 Use ElggSite::removeEntity()
+	 * @deprecated 1.9 Use \ElggSite::removeEntity()
 	 */
 	public function removeUser($user_guid) {
-		elgg_deprecated_notice('ElggSite::removeUser() is deprecated. Use ElggEntity::removeEntity()', 1.9);
+		elgg_deprecated_notice('\ElggSite::removeUser() is deprecated. Use \ElggEntity::removeEntity()', 1.9);
 		return remove_site_user($this->getGUID(), $user_guid);
 	}
 
 	/**
-	 * Returns an array of ElggObject entities that belong to the site.
+	 * Returns an array of \ElggObject entities that belong to the site.
 	 *
 	 * @warning This only returns objects that have been explicitly added to the
 	 * site through addObject()
@@ -383,10 +383,10 @@ class ElggSite extends ElggEntity {
 	 * @param int    $offset  Offset
 	 *
 	 * @return array
-	 * @deprecated 1.9 Use ElggSite:getEntities()
+	 * @deprecated 1.9 Use \ElggSite:getEntities()
 	 */
 	public function getObjects($subtype = "", $limit = 10, $offset = 0) {
-		elgg_deprecated_notice('ElggSite::getObjects() is deprecated. Use ElggSite::getEntities()', 1.9);
+		elgg_deprecated_notice('\ElggSite::getObjects() is deprecated. Use \ElggSite::getEntities()', 1.9);
 		return get_site_objects($this->getGUID(), $subtype, $limit, $offset);
 	}
 
@@ -396,10 +396,10 @@ class ElggSite extends ElggEntity {
 	 * @param int $object_guid GUID
 	 *
 	 * @return bool
-	 * @deprecated 1.9 Use ElggSite::addEntity()
+	 * @deprecated 1.9 Use \ElggSite::addEntity()
 	 */
 	public function addObject($object_guid) {
-		elgg_deprecated_notice('ElggSite::addObject() is deprecated. Use ElggEntity::addEntity()', 1.9);
+		elgg_deprecated_notice('\ElggSite::addObject() is deprecated. Use \ElggEntity::addEntity()', 1.9);
 		return add_site_object($this->getGUID(), $object_guid);
 	}
 
@@ -409,10 +409,10 @@ class ElggSite extends ElggEntity {
 	 * @param int $object_guid GUID
 	 *
 	 * @return bool
-	 * @deprecated 1.9 Use ElggSite::removeEntity()
+	 * @deprecated 1.9 Use \ElggSite::removeEntity()
 	 */
 	public function removeObject($object_guid) {
-		elgg_deprecated_notice('ElggSite::removeObject() is deprecated. Use ElggEntity::removeEntity()', 1.9);
+		elgg_deprecated_notice('\ElggSite::removeObject() is deprecated. Use \ElggEntity::removeEntity()', 1.9);
 		return remove_site_object($this->getGUID(), $object_guid);
 	}
 
@@ -423,7 +423,7 @@ class ElggSite extends ElggEntity {
 	 * @param int    $limit   Limit
 	 * @param int    $offset  Offset
 	 *
-	 * @return unknown
+	 * @return mixed
 	 * @deprecated 1.8 Was never implemented
 	 */
 	public function getCollections($subtype = "", $limit = 10, $offset = 0) {

--- a/engine/classes/ElggStaticVariableCache.php
+++ b/engine/classes/ElggStaticVariableCache.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * ElggStaticVariableCache
+ * \ElggStaticVariableCache
  * Dummy cache which stores values in a static array. Using this makes future
  * replacements to other caching back ends (eg memcache) much easier.
  *
  * @package    Elgg.Core
  * @subpackage Cache
  */
-class ElggStaticVariableCache extends ElggSharedMemoryCache {
+class ElggStaticVariableCache extends \ElggSharedMemoryCache {
 	/**
 	 * The cache.
 	 *
@@ -40,7 +40,7 @@ class ElggStaticVariableCache extends ElggSharedMemoryCache {
 	public function save($key, $data) {
 		$namespace = $this->getNamespace();
 
-		ElggStaticVariableCache::$__cache[$namespace][$key] = $data;
+		\ElggStaticVariableCache::$__cache[$namespace][$key] = $data;
 
 		return true;
 	}
@@ -57,8 +57,8 @@ class ElggStaticVariableCache extends ElggSharedMemoryCache {
 	public function load($key, $offset = 0, $limit = null) {
 		$namespace = $this->getNamespace();
 
-		if (isset(ElggStaticVariableCache::$__cache[$namespace][$key])) {
-			return ElggStaticVariableCache::$__cache[$namespace][$key];
+		if (isset(\ElggStaticVariableCache::$__cache[$namespace][$key])) {
+			return \ElggStaticVariableCache::$__cache[$namespace][$key];
 		}
 
 		return false;
@@ -74,7 +74,7 @@ class ElggStaticVariableCache extends ElggSharedMemoryCache {
 	public function delete($key) {
 		$namespace = $this->getNamespace();
 
-		unset(ElggStaticVariableCache::$__cache[$namespace][$key]);
+		unset(\ElggStaticVariableCache::$__cache[$namespace][$key]);
 
 		return true;
 	}
@@ -87,10 +87,10 @@ class ElggStaticVariableCache extends ElggSharedMemoryCache {
 	public function clear() {
 		$namespace = $this->getNamespace();
 
-		if (!isset(ElggStaticVariableCache::$__cache)) {
-			ElggStaticVariableCache::$__cache = array();
+		if (!isset(\ElggStaticVariableCache::$__cache)) {
+			\ElggStaticVariableCache::$__cache = array();
 		}
 
-		ElggStaticVariableCache::$__cache[$namespace] = array();
+		\ElggStaticVariableCache::$__cache[$namespace] = array();
 	}
 }

--- a/engine/classes/ElggUpgrade.php
+++ b/engine/classes/ElggUpgrade.php
@@ -3,7 +3,7 @@
  * Upgrade object for upgrades that need to be tracked
  * and listed in the admin area.
  *
- * @todo Expand for all upgrades to be ElggUpgrade subclasses.
+ * @todo Expand for all upgrades to be \ElggUpgrade subclasses.
  */
 
 /**
@@ -12,7 +12,7 @@
  *
  * @package Elgg.Admin
  */
-class ElggUpgrade extends ElggObject {
+class ElggUpgrade extends \ElggObject {
 	private $requiredProperties = array(
 		'title',
 		'description',
@@ -75,13 +75,13 @@ class ElggUpgrade extends ElggObject {
 		// elgg_normalize_url() returns the root URL if passed an empty string
 		
 		if (!$url) {
-			throw new InvalidArgumentException(elgg_echo('ElggUpgrade:error:url_invalid'));
+			throw new \InvalidArgumentException(elgg_echo('ElggUpgrade:error:url_invalid'));
 		}
 
 		$url = elgg_normalize_url($url);
 
 		if ($this->getUpgradeFromURL($url)) {
-			throw new InvalidArgumentException(elgg_echo('ElggUpgrade:error:url_not_unique'));
+			throw new \InvalidArgumentException(elgg_echo('ElggUpgrade:error:url_not_unique'));
 		}
 
 		return $this->upgrade_url = $url;
@@ -128,7 +128,7 @@ class ElggUpgrade extends ElggObject {
 	public function save() {
 		foreach ($this->requiredProperties as $prop) {
 			if (!$this->$prop) {
-				throw new UnexpectedValueException(elgg_echo("ElggUpgrade:error:{$prop}_required"));
+				throw new \UnexpectedValueException(elgg_echo("ElggUpgrade:error:{$prop}_required"));
 			}
 		}
 
@@ -168,10 +168,10 @@ class ElggUpgrade extends ElggObject {
 	}
 
 	/**
-	 * Find an ElggUpgrade object by the unique URL
+	 * Find an \ElggUpgrade object by the unique URL
 	 *
-	 * @param type $url The Upgrade URL
-	 * @return boolean
+	 * @param string $url The Upgrade URL
+	 * @return \ElggUpgrade|boolean
 	 */
 	public function getUpgradeFromURL($url) {
 		$url = elgg_normalize_url($url);

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ElggUser
+ * \ElggUser
  *
  * Representation of a "user" in the system.
  *
@@ -16,7 +16,7 @@
  * @property string $password The hashed password of the user
  * @property string $salt     The salt used to secure the password before hashing
  */
-class ElggUser extends ElggEntity
+class ElggUser extends \ElggEntity
 	implements Friendable {
 
 	/**
@@ -49,7 +49,7 @@ class ElggUser extends ElggEntity
 	 * Plugin developers should only use the constructor to create a new entity.
 	 * To retrieve entities, use get_entity() and the elgg_get_entities* functions.
 	 *
-	 * @param stdClass $row Database row result. Default is null to create a new user.
+	 * @param \stdClass $row Database row result. Default is null to create a new user.
 	 *
 	 * @throws IOException|InvalidParameterException if there was a problem creating the user.
 	 */
@@ -61,11 +61,11 @@ class ElggUser extends ElggEntity
 
 		if (!empty($row)) {
 			// Is $row is a DB entity row
-			if ($row instanceof stdClass) {
+			if ($row instanceof \stdClass) {
 				// Load the rest
 				if (!$this->load($row)) {
 					$msg = "Failed to load new " . get_class() . " for GUID:" . $row->guid;
-					throw new IOException($msg);
+					throw new \IOException($msg);
 				}
 			} else if (is_string($row)) {
 				// $row is a username
@@ -76,9 +76,9 @@ class ElggUser extends ElggEntity
 						$this->attributes[$key] = $value;
 					}
 				}
-			} else if ($row instanceof ElggUser) {
-				// $row is an ElggUser so this is a copy constructor
-				elgg_deprecated_notice('This type of usage of the ElggUser constructor was deprecated. Please use the clone method.', 1.7);
+			} else if ($row instanceof \ElggUser) {
+				// $row is an \ElggUser so this is a copy constructor
+				elgg_deprecated_notice('This type of usage of the \ElggUser constructor was deprecated. Please use the clone method.', 1.7);
 				foreach ($row->attributes as $key => $value) {
 					$this->attributes[$key] = $value;
 				}
@@ -86,23 +86,23 @@ class ElggUser extends ElggEntity
 				// $row is a GUID so load entity
 				elgg_deprecated_notice('Passing a GUID to constructor is deprecated. Use get_entity()', 1.9);
 				if (!$this->load($row)) {
-					throw new IOException("Failed to load new " . get_class() . " from GUID:" . $row);
+					throw new \IOException("Failed to load new " . get_class() . " from GUID:" . $row);
 				}
 			} else {
-				throw new InvalidParameterException("Unrecognized value passed to constuctor.");
+				throw new \InvalidParameterException("Unrecognized value passed to constuctor.");
 			}
 		}
 	}
 
 	/**
-	 * Load the ElggUser data from the database
+	 * Load the \ElggUser data from the database
 	 *
-	 * @param mixed $guid ElggUser GUID or stdClass database row from entity table
+	 * @param mixed $guid \ElggUser GUID or \stdClass database row from entity table
 	 *
 	 * @return bool
 	 */
 	protected function load($guid) {
-		$attr_loader = new Elgg_AttributeLoader(get_class(), 'user', $this->attributes);
+		$attr_loader = new \Elgg\AttributeLoader(get_class(), 'user', $this->attributes);
 		$attr_loader->secondary_loader = 'get_user_entity_as_row';
 
 		$attrs = $attr_loader->getRequiredAttributes($guid);
@@ -327,7 +327,7 @@ class ElggUser extends ElggEntity
 	 */
 	public function getSites($options = "", $limit = 10, $offset = 0) {
 		if (is_string($options)) {
-			elgg_deprecated_notice('ElggUser::getSites() takes an options array', 1.9);
+			elgg_deprecated_notice('\ElggUser::getSites() takes an options array', 1.9);
 			return get_user_sites($this->getGUID(), $limit, $offset);
 		}
 
@@ -337,13 +337,13 @@ class ElggUser extends ElggEntity
 	/**
 	 * Add this user to a particular site
 	 *
-	 * @param ElggSite $site The site to add this user to. This used to be the
+	 * @param \ElggSite $site The site to add this user to. This used to be the
 	 *                       the site guid (still supported by deprecated)
 	 * @return bool
 	 */
 	public function addToSite($site) {
 		if (is_numeric($site)) {
-			elgg_deprecated_notice('ElggUser::addToSite() takes a site entity', 1.9);
+			elgg_deprecated_notice('\ElggUser::addToSite() takes a site entity', 1.9);
 			return add_site_user($site, $this->getGUID());
 		}
 
@@ -353,13 +353,13 @@ class ElggUser extends ElggEntity
 	/**
 	 * Remove this user from a particular site
 	 *
-	 * @param ElggSite $site The site to remove the user from. Used to be site GUID
+	 * @param \ElggSite $site The site to remove the user from. Used to be site GUID
 	 *
 	 * @return bool
 	 */
 	public function removeFromSite($site) {
 		if (is_numeric($site)) {
-			elgg_deprecated_notice('ElggUser::removeFromSite() takes a site entity', 1.9);
+			elgg_deprecated_notice('\ElggUser::removeFromSite() takes a site entity', 1.9);
 			return remove_site_user($site, $this->guid);
 		}
 
@@ -372,7 +372,7 @@ class ElggUser extends ElggEntity
 	 * @param int $friend_guid The GUID of the user to add
 	 *
 	 * @return bool
-	 * @todo change to accept ElggUser
+	 * @todo change to accept \ElggUser
 	 */
 	public function addFriend($friend_guid) {
 		if (!get_user($friend_guid)) {
@@ -388,7 +388,7 @@ class ElggUser extends ElggEntity
 	 * @param int $friend_guid The GUID of the user to remove
 	 *
 	 * @return bool
-	 * @todo change to accept ElggUser
+	 * @todo change to accept \ElggUser
 	 */
 	public function removeFriend($friend_guid) {
 		if (!get_user($friend_guid)) {
@@ -447,7 +447,7 @@ class ElggUser extends ElggEntity
 	 * @param int   $limit   The number of users to retrieve (deprecated)
 	 * @param int   $offset  Indexing offset, if any (deprecated)
 	 *
-	 * @return array|false Array of ElggUser, or false, depending on success
+	 * @return array|false Array of \ElggUser, or false, depending on success
 	 */
 	public function getFriends($options = array(), $limit = 10, $offset = 0) {
 		if (is_array($options)) {
@@ -456,7 +456,7 @@ class ElggUser extends ElggEntity
 			$options['type'] = 'user';
 			return elgg_get_entities_from_relationship($options);
 		} else {
-			elgg_deprecated_notice("ElggUser::getFriends takes an options array", 1.9);
+			elgg_deprecated_notice("\ElggUser::getFriends takes an options array", 1.9);
 			return elgg_get_entities_from_relationship(array(
 				'relationship' => 'friend',
 				'relationship_guid' => $this->guid,
@@ -478,7 +478,7 @@ class ElggUser extends ElggEntity
 	 * @param int   $limit   The number of users to retrieve (deprecated)
 	 * @param int   $offset  Indexing offset, if any (deprecated)
 	 *
-	 * @return array|false Array of ElggUser, or false, depending on success
+	 * @return array|false Array of \ElggUser, or false, depending on success
 	 */
 	public function getFriendsOf($options = array(), $limit = 10, $offset = 0) {
 		if (is_array($options)) {
@@ -488,7 +488,7 @@ class ElggUser extends ElggEntity
 			$options['type'] = 'user';
 			return elgg_get_entities_from_relationship($options);
 		} else {
-			elgg_deprecated_notice("ElggUser::getFriendsOf takes an options array", 1.9);
+			elgg_deprecated_notice("\ElggUser::getFriendsOf takes an options array", 1.9);
 			return elgg_get_entities_from_relationship(array(
 				'relationship' => 'friend',
 				'relationship_guid' => $this->guid,
@@ -512,7 +512,7 @@ class ElggUser extends ElggEntity
 	 * @deprecated 1.9 Use elgg_list_entities_from_relationship()
 	 */
 	public function listFriends($subtype = "", $limit = 10, array $vars = array()) {
-		elgg_deprecated_notice('ElggUser::listFriends() is deprecated. Use elgg_list_entities_from_relationship()', 1.9);
+		elgg_deprecated_notice('\ElggUser::listFriends() is deprecated. Use elgg_list_entities_from_relationship()', 1.9);
 		$defaults = array(
 			'type' => 'user',
 			'relationship' => 'friend',
@@ -537,11 +537,11 @@ class ElggUser extends ElggEntity
 	 * @param int   $limit   The number of groups to retrieve (deprecated)
 	 * @param int   $offset  Indexing offset, if any (deprecated)
 	 *
-	 * @return array|false Array of ElggGroup, or false, depending on success
+	 * @return array|false Array of \ElggGroup, or false, depending on success
 	 */
 	public function getGroups($options = "", $limit = 10, $offset = 0) {
 		if (is_string($options)) {
-			elgg_deprecated_notice('ElggUser::getGroups() takes an options array', 1.9);
+			elgg_deprecated_notice('\ElggUser::getGroups() takes an options array', 1.9);
 			$subtype = $options;
 			$options = array(
 				'type' => 'group',
@@ -592,7 +592,7 @@ class ElggUser extends ElggEntity
 	}
 
 	/**
-	 * Get an array of ElggObject owned by this user.
+	 * Get an array of \ElggObject owned by this user.
 	 *
 	 * @param array $options Options array. See elgg_get_entities() for a list of options.
 	 *                       'type' is set to object and owner_guid to this entity.
@@ -607,7 +607,7 @@ class ElggUser extends ElggEntity
 			$options['owner_guid'] = $this->getGUID();
 			return elgg_get_entities($options);
 		} else {
-			elgg_deprecated_notice("ElggUser::getObjects takes an options array", 1.9);
+			elgg_deprecated_notice("\ElggUser::getObjects takes an options array", 1.9);
 			return elgg_get_entities(array(
 				'type' => 'object',
 				'subtype' => $options,
@@ -619,7 +619,7 @@ class ElggUser extends ElggEntity
 	}
 
 	/**
-	 * Get an array of ElggObjects owned by this user's friends.
+	 * Get an array of \ElggObjects owned by this user's friends.
 	 *
 	 * @param array $options Options array. See elgg_get_entities_from_relationship()
 	 *                       for a list of options. 'relationship_guid' is set to
@@ -638,7 +638,7 @@ class ElggUser extends ElggEntity
 			$options['relationship_join_on'] = 'container_guid';
 			return elgg_get_entities_from_relationship($options);
 		} else {
-			elgg_deprecated_notice("ElggUser::getFriendsObjects takes an options array", 1.9);
+			elgg_deprecated_notice("\ElggUser::getFriendsObjects takes an options array", 1.9);
 			return elgg_get_entities_from_relationship(array(
 				'type' => 'object',
 				'subtype' => $options,
@@ -652,15 +652,15 @@ class ElggUser extends ElggEntity
 	}
 
 	/**
-	 * Counts the number of ElggObjects owned by this user
+	 * Counts the number of \ElggObjects owned by this user
 	 *
 	 * @param string $subtype The subtypes of the objects, if any
 	 *
-	 * @return int The number of ElggObjects
+	 * @return int The number of \ElggObjects
 	 * @deprecated 1.9 Use elgg_get_entities()
 	 */
 	public function countObjects($subtype = "") {
-		elgg_deprecated_notice("ElggUser::countObjects() is deprecated. Use elgg_get_entities()", 1.9);
+		elgg_deprecated_notice("\ElggUser::countObjects() is deprecated. Use elgg_get_entities()", 1.9);
 		return count_user_objects($this->getGUID(), $subtype);
 	}
 
@@ -674,7 +674,7 @@ class ElggUser extends ElggEntity
 	 * @return array|false
 	 */
 	public function getCollections($subtype = "", $limit = 10, $offset = 0) {
-		elgg_deprecated_notice("ElggUser::getCollections() has been deprecated", 1.8);
+		elgg_deprecated_notice("\ElggUser::getCollections() has been deprecated", 1.8);
 		return false;
 	}
 
@@ -700,7 +700,7 @@ class ElggUser extends ElggEntity
 	 * @deprecated 1.8 Use getOwnerGUID()
 	 */
 	public function getOwner() {
-		elgg_deprecated_notice("ElggUser::getOwner deprecated for ElggUser::getOwnerGUID", 1.8);
+		elgg_deprecated_notice("\ElggUser::getOwner deprecated for \ElggUser::getOwnerGUID", 1.8);
 		$this->getOwnerGUID();
 	}
 
@@ -735,7 +735,7 @@ class ElggUser extends ElggEntity
 	/**
 	 * Can a user comment on this user?
 	 *
-	 * @see ElggEntity::canComment()
+	 * @see \ElggEntity::canComment()
 	 * 
 	 * @param int $user_guid User guid (default is logged in user)
 	 * @return bool

--- a/engine/classes/ElggVolatileMetadataCache.php
+++ b/engine/classes/ElggVolatileMetadataCache.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ElggVolatileMetadataCache
+ * \ElggVolatileMetadataCache
  * In memory cache of known metadata values stored by entity.
  *
  * @package    Elgg.Core

--- a/engine/classes/ElggWidget.php
+++ b/engine/classes/ElggWidget.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * ElggWidget
+ * \ElggWidget
  *
- * Stores metadata in private settings rather than as ElggMetadata
+ * Stores metadata in private settings rather than as \ElggMetadata
  *
  * @package    Elgg.Core
  * @subpackage Widgets
@@ -13,7 +13,7 @@
  * @property-read string $order   internal, do not use
  * @property-read string $context internal, do not use
  */
-class ElggWidget extends ElggObject {
+class ElggWidget extends \ElggObject {
 
 	/**
 	 * Set subtype to widget.

--- a/engine/classes/ElggXMLElement.php
+++ b/engine/classes/ElggXMLElement.php
@@ -12,7 +12,7 @@ class ElggXMLElement {
 	private $_element;
 
 	/**
-	 * Creates an ElggXMLParser from a string or existing SimpleXMLElement
+	 * Creates an \ElggXMLParser from a string or existing SimpleXMLElement
 	 * 
 	 * @param string|SimpleXMLElement $xml The XML to parse
 	 */
@@ -69,13 +69,13 @@ class ElggXMLElement {
 	}
 
 	/**
-	 * @return ElggXMLElement[] Child elements
+	 * @return \ElggXMLElement[] Child elements
 	 */
 	public function getChildren() {
 		$children = $this->_element->children();
 		$result = array();
 		foreach ($children as $val) {
-			$result[] = new ElggXMLElement($val);
+			$result[] = new \ElggXMLElement($val);
 		}
 
 		return $result;

--- a/engine/classes/ExportException.php
+++ b/engine/classes/ExportException.php
@@ -6,4 +6,4 @@
  * @subpackage Exception
  * @deprecated 1.9
  */
-class ExportException extends DataFormatException {}
+class ExportException extends \DataFormatException {}

--- a/engine/classes/IOException.php
+++ b/engine/classes/IOException.php
@@ -6,4 +6,4 @@
  * @package    Elgg.Core
  * @subpackage Exception
  */
-class IOException extends Exception {}
+class IOException extends \Exception {}

--- a/engine/classes/ImportException.php
+++ b/engine/classes/ImportException.php
@@ -6,4 +6,4 @@
  * @subpackage Exception
  * @deprecated 1.9
  */
-class ImportException extends DataFormatException {}
+class ImportException extends \DataFormatException {}

--- a/engine/classes/IncompleteEntityException.php
+++ b/engine/classes/IncompleteEntityException.php
@@ -7,4 +7,4 @@
  * @subpackage Exception
  * @access private
  */
-class IncompleteEntityException extends Exception {}
+class IncompleteEntityException extends \Exception {}

--- a/engine/classes/InstallationException.php
+++ b/engine/classes/InstallationException.php
@@ -6,4 +6,4 @@
  * @package    Elgg.Core
  * @subpackage Exception
  */
-class InstallationException extends ConfigurationException {}
+class InstallationException extends \ConfigurationException {}

--- a/engine/classes/InvalidClassException.php
+++ b/engine/classes/InvalidClassException.php
@@ -6,4 +6,4 @@
  * @package    Elgg.Core
  * @subpackage Exception
  */
-class InvalidClassException extends ClassException {}
+class InvalidClassException extends \ClassException {}

--- a/engine/classes/InvalidParameterException.php
+++ b/engine/classes/InvalidParameterException.php
@@ -6,4 +6,4 @@
  * @package    Elgg.Core
  * @subpackage Exception
  */
-class InvalidParameterException extends CallException {}
+class InvalidParameterException extends \CallException {}

--- a/engine/classes/Loggable.php
+++ b/engine/classes/Loggable.php
@@ -51,7 +51,7 @@ interface Loggable {
 	 *
 	 * @param int $id GUID of an entity
 	 *
-	 * @return ElggEntity
+	 * @return \ElggEntity
 	 */
 	public function getObjectFromID($id);
 

--- a/engine/classes/LoginException.php
+++ b/engine/classes/LoginException.php
@@ -7,4 +7,4 @@
  * @package    Elgg.Core
  * @subpackage Exceptions.Stub
  */
-class LoginException extends Exception {}
+class LoginException extends \Exception {}

--- a/engine/classes/NotificationException.php
+++ b/engine/classes/NotificationException.php
@@ -5,4 +5,4 @@
  * @package    Elgg.Core
  * @subpackage Exception
  */
-class NotificationException extends Exception {}
+class NotificationException extends \Exception {}

--- a/engine/classes/ODDDocument.php
+++ b/engine/classes/ODDDocument.php
@@ -6,7 +6,7 @@
  * @subpackage ODD
  * @deprecated 1.9
  */
-class ODDDocument implements Iterator {
+class ODDDocument implements \Iterator {
 	/**
 	 * ODD Version
 	 *
@@ -100,11 +100,11 @@ class ODDDocument implements Iterator {
 	/**
 	 * Set an optional wrapper factory to optionally embed the ODD document in another format.
 	 *
-	 * @param ODDWrapperFactory $factory The factory
+	 * @param \ODDWrapperFactory $factory The factory
 	 *
 	 * @return void
 	 */
-	public function setWrapperFactory(ODDWrapperFactory $factory) {
+	public function setWrapperFactory(\ODDWrapperFactory $factory) {
 		$this->wrapperfactory = $factory;
 	}
 

--- a/engine/classes/PluginException.php
+++ b/engine/classes/PluginException.php
@@ -8,4 +8,4 @@
  * @package    Elgg.Core
  * @subpackage Exception
  */
-class PluginException extends Exception {}
+class PluginException extends \Exception {}

--- a/engine/classes/RegistrationException.php
+++ b/engine/classes/RegistrationException.php
@@ -6,4 +6,4 @@
  * @package    Elgg.Core
  * @subpackage Exceptions
  */
-class RegistrationException extends InstallationException {}
+class RegistrationException extends \InstallationException {}

--- a/engine/classes/SecurityException.php
+++ b/engine/classes/SecurityException.php
@@ -7,4 +7,4 @@
  * @package    Elgg.Core
  * @subpackage Exception
  */
-class SecurityException extends Exception {}
+class SecurityException extends \Exception {}

--- a/engine/handlers/cache_handler.php
+++ b/engine/handlers/cache_handler.php
@@ -17,7 +17,7 @@
 require_once dirname(dirname(__FILE__)) . '/classes/Elgg/CacheHandler.php';
 
 require_once dirname(dirname(__FILE__)) . '/settings.php';
-/* @var stdClass $CONFIG */
+/* @var \stdClass $CONFIG */
 
 // dataroot must have trailing slash
 // @todo need a lib with core functions that have no depedencies
@@ -25,6 +25,6 @@ if (isset($CONFIG->dataroot)) {
 	$CONFIG->dataroot = rtrim($CONFIG->dataroot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 }
 
-$handler = new Elgg_CacheHandler($CONFIG);
+$handler = new \Elgg\CacheHandler($CONFIG);
 
 $handler->handleRequest($_GET, $_SERVER);

--- a/engine/handlers/export_handler.php
+++ b/engine/handlers/export_handler.php
@@ -26,7 +26,7 @@ if (($guid != "") && ($type == "") && ($id_or_name == "")) {
 
 	if (!$entity) {
 		$query = "GUID:" . $guid . " could not be found, or you can not access it.";
-		throw new InvalidParameterException($query);
+		throw new \InvalidParameterException($query);
 	}
 
 	$title = "GUID:$guid";
@@ -38,7 +38,7 @@ if (($guid != "") && ($type == "") && ($id_or_name == "")) {
 	$entity = get_entity($guid);
 	if (!$entity) {
 		$msg = "GUID:" . $guid . " could not be found, or you can not access it.";
-		throw new InvalidParameterException($msg);
+		throw new \InvalidParameterException($msg);
 	}
 
 	$uuid = guid_to_uuid($entity->getGUID()) . "$type/$id_or_name/";
@@ -48,10 +48,10 @@ if (($guid != "") && ($type == "") && ($id_or_name == "")) {
 			$v = $entity->get($id_or_name);
 			if (!$v) {
 				$msg = "Sorry, '" . $id_or_name . "' does not exist for guid:" . $guid;
-				throw new InvalidParameterException($msg);
+				throw new \InvalidParameterException($msg);
 			}
 
-			$m = new ElggMetadata();
+			$m = new \ElggMetadata();
 
 			$m->value = $v;
 			$m->name = $id_or_name;
@@ -80,18 +80,18 @@ if (($guid != "") && ($type == "") && ($id_or_name == "")) {
 
 		default :
 			$msg = "Sorry, I don't know how to export '" . $type . "'";
-			throw new InvalidParameterException($msg);
+			throw new \InvalidParameterException($msg);
 	}
 
 	// Render metadata or relationship
 	if ((!$m) && (!$r)) {
-		throw new InvalidParameterException("Could not find any data.");
+		throw new \InvalidParameterException("Could not find any data.");
 	}
 
 	// Exporting metadata?
 	if ($m) {
 		if ($m->entity_guid != $entity->guid) {
-			throw new InvalidParameterException("Does not belong to entity.");
+			throw new \InvalidParameterException("Does not belong to entity.");
 		}
 
 		$title = "$type:$id_or_name";
@@ -101,7 +101,7 @@ if (($guid != "") && ($type == "") && ($id_or_name == "")) {
 	// Exporting relationship
 	if ($r) {
 		if (($r->guid_one != $entity->guid) && ($r->guid_two != $entity->guid)) {
-			throw new InvalidParameterException("Does not belong to entity or refer to entity.");
+			throw new \InvalidParameterException("Does not belong to entity or refer to entity.");
 		}
 
 		$title = "$type:$id_or_name";
@@ -110,7 +110,7 @@ if (($guid != "") && ($type == "") && ($id_or_name == "")) {
 
 	// Something went wrong
 } else {
-	throw new InvalidParameterException("Missing parameter, you need to provide a GUID.");
+	throw new \InvalidParameterException("Missing parameter, you need to provide a GUID.");
 }
 
 $body = elgg_view_layout('one_sidebar', array(

--- a/engine/lib/access.php
+++ b/engine/lib/access.php
@@ -59,9 +59,9 @@ function elgg_get_ignore_access() {
 }
 
 /**
- * Return an ElggCache static variable cache for the access caches
+ * Return an \ElggCache static variable cache for the access caches
  *
- * @staticvar ElggStaticVariableCache $access_cache
+ * @staticvar \ElggStaticVariableCache $access_cache
  * @return \ElggStaticVariableCache
  * @access private
  */
@@ -72,7 +72,7 @@ function _elgg_get_access_cache() {
 	static $access_cache;
 
 	if (!$access_cache) {
-		$access_cache = new ElggStaticVariableCache('access');
+		$access_cache = new \ElggStaticVariableCache('access');
 	}
 
 	return $access_cache;
@@ -239,11 +239,11 @@ function get_access_array($user_guid = 0, $site_guid = 0, $flush = false) {
  * If want you to change the default access based on group of other information,
  * use the 'default', 'access' plugin hook.
  *
- * @param ElggUser $user Get the user's default access. Defaults to logged in user.
+ * @param \ElggUser $user Get the user's default access. Defaults to logged in user.
  *
  * @return int default access id (see ACCESS defines in elgglib.php)
  */
-function get_default_access(ElggUser $user = null) {
+function get_default_access(\ElggUser $user = null) {
 	global $CONFIG;
 
 	// site default access
@@ -426,8 +426,8 @@ function _elgg_get_access_where_sql(array $options = array()) {
  * entity to test access for. We need to be able to tell whether the entity exists
  * and whether the user has access to the entity.
  *
- * @param ElggEntity $entity The entity to check access for.
- * @param ElggUser   $user   Optionally user to check access for. Defaults to
+ * @param \ElggEntity $entity The entity to check access for.
+ * @param \ElggUser   $user   Optionally user to check access for. Defaults to
  *                           logged in user (which is a useless default).
  *
  * @return bool
@@ -555,7 +555,7 @@ function can_edit_access_collection($collection_id, $user_guid = null) {
 
 	$collection = get_access_collection($collection_id);
 
-	if (!($user instanceof ElggUser) || !$collection) {
+	if (!($user instanceof \ElggUser) || !$collection) {
 		return false;
 	}
 
@@ -840,7 +840,7 @@ function get_user_access_collections($owner_guid, $site_guid = 0) {
  * @param int  $collection The collection's ID
  * @param bool $idonly     If set to true, will only return the members' GUIDs (default: false)
  *
- * @return array ElggUser guids or entities if successful, false if not
+ * @return ElggUser[]|int[]|false guids or entities if successful, false if not
  * @see add_user_to_access_collection()
  */
 function get_members_of_access_collection($collection, $idonly = false) {
@@ -967,12 +967,12 @@ function elgg_check_access_overrides($user_guid = 0) {
 }
 
 /**
- * Returns the Elgg_Access object.
+ * Returns the \Elgg\Access object.
  *
  * // @todo comment is incomplete
  * This is used to
  *
- * @return Elgg_Access
+ * @return \Elgg\Access
  * @since 1.7.0
  * @access private
  */
@@ -980,7 +980,7 @@ function elgg_get_access_object() {
 	static $elgg_access;
 
 	if (!$elgg_access) {
-		$elgg_access = new Elgg_Access();
+		$elgg_access = new \Elgg\Access();
 	}
 
 	return $elgg_access;
@@ -1038,7 +1038,7 @@ function elgg_override_permissions($hook, $type, $value, $params) {
 	}
 
 	// don't do this so ignore access still works with no one logged in
-	//if (!$user instanceof ElggUser) {
+	//if (!$user instanceof \ElggUser) {
 	//	return false;
 	//}
 

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -83,7 +83,7 @@ function elgg_add_admin_notice($id, $message) {
 		// need to handle when no one is logged in
 		$old_ia = elgg_set_ignore_access(true);
 
-		$admin_notice = new ElggObject();
+		$admin_notice = new \ElggObject();
 		$admin_notice->subtype = 'admin_notice';
 		// admins can see ACCESS_PRIVATE but no one else can.
 		$admin_notice->access_id = ACCESS_PRIVATE;
@@ -220,15 +220,15 @@ function elgg_register_admin_menu_item($section, $menu_id, $parent_id = null, $p
 }
 
 /**
- * Add an admin notice when a new ElggUpgrade object is created.
+ * Add an admin notice when a new \ElggUpgrade object is created.
  *
  * @param string     $event
  * @param string     $type
- * @param ElggObject $object
+ * @param \ElggObject $object
  * @access private
  */
 function _elgg_create_notice_of_pending_upgrade($event, $type, $object) {
-	if ($object instanceof ElggUpgrade) {
+	if ($object instanceof \ElggUpgrade) {
 		// Link to the Upgrades section
 		$link = elgg_view('output/url', array(
 			'href' => 'admin/upgrades',
@@ -489,19 +489,19 @@ function _elgg_admin_add_plugin_settings_menu() {
 function _elgg_admin_sort_page_menu($hook, $type, $return, $params) {
 	$configure_items = $return['configure'];
 	if (is_array($configure_items)) {
-		/* @var ElggMenuItem[] $configure_items */
+		/* @var \ElggMenuItem[] $configure_items */
 		foreach ($configure_items as $menu_item) {
 			if ($menu_item->getName() == 'settings') {
 				$settings = $menu_item;
 			}
 		}
 
-		if (!empty($settings) && $settings instanceof ElggMenuItem) {
+		if (!empty($settings) && $settings instanceof \ElggMenuItem) {
 			// keep the basic and advanced settings at the top
-			/* @var ElggMenuItem $settings */
+			/* @var \ElggMenuItem $settings */
 			$children = $settings->getChildren();
 			$site_settings = array_splice($children, 0, 2);
-			usort($children, array('ElggMenuBuilder', 'compareByText'));
+			usort($children, array('\ElggMenuBuilder', 'compareByText'));
 			array_splice($children, 0, 0, $site_settings);
 			$settings->setChildren($children);
 		}
@@ -807,7 +807,7 @@ function _elgg_admin_maintenance_action_check($hook, $type) {
  *
  * @param string $event
  * @param string $type
- * @param ElggUser $user
+ * @param \ElggUser $user
  *
  * @return null|true
  * @access private
@@ -831,7 +831,7 @@ function _elgg_add_admin_widgets($event, $type, $user) {
 			$guid = elgg_create_widget($user->getGUID(), $handler, 'admin');
 			if ($guid) {
 				$widget = get_entity($guid);
-				/* @var ElggWidget $widget */
+				/* @var \ElggWidget $widget */
 				$widget->move($column, $position);
 			}
 		}

--- a/engine/lib/annotations.php
+++ b/engine/lib/annotations.php
@@ -8,20 +8,20 @@
  */
 
 /**
- * Convert a database row to a new ElggAnnotation
+ * Convert a database row to a new \ElggAnnotation
  *
- * @param stdClass $row Db row result object
+ * @param \stdClass $row Db row result object
  *
- * @return ElggAnnotation
+ * @return \ElggAnnotation
  * @access private
  */
 function row_to_elggannotation($row) {
-	if (!($row instanceof stdClass)) {
+	if (!($row instanceof \stdClass)) {
 		// @todo should throw in this case?
 		return $row;
 	}
 
-	return new ElggAnnotation($row);
+	return new \ElggAnnotation($row);
 }
 
 /**
@@ -31,7 +31,7 @@ function row_to_elggannotation($row) {
  *
  * @param int $id The id of the annotation object being retrieved.
  *
- * @return ElggAnnotation|false
+ * @return \ElggAnnotation|false
  */
 function elgg_get_annotation_from_id($id) {
 	return _elgg_get_metastring_based_object_from_id($id, 'annotation');
@@ -194,13 +194,13 @@ function update_annotation($annotation_id, $name, $value, $value_type, $owner_gu
  *                                   "calculation" option to elgg_get_entities_from_annotation_calculation().
  *                                   The "annotation_calculation" option causes this function to
  *                                   return the result of performing a mathematical calculation on
- *                                   all annotations that match the query instead of ElggAnnotation
+ *                                   all annotations that match the query instead of \ElggAnnotation
  *                                   objects.
  *                                   See the docs for elgg_get_entities_from_annotation_calculation()
  *                                   for the proper use of the "calculation" option.
  *
  *
- * @return ElggAnnotation[]|mixed
+ * @return \ElggAnnotation[]|mixed
  * @since 1.8.0
  */
 function elgg_get_annotations(array $options = array()) {
@@ -516,7 +516,7 @@ function elgg_annotation_exists($entity_guid, $annotation_type, $owner_guid = nu
  */
 function _elgg_set_comment_url($hook, $type, $url, $params) {
 	$annotation = $params['extender'];
-	/* @var ElggExtender $annotation */
+	/* @var \ElggExtender $annotation */
 	if ($annotation->getSubtype() == 'generic_comment') {
 		$entity = $annotation->getEntity();
 		if ($entity) {

--- a/engine/lib/autoloader.php
+++ b/engine/lib/autoloader.php
@@ -10,7 +10,7 @@
 require_once dirname(dirname(__DIR__)) . '/vendor/autoload.php';
 
 /**
- * @return Elgg_Di_ServiceProvider
+ * @return \Elgg\Di\ServiceProvider
  * @access private
  */
 function _elgg_services() {
@@ -32,13 +32,13 @@ function _elgg_services() {
  * @access private
  */
 function _elgg_create_service_provider() {
-	$loader = new Elgg_ClassLoader(new Elgg_ClassMap());
+	$loader = new \Elgg\ClassLoader(new \Elgg\ClassMap());
 	// until the cache can be loaded, just setup PSR-0 autoloading
 	// out of the classes directory. No need to build a full map.
 	$loader->register();
-	$manager = new Elgg_AutoloadManager($loader);
+	$manager = new \Elgg\AutoloadManager($loader);
 
-	return new Elgg_Di_ServiceProvider($manager);
+	return new \Elgg\Di\ServiceProvider($manager);
 }
 
 /**
@@ -77,7 +77,7 @@ function _elgg_delete_autoload_cache() {
 /**
  * Get Elgg's class loader
  *
- * @return Elgg_ClassLoader
+ * @return \Elgg\ClassLoader
  */
 function elgg_get_class_loader() {
 	return _elgg_services()->autoloadManager->getLoader();

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -10,12 +10,12 @@
 /* Filepath Cache */
 
 /**
- * Returns an ElggCache object suitable for caching system information
+ * Returns an \ElggCache object suitable for caching system information
  *
  * @todo Can this be done in a cleaner way?
  * @todo Swap to memcache etc?
  *
- * @return ElggFileCache
+ * @return \ElggFileCache
  */
 function elgg_get_system_cache() {
 	global $CONFIG;
@@ -26,7 +26,7 @@ function elgg_get_system_cache() {
 	static $FILE_PATH_CACHE;
 
 	if (!$FILE_PATH_CACHE) {
-		$FILE_PATH_CACHE = new ElggFileCache($CONFIG->dataroot . 'system_cache/');
+		$FILE_PATH_CACHE = new \ElggFileCache($CONFIG->dataroot . 'system_cache/');
 	}
 
 	return $FILE_PATH_CACHE;
@@ -303,7 +303,7 @@ function _elgg_load_cache() {
 
 	$CONFIG->system_cache_loaded = false;
 
-	$CONFIG->views = new stdClass();
+	$CONFIG->views = new \stdClass();
 	$data = elgg_load_system_cache('view_locations');
 	if (!is_string($data)) {
 		return;

--- a/engine/lib/comments.php
+++ b/engine/lib/comments.php
@@ -46,13 +46,13 @@ function _elgg_comments_page_handler($page) {
 				forward(REFERER);
 			}
 			$comment = get_entity($page[1]);
-			if (!($comment instanceof ElggComment) || !$comment->canEdit()) {
+			if (!($comment instanceof \ElggComment) || !$comment->canEdit()) {
 				register_error(elgg_echo('generic_comment:notfound'));
 				forward(REFERER);
 			}
 
 			$target = $comment->getContainerEntity();
-			if (!($target instanceof ElggEntity)) {
+			if (!($target instanceof \ElggEntity)) {
 				register_error(elgg_echo('generic_comment:notfound'));
 				forward(REFERER);
 			}
@@ -90,7 +90,7 @@ function _elgg_comments_page_handler($page) {
  *
  * @param string         $hook   'register'
  * @param string         $type   'menu:entity'
- * @param ElggMenuItem[] $return Array of ElggMenuItem objects
+ * @param \ElggMenuItem[] $return Array of \ElggMenuItem objects
  * @param array          $params Array of view vars
  *
  * @return array
@@ -131,7 +131,7 @@ function _elgg_comment_setup_entity_menu($hook, $type, $return, $params) {
  */
 function _elgg_comment_url_handler($hook, $type, $return, $params) {
 	$entity = $params['entity'];
-	/* @var ElggObject $entity */
+	/* @var \ElggObject $entity */
 
 	if (!elgg_instanceof($entity, 'object', 'comment') || !$entity->getOwnerEntity()) {
 		// not a comment or has no owner

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -33,10 +33,10 @@ function elgg_get_site_url($site_guid = 0) {
 
 	$site = get_entity($site_guid);
 
-	if (!$site instanceof ElggSite) {
+	if (!$site instanceof \ElggSite) {
 		return false;
 	}
-	/* @var ElggSite $site */
+	/* @var \ElggSite $site */
 
 	return $site->url;
 }
@@ -222,7 +222,7 @@ function datalist_get($name) {
 	$value = null;
 	static $datalist_memcache = null;
 	if (!$datalist_memcache && is_memcache_available()) {
-		$datalist_memcache = new ElggMemcache('datalist_memcache');
+		$datalist_memcache = new \ElggMemcache('datalist_memcache');
 	}
 	if ($datalist_memcache) {
 		$value = $datalist_memcache->load($name);
@@ -280,7 +280,7 @@ function datalist_set($name, $value) {
 	// If memcache is available then invalidate the cached copy
 	static $datalist_memcache = null;
 	if ((!$datalist_memcache) && (is_memcache_available())) {
-		$datalist_memcache = new ElggMemcache('datalist_memcache');
+		$datalist_memcache = new \ElggMemcache('datalist_memcache');
 	}
 
 	if ($datalist_memcache) {
@@ -555,7 +555,7 @@ function _elgg_load_site_config() {
 	$CONFIG->site_id = $CONFIG->site_guid;
 	$CONFIG->site = get_entity($CONFIG->site_guid);
 	if (!$CONFIG->site) {
-		throw new InstallationException("Unable to handle this request. This site is not configured or the database is down.");
+		throw new \InstallationException("Unable to handle this request. This site is not configured or the database is down.");
 	}
 
 	$CONFIG->wwwroot = $CONFIG->site->url;

--- a/engine/lib/cron.php
+++ b/engine/lib/cron.php
@@ -54,7 +54,7 @@ function _elgg_cron_page_handler($page) {
 	$allowed_periods = elgg_get_config('elgg_cron_periods');
 
 	if (!in_array($period, $allowed_periods)) {
-		throw new CronException("$period is not a recognized cron period.");
+		throw new \CronException("$period is not a recognized cron period.");
 	}
 
 	// Get a list of parameters

--- a/engine/lib/database.php
+++ b/engine/lib/database.php
@@ -199,7 +199,7 @@ function _elgg_db_log_profiling_data() {
  * $counter->setDeltaHeader();
  * </code>
  *
- * @return Elgg_Database_QueryCounter
+ * @return \Elgg\Database\QueryCounter
  * @access private
  */
 function _elgg_db_get_query_counter() {

--- a/engine/lib/deprecated-1.7.php
+++ b/engine/lib/deprecated-1.7.php
@@ -96,7 +96,7 @@ function get_entities_from_access_collection($collection_id, $entity_type = "", 
  * @param int    $timelower      Lower time limit
  * @param int    $timeupper      Upper time limit
  *
- * @return unknown_type
+ * @return ElggEntity[]|int
  */
 function get_entities_from_annotations($entity_type = "", $entity_subtype = "", $name = "",
 $value = "", $owner_guid = 0, $group_guid = 0, $limit = 10, $offset = 0, $order_by = "asc",
@@ -749,7 +749,7 @@ $count = false, $meta_array_operator = 'and') {
  * @param string $menu_name The name of the menu item
  * @param string $menu_url  Its URL
  *
- * @return stdClass|false Depending on success
+ * @return \stdClass|false Depending on success
  * @deprecated 1.7
  */
 function menu_item($menu_name, $menu_url) {
@@ -1109,7 +1109,7 @@ function get_views($dir, $base) {
  * @param mixed  $register_value The value of the register
  * @param array  $children_array Optionally, an array of children
  *
- * @return false|stdClass Depending on success
+ * @return false|\stdClass Depending on success
  * @deprecated 1.7 Use {@link add_submenu_item()}
  */
 function make_register_object($register_name, $register_value, $children_array = array()) {
@@ -1118,7 +1118,7 @@ function make_register_object($register_name, $register_value, $children_array =
 		return false;
 	}
 
-	$register = new stdClass;
+	$register = new \stdClass;
 	$register->name = $register_name;
 	$register->value = $register_value;
 	$register->children = $children_array;

--- a/engine/lib/deprecated-1.8.php
+++ b/engine/lib/deprecated-1.8.php
@@ -155,7 +155,7 @@ function get_entities_from_annotations_calculate_x($sum = "sum", $entity_type = 
  * @param string $orderdir       Order of results
  * @param bool   $count          Return count or entities
  *
- * @return unknown
+ * @return ElggEntity[]|int
  */
 function get_entities_from_annotation_count($entity_type = "", $entity_subtype = "", $name = "", $mdname = '', $mdvalue = '', $owner_guid = 0, $limit = 10, $offset = 0, $orderdir = 'desc', $count = false) {
 
@@ -293,7 +293,7 @@ function add_to_register($register_name, $subregister_name, $subregister_value, 
 		$CONFIG->registers[$register_name] = array();
 	}
 
-	$subregister = new stdClass;
+	$subregister = new \stdClass;
 	$subregister->name = $subregister_name;
 	$subregister->value = $subregister_value;
 
@@ -358,13 +358,13 @@ function get_register($register_name) {
 	if ($register_name == 'menu') {
 		// backward compatible code for site menu
 		$menu = $CONFIG->menus['site'];
-		$builder = new ElggMenuBuilder($menu);
+		$builder = new \ElggMenuBuilder($menu);
 		$menu_items = $builder->getMenu('text');
 		$menu_items = $menu_items['default'];
 
 		$menu = array();
 		foreach ($menu_items as $item) {
-			$subregister = new stdClass;
+			$subregister = new \stdClass;
 			$subregister->name = $item->getText();
 			$subregister->value = $item->getHref();
 			$menu[$subregister->name] = $subregister;
@@ -677,7 +677,7 @@ function callpath_gatekeeper($path, $include_subdirs = true, $strict_mode = fals
  * @param string     $table       Entity table prefix as defined in SELECT...FROM entities $table
  * @param NULL|array $owner_guids Owner GUIDs
  *
- * @return FALSE|str
+ * @return string|false
  * @since 1.7.0
  * @access private
  */
@@ -964,7 +964,7 @@ function get_entities_from_metadata_groups($group_guid, $meta_name, $meta_value 
  * @param int    $site_guid      Site GUID. 0 for current, -1 for any
  * @param bool   $count          Return count of entities instead of entities
  *
- * @return int|array List of ElggEntities, or the total number if count is set to false
+ * @return int|array List of \ElggEntities, or the total number if count is set to false
  * @deprecated 1.8 Use elgg_get_entities_from_metadata()
  */
 function get_entities_from_metadata_groups_multi($group_guid, $meta_array, $entity_type = "", $entity_subtype = "", $owner_guid = 0, $limit = 10, $offset = 0, $order_by = "", $site_guid = 0, $count = false) {
@@ -1059,9 +1059,9 @@ function get_entities_from_metadata_groups_multi($group_guid, $meta_array, $enti
 /**
  * List items within a given geographic area.
  *
- * @param real   $lat            Latitude
- * @param real   $long           Longitude
- * @param real   $radius         The radius
+ * @param float  $lat            Latitude
+ * @param float  $long           Longitude
+ * @param float  $radius         The radius
  * @param string $type           The type of entity (eg "user", "object" etc)
  * @param string $subtype        The arbitrary subtype of the entity
  * @param int    $owner_guid     The GUID of the owning user
@@ -1274,7 +1274,7 @@ function list_entities_from_metadata($meta_name, $meta_value = "", $entity_type 
  * @param bool   $listtypetoggle Allow users to toggle to the gallery view. Default: true
  * @param bool   $pagination     Display pagination? Default: true
  *
- * @return string List of ElggEntities suitable for display
+ * @return string List of \ElggEntities suitable for display
  *
  * @deprecated 1.8 Use elgg_list_entities_from_metadata() instead
  */
@@ -1503,7 +1503,7 @@ function page_owner() {
  * Gets the owner entity for the current page.
  *
  * @deprecated 1.8  Use elgg_get_page_owner_entity()
- * @return ElggEntity|false The current page owner or false if none.
+ * @return \ElggEntity|false The current page owner or false if none.
  */
 function page_owner_entity() {
 	elgg_deprecated_notice('page_owner_entity() was deprecated by elgg_get_page_owner_entity().', 1.8);
@@ -1651,18 +1651,18 @@ function get_plugin_name($mainfilename = false) {
 /**
  * Load and parse a plugin manifest from a plugin XML file.
  *
- * @deprecated 1.8 Use ElggPlugin->getManifest()
+ * @deprecated 1.8 Use \ElggPlugin->getManifest()
  *
  * @param string $plugin Plugin name.
  * @return array of values
  */
 function load_plugin_manifest($plugin) {
-	elgg_deprecated_notice('load_plugin_manifest() is deprecated by ElggPlugin->getManifest()', 1.8);
+	elgg_deprecated_notice('load_plugin_manifest() is deprecated by \ElggPlugin->getManifest()', 1.8);
 
 	$xml_file = elgg_get_plugins_path() . "$plugin/manifest.xml";
 
 	try {
-		$manifest = new ElggPluginManifest($xml_file, $plugin);
+		$manifest = new \ElggPluginManifest($xml_file, $plugin);
 	} catch(Exception $e) {
 		return false;
 	}
@@ -1674,13 +1674,13 @@ function load_plugin_manifest($plugin) {
  * This function checks a plugin manifest 'elgg_version' value against the current install
  * returning TRUE if the elgg_version is >= the current install's version.
  *
- * @deprecated 1.8 Use ElggPlugin->canActivate()
+ * @deprecated 1.8 Use \ElggPlugin->canActivate()
  *
  * @param string $manifest_elgg_version_string The build version (eg 2009010201).
  * @return bool
  */
 function check_plugin_compatibility($manifest_elgg_version_string) {
-	elgg_deprecated_notice('check_plugin_compatibility() is deprecated by ElggPlugin->canActivate()', 1.8);
+	elgg_deprecated_notice('check_plugin_compatibility() is deprecated by \ElggPlugin->canActivate()', 1.8);
 
 	$version = elgg_get_version();
 
@@ -1767,7 +1767,7 @@ function get_installed_plugins($status = 'all') {
  * 		elgg_regenerate_simplecache();
  *		elgg_reset_system_cache();
  *
- * @deprecated 1.8 Use ElggPlugin->activate()
+ * @deprecated 1.8 Use \ElggPlugin->activate()
  *
  * @param string $plugin    The plugin name.
  * @param int    $site_guid The site id, if not specified then this is detected.
@@ -1776,7 +1776,7 @@ function get_installed_plugins($status = 'all') {
  * @throws InvalidClassException
  */
 function enable_plugin($plugin, $site_guid = null) {
-	elgg_deprecated_notice('enable_plugin() was deprecated by ElggPlugin->activate()', 1.8);
+	elgg_deprecated_notice('enable_plugin() was deprecated by \ElggPlugin->activate()', 1.8);
 
 	$plugin = sanitise_string($plugin);
 
@@ -1787,7 +1787,7 @@ function enable_plugin($plugin, $site_guid = null) {
 	}
 
 	try {
-		$plugin = new ElggPlugin($plugin);
+		$plugin = new \ElggPlugin($plugin);
 	} catch(Exception $e) {
 		return false;
 	}
@@ -1808,7 +1808,7 @@ function enable_plugin($plugin, $site_guid = null) {
  * 		elgg_regenerate_simplecache();
  *		elgg_reset_system_cache();
  *
- * @deprecated 1.8 Use ElggPlugin->deactivate()
+ * @deprecated 1.8 Use \ElggPlugin->deactivate()
  *
  * @param string $plugin    The plugin name.
  * @param int    $site_guid The site id, if not specified then this is detected.
@@ -1817,7 +1817,7 @@ function enable_plugin($plugin, $site_guid = null) {
  * @throws InvalidClassException
  */
 function disable_plugin($plugin, $site_guid = 0) {
-	elgg_deprecated_notice('disable_plugin() was deprecated by ElggPlugin->deactivate()', 1.8);
+	elgg_deprecated_notice('disable_plugin() was deprecated by \ElggPlugin->deactivate()', 1.8);
 
 	$plugin = sanitise_string($plugin);
 
@@ -1828,7 +1828,7 @@ function disable_plugin($plugin, $site_guid = 0) {
 	}
 
 	try {
-		$plugin = new ElggPlugin($plugin);
+		$plugin = new \ElggPlugin($plugin);
 	} catch(Exception $e) {
 		return false;
 	}
@@ -2500,20 +2500,20 @@ $owner_guid = "", $owner_relationship = "") {
 
 /**
  * Perform standard authentication with a given username and password.
- * Returns an ElggUser object for use with login.
+ * Returns an \ElggUser object for use with login.
  *
  * @see login
  *
  * @param string $username The username, optionally (for standard logins)
  * @param string $password The password, optionally (for standard logins)
  *
- * @return ElggUser|false The authenticated user object, or false on failure.
+ * @return \ElggUser|false The authenticated user object, or false on failure.
  *
  * @deprecated 1.8 Use elgg_authenticate
  */
 function authenticate($username, $password) {
 	elgg_deprecated_notice('authenticate() has been deprecated for elgg_authenticate()', 1.8);
-	$pam = new ElggPAM('user');
+	$pam = new \ElggPAM('user');
 	$credentials = array('username' => $username, 'password' => $password);
 	$result = $pam->authenticate($credentials);
 	if ($result) {
@@ -2531,11 +2531,11 @@ function authenticate($username, $password) {
  * @param int $offset    Offset
  *
  * @return mixed
- * @deprecated 1.8 Use ElggSite::getMembers()
+ * @deprecated 1.8 Use \ElggSite::getMembers()
  */
 function get_site_members($site_guid, $limit = 10, $offset = 0) {
 	elgg_deprecated_notice("get_site_members() deprecated.
-		Use ElggSite::getMembers()", 1.8);
+		Use \ElggSite::getMembers()", 1.8);
 
 	$site = get_entity($site_guid);
 	if ($site) {
@@ -2553,11 +2553,11 @@ function get_site_members($site_guid, $limit = 10, $offset = 0) {
  * @param bool $fullview  Whether or not to display the full view (default: true)
  *
  * @return string A displayable list of members
- * @deprecated 1.8 Use ElggSite::listMembers()
+ * @deprecated 1.8 Use \ElggSite::listMembers()
  */
 function list_site_members($site_guid, $limit = 10, $fullview = true) {
 	elgg_deprecated_notice("list_site_members() deprecated.
-		Use ElggSite::listMembers()", 1.8);
+		Use \ElggSite::listMembers()", 1.8);
 
 	$options = array(
 		'limit' => $limit,
@@ -2755,7 +2755,7 @@ $entity_subtype = "", $owner_guid = "", $site_guid = -1, $start_ts = "", $end_ts
  * @param int    $timelower The earliest time the entity can have been created. Default: all
  * @param int    $timeupper The latest time the entity can have been created. Default: all
  *
- * @return false|array An array of ElggObjects or false, depending on success
+ * @return false|array An array of \ElggObjects or false, depending on success
  * @deprecated 1.8 Use elgg_get_entities() instead
  */
 function get_user_objects($user_guid, $subtype = ELGG_ENTITIES_ANY_VALUE, $limit = 10,
@@ -2840,7 +2840,7 @@ $fullview = true, $listtypetoggle = true, $pagination = true, $timelower = 0, $t
  * @param int    $limit     The number of results to return (default 10)
  * @param int    $offset    Indexing offset, if any
  *
- * @return false|array An array of ElggObjects or false, depending on success
+ * @return false|array An array of \ElggObjects or false, depending on success
  * @deprecated 1.8 Use elgg_get_entities_from_metadata() instead
  */
 function get_user_objects_by_metadata($user_guid, $subtype = "", $metadata = array(),
@@ -2876,7 +2876,7 @@ function request_user_validation($user_guid) {
 		Plugins should register for the 'register, user' plugin hook", 1.8);
 	$user = get_entity($user_guid);
 
-	if (($user) && ($user instanceof ElggUser)) {
+	if (($user) && ($user instanceof \ElggUser)) {
 		// invalidate any existing validations
 		set_user_validation_status($user_guid, false);
 
@@ -2954,13 +2954,13 @@ function elgg_view_listing($icon, $info) {
  *
  * @internal This is passed an entity rather than a guid to handle non-created entities.
  *
- * @param ElggEntity $entity The entity
+ * @param \ElggEntity $entity The entity
  * @param string     $size   Icon size
  *
  * @return string URL to the entity icon.
  * @deprecated 1.8 Use $entity->getIconURL()
  */
-function get_entity_icon_url(ElggEntity $entity, $size = 'medium') {
+function get_entity_icon_url(\ElggEntity $entity, $size = 'medium') {
 	elgg_deprecated_notice("get_entity_icon_url() deprecated for getIconURL()", 1.8);
 	global $CONFIG;
 
@@ -3030,7 +3030,7 @@ function get_entity_icon_url(ElggEntity $entity, $size = 'medium') {
  * way to provide user details to the ACL system without touching the session.
  *
  * @deprecated 1.8 Use elgg_get_logged_in_user_entity()
- * @return ElggUser|NULL
+ * @return \ElggUser|NULL
  */
 function get_loggedin_user() {
 	elgg_deprecated_notice('get_loggedin_user() is deprecated by elgg_get_logged_in_user_entity()', 1.8);
@@ -3091,7 +3091,7 @@ function load_plugins() {
  * @param string $plugin_id Plugin name.
  * @param int    $user_guid The guid who's settings to retrieve.
  *
- * @deprecated 1.8 Use elgg_get_all_plugin_user_settings() or ElggPlugin->getAllUserSettings()
+ * @deprecated 1.8 Use elgg_get_all_plugin_user_settings() or \ElggPlugin->getAllUserSettings()
  * @return StdClass Object with all user settings.
  */
 function find_plugin_usersettings($plugin_id = null, $user_guid = 0) {
@@ -3109,7 +3109,7 @@ function find_plugin_usersettings($plugin_id = null, $user_guid = 0) {
  *                          is detected from where you are calling from.
  *
  * @return bool
- * @deprecated 1.8 Use elgg_set_plugin_user_setting() or ElggPlugin->setUserSetting()
+ * @deprecated 1.8 Use elgg_set_plugin_user_setting() or \ElggPlugin->setUserSetting()
  */
 function set_plugin_usersetting($name, $value, $user_guid = 0, $plugin_id = "") {
 	elgg_deprecated_notice('find_plugin_usersettings() is deprecated by elgg_get_all_plugin_user_settings()', 1.8);
@@ -3119,11 +3119,11 @@ function set_plugin_usersetting($name, $value, $user_guid = 0, $plugin_id = "") 
 /**
  * Clears a user-specific plugin setting
  *
- * @param str $name      Name of the plugin setting
- * @param int $user_guid Defaults to logged in user
- * @param str $plugin_id Defaults to contextual plugin name
+ * @param string $name      Name of the plugin setting
+ * @param int    $user_guid Defaults to logged in user
+ * @param string $plugin_id Defaults to contextual plugin name
  *
- * @deprecated 1.8 Use elgg_unset_plugin_user_setting or ElggPlugin->unsetUserSetting().
+ * @deprecated 1.8 Use elgg_unset_plugin_user_setting or \ElggPlugin->unsetUserSetting().
  * @return bool Success
  */
 function clear_plugin_usersetting($name, $user_guid = 0, $plugin_id = '') {
@@ -3139,7 +3139,7 @@ function clear_plugin_usersetting($name, $user_guid = 0, $plugin_id = '') {
  * @param string $plugin_id Optional plugin name, if not specified
  *                          it is detected from where you are calling.
  *
- * @deprecated 1.8 Use elgg_get_plugin_user_setting() or ElggPlugin->getUserSetting()
+ * @deprecated 1.8 Use elgg_get_plugin_user_setting() or \ElggPlugin->getUserSetting()
  * @return mixed
  */
 function get_plugin_usersetting($name, $user_guid = 0, $plugin_id = "") {
@@ -3155,7 +3155,7 @@ function get_plugin_usersetting($name, $user_guid = 0, $plugin_id = "") {
  * @param string $plugin_id Optional plugin name, if not specified
  *                          then it is detected from where you are calling from.
  *
- * @deprecated 1.8 Use elgg_set_plugin_setting() or ElggPlugin->setSetting()
+ * @deprecated 1.8 Use elgg_set_plugin_setting() or \ElggPlugin->setSetting()
  * @return int|false
  */
 function set_plugin_setting($name, $value, $plugin_id = null) {
@@ -3170,7 +3170,7 @@ function set_plugin_setting($name, $value, $plugin_id = null) {
  * @param string $plugin_id Optional plugin name, if not specified
  *                          then it is detected from where you are calling from.
  *
- * @deprecated 1.8 Use elgg_get_plugin_setting() or ElggPlugin->getSetting()
+ * @deprecated 1.8 Use elgg_get_plugin_setting() or \ElggPlugin->getSetting()
  * @return mixed
  */
 function get_plugin_setting($name, $plugin_id = "") {
@@ -3185,7 +3185,7 @@ function get_plugin_setting($name, $plugin_id = "") {
  * @param string $plugin_id Optional plugin name, if not specified
  *                          then it is detected from where you are calling from.
  *
- * @deprecated 1.8 Use elgg_unset_plugin_setting() or ElggPlugin->unsetSetting()
+ * @deprecated 1.8 Use elgg_unset_plugin_setting() or \ElggPlugin->unsetSetting()
  * @return bool
  */
 function clear_plugin_setting($name, $plugin_id = "") {
@@ -3200,7 +3200,7 @@ function clear_plugin_setting($name, $plugin_id = "") {
  *                          then it is detected from where you are calling from.
  *
  * @return bool
- * @deprecated 1.8 Use elgg_unset_all_plugin_settings() or ElggPlugin->unsetAllSettings()
+ * @deprecated 1.8 Use elgg_unset_all_plugin_settings() or \ElggPlugin->unsetAllSettings()
  * @since 1.7.0
  */
 function clear_all_plugin_settings($plugin_id = "") {
@@ -3671,7 +3671,7 @@ function find_metadata($meta_name = "", $meta_value = "", $entity_type = "", $en
  * @param int    $entity_guid Entity GUID
  * @param string $meta_name   Metadata name
  *
- * @return mixed ElggMetadata object, an array of ElggMetadata or false.
+ * @return ElggMetadata|ElggMetadata[]|false object, an array of \ElggMetadata or false.
  * @deprecated 1.8 Use elgg_get_metadata()
  */
 function get_metadata_byname($entity_guid, $meta_name) {
@@ -3724,7 +3724,7 @@ function get_metadata_for_entity($entity_guid) {
  *
  * @param int $id The id of the metadata being retrieved.
  *
- * @return mixed False on failure or ElggMetadata
+ * @return mixed False on failure or \ElggMetadata
  * @deprecated 1.8 Use elgg_get_metadata_from_id()
  */
 function get_metadata($id) {
@@ -3816,7 +3816,7 @@ function remove_metadata($guid, $name, $value = "") {
  *
  * @param int $annotation_id Annotation ID
  *
- * @return ElggAnnotation
+ * @return \ElggAnnotation
  * @deprecated 1.8 Use elgg_get_annotation_from_id()
  */
 function get_annotation($annotation_id) {
@@ -4095,10 +4095,10 @@ function is_installed() {
  * @param string $policy - the policy type, default is "user"
  * @return bool true if authenticated, false if not.
  *
- * @deprecated 1.8 See {@link ElggPAM}
+ * @deprecated 1.8 See {@link \ElggPAM}
  */
 function pam_authenticate($credentials = NULL, $policy = "user") {
-	elgg_deprecated_notice('pam_authenticate has been deprecated for ElggPAM', 1.8);
+	elgg_deprecated_notice('pam_authenticate has been deprecated for \ElggPAM', 1.8);
 	global $_PAM_HANDLERS, $_PAM_HANDLERS_MSG;
 
 	$_PAM_HANDLERS_MSG = array();
@@ -4142,16 +4142,16 @@ function pam_authenticate($credentials = NULL, $policy = "user") {
  * When given a widget entity and a new requested location, saves the new location
  * and also provides a sensible ordering for all widgets in that column
  *
- * @param ElggObject $widget The widget entity
+ * @param \ElggObject $widget The widget entity
  * @param int        $order  The order within the column
  * @param int        $column The column (1, 2 or 3)
  *
  * @return bool Depending on success
- * @deprecated 1.8 use ElggWidget::move()
+ * @deprecated 1.8 use \ElggWidget::move()
  */
-function save_widget_location(ElggObject $widget, $order, $column) {
+function save_widget_location(\ElggObject $widget, $order, $column) {
 	elgg_deprecated_notice('save_widget_location() is deprecated', 1.8);
-	if ($widget instanceof ElggObject) {
+	if ($widget instanceof \ElggObject) {
 		if ($widget->getSubtype() == "widget") {
 			// If you can't move the widget, don't save a new location
 			if (!$widget->draggable) {
@@ -4209,7 +4209,7 @@ function save_widget_location(ElggObject $widget, $order, $column) {
  * @param string $context   The context (profile, dashboard etc)
  * @param int    $column    The column (1 or 2)
  *
- * @return array|false An array of widget ElggObjects, or false
+ * @return array|false An array of widget \ElggObjects, or false
  * @deprecated 1.8 Use elgg_get_widgets()
  */
 function get_widgets($user_guid, $context, $column) {
@@ -4259,7 +4259,7 @@ function add_widget($entity_guid, $handler, $context, $order = 0, $column = 1, $
 	}
 
 	if ($entity = get_entity($entity_guid)) {
-		$widget = new ElggWidget;
+		$widget = new \ElggWidget;
 		$widget->owner_guid = $entity_guid;
 		$widget->container_guid = $entity_guid;
 		if (isset($access_id)) {
@@ -4270,7 +4270,7 @@ function add_widget($entity_guid, $handler, $context, $order = 0, $column = 1, $
 
 		$guid = $widget->save();
 
-		// private settings cannot be set until ElggWidget saved
+		// private settings cannot be set until \ElggWidget saved
 		$widget->handler = $handler;
 		$widget->context = $context;
 		$widget->column = $column;
@@ -4333,7 +4333,7 @@ function widget_type_exists($handler) {
 }
 
 /**
- * Returns an array of stdClass objects representing the defined widget types
+ * Returns an array of \stdClass objects representing the defined widget types
  *
  * @return array A list of types defined (if any)
  * @deprecated 1.8 Use elgg_get_widget_types
@@ -4403,9 +4403,9 @@ function save_widget_info($widget_guid, $params) {
 /**
  * Reorders the widgets from a widget panel
  *
- * @param string $panelstring1 String of guids of ElggWidget objects separated by ::
- * @param string $panelstring2 String of guids of ElggWidget objects separated by ::
- * @param string $panelstring3 String of guids of ElggWidget objects separated by ::
+ * @param string $panelstring1 String of guids of \ElggWidget objects separated by ::
+ * @param string $panelstring2 String of guids of \ElggWidget objects separated by ::
+ * @param string $panelstring3 String of guids of \ElggWidget objects separated by ::
  * @param string $context      Profile or dashboard
  * @param int    $owner        Owner guid
  *
@@ -4489,7 +4489,7 @@ function reorder_widgets_from_panel($panelstring1, $panelstring2, $panelstring3,
 						$return = false;
 					} else {
 						// Remove state cookie
-						$cookie = new ElggCookie("widget$dbguid");
+						$cookie = new \ElggCookie("widget$dbguid");
 						$cookie->value = NULL;
 						elgg_set_cookie($cookie);
 					}
@@ -4527,7 +4527,7 @@ function use_widgets($context) {
 	global $CONFIG;
 
 	if (!isset($CONFIG->widgets)) {
-		$CONFIG->widgets = new stdClass;
+		$CONFIG->widgets = new \stdClass;
 	}
 
 	if (!isset($CONFIG->widgets->contexts)) {
@@ -4562,12 +4562,12 @@ function using_widgets() {
 /**
  * Displays a particular widget
  *
- * @param ElggObject $widget The widget to display
+ * @param \ElggObject $widget The widget to display
  * @return string The HTML for the widget, including JavaScript wrapper
  * 
  * @deprecated 1.8 Use elgg_view_entity()
  */
-function display_widget(ElggObject $widget) {
+function display_widget(\ElggObject $widget) {
 	elgg_deprecated_notice("display_widget() was been deprecated. Use elgg_view_entity().", 1.8);
 	return elgg_view_entity($widget);
 }
@@ -4575,14 +4575,14 @@ function display_widget(ElggObject $widget) {
 /**
  * Count the number of comments attached to an entity
  *
- * @param ElggEntity $entity
+ * @param \ElggEntity $entity
  * @return int Number of comments
- * @deprecated 1.8 Use ElggEntity->countComments()
+ * @deprecated 1.8 Use \ElggEntity->countComments()
  */
 function elgg_count_comments($entity) {
-	elgg_deprecated_notice('elgg_count_comments() is deprecated by ElggEntity->countComments()', 1.8);
+	elgg_deprecated_notice('elgg_count_comments() is deprecated by \ElggEntity->countComments()', 1.8);
 
-	if ($entity instanceof ElggEntity) {
+	if ($entity instanceof \ElggEntity) {
 		return $entity->countComments();
 	}
 
@@ -4703,13 +4703,13 @@ function invalidate_cache_for_entity($guid) {
  *
  * Stores an entity in $ENTITY_CACHE;
  *
- * @param ElggEntity $entity Entity to cache
+ * @param \ElggEntity $entity Entity to cache
  *
  * @return void
  * @access private
  * @deprecated 1.8
  */
-function cache_entity(ElggEntity $entity) {
+function cache_entity(\ElggEntity $entity) {
 	elgg_deprecated_notice('cache_entity() is a private function and should not be used.', 1.8);
 	_elgg_cache_entity($entity);
 }
@@ -4719,7 +4719,7 @@ function cache_entity(ElggEntity $entity) {
  *
  * @param int $guid The guid
  *
- * @return ElggEntity|bool false if entity not cached, or not fully loaded
+ * @return \ElggEntity|bool false if entity not cached, or not fully loaded
  * @access private
  * @deprecated 1.8
  */

--- a/engine/lib/deprecated-1.9.php
+++ b/engine/lib/deprecated-1.9.php
@@ -30,12 +30,12 @@ function full_url() {
  *
  * @return bool Depending on success
  * @see get_entity_url()
- * @see ElggEntity::getURL()
+ * @see \ElggEntity::getURL()
  * @since 1.8.0
- * @deprecated 1.9.0 Use the plugin hook in ElggEntity::getURL()
+ * @deprecated 1.9.0 Use the plugin hook in \ElggEntity::getURL()
  */
 function elgg_register_entity_url_handler($entity_type, $entity_subtype, $function_name) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use the plugin hook in ElggEntity::getURL()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use the plugin hook in \ElggEntity::getURL()', 1.9);
 	global $CONFIG;
 
 	if (!is_callable($function_name, true)) {
@@ -62,7 +62,7 @@ function elgg_register_entity_url_handler($entity_type, $entity_subtype, $functi
  * @param string $function_name     The function to register
  *
  * @return bool Depending on success
- * @deprecated 1.9 Use the plugin hook in ElggRelationship::getURL()
+ * @deprecated 1.9 Use the plugin hook in \ElggRelationship::getURL()
  */
 function elgg_register_relationship_url_handler($relationship_type, $function_name) {
 	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use the plugin hook in getURL()', 1.9);
@@ -87,10 +87,10 @@ function elgg_register_relationship_url_handler($relationship_type, $function_na
  * @param int $id Relationship ID
  *
  * @return string
- * @deprecated 1.9 Use ElggRelationship::getURL()
+ * @deprecated 1.9 Use \ElggRelationship::getURL()
  */
 function get_relationship_url($id) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggRelationship::getURL()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggRelationship::getURL()', 1.9);
 	global $CONFIG;
 
 	$id = (int)$id;
@@ -137,7 +137,7 @@ function get_relationship_url($id) {
  * @param string $function_name The function to register
  *
  * @return bool
- * @deprecated 1.9 Use plugin hook in ElggExtender::getURL()
+ * @deprecated 1.9 Use plugin hook in \ElggExtender::getURL()
  */
 function elgg_register_extender_url_handler($extender_type, $extender_name, $function_name) {
 	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use the plugin hook in getURL()', 1.9, 2);
@@ -163,13 +163,13 @@ function elgg_register_extender_url_handler($extender_type, $extender_name, $fun
  * Get the URL of a given elgg extender.
  * Used by get_annotation_url and get_metadata_url.
  *
- * @param ElggExtender $extender An extender object
+ * @param \ElggExtender $extender An extender object
  *
  * @return string
  * @deprecated 1.9 Use method getURL()
  */
-function get_extender_url(ElggExtender $extender) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggExtender::getURL()', 1.9);
+function get_extender_url(\ElggExtender $extender) {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggExtender::getURL()', 1.9);
 	global $CONFIG;
 
 	$view = elgg_get_viewtype();
@@ -216,7 +216,7 @@ function get_extender_url(ElggExtender $extender) {
  * @deprecated 1.9 Use method getURL() on annotation object
  */
 function get_annotation_url($id) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggAnnotation::getURL()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggAnnotation::getURL()', 1.9);
 	$id = (int)$id;
 
 	if ($extender = elgg_get_annotation_from_id($id)) {
@@ -232,7 +232,7 @@ function get_annotation_url($id) {
  * @param string $function      The function name.
  *
  * @return bool
- * @deprecated 1.9 Use the plugin hook in ElggExtender::getURL()
+ * @deprecated 1.9 Use the plugin hook in \ElggExtender::getURL()
  */
 function elgg_register_metadata_url_handler($extender_name, $function) {
 	// deprecation notice comes from elgg_register_extender_url_handler()
@@ -246,7 +246,7 @@ function elgg_register_metadata_url_handler($extender_name, $function) {
  * @param string $function_name The function.
  *
  * @return string
- * @deprecated 1.9 Use the plugin hook in ElggExtender::getURL()
+ * @deprecated 1.9 Use the plugin hook in \ElggExtender::getURL()
  */
 function elgg_register_annotation_url_handler($extender_name = "all", $function_name) {
 	// deprecation notice comes from elgg_register_extender_url_handler()
@@ -263,10 +263,10 @@ function elgg_register_annotation_url_handler($extender_name = "all", $function_
  * @param bool $count      Return the users (false) or the count of them (true)
  *
  * @return mixed
- * @deprecated 1.9 Use ElggGroup::getMembers()
+ * @deprecated 1.9 Use \ElggGroup::getMembers()
  */
 function get_group_members($group_guid, $limit = 10, $offset = 0, $site_guid = 0, $count = false) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggGroup::getMembers()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggGroup::getMembers()', 1.9);
 
 	// in 1.7 0 means "not set."  rewrite to make sense.
 	if (!$site_guid) {
@@ -289,14 +289,14 @@ function get_group_members($group_guid, $limit = 10, $offset = 0, $site_guid = 0
  * Add an object to the given group.
  *
  * @param int $group_guid  The group to add the object to.
- * @param int $object_guid The guid of the elgg object (must be ElggObject or a child thereof)
+ * @param int $object_guid The guid of the elgg object (must be \ElggObject or a child thereof)
  *
  * @return bool
  * @throws InvalidClassException
- * @deprecated 1.9 Use ElggGroup::addObjectToGroup()
+ * @deprecated 1.9 Use \ElggGroup::addObjectToGroup()
  */
 function add_object_to_group($group_guid, $object_guid) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggGroup::addObjectToGroup()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggGroup::addObjectToGroup()', 1.9);
 	$group_guid = (int)$group_guid;
 	$object_guid = (int)$object_guid;
 
@@ -307,14 +307,14 @@ function add_object_to_group($group_guid, $object_guid) {
 		return false;
 	}
 
-	if (!($group instanceof ElggGroup)) {
-		$msg = "GUID:" . $group_guid . " is not a valid " . 'ElggGroup';
-		throw new InvalidClassException($msg);
+	if (!($group instanceof \ElggGroup)) {
+		$msg = "GUID:" . $group_guid . " is not a valid " . '\ElggGroup';
+		throw new \InvalidClassException($msg);
 	}
 
-	if (!($object instanceof ElggObject)) {
-		$msg = "GUID:" . $object_guid . " is not a valid " . 'ElggObject';
-		throw new InvalidClassException($msg);
+	if (!($object instanceof \ElggObject)) {
+		$msg = "GUID:" . $object_guid . " is not a valid " . '\ElggObject';
+		throw new \InvalidClassException($msg);
 	}
 
 	$object->container_guid = $group_guid;
@@ -329,10 +329,10 @@ function add_object_to_group($group_guid, $object_guid) {
  *
  * @return bool
  * @throws InvalidClassException
- * @deprecated 1.9 Use ElggGroup::removeObjectFromGroup()
+ * @deprecated 1.9 Use \ElggGroup::removeObjectFromGroup()
  */
 function remove_object_from_group($group_guid, $object_guid) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggGroup::removeObjectFromGroup()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggGroup::removeObjectFromGroup()', 1.9);
 	$group_guid = (int)$group_guid;
 	$object_guid = (int)$object_guid;
 
@@ -343,14 +343,14 @@ function remove_object_from_group($group_guid, $object_guid) {
 		return false;
 	}
 
-	if (!($group instanceof ElggGroup)) {
-		$msg = "GUID:" . $group_guid . " is not a valid " . 'ElggGroup';
-		throw new InvalidClassException($msg);
+	if (!($group instanceof \ElggGroup)) {
+		$msg = "GUID:" . $group_guid . " is not a valid " . '\ElggGroup';
+		throw new \InvalidClassException($msg);
 	}
 
-	if (!($object instanceof ElggObject)) {
-		$msg = "GUID:" . $object_guid . " is not a valid " . 'ElggObject';
-		throw new InvalidClassException($msg);
+	if (!($object instanceof \ElggObject)) {
+		$msg = "GUID:" . $object_guid . " is not a valid " . '\ElggObject';
+		throw new \InvalidClassException($msg);
 	}
 
 	$object->container_guid = $object->owner_guid;
@@ -364,10 +364,10 @@ function remove_object_from_group($group_guid, $object_guid) {
  * @param int $user_guid  The user guid
  *
  * @return bool
- * @deprecated 1.9 Use Use ElggGroup::isMember()
+ * @deprecated 1.9 Use Use \ElggGroup::isMember()
  */
 function is_group_member($group_guid, $user_guid) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggGroup::isMember()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggGroup::isMember()', 1.9);
 	$object = check_entity_relationship($user_guid, 'member', $group_guid);
 	if ($object) {
 		return true;
@@ -383,10 +383,10 @@ function is_group_member($group_guid, $user_guid) {
  * @param int $user_guid GUID of user
  *
  * @return array|false
- * @deprecated 1.9 Use ElggUser::getGroups()
+ * @deprecated 1.9 Use \ElggUser::getGroups()
  */
 function get_users_membership($user_guid) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggUser::getGroups()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggUser::getGroups()', 1.9);
 	$options = array(
 		'type' => 'group',
 		'relationship' => 'member',
@@ -404,10 +404,10 @@ function get_users_membership($user_guid) {
  * @param int $friend_guid The GUID of the friend
  *
  * @return bool
- * @deprecated 1.9 Use ElggUser::isFriendsOf() or ElggUser::isFriendsWith()
+ * @deprecated 1.9 Use \ElggUser::isFriendsOf() or \ElggUser::isFriendsWith()
  */
 function user_is_friend($user_guid, $friend_guid) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggUser::isFriendsOf() or ElggUser::isFriendsWith()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggUser::isFriendsOf() or \ElggUser::isFriendsWith()', 1.9);
 	return check_entity_relationship($user_guid, "friend", $friend_guid) !== false;
 }
 
@@ -419,12 +419,12 @@ function user_is_friend($user_guid, $friend_guid) {
  * @param int    $limit     Number of results to return (default 10)
  * @param int    $offset    Indexing offset, if any
  *
- * @return ElggUser[]|false Either an array of ElggUsers or false, depending on success
- * @deprecated 1.9 Use ElggUser::getFriends()
+ * @return \ElggUser[]|false Either an array of \ElggUsers or false, depending on success
+ * @deprecated 1.9 Use \ElggUser::getFriends()
  */
 function get_user_friends($user_guid, $subtype = ELGG_ENTITIES_ANY_VALUE, $limit = 10,
 $offset = 0) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggUser::getFriends()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggUser::getFriends()', 1.9);
 
 	return elgg_get_entities_from_relationship(array(
 		'relationship' => 'friend',
@@ -444,12 +444,12 @@ $offset = 0) {
  * @param int    $limit     Number of results to return (default 10)
  * @param int    $offset    Indexing offset, if any
  *
- * @return ElggUser[]|false Either an array of ElggUsers or false, depending on success
- * @deprecated 1.9 Use ElggUser::getFriendsOf()
+ * @return \ElggUser[]|false Either an array of \ElggUsers or false, depending on success
+ * @deprecated 1.9 Use \ElggUser::getFriendsOf()
  */
 function get_user_friends_of($user_guid, $subtype = ELGG_ENTITIES_ANY_VALUE, $limit = 10,
 $offset = 0) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggUser::getFriendsOf()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggUser::getFriendsOf()', 1.9);
 
 	return elgg_get_entities_from_relationship(array(
 		'relationship' => 'friend',
@@ -469,10 +469,10 @@ $offset = 0) {
  * @param int $friend_guid The GUID of the user to friend
  *
  * @return bool Depending on success
- * @deprecated 1.9 Use ElggUser::addFriend()
+ * @deprecated 1.9 Use \ElggUser::addFriend()
  */
 function user_add_friend($user_guid, $friend_guid) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggUser::addFriend()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggUser::addFriend()', 1.9);
 	$user_guid = (int) $user_guid;
 	$friend_guid = (int) $friend_guid;
 	if ($user_guid == $friend_guid) {
@@ -484,7 +484,7 @@ function user_add_friend($user_guid, $friend_guid) {
 	if (!$user = get_entity($user_guid)) {
 		return false;
 	}
-	if ((!($user instanceof ElggUser)) || (!($friend instanceof ElggUser))) {
+	if ((!($user instanceof \ElggUser)) || (!($friend instanceof \ElggUser))) {
 		return false;
 	}
 	return add_entity_relationship($user_guid, "friend", $friend_guid);
@@ -497,10 +497,10 @@ function user_add_friend($user_guid, $friend_guid) {
  * @param int $friend_guid The GUID of the user on the friends list
  *
  * @return bool Depending on success
- * @deprecated 1.9 Use ElggUser::removeFriend()
+ * @deprecated 1.9 Use \ElggUser::removeFriend()
  */
 function user_remove_friend($user_guid, $friend_guid) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggUser::removeFriend()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggUser::removeFriend()', 1.9);
 	$user_guid = (int) $user_guid;
 	$friend_guid = (int) $friend_guid;
 
@@ -522,10 +522,10 @@ function user_remove_friend($user_guid, $friend_guid) {
  * @param int $user_guid User guid
  *
  * @return bool
- * @deprecated 1.9 Use ElggSite::addEntity()
+ * @deprecated 1.9 Use \ElggSite::addEntity()
  */
 function add_site_user($site_guid, $user_guid) {
-	elgg_deprecated_notice('add_site_user() is deprecated. Use ElggEntity::addEntity()', 1.9);
+	elgg_deprecated_notice('add_site_user() is deprecated. Use \ElggEntity::addEntity()', 1.9);
 	$site_guid = (int)$site_guid;
 	$user_guid = (int)$user_guid;
 
@@ -539,10 +539,10 @@ function add_site_user($site_guid, $user_guid) {
  * @param int $user_guid User GUID
  *
  * @return bool
- * @deprecated 1.9 Use ElggSite::removeEntity()
+ * @deprecated 1.9 Use \ElggSite::removeEntity()
  */
 function remove_site_user($site_guid, $user_guid) {
-	elgg_deprecated_notice('remove_site_user() is deprecated. Use ElggEntity::removeEntity()', 1.9);
+	elgg_deprecated_notice('remove_site_user() is deprecated. Use \ElggEntity::removeEntity()', 1.9);
 	$site_guid = (int)$site_guid;
 	$user_guid = (int)$user_guid;
 
@@ -556,10 +556,10 @@ function remove_site_user($site_guid, $user_guid) {
  * @param int $object_guid Object GUID
  *
  * @return mixed
- * @deprecated 1.9 Use ElggSite::addEntity()
+ * @deprecated 1.9 Use \ElggSite::addEntity()
  */
 function add_site_object($site_guid, $object_guid) {
-	elgg_deprecated_notice('add_site_object() is deprecated. Use ElggEntity::addEntity()', 1.9);
+	elgg_deprecated_notice('add_site_object() is deprecated. Use \ElggEntity::addEntity()', 1.9);
 	$site_guid = (int)$site_guid;
 	$object_guid = (int)$object_guid;
 
@@ -573,10 +573,10 @@ function add_site_object($site_guid, $object_guid) {
  * @param int $object_guid Object GUID
  *
  * @return bool
- * @deprecated 1.9 Use ElggSite::removeEntity()
+ * @deprecated 1.9 Use \ElggSite::removeEntity()
  */
 function remove_site_object($site_guid, $object_guid) {
-	elgg_deprecated_notice('remove_site_object() is deprecated. Use ElggEntity::removeEntity()', 1.9);
+	elgg_deprecated_notice('remove_site_object() is deprecated. Use \ElggEntity::removeEntity()', 1.9);
 	$site_guid = (int)$site_guid;
 	$object_guid = (int)$object_guid;
 
@@ -592,10 +592,10 @@ function remove_site_object($site_guid, $object_guid) {
  * @param int    $offset    Offset
  *
  * @return mixed
- * @deprecated 1.9 Use ElggSite::getEntities()
+ * @deprecated 1.9 Use \ElggSite::getEntities()
  */
 function get_site_objects($site_guid, $subtype = "", $limit = 10, $offset = 0) {
-	elgg_deprecated_notice('get_site_objects() is deprecated. Use ElggSite::getEntities()', 1.9);
+	elgg_deprecated_notice('get_site_objects() is deprecated. Use \ElggSite::getEntities()', 1.9);
 	$site_guid = (int)$site_guid;
 	$limit = (int)$limit;
 	$offset = (int)$offset;
@@ -618,11 +618,11 @@ function get_site_objects($site_guid, $subtype = "", $limit = 10, $offset = 0) {
  * @param int $limit       Number of results to return
  * @param int $offset      Any indexing offset
  *
- * @return array On success, an array of ElggSites
- * @deprecated 1.9 Use ElggEntity::getSites()
+ * @return array On success, an array of \ElggSites
+ * @deprecated 1.9 Use \ElggEntity::getSites()
  */
 function get_object_sites($object_guid, $limit = 10, $offset = 0) {
-	elgg_deprecated_notice('get_object_sites() is deprecated. Use ElggEntity::getSites()', 1.9);
+	elgg_deprecated_notice('get_object_sites() is deprecated. Use \ElggEntity::getSites()', 1.9);
 	$object_guid = (int)$object_guid;
 	$limit = (int)$limit;
 	$offset = (int)$offset;
@@ -643,11 +643,11 @@ function get_object_sites($object_guid, $limit = 10, $offset = 0) {
  * @param int $limit     Number of results to return
  * @param int $offset    Any indexing offset
  *
- * @return ElggSite[]|false On success, an array of ElggSites
- * @deprecated 1.9 Use ElggEntity::getSites()
+ * @return \ElggSite[]|false On success, an array of \ElggSites
+ * @deprecated 1.9 Use \ElggEntity::getSites()
  */
 function get_user_sites($user_guid, $limit = 10, $offset = 0) {
-	elgg_deprecated_notice('get_user_sites() is deprecated. Use ElggEntity::getSites()', 1.9);
+	elgg_deprecated_notice('get_user_sites() is deprecated. Use \ElggEntity::getSites()', 1.9);
 	$user_guid = (int)$user_guid;
 	$limit = (int)$limit;
 	$offset = (int)$offset;
@@ -674,7 +674,7 @@ function get_user_sites($user_guid, $limit = 10, $offset = 0) {
  * @deprecated 1.9 Use the appropriate canEdit() method on metadata or annotations
  */
 function can_edit_extender($extender_id, $type, $user_guid = 0) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggExtender::canEdit()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggExtender::canEdit()', 1.9);
 
 	// Since Elgg 1.0, Elgg has returned false from can_edit_extender()
 	// if no user was logged in. This breaks the access override so we add this
@@ -699,10 +699,10 @@ function can_edit_extender($extender_id, $type, $user_guid = 0) {
 		return false;
 	}
 
-	if (!($extender instanceof ElggExtender)) {
+	if (!($extender instanceof \ElggExtender)) {
 		return false;
 	}
-	/* @var ElggExtender $extender */
+	/* @var \ElggExtender $extender */
 
 	// If the owner is the specified user, great! They can edit.
 	if ($extender->getOwnerGUID() == $user_guid) {
@@ -842,7 +842,7 @@ function get_metastring_id($string, $case_sensitive = TRUE) {
 		$msfc = null;
 		static $metastrings_memcache;
 		if ((!$metastrings_memcache) && (is_memcache_available())) {
-			$metastrings_memcache = new ElggMemcache('metastrings_memcache');
+			$metastrings_memcache = new \ElggMemcache('metastrings_memcache');
 		}
 		if ($metastrings_memcache) {
 			$msfc = $metastrings_memcache->load($string);
@@ -958,7 +958,7 @@ function get_metastring($id) {
  * @param int    $timelower The earliest time the entity can have been created. Default: all
  * @param int    $timeupper The latest time the entity can have been created. Default: all
  *
- * @return ElggObject[]|false An array of ElggObjects or false, depending on success
+ * @return \ElggObject[]|false An array of \ElggObjects or false, depending on success
  * @deprecated 1.9 Use elgg_get_entities_from_relationship()
  */
 function get_user_friends_objects($user_guid, $subtype = ELGG_ENTITIES_ANY_VALUE, $limit = 10,
@@ -1109,7 +1109,7 @@ function elgg_geocode_location($location) {
  *					single float will result in a square in degrees.
  * @warning The Earth is round.
  *
- * @see ElggEntity::setLatLong()
+ * @see \ElggEntity::setLatLong()
  *
  * @return mixed If count, int. If not count, array. false on errors.
  * @since 1.8.0
@@ -2040,7 +2040,7 @@ function already_attached($guid_one, $guid_two) {
  * @param int    $guid Entity GUID
  * @param string $type The type of object to return e.g. 'file', 'friend_of' etc
  *
- * @return an array of objects
+ * @return ElggObject[] array of objects
  * @access private
  * @deprecated 1.9 Use elgg_get_entities_from_relationship()
  */
@@ -2105,10 +2105,10 @@ function make_attachment($guid_one, $guid_two) {
  * @param int $entity_guid The GUID of the entity
  *
  * @return string The URL of the entity
- * @deprecated 1.9 Use ElggEntity::getURL()
+ * @deprecated 1.9 Use \ElggEntity::getURL()
  */
 function get_entity_url($entity_guid) {
-	elgg_deprecated_notice('get_entity_url has been deprecated in favor of ElggEntity::getURL', '1.9');
+	elgg_deprecated_notice('get_entity_url has been deprecated in favor of \ElggEntity::getURL', '1.9');
 	if ($entity = get_entity($entity_guid)) {
 		return $entity->getURL();
 	}
@@ -2134,10 +2134,10 @@ function get_entity_url($entity_guid) {
  *
  * @return bool
  * @access private
- * @deprecated 1.9 Use ElggEntity::delete() instead.
+ * @deprecated 1.9 Use \ElggEntity::delete() instead.
  */
 function delete_entity($guid, $recursive = true) {
-	elgg_deprecated_notice('delete_entity has been deprecated in favor of ElggEntity::delete', '1.9');
+	elgg_deprecated_notice('delete_entity has been deprecated in favor of \ElggEntity::delete', '1.9');
 	$guid = (int)$guid;
 	if ($entity = get_entity($guid)) {
 		return $entity->delete($recursive);
@@ -2148,7 +2148,7 @@ function delete_entity($guid, $recursive = true) {
 /**
  * Enable an entity.
  *
- * @warning In order to enable an entity using ElggEntity::enable(),
+ * @warning In order to enable an entity using \ElggEntity::enable(),
  * you must first use {@link access_show_hidden_entities()}.
  *
  * @param int  $guid      GUID of entity to enable
@@ -2185,13 +2185,13 @@ function enable_entity($guid, $recursive = true) {
  *
  * @param int          $entity_guid The GUID of the entity
  * @param int          $user_guid   The GUID of the user
- * @param ElggMetadata $metadata    The metadata to specifically check (if any; default null)
+ * @param \ElggMetadata $metadata    The metadata to specifically check (if any; default null)
  *
  * @return bool Whether the user can edit metadata on the entity.
- * @deprecated 1.9 Use ElggEntity::canEditMetadata
+ * @deprecated 1.9 Use \ElggEntity::canEditMetadata
  */
 function can_edit_entity_metadata($entity_guid, $user_guid = 0, $metadata = null) {
-	elgg_deprecated_notice('can_edit_entity_metadata has been deprecated in favor of ElggEntity::canEditMetadata', '1.9');
+	elgg_deprecated_notice('can_edit_entity_metadata has been deprecated in favor of \ElggEntity::canEditMetadata', '1.9');
 	if ($entity = get_entity($entity_guid)) {
 		return $entity->canEditMetadata($metadata, $user_guid);
 	} else {
@@ -2217,10 +2217,10 @@ function can_edit_entity_metadata($entity_guid, $user_guid = 0, $metadata = null
  * @return bool
  * @see access_show_hidden_entities()
  * @access private
- * @deprecated 1.9 Use ElggEntity::disable instead.
+ * @deprecated 1.9 Use \ElggEntity::disable instead.
  */
 function disable_entity($guid, $reason = "", $recursive = true) {
-	elgg_deprecated_notice('disable_entity was deprecated in favor of ElggEntity::disable', '1.9');
+	elgg_deprecated_notice('disable_entity was deprecated in favor of \ElggEntity::disable', '1.9');
 	
 	if ($entity = get_entity($guid)) {
 		return $entity->disable($reason, $recursive);
@@ -2240,10 +2240,10 @@ function disable_entity($guid, $reason = "", $recursive = true) {
  * @param int $user_guid   The GUID of the user
  *
  * @return bool
- * @deprecated 1.9 Use ElggEntity::canEdit instead
+ * @deprecated 1.9 Use \ElggEntity::canEdit instead
  */
 function can_edit_entity($entity_guid, $user_guid = 0) {
-	elgg_deprecated_notice('can_edit_entity was deprecated in favor of ElggEntity::canEdit', '1.9');
+	elgg_deprecated_notice('can_edit_entity was deprecated in favor of \ElggEntity::canEdit', '1.9');
 	if ($entity = get_entity($entity_guid)) {
 		return $entity->canEdit($user_guid);
 	}
@@ -2258,15 +2258,15 @@ function can_edit_entity($entity_guid, $user_guid = 0) {
  * @param int $user_guid  The user GUID.
  *
  * @return bool
- * @deprecated 1.9 Use ElggGroup::join instead.
+ * @deprecated 1.9 Use \ElggGroup::join instead.
  */
 function join_group($group_guid, $user_guid) {
-	elgg_deprecated_notice('join_group was deprecated in favor of ElggGroup::join', '1.9');
+	elgg_deprecated_notice('join_group was deprecated in favor of \ElggGroup::join', '1.9');
 	
 	$group = get_entity($group_guid);
 	$user = get_entity($user_guid);
 	
-	if ($group instanceof ElggGroup && $user instanceof ElggUser) {
+	if ($group instanceof \ElggGroup && $user instanceof \ElggUser) {
 		return $group->join($user);
 	}
 	
@@ -2280,14 +2280,14 @@ function join_group($group_guid, $user_guid) {
  * @param int $user_guid  The user.
  *
  * @return bool Whether the user was removed from the group.
- * @deprecated 1.9 Use ElggGroup::leave()
+ * @deprecated 1.9 Use \ElggGroup::leave()
  */
 function leave_group($group_guid, $user_guid) {
-	elgg_deprecated_notice('leave_group was deprecated in favor of ElggGroup::leave', '1.9');
+	elgg_deprecated_notice('leave_group was deprecated in favor of \ElggGroup::leave', '1.9');
 	$group = get_entity($group_guid);
 	$user = get_entity($user_guid);
 	
-	if ($group instanceof ElggGroup && $user instanceof ElggUser) {
+	if ($group instanceof \ElggGroup && $user instanceof \ElggUser) {
 		return $group->leave($user);
 	}
 
@@ -2380,10 +2380,10 @@ function unregister_service_handler($handler) {
  *
  * @return bool
  * @access private
- * @deprecated 1.9 Use ElggSite constructor
+ * @deprecated 1.9 Use \ElggSite constructor
  */
 function create_site_entity($guid, $name, $description, $url) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggSite constructor', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggSite constructor', 1.9);
 	global $CONFIG;
 
 	$guid = (int)$guid;
@@ -2442,10 +2442,10 @@ function create_site_entity($guid, $name, $description, $url) {
  *
  * @return bool
  * @access private
- * @deprecated 1.9 Use ElggGroup constructor
+ * @deprecated 1.9 Use \ElggGroup constructor
  */
 function create_group_entity($guid, $name, $description) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggGroup constructor', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggGroup constructor', 1.9);
 	global $CONFIG;
 
 	$guid = (int)$guid;
@@ -2505,10 +2505,10 @@ function create_group_entity($guid, $name, $description) {
  *
  * @return bool
  * @access private
- * @deprecated 1.9 Use ElggUser constructor
+ * @deprecated 1.9 Use \ElggUser constructor
  */
 function create_user_entity($guid, $name, $username, $password, $salt, $email, $language, $code) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggUser constructor', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggUser constructor', 1.9);
 	global $CONFIG;
 
 	$guid = (int)$guid;
@@ -2570,10 +2570,10 @@ function create_user_entity($guid, $name, $username, $password, $salt, $email, $
  *
  * @return bool
  * @access private
- * @deprecated 1.9 Use ElggObject constructor
+ * @deprecated 1.9 Use \ElggObject constructor
  */
 function create_object_entity($guid, $title, $description) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggObject constructor', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggObject constructor', 1.9);
 	global $CONFIG;
 
 	$guid = (int)$guid;
@@ -2665,11 +2665,11 @@ function ODD_factory (XmlElement $element) {
 
 /**
  * Utility function used by import_entity_plugin_hook() to
- * process an ODDEntity into an unsaved ElggEntity.
+ * process an ODDEntity into an unsaved \ElggEntity.
  *
  * @param ODDEntity $element The OpenDD element
  *
- * @return ElggEntity the unsaved entity which should be populated by items.
+ * @return \ElggEntity the unsaved entity which should be populated by items.
  * @todo Remove this.
  * @access private
  *
@@ -2691,9 +2691,9 @@ function oddentity_to_elggentity(ODDEntity $element) {
 			if (class_exists($classname)) {
 				$tmp = new $classname();
 
-				if (!($tmp instanceof ElggEntity)) {
+				if (!($tmp instanceof \ElggEntity)) {
 					$msg = $classname . " is not a " . get_class() . ".";
-					throw new ClassException($msg);
+					throw new \ClassException($msg);
 				}
 			} else {
 				error_log("Class '" . $classname . "' was not found, missing plugin?");
@@ -2701,20 +2701,20 @@ function oddentity_to_elggentity(ODDEntity $element) {
 		} else {
 			switch ($class) {
 				case 'object' :
-					$tmp = new ElggObject();
+					$tmp = new \ElggObject();
 					break;
 				case 'user' :
-					$tmp = new ElggUser();
+					$tmp = new \ElggUser();
 					break;
 				case 'group' :
-					$tmp = new ElggGroup();
+					$tmp = new \ElggGroup();
 					break;
 				case 'site' :
-					$tmp = new ElggSite();
+					$tmp = new \ElggSite();
 					break;
 				default:
 					$msg = "Type " . $class . " is not supported. This indicates an error in your installation, most likely caused by an incomplete upgrade.";
-					throw new InstallationException($msg);
+					throw new \InstallationException($msg);
 			}
 		}
 	}
@@ -2722,7 +2722,7 @@ function oddentity_to_elggentity(ODDEntity $element) {
 	if ($tmp) {
 		if (!$tmp->import($element)) {
 			$msg = "Could not import element " . $element->getAttribute('uuid');
-			throw new ImportException($msg);
+			throw new \ImportException($msg);
 		}
 
 		return $tmp;
@@ -2790,16 +2790,16 @@ function ODD_Export(ODDDocument $document) {
 /**
  * Get a UUID from a given object.
  *
- * @param mixed $object The object either an ElggEntity, ElggRelationship or ElggExtender
+ * @param mixed $object The object either an \ElggEntity, \ElggRelationship or \ElggExtender
  *
  * @return string|false the UUID or false
  * @deprecated 1.9
  */
 function get_uuid_from_object($object) {
 	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated', 1.9);
-	if ($object instanceof ElggEntity) {
+	if ($object instanceof \ElggEntity) {
 		return guid_to_uuid($object->guid);
-	} else if ($object instanceof ElggExtender) {
+	} else if ($object instanceof \ElggExtender) {
 		$type = $object->type;
 		if ($type == 'volatile') {
 			$uuid = guid_to_uuid($object->entity_guid) . $type . "/{$object->name}/";
@@ -2808,7 +2808,7 @@ function get_uuid_from_object($object) {
 		}
 
 		return $uuid;
-	} else if ($object instanceof ElggRelationship) {
+	} else if ($object instanceof \ElggRelationship) {
 		return guid_to_uuid($object->guid_one) . "relationship/{$object->id}/";
 	}
 
@@ -2850,7 +2850,7 @@ function is_uuid_this_domain($uuid) {
  *
  * @param string $uuid A unique ID
  *
- * @return ElggEntity|false
+ * @return \ElggEntity|false
  * @deprecated 1.9
  */
 function get_entity_from_uuid($uuid) {
@@ -2943,7 +2943,7 @@ function exportAsArray($guid) {
 
 	// Sanity check
 	if ((!is_array($to_be_serialised)) || (count($to_be_serialised) == 0)) {
-		throw new ExportException("No such entity GUID:" . $guid);
+		throw new \ExportException("No such entity GUID:" . $guid);
 	}
 
 	return $to_be_serialised;
@@ -2960,7 +2960,7 @@ function exportAsArray($guid) {
  * @param int $guid The GUID.
  *
  * @return string XML
- * @see ElggEntity for an example of its usage.
+ * @see \ElggEntity for an example of its usage.
  * @access private
  * @deprecated 1.9
  */
@@ -2991,7 +2991,7 @@ function import($xml) {
 
 	$document = ODD_Import($xml);
 	if (!$document) {
-		throw new ImportException("No OpenDD elements found in import data, import failed.");
+		throw new \ImportException("No OpenDD elements found in import data, import failed.");
 	}
 
 	foreach ($document as $element) {
@@ -2999,7 +2999,7 @@ function import($xml) {
 	}
 
 	if ($IMPORTED_OBJECT_COUNTER != count($IMPORTED_DATA)) {
-		throw new ImportException("Not all elements were imported.");
+		throw new \ImportException("Not all elements were imported.");
 	}
 
 	return true;
@@ -3151,7 +3151,7 @@ $posted = 0, $annotation_id = 0, $target_guid = 0) {
 /**
  * This function serialises an object recursively into an XML representation.
  *
- * The function attempts to call $data->export() which expects a stdClass in return,
+ * The function attempts to call $data->export() which expects a \stdClass in return,
  * otherwise it will attempt to get the object variables using get_object_vars (which
  * will only return public variables!)
  *
@@ -3171,7 +3171,7 @@ function serialise_object_to_xml($data, $name = "", $n = 0) {
 
 	$output = "";
 
-	if (($n == 0) || ( is_object($data) && !($data instanceof stdClass))) {
+	if (($n == 0) || ( is_object($data) && !($data instanceof \stdClass))) {
 		$output = "<$classname>";
 	}
 
@@ -3191,7 +3191,7 @@ function serialise_object_to_xml($data, $name = "", $n = 0) {
 		$output .= "</$key>\n";
 	}
 
-	if (($n == 0) || (is_object($data) && !($data instanceof stdClass))) {
+	if (($n == 0) || (is_object($data) && !($data instanceof \stdClass))) {
 		$output .= "</$classname>\n";
 	}
 
@@ -3251,28 +3251,28 @@ function serialise_array_to_xml(array $data, $n = 0) {
  *
  * @param string $xml The XML
  *
- * @return ElggXMLElement
- * @deprecated 1.9 Use ElggXMLElement
+ * @return \ElggXMLElement
+ * @deprecated 1.9 Use \ElggXMLElement
  */
 function xml_to_object($xml) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated by ElggXMLElement', 1.9);
-	return new ElggXMLElement($xml);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated by \ElggXMLElement', 1.9);
+	return new \ElggXMLElement($xml);
 }
 
 /**
  * Retrieve a site and return the domain portion of its url.
  *
- * @param int $guid ElggSite GUID
+ * @param int $guid \ElggSite GUID
  *
  * @return string
- * @deprecated 1.9 Use ElggSite::getDomain()
+ * @deprecated 1.9 Use \ElggSite::getDomain()
  */
 function get_site_domain($guid) {
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use ElggSite::getDomain()', 1.9);
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use \ElggSite::getDomain()', 1.9);
 	$guid = (int)$guid;
 
 	$site = get_entity($guid);
-	if ($site instanceof ElggSite) {
+	if ($site instanceof \ElggSite) {
 		$breakdown = parse_url($site->url);
 		return $breakdown['host'];
 	}
@@ -3343,7 +3343,7 @@ function remove_notification_interest($user_guid, $author_guid) {
  * @deprecated 1.9
  */
 function object_notifications($event, $object_type, $object) {
-	throw new BadFunctionCallException("object_notifications is a private function and should not be called directly");
+	throw new \BadFunctionCallException("object_notifications is a private function and should not be called directly");
 }
 
 /**
@@ -3351,7 +3351,7 @@ function object_notifications($event, $object_type, $object) {
  *
  * @param string $method  The method
  * @param string $handler The handler function, in the format
- *                        "handler(ElggEntity $from, ElggUser $to, $subject,
+ *                        "handler(\ElggEntity $from, \ElggUser $to, $subject,
  *                        $message, array $params = NULL)". This function should
  *                        return false on failure, and true/a tracking message ID on success.
  * @param array  $params  An associated array of other parameters for this handler
@@ -3412,12 +3412,12 @@ function import_entity_plugin_hook($hook, $entity_type, $returnvalue, $params) {
 			// Make sure its saved
 			if (!$tmp->save()) {
 				$msg = "There was a problem saving " . $element->getAttribute('uuid');
-				throw new ImportException($msg);
+				throw new \ImportException($msg);
 			}
 
 			// Belts and braces
 			if (!$tmp->guid) {
-				throw new ImportException("New entity created but has no GUID, this should not happen.");
+				throw new \ImportException("New entity created but has no GUID, this should not happen.");
 			}
 
 			// We have saved, so now tag
@@ -3448,20 +3448,20 @@ function import_entity_plugin_hook($hook, $entity_type, $returnvalue, $params) {
 function export_entity_plugin_hook($hook, $entity_type, $returnvalue, $params) {
 	// Sanity check values
 	if ((!is_array($params)) && (!isset($params['guid']))) {
-		throw new InvalidParameterException("GUID has not been specified during export, this should never happen.");
+		throw new \InvalidParameterException("GUID has not been specified during export, this should never happen.");
 	}
 
 	if (!is_array($returnvalue)) {
-		throw new InvalidParameterException("Entity serialisation function passed a non-array returnvalue parameter");
+		throw new \InvalidParameterException("Entity serialisation function passed a non-array returnvalue parameter");
 	}
 
 	$guid = (int)$params['guid'];
 
 	// Get the entity
 	$entity = get_entity($guid);
-	if (!($entity instanceof ElggEntity)) {
+	if (!($entity instanceof \ElggEntity)) {
 		$msg = "GUID:" . $guid . " is not a valid " . get_class();
-		throw new InvalidClassException($msg);
+		throw new \InvalidClassException($msg);
 	}
 
 	$export = $entity->export();
@@ -3485,7 +3485,7 @@ function export_entity_plugin_hook($hook, $entity_type, $returnvalue, $params) {
  * @param string $returnvalue Return value from previous hook
  * @param array  $params      The parameters, passed 'guid' and 'varname'
  *
- * @return ElggMetadata|null
+ * @return \ElggMetadata|null
  * @elgg_plugin_hook_handler volatile metadata
  * @todo investigate more.
  * @access private
@@ -3504,7 +3504,7 @@ function volatile_data_export_plugin_hook($hook, $entity_type, $returnvalue, $pa
 					$view = elgg_view_entity(get_entity($guid));
 					elgg_set_viewtype();
 
-					$tmp = new ElggMetadata();
+					$tmp = new \ElggMetadata();
 					$tmp->type = 'volatile';
 					$tmp->name = 'renderedentity';
 					$tmp->value = $view;
@@ -3536,11 +3536,11 @@ function volatile_data_export_plugin_hook($hook, $entity_type, $returnvalue, $pa
 function export_annotation_plugin_hook($hook, $type, $returnvalue, $params) {
 	// Sanity check values
 	if ((!is_array($params)) && (!isset($params['guid']))) {
-		throw new InvalidParameterException("GUID has not been specified during export, this should never happen.");
+		throw new \InvalidParameterException("GUID has not been specified during export, this should never happen.");
 	}
 
 	if (!is_array($returnvalue)) {
-		throw new InvalidParameterException("Entity serialization function passed a non-array returnvalue parameter");
+		throw new \InvalidParameterException("Entity serialization function passed a non-array returnvalue parameter");
 	}
 
 	$guid = (int)$params['guid'];
@@ -3586,7 +3586,7 @@ function import_extender_plugin_hook($hook, $entity_type, $returnvalue, $params)
 		$entity_uuid = $element->getAttribute('entity_uuid');
 		$entity = get_entity_from_uuid($entity_uuid);
 		if (!$entity) {
-			throw new ImportException("Entity '" . $entity_uuid . "' could not be found.");
+			throw new \ImportException("Entity '" . $entity_uuid . "' could not be found.");
 		}
 
 		oddmetadata_to_elggextender($entity, $element);
@@ -3595,7 +3595,7 @@ function import_extender_plugin_hook($hook, $entity_type, $returnvalue, $params)
 		if (!$entity->save()) {
 			$attr_name = $element->getAttribute('name');
 			$msg = "There was a problem updating '" . $attr_name . "' on entity '" . $entity_uuid . "'";
-			throw new ImportException($msg);
+			throw new \ImportException($msg);
 		}
 
 		return true;
@@ -3607,14 +3607,14 @@ function import_extender_plugin_hook($hook, $entity_type, $returnvalue, $params)
  * an ODDMetaData and add it to an entity. This function does not
  * hit ->save() on the entity (this lets you construct in memory)
  *
- * @param ElggEntity  $entity  The entity to add the data to.
+ * @param \ElggEntity  $entity  The entity to add the data to.
  * @param ODDMetaData $element The OpenDD element
  *
  * @return bool
  * @access private
  * @deprecated 1.9
  */
-function oddmetadata_to_elggextender(ElggEntity $entity, ODDMetaData $element) {
+function oddmetadata_to_elggextender(\ElggEntity $entity, ODDMetaData $element) {
 	// Get the type of extender (metadata, type, attribute etc)
 	$type = $element->getAttribute('type');
 	$attr_name = $element->getAttribute('name');
@@ -3660,11 +3660,11 @@ function oddmetadata_to_elggextender(ElggEntity $entity, ODDMetaData $element) {
 function export_metadata_plugin_hook($hook, $entity_type, $returnvalue, $params) {
 	// Sanity check values
 	if ((!is_array($params)) && (!isset($params['guid']))) {
-		throw new InvalidParameterException("GUID has not been specified during export, this should never happen.");
+		throw new \InvalidParameterException("GUID has not been specified during export, this should never happen.");
 	}
 
 	if (!is_array($returnvalue)) {
-		throw new InvalidParameterException("Entity serialisation function passed a non-array returnvalue parameter");
+		throw new \InvalidParameterException("Entity serialisation function passed a non-array returnvalue parameter");
 	}
 
 	$result = elgg_get_metadata(array(
@@ -3673,7 +3673,7 @@ function export_metadata_plugin_hook($hook, $entity_type, $returnvalue, $params)
 	));
 
 	if ($result) {
-		/* @var ElggMetadata[] $result */
+		/* @var \ElggMetadata[] $result */
 		foreach ($result as $r) {
 			$returnvalue[] = $r->export();
 		}
@@ -3699,11 +3699,11 @@ function export_metadata_plugin_hook($hook, $entity_type, $returnvalue, $params)
 function export_relationship_plugin_hook($hook, $entity_type, $returnvalue, $params) {
 	// Sanity check values
 	if ((!is_array($params)) && (!isset($params['guid']))) {
-		throw new InvalidParameterException("GUID has not been specified during export, this should never happen.");
+		throw new \InvalidParameterException("GUID has not been specified during export, this should never happen.");
 	}
 
 	if (!is_array($returnvalue)) {
-		throw new InvalidParameterException("Entity serialisation function passed a non-array returnvalue parameter");
+		throw new \InvalidParameterException("Entity serialisation function passed a non-array returnvalue parameter");
 	}
 
 	$guid = (int)$params['guid'];
@@ -3737,7 +3737,7 @@ function import_relationship_plugin_hook($hook, $entity_type, $returnvalue, $par
 	$tmp = NULL;
 
 	if ($element instanceof ODDRelationship) {
-		$tmp = new ElggRelationship();
+		$tmp = new \ElggRelationship();
 		$tmp->import($element);
 
 		return $tmp;

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -50,12 +50,12 @@ function elgg_load_library($name) {
 
 	if (!isset($CONFIG->libraries[$name])) {
 		$error = $name . " is not a registered library";
-		throw new InvalidParameterException($error);
+		throw new \InvalidParameterException($error);
 	}
 
 	if (!include_once($CONFIG->libraries[$name])) {
 		$error = "Could not load the " . $name . " library from " . $CONFIG->libraries[$name];
-		throw new InvalidParameterException($error);
+		throw new \InvalidParameterException($error);
 	}
 
 	$loaded_libraries[] = $name;
@@ -96,7 +96,7 @@ function forward($location = "", $reason = 'system') {
 			exit;
 		}
 	} else {
-		throw new SecurityException("Redirect could not be issued due to headers already being sent. Halting execution for security. "
+		throw new \SecurityException("Redirect could not be issued due to headers already being sent. Halting execution for security. "
 			. "Output started in file $file at line $line. Search http://docs.elgg.org/ for more information.");
 	}
 }
@@ -316,7 +316,7 @@ function elgg_register_external_file($type, $name, $url, $location, $priority = 
 			$priority = $CONFIG->externals[$type]->add($item, $priority);
 		}
 	} else {
-		$item = new stdClass();
+		$item = new \stdClass();
 		$item->loaded = false;
 		$item->url = $url;
 		$item->location = $location;
@@ -376,7 +376,7 @@ function elgg_load_external_file($type, $name) {
 		// update a registered item
 		$item->loaded = true;
 	} else {
-		$item = new stdClass();
+		$item = new \stdClass();
 		$item->loaded = true;
 		$item->url = '';
 		$item->location = '';
@@ -398,7 +398,7 @@ function elgg_load_external_file($type, $name) {
 function elgg_get_loaded_external_files($type, $location) {
 	global $CONFIG;
 
-	if (isset($CONFIG->externals) && $CONFIG->externals[$type] instanceof ElggPriorityList) {
+	if (isset($CONFIG->externals) && $CONFIG->externals[$type] instanceof \ElggPriorityList) {
 		$items = $CONFIG->externals[$type]->getElements();
 
 		$callback = "return \$v->loaded == true && \$v->location == '$location';";
@@ -424,8 +424,8 @@ function _elgg_bootstrap_externals_data_structure($type) {
 		$CONFIG->externals = array();
 	}
 
-	if (!isset($CONFIG->externals[$type]) || !$CONFIG->externals[$type] instanceof ElggPriorityList) {
-		$CONFIG->externals[$type] = new ElggPriorityList();
+	if (!isset($CONFIG->externals[$type]) || !$CONFIG->externals[$type] instanceof \ElggPriorityList) {
+		$CONFIG->externals[$type] = new \ElggPriorityList();
 	}
 
 	if (!isset($CONFIG->externals_map)) {
@@ -759,7 +759,7 @@ function elgg_trigger_before_event($event, $object_type, $object = null) {
  */
 function elgg_trigger_after_event($event, $object_type, $object = null) {
 	$options = array(
-		Elgg_EventsService::OPTION_STOPPABLE => false,
+		\Elgg\EventsService::OPTION_STOPPABLE => false,
 	);
 	return _elgg_services()->events->trigger("$event:after", $object_type, $object, $options);
 }
@@ -779,8 +779,8 @@ function elgg_trigger_after_event($event, $object_type, $object = null) {
  */
 function elgg_trigger_deprecated_event($event, $object_type, $object = null, $message, $version) {
 	$options = array(
-		Elgg_EventsService::OPTION_DEPRECATION_MESSAGE => $message,
-		Elgg_EventsService::OPTION_DEPRECATION_VERSION => $version,
+		\Elgg\EventsService::OPTION_DEPRECATION_MESSAGE => $message,
+		\Elgg\EventsService::OPTION_DEPRECATION_VERSION => $version,
 	);
 	return _elgg_services()->events->trigger($event, $object_type, $object, $options);
 }
@@ -1039,7 +1039,7 @@ function _elgg_php_error_handler($errno, $errmsg, $filename, $linenum, $vars) {
 			register_error("ERROR: $error");
 
 			// Since this is a fatal error, we want to stop any further execution but do so gracefully.
-			throw new Exception($error);
+			throw new \Exception($error);
 			break;
 
 		case E_WARNING :
@@ -1821,9 +1821,9 @@ function _elgg_sql_reverse_order_by_clause($order_by) {
 /**
  * Enable objects with an enable() method.
  *
- * Used as a callback for ElggBatch.
+ * Used as a callback for \ElggBatch.
  *
- * @todo why aren't these static methods on ElggBatch?
+ * @todo why aren't these static methods on \ElggBatch?
  *
  * @param object $object The object to enable
  * @return bool
@@ -1837,7 +1837,7 @@ function elgg_batch_enable_callback($object) {
 /**
  * Disable objects with a disable() method.
  *
- * Used as a callback for ElggBatch.
+ * Used as a callback for \ElggBatch.
  *
  * @param object $object The object to disable
  * @return bool
@@ -1851,7 +1851,7 @@ function elgg_batch_disable_callback($object) {
 /**
  * Delete objects with a delete() method.
  *
- * Used as a callback for ElggBatch.
+ * Used as a callback for \ElggBatch.
  *
  * @param object $object The object to disable
  * @return bool
@@ -1983,7 +1983,7 @@ function _elgg_walled_garden_init() {
 	elgg_register_page_handler('walled_garden', '_elgg_walled_garden_ajax_handler');
 
 	// check for external page view
-	if (isset($CONFIG->site) && $CONFIG->site instanceof ElggSite) {
+	if (isset($CONFIG->site) && $CONFIG->site instanceof \ElggSite) {
 		$CONFIG->site->checkWalledGarden();
 	}
 }
@@ -2107,7 +2107,7 @@ function _elgg_api_test($hook, $type, $value, $params) {
 }
 
 /**#@+
- * Controls access levels on ElggEntity entities, metadata, and annotations.
+ * Controls access levels on \ElggEntity entities, metadata, and annotations.
  *
  * @warning ACCESS_DEFAULT is a place holder for the input/access view. Do not
  * use it when saving an entity.

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Procedural code for creating, loading, and modifying ElggEntity objects.
+ * Procedural code for creating, loading, and modifying \ElggEntity objects.
  *
  * @package Elgg.Core
  * @subpackage DataModel.Entities
@@ -9,7 +9,7 @@
 /**
  * Cache entities in memory once loaded.
  *
- * @global ElggEntity[] $ENTITY_CACHE
+ * @global \ElggEntity[] $ENTITY_CACHE
  * @access private
  */
 global $ENTITY_CACHE;
@@ -90,20 +90,20 @@ function _elgg_invalidate_cache_for_entity($guid) {
  *
  * Stores an entity in $ENTITY_CACHE;
  *
- * @param ElggEntity $entity Entity to cache
+ * @param \ElggEntity $entity Entity to cache
  *
  * @return void
  * @see _elgg_retrieve_cached_entity()
  * @see _elgg_invalidate_cache_for_entity()
  * @access private
- * @todo Use an ElggCache object
+ * @todo Use an \ElggCache object
  */
-function _elgg_cache_entity(ElggEntity $entity) {
+function _elgg_cache_entity(\ElggEntity $entity) {
 	global $ENTITY_CACHE, $ENTITY_CACHE_DISABLED_GUIDS;
 
 	// Don't cache non-plugin entities while access control is off, otherwise they could be
 	// exposed to users who shouldn't see them when control is re-enabled.
-	if (!($entity instanceof ElggPlugin) && elgg_get_ignore_access()) {
+	if (!($entity instanceof \ElggPlugin) && elgg_get_ignore_access()) {
 		return;
 	}
 
@@ -126,7 +126,7 @@ function _elgg_cache_entity(ElggEntity $entity) {
  *
  * @param int $guid The guid
  *
- * @return ElggEntity|bool false if entity not cached, or not fully loaded
+ * @return \ElggEntity|bool false if entity not cached, or not fully loaded
  * @see _elgg_cache_entity()
  * @see _elgg_invalidate_cache_for_entity()
  * @access private
@@ -146,11 +146,11 @@ function _elgg_retrieve_cached_entity($guid) {
 /**
  * Return the id for a given subtype.
  *
- * ElggEntity objects have a type and a subtype.  Subtypes
+ * \ElggEntity objects have a type and a subtype.  Subtypes
  * are defined upon creation and cannot be changed.
  *
  * Plugin authors generally don't need to use this function
- * unless writing their own SQL queries.  Use {@link ElggEntity::getSubtype()}
+ * unless writing their own SQL queries.  Use {@link \ElggEntity::getSubtype()}
  * to return the string subtype.
  *
  * @internal Subtypes are stored in the entity_subtypes table.  There is a foreign
@@ -214,7 +214,7 @@ function get_subtype_from_id($subtype_id) {
  *
  * @param string $type
  * @param string $subtype
- * @return stdClass|null
+ * @return \stdClass|null
  *
  * @access private
  */
@@ -309,7 +309,7 @@ function get_subtype_class_from_id($subtype_id) {
 }
 
 /**
- * Register ElggEntities with a certain type and subtype to be loaded as a specific class.
+ * Register \ElggEntities with a certain type and subtype to be loaded as a specific class.
  *
  * By default entities are loaded as one of the 4 parent objects: site, user, object, or group.
  * If you subclass any of these you can register the classname with add_subtype() so
@@ -361,7 +361,7 @@ function add_subtype($type, $subtype, $class = "") {
 }
 
 /**
- * Removes a registered ElggEntity type, subtype, and classname.
+ * Removes a registered \ElggEntity type, subtype, and classname.
  *
  * @warning You do not want to use this function. If you want to unregister
  * a class for a subtype, use update_subtype(). Using this function will
@@ -392,7 +392,7 @@ function remove_subtype($type, $subtype) {
 }
 
 /**
- * Update a registered ElggEntity type, subtype, and class name
+ * Update a registered \ElggEntity type, subtype, and class name
  *
  * @param string $type    Type
  * @param string $subtype Subtype
@@ -495,7 +495,7 @@ function can_write_to_container($user_guid = 0, $container_guid = 0, $type = 'al
  *
  * @param int $guid The GUID of the object to extract
  *
- * @return stdClass|false
+ * @return \stdClass|false
  * @see entity_row_to_elggstar()
  * @access private
  */
@@ -517,9 +517,9 @@ function get_entity_as_row($guid) {
  *
  * Handles loading all tables into the correct class.
  *
- * @param stdClass $row The row of the entry in the entities table.
+ * @param \stdClass $row The row of the entry in the entities table.
  *
- * @return ElggEntity|false
+ * @return \ElggEntity|false
  * @see get_entity_as_row()
  * @see add_subtype()
  * @see get_entity()
@@ -528,7 +528,7 @@ function get_entity_as_row($guid) {
  * @throws ClassException|InstallationException
  */
 function entity_row_to_elggstar($row) {
-	if (!($row instanceof stdClass)) {
+	if (!($row instanceof \stdClass)) {
 		return $row;
 	}
 
@@ -541,7 +541,7 @@ function entity_row_to_elggstar($row) {
 	// Create a memcache cache if we can
 	static $newentity_cache;
 	if ((!$newentity_cache) && (is_memcache_available())) {
-		$newentity_cache = new ElggMemcache('new_entity_cache');
+		$newentity_cache = new \ElggMemcache('new_entity_cache');
 	}
 	if ($newentity_cache) {
 		$new_entity = $newentity_cache->load($row->guid);
@@ -556,9 +556,9 @@ function entity_row_to_elggstar($row) {
 		if (class_exists($classname)) {
 			$new_entity = new $classname($row);
 
-			if (!($new_entity instanceof ElggEntity)) {
-				$msg = $classname . " is not a " . 'ElggEntity' . ".";
-				throw new ClassException($msg);
+			if (!($new_entity instanceof \ElggEntity)) {
+				$msg = $classname . " is not a " . '\ElggEntity' . ".";
+				throw new \ClassException($msg);
 			}
 		} else {
 			error_log("Class '" . $classname . "' was not found, missing plugin?");
@@ -569,20 +569,20 @@ function entity_row_to_elggstar($row) {
 		//@todo Make this into a function
 		switch ($row->type) {
 			case 'object' :
-				$new_entity = new ElggObject($row);
+				$new_entity = new \ElggObject($row);
 				break;
 			case 'user' :
-				$new_entity = new ElggUser($row);
+				$new_entity = new \ElggUser($row);
 				break;
 			case 'group' :
-				$new_entity = new ElggGroup($row);
+				$new_entity = new \ElggGroup($row);
 				break;
 			case 'site' :
-				$new_entity = new ElggSite($row);
+				$new_entity = new \ElggSite($row);
 				break;
 			default:
 				$msg = "Entity type " . $row->type . " is not supported.";
-				throw new InstallationException($msg);
+				throw new \InstallationException($msg);
 		}
 	}
 
@@ -599,7 +599,7 @@ function entity_row_to_elggstar($row) {
  *
  * @param int $guid The GUID of the entity
  *
- * @return ElggEntity The correct Elgg or custom object based upon entity type and subtype
+ * @return \ElggEntity The correct Elgg or custom object based upon entity type and subtype
  */
 function get_entity($guid) {
 	// This should not be a static local var. Notice that cache writing occurs in a completely
@@ -623,7 +623,7 @@ function get_entity($guid) {
 	// Check shared memory cache, if available
 	if (null === $shared_cache) {
 		if (is_memcache_available()) {
-			$shared_cache = new ElggMemcache('new_entity_cache');
+			$shared_cache = new \ElggMemcache('new_entity_cache');
 		} else {
 			$shared_cache = false;
 		}
@@ -931,11 +931,11 @@ function elgg_get_entities(array $options = array()) {
 			// populate entity and metadata caches
 			$guids = array();
 			foreach ($dt as $item) {
-				// A custom callback could result in items that aren't ElggEntity's, so check for them
-				if ($item instanceof ElggEntity) {
+				// A custom callback could result in items that aren't \ElggEntity's, so check for them
+				if ($item instanceof \ElggEntity) {
 					_elgg_cache_entity($item);
 					// plugins usually have only settings
-					if (!$item instanceof ElggPlugin) {
+					if (!$item instanceof \ElggPlugin) {
 						$guids[] = $item->guid;
 					}
 				}
@@ -958,13 +958,13 @@ function elgg_get_entities(array $options = array()) {
  * Return entities from an SQL query generated by elgg_get_entities.
  *
  * @param string    $sql
- * @param ElggBatch $batch
- * @return ElggEntity[]
+ * @param \ElggBatch $batch
+ * @return \ElggEntity[]
  *
  * @access private
  * @throws LogicException
  */
-function _elgg_fetch_entities_from_sql($sql, ElggBatch $batch = null) {
+function _elgg_fetch_entities_from_sql($sql, \ElggBatch $batch = null) {
 	static $plugin_subtype;
 	if (null === $plugin_subtype) {
 		$plugin_subtype = get_subtype_id('object', 'plugin');
@@ -997,7 +997,7 @@ function _elgg_fetch_entities_from_sql($sql, ElggBatch $batch = null) {
 	// First pass: use cache where possible, gather GUIDs that we're optimizing
 	foreach ($rows as $i => $row) {
 		if (empty($row->guid) || empty($row->type)) {
-			throw new LogicException('Entity row missing guid or type');
+			throw new \LogicException('Entity row missing guid or type');
 		}
 		$entity = _elgg_retrieve_cached_entity($row->guid);
 		if ($entity) {
@@ -1035,7 +1035,7 @@ function _elgg_fetch_entities_from_sql($sql, ElggBatch $batch = null) {
 	}
 	// Second pass to finish conversion
 	foreach ($rows as $i => $row) {
-		if ($row instanceof ElggEntity) {
+		if ($row instanceof \ElggEntity) {
 			continue;
 		} else {
 			try {
@@ -1407,7 +1407,7 @@ function elgg_list_entities(array $options = array(), $getter = 'elgg_get_entiti
  * 	attribute_name_value_pairs_operator => null|STR The operator to use for combining
  *                                        (name = value) OPERATOR (name = value); default is AND
  *
- * @return ElggEntity[]|mixed If count, int. If not count, array. false on errors.
+ * @return \ElggEntity[]|mixed If count, int. If not count, array. false on errors.
  * @since 1.9.0
  * @throws InvalidArgumentException
  * @todo Does not support ordering by attributes or using an attribute pair shortcut like this ('title' => 'foo')
@@ -1459,11 +1459,11 @@ function elgg_get_entities_from_attributes(array $options = array()) {
 function _elgg_get_entity_attribute_where_sql(array $options = array()) {
 
 	if (!isset($options['types'])) {
-		throw new InvalidArgumentException("The entity type must be defined for elgg_get_entities_from_attributes()");
+		throw new \InvalidArgumentException("The entity type must be defined for elgg_get_entities_from_attributes()");
 	}
 
 	if (is_array($options['types']) && count($options['types']) !== 1) {
-		throw new InvalidArgumentException("Only one type can be passed to elgg_get_entities_from_attributes()");
+		throw new \InvalidArgumentException("Only one type can be passed to elgg_get_entities_from_attributes()");
 	}
 
 	// type can be passed as string or array
@@ -1472,9 +1472,9 @@ function _elgg_get_entity_attribute_where_sql(array $options = array()) {
 		$type = $type[0];
 	}
 
-	// @todo the types should be defined somewhere (as constant on ElggEntity?)
+	// @todo the types should be defined somewhere (as constant on \ElggEntity?)
 	if (!in_array($type, array('group', 'object', 'site', 'user'))) {
-		throw new InvalidArgumentException("Invalid type '$type' passed to elgg_get_entities_from_attributes()");
+		throw new \InvalidArgumentException("Invalid type '$type' passed to elgg_get_entities_from_attributes()");
 	}
 
 	global $CONFIG;
@@ -1491,7 +1491,7 @@ function _elgg_get_entity_attribute_where_sql(array $options = array()) {
 	}
 
 	if (!is_array($options['attribute_name_value_pairs'])) {
-		throw new InvalidArgumentException("attribute_name_value_pairs must be an array for elgg_get_entities_from_attributes()");
+		throw new \InvalidArgumentException("attribute_name_value_pairs must be an array for elgg_get_entities_from_attributes()");
 	}
 
 	$wheres = array();
@@ -1870,7 +1870,7 @@ function elgg_list_registered_entities(array $options = array()) {
 }
 
 /**
- * Checks if $entity is an ElggEntity and optionally for type and subtype.
+ * Checks if $entity is an \ElggEntity and optionally for type and subtype.
  *
  * @tip Use this function in actions and views to check that you are dealing
  * with the correct type of entity.
@@ -1884,10 +1884,10 @@ function elgg_list_registered_entities(array $options = array()) {
  * @since 1.8.0
  */
 function elgg_instanceof($entity, $type = null, $subtype = null, $class = null) {
-	$return = ($entity instanceof ElggEntity);
+	$return = ($entity instanceof \ElggEntity);
 
 	if ($type) {
-		/* @var ElggEntity $entity */
+		/* @var \ElggEntity $entity */
 		$return = $return && ($entity->getType() == $type);
 	}
 

--- a/engine/lib/filestore.php
+++ b/engine/lib/filestore.php
@@ -316,9 +316,9 @@ function get_image_resize_parameters($width, $height, $options) {
 }
 
 /**
- * Delete an ElggFile file
+ * Delete an \ElggFile file
  *
- * @param int $guid ElggFile GUID
+ * @param int $guid \ElggFile GUID
  *
  * @return bool
  */
@@ -329,19 +329,19 @@ function file_delete($guid) {
 			$smallthumb = $file->smallthumb;
 			$largethumb = $file->largethumb;
 			if ($thumbnail) {
-				$delfile = new ElggFile();
+				$delfile = new \ElggFile();
 				$delfile->owner_guid = $file->owner_guid;
 				$delfile->setFilename($thumbnail);
 				$delfile->delete();
 			}
 			if ($smallthumb) {
-				$delfile = new ElggFile();
+				$delfile = new \ElggFile();
 				$delfile->owner_guid = $file->owner_guid;
 				$delfile->setFilename($smallthumb);
 				$delfile->delete();
 			}
 			if ($largethumb) {
-				$delfile = new ElggFile();
+				$delfile = new \ElggFile();
 				$delfile->owner_guid = $file->owner_guid;
 				$delfile->setFilename($largethumb);
 				$delfile->delete();
@@ -437,18 +437,18 @@ function delete_directory($directory) {
  * @warning This only deletes the physical files and not their entities.
  * This will result in FileExceptions being thrown.  Don't use this function.
  *
- * @warning This must be kept in sync with ElggDiskFilestore.
+ * @warning This must be kept in sync with \ElggDiskFilestore.
  *
  * @todo Remove this when all files are entities.
  *
- * @param ElggUser $user An ElggUser
+ * @param \ElggUser $user An \ElggUser
  *
  * @return void
  */
 function clear_user_files($user) {
 	global $CONFIG;
 
-	$dir = new Elgg_EntityDirLocator($user->guid);
+	$dir = new \Elgg\EntityDirLocator($user->guid);
 	$file_path = $CONFIG->dataroot . $dir;
 	if (file_exists($file_path)) {
 		delete_directory($file_path);
@@ -462,7 +462,7 @@ $DEFAULT_FILE_STORE = null;
 /**
  * Return the default filestore.
  *
- * @return ElggFilestore
+ * @return \ElggFilestore
  */
 function get_default_filestore() {
 	global $DEFAULT_FILE_STORE;
@@ -473,11 +473,11 @@ function get_default_filestore() {
 /**
  * Set the default filestore for the system.
  *
- * @param ElggFilestore $filestore An ElggFilestore object.
+ * @param \ElggFilestore $filestore An \ElggFilestore object.
  *
  * @return true
  */
-function set_default_filestore(ElggFilestore $filestore) {
+function set_default_filestore(\ElggFilestore $filestore) {
 	global $DEFAULT_FILE_STORE;
 
 	$DEFAULT_FILE_STORE = $filestore;
@@ -497,7 +497,7 @@ function _elgg_filestore_init() {
 
 	// Now register a default filestore
 	if (isset($CONFIG->dataroot)) {
-		set_default_filestore(new ElggDiskFilestore($CONFIG->dataroot));
+		set_default_filestore(new \ElggDiskFilestore($CONFIG->dataroot));
 	}
 
 	// Unit testing

--- a/engine/lib/friends.php
+++ b/engine/lib/friends.php
@@ -79,14 +79,14 @@ function _elgg_friends_page_setup() {
  */
 function _elgg_friends_setup_user_hover_menu($hook, $type, $return, $params) {
 	$user = $params['entity'];
-	/* @var ElggUser $user */
+	/* @var \ElggUser $user */
 
 	if (elgg_is_logged_in()) {
 		if (elgg_get_logged_in_user_guid() != $user->guid) {
 			$isFriend = $user->isFriend();
 
 			// Always emit both to make it super easy to toggle with ajax
-			$return[] = ElggMenuItem::factory(array(
+			$return[] = \ElggMenuItem::factory(array(
 				'name' => 'remove_friend',
 				'href' => elgg_add_action_tokens_to_url("action/friends/remove?friend={$user->guid}"),
 				'text' => elgg_echo('friend:remove'),
@@ -94,7 +94,7 @@ function _elgg_friends_setup_user_hover_menu($hook, $type, $return, $params) {
 				'item_class' => $isFriend ? '' : 'hidden',
 			));
 
-			$return[] = ElggMenuItem::factory(array(
+			$return[] = \ElggMenuItem::factory(array(
 				'name' => 'add_friend',
 				'href' => elgg_add_action_tokens_to_url("action/friends/add?friend={$user->guid}"),
 				'text' => elgg_echo('friend:add'),
@@ -201,14 +201,14 @@ function _elgg_setup_collections_menu() {
  *
  * @param string           $event  Event name
  * @param string           $type   Object type
- * @param ElggRelationship $object Object
+ * @param \ElggRelationship $object Object
  *
  * @return bool
  * @access private
  */
 function _elgg_send_friend_notification($event, $type, $object) {
 	$user_one = get_entity($object->guid_one);
-	/* @var ElggUser $user_one */
+	/* @var \ElggUser $user_one */
 
 	return notify_user($object->guid_two,
 			$object->guid_one,

--- a/engine/lib/group.php
+++ b/engine/lib/group.php
@@ -43,7 +43,7 @@ function add_group_tool_option($name, $label, $default_on = true) {
 		$CONFIG->group_tool_options = array();
 	}
 
-	$group_tool_option = new stdClass;
+	$group_tool_option = new \stdClass;
 
 	$group_tool_option->name = $name;
 	$group_tool_option->label = $label;
@@ -90,7 +90,7 @@ function _elgg_groups_container_override($hook, $type, $result, $params) {
 	$container = $params['container'];
 	$user = $params['user'];
 	if (elgg_instanceof($container, 'group') && $user) {
-		/* @var ElggGroup $container */
+		/* @var \ElggGroup $container */
 		if ($container->isMember($user)) {
 			return true;
 		}

--- a/engine/lib/input.php
+++ b/engine/lib/input.php
@@ -384,7 +384,7 @@ function input_livesearch_page_handler($page) {
 					foreach ($entities as $entity) {
 						// @todo use elgg_get_entities (don't query in a loop!)
 						$entity = get_entity($entity->guid);
-						/* @var ElggGroup $entity */
+						/* @var \ElggGroup $entity */
 						if (!$entity) {
 							continue;
 						}

--- a/engine/lib/memcache.php
+++ b/engine/lib/memcache.php
@@ -25,7 +25,7 @@ function is_memcache_available() {
 	// If we haven't set variable to something
 	if (($memcache_available !== true) && ($memcache_available !== false)) {
 		try {
-			$tmp = new ElggMemcache();
+			$tmp = new \ElggMemcache();
 			// No exception thrown so we have memcache available
 			$memcache_available = true;
 		} catch (Exception $e) {
@@ -48,7 +48,7 @@ function _elgg_invalidate_memcache_for_entity($entity_guid) {
 	static $newentity_cache;
 	
 	if ((!$newentity_cache) && (is_memcache_available())) {
-		$newentity_cache = new ElggMemcache('new_entity_cache');
+		$newentity_cache = new \ElggMemcache('new_entity_cache');
 	}
 	
 	if ($newentity_cache) {

--- a/engine/lib/metadata.php
+++ b/engine/lib/metadata.php
@@ -8,19 +8,19 @@
  */
 
 /**
- * Convert a database row to a new ElggMetadata
+ * Convert a database row to a new \ElggMetadata
  *
- * @param stdClass $row An object from the database
+ * @param \stdClass $row An object from the database
  *
- * @return stdClass|ElggMetadata
+ * @return \stdClass|\ElggMetadata
  * @access private
  */
 function row_to_elggmetadata($row) {
-	if (!($row instanceof stdClass)) {
+	if (!($row instanceof \stdClass)) {
 		return $row;
 	}
 
-	return new ElggMetadata($row);
+	return new \ElggMetadata($row);
 }
 
 /**
@@ -30,7 +30,7 @@ function row_to_elggmetadata($row) {
  *
  * @param int $id The id of the metadata object being retrieved.
  *
- * @return ElggMetadata|false  false if not found
+ * @return \ElggMetadata|false  false if not found
  */
 function elgg_get_metadata_from_id($id) {
 	return _elgg_get_metastring_based_object_from_id($id, 'metadata');
@@ -168,11 +168,11 @@ function update_metadata($id, $name, $value, $value_type, $owner_guid, $access_i
 	// If memcached then we invalidate the cache for this entry
 	static $metabyname_memcache;
 	if ((!$metabyname_memcache) && (is_memcache_available())) {
-		$metabyname_memcache = new ElggMemcache('metabyname_memcache');
+		$metabyname_memcache = new \ElggMemcache('metabyname_memcache');
 	}
 
 	if ($metabyname_memcache) {
-		// @todo fix memcache (name_id is not a property of ElggMetadata)
+		// @todo fix memcache (name_id is not a property of \ElggMetadata)
 		$metabyname_memcache->delete("{$md->entity_guid}:{$md->name_id}");
 	}
 
@@ -274,9 +274,9 @@ $access_id = ACCESS_PRIVATE, $allow_multiple = false) {
  *                                   The "metadata_calculation" option causes this function to
  *                                   return the result of performing a mathematical calculation on
  *                                   all metadata that match the query instead of returning
- *                                   ElggMetadata objects.
+ *                                   \ElggMetadata objects.
  *
- * @return ElggMetadata[]|mixed
+ * @return \ElggMetadata[]|mixed
  * @since 1.8.0
  */
 function elgg_get_metadata(array $options = array()) {
@@ -365,7 +365,7 @@ function elgg_enable_metadata(array $options) {
 }
 
 /**
- * ElggEntities interfaces
+ * \ElggEntities interfaces
  */
 
 /**
@@ -425,7 +425,7 @@ function elgg_enable_metadata(array $options) {
  *
  *  metadata_owner_guids => null|ARR guids for metadata owners
  *
- * @return ElggEntity[]|mixed If count, int. If not count, array. false on errors.
+ * @return \ElggEntity[]|mixed If count, int. If not count, array. false on errors.
  * @since 1.7.0
  */
 function elgg_get_entities_from_metadata(array $options = array()) {
@@ -815,13 +815,13 @@ function is_metadata_independent($type, $subtype) {
  *
  * @param string     $event       The name of the event
  * @param string     $object_type The type of object
- * @param ElggEntity $object      The entity itself
+ * @param \ElggEntity $object      The entity itself
  *
  * @return true
  * @access private Set as private in 1.9.0
  */
 function metadata_update($event, $object_type, $object) {
-	if ($object instanceof ElggEntity) {
+	if ($object instanceof \ElggEntity) {
 		if (!is_metadata_independent($object->getType(), $object->getSubtype())) {
 			$db_prefix = elgg_get_config('dbprefix');
 			$access_id = (int) $object->access_id;
@@ -836,14 +836,14 @@ function metadata_update($event, $object_type, $object) {
 /**
  * Get the global metadata cache instance
  *
- * @return ElggVolatileMetadataCache
+ * @return \ElggVolatileMetadataCache
  *
  * @access private
  */
 function _elgg_get_metadata_cache() {
 	global $CONFIG;
 	if (empty($CONFIG->local_metadata_cache)) {
-		$CONFIG->local_metadata_cache = new ElggVolatileMetadataCache();
+		$CONFIG->local_metadata_cache = new \ElggVolatileMetadataCache();
 	}
 	return $CONFIG->local_metadata_cache;
 }

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -46,7 +46,7 @@ function elgg_get_metastring_id($string, $case_sensitive = true) {
 		$msfc = null;
 		static $metastrings_memcache;
 		if ((!$metastrings_memcache) && (is_memcache_available())) {
-			$metastrings_memcache = new ElggMemcache('metastrings_memcache');
+			$metastrings_memcache = new \ElggMemcache('metastrings_memcache');
 		}
 		if ($metastrings_memcache) {
 			$msfc = $metastrings_memcache->load($string);
@@ -131,7 +131,7 @@ function _elgg_delete_orphaned_metastrings() {
 		if ($dead) {
 			static $metastrings_memcache;
 			if (!$metastrings_memcache) {
-				$metastrings_memcache = new ElggMemcache('metastrings_memcache');
+				$metastrings_memcache = new \ElggMemcache('metastrings_memcache');
 			}
 
 			foreach ($dead as $d) {
@@ -153,7 +153,7 @@ function _elgg_delete_orphaned_metastrings() {
 }
 
 /**
- * Returns an array of either ElggAnnotation or ElggMetadata objects.
+ * Returns an array of either \ElggAnnotation or \ElggMetadata objects.
  * Accepts all elgg_get_entities() options for entity restraints.
  *
  * @see elgg_get_entities
@@ -179,7 +179,7 @@ function _elgg_delete_orphaned_metastrings() {
  *                                            This differs from egef_annotation_calculation in that
  *                                            it returns only the calculation of all annotation values.
  *                                            You can sum, avg, count, etc. egef_annotation_calculation()
- *                                            returns ElggEntities ordered by a calculation on their
+ *                                            returns \ElggEntities ordered by a calculation on their
  *                                            annotation values.
  *
  *  metastring_type               => STR      metadata or annotation(s)
@@ -674,7 +674,7 @@ function _elgg_batch_metastring_based_objects(array $options, $callback, $inc_of
 		return false;
 	}
 
-	$batch = new ElggBatch('_elgg_get_metastring_based_objects', $options, $callback, 50, $inc_offset);
+	$batch = new \ElggBatch('_elgg_get_metastring_based_objects', $options, $callback, 50, $inc_offset);
 	return $batch->callbackResult;
 }
 
@@ -683,7 +683,7 @@ function _elgg_batch_metastring_based_objects(array $options, $callback, $inc_of
  *
  * @param int    $id   The metastring-based object's ID
  * @param string $type The type: annotation or metadata
- * @return ElggExtender
+ * @return \ElggExtender
  * @access private
  */
 function _elgg_get_metastring_based_object_from_id($id, $type) {
@@ -742,7 +742,7 @@ function _elgg_delete_metastring_based_object_by_id($id, $type) {
 		if ($type == 'metadata') {
 			static $metabyname_memcache;
 			if ((!$metabyname_memcache) && (is_memcache_available())) {
-				$metabyname_memcache = new ElggMemcache('metabyname_memcache');
+				$metabyname_memcache = new \ElggMemcache('metabyname_memcache');
 			}
 
 			if ($metabyname_memcache) {

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -62,7 +62,7 @@
  *
  * @param string $menu_name The name of the menu: site, page, userhover,
  *                          userprofile, groupprofile, or any custom menu
- * @param mixed  $menu_item A ElggMenuItem object or an array of options in format:
+ * @param mixed  $menu_item A \ElggMenuItem object or an array of options in format:
  *                          name        => STR  Menu item identifier (required)
  *                          text        => STR  Menu item display text as HTML (required)
  *                          href        => STR  Menu item URL (required) (false for non-links.
@@ -96,7 +96,7 @@ function elgg_register_menu_item($menu_name, $menu_item) {
 	}
 
 	if (is_array($menu_item)) {
-		$item = ElggMenuItem::factory($menu_item);
+		$item = \ElggMenuItem::factory($menu_item);
 		if (!$item) {
 			elgg_log("Unable to add menu item '{$menu_item['name']}' to '$menu_name' menu", 'WARNING');
 			return false;
@@ -115,7 +115,7 @@ function elgg_register_menu_item($menu_name, $menu_item) {
  * @param string $menu_name The name of the menu
  * @param string $item_name The unique identifier for this menu item
  *
- * @return ElggMenuItem|null
+ * @return \ElggMenuItem|null
  * @since 1.8.0
  */
 function elgg_unregister_menu_item($menu_name, $item_name) {
@@ -126,7 +126,7 @@ function elgg_unregister_menu_item($menu_name, $item_name) {
 	}
 
 	foreach ($CONFIG->menus[$menu_name] as $index => $menu_object) {
-		/* @var ElggMenuItem $menu_object */
+		/* @var \ElggMenuItem $menu_object */
 		if ($menu_object->getName() == $item_name) {
 			$item = $CONFIG->menus[$menu_name][$index];
 			unset($CONFIG->menus[$menu_name][$index]);
@@ -154,7 +154,7 @@ function elgg_is_menu_item_registered($menu_name, $item_name) {
 	}
 
 	foreach ($CONFIG->menus[$menu_name] as $menu_object) {
-		/* @var ElggMenuItem $menu_object */
+		/* @var \ElggMenuItem $menu_object */
 		if ($menu_object->getName() == $item_name) {
 			return true;
 		}
@@ -169,7 +169,7 @@ function elgg_is_menu_item_registered($menu_name, $item_name) {
  * @param string $menu_name The name of the menu
  * @param string $item_name The unique identifier for this menu item
  *
- * @return ElggMenuItem
+ * @return \ElggMenuItem
  * @since 1.9.0
  */
 function elgg_get_menu_item($menu_name, $item_name) {
@@ -180,7 +180,7 @@ function elgg_get_menu_item($menu_name, $item_name) {
 	}
 
 	foreach ($CONFIG->menus[$menu_name] as $index => $menu_object) {
-		/* @var ElggMenuItem $menu_object */
+		/* @var \ElggMenuItem $menu_object */
 		if ($menu_object->getName() == $item_name) {
 			return $CONFIG->menus[$menu_name][$index];
 		}
@@ -293,7 +293,7 @@ function _elgg_site_menu_setup($hook, $type, $return, $params) {
 		// we have featured or custom menu items
 
 		$registered = $return['default'];
-		/* @var ElggMenuItem[] $registered */
+		/* @var \ElggMenuItem[] $registered */
 
 		// set up featured menu items
 		$featured = array();
@@ -309,7 +309,7 @@ function _elgg_site_menu_setup($hook, $type, $return, $params) {
 		// add custom menu items
 		$n = 1;
 		foreach ($custom_menu_items as $title => $url) {
-			$item = new ElggMenuItem("custom$n", $title, $url);
+			$item = new \ElggMenuItem("custom$n", $title, $url);
 			$featured[] = $item;
 			$n++;
 		}
@@ -333,7 +333,7 @@ function _elgg_site_menu_setup($hook, $type, $return, $params) {
 	// check if we have anything selected
 	$selected = false;
 	foreach ($return as $section) {
-		/* @var ElggMenuItem[] $section */
+		/* @var \ElggMenuItem[] $section */
 
 		foreach ($section as $item) {
 			if ($item->getSelected()) {
@@ -373,7 +373,7 @@ function _elgg_site_menu_setup($hook, $type, $return, $params) {
 function _elgg_river_menu_setup($hook, $type, $return, $params) {
 	if (elgg_is_logged_in()) {
 		$item = $params['item'];
-		/* @var ElggRiverItem $item */
+		/* @var \ElggRiverItem $item */
 		$object = $item->getObjectEntity();
 		// add comment link but annotations cannot be commented on
 		if ($item->annotation_id == 0) {
@@ -386,7 +386,7 @@ function _elgg_river_menu_setup($hook, $type, $return, $params) {
 					'rel' => 'toggle',
 					'priority' => 50,
 				);
-				$return[] = ElggMenuItem::factory($options);
+				$return[] = \ElggMenuItem::factory($options);
 			}
 		}
 		
@@ -399,7 +399,7 @@ function _elgg_river_menu_setup($hook, $type, $return, $params) {
 				'confirm' => elgg_echo('deleteconfirm'),
 				'priority' => 200,
 			);
-			$return[] = ElggMenuItem::factory($options);
+			$return[] = \ElggMenuItem::factory($options);
 		}
 	}
 
@@ -416,7 +416,7 @@ function _elgg_entity_menu_setup($hook, $type, $return, $params) {
 	}
 	
 	$entity = $params['entity'];
-	/* @var ElggEntity $entity */
+	/* @var \ElggEntity $entity */
 	$handler = elgg_extract('handler', $params, false);
 
 	// access
@@ -427,7 +427,7 @@ function _elgg_entity_menu_setup($hook, $type, $return, $params) {
 		'href' => false,
 		'priority' => 100,
 	);
-	$return[] = ElggMenuItem::factory($options);
+	$return[] = \ElggMenuItem::factory($options);
 
 	if ($entity->canEdit() && $handler) {
 		// edit link
@@ -438,7 +438,7 @@ function _elgg_entity_menu_setup($hook, $type, $return, $params) {
 			'href' => "$handler/edit/{$entity->getGUID()}",
 			'priority' => 200,
 		);
-		$return[] = ElggMenuItem::factory($options);
+		$return[] = \ElggMenuItem::factory($options);
 
 		// delete link
 		$options = array(
@@ -449,7 +449,7 @@ function _elgg_entity_menu_setup($hook, $type, $return, $params) {
 			'confirm' => elgg_echo('deleteconfirm'),
 			'priority' => 300,
 		);
-		$return[] = ElggMenuItem::factory($options);
+		$return[] = \ElggMenuItem::factory($options);
 	}
 
 	return $return;
@@ -462,7 +462,7 @@ function _elgg_entity_menu_setup($hook, $type, $return, $params) {
 function _elgg_widget_menu_setup($hook, $type, $return, $params) {
 
 	$widget = $params['entity'];
-	/* @var ElggWidget $widget */
+	/* @var \ElggWidget $widget */
 	$show_edit = elgg_extract('show_edit', $params, true);
 
 	$collapse = array(
@@ -473,7 +473,7 @@ function _elgg_widget_menu_setup($hook, $type, $return, $params) {
 		'rel' => 'toggle',
 		'priority' => 1,
 	);
-	$return[] = ElggMenuItem::factory($collapse);
+	$return[] = \ElggMenuItem::factory($collapse);
 
 	if ($widget->canEdit()) {
 		$delete = array(
@@ -487,7 +487,7 @@ function _elgg_widget_menu_setup($hook, $type, $return, $params) {
 			'data-elgg-widget-type' => $widget->handler,
 			'priority' => 900,
 		);
-		$return[] = ElggMenuItem::factory($delete);
+		$return[] = \ElggMenuItem::factory($delete);
 
 		if ($show_edit) {
 			$edit = array(
@@ -499,7 +499,7 @@ function _elgg_widget_menu_setup($hook, $type, $return, $params) {
 				'rel' => 'toggle',
 				'priority' => 800,
 			);
-			$return[] = ElggMenuItem::factory($edit);
+			$return[] = \ElggMenuItem::factory($edit);
 		}
 	}
 
@@ -513,7 +513,7 @@ function _elgg_widget_menu_setup($hook, $type, $return, $params) {
 function _elgg_login_menu_setup($hook, $type, $return, $params) {
 
 	if (elgg_get_config('allow_registration')) {
-		$return[] = ElggMenuItem::factory(array(
+		$return[] = \ElggMenuItem::factory(array(
 			'name' => 'register',
 			'href' => 'register',
 			'text' => elgg_echo('register'),
@@ -521,7 +521,7 @@ function _elgg_login_menu_setup($hook, $type, $return, $params) {
 		));
 	}
 
-	$return[] = ElggMenuItem::factory(array(
+	$return[] = \ElggMenuItem::factory(array(
 		'name' => 'forgotpassword',
 		'href' => 'forgotpassword',
 		'text' => elgg_echo('user:password:lost'),
@@ -543,7 +543,7 @@ function _elgg_nav_init() {
 	elgg_register_plugin_hook_handler('register', 'menu:widget', '_elgg_widget_menu_setup');
 	elgg_register_plugin_hook_handler('register', 'menu:login', '_elgg_login_menu_setup');
 
-	elgg_register_menu_item('footer', ElggMenuItem::factory(array(
+	elgg_register_menu_item('footer', \ElggMenuItem::factory(array(
 		'name' => 'powered',
 		'text' => elgg_echo("elgg:powered"),
 		'href' => 'http://elgg.org',

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -10,12 +10,12 @@
  *    would be named 'publish:object:blog'.
  * 
  *    The parameter array for the plugin hook has the keys 'event', 'method',
- *    'recipient', and 'language'. The event is an Elgg_Notifications_Event 
+ *    'recipient', and 'language'. The event is an \Elgg\Notifications\Event 
  *    object and can provide access to the original object of the event through 
  *    the method getObject() and the original actor through getActor().
  * 
  *    The plugin hook callback modifies and returns a 
- *    Elgg_Notifications_Notification object that holds the message content.
+ *    \Elgg\Notifications\Notification object that holds the message content.
  *
  *
  * Adding a Delivery Method
@@ -24,7 +24,9 @@
  * 
  * 2. Register for the plugin hook for sending notifications:
  *    'send', 'notification:[method name]'. It receives the notification object 
- *    of the class Elgg_Notifications_Notification in the params array with the 
+ *    of the namespace Elgg\Notifications;
+
+class Notification in the params array with the 
  *    key 'notification'. The callback should return a boolean to indicate whether 
  *    the message was sent.
  * 
@@ -77,7 +79,7 @@ function elgg_unregister_notification_event($object_type, $object_subtype) {
  * 
  * Register for the 'send', 'notification:[method name]' plugin hook to handle
  * sending a notification. A notification object is in the params array for the
- * hook with the key 'notification'. See Elgg_Notifications_Notification.
+ * hook with the key 'notification'. See \Elgg\Notifications\Notification.
  *
  * @param string $name The notification method name
  * @return void
@@ -112,7 +114,7 @@ function elgg_unregister_notification_method($name) {
 function elgg_add_subscription($user_guid, $method, $target_guid) {
 	$methods = _elgg_services()->notifications->getMethods();
 	$db = _elgg_services()->db;
-	$subs = new Elgg_Notifications_SubscriptionsService($db, $methods);
+	$subs = new \Elgg\Notifications\SubscriptionsService($db, $methods);
 	return $subs->addSubscription($user_guid, $method, $target_guid);
 }
 
@@ -128,7 +130,7 @@ function elgg_add_subscription($user_guid, $method, $target_guid) {
 function elgg_remove_subscription($user_guid, $method, $target_guid) {
 	$methods = _elgg_services()->notifications->getMethods();
 	$db = _elgg_services()->db;
-	$subs = new Elgg_Notifications_SubscriptionsService($db, $methods);
+	$subs = new \Elgg\Notifications\SubscriptionsService($db, $methods);
 	return $subs->removeSubscription($user_guid, $method, $target_guid);
 }
 
@@ -149,7 +151,7 @@ function elgg_remove_subscription($user_guid, $method, $target_guid) {
 function elgg_get_subscriptions_for_container($container_guid) {
 	$methods = _elgg_services()->notifications->getMethods();
 	$db = _elgg_services()->db;
-	$subs = new Elgg_Notifications_SubscriptionsService($db, $methods);
+	$subs = new \Elgg\Notifications\SubscriptionsService($db, $methods);
 	return $subs->getSubscriptionsForContainer($container_guid);
 }
 
@@ -163,7 +165,7 @@ function elgg_get_subscriptions_for_container($container_guid) {
  *
  * @param string   $action The name of the action
  * @param string   $type   The type of the object
- * @param ElggData $object The object of the event
+ * @param \ElggData $object The object of the event
  * @return void
  * @access private
  * @since 1.9
@@ -193,7 +195,7 @@ function _elgg_notifications_cron() {
  * @access private
  */
 function _elgg_send_email_notification($hook, $type, $result, $params) {
-	/* @var Elgg_Notifications_Notification $message */
+	/* @var \Elgg\Notifications\Notification $message */
 	$message = $params['notification'];
 
 	$sender = $message->getSender();
@@ -211,7 +213,7 @@ function _elgg_send_email_notification($hook, $type, $result, $params) {
 
 	$site = elgg_get_site_entity();
 	// If there's an email address, use it - but only if it's not from a user.
-	if (!($sender instanceof ElggUser) && $sender->email) {
+	if (!($sender instanceof \ElggUser) && $sender->email) {
 		$from = $sender->email;
 	} else if ($site->email) {
 		$from = $site->email;
@@ -237,10 +239,10 @@ function _elgg_send_email_notification($hook, $type, $result, $params) {
 function _elgg_notifications_smtp_thread_headers($hook, $type, $returnvalue, $params) {
 
 	$notificationParams = elgg_extract('params', $returnvalue, array());
-	/** @var Elgg_Notifications_Notification */
+	/** @var \Elgg\Notifications\Notification */
 	$notification = elgg_extract('notification', $notificationParams);
 
-	if (!($notification instanceof Elgg_Notifications_Notification)) {
+	if (!($notification instanceof \Elgg\Notifications\Notification)) {
 		return $returnvalue;
 	}
 
@@ -248,10 +250,10 @@ function _elgg_notifications_smtp_thread_headers($hook, $type, $returnvalue, $pa
 	$urlPath = parse_url(elgg_get_site_url(), PHP_URL_PATH);
 
 	$object = elgg_extract('object', $notification->params);
-	/** @var Elgg_Notifications_Event $event */
+	/** @var \Elgg\Notifications\Event $event */
 	$event = elgg_extract('event', $notification->params);
 
-	if (($object instanceof ElggEntity) && ($event instanceof Elgg_Notifications_Event)) {
+	if (($object instanceof \ElggEntity) && ($event instanceof \Elgg\Notifications\Event)) {
 		if ($event->getAction() === 'create') {
 			// create event happens once per entity and we need to guarantee message id uniqueness
 			// and at the same time have thread message id that we don't need to store
@@ -264,7 +266,7 @@ function _elgg_notifications_smtp_thread_headers($hook, $type, $returnvalue, $pa
 		$container = $object->getContainerEntity();
 
 		// let's just thread comments by default
-		if (($container instanceof ElggEntity) && ($object instanceof ElggComment)) {
+		if (($container instanceof \ElggEntity) && ($object instanceof \ElggComment)) {
 
 			$threadMessageId = "<{$urlPath}.entity.{$container->guid}@{$hostname}>";
 			$returnvalue['headers']['In-Reply-To'] = $threadMessageId;
@@ -416,7 +418,7 @@ function _elgg_notify_user($to, $from, $subject, $message, array $params = null,
  *                                 By default Elgg core supports three parameters, which give
  *                                 notification plugins more control over the notifications:
  *
- *                                 object => null|ElggEntity|ElggAnnotation The object that
+ *                                 object => null|\ElggEntity|\ElggAnnotation The object that
  *                                           is triggering the notification.
  *
  *                                 action => null|string Word that describes the action that
@@ -451,7 +453,7 @@ function notify_user($to, $from, $subject, $message, array $params = array(), $m
 	// temporary backward compatibility for 1.8 and earlier notifications
 	$event = null;
 	if (isset($params['object']) && isset($params['action'])) {
-		$event = new Elgg_Notifications_Event($params['object'], $params['action'], $sender);
+		$event = new \Elgg\Notifications\Event($params['object'], $params['action'], $sender);
 	}
 	$params['event'] = $event;
 
@@ -486,7 +488,7 @@ function notify_user($to, $from, $subject, $message, array $params = array(), $m
 							continue;
 						}
 						$language = $recipient->language;
-						$notification = new Elgg_Notifications_Notification($sender, $recipient, $language, $subject, $message, $summary, $params);
+						$notification = new \Elgg\Notifications\Notification($sender, $recipient, $language, $subject, $message, $summary, $params);
 						$params['notification'] = $notification;
 						$result[$guid][$method] = _elgg_services()->hooks->trigger('send', "notification:$method", $params, false);
 					} else {
@@ -505,7 +507,7 @@ function notify_user($to, $from, $subject, $message, array $params = array(), $m
  *
  * @param int $user_guid The user id
  *
- * @return stdClass|false
+ * @return \stdClass|false
  */
 function get_user_notification_settings($user_guid = 0) {
 	$user_guid = (int)$user_guid;
@@ -522,7 +524,7 @@ function get_user_notification_settings($user_guid = 0) {
 	));
 	if ($all_metadata) {
 		$prefix = "notification:method:";
-		$return = new stdClass;
+		$return = new \stdClass;
 
 		foreach ($all_metadata as $meta) {
 			$name = substr($meta->name, strlen($prefix));
@@ -557,7 +559,7 @@ function set_user_notification_setting($user_guid, $method, $value) {
 		$user = elgg_get_logged_in_user_entity();
 	}
 
-	if (($user) && ($user instanceof ElggUser)) {
+	if (($user) && ($user instanceof \ElggUser)) {
 		$prefix = "notification:method:$method";
 		$user->$prefix = $value;
 		$user->save();
@@ -586,12 +588,12 @@ function elgg_send_email($from, $to, $subject, $body, array $params = null) {
 
 	if (!$from) {
 		$msg = "Missing a required parameter, '" . 'from' . "'";
-		throw new NotificationException($msg);
+		throw new \NotificationException($msg);
 	}
 
 	if (!$to) {
 		$msg = "Missing a required parameter, '" . 'to' . "'";
-		throw new NotificationException($msg);
+		throw new \NotificationException($msg);
 	}
 
 	$headers = array(

--- a/engine/lib/objects.php
+++ b/engine/lib/objects.php
@@ -23,7 +23,7 @@ function get_object_entity_as_row($guid) {
 }
 
 /**
- * Runs unit tests for ElggObject
+ * Runs unit tests for \ElggObject
  *
  * @param string $hook   unit_test
  * @param string $type   system

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -165,7 +165,7 @@ function elgg_format_attributes(array $attrs = array()) {
 		 * Ignore non-array values and allow attribute values to be an array
 		 *  <code>
 		 *  $attrs = array(
-		 *		'entity' => <ElggObject>, // will be ignored
+		 *		'entity' => <\ElggObject>, // will be ignored
 		 * 		'class' => array('elgg-input', 'elgg-input-text'), // will be imploded with spaces
 		 * 		'style' => array('margin-left:10px;', 'color: #666;'), // will be imploded with spaces
 		 *		'alt' => 'Alt text', // will be left as is
@@ -214,7 +214,7 @@ function elgg_format_attributes(array $attrs = array()) {
  */
 function elgg_format_element($tag_name, array $attributes = array(), $text = '', array $options = array()) {
 	if (!is_string($tag_name)) {
-		throw new InvalidArgumentException('$tag_name is required');
+		throw new \InvalidArgumentException('$tag_name is required');
 	}
 
 	if (isset($options['is_void'])) {
@@ -378,7 +378,7 @@ function elgg_get_friendly_title($title) {
 	// titles are often stored HTML encoded
 	$title = html_entity_decode($title, ENT_QUOTES, 'UTF-8');
 	
-	$title = Elgg_Translit::urlize($title);
+	$title = \Elgg\Translit::urlize($title);
 
 	return $title;
 }

--- a/engine/lib/pagehandler.php
+++ b/engine/lib/pagehandler.php
@@ -124,7 +124,7 @@ function elgg_group_gatekeeper($forward = true, $group_guid = null) {
 	}
 
 	// this handles non-groups and invisible groups
-	$visibility = Elgg_GroupItemVisibility::factory($group_guid);
+	$visibility = \Elgg\GroupItemVisibility::factory($group_guid);
 
 	if (!$visibility->shouldHideItems) {
 		return true;

--- a/engine/lib/pageowner.php
+++ b/engine/lib/pageowner.php
@@ -41,7 +41,7 @@ function elgg_get_page_owner_guid($guid = 0) {
  *
  * @note Access is disabled when getting the page owner entity.
  *
- * @return ElggUser|ElggGroup|false The current page owner or false if none.
+ * @return \ElggUser|\ElggGroup|false The current page owner or false if none.
  *
  * @since 1.8.0
  */

--- a/engine/lib/pam.php
+++ b/engine/lib/pam.php
@@ -14,7 +14,7 @@
  * For more information on PAMs see:
  * http://www.freebsd.org/doc/en/articles/pam/index.html
  *
- * @see ElggPAM
+ * @see \ElggPAM
  *
  * @package Elgg.Core
  * @subpackage Authentication.PAM
@@ -49,7 +49,7 @@ function register_pam_handler($handler, $importance = "sufficient", $policy = "u
 
 	// @todo remove requirement that $handle be a global function
 	if (is_string($handler) && is_callable($handler, true)) {
-		$_PAM_HANDLERS[$policy][$handler] = new stdClass;
+		$_PAM_HANDLERS[$policy][$handler] = new \stdClass;
 
 		$_PAM_HANDLERS[$policy][$handler]->handler = $handler;
 		$_PAM_HANDLERS[$policy][$handler]->importance = strtolower($importance);

--- a/engine/lib/plugins.php
+++ b/engine/lib/plugins.php
@@ -8,22 +8,22 @@
  */
 
 /**
- * Tells ElggPlugin::start() to include the start.php file.
+ * Tells \ElggPlugin::start() to include the start.php file.
  */
 define('ELGG_PLUGIN_INCLUDE_START', 1);
 
 /**
- * Tells ElggPlugin::start() to automatically register the plugin's views.
+ * Tells \ElggPlugin::start() to automatically register the plugin's views.
  */
 define('ELGG_PLUGIN_REGISTER_VIEWS', 2);
 
 /**
- * Tells ElggPlugin::start() to automatically register the plugin's languages.
+ * Tells \ElggPlugin::start() to automatically register the plugin's languages.
  */
 define('ELGG_PLUGIN_REGISTER_LANGUAGES', 4);
 
 /**
- * Tells ElggPlugin::start() to automatically register the plugin's classes.
+ * Tells \ElggPlugin::start() to automatically register the plugin's classes.
  */
 define('ELGG_PLUGIN_REGISTER_CLASSES', 8);
 
@@ -43,7 +43,7 @@ define('ELGG_PLUGIN_USER_SETTING_PREFIX', 'plugin:user_setting:');
 /**
  * Internal settings prefix
  *
- * @todo This could be resolved by promoting ElggPlugin to a 5th type.
+ * @todo This could be resolved by promoting \ElggPlugin to a 5th type.
  */
 define('ELGG_PLUGIN_INTERNAL_PREFIX', 'elgg:internal:');
 
@@ -81,10 +81,10 @@ function _elgg_get_plugin_dirs_in_dir($dir = null) {
 }
 
 /**
- * Discovers plugins in the plugins_path setting and creates ElggPlugin
+ * Discovers plugins in the plugins_path setting and creates \ElggPlugin
  * entities for them if they don't exist.  If there are plugins with entities
- * but not actual files, will disable the ElggPlugin entities and mark as inactive.
- * The ElggPlugin object holds config data, so don't delete.
+ * but not actual files, will disable the \ElggPlugin entities and mark as inactive.
+ * The \ElggPlugin object holds config data, so don't delete.
  *
  * @return bool
  * @since 1.8.0
@@ -110,7 +110,7 @@ function _elgg_generate_plugin_entities() {
 		'limit' => ELGG_ENTITIES_NO_VALUE,
 	);
 	$known_plugins = elgg_get_entities_from_relationship($options);
-	/* @var ElggPlugin[] $known_plugins */
+	/* @var \ElggPlugin[] $known_plugins */
 
 	if (!$known_plugins) {
 		$known_plugins = array();
@@ -153,7 +153,7 @@ function _elgg_generate_plugin_entities() {
 		} else {
 			// create new plugin
 			// priority is forced to last in save() if not set.
-			$plugin = new ElggPlugin($mod_dir . $plugin_id);
+			$plugin = new \ElggPlugin($mod_dir . $plugin_id);
 			$plugin->save();
 		}
 	}
@@ -184,21 +184,21 @@ function _elgg_generate_plugin_entities() {
 /**
  * Cache a reference to this plugin by its ID
  * 
- * @param ElggPlugin $plugin
+ * @param \ElggPlugin $plugin
  * 
  * @access private
  */
-function _elgg_cache_plugin_by_id(ElggPlugin $plugin) {
+function _elgg_cache_plugin_by_id(\ElggPlugin $plugin) {
 	$map = (array) elgg_get_config('plugins_by_id_map');
 	$map[$plugin->getID()] = $plugin;
 	elgg_set_config('plugins_by_id_map', $map);
 }
 
 /**
- * Returns an ElggPlugin object with the path $path.
+ * Returns an \ElggPlugin object with the path $path.
  *
  * @param string $plugin_id The id (dir name) of the plugin. NOT the guid.
- * @return ElggPlugin|null
+ * @return \ElggPlugin|null
  * @since 1.8.0
  */
 function elgg_get_plugin_from_id($plugin_id) {
@@ -289,7 +289,7 @@ function elgg_is_active_plugin($plugin_id, $site_guid = null) {
 		$site = elgg_get_site_entity();
 	}
 
-	if (!($site instanceof ElggSite)) {
+	if (!($site instanceof \ElggSite)) {
 		return false;
 	}
 
@@ -366,7 +366,7 @@ function _elgg_load_plugins() {
  *
  * @param string $status    The status of the plugins. active, inactive, or all.
  * @param mixed  $site_guid Optional site guid
- * @return ElggPlugin[]
+ * @return \ElggPlugin[]
  * @since 1.8.0
  */
 function elgg_get_plugins($status = 'active', $site_guid = null) {
@@ -423,7 +423,7 @@ function elgg_get_plugins($status = 'active', $site_guid = null) {
  * Reorder plugins to an order specified by the array.
  * Plugins not included in this array will be appended to the end.
  *
- * @note This doesn't use the ElggPlugin->setPriority() method because
+ * @note This doesn't use the \ElggPlugin->setPriority() method because
  *       all plugins are being changed and we don't want it to automatically
  *       reorder plugins.
  *
@@ -447,7 +447,7 @@ function _elgg_set_plugin_priorities(array $order) {
 	$order = array_values($order);
 
 	$missing_plugins = array();
-	/* @var ElggPlugin[] $missing_plugins */
+	/* @var \ElggPlugin[] $missing_plugins */
 
 	foreach ($plugins as $plugin) {
 		$plugin_id = $plugin->getID();
@@ -534,7 +534,7 @@ function _elgg_namespace_plugin_private_setting($type, $name, $id = null) {
 
 /**
  * @var array cache used by elgg_get_plugins_provides function
- * @todo move it with all other functions to Elgg_PluginsService
+ * @todo move it with all other functions to \Elgg\PluginsService
  */
 global $ELGG_PLUGINS_PROVIDES_CACHE;
 
@@ -567,7 +567,7 @@ function _elgg_get_plugins_provides($type = null, $name = null) {
 		foreach ($active_plugins as $plugin) {
 			$plugin_provides = array();
 			$manifest = $plugin->getManifest();
-			if ($manifest instanceof ElggPluginManifest) {
+			if ($manifest instanceof \ElggPluginManifest) {
 				$plugin_provides = $plugin->getManifest()->getProvides();
 			}
 			if ($plugin_provides) {
@@ -660,7 +660,7 @@ function _elgg_check_plugins_provides($type, $name, $version = null, $comparison
  * 	'comment'		=>	Free form text to help resovle the problem ("Enable / Search for plugin <link>")
  * )
  *
- * @param array $dep An ElggPluginPackage dependency array
+ * @param array $dep An \ElggPluginPackage dependency array
  * @return array
  * @since 1.8.0
  * @access private
@@ -779,9 +779,9 @@ function _elgg_get_plugin_dependency_strings($dep) {
 }
 
 /**
- * Returns the ElggPlugin entity of the last plugin called.
+ * Returns the \ElggPlugin entity of the last plugin called.
  *
- * @return mixed ElggPlugin or false
+ * @return ElggPlugin|false
  * @since 1.8.0
  * @access private
  * @deprecated 1.9
@@ -806,7 +806,7 @@ function elgg_get_calling_plugin_entity() {
  *                           views where the settings are passed as $vars['entity'].
  * @return array
  * @since 1.8.0
- * @see ElggPlugin::getAllUserSettings()
+ * @see \ElggPlugin::getAllUserSettings()
  */
 function elgg_get_all_plugin_user_settings($user_guid = 0, $plugin_id = null, $return_obj = false) {
 	if ($plugin_id) {
@@ -816,14 +816,14 @@ function elgg_get_all_plugin_user_settings($user_guid = 0, $plugin_id = null, $r
 		$plugin = elgg_get_calling_plugin_entity();
 	}
 
-	if (!$plugin instanceof ElggPlugin) {
+	if (!$plugin instanceof \ElggPlugin) {
 		return false;
 	}
 
 	$settings = $plugin->getAllUserSettings((int)$user_guid);
 
 	if ($settings && $return_obj) {
-		$return = new stdClass;
+		$return = new \stdClass;
 
 		foreach ($settings as $k => $v) {
 			$return->$k = $v;
@@ -845,7 +845,7 @@ function elgg_get_all_plugin_user_settings($user_guid = 0, $plugin_id = null, $r
  *
  * @return bool
  * @since 1.8.0
- * @see ElggPlugin::setUserSetting()
+ * @see \ElggPlugin::setUserSetting()
  */
 function elgg_set_plugin_user_setting($name, $value, $user_guid = 0, $plugin_id = null) {
 	if ($plugin_id) {
@@ -871,7 +871,7 @@ function elgg_set_plugin_user_setting($name, $value, $user_guid = 0, $plugin_id 
  *
  * @return bool
  * @since 1.8.0
- * @see ElggPlugin::unsetUserSetting()
+ * @see \ElggPlugin::unsetUserSetting()
  */
 function elgg_unset_plugin_user_setting($name, $user_guid = 0, $plugin_id = null) {
 	if ($plugin_id) {
@@ -897,7 +897,7 @@ function elgg_unset_plugin_user_setting($name, $user_guid = 0, $plugin_id = null
  *
  * @return mixed
  * @since 1.8.0
- * @see ElggPlugin::getUserSetting()
+ * @see \ElggPlugin::getUserSetting()
  */
 function elgg_get_plugin_user_setting($name, $user_guid = 0, $plugin_id = null) {
 	if ($plugin_id) {
@@ -923,7 +923,7 @@ function elgg_get_plugin_user_setting($name, $user_guid = 0, $plugin_id = null) 
  *
  * @return bool
  * @since 1.8.0
- * @see ElggPlugin::setSetting()
+ * @see \ElggPlugin::setSetting()
  */
 function elgg_set_plugin_setting($name, $value, $plugin_id = null) {
 	if ($plugin_id) {
@@ -949,7 +949,7 @@ function elgg_set_plugin_setting($name, $value, $plugin_id = null) {
  *
  * @return mixed
  * @since 1.8.0
- * @see ElggPlugin::getSetting()
+ * @see \ElggPlugin::getSetting()
  */
 function elgg_get_plugin_setting($name, $plugin_id = null, $default = null) {
 	if ($plugin_id) {
@@ -974,7 +974,7 @@ function elgg_get_plugin_setting($name, $plugin_id = null, $default = null) {
  *
  * @return bool
  * @since 1.8.0
- * @see ElggPlugin::unsetSetting()
+ * @see \ElggPlugin::unsetSetting()
  */
 function elgg_unset_plugin_setting($name, $plugin_id = null) {
 	if ($plugin_id) {
@@ -998,7 +998,7 @@ function elgg_unset_plugin_setting($name, $plugin_id = null) {
  *
  * @return bool
  * @since 1.8.0
- * @see ElggPlugin::unsetAllSettings()
+ * @see \ElggPlugin::unsetAllSettings()
  */
 function elgg_unset_all_plugin_settings($plugin_id = null) {
 	if ($plugin_id) {

--- a/engine/lib/private_settings.php
+++ b/engine/lib/private_settings.php
@@ -278,7 +278,7 @@ function get_private_setting($entity_guid, $name) {
 	$name = sanitise_string($name);
 
 	$entity = get_entity($entity_guid);
-	if (!$entity instanceof ElggEntity) {
+	if (!$entity instanceof \ElggEntity) {
 		return null;
 	}
 
@@ -297,7 +297,7 @@ function get_private_setting($entity_guid, $name) {
  *
  * @param int $entity_guid The entity GUID
  *
- * @return array|empty array if no settings
+ * @return string[] empty array if no settings
  * @see set_private_setting()
  * @see get_private_settings()
  * @see remove_private_setting()
@@ -308,7 +308,7 @@ function get_all_private_settings($entity_guid) {
 
 	$entity_guid = (int) $entity_guid;
 	$entity = get_entity($entity_guid);
-	if (!$entity instanceof ElggEntity) {
+	if (!$entity instanceof \ElggEntity) {
 		return false;
 	}
 
@@ -372,7 +372,7 @@ function remove_private_setting($entity_guid, $name) {
 	$entity_guid = (int) $entity_guid;
 
 	$entity = get_entity($entity_guid);
-	if (!$entity instanceof ElggEntity) {
+	if (!$entity instanceof \ElggEntity) {
 		return false;
 	}
 
@@ -400,7 +400,7 @@ function remove_all_private_settings($entity_guid) {
 	$entity_guid = (int) $entity_guid;
 
 	$entity = get_entity($entity_guid);
-	if (!$entity instanceof ElggEntity) {
+	if (!$entity instanceof \ElggEntity) {
 		return false;
 	}
 

--- a/engine/lib/relationships.php
+++ b/engine/lib/relationships.php
@@ -7,16 +7,16 @@
  */
 
 /**
- * Convert a database row to a new ElggRelationship
+ * Convert a database row to a new \ElggRelationship
  *
- * @param stdClass $row Database row from the relationship table
+ * @param \stdClass $row Database row from the relationship table
  *
- * @return ElggRelationship|false
+ * @return \ElggRelationship|false
  * @access private
  */
 function row_to_elggrelationship($row) {
-	if ($row instanceof stdClass) {
-		return new ElggRelationship($row);
+	if ($row instanceof \stdClass) {
+		return new \ElggRelationship($row);
 	}
 
 	return false;
@@ -27,7 +27,7 @@ function row_to_elggrelationship($row) {
  *
  * @param int $id The relationship ID
  *
- * @return ElggRelationship|false False if not found
+ * @return \ElggRelationship|false False if not found
  */
 function get_relationship($id) {
 	$row = _elgg_get_relationship_row($id);
@@ -35,7 +35,7 @@ function get_relationship($id) {
 		return false;
 	}
 
-	return new ElggRelationship($row);
+	return new \ElggRelationship($row);
 }
 
 /**
@@ -43,7 +43,7 @@ function get_relationship($id) {
  *
  * @param int $id The relationship ID
  *
- * @return stdClass|false False if no row found
+ * @return \stdClass|false False if no row found
  * @access private
  */
 function _elgg_get_relationship_row($id) {
@@ -91,8 +91,8 @@ function delete_relationship($id) {
 function add_entity_relationship($guid_one, $relationship, $guid_two) {
 	global $CONFIG;
 
-	if (strlen($relationship) > ElggRelationship::RELATIONSHIP_LIMIT) {
-		$msg = "relationship name cannot be longer than " . ElggRelationship::RELATIONSHIP_LIMIT;
+	if (strlen($relationship) > \ElggRelationship::RELATIONSHIP_LIMIT) {
+		$msg = "relationship name cannot be longer than " . \ElggRelationship::RELATIONSHIP_LIMIT;
 		throw InvalidArgumentException($msg);
 	}
 
@@ -136,7 +136,7 @@ function add_entity_relationship($guid_one, $relationship, $guid_two) {
  * @param string $relationship Type of the relationship
  * @param int    $guid_two     GUID of the target entity of the relationship
  *
- * @return ElggRelationship|false Depending on success
+ * @return \ElggRelationship|false Depending on success
  */
 function check_entity_relationship($guid_one, $relationship, $guid_two) {
 	global $CONFIG;
@@ -252,7 +252,7 @@ function remove_entity_relationships($guid, $relationship = "", $inverse_relatio
  * @param bool $inverse_relationship Is $guid the target of the deleted relationships? By default $guid is
  *                                   the subject of the relationships.
  *
- * @return ElggRelationship[]
+ * @return \ElggRelationship[]
  */
 function get_entity_relationships($guid, $inverse_relationship = false) {
 	global $CONFIG;
@@ -298,7 +298,7 @@ function get_entity_relationships($guid, $inverse_relationship = false) {
  *                          2. use 'owner_guid' if you want the entities the user's friends own (including in groups)
  *                          3. use 'container_guid' if you want the entities in the user's personal space (non-group)
  *
- * @return ElggEntity[]|mixed If count, int. If not count, array. false on errors.
+ * @return \ElggEntity[]|mixed If count, int. If not count, array. false on errors.
  * @since 1.7.0
  */
 function elgg_get_entities_from_relationship($options) {
@@ -422,7 +422,7 @@ function elgg_list_entities_from_relationship(array $options = array()) {
  *
  * @param array $options An options array compatible with elgg_get_entities_from_relationship()
  *
- * @return ElggEntity[]|int|boolean If count, int. If not count, array. false on errors.
+ * @return \ElggEntity[]|int|boolean If count, int. If not count, array. false on errors.
  * @since 1.8.0
  */
 function elgg_get_entities_from_relationship_count(array $options = array()) {

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -432,7 +432,7 @@ function elgg_get_river(array $options = array()) {
 /**
  * Prefetch entities that will be displayed in the river.
  *
- * @param ElggRiverItem[] $river_items
+ * @param \ElggRiverItem[] $river_items
  * @access private
  */
 function _elgg_prefetch_river_entities(array $river_items) {
@@ -523,20 +523,20 @@ function elgg_list_river(array $options = array()) {
 }
 
 /**
- * Convert a database row to a new ElggRiverItem
+ * Convert a database row to a new \ElggRiverItem
  *
- * @param stdClass $row Database row from the river table
+ * @param \stdClass $row Database row from the river table
  *
- * @return ElggRiverItem
+ * @return \ElggRiverItem
  * @since 1.8.0
  * @access private
  */
 function _elgg_row_to_elgg_river_item($row) {
-	if (!($row instanceof stdClass)) {
+	if (!($row instanceof \stdClass)) {
 		return null;
 	}
 
-	return new ElggRiverItem($row);
+	return new \ElggRiverItem($row);
 }
 
 /**
@@ -811,7 +811,7 @@ QUERY;
  */
 function _elgg_river_init() {
 	elgg_register_page_handler('activity', '_elgg_river_page_handler');
-	$item = new ElggMenuItem('activity', elgg_echo('activity'), 'activity');
+	$item = new \ElggMenuItem('activity', elgg_echo('activity'), 'activity');
 	elgg_register_menu_item('site', $item);
 
 	elgg_register_widget_type('river_widget', elgg_echo('river:widget:title'), elgg_echo('river:widget:description'));

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -17,7 +17,7 @@ global $SESSION;
 /**
  * Gets Elgg's session object
  *
- * @return ElggSession
+ * @return \ElggSession
  * @since 1.9
  */
 function elgg_get_session() {
@@ -27,7 +27,7 @@ function elgg_get_session() {
 /**
  * Return the current logged in user, or null if no user is logged in.
  *
- * @return ElggUser
+ * @return \ElggUser
  */
 function elgg_get_logged_in_user_entity() {
 	return _elgg_services()->session->getLoggedInUser();
@@ -145,7 +145,7 @@ function elgg_is_admin_user($user_guid) {
  * @access private
  */
 function elgg_authenticate($username, $password) {
-	$pam = new ElggPAM('user');
+	$pam = new \ElggPAM('user');
 	$credentials = array('username' => $username, 'password' => $password);
 	$result = $pam->authenticate($credentials);
 	if (!$result) {
@@ -174,16 +174,16 @@ function pam_auth_userpass(array $credentials = array()) {
 
 	$user = get_user_by_username($credentials['username']);
 	if (!$user) {
-		throw new LoginException(elgg_echo('LoginException:UsernameFailure'));
+		throw new \LoginException(elgg_echo('LoginException:UsernameFailure'));
 	}
 
 	if (check_rate_limit_exceeded($user->guid)) {
-		throw new LoginException(elgg_echo('LoginException:AccountLocked'));
+		throw new \LoginException(elgg_echo('LoginException:AccountLocked'));
 	}
 
 	if ($user->password !== generate_user_password($user, $credentials['password'])) {
 		log_login_failure($user->guid);
-		throw new LoginException(elgg_echo('LoginException:PasswordFailure'));
+		throw new \LoginException(elgg_echo('LoginException:PasswordFailure'));
 	}
 
 	return true;
@@ -200,7 +200,7 @@ function log_login_failure($user_guid) {
 	$user_guid = (int)$user_guid;
 	$user = get_entity($user_guid);
 
-	if (($user_guid) && ($user) && ($user instanceof ElggUser)) {
+	if (($user_guid) && ($user) && ($user instanceof \ElggUser)) {
 		$fails = (int)$user->getPrivateSetting("login_failures");
 		$fails++;
 
@@ -223,7 +223,7 @@ function reset_login_failure_count($user_guid) {
 	$user_guid = (int)$user_guid;
 	$user = get_entity($user_guid);
 
-	if (($user_guid) && ($user) && ($user instanceof ElggUser)) {
+	if (($user_guid) && ($user) && ($user instanceof \ElggUser)) {
 		$fails = (int)$user->getPrivateSetting("login_failures");
 
 		if ($fails) {
@@ -256,7 +256,7 @@ function check_rate_limit_exceeded($user_guid) {
 	$user_guid = (int)$user_guid;
 	$user = get_entity($user_guid);
 
-	if (($user_guid) && ($user) && ($user instanceof ElggUser)) {
+	if (($user_guid) && ($user) && ($user instanceof \ElggUser)) {
 		$fails = (int)$user->getPrivateSetting("login_failures");
 		if ($fails >= $limit) {
 			$cnt = 0;
@@ -283,11 +283,11 @@ function check_rate_limit_exceeded($user_guid) {
  *
  * To customize all cookies, register for the 'init:cookie', 'all' event.
  *
- * @param ElggCookie $cookie The cookie that is being set
+ * @param \ElggCookie $cookie The cookie that is being set
  * @return bool
  * @since 1.9
  */
-function elgg_set_cookie(ElggCookie $cookie) {
+function elgg_set_cookie(\ElggCookie $cookie) {
 	if (elgg_trigger_event('init:cookie', $cookie->name, $cookie)) {
 		return setcookie($cookie->name, $cookie->value, $cookie->expire, $cookie->path,
 						$cookie->domain, $cookie->secure, $cookie->httpOnly);
@@ -296,27 +296,27 @@ function elgg_set_cookie(ElggCookie $cookie) {
 }
 
 /**
- * Logs in a specified ElggUser. For standard registration, use in conjunction
+ * Logs in a specified \ElggUser. For standard registration, use in conjunction
  * with elgg_authenticate.
  *
  * @see elgg_authenticate
  *
- * @param ElggUser $user       A valid Elgg user object
- * @param boolean  $persistent Should this be a persistent login?
+ * @param \ElggUser $user       A valid Elgg user object
+ * @param boolean   $persistent Should this be a persistent login?
  *
  * @return true or throws exception
  * @throws LoginException
  */
-function login(ElggUser $user, $persistent = false) {
+function login(\ElggUser $user, $persistent = false) {
 	if ($user->isBanned()) {
-		throw new LoginException(elgg_echo('LoginException:BannedUser'));
+		throw new \LoginException(elgg_echo('LoginException:BannedUser'));
 	}
 
 	$session = _elgg_services()->session;
 
 	// give plugins a chance to reject the login of this user (no user in session!)
 	if (!elgg_trigger_before_event('login', 'user', $user)) {
-		throw new LoginException(elgg_echo('LoginException:Unknown'));
+		throw new \LoginException(elgg_echo('LoginException:Unknown'));
 	}
 
 	// #5933: set logged in user early so code in login event will be able to
@@ -328,7 +328,7 @@ function login(ElggUser $user, $persistent = false) {
 	$version = "1.9";
 	if (!elgg_trigger_deprecated_event('login', 'user', $user, $message, $version)) {
 		$session->removeLoggedInUser();
-		throw new LoginException(elgg_echo('LoginException:Unknown'));
+		throw new \LoginException(elgg_echo('LoginException:Unknown'));
 	}
 
 	// if remember me checked, set cookie with token and store hash(token) for user
@@ -429,7 +429,7 @@ function _elgg_session_boot() {
 
 	// initialize the deprecated global session wrapper
 	global $SESSION;
-	$SESSION = new Elgg_DeprecationWrapper($session, "\$SESSION is deprecated", 1.9);
+	$SESSION = new \Elgg\DeprecationWrapper($session, "\$SESSION is deprecated", 1.9);
 
 	// logout a user with open session who has been banned
 	$user = $session->getLoggedInUser();

--- a/engine/lib/sites.php
+++ b/engine/lib/sites.php
@@ -8,11 +8,11 @@
  */
 
 /**
- * Get an ElggSite entity (default is current site)
+ * Get an \ElggSite entity (default is current site)
  *
  * @param int $site_guid Optional. Site GUID.
  *
- * @return ElggSite
+ * @return \ElggSite
  * @since 1.8.0
  */
 function elgg_get_site_entity($site_guid = 0) {
@@ -26,7 +26,7 @@ function elgg_get_site_entity($site_guid = 0) {
 		$site = get_entity($site_guid);
 	}
 	
-	if ($site instanceof ElggSite) {
+	if ($site instanceof \ElggSite) {
 		$result = $site;
 	}
 

--- a/engine/lib/system_log.php
+++ b/engine/lib/system_log.php
@@ -129,7 +129,7 @@ function get_log_entry($entry_id) {
 /**
  * Return the object referred to by a given log entry
  *
- * @param stdClass|int $entry The log entry row or its ID
+ * @param \stdClass|int $entry The log entry row or its ID
  *
  * @return mixed
  */
@@ -192,7 +192,7 @@ function system_log($object, $event) {
 
 	if ($object instanceof Loggable) {
 
-		/* @var ElggEntity|ElggExtender $object */
+		/* @var \ElggEntity|\ElggExtender $object */
 		if (datalist_get('version') < 2012012000) {
 			// this is a site that doesn't have the ip_address column yet
 			return;

--- a/engine/lib/upgrades/2010033101.php
+++ b/engine/lib/upgrades/2010033101.php
@@ -63,7 +63,7 @@ if ($dbversion < 2009100701) {
 
 		foreach ($qs as $q) {
 			if (!update_data($q)) {
-				throw new Exception('Couldn\'t execute upgrade query: ' . $q);
+				throw new \Exception('Couldn\'t execute upgrade query: ' . $q);
 			}
 		}
 	}

--- a/engine/lib/upgrades/2010061501.php
+++ b/engine/lib/upgrades/2010061501.php
@@ -41,7 +41,7 @@ if ($dbversion < 2009100701) {
 
 		foreach ($qs as $q) {
 			if (!update_data($q)) {
-				throw new Exception('Couldn\'t execute upgrade query: ' . $q);
+				throw new \Exception('Couldn\'t execute upgrade query: ' . $q);
 			}
 		}
 

--- a/engine/lib/upgrades/2011010101.php
+++ b/engine/lib/upgrades/2011010101.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Migrate plugins to the new system using ElggPlugin and private settings
+ * Migrate plugins to the new system using \ElggPlugin and private settings
  */
 
 $old_ia = elgg_set_ignore_access(true);

--- a/engine/lib/upgrades/2011030700-1.8_svn-blog_status_metadata-4645225d7b440876.php
+++ b/engine/lib/upgrades/2011030700-1.8_svn-blog_status_metadata-4645225d7b440876.php
@@ -12,7 +12,7 @@ $options = array(
 	'subtype' => 'blog',
 	'limit' => 0,
 );
-$batch = new ElggBatch('elgg_get_entities', $options);
+$batch = new \ElggBatch('elgg_get_entities', $options);
 
 foreach ($batch as $entity) {
 	if (!$entity->status) {

--- a/engine/lib/upgrades/2011061200-1.8b1-sites_need_a_site_guid-6d9dcbf46c0826cc.php
+++ b/engine/lib/upgrades/2011061200-1.8b1-sites_need_a_site_guid-6d9dcbf46c0826cc.php
@@ -18,7 +18,7 @@ $options = array(
 	'site_guid' => 0,
 	'limit' => 0,
 );
-$batch = new ElggBatch('elgg_get_entities', $options);
+$batch = new \ElggBatch('elgg_get_entities', $options);
 
 foreach ($batch as $entity) {
 	if (!$entity->site_guid) {

--- a/engine/lib/upgrades/2011123101-1.8.2-fix_blog_status-b14c2a0e7b9e7d55.php
+++ b/engine/lib/upgrades/2011123101-1.8.2-fix_blog_status-b14c2a0e7b9e7d55.php
@@ -13,7 +13,7 @@ $options = array(
 	'subtype' => 'blog',
 	'limit' => 0,
 );
-$batch = new ElggBatch('elgg_get_entities', $options);
+$batch = new \ElggBatch('elgg_get_entities', $options);
 
 foreach ($batch as $entity) {
 	if (!$entity->status) {

--- a/engine/lib/upgrades/2013010400-1.9.0_dev-comments_to_entities-faba94768b055b08.php
+++ b/engine/lib/upgrades/2013010400-1.9.0_dev-comments_to_entities-faba94768b055b08.php
@@ -5,7 +5,7 @@
  *
  * Convert comment annotations to entities.
  *
- * Register comment subtype and add ElggUpgrade for ajax upgrade.
+ * Register comment subtype and add \ElggUpgrade for ajax upgrade.
  * 
  * We do not migrate comments in this upgrade. See the comment
  * upgrade action in actions/admin/upgrades/upgrade_comments.php for that.
@@ -22,7 +22,7 @@ $access_status = access_get_show_hidden_status();
 access_show_hidden_entities(true);
 $ia = elgg_set_ignore_access(true);
 
-// add ElggUpgrade object if need to migrate comments
+// add \ElggUpgrade object if need to migrate comments
 $options = array(
 	'annotation_names' => 'generic_comment',
 	'order_by' => 'n_table.id DESC',
@@ -31,7 +31,7 @@ $options = array(
 
 if (elgg_get_annotations($options)) {
 	$url = "admin/upgrades/comments";
-	$upgrade = new ElggUpgrade();
+	$upgrade = new \ElggUpgrade();
 
 	// Create the upgrade if one with the same URL doesn't already exist
 	if (!$upgrade->getUpgradeFromURL($url)) {

--- a/engine/lib/upgrades/2013022000-1.9.0-datadir_dates_to_guids-efb02ff11b9d6444.php
+++ b/engine/lib/upgrades/2013022000-1.9.0-datadir_dates_to_guids-efb02ff11b9d6444.php
@@ -10,7 +10,7 @@
  * See file actions/admin/upgrades/upgrade_comments.php for details.
  */
 
-$upgrade = new ElggUpgrade();
+$upgrade = new \ElggUpgrade();
 $url = "admin/upgrades/datadirs";
 
 // Create the upgrade if one with the same URL doesn't already exist

--- a/engine/lib/upgrades/2013030600-1.8.13-update_user_location-8999eb8bf1bdd9a3.php
+++ b/engine/lib/upgrades/2013030600-1.8.13-update_user_location-8999eb8bf1bdd9a3.php
@@ -14,7 +14,7 @@ $options = array(
 	'metadata_name' => 'location',
 	'limit' => 0,
 );
-$batch = new ElggBatch('elgg_get_entities_from_metadata', $options);
+$batch = new \ElggBatch('elgg_get_entities_from_metadata', $options);
 
 foreach ($batch as $entity) {
 	if (is_array($entity->location)) {

--- a/engine/lib/upgrades/2014031100-1.9.0_dev-elgg_upgrade_object-5577af53c93abd1a.php
+++ b/engine/lib/upgrades/2014031100-1.9.0_dev-elgg_upgrade_object-5577af53c93abd1a.php
@@ -3,7 +3,7 @@
  * Elgg 1.9.0-dev upgrade 2014031100
  * elgg_upgrade_object
  *
- * Registers an ElggUpgrade object.
+ * Registers an \ElggUpgrade object.
  */
 
 if (get_subtype_id('object', 'elgg_upgrade')) {

--- a/engine/lib/upgrades/2014032200-1.9.0_dev-tinymce_to_ck-bbd2daa1912deaef.php
+++ b/engine/lib/upgrades/2014032200-1.9.0_dev-tinymce_to_ck-bbd2daa1912deaef.php
@@ -9,9 +9,9 @@
 
 $tiny = elgg_get_plugin_from_id('tinymce');
 
-if ($tiny instanceof ElggPlugin && $tiny->isActive()) {
+if ($tiny instanceof \ElggPlugin && $tiny->isActive()) {
 	$ck = elgg_get_plugin_from_id('ckeditor');
-	if ($ck instanceof ElggPlugin) {
+	if ($ck instanceof \ElggPlugin) {
 		$ck->activate();
 	}
 

--- a/engine/lib/upgrades/2014050600-1.9.0_dev-replies_to_entities-094ea0e36bc027d3.php
+++ b/engine/lib/upgrades/2014050600-1.9.0_dev-replies_to_entities-094ea0e36bc027d3.php
@@ -3,7 +3,7 @@
  * Elgg 1.9.0-dev upgrade 2014050600
  * replies_to_entities
  *
- * Registers discussion reply subtype and adds ElggUpgrade for ajax upgrade.
+ * Registers discussion reply subtype and adds \ElggUpgrade for ajax upgrade.
  *
  * We do not migrate discussion replies in this upgrade. See the upgrade action
  * in actions/admin/upgrades/upgrade_discussion_replies.php for that.
@@ -33,7 +33,7 @@ $discussion_replies = elgg_get_annotations(array(
 // Notify administrator only if there are existing discussion replies
 if ($discussion_replies) {
 	$url = "admin/upgrades/discussion_replies";
-	$upgrade = new ElggUpgrade();
+	$upgrade = new \ElggUpgrade();
 
 	// Create the upgrade if one with the same URL doesn't already exist
 	if (!$upgrade->getUpgradeFromURL($url)) {

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -18,7 +18,7 @@ $USERNAME_TO_GUID_MAP_CACHE = array();
 /**
  * Return the user specific details of a user by a row.
  *
- * @param int $guid The ElggUser guid
+ * @param int $guid The \ElggUser guid
  *
  * @return mixed
  * @access private
@@ -71,7 +71,7 @@ function ban_user($user_guid, $reason = "") {
 
 	$user = get_entity($user_guid);
 
-	if (($user) && ($user->canEdit()) && ($user instanceof ElggUser)) {
+	if (($user) && ($user->canEdit()) && ($user instanceof \ElggUser)) {
 		if (elgg_trigger_event('ban', 'user', $user)) {
 			// Add reason
 			if ($reason) {
@@ -81,7 +81,7 @@ function ban_user($user_guid, $reason = "") {
 			// invalidate memcache for this user
 			static $newentity_cache;
 			if ((!$newentity_cache) && (is_memcache_available())) {
-				$newentity_cache = new ElggMemcache('new_entity_cache');
+				$newentity_cache = new \ElggMemcache('new_entity_cache');
 			}
 
 			if ($newentity_cache) {
@@ -113,14 +113,14 @@ function unban_user($user_guid) {
 
 	$user = get_entity($user_guid);
 
-	if (($user) && ($user->canEdit()) && ($user instanceof ElggUser)) {
+	if (($user) && ($user->canEdit()) && ($user instanceof \ElggUser)) {
 		if (elgg_trigger_event('unban', 'user', $user)) {
 			create_metadata($user_guid, 'ban_reason', '', '', 0, ACCESS_PUBLIC);
 
 			// invalidate memcache for this user
 			static $newentity_cache;
 			if ((!$newentity_cache) && (is_memcache_available())) {
-				$newentity_cache = new ElggMemcache('new_entity_cache');
+				$newentity_cache = new \ElggMemcache('new_entity_cache');
 			}
 
 			if ($newentity_cache) {
@@ -150,13 +150,13 @@ function make_user_admin($user_guid) {
 
 	$user = get_entity((int)$user_guid);
 
-	if (($user) && ($user instanceof ElggUser) && ($user->canEdit())) {
+	if (($user) && ($user instanceof \ElggUser) && ($user->canEdit())) {
 		if (elgg_trigger_event('make_admin', 'user', $user)) {
 
 			// invalidate memcache for this user
 			static $newentity_cache;
 			if ((!$newentity_cache) && (is_memcache_available())) {
-				$newentity_cache = new ElggMemcache('new_entity_cache');
+				$newentity_cache = new \ElggMemcache('new_entity_cache');
 			}
 
 			if ($newentity_cache) {
@@ -186,13 +186,13 @@ function remove_user_admin($user_guid) {
 
 	$user = get_entity((int)$user_guid);
 
-	if (($user) && ($user instanceof ElggUser) && ($user->canEdit())) {
+	if (($user) && ($user instanceof \ElggUser) && ($user->canEdit())) {
 		if (elgg_trigger_event('remove_admin', 'user', $user)) {
 
 			// invalidate memcache for this user
 			static $newentity_cache;
 			if ((!$newentity_cache) && (is_memcache_available())) {
-				$newentity_cache = new ElggMemcache('new_entity_cache');
+				$newentity_cache = new \ElggMemcache('new_entity_cache');
 			}
 
 			if ($newentity_cache) {
@@ -213,11 +213,11 @@ function remove_user_admin($user_guid) {
 /**
  * Get a user object from a GUID.
  *
- * This function returns an ElggUser from a given GUID.
+ * This function returns an \ElggUser from a given GUID.
  *
  * @param int $guid The GUID
  *
- * @return ElggUser|false
+ * @return \ElggUser|false
  */
 function get_user($guid) {
 	// Fixes "Exception thrown without stack frame" when db_select fails
@@ -225,7 +225,7 @@ function get_user($guid) {
 		$result = get_entity($guid);
 	}
 
-	if ((!empty($result)) && (!($result instanceof ElggUser))) {
+	if ((!empty($result)) && (!($result instanceof \ElggUser))) {
 		return false;
 	}
 
@@ -241,7 +241,7 @@ function get_user($guid) {
  *
  * @param string $username The user's username
  *
- * @return ElggUser|false Depending on success
+ * @return \ElggUser|false Depending on success
  */
 function get_user_by_username($username) {
 	global $CONFIG, $USERNAME_TO_GUID_MAP_CACHE;
@@ -279,7 +279,7 @@ function get_user_by_username($username) {
  *
  * @param string $hash Hash of the persistent login password
  *
- * @return ElggUser
+ * @return \ElggUser
  */
 function get_user_by_code($hash) {
 	_elgg_services()->persistentLogin->getUserFromHash($hash);
@@ -322,7 +322,7 @@ function get_user_by_email($email) {
  * @param int   $offset  Offset (deprecated usage, use $options)
  * @param bool  $count   Count (deprecated usage, use $options)
  *
- * @return ElggUser[]|int
+ * @return \ElggUser[]|int
  */
 function find_active_users($options = array(), $limit = 10, $offset = 0, $count = false) {
 
@@ -387,7 +387,7 @@ function send_new_password_request($user_guid) {
 	$user_guid = (int)$user_guid;
 
 	$user = get_entity($user_guid);
-	if ($user instanceof ElggUser) {
+	if ($user instanceof \ElggUser) {
 		// generate code
 		$code = generate_random_cleartext_password();
 		$user->setPrivateSetting('passwd_conf_code', $code);
@@ -419,7 +419,7 @@ function send_new_password_request($user_guid) {
  */
 function force_user_password_reset($user_guid, $password) {
 	$user = get_entity($user_guid);
-	if ($user instanceof ElggUser) {
+	if ($user instanceof \ElggUser) {
 		$ia = elgg_set_ignore_access();
 
 		$user->salt = _elgg_generate_password_salt();
@@ -498,7 +498,7 @@ function execute_new_password_request($user_guid, $conf_code, $password = null) 
  * @return string
  */
 function generate_random_cleartext_password() {
-	return _elgg_services()->crypto->getRandomString(12, ElggCrypto::CHARS_PASSWORD);
+	return _elgg_services()->crypto->getRandomString(12, \ElggCrypto::CHARS_PASSWORD);
 }
 
 /**
@@ -514,12 +514,12 @@ function _elgg_generate_password_salt() {
 /**
  * Hash a password for storage. Currently salted MD5.
  *
- * @param ElggUser $user     The user this is being generated for.
- * @param string   $password Password in clear text
+ * @param \ElggUser $user     The user this is being generated for.
+ * @param string    $password Password in clear text
  *
  * @return string
  */
-function generate_user_password(ElggUser $user, $password) {
+function generate_user_password(\ElggUser $user, $password) {
 	return md5($password . $user->salt);
 }
 
@@ -543,13 +543,13 @@ function validate_username($username) {
 
 	if (strlen($username) < $CONFIG->minusername) {
 		$msg = elgg_echo('registration:usernametooshort', array($CONFIG->minusername));
-		throw new RegistrationException($msg);
+		throw new \RegistrationException($msg);
 	}
 	
 	// username in the database has a limit of 128 characters
 	if (strlen($username) > 128) {
 		$msg = elgg_echo('registration:usernametoolong', array(128));
-		throw new RegistrationException($msg);
+		throw new \RegistrationException($msg);
 	}
 
 	// Blacklist for bad characters (partially nicked from mediawiki)
@@ -564,7 +564,7 @@ function validate_username($username) {
 
 	if (preg_match($blacklist, $username)) {
 		// @todo error message needs work
-		throw new RegistrationException(elgg_echo('registration:invalidchars'));
+		throw new \RegistrationException(elgg_echo('registration:invalidchars'));
 	}
 
 	// Belts and braces
@@ -575,7 +575,7 @@ function validate_username($username) {
 		if (strpos($username, $blacklist2[$n]) !== false) {
 			$msg = elgg_echo('registration:invalidchars', array($blacklist2[$n], $blacklist2));
 			$msg = htmlspecialchars($msg, ENT_QUOTES, 'UTF-8');
-			throw new RegistrationException($msg);
+			throw new \RegistrationException($msg);
 		}
 	}
 
@@ -601,7 +601,7 @@ function validate_password($password) {
 
 	if (strlen($password) < $CONFIG->min_password_length) {
 		$msg = elgg_echo('registration:passwordtooshort', array($CONFIG->min_password_length));
-		throw new RegistrationException($msg);
+		throw new \RegistrationException($msg);
 	}
 
 	$result = true;
@@ -619,7 +619,7 @@ function validate_password($password) {
  */
 function validate_email_address($address) {
 	if (!is_email_address($address)) {
-		throw new RegistrationException(elgg_echo('registration:notemail'));
+		throw new \RegistrationException(elgg_echo('registration:notemail'));
 	}
 
 	// Got here, so lets try a hook (defaulting to ok)
@@ -661,29 +661,29 @@ function register_user($username, $password, $name, $email, $allow_multiple_emai
 	access_show_hidden_entities(true);
 
 	if (!validate_email_address($email)) {
-		throw new RegistrationException(elgg_echo('registration:emailnotvalid'));
+		throw new \RegistrationException(elgg_echo('registration:emailnotvalid'));
 	}
 
 	if (!validate_password($password)) {
-		throw new RegistrationException(elgg_echo('registration:passwordnotvalid'));
+		throw new \RegistrationException(elgg_echo('registration:passwordnotvalid'));
 	}
 
 	if (!validate_username($username)) {
-		throw new RegistrationException(elgg_echo('registration:usernamenotvalid'));
+		throw new \RegistrationException(elgg_echo('registration:usernamenotvalid'));
 	}
 
 	if ($user = get_user_by_username($username)) {
-		throw new RegistrationException(elgg_echo('registration:userexists'));
+		throw new \RegistrationException(elgg_echo('registration:userexists'));
 	}
 
 	if ((!$allow_multiple_emails) && (get_user_by_email($email))) {
-		throw new RegistrationException(elgg_echo('registration:dupeemail'));
+		throw new \RegistrationException(elgg_echo('registration:dupeemail'));
 	}
 
 	access_show_hidden_entities($access_status);
 
 	// Create user
-	$user = new ElggUser();
+	$user = new \ElggUser();
 	$user->username = $username;
 	$user->email = $email;
 	$user->name = $name;
@@ -830,7 +830,7 @@ function set_last_login($user_guid) {
  *
  * @param string   $event       create
  * @param string   $object_type user
- * @param ElggUser $object      User object
+ * @param \ElggUser $object      User object
  *
  * @return void
  * @access private
@@ -866,17 +866,17 @@ function user_avatar_hook($hook, $entity_type, $returnvalue, $params) {
  */
 function elgg_user_hover_menu($hook, $type, $return, $params) {
 	$user = $params['entity'];
-	/* @var ElggUser $user */
+	/* @var \ElggUser $user */
 
 	if (elgg_is_logged_in()) {
 		if (elgg_get_logged_in_user_guid() == $user->guid) {
 			$url = "profile/$user->username/edit";
-			$item = new ElggMenuItem('profile:edit', elgg_echo('profile:edit'), $url);
+			$item = new \ElggMenuItem('profile:edit', elgg_echo('profile:edit'), $url);
 			$item->setSection('action');
 			$return[] = $item;
 
 			$url = "avatar/edit/$user->username";
-			$item = new ElggMenuItem('avatar:edit', elgg_echo('avatar:edit'), $url);
+			$item = new \ElggMenuItem('avatar:edit', elgg_echo('avatar:edit'), $url);
 			$item->setSection('action');
 			$return[] = $item;
 		}
@@ -905,7 +905,7 @@ function elgg_user_hover_menu($hook, $type, $return, $params) {
 		foreach ($actions as $action) {
 			$url = "action/admin/user/$action?guid={$user->guid}";
 			$url = elgg_add_action_tokens_to_url($url);
-			$item = new ElggMenuItem($action, elgg_echo($action), $url);
+			$item = new \ElggMenuItem($action, elgg_echo($action), $url);
 			$item->setSection('admin');
 			$item->setLinkClass('elgg-requires-confirmation');
 
@@ -913,17 +913,17 @@ function elgg_user_hover_menu($hook, $type, $return, $params) {
 		}
 
 		$url = "profile/$user->username/edit";
-		$item = new ElggMenuItem('profile:edit', elgg_echo('profile:edit'), $url);
+		$item = new \ElggMenuItem('profile:edit', elgg_echo('profile:edit'), $url);
 		$item->setSection('admin');
 		$return[] = $item;
 
 		$url = "settings/user/$user->username";
-		$item = new ElggMenuItem('settings:edit', elgg_echo('settings:edit'), $url);
+		$item = new \ElggMenuItem('settings:edit', elgg_echo('settings:edit'), $url);
 		$item->setSection('admin');
 		$return[] = $item;
 
 		$url = "activity/owner/$user->username";
-		$item = new ElggMenuItem('activity:owner', elgg_echo('activity:owner'), $url);
+		$item = new \ElggMenuItem('activity:owner', elgg_echo('activity:owner'), $url);
 		$item->setSection('action');
 		$return[] = $item;
 	}
@@ -951,7 +951,7 @@ function elgg_users_setup_entity_menu($hook, $type, $return, $params) {
 	if (!elgg_instanceof($entity, 'user')) {
 		return $return;
 	}
-	/* @var ElggUser $entity */
+	/* @var \ElggUser $entity */
 
 	if ($entity->isBanned()) {
 		$banned = elgg_echo('banned');
@@ -961,7 +961,7 @@ function elgg_users_setup_entity_menu($hook, $type, $return, $params) {
 			'href' => false,
 			'priority' => 0,
 		);
-		$return = array(ElggMenuItem::factory($options));
+		$return = array(\ElggMenuItem::factory($options));
 	} else {
 		$return = array();
 		if (isset($entity->location)) {
@@ -972,7 +972,7 @@ function elgg_users_setup_entity_menu($hook, $type, $return, $params) {
 				'href' => false,
 				'priority' => 150,
 			);
-			$return[] = ElggMenuItem::factory($options);
+			$return[] = \ElggMenuItem::factory($options);
 		}
 	}
 
@@ -1184,7 +1184,7 @@ function users_init() {
 }
 
 /**
- * Runs unit tests for ElggUser
+ * Runs unit tests for \ElggUser
  *
  * @param string $hook   unit_test
  * @param string $type   system

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -659,7 +659,7 @@ function elgg_view_layout($layout_name, $vars = array()) {
  *                                  'register' (registration order) or a
  *                                  php callback (a compare function for usort)
  *                              handler: string the page handler to build action URLs
- *                              entity: ElggEntity to use to build action URLs
+ *                              entity: \ElggEntity to use to build action URLs
  *                              class: string the class for the entire menu.
  *                              show_section_headers: bool show headers before menu sections.
  *
@@ -683,7 +683,7 @@ function elgg_view_menu($menu_name, array $vars = array()) {
 	// This supports dynamic menus (example: user_hover).
 	$menu = elgg_trigger_plugin_hook('register', "menu:$menu_name", $vars, $menu);
 
-	$builder = new ElggMenuBuilder($menu);
+	$builder = new \ElggMenuBuilder($menu);
 	$vars['menu'] = $builder->getMenu($sort_by);
 	$vars['selected_item'] = $builder->getSelected();
 
@@ -700,12 +700,12 @@ function elgg_view_menu($menu_name, array $vars = array()) {
 /**
  * Render a menu item (usually as a link)
  *
- * @param ElggMenuItem $item The menu item
- * @param array        $vars Options to pass to output/url if a link
+ * @param \ElggMenuItem $item The menu item
+ * @param array         $vars Options to pass to output/url if a link
  * @return string
  * @since 1.9.0
  */
-function elgg_view_menu_item(ElggMenuItem $item, array $vars = array()) {
+function elgg_view_menu_item(\ElggMenuItem $item, array $vars = array()) {
 	if (!isset($vars['class'])) {
 		$vars['class'] = 'elgg-menu-content';
 	}
@@ -750,7 +750,7 @@ function elgg_view_menu_item(ElggMenuItem $item, array $vars = array()) {
  * using the $type/default view.
  *
  * The entity view is called with the following in $vars:
- *  - ElggEntity 'entity' The entity being viewed
+ *  - \ElggEntity 'entity' The entity being viewed
  *
  * Other common view $vars paramters:
  *  - bool 'full_view' Whether to show a full or condensed view. (Default: true)
@@ -759,20 +759,20 @@ function elgg_view_menu_item(ElggMenuItem $item, array $vars = array()) {
  * view and a handler is registered for the entity:annotate.  See https://github.com/Elgg/Elgg/issues/964 and
  * {@link elgg_view_entity_annotations()}.
  *
- * @param ElggEntity $entity The entity to display
- * @param array      $vars   Array of variables to pass to the entity view.
- *                           In Elgg 1.7 and earlier it was the boolean $full_view
- * @param boolean    $bypass If true, will not pass to a custom template handler.
- *                           {@link set_template_handler()}
- * @param boolean    $debug  Complain if views are missing
+ * @param \ElggEntity $entity The entity to display
+ * @param array       $vars   Array of variables to pass to the entity view.
+ *                            In Elgg 1.7 and earlier it was the boolean $full_view
+ * @param boolean     $bypass If true, will not pass to a custom template handler.
+ *                            {@link set_template_handler()}
+ * @param boolean     $debug  Complain if views are missing
  *
  * @return string HTML to display or false
  * @todo The annotation hook might be better as a generic plugin hook to append content.
  */
-function elgg_view_entity(ElggEntity $entity, $vars = array(), $bypass = false, $debug = false) {
+function elgg_view_entity(\ElggEntity $entity, $vars = array(), $bypass = false, $debug = false) {
 
 	// No point continuing if entity is null
-	if (!$entity || !($entity instanceof ElggEntity)) {
+	if (!$entity || !($entity instanceof \ElggEntity)) {
 		return false;
 	}
 
@@ -833,18 +833,18 @@ function elgg_view_entity(ElggEntity $entity, $vars = array(), $bypass = false, 
  * Entities that do not have a defined icon/$type/$subtype view will fall back to using
  * the icon/$type/default view.
  *
- * @param ElggEntity $entity The entity to display
- * @param string     $size   The size: tiny, small, medium, large
- * @param array      $vars   An array of variables to pass to the view. Some possible
- *                           variables are img_class and link_class. See the
- *                           specific icon view for more parameters.
+ * @param \ElggEntity $entity The entity to display
+ * @param string      $size   The size: tiny, small, medium, large
+ * @param array       $vars   An array of variables to pass to the view. Some possible
+ *                            variables are img_class and link_class. See the
+ *                            specific icon view for more parameters.
  *
  * @return string HTML to display or false
  */
-function elgg_view_entity_icon(ElggEntity $entity, $size = 'medium', $vars = array()) {
+function elgg_view_entity_icon(\ElggEntity $entity, $size = 'medium', $vars = array()) {
 
 	// No point continuing if entity is null
-	if (!$entity || !($entity instanceof ElggEntity)) {
+	if (!$entity || !($entity instanceof \ElggEntity)) {
 		return false;
 	}
 
@@ -882,17 +882,17 @@ function elgg_view_entity_icon(ElggEntity $entity, $size = 'medium', $vars = arr
  * @warning annotation/default is not currently defined in core.
  *
  * The annotation view is called with the following in $vars:
- *  - ElggEntity 'annotation' The annotation being viewed.
+ *  - \ElggEntity 'annotation' The annotation being viewed.
  *
- * @param ElggAnnotation $annotation The annotation to display
- * @param array          $vars       Variable array for view.
- * @param bool           $bypass     If true, will not pass to a custom
- *                                   template handler. {@link set_template_handler()}
- * @param bool           $debug      Complain if views are missing
+ * @param \ElggAnnotation $annotation The annotation to display
+ * @param array           $vars       Variable array for view.
+ * @param bool            $bypass     If true, will not pass to a custom
+ *                                    template handler. {@link set_template_handler()}
+ * @param bool            $debug      Complain if views are missing
  *
  * @return string/false Rendered annotation
  */
-function elgg_view_annotation(ElggAnnotation $annotation, array $vars = array(), $bypass = false, $debug = false) {
+function elgg_view_annotation(\ElggAnnotation $annotation, array $vars = array(), $bypass = false, $debug = false) {
 	global $autofeed;
 	$autofeed = true;
 
@@ -1051,14 +1051,14 @@ function elgg_view_annotation_list($annotations, array $vars = array()) {
  *
  * This is called automatically by the framework from {@link elgg_view_entity()}
  *
- * @param ElggEntity $entity    Entity
- * @param bool       $full_view Display full view?
+ * @param \ElggEntity $entity    Entity
+ * @param bool        $full_view Display full view?
  *
  * @return mixed string or false on failure
  * @todo Change the hook name.
  */
-function elgg_view_entity_annotations(ElggEntity $entity, $full_view = true) {
-	if (!($entity instanceof ElggEntity)) {
+function elgg_view_entity_annotations(\ElggEntity $entity, $full_view = true) {
+	if (!($entity instanceof \ElggEntity)) {
 		return false;
 	}
 
@@ -1117,14 +1117,14 @@ function elgg_view_friendly_time($time) {
  * for the comments, $entity_type hook.  The handler is responsible
  * for formatting the comments and the add comment form.
  *
- * @param ElggEntity $entity      The entity to view comments of
- * @param bool       $add_comment Include a form to add comments?
- * @param array      $vars        Variables to pass to comment view
+ * @param \ElggEntity $entity      The entity to view comments of
+ * @param bool        $add_comment Include a form to add comments?
+ * @param array       $vars        Variables to pass to comment view
  *
  * @return string|false Rendered comments or false on failure
  */
 function elgg_view_comments($entity, $add_comment = true, array $vars = array()) {
-	if (!($entity instanceof ElggEntity)) {
+	if (!($entity instanceof \ElggEntity)) {
 		return false;
 	}
 
@@ -1187,13 +1187,13 @@ function elgg_view_module($type, $title, $body, array $vars = array()) {
 /**
  * Renders a human-readable representation of a river item
  *
- * @param ElggRiverItem $item A river item object
- * @param array         $vars An array of variables for the view
+ * @param \ElggRiverItem $item A river item object
+ * @param array          $vars An array of variables for the view
  *
  * @return string returns empty string if could not be rendered
  */
 function elgg_view_river_item($item, array $vars = array()) {
-	if (!($item instanceof ElggRiverItem)) {
+	if (!($item instanceof \ElggRiverItem)) {
 		return '';
 	}
 	// checking default viewtype since some viewtypes do not have unique views per item (rss)
@@ -1214,7 +1214,7 @@ function elgg_view_river_item($item, array $vars = array()) {
 	// see https://github.com/elgg/elgg/issues/4789
 	//	else {
 	//		// hide based on object's container
-	//		$visibility = Elgg_GroupItemVisibility::factory($object->container_guid);
+	//		$visibility = \Elgg\GroupItemVisibility::factory($object->container_guid);
 	//		if ($visibility->shouldHideItems) {
 	//			return '';
 	//		}
@@ -1317,7 +1317,7 @@ function elgg_view_tagcloud(array $options = array()) {
 /**
  * View an item in a list
  *
- * @param ElggEntity|ElggAnnotation $item
+ * @param \ElggEntity|\ElggAnnotation $item
  * @param array  $vars Additional parameters for the rendering
  *
  * @return string
@@ -1480,7 +1480,7 @@ function _elgg_views_minify($hook, $type, $content, $params) {
  * @access private
  */
 function _elgg_views_amd($hook, $type, $content, $params) {
-	$filter = new Elgg_Amd_ViewFilter();
+	$filter = new \Elgg\Amd\ViewFilter();
 	return $filter->filter($params['view'], $content);
 }
 

--- a/engine/lib/widgets.php
+++ b/engine/lib/widgets.php
@@ -17,7 +17,7 @@
  * @param int    $owner_guid The owner GUID of the layout
  * @param string $context    The context (profile, dashboard, etc)
  *
- * @return array An 2D array of ElggWidget objects
+ * @return array An 2D array of \ElggWidget objects
  * @since 1.8.0
  */
 function elgg_get_widgets($owner_guid, $context) {
@@ -108,7 +108,7 @@ function elgg_is_widget_type($handler) {
 /**
  * Get the widget types for a context
  *
- * The widget types are stdClass objects.
+ * The widget types are \stdClass objects.
  *
  * @param string $context The widget context or empty string for current context
  * @param bool   $exact   Only return widgets registered for this context (false)
@@ -214,7 +214,7 @@ function _elgg_default_widgets_init() {
  *
  * @param string $event  The event
  * @param string $type   The type of object
- * @param ElggEntity $entity The entity being created
+ * @param \ElggEntity $entity The entity being created
  * @return void
  * @access private
  */
@@ -250,7 +250,7 @@ function _elgg_create_default_widgets($event, $type, $entity) {
 				);
 
 				$widgets = elgg_get_entities_from_private_settings($options);
-				/* @var ElggWidget[] $widgets */
+				/* @var \ElggWidget[] $widgets */
 
 				foreach ($widgets as $widget) {
 					// change the container and owner

--- a/engine/settings.example.php
+++ b/engine/settings.example.php
@@ -16,7 +16,7 @@
 
 global $CONFIG;
 if (!isset($CONFIG)) {
-	$CONFIG = new stdClass;
+	$CONFIG = new \stdClass;
 }
 
 /*

--- a/engine/start.php
+++ b/engine/start.php
@@ -35,11 +35,11 @@ $START_MICROTIME = microtime(true);
  *
  * @see elgg_get_config()
  * @see engine/settings.php
- * @global stdClass $CONFIG
+ * @global \stdClass $CONFIG
  */
 global $CONFIG;
 if (!isset($CONFIG)) {
-	$CONFIG = new stdClass;
+	$CONFIG = new \stdClass;
 }
 $CONFIG->boot_complete = false;
 

--- a/engine/tests/ElggAnnotationTest.php
+++ b/engine/tests/ElggAnnotationTest.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * test ElggAnnotation
+ * test \ElggAnnotation
  *
  * @package Elgg
  * @subpackage Test
  */
-class ElggAnnotationTest extends ElggCoreUnitTest {
+class ElggAnnotationTest extends \ElggCoreUnitTest {
 
 	/**
-	 * @var ElggEntity
+	 * @var \ElggEntity
 	 */
 	protected $entity;
 
@@ -17,9 +17,9 @@ class ElggAnnotationTest extends ElggCoreUnitTest {
 	 */
 	public function setUp() {
 		$this->original_hooks = _elgg_services()->hooks;
-		_elgg_services()->hooks = new Elgg_PluginHooksService();
+		_elgg_services()->hooks = new \Elgg\PluginHooksService();
 
-		$this->entity = new ElggObject();
+		$this->entity = new \ElggObject();
 		$this->entity->subtype = 'elgg_annotation_test';
 		$this->entity->access_id = ACCESS_PUBLIC;
 		$this->entity->save();
@@ -36,7 +36,7 @@ class ElggAnnotationTest extends ElggCoreUnitTest {
 	}
 
 	public function testCanEdit() {
-		$user = new ElggUser();
+		$user = new \ElggUser();
 		$user->save();
 
 		$id = $this->entity->annotate('test', 'foo', ACCESS_LOGGED_IN, elgg_get_logged_in_user_guid());

--- a/engine/tests/ElggBatchTest.php
+++ b/engine/tests/ElggBatchTest.php
@@ -1,10 +1,10 @@
 <?php
 
 /**
- * test ElggBatch
+ * test \ElggBatch
  *
  */
-class ElggBatchTest extends ElggCoreUnitTest {
+class ElggBatchTest extends \ElggCoreUnitTest {
 
 	// see https://github.com/elgg/elgg/issues/4288
 	public function testElggBatchIncOffset() {
@@ -13,7 +13,7 @@ class ElggBatchTest extends ElggCoreUnitTest {
 			'offset' => 0,
 			'limit' => 11
 		);
-		$batch = new ElggBatch(array('ElggBatchTest', 'elgg_batch_callback_test'), $options,
+		$batch = new \ElggBatch(array('\ElggBatchTest', 'elgg_batch_callback_test'), $options,
 				null, 5);
 		$j = 0;
 		foreach ($batch as $e) {
@@ -26,12 +26,12 @@ class ElggBatchTest extends ElggCoreUnitTest {
 		$this->assertEqual(11, $j);
 
 		// no increment, 0 start
-		ElggBatchTest::elgg_batch_callback_test(array(), true);
+		\ElggBatchTest::elgg_batch_callback_test(array(), true);
 		$options = array(
 			'offset' => 0,
 			'limit' => 11
 		);
-		$batch = new ElggBatch(array('ElggBatchTest', 'elgg_batch_callback_test'), $options,
+		$batch = new \ElggBatch(array('\ElggBatchTest', 'elgg_batch_callback_test'), $options,
 				null, 5);
 		$batch->setIncrementOffset(false);
 
@@ -45,12 +45,12 @@ class ElggBatchTest extends ElggCoreUnitTest {
 		$this->assertEqual(11, $j);
 
 		// no increment, 3 start
-		ElggBatchTest::elgg_batch_callback_test(array(), true);
+		\ElggBatchTest::elgg_batch_callback_test(array(), true);
 		$options = array(
 			'offset' => 3,
 			'limit' => 11
 		);
-		$batch = new ElggBatch(array('ElggBatchTest', 'elgg_batch_callback_test'), $options,
+		$batch = new \ElggBatch(array('\ElggBatchTest', 'elgg_batch_callback_test'), $options,
 				null, 5);
 		$batch->setIncrementOffset(false);
 
@@ -69,7 +69,7 @@ class ElggBatchTest extends ElggCoreUnitTest {
 		$num_test_entities = 8;
 		$guids = array();
 		for ($i = $num_test_entities; $i > 0; $i--) {
-			$entity = new ElggObject();
+			$entity = new \ElggObject();
 			$entity->type = 'object';
 			$entity->subtype = 'test_5357_subtype';
 			$entity->access_id = ACCESS_PUBLIC;
@@ -93,8 +93,8 @@ class ElggBatchTest extends ElggCoreUnitTest {
 		);
 
 		$entities_visited = array();
-		$batch = new ElggBatch('elgg_get_entities', $options, null, 2);
-		/* @var ElggEntity[] $batch */
+		$batch = new \ElggBatch('elgg_get_entities', $options, null, 2);
+		/* @var \ElggEntity[] $batch */
 		foreach ($batch as $entity) {
 			$entities_visited[] = $entity->guid;
 		}
@@ -120,7 +120,7 @@ class ElggBatchTest extends ElggCoreUnitTest {
 		$num_test_entities = 8;
 		$guids = array();
 		for ($i = $num_test_entities; $i > 0; $i--) {
-			$entity = new ElggObject();
+			$entity = new \ElggObject();
 			$entity->type = 'object';
 			$entity->subtype = 'test_5357_subtype';
 			$entity->access_id = ACCESS_PUBLIC;
@@ -144,8 +144,8 @@ class ElggBatchTest extends ElggCoreUnitTest {
 		);
 
 		$entities_visited = array();
-		$batch = new ElggBatch('elgg_get_entities', $options, null, 2, false);
-		/* @var ElggEntity[] $batch */
+		$batch = new \ElggBatch('elgg_get_entities', $options, null, 2, false);
+		/* @var \ElggEntity[] $batch */
 		foreach ($batch as $entity) {
 			$entities_visited[] = $entity->guid;
 			$entity->delete();

--- a/engine/tests/ElggCoreAccessCollectionsTest.php
+++ b/engine/tests/ElggCoreAccessCollectionsTest.php
@@ -5,7 +5,7 @@
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreAccessCollectionsTest extends ElggCoreUnitTest {
+class ElggCoreAccessCollectionsTest extends \ElggCoreUnitTest {
 
 	/**
 	 * Called before each test object.
@@ -15,7 +15,7 @@ class ElggCoreAccessCollectionsTest extends ElggCoreUnitTest {
 
 		$this->dbPrefix = get_config("dbprefix");
 
-		$user = new ElggUser();
+		$user = new \ElggUser();
 		$user->username = 'test_user_' . rand();
 		$user->email = 'fake_email@fake.com' . rand();
 		$user->name = 'fake user';
@@ -78,7 +78,7 @@ class ElggCoreAccessCollectionsTest extends ElggCoreUnitTest {
 
 	public function testUpdateACL() {
 		// another fake user to test with
-		$user = new ElggUser();
+		$user = new \ElggUser();
 		$user->username = 'test_user_' . rand();
 		$user->email = 'fake_email@fake.com' . rand();
 		$user->name = 'fake user';
@@ -197,7 +197,7 @@ class ElggCoreAccessCollectionsTest extends ElggCoreUnitTest {
 			return;
 		}
 		
-		$group = new ElggGroup();
+		$group = new \ElggGroup();
 		$group->name = 'Test group';
 		$group->save();
 		$acl = get_access_collection($group->group_acl);
@@ -219,7 +219,7 @@ class ElggCoreAccessCollectionsTest extends ElggCoreUnitTest {
 			return;
 		}
 
-		$group = new ElggGroup();
+		$group = new \ElggGroup();
 		$group->name = 'Test group';
 		$group->save();
 
@@ -253,7 +253,7 @@ class ElggCoreAccessCollectionsTest extends ElggCoreUnitTest {
 
 	public function testAccessCaching() {
 		// create a new user to check against
-		$user = new ElggUser();
+		$user = new \ElggUser();
 		$user->username = 'access_test_user';
 		$user->save();
 

--- a/engine/tests/ElggCoreAccessSQLTest.php
+++ b/engine/tests/ElggCoreAccessSQLTest.php
@@ -5,9 +5,9 @@
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreAccessSQLTest extends ElggCoreUnitTest {
+class ElggCoreAccessSQLTest extends \ElggCoreUnitTest {
 
-	/** @var ElggUser */
+	/** @var \ElggUser */
 	protected $user;
 	
 	/**
@@ -16,7 +16,7 @@ class ElggCoreAccessSQLTest extends ElggCoreUnitTest {
 	public function __construct() {
 		parent::__construct();
 
-		$this->user = new ElggUser();
+		$this->user = new \ElggUser();
 		$this->user->username = 'fake_user_' . rand();
 		$this->user->email = 'fake_email@fake.com' . rand();
 		$this->user->name = 'fake user ' . rand();
@@ -34,7 +34,7 @@ class ElggCoreAccessSQLTest extends ElggCoreUnitTest {
 	public function setUp() {
 		// Replace current hook service with new instance for each test
 		$this->original_hooks = _elgg_services()->hooks;
-		_elgg_services()->hooks = new Elgg_PluginHooksService();
+		_elgg_services()->hooks = new \Elgg\PluginHooksService();
 	}
 
 	/**
@@ -122,7 +122,7 @@ class ElggCoreAccessSQLTest extends ElggCoreUnitTest {
 
 	public function testLoggedOutUser() {
 		$originalSession = _elgg_services()->session;
-		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
+		_elgg_services()->setValue('session', new \ElggSession(new \Elgg\Http\MockSessionStorage()));
 
 		$sql = _elgg_get_access_where_sql();
 		$access_clause = $this->getLoggedOutAccessListClause('e');

--- a/engine/tests/ElggCoreAnnotationAPITest.php
+++ b/engine/tests/ElggCoreAnnotationAPITest.php
@@ -5,14 +5,14 @@
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreAnnotationAPITest extends ElggCoreUnitTest {
+class ElggCoreAnnotationAPITest extends \ElggCoreUnitTest {
 	protected $metastrings;
 
 	/**
 	 * Called before each test method.
 	 */
 	public function setUp() {
-		$this->object = new ElggObject();
+		$this->object = new \ElggObject();
 	}
 
 	/**
@@ -43,7 +43,7 @@ class ElggCoreAnnotationAPITest extends ElggCoreUnitTest {
 	}
 
 	public function testElggDeleteAnnotations() {
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->save();
 
 		for ($i=0; $i<30; $i++) {
@@ -70,7 +70,7 @@ class ElggCoreAnnotationAPITest extends ElggCoreUnitTest {
 	}
 
 	public function testElggDisableAnnotations() {
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->save();
 
 		for ($i=0; $i<30; $i++) {
@@ -96,7 +96,7 @@ class ElggCoreAnnotationAPITest extends ElggCoreUnitTest {
 	}
 
 	public function testElggEnableAnnotations() {
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->save();
 
 		for ($i=0; $i<30; $i++) {
@@ -124,7 +124,7 @@ class ElggCoreAnnotationAPITest extends ElggCoreUnitTest {
 	}
 
 	public function testElggAnnotationExists() {
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->save();
 		$guid = $e->getGUID();
 

--- a/engine/tests/ElggCoreAttributeLoaderTest.php
+++ b/engine/tests/ElggCoreAttributeLoaderTest.php
@@ -3,7 +3,7 @@
 /**
  * Test attribute loader for entities
  */
-class ElggCoreAttributeLoaderTest extends ElggCoreUnitTest {
+class ElggCoreAttributeLoaderTest extends \ElggCoreUnitTest {
 
 	/**
 	 * Checks if additional select columns are readable as volatile data
@@ -16,7 +16,7 @@ class ElggCoreAttributeLoaderTest extends ElggCoreUnitTest {
 		$access = elgg_set_ignore_access(false);
 
 		// may not have groups in DB but guaranteed to have user, object, site
-		$group = new ElggGroup();
+		$group = new \ElggGroup();
 		$group->name = 'test_group';
 		$group->access_id = ACCESS_PUBLIC;
 		$this->assertTrue($group->save() !== false);
@@ -28,7 +28,7 @@ class ElggCoreAttributeLoaderTest extends ElggCoreUnitTest {
 				'limit' => 1,
 			));
 			$entity = array_shift($entities);
-			$this->assertTrue($entity instanceof ElggEntity);
+			$this->assertTrue($entity instanceof \ElggEntity);
 			$this->assertEqual($entity->added_col2, null, "Additional select columns are leaking to attributes for " . get_class($entity));
 			$this->assertEqual($entity->getVolatileData('select:added_col2'), 42);
 		}
@@ -49,7 +49,7 @@ class ElggCoreAttributeLoaderTest extends ElggCoreUnitTest {
 		$access = elgg_set_ignore_access(false);
 
 		// may not have groups in DB - let's create one
-		$group = new ElggGroup();
+		$group = new \ElggGroup();
 		$group->name = 'test_group';
 		$group->access_id = ACCESS_PUBLIC;
 		$this->assertTrue($group->save() !== false);
@@ -61,7 +61,7 @@ class ElggCoreAttributeLoaderTest extends ElggCoreUnitTest {
 				'limit' => 1,
 			));
 			$entity = array_shift($entities);
-			$this->assertTrue($entity instanceof ElggEntity);
+			$this->assertTrue($entity instanceof \ElggEntity);
 			$this->assertEqual($entity->added_col3, null, "Additional select columns are leaking to attributes for " . get_class($entity));
 			$this->assertEqual($entity->getVolatileData('select:added_col3'), 42);
 
@@ -77,7 +77,7 @@ class ElggCoreAttributeLoaderTest extends ElggCoreUnitTest {
 				'limit' => 1,
 			));
 			$entity = array_shift($entities);
-			$this->assertTrue($entity instanceof ElggEntity);
+			$this->assertTrue($entity instanceof \ElggEntity);
 			$this->assertEqual($entity->added_col3, null, "Additional select columns are leaking to attributes for " . get_class($entity));
 			$this->assertEqual($entity->getVolatileData('select:added_col3'), 64, "Failed to overwrite volatile data in cached entity");
 		}

--- a/engine/tests/ElggCoreConfigTest.php
+++ b/engine/tests/ElggCoreConfigTest.php
@@ -3,12 +3,12 @@
 /**
  * Test configuration for site and application (datalist)
  */
-class ElggCoreConfigTest extends ElggCoreUnitTest {
+class ElggCoreConfigTest extends \ElggCoreUnitTest {
 
 	public function testSetConfigWithTooLongName() {
 		// prevent the error message from being logged
 		$old_log_level = _elgg_services()->logger->getLevel();
-		_elgg_services()->logger->setLevel(Elgg_Logger::OFF);
+		_elgg_services()->logger->setLevel(\Elgg\Logger::OFF);
 
 		$name = '';
 		for ($i = 1; $i <= 256; $i++) {
@@ -40,7 +40,7 @@ class ElggCoreConfigTest extends ElggCoreUnitTest {
 
 	public function testSetConfigWithObject() {
 		$name = 'foo' . rand(0, 1000);
-		$value = new stdClass();
+		$value = new \stdClass();
 		$value->test = true;
 		$this->assertTrue(set_config($name, $value, 22));
 		$this->assertIdentical($value, get_config($name, 22));
@@ -98,7 +98,7 @@ class ElggCoreConfigTest extends ElggCoreUnitTest {
 	public function testDatalistSetWithTooLongName() {
 		// prevent the error message from being logged
 		$old_log_level = _elgg_services()->logger->getLevel();
-		_elgg_services()->logger->setLevel(Elgg_Logger::OFF);
+		_elgg_services()->logger->setLevel(\Elgg\Logger::OFF);
 
 		$name = '';
 		for ($i = 1; $i <= 256; $i++) {

--- a/engine/tests/ElggCoreDatabaseQueueTest.php
+++ b/engine/tests/ElggCoreDatabaseQueueTest.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Elgg_Queue_DatabaseQueue tests
+ * \Elgg\Queue\DatabaseQueue tests
  *
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreDatabaseQueueTest extends ElggCoreUnitTest {
+class ElggCoreDatabaseQueueTest extends \ElggCoreUnitTest {
 
 	public function testEnqueueAndDequeue() {
-		$queue = new Elgg_Queue_DatabaseQueue('unit:test', _elgg_services()->db);
+		$queue = new \Elgg\Queue\DatabaseQueue('unit:test', _elgg_services()->db);
 		$first = array(1, 2, 3);
 		$second = array(4, 5, 6);
 
@@ -29,8 +29,8 @@ class ElggCoreDatabaseQueueTest extends ElggCoreUnitTest {
 	}
 
 	public function testMultipleQueues() {
-		$queue1 = new Elgg_Queue_DatabaseQueue('unit:test1', _elgg_services()->db);
-		$queue2 = new Elgg_Queue_DatabaseQueue('unit:test2', _elgg_services()->db);
+		$queue1 = new \Elgg\Queue\DatabaseQueue('unit:test1', _elgg_services()->db);
+		$queue2 = new \Elgg\Queue\DatabaseQueue('unit:test2', _elgg_services()->db);
 		$first = array(1, 2, 3);
 		$second = array(4, 5, 6);
 
@@ -49,7 +49,7 @@ class ElggCoreDatabaseQueueTest extends ElggCoreUnitTest {
 	}
 
 	public function testClear() {
-		$queue = new Elgg_Queue_DatabaseQueue('unit:test',  _elgg_services()->db);
+		$queue = new \Elgg\Queue\DatabaseQueue('unit:test',  _elgg_services()->db);
 		$first = array(1, 2, 3);
 		$second = array(4, 5, 6);
 

--- a/engine/tests/ElggCoreFilestoreTest.php
+++ b/engine/tests/ElggCoreFilestoreTest.php
@@ -5,13 +5,13 @@
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreFilestoreTest extends ElggCoreUnitTest {
+class ElggCoreFilestoreTest extends \ElggCoreUnitTest {
 
 	/**
 	 * Called before each test method.
 	 */
 	public function setUp() {
-		$this->filestore = new ElggDiskFilestore();
+		$this->filestore = new \ElggDiskFilestore();
 	}
 
 	/**
@@ -26,10 +26,10 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 		
 		// create a user to own the file
 		$user = $this->createTestUser();
-		$dir = new Elgg_EntityDirLocator($user->guid);
+		$dir = new \Elgg\EntityDirLocator($user->guid);
 		
 		// setup a test file
-		$file = new ElggFile();
+		$file = new \ElggFile();
 		$file->owner_guid = $user->guid;
 		$file->setFilename('testing/filestore.txt');
 		$file->open('write');
@@ -53,9 +53,9 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 		
 		$user = $this->createTestUser();
 		$filestore = $this->filestore;
-		$dir = new Elgg_EntityDirLocator($user->guid);
+		$dir = new \Elgg\EntityDirLocator($user->guid);
 		
-		$file = new ElggFile();
+		$file = new \ElggFile();
 		$file->owner_guid = $user->guid;
 		$file->setFilename('testing/ElggFileDelete');
 		$this->assertTrue($file->open('write'));
@@ -74,7 +74,7 @@ class ElggCoreFilestoreTest extends ElggCoreUnitTest {
 	}
 
 	protected function createTestUser($username = 'fileTest') {
-		$user = new ElggUser();
+		$user = new \ElggUser();
 		$user->username = $username;
 		$guid = $user->save();
 		

--- a/engine/tests/ElggCoreGetEntitiesBaseTest.php
+++ b/engine/tests/ElggCoreGetEntitiesBaseTest.php
@@ -3,7 +3,7 @@
 /**
  * Setup entities for getter tests
  */
-abstract class ElggCoreGetEntitiesBaseTest extends ElggCoreUnitTest {
+abstract class ElggCoreGetEntitiesBaseTest extends \ElggCoreUnitTest {
 
 	/** @var array */
 	protected $entities;
@@ -34,7 +34,7 @@ abstract class ElggCoreGetEntitiesBaseTest extends ElggCoreUnitTest {
 		// 5 with random subtypes
 		for ($i=0; $i<5; $i++) {
 			$subtype = 'test_object_subtype_' . rand();
-			$e = new ElggObject();
+			$e = new \ElggObject();
 			$e->subtype = $subtype;
 			$e->save();
 
@@ -45,7 +45,7 @@ abstract class ElggCoreGetEntitiesBaseTest extends ElggCoreUnitTest {
 		// and users
 		for ($i=0; $i<5; $i++) {
 			$subtype = "test_user_subtype_" . rand();
-			$e = new ElggUser();
+			$e = new \ElggUser();
 			$e->username = "test_user_" . rand();
 			$e->subtype = $subtype;
 			$e->save();
@@ -57,7 +57,7 @@ abstract class ElggCoreGetEntitiesBaseTest extends ElggCoreUnitTest {
 		// and groups
 		for ($i=0; $i<5; $i++) {
 			$subtype = "test_group_subtype_" . rand();
-			$e = new ElggGroup();
+			$e = new \ElggGroup();
 			$e->subtype = $subtype;
 			$e->save();
 
@@ -151,7 +151,7 @@ abstract class ElggCoreGetEntitiesBaseTest extends ElggCoreUnitTest {
 	 * Return an array of invalid strings for type or subtypes.
 	 *
 	 * @param int $num
-	 * @return arr
+	 * @return string[]
 	 */
 	protected function getRandomInvalids($num = 1) {
 		$r = array();

--- a/engine/tests/ElggCoreGetEntitiesFromAnnotationsTest.php
+++ b/engine/tests/ElggCoreGetEntitiesFromAnnotationsTest.php
@@ -3,12 +3,12 @@
  * Test elgg_get_entities_from_annotations() and
  * elgg_get_entities_from_annotation_calculation()
  */
-class ElggCoreGetEntitiesFromAnnotationsTest extends ElggCoreGetEntitiesBaseTest {
+class ElggCoreGetEntitiesFromAnnotationsTest extends \ElggCoreGetEntitiesBaseTest {
 
 	/**
 	 * Creates random annotations on $entity
 	 *
-	 * @param ElggEntity $entity
+	 * @param \ElggEntity $entity
 	 * @param int        $max
 	 */
 	protected function createRandomAnnotations($entity, $max = 1) {
@@ -39,13 +39,13 @@ class ElggCoreGetEntitiesFromAnnotationsTest extends ElggCoreGetEntitiesBaseTest
 		$guids = array();
 
 		// our targets
-		$valid = new ElggObject();
+		$valid = new \ElggObject();
 		$valid->subtype = $subtype;
 		$valid->save();
 		$guids[] = $valid->getGUID();
 		create_annotation($valid->getGUID(), $annotation_name, $annotation_value, 'integer', $users[0]->getGUID());
 
-		$valid2 = new ElggObject();
+		$valid2 = new \ElggObject();
 		$valid2->subtype = $subtype;
 		$valid2->save();
 		$guids[] = $valid2->getGUID();

--- a/engine/tests/ElggCoreGetEntitiesFromAttributesTest.php
+++ b/engine/tests/ElggCoreGetEntitiesFromAttributesTest.php
@@ -2,25 +2,25 @@
 /**
  * Test elgg_get_entities_from_attributes()
  */
-class ElggCoreGetEntitiesFromAttributesTest extends ElggCoreGetEntitiesBaseTest {
+class ElggCoreGetEntitiesFromAttributesTest extends \ElggCoreGetEntitiesBaseTest {
 
 	public function testWithoutType() {
-		$this->expectException(new InvalidArgumentException('The entity type must be defined for elgg_get_entities_from_attributes()'));
+		$this->expectException(new \InvalidArgumentException('The entity type must be defined for elgg_get_entities_from_attributes()'));
 		elgg_get_entities_from_attributes();
 	}
 
 	public function testWithMoreThanOneType() {
-		$this->expectException(new InvalidArgumentException('Only one type can be passed to elgg_get_entities_from_attributes()'));
+		$this->expectException(new \InvalidArgumentException('Only one type can be passed to elgg_get_entities_from_attributes()'));
 		elgg_get_entities_from_attributes(array('types' => array('one', 'two')));
 	}
 
 	public function testWithInvalidType() {
-		$this->expectException(new InvalidArgumentException("Invalid type 'test' passed to elgg_get_entities_from_attributes()"));
+		$this->expectException(new \InvalidArgumentException("Invalid type 'test' passed to elgg_get_entities_from_attributes()"));
 		elgg_get_entities_from_attributes(array('type' => 'test'));
 	}
 
 	public function testWithInvalidPair() {
-		$this->expectException(new InvalidArgumentException("attribute_name_value_pairs must be an array for elgg_get_entities_from_attributes()"));
+		$this->expectException(new \InvalidArgumentException("attribute_name_value_pairs must be an array for elgg_get_entities_from_attributes()"));
 		elgg_get_entities_from_attributes(array(
 			'types' => 'object',
 			'attribute_name_value_pairs' => 'invalid',

--- a/engine/tests/ElggCoreGetEntitiesFromMetadataTest.php
+++ b/engine/tests/ElggCoreGetEntitiesFromMetadataTest.php
@@ -2,7 +2,7 @@
 /**
  * Test elgg_get_entities_from_metadata()
  */
-class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
+class ElggCoreGetEntitiesFromMetadataTest extends \ElggCoreGetEntitiesBaseTest {
 
 	//names
 	function testElggApiGettersEntityMetadataNameValidSingle() {
@@ -13,7 +13,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$md_name = 'test_metadata_name_' . rand();
 		$md_value = 'test_metadata_value_' . rand();
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $md_value;
 		$e->save();
@@ -47,7 +47,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$md_names[] = $md_name;
 		$e_guids = array();
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $md_value;
 		$e->save();
@@ -57,7 +57,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$md_value = 'test_metadata_value_' . rand();
 		$md_names[] = $md_name;
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $md_value;
 		$e->save();
@@ -86,7 +86,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$md_name = 'test_metadata_name_' . rand();
 		$md_value = 'test_metadata_value_' . rand();
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $md_value;
 		$e->save();
@@ -112,7 +112,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$md_name = 'test_metadata_name_' . rand();
 		$md_value = 'test_metadata_value_' . rand();
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $md_value;
 		$e->save();
@@ -145,7 +145,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$md_names[] = $md_name;
 		$e_guids = array();
 
-		$valid = new ElggObject();
+		$valid = new \ElggObject();
 		$valid->subtype = $subtype;
 		$valid->$md_name = $md_value;
 		$valid->save();
@@ -157,7 +157,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		// add a random invalid name.
 		$md_names[] = 'test_metadata_name_' . rand();
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $md_value;
 		$e->save();
@@ -195,7 +195,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$md_name = 'test_metadata_name_' . rand();
 		$md_value = 'test_metadata_value_' . rand();
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $md_value;
 		$e->save();
@@ -229,7 +229,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$md_values[] = $md_value;
 		$e_guids = array();
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $md_value;
 		$e->save();
@@ -239,7 +239,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$md_value = 'test_metadata_value_' . rand();
 		$md_values[] = $md_value;
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $md_value;
 		$e->save();
@@ -268,7 +268,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$md_name = 'test_metadata_name_' . rand();
 		$md_value = 'test_metadata_value_' . rand();
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $md_value;
 		$e->save();
@@ -294,7 +294,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$md_name = 'test_metadata_name_' . rand();
 		$md_value = 'test_metadata_value_' . rand();
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $md_value;
 		$e->save();
@@ -327,7 +327,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$md_values[] = $md_value;
 		$e_guids = array();
 
-		$valid = new ElggObject();
+		$valid = new \ElggObject();
 		$valid->subtype = $subtype;
 		$valid->$md_name = $md_value;
 		$valid->save();
@@ -339,7 +339,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		// add a random invalid value.
 		$md_values[] = 'test_metadata_value_' . rand();
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $md_value;
 		$e->save();
@@ -379,7 +379,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$guids = array();
 
 		// our target
-		$valid = new ElggObject();
+		$valid = new \ElggObject();
 		$valid->subtype = $subtype;
 		$valid->$md_name = $md_value;
 		$valid->save();
@@ -387,14 +387,14 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 
 		// make some bad ones
 		$invalid_md_name = 'test_metadata_name_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$invalid_md_name = $md_value;
 		$e->save();
 		$guids[] = $e->getGUID();
 
 		$invalid_md_value = 'test_metadata_value_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $invalid_md_value;
 		$e->save();
@@ -444,7 +444,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$guids = array();
 
 		// our target
-		$valid = new ElggObject();
+		$valid = new \ElggObject();
 		$valid->subtype = $subtype;
 		$valid->$md_name = $md_value;
 		$valid->$md_name2 = $md_value2;
@@ -456,7 +456,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$invalid_md_name = 'test_metadata_name_' . rand();
 		$invalid_md_name2 = 'test_metadata_name_' . rand();
 		$invalid_md_name3 = 'test_metadata_name_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$invalid_md_name = $md_value;
 		$e->$invalid_md_name2 = $md_value2;
@@ -465,7 +465,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$guids[] = $e->getGUID();
 
 		$invalid_md_value = 'test_metadata_value_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $invalid_md_value;
 		$e->$md_name2 = $invalid_md_value;
@@ -524,7 +524,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$guids = array();
 
 		// our target
-		$valid = new ElggObject();
+		$valid = new \ElggObject();
 		$valid->subtype = $subtype;
 		$valid->$md_name = $md_value;
 		$valid->$md_name2 = $md_value2;
@@ -534,7 +534,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		// make some bad ones
 		$invalid_md_name = 'test_metadata_name_' . rand();
 		$invalid_md_name2 = 'test_metadata_name_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$invalid_md_name = $md_value;
 		$e->$invalid_md_name2 = $md_value2;
@@ -542,7 +542,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$guids[] = $e->getGUID();
 
 		$invalid_md_value = 'test_metadata_value_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $invalid_md_value;
 		$e->$md_name2 = $invalid_md_value;
@@ -609,7 +609,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$guids = array();
 
 		// our target
-		$valid = new ElggObject();
+		$valid = new \ElggObject();
 		$valid->subtype = $subtype;
 		$valid->$md_name = $md_value;
 		$valid->$md_name2 = $md_value2;
@@ -621,7 +621,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 
 		// make some bad ones
 		$invalid_md_name = 'test_metadata_name_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$invalid_md_name = $md_value;
 		$e->$md_name2 = $md_value2;
@@ -632,7 +632,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$guids[] = $e->getGUID();
 
 		$invalid_md_value = 'test_metadata_value_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $invalid_md_value;
 		$e->$md_name2 = $invalid_md_value;
@@ -701,14 +701,14 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 
 		// make some bad ones
 		$invalid_md_name = 'test_metadata_name_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$invalid_md_name = $md_value;
 		$e->save();
 		$guids[] = $e->getGUID();
 
 		$invalid_md_value = 'test_metadata_value_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $invalid_md_value;
 		$e->save();
@@ -748,14 +748,14 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 
 		// make some bad ones
 		$invalid_md_name = 'test_metadata_name_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$invalid_md_name = $md_value;
 		$e->save();
 		$guids[] = $e->getGUID();
 
 		$invalid_md_value = 'test_metadata_value_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $invalid_md_value;
 		$e->save();
@@ -793,7 +793,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$valid_guids = array();
 
 		// our targets
-		$valid = new ElggObject();
+		$valid = new \ElggObject();
 		$valid->subtype = $subtype;
 		$valid->$md_name = $md_value;
 		$valid->save();
@@ -803,7 +803,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$md_name2 = 'test_metadata_name_' . rand();
 		$md_value2 = 'test_metadata_value_' . rand();
 
-		$valid2 = new ElggObject();
+		$valid2 = new \ElggObject();
 		$valid2->subtype = $subtype;
 		$valid2->$md_name2 = $md_value2;
 		$valid2->save();
@@ -812,14 +812,14 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 
 		// make some bad ones
 		$invalid_md_name = 'test_metadata_name_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$invalid_md_name = $md_value;
 		$e->save();
 		$guids[] = $e->getGUID();
 
 		$invalid_md_value = 'test_metadata_value_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $invalid_md_value;
 		$e->save();
@@ -871,7 +871,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$valid_guids = array();
 
 		// our targets
-		$valid = new ElggObject();
+		$valid = new \ElggObject();
 		$valid->subtype = $subtype;
 		$valid->$md_name = $md_value;
 		$valid->save();
@@ -881,7 +881,7 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$md_name2 = 'test_metadata_name_' . rand();
 		$md_value2 = 'test_metadata_value_' . rand();
 
-		$valid2 = new ElggObject();
+		$valid2 = new \ElggObject();
 		$valid2->subtype = $subtype;
 		$valid2->$md_name2 = $md_value2;
 		$valid2->save();
@@ -890,14 +890,14 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 
 		// make some bad ones
 		$invalid_md_name = 'test_metadata_name_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$invalid_md_name = $md_value;
 		$e->save();
 		$guids[] = $e->getGUID();
 
 		$invalid_md_value = 'test_metadata_value_' . rand();
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->subtype = $subtype;
 		$e->$md_name = $invalid_md_value;
 		$e->save();
@@ -948,21 +948,21 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$valid_guids = array();
 
 		// our targets
-		$valid = new ElggObject();
+		$valid = new \ElggObject();
 		$valid->subtype = $subtype;
 		$valid->$md_name = 1;
 		$valid->save();
 		$guids[] = $valid->getGUID();
 		$valid_guids[] = $valid->getGUID();
 
-		$valid2 = new ElggObject();
+		$valid2 = new \ElggObject();
 		$valid2->subtype = $subtype;
 		$valid2->$md_name = 2;
 		$valid2->save();
 		$guids[] = $valid->getGUID();
 		$valid_guids[] = $valid2->getGUID();
 
-		$valid3 = new ElggObject();
+		$valid3 = new \ElggObject();
 		$valid3->subtype = $subtype;
 		$valid3->$md_name = 3;
 		$valid3->save();
@@ -1006,21 +1006,21 @@ class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
 		$valid_guids = array();
 
 		// our targets
-		$valid = new ElggObject();
+		$valid = new \ElggObject();
 		$valid->subtype = $subtype;
 		$valid->$md_name = 'a';
 		$valid->save();
 		$guids[] = $valid->getGUID();
 		$valid_guids[] = $valid->getGUID();
 
-		$valid2 = new ElggObject();
+		$valid2 = new \ElggObject();
 		$valid2->subtype = $subtype;
 		$valid2->$md_name = 'b';
 		$valid2->save();
 		$guids[] = $valid->getGUID();
 		$valid_guids[] = $valid2->getGUID();
 
-		$valid3 = new ElggObject();
+		$valid3 = new \ElggObject();
 		$valid3->subtype = $subtype;
 		$valid3->$md_name = 'c';
 		$valid3->save();

--- a/engine/tests/ElggCoreGetEntitiesFromPrivateSettingsTest.php
+++ b/engine/tests/ElggCoreGetEntitiesFromPrivateSettingsTest.php
@@ -2,7 +2,7 @@
 /**
  * Test elgg_get_entities_from_private_settings()
  */
-class ElggCoreGetEntitiesFromPrivateSettingsTest extends ElggCoreGetEntitiesBaseTest {
+class ElggCoreGetEntitiesFromPrivateSettingsTest extends \ElggCoreGetEntitiesBaseTest {
 
 	public function testElggApiGettersEntitiesFromPrivateSettings() {
 
@@ -17,14 +17,14 @@ class ElggCoreGetEntitiesFromPrivateSettingsTest extends ElggCoreGetEntitiesBase
 		$guids = array();
 
 		// our targets
-		$valid = new ElggObject();
+		$valid = new \ElggObject();
 		$valid->subtype = $subtype;
 		$valid->save();
 		$guids[] = $valid->getGUID();
 		set_private_setting($valid->getGUID(), $setting_name, $setting_value);
 		set_private_setting($valid->getGUID(), $setting_name2, $setting_value2);
 
-		$valid2 = new ElggObject();
+		$valid2 = new \ElggObject();
 		$valid2->subtype = $subtype;
 		$valid2->save();
 		$guids[] = $valid2->getGUID();

--- a/engine/tests/ElggCoreGetEntitiesFromRelationshipTest.php
+++ b/engine/tests/ElggCoreGetEntitiesFromRelationshipTest.php
@@ -3,18 +3,18 @@
  * Test elgg_get_entities_from_relationship() and
  * elgg_get_entities_from_relationship_count()
  */
-class ElggCoreGetEntitiesFromRelationshipTest extends ElggCoreGetEntitiesBaseTest {
+class ElggCoreGetEntitiesFromRelationshipTest extends \ElggCoreGetEntitiesBaseTest {
 
 	// Make sure metadata doesn't affect getting entities by relationship.  See #2274
 	public function testElggApiGettersEntityRelationshipWithMetadata() {
 		$guids = array();
 
-		$obj1 = new ElggObject();
+		$obj1 = new \ElggObject();
 		$obj1->test_md = 'test';
 		$obj1->save();
 		$guids[] = $obj1->guid;
 
-		$obj2 = new ElggObject();
+		$obj2 = new \ElggObject();
 		$obj2->test_md = 'test';
 		$obj2->save();
 		$guids[] = $obj2->guid;
@@ -43,11 +43,11 @@ class ElggCoreGetEntitiesFromRelationshipTest extends ElggCoreGetEntitiesBaseTes
 	public function testElggApiGettersEntityRelationshipWithOutMetadata() {
 		$guids = array();
 
-		$obj1 = new ElggObject();
+		$obj1 = new \ElggObject();
 		$obj1->save();
 		$guids[] = $obj1->guid;
 
-		$obj2 = new ElggObject();
+		$obj2 = new \ElggObject();
 		$obj2->save();
 		$guids[] = $obj2->guid;
 
@@ -75,12 +75,12 @@ class ElggCoreGetEntitiesFromRelationshipTest extends ElggCoreGetEntitiesBaseTes
 	public function testElggApiGettersEntityRelationshipWithMetadataIncludingRealMetadata() {
 		$guids = array();
 
-		$obj1 = new ElggObject();
+		$obj1 = new \ElggObject();
 		$obj1->test_md = 'test';
 		$obj1->save();
 		$guids[] = $obj1->guid;
 
-		$obj2 = new ElggObject();
+		$obj2 = new \ElggObject();
 		$obj2->test_md = 'test';
 		$obj2->save();
 		$guids[] = $obj2->guid;
@@ -111,12 +111,12 @@ class ElggCoreGetEntitiesFromRelationshipTest extends ElggCoreGetEntitiesBaseTes
 	public function testElggApiGettersEntityRelationshipWithMetadataIncludingFakeMetadata() {
 		$guids = array();
 
-		$obj1 = new ElggObject();
+		$obj1 = new \ElggObject();
 		$obj1->test_md = 'test';
 		$obj1->save();
 		$guids[] = $obj1->guid;
 
-		$obj2 = new ElggObject();
+		$obj2 = new \ElggObject();
 		$obj2->test_md = 'test';
 		$obj2->save();
 		$guids[] = $obj2->guid;

--- a/engine/tests/ElggCoreGetEntitiesTest.php
+++ b/engine/tests/ElggCoreGetEntitiesTest.php
@@ -3,7 +3,7 @@
 /**
  * Test elgg_get_entities()
  */
-class ElggCoreGetEntitiesTest extends ElggCoreGetEntitiesBaseTest {
+class ElggCoreGetEntitiesTest extends \ElggCoreGetEntitiesBaseTest {
 
 	/***********************************
 	 * TYPE TESTS
@@ -624,7 +624,7 @@ class ElggCoreGetEntitiesTest extends ElggCoreGetEntitiesBaseTest {
 		// create an entity we can later delete.
 		// order by guid and limit by 1 should == this entity.
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->save();
 
 		$options = array(
@@ -651,7 +651,7 @@ class ElggCoreGetEntitiesTest extends ElggCoreGetEntitiesBaseTest {
 		// create an entity we can later delete.
 		// order by time created and limit by 1 should == this entity.
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->save();
 
 		$options = array(
@@ -682,11 +682,11 @@ class ElggCoreGetEntitiesTest extends ElggCoreGetEntitiesBaseTest {
 
 		$subtype = 'subtype_' . rand();
 
-		$e_subtype = new ElggObject();
+		$e_subtype = new \ElggObject();
 		$e_subtype->subtype = $subtype;
 		$e_subtype->save();
 
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->save();
 
 		$options = array(
@@ -721,7 +721,7 @@ class ElggCoreGetEntitiesTest extends ElggCoreGetEntitiesBaseTest {
 
 		$guids = array();
 
-		$obj1 = new ElggObject();
+		$obj1 = new \ElggObject();
 		$obj1->test_md = 'test';
 		// luckily this is never checked.
 		$obj1->site_guid = 2;
@@ -729,7 +729,7 @@ class ElggCoreGetEntitiesTest extends ElggCoreGetEntitiesBaseTest {
 		$guids[] = $obj1->guid;
 		$right_guid = $obj1->guid;
 
-		$obj2 = new ElggObject();
+		$obj2 = new \ElggObject();
 		$obj2->test_md = 'test';
 		$obj2->site_guid = $CONFIG->site->guid;
 		$obj2->save();
@@ -756,14 +756,14 @@ class ElggCoreGetEntitiesTest extends ElggCoreGetEntitiesBaseTest {
 
 		$guids = array();
 
-		$obj1 = new ElggObject();
+		$obj1 = new \ElggObject();
 		$obj1->test_md = 'test';
 		// luckily this is never checked.
 		$obj1->site_guid = 2;
 		$obj1->save();
 		$guids[] = $obj1->guid;
 
-		$obj2 = new ElggObject();
+		$obj2 = new \ElggObject();
 		$obj2->test_md = 'test';
 		$obj2->site_guid = $CONFIG->site->guid;
 		$obj2->save();
@@ -795,14 +795,14 @@ class ElggCoreGetEntitiesTest extends ElggCoreGetEntitiesBaseTest {
 
 		$guids = array();
 
-		$obj1 = new ElggObject();
+		$obj1 = new \ElggObject();
 		$obj1->test_md = 'test';
 		// luckily this is never checked.
 		$obj1->site_guid = 2;
 		$obj1->save();
 		$guids[] = $obj1->guid;
 
-		$obj2 = new ElggObject();
+		$obj2 = new \ElggObject();
 		$obj2->test_md = 'test';
 		$obj2->site_guid = $CONFIG->site->guid;
 		$obj2->save();
@@ -834,14 +834,14 @@ class ElggCoreGetEntitiesTest extends ElggCoreGetEntitiesBaseTest {
 
 		$guids = array();
 
-		$obj1 = new ElggObject();
+		$obj1 = new \ElggObject();
 		$obj1->test_md = 'test';
 		// luckily this is never checked.
 		$obj1->site_guid = 2;
 		$obj1->save();
 		$guids[] = $obj1->guid;
 
-		$obj2 = new ElggObject();
+		$obj2 = new \ElggObject();
 		$obj2->test_md = 'test';
 		$obj2->save();
 		$guids[] = $obj2->guid;
@@ -872,14 +872,14 @@ class ElggCoreGetEntitiesTest extends ElggCoreGetEntitiesBaseTest {
 
 		$guids = array();
 
-		$obj1 = new ElggObject();
+		$obj1 = new \ElggObject();
 		$obj1->test_md = 'test';
 		// luckily this is never checked.
 		$obj1->site_guid = 2;
 		$obj1->save();
 		$guids[] = $obj1->guid;
 
-		$obj2 = new ElggObject();
+		$obj2 = new \ElggObject();
 		$obj2->test_md = 'test';
 		$obj2->save();
 		$guids[] = $obj2->guid;

--- a/engine/tests/ElggCoreHelpersTest.php
+++ b/engine/tests/ElggCoreHelpersTest.php
@@ -6,7 +6,7 @@
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreHelpersTest extends ElggCoreUnitTest {
+class ElggCoreHelpersTest extends \ElggCoreUnitTest {
 
 	/**
 	 * Called before each test object.
@@ -44,7 +44,7 @@ class ElggCoreHelpersTest extends ElggCoreUnitTest {
 	 * Test elgg_instanceof()
 	 */
 	public function testElggInstanceOf() {
-		$entity = new ElggObject();
+		$entity = new \ElggObject();
 		$entity->subtype = 'test_subtype';
 		$entity->save();
 

--- a/engine/tests/ElggCoreMetadataAPITest.php
+++ b/engine/tests/ElggCoreMetadataAPITest.php
@@ -5,7 +5,7 @@
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreMetadataAPITest extends ElggCoreUnitTest {
+class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 	protected $metastrings;
 
 	/**
@@ -13,7 +13,7 @@ class ElggCoreMetadataAPITest extends ElggCoreUnitTest {
 	 */
 	public function setUp() {
 		$this->metastrings = array();
-		$this->object = new ElggObject();
+		$this->object = new \ElggObject();
 	}
 
 	/**
@@ -97,7 +97,7 @@ class ElggCoreMetadataAPITest extends ElggCoreUnitTest {
 	}
 
 	public function testElggDeleteMetadata() {
-		$e = new ElggObject();
+		$e = new \ElggObject();
 		$e->save();
 
 		for ($i = 0; $i < 30; $i++) {
@@ -139,15 +139,15 @@ class ElggCoreMetadataAPITest extends ElggCoreUnitTest {
 	// by another user
 	// https://github.com/elgg/elgg/issues/2776
 	public function test_elgg_metadata_multiple_values() {
-		$u1 = new ElggUser();
+		$u1 = new \ElggUser();
 		$u1->username = rand();
 		$u1->save();
 
-		$u2 = new ElggUser();
+		$u2 = new \ElggUser();
 		$u2->username = rand();
 		$u2->save();
 
-		$obj = new ElggObject();
+		$obj = new \ElggObject();
 		$obj->owner_guid = $u1->guid;
 		$obj->container_guid = $u1->guid;
 		$obj->access_id = ACCESS_PUBLIC;

--- a/engine/tests/ElggCoreMetadataCacheTest.php
+++ b/engine/tests/ElggCoreMetadataCacheTest.php
@@ -5,15 +5,15 @@
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreMetadataCacheTest extends ElggCoreUnitTest {
+class ElggCoreMetadataCacheTest extends \ElggCoreUnitTest {
 
 	/**
-	 * @var ElggVolatileMetadataCache
+	 * @var \ElggVolatileMetadataCache
 	 */
 	protected $cache;
 
 	/**
-	 * @var ElggObject
+	 * @var \ElggObject
 	 */
 	protected $obj1;
 
@@ -23,7 +23,7 @@ class ElggCoreMetadataCacheTest extends ElggCoreUnitTest {
 	protected $guid1;
 
 	/**
-	 * @var ElggObject
+	 * @var \ElggObject
 	 */
 	protected $obj2;
 
@@ -44,11 +44,11 @@ class ElggCoreMetadataCacheTest extends ElggCoreUnitTest {
 
 		$this->cache = _elgg_get_metadata_cache();
 
-		$this->obj1 = new ElggObject();
+		$this->obj1 = new \ElggObject();
 		$this->obj1->save();
 		$this->guid1 = $this->obj1->guid;
 
-		$this->obj2 = new ElggObject();
+		$this->obj2 = new \ElggObject();
 		$this->obj2->save();
 		$this->guid2 = $this->obj2->guid;
 	}
@@ -65,7 +65,7 @@ class ElggCoreMetadataCacheTest extends ElggCoreUnitTest {
 
 	public function testBasicApi() {
 		// test de-coupled instance
-		$cache = new ElggVolatileMetadataCache();
+		$cache = new \ElggVolatileMetadataCache();
 		$cache->setIgnoreAccess(false);
 		$guid = 1;
 

--- a/engine/tests/ElggCoreMetastringsTest.php
+++ b/engine/tests/ElggCoreMetastringsTest.php
@@ -5,7 +5,7 @@
  * @package Elgg.Core
  * @subpackage Metastrings.Test
  */
-class ElggCoreMetastringsTest extends ElggCoreUnitTest {
+class ElggCoreMetastringsTest extends \ElggCoreUnitTest {
 
 	public $metastringTypes = array('metadata', 'annotation');
 	public $metastringTables = array(
@@ -20,7 +20,7 @@ class ElggCoreMetastringsTest extends ElggCoreUnitTest {
 		parent::__construct();
 
 		$this->metastrings = array();
-		$this->object = new ElggObject();
+		$this->object = new \ElggObject();
 		$this->object->save();
 	}
 

--- a/engine/tests/ElggCoreOutputAutoPTest.php
+++ b/engine/tests/ElggCoreOutputAutoPTest.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Test case for ElggAutoP functionality.
+ * Test case for \ElggAutoP functionality.
  */
-class ElggCoreOutputAutoPTest extends ElggCoreUnitTest {
+class ElggCoreOutputAutoPTest extends \ElggCoreUnitTest {
 
 	/**
-	 * @var ElggAutoP
+	 * @var \ElggAutoP
 	 */
 	protected $_autop;
 
 	public function setUp() {
-		$this->_autop = new ElggAutoP();
+		$this->_autop = new \ElggAutoP();
 	}
 	
 	public function testDomRoundtrip() {

--- a/engine/tests/ElggCorePluginsAPITest.php
+++ b/engine/tests/ElggCorePluginsAPITest.php
@@ -5,7 +5,7 @@
  * @package Elgg.Core
  * @subpackage Plugins.Test
  */
-class ElggCorePluginsAPITest extends ElggCoreUnitTest {
+class ElggCorePluginsAPITest extends \ElggCoreUnitTest {
 	// 1.8 manifest object
 	var $manifest18;
 
@@ -21,34 +21,34 @@ class ElggCorePluginsAPITest extends ElggCoreUnitTest {
 	public function __construct() {
 		parent::__construct();
 
-		$this->manifest18 = new ElggPluginManifest(get_config('path') . 'engine/tests/test_files/plugin_18/manifest.xml', 'plugin_test_18');
-		$this->manifest17 = new ElggPluginManifest(get_config('path') . 'engine/tests/test_files/plugin_17/manifest.xml', 'plugin_test_17');
+		$this->manifest18 = new \ElggPluginManifest(get_config('path') . 'engine/tests/test_files/plugin_18/manifest.xml', 'plugin_test_18');
+		$this->manifest17 = new \ElggPluginManifest(get_config('path') . 'engine/tests/test_files/plugin_17/manifest.xml', 'plugin_test_17');
 
-		$this->package18 = new ElggPluginPackage(get_config('path') . 'engine/tests/test_files/plugin_18');
-		$this->package17 = new ElggPluginPackage(get_config('path') . 'engine/tests/test_files/plugin_17');
+		$this->package18 = new \ElggPluginPackage(get_config('path') . 'engine/tests/test_files/plugin_18');
+		$this->package17 = new \ElggPluginPackage(get_config('path') . 'engine/tests/test_files/plugin_17');
 	}
 
 	// generic tests
 	public function testElggPluginManifestFromString() {
 		$manifest_file = file_get_contents(get_config('path') . 'engine/tests/test_files/plugin_17/manifest.xml');
-		$manifest = new ElggPluginManifest($manifest_file);
+		$manifest = new \ElggPluginManifest($manifest_file);
 
-		$this->assertIsA($manifest, 'ElggPluginManifest');
+		$this->assertIsA($manifest, '\ElggPluginManifest');
 	}
 
 	public function testElggPluginManifestFromFile() {
 		$file = get_config('path') . 'engine/tests/test_files/plugin_17/manifest.xml';
-		$manifest = new ElggPluginManifest($file);
+		$manifest = new \ElggPluginManifest($file);
 
-		$this->assertIsA($manifest, 'ElggPluginManifest');
+		$this->assertIsA($manifest, '\ElggPluginManifest');
 	}
 
 	public function testElggPluginManifestFromXMLEntity() {
 		$manifest_file = file_get_contents(get_config('path') . 'engine/tests/test_files/plugin_17/manifest.xml');
-		$xml = new ElggXMLElement($manifest_file);
-		$manifest = new ElggPluginManifest($xml);
+		$xml = new \ElggXMLElement($manifest_file);
+		$manifest = new \ElggPluginManifest($xml);
 
-		$this->assertIsA($manifest, 'ElggPluginManifest');
+		$this->assertIsA($manifest, '\ElggPluginManifest');
 	}
 
 	// exact manifest values
@@ -297,27 +297,27 @@ class ElggCorePluginsAPITest extends ElggCoreUnitTest {
 		$this->assertIdentical($this->manifest18->getActivateOnInstall(), true);
 	}
 
-	// ElggPluginPackage
+	// \ElggPluginPackage
 	public function testElggPluginPackageDetectIDFromPath() {
 		$this->assertEqual($this->package18->getID(), 'plugin_18');
 	}
 
 	public function testElggPluginPackageDetectIDFromPluginID() {
-		$package = new ElggPluginPackage('profile');
+		$package = new \ElggPluginPackage('profile');
 		$this->assertEqual($package->getID(), 'profile');
 	}
 	
-	// ElggPlugin
+	// \ElggPlugin
 	public function testElggPluginIsValid() {
 		
-		$test_plugin = new ElggPlugin('profile');
+		$test_plugin = new \ElggPlugin('profile');
 		
 		$this->assertIdentical(true, $test_plugin->isValid());
 	}
 	
 	public function testElggPluginGetID() {
 		
-		$test_plugin = new ElggPlugin('profile');
+		$test_plugin = new \ElggPlugin('profile');
 		
 		$this->assertIdentical('profile', $test_plugin->getID());
 	}

--- a/engine/tests/ElggCoreRegressionBugsTest.php
+++ b/engine/tests/ElggCoreRegressionBugsTest.php
@@ -6,7 +6,7 @@
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
+class ElggCoreRegressionBugsTest extends \ElggCoreUnitTest {
 
 	/**
 	 * Called before each test object.
@@ -31,7 +31,7 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 	 * #1558
 	 */
 	public function testElggObjectDeleteAnnotations() {
-		$this->entity = new ElggObject();
+		$this->entity = new \ElggObject();
 		$guid = $this->entity->save();
 
 		$this->entity->annotate('test', 'hello', ACCESS_PUBLIC);
@@ -100,7 +100,7 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 
 	// #3722 Check canEdit() works for contains regardless of groups
 	function test_can_write_to_container() {
-		$user = new ElggUser();
+		$user = new \ElggUser();
 		$user->username = 'test_user_' . rand();
 		$user->name = 'test_user_name_' . rand();
 		$user->email = 'test@user.net';
@@ -108,10 +108,10 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 		$user->owner_guid = 0;
 		$user->save();
 
-		$object = new ElggObject();
+		$object = new \ElggObject();
 		$object->save();
 
-		$group = new ElggGroup();
+		$group = new \ElggGroup();
 		$group->save();
 
 		// disable access overrides because we're admin.
@@ -172,7 +172,7 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 		);
 
 		// where available, string is converted to NFC before transliteration
-		if (Elgg_Translit::hasNormalizerSupport()) {
+		if (\Elgg\Translit::hasNormalizerSupport()) {
 			$form_d = "A\xCC\x8A"; // A followed by 'COMBINING RING ABOVE' (U+030A)
 			$cases[$form_d] = "a";
 		}
@@ -255,7 +255,7 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 		global $ENTITY_CACHE;
 
 		// may not have groups in DB - let's create one
-		$group = new ElggGroup();
+		$group = new \ElggGroup();
 		$group->name = 'test_group';
 		$group->access_id = ACCESS_PUBLIC;
 		$this->assertTrue($group->save() !== false);
@@ -280,14 +280,14 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 	}
 
 	/**
-	 * Ensure that ElggBatch doesn't go into infinite loop when disabling annotations recursively when show hidden is enabled.
+	 * Ensure that \ElggBatch doesn't go into infinite loop when disabling annotations recursively when show hidden is enabled.
 	 *
 	 * https://github.com/Elgg/Elgg/issues/5952
 	 */
 	public function test_disabling_annotations_infinite_loop() {
 
 		//let's have some entity
-		$group = new ElggGroup();
+		$group = new \ElggGroup();
 		$group->name = 'test_group';
 		$group->access_id = ACCESS_PUBLIC;
 		$this->assertTrue($group->save() !== false);
@@ -303,7 +303,7 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 		access_show_hidden_entities(true);
 		$options = array(
 			'guid' => $group->guid,
-			'limit' => $total, //using strict limit to avoid real infinite loop and just see ElggBatch limiting on it before finishing the work
+			'limit' => $total, //using strict limit to avoid real infinite loop and just see \ElggBatch limiting on it before finishing the work
 		);
 		elgg_disable_annotations($options);
 		access_show_hidden_entities($show_hidden);
@@ -341,7 +341,7 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 
 		if ($can_load_entity) {
 			$this->expectError("SimpleXMLElement::__construct(): I/O warning : failed to load external entity &quot;" . $path . "&quot;");
-			$el = new ElggXMLElement($payload);
+			$el = new \ElggXMLElement($payload);
 			$chidren = $el->getChildren();
 			$content = $chidren[0]->getContent();
 			$this->assertNoPattern('/secret/', $content);
@@ -351,17 +351,17 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 	}
 
 	public function test_update_handlers_can_change_attributes() {
-		$object = new ElggObject();
+		$object = new \ElggObject();
 		$object->subtype = 'issue6225';
 		$object->access_id = ACCESS_PUBLIC;
 		$object->save();
 		$guid = $object->guid;
 
-		elgg_register_event_handler('update', 'object', array('ElggCoreRegressionBugsTest', 'handleUpdateForIssue6225test'));
+		elgg_register_event_handler('update', 'object', array('\ElggCoreRegressionBugsTest', 'handleUpdateForIssue6225test'));
 
 		$object->save();
 
-		elgg_unregister_event_handler('update', 'object', array('ElggCoreRegressionBugsTest', 'handleUpdateForIssue6225test'));
+		elgg_unregister_event_handler('update', 'object', array('\ElggCoreRegressionBugsTest', 'handleUpdateForIssue6225test'));
 
 		_elgg_invalidate_cache_for_entity($guid);
 		$object = get_entity($guid);
@@ -370,7 +370,7 @@ class ElggCoreRegressionBugsTest extends ElggCoreUnitTest {
 		$object->delete();
 	}
 
-	public static function handleUpdateForIssue6225test($event, $type, ElggObject $object) {
+	public static function handleUpdateForIssue6225test($event, $type, \ElggObject $object) {
 		$object->access_id = ACCESS_PRIVATE;
 	}
 

--- a/engine/tests/ElggCoreRiverAPITest.php
+++ b/engine/tests/ElggCoreRiverAPITest.php
@@ -5,7 +5,7 @@
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreRiverAPITest extends ElggCoreUnitTest {
+class ElggCoreRiverAPITest extends \ElggCoreUnitTest {
 
 	public function testElggCreateRiverItemWorks() {
 		$entity = elgg_get_entities(array('limit' => 1));
@@ -100,10 +100,10 @@ class ElggCoreRiverAPITest extends ElggCoreUnitTest {
 	}
 	
 	public function testElggRiverDisableEnable() {
-		$user = new ElggUser();
+		$user = new \ElggUser();
 		$user->save();
 		
-		$entity = new ElggObject();
+		$entity = new \ElggObject();
 		$entity->save();
 		
 		$params = array(

--- a/engine/tests/ElggCoreSkeletonTest.php
+++ b/engine/tests/ElggCoreSkeletonTest.php
@@ -15,7 +15,7 @@
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreSkeletonTest extends ElggCoreUnitTest {
+class ElggCoreSkeletonTest extends \ElggCoreUnitTest {
 
 	/**
 	 * Called before each test object.

--- a/engine/tests/ElggCoreUnitTest.php
+++ b/engine/tests/ElggCoreUnitTest.php
@@ -35,11 +35,11 @@ abstract class ElggCoreUnitTest extends UnitTestCase {
 	 * @param string $message Message to display.
 	 * @return boolean
 	 */
-	public function assertIdenticalEntities(ElggEntity $first, ElggEntity $second, $message = '%s') {
-		if (!($res = $this->assertIsA($first, 'ElggEntity'))) {
+	public function assertIdenticalEntities(\ElggEntity $first, \ElggEntity $second, $message = '%s') {
+		if (!($res = $this->assertIsA($first, '\ElggEntity'))) {
 			return $res;
 		}
-		if (!($res = $this->assertIsA($second, 'ElggEntity'))) {
+		if (!($res = $this->assertIsA($second, '\ElggEntity'))) {
 			return $res;
 		}
 		if (!($res = $this->assertEqual(get_class($first), get_class($second)))) {
@@ -83,7 +83,7 @@ class IdenticalEntityExpectation extends EqualExpectation {
 	/**
 	 * Converts entity to array and filters not important attributes
 	 *
-	 * @param ElggEntity $entity An entity to convert
+	 * @param \ElggEntity $entity An entity to convert
 	 * @return array
 	 */
 	protected function entityToFilteredArray($entity) {

--- a/engine/tests/ElggEntityTest.php
+++ b/engine/tests/ElggEntityTest.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Test ElggEntity
+ * Test \ElggEntity
  *
  */
-class ElggCoreEntityTest extends ElggCoreUnitTest {
+class ElggCoreEntityTest extends \ElggCoreUnitTest {
 
 	/**
-	 * @var ElggEntity
+	 * @var \ElggEntity
 	 */
 	protected $entity;
 
@@ -14,8 +14,8 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 	 * Called before each test method.
 	 */
 	public function setUp() {
-		// use ElggObject since ElggEntity is an abstract class
-		$this->entity = new ElggObject();
+		// use \ElggObject since \ElggEntity is an abstract class
+		$this->entity = new \ElggObject();
 		$this->entity->subtype = 'elgg_entity_test_subtype';
 		$this->entity->save();
 	}
@@ -65,7 +65,7 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 
 	public function testSubtypeAddRemove() {
 		$test_subtype = 'test_1389988642';
-		$object = new ElggObject();
+		$object = new \ElggObject();
 		$object->subtype = $test_subtype;
 		$object->save();
 
@@ -83,7 +83,7 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 		// save entity and check for annotation
 		$this->entity->annotate('non_existent', 'foo');
 		$annotations = $this->entity->getAnnotations(array('annotation_name' => 'non_existent'));
-		$this->assertIsA($annotations[0], 'ElggAnnotation');
+		$this->assertIsA($annotations[0], '\ElggAnnotation');
 		$this->assertIdentical($annotations[0]->name, 'non_existent');
 		$this->assertEqual($this->entity->countAnnotations('non_existent'), 1);
 
@@ -151,10 +151,10 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 	public function testElggEntityRecursiveDisableAndEnable() {
 		global $CONFIG;
 
-		$obj1 = new ElggObject();
+		$obj1 = new \ElggObject();
 		$obj1->container_guid = $this->entity->getGUID();
 		$obj1->save();
-		$obj2 = new ElggObject();
+		$obj2 = new \ElggObject();
 		$obj2->container_guid = $this->entity->getGUID();
 		$obj2->save();
 
@@ -205,7 +205,7 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 	}
 
 	public function testElggEntityMultipleMetadata() {
-		foreach (array($this->entity, new ElggObject()) as $obj) {
+		foreach (array($this->entity, new \ElggObject()) as $obj) {
 			$md = array('brett', 'bryan', 'brad');
 			$name = 'test_md_' . rand();
 
@@ -216,7 +216,7 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 	}
 
 	public function testElggEntitySingleElementArrayMetadata() {
-		foreach (array($this->entity, new ElggObject()) as $obj) {
+		foreach (array($this->entity, new \ElggObject()) as $obj) {
 			$md = array('test');
 			$name = 'test_md_' . rand();
 
@@ -227,7 +227,7 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 	}
 
 	public function testElggEntityAppendMetadata() {
-		foreach (array($this->entity, new ElggObject()) as $obj) {
+		foreach (array($this->entity, new \ElggObject()) as $obj) {
 			$md = 'test';
 			$name = 'test_md_' . rand();
 
@@ -239,7 +239,7 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 	}
 
 	public function testElggEntitySingleElementArrayAppendMetadata() {
-		foreach (array($this->entity, new ElggObject()) as $obj) {
+		foreach (array($this->entity, new \ElggObject()) as $obj) {
 			$md = 'test';
 			$name = 'test_md_' . rand();
 
@@ -251,7 +251,7 @@ class ElggCoreEntityTest extends ElggCoreUnitTest {
 	}
 
 	public function testElggEntityArrayAppendMetadata() {
-		foreach (array($this->entity, new ElggObject()) as $obj) {
+		foreach (array($this->entity, new \ElggObject()) as $obj) {
 			$md = array('brett', 'bryan', 'brad');
 			$md2 = array('test1', 'test2', 'test3');
 			$name = 'test_md_' . rand();

--- a/engine/tests/ElggGroupTest.php
+++ b/engine/tests/ElggGroupTest.php
@@ -1,18 +1,18 @@
 <?php
 /**
- * Elgg Test ElggGroup
+ * Elgg Test \ElggGroup
  *
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreGroupTest extends ElggCoreUnitTest {
+class ElggCoreGroupTest extends \ElggCoreUnitTest {
 	/**
-	 * @var ElggGroup
+	 * @var \ElggGroup
 	 */
 	protected $group;
 
 	/**
-	 * @var ElggUser
+	 * @var \ElggUser
 	 */
 	protected $user;
 
@@ -20,18 +20,18 @@ class ElggCoreGroupTest extends ElggCoreUnitTest {
 	 * Called before each test method.
 	 */
 	public function setUp() {
-		$this->group = new ElggGroup();
+		$this->group = new \ElggGroup();
 		$this->group->membership = ACCESS_PUBLIC;
 		$this->group->access_id = ACCESS_PUBLIC;
 		$this->group->save();
-		$this->user = new ElggUser();
+		$this->user = new \ElggUser();
 		$this->user->username = 'test_user_' . rand();
 		$this->user->save();
 	}
 
 	public function testContentAccessMode() {
-		$unrestricted = ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED;
-		$membersonly = ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY;
+		$unrestricted = \ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED;
+		$membersonly = \ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY;
 
 		// if mode not set, open groups are unrestricted
 		$this->assertEqual($this->group->getContentAccessMode(), $unrestricted);
@@ -57,26 +57,26 @@ class ElggCoreGroupTest extends ElggCoreUnitTest {
 		$group_guid = $this->group->guid;
 
 		// unrestricted: pass non-members
-		$this->group->setContentAccessMode(ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED);
-		$vis = Elgg_GroupItemVisibility::factory($group_guid, false);
+		$this->group->setContentAccessMode(\ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED);
+		$vis = \Elgg\GroupItemVisibility::factory($group_guid, false);
 
 		$this->assertFalse($vis->shouldHideItems);
 
 		// membersonly: non-members fail
-		$this->group->setContentAccessMode(ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY);
-		$vis = Elgg_GroupItemVisibility::factory($group_guid, false);
+		$this->group->setContentAccessMode(\ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY);
+		$vis = \Elgg\GroupItemVisibility::factory($group_guid, false);
 
 		$this->assertTrue($vis->shouldHideItems);
 
 		// members succeed
 		$this->group->join($this->user);
-		$vis = Elgg_GroupItemVisibility::factory($group_guid, false);
+		$vis = \Elgg\GroupItemVisibility::factory($group_guid, false);
 
 		$this->assertFalse($vis->shouldHideItems);
 
 		// non-member admins succeed - assumes admin logged in
 		_elgg_services()->session->setLoggedInUser($original_user);
-		$vis = Elgg_GroupItemVisibility::factory($group_guid, false);
+		$vis = \Elgg\GroupItemVisibility::factory($group_guid, false);
 
 		$this->assertFalse($vis->shouldHideItems);
 	}

--- a/engine/tests/ElggObjectTest.php
+++ b/engine/tests/ElggObjectTest.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Elgg Test ElggObject
+ * Elgg Test \ElggObject
  *
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreObjectTest extends ElggCoreUnitTest {
+class ElggCoreObjectTest extends \ElggCoreUnitTest {
 
 	/**
 	 * Called before each test object.
@@ -18,7 +18,7 @@ class ElggCoreObjectTest extends ElggCoreUnitTest {
 	 * Called before each test method.
 	 */
 	public function setUp() {
-		$this->entity = new ElggObjectTest();
+		$this->entity = new \ElggObjectTest();
 	}
 
 	/**
@@ -65,17 +65,17 @@ class ElggCoreObjectTest extends ElggCoreUnitTest {
 		$this->AssertNotEqual($guid, 0);
 
 		$entity_row = $this->get_entity_row($guid);
-		$this->assertIsA($entity_row, 'stdClass');
+		$this->assertIsA($entity_row, '\stdClass');
 
 		// update existing object
 		$this->entity->title = 'testing';
-		$this->entity->description = 'ElggObject';
+		$this->entity->description = '\ElggObject';
 		$this->assertEqual($this->entity->save(), $guid);
 
 		$object_row = $this->get_object_row($guid);
-		$this->assertIsA($object_row, 'stdClass');
+		$this->assertIsA($object_row, '\stdClass');
 		$this->assertIdentical($object_row->title, 'testing');
-		$this->assertIdentical($object_row->description, 'ElggObject');
+		$this->assertIdentical($object_row->description, '\ElggObject');
 
 		// clean up
 		$this->entity->delete();
@@ -83,7 +83,7 @@ class ElggCoreObjectTest extends ElggCoreUnitTest {
 
 	public function testElggConstructorWithGarbage() {
 		try {
-			$error = new ElggObjectTest('garbage');
+			$error = new \ElggObjectTest('garbage');
 			$this->assertTrue(false);
 		} catch (Exception $e) {
 			$this->assertIsA($e, 'InvalidParameterException');
@@ -92,7 +92,7 @@ class ElggCoreObjectTest extends ElggCoreUnitTest {
 
 	public function testElggObjectClone() {
 		$this->entity->title = 'testing';
-		$this->entity->description = 'ElggObject';
+		$this->entity->description = '\ElggObject';
 		$this->entity->var1 = "test";
 		$this->entity->var2 = 1;
 		$this->entity->var3 = true;
@@ -103,13 +103,13 @@ class ElggCoreObjectTest extends ElggCoreUnitTest {
 		$tagarray = string_to_tag_array($tag_string);
 		$this->entity->tags = $tagarray;
 
-		// a cloned ElggEntity has the guid reset
+		// a cloned \ElggEntity has the guid reset
 		$object = clone $this->entity;
 		$this->assertIdentical(0, (int)$object->guid);
 
 		// make sure attributes were copied over
 		$this->assertIdentical($object->title, 'testing');
-		$this->assertIdentical($object->description, 'ElggObject');
+		$this->assertIdentical($object->description, '\ElggObject');
 
 		$guid = $object->save();
 		$this->assertTrue($guid !== 0);
@@ -130,7 +130,7 @@ class ElggCoreObjectTest extends ElggCoreUnitTest {
 		$this->assertEqual($this->entity->getContainerGUID(), elgg_get_logged_in_user_guid());
 
 		// create and save to group
-		$group = new ElggGroup();
+		$group = new \ElggGroup();
 		$guid = $group->save();
 		$this->assertTrue($this->entity->setContainerGUID($guid));
 
@@ -186,14 +186,14 @@ class ElggCoreObjectTest extends ElggCoreUnitTest {
 
 	// see https://github.com/elgg/elgg/issues/1196
 	public function testElggEntityRecursiveDisableWhenLoggedOut() {
-		$e1 = new ElggObject();
+		$e1 = new \ElggObject();
 		$e1->access_id = ACCESS_PUBLIC;
 		$e1->owner_guid = 0;
 		$e1->container_guid = 0;
 		$e1->save();
 		$guid1 = $e1->getGUID();
 
-		$e2 = new ElggObject();
+		$e2 = new \ElggObject();
 		$e2->container_guid = $guid1;
 		$e2->access_id = ACCESS_PUBLIC;
 		$e2->owner_guid = 0;
@@ -230,18 +230,18 @@ class ElggCoreObjectTest extends ElggCoreUnitTest {
 	}
 
 	public function testElggRecursiveDelete() {
-		$types = array('ElggGroup', 'ElggObject', 'ElggUser', 'ElggSite');
+		$types = array('\ElggGroup', '\ElggObject', '\ElggUser', '\ElggSite');
 		$db_prefix = elgg_get_config('dbprefix');
 
 		foreach ($types as $type) {
 			$parent = new $type();
 			$this->assertTrue($parent->save());
 			
-			$child = new ElggObject();
+			$child = new \ElggObject();
 			$child->container_guid = $parent->guid;
 			$this->assertTrue($child->save());
 
-			$grandchild = new ElggObject();
+			$grandchild = new \ElggObject();
 			$grandchild->container_guid = $child->guid;
 			$this->assertTrue($grandchild->save());
 
@@ -262,7 +262,7 @@ class ElggCoreObjectTest extends ElggCoreUnitTest {
 
 		// object that owns itself
 		// can't check container_guid because of infinite loops in can_edit_entity()
-		$obj = new ElggObject();
+		$obj = new \ElggObject();
 		$obj->save();
 		$obj->owner_guid = $obj->guid;
 		$obj->save();
@@ -289,7 +289,7 @@ class ElggCoreObjectTest extends ElggCoreUnitTest {
 	}
 }
 
-class ElggObjectTest extends ElggObject {
+class ElggObjectTest extends \ElggObject {
 	public function expose_attributes() {
 		return $this->attributes;
 	}

--- a/engine/tests/ElggSiteTest.php
+++ b/engine/tests/ElggSiteTest.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Elgg Test ElggSite
+ * Elgg Test \ElggSite
  *
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreSiteTest extends ElggCoreUnitTest {
+class ElggCoreSiteTest extends \ElggCoreUnitTest {
 
 	/**
-	 * @var ElggSite
+	 * @var \ElggSite
 	 */
 	public $site;
 
@@ -23,7 +23,7 @@ class ElggCoreSiteTest extends ElggCoreUnitTest {
 	 * Called before each test method.
 	 */
 	public function setUp() {
-		$this->site = new ElggSiteTest();
+		$this->site = new \ElggSiteTest();
 	}
 
 	/**
@@ -77,7 +77,7 @@ class ElggCoreSiteTest extends ElggCoreUnitTest {
 	}
 }
 
-class ElggSiteTest extends ElggSite {
+class ElggSiteTest extends \ElggSite {
 	public function expose_attributes() {
 		return $this->attributes;
 	}

--- a/engine/tests/ElggTravisInstallTest.php
+++ b/engine/tests/ElggTravisInstallTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggTravisInstallTest extends ElggCoreUnitTest {
+class ElggTravisInstallTest extends \ElggCoreUnitTest {
 
 	public function setUp() {
 		if (!getenv('TRAVIS')) {
@@ -15,7 +15,7 @@ class ElggTravisInstallTest extends ElggCoreUnitTest {
 	public function testThemePluginsAreLast() {
 		$plugins = elgg_get_plugins('all');
 		$plugins = array_reverse($plugins);
-		/* @var ElggPlugin[] $plugins */
+		/* @var \ElggPlugin[] $plugins */
 
 		$found_non_theme = false;
 		foreach ($plugins as $i => $plugin) {

--- a/engine/tests/ElggUserTest.php
+++ b/engine/tests/ElggUserTest.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Elgg Test ElggUser
+ * Elgg Test \ElggUser
  *
  * @package Elgg
  * @subpackage Test
  */
-class ElggCoreUserTest extends ElggCoreUnitTest {
+class ElggCoreUserTest extends \ElggCoreUnitTest {
 
 	/**
 	 * Called before each test object.
@@ -20,7 +20,7 @@ class ElggCoreUserTest extends ElggCoreUnitTest {
 	 * Called before each test method.
 	 */
 	public function setUp() {
-		$this->user = new ElggUserTest();
+		$this->user = new \ElggUserTest();
 	}
 
 	/**
@@ -73,7 +73,7 @@ class ElggCoreUserTest extends ElggCoreUnitTest {
 
 	public function testElggUserLoad() {
 		// new object
-		$object = new ElggObject();
+		$object = new \ElggObject();
 		$this->AssertEqual($object->getGUID(), 0);
 		$guid = $object->save();
 		$this->AssertNotEqual($guid, 0);
@@ -87,7 +87,7 @@ class ElggCoreUserTest extends ElggCoreUnitTest {
 
 	public function testElggUserConstructorWithGarbage() {
 		try {
-			$error = new ElggUserTest(array('invalid'));
+			$error = new \ElggUserTest(array('invalid'));
 			$this->assertTrue(false);
 		} catch (Exception $e) {
 			$this->assertIsA($e, 'InvalidParameterException');
@@ -96,7 +96,7 @@ class ElggCoreUserTest extends ElggCoreUnitTest {
 
 	public function testElggUserConstructorByDbRow() {
 		$row = $this->fetchUser(elgg_get_logged_in_user_guid());
-		$user = new ElggUser($row);
+		$user = new \ElggUser($row);
 		$this->assertIdenticalEntities($user, $_SESSION['user']);
 	}
 
@@ -219,7 +219,7 @@ class ElggCoreUserTest extends ElggCoreUnitTest {
 	}
 }
 
-class ElggUserTest extends ElggUser {
+class ElggUserTest extends \ElggUser {
 	public function expose_attributes() {
 		return $this->attributes;
 	}

--- a/engine/tests/phpunit/Elgg/ActionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ActionsServiceTest.php
@@ -1,11 +1,13 @@
 <?php
+namespace Elgg;
 // @codeCoverageIgnoreStart
 $engine = dirname(dirname(dirname(dirname(__FILE__))));
 // require_once "$engine/lib/configuration.php";
 require_once "$engine/lib/actions.php";
 // @codeCoverageIgnoreEnd
 
-class Elgg_ActionsServiceTest extends PHPUnit_Framework_TestCase {
+
+class ActionsServiceTest extends \PHPUnit_Framework_TestCase {
 
 	public function setUp() {
 		$this->actionsDir = dirname(dirname(__FILE__)) . "/test_files/actions";
@@ -15,7 +17,7 @@ class Elgg_ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	 * Tests register, exists and unregisrer
 	 */
 	public function testCanRegisterFilesAsActions() {
-		$actions = new Elgg_ActionsService();
+		$actions = new \Elgg\ActionsService();
 		
 		$this->assertFalse($actions->exists('test/output'));
 		$this->assertFalse($actions->exists('test/not_registered'));
@@ -48,7 +50,7 @@ class Elgg_ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	 * Tests overwriting existing action
 	 */
 	public function testCanOverrideRegisteredActions() {
-		$actions = new Elgg_ActionsService();
+		$actions = new \Elgg\ActionsService();
 		
 		$this->assertFalse($actions->exists('test/output'));
 		
@@ -62,7 +64,7 @@ class Elgg_ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 	
 	public function testActionsAccessLevels() {
-		$actions = new Elgg_ActionsService();
+		$actions = new \Elgg\ActionsService();
 		
 		$this->assertFalse($actions->exists('test/output'));
 		$this->assertFalse($actions->exists('test/not_registered'));
@@ -81,7 +83,7 @@ class Elgg_ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	
 	//TODO token generation/validation
 // 	public function testGenerateValidateTokens() {
-// 		$actions = new Elgg_ActionsService();
+// 		$actions = new \Elgg\ActionsService();
 		
 // 		$i = 40;
 		
@@ -97,3 +99,4 @@ class Elgg_ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	
 	//TODO gatekeeper?
 }
+

--- a/engine/tests/phpunit/Elgg/Amd/ConfigTest.php
+++ b/engine/tests/phpunit/Elgg/Amd/ConfigTest.php
@@ -1,9 +1,11 @@
 <?php
+namespace Elgg\Amd;
 
-class Elgg_Amd_ConfigTest extends PHPUnit_Framework_TestCase {
+
+class ConfigTest extends \PHPUnit_Framework_TestCase {
 	
 	public function testCanConfigureModulePaths() {
-		$amdConfig = new Elgg_Amd_Config();
+		$amdConfig = new \Elgg\Amd\Config();
 		$amdConfig->addPath('jquery', '/some/path.js');
 		
 		$configArray = $amdConfig->getConfig();
@@ -12,7 +14,7 @@ class Elgg_Amd_ConfigTest extends PHPUnit_Framework_TestCase {
 	}
 	
 	public function testCanConfigureModuleShims() {
-		$amdConfig = new Elgg_Amd_Config();
+		$amdConfig = new \Elgg\Amd\Config();
 		$amdConfig->addShim('jquery', array(
 			'deps' => array('dep'),
 			'exports' => 'jQuery',
@@ -27,7 +29,7 @@ class Elgg_Amd_ConfigTest extends PHPUnit_Framework_TestCase {
 	}
 	
 	public function testCanRequireUnregisteredAmdModules() {
-		$amdConfig = new Elgg_Amd_Config();
+		$amdConfig = new \Elgg\Amd\Config();
 		$amdConfig->addDependency('jquery');
 		
 		$configArray = $amdConfig->getConfig();
@@ -36,10 +38,10 @@ class Elgg_Amd_ConfigTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-     * @expectedException InvalidParameterException
+     * @expectedException \InvalidParameterException
      */
 	public function testThrowsOnBadShim() {
-		$amdConfig = new Elgg_Amd_Config();
+		$amdConfig = new \Elgg\Amd\Config();
 		$amdConfig->addShim('bad_shim', array('invalid' => 'config'));
 
 		$configArray = $amdConfig->getConfig();
@@ -48,7 +50,7 @@ class Elgg_Amd_ConfigTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanAddModuleAsAmd() {
-		$amdConfig = new Elgg_Amd_Config();
+		$amdConfig = new \Elgg\Amd\Config();
 		$amdConfig->addModule('jquery');
 
 		$configArray = $amdConfig->getConfig();
@@ -57,7 +59,7 @@ class Elgg_Amd_ConfigTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanAddModuleAsShim() {
-		$amdConfig = new Elgg_Amd_Config();
+		$amdConfig = new \Elgg\Amd\Config();
 		$amdConfig->addModule('jquery.form', array('exports' => 'jquery.fn.ajaxform'));
 
 		$configArray = $amdConfig->getConfig();
@@ -66,3 +68,4 @@ class Elgg_Amd_ConfigTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('exports' => 'jquery.fn.ajaxform'), $configArray['shim']['jquery.form']);
 	}
 }
+

--- a/engine/tests/phpunit/Elgg/Amd/ViewFilterTest.php
+++ b/engine/tests/phpunit/Elgg/Amd/ViewFilterTest.php
@@ -1,9 +1,11 @@
 <?php
+namespace Elgg\Amd;
 
-class Elgg_Amd_ViewFilterTest extends PHPUnit_Framework_TestCase {
+
+class ViewFilterTest extends \PHPUnit_Framework_TestCase {
 	
 	public function testInsertsNamesForAnonymousModules() {
-		$viewFilter = new Elgg_Amd_ViewFilter();
+		$viewFilter = new \Elgg\Amd\ViewFilter();
 		
 		$originalContent = "// Comment\ndefine({})";
 		$filteredContent = $viewFilter->filter('js/my/mod.js', $originalContent);
@@ -12,10 +14,11 @@ class Elgg_Amd_ViewFilterTest extends PHPUnit_Framework_TestCase {
 	}
 	
 	public function testLeavesNamedModulesAlone() {
-		$viewFilter = new Elgg_Amd_ViewFilter();
+		$viewFilter = new \Elgg\Amd\ViewFilter();
 		
 		$originalContent = "// Comment\ndefine('any/mod', {})";
 		$filteredContent = $viewFilter->filter('js/my/mod.js', $originalContent);
 		$this->assertEquals($originalContent, $filteredContent);
 	}
 }
+

--- a/engine/tests/phpunit/Elgg/CacheHandlerTest.php
+++ b/engine/tests/phpunit/Elgg/CacheHandlerTest.php
@@ -1,15 +1,17 @@
 <?php
+namespace Elgg;
 
-class Elgg_CacheHandlerTest extends PHPUnit_Framework_TestCase {
+
+class CacheHandlerTest extends \PHPUnit_Framework_TestCase {
 
 	/**
-	 * @var Elgg_CacheHandler
+	 * @var \Elgg\CacheHandler
 	 */
 	protected $handler;
 
 	public function setUp() {
 		$config = (object)array();
-		$this->handler = new Elgg_CacheHandler($config);
+		$this->handler = new \Elgg\CacheHandler($config);
 	}
 
 	protected function _testParseFail($input) {
@@ -48,3 +50,4 @@ class Elgg_CacheHandlerTest extends PHPUnit_Framework_TestCase {
 		), $this->handler->parseRequestVar('/1234/default/hel/8lo-wo_rl.d.js'));
 	}
 }
+

--- a/engine/tests/phpunit/Elgg/Database/ConfigTest.php
+++ b/engine/tests/phpunit/Elgg/Database/ConfigTest.php
@@ -1,24 +1,26 @@
 <?php
+namespace Elgg\Database;
 
-class Elgg_Database_ConfigTest extends PHPUnit_Framework_TestCase {
+
+class ConfigTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetTablePrefix() {
-		$CONFIG = new stdClass();
+		$CONFIG = new \stdClass();
 		$CONFIG->dbprefix = "foo";
-		$conf = new Elgg_Database_Config($CONFIG);
+		$conf = new \Elgg\Database\Config($CONFIG);
 		$this->assertEquals($CONFIG->dbprefix, $conf->getTablePrefix());
 	}
 
 	public function testIsDatabaseSplitNotSet() {
-		$CONFIG = new stdClass();
-		$conf = new Elgg_Database_Config($CONFIG);
+		$CONFIG = new \stdClass();
+		$conf = new \Elgg\Database\Config($CONFIG);
 		$this->assertFalse($conf->isDatabaseSplit());
 	}
 
 	public function testIsDatabaseSplitInSettings() {
-		$CONFIG = new stdClass();
+		$CONFIG = new \stdClass();
 		$CONFIG->db['split'] = true;
-		$conf = new Elgg_Database_Config($CONFIG);
+		$conf = new \Elgg\Database\Config($CONFIG);
 		$this->assertTrue($conf->isDatabaseSplit());
 	}
 
@@ -29,12 +31,12 @@ class Elgg_Database_ConfigTest extends PHPUnit_Framework_TestCase {
 			'password' => 'xxxx',
 			'database' => 'elgg',
 		);
-		$CONFIG = new stdClass();
+		$CONFIG = new \stdClass();
 		$CONFIG->dbhost = $ans['host'];
 		$CONFIG->dbuser = $ans['user'];
 		$CONFIG->dbpass = $ans['password'];
 		$CONFIG->dbname = $ans['database'];
-		$conf = new Elgg_Database_Config($CONFIG);
+		$conf = new \Elgg\Database\Config($CONFIG);
 		$this->assertEquals($ans, $conf->getConnectionConfig());
 	}
 
@@ -45,13 +47,13 @@ class Elgg_Database_ConfigTest extends PHPUnit_Framework_TestCase {
 			'password' => 'xxxx',
 			'database' => 'elgg',
 		);
-		$CONFIG = new stdClass();
+		$CONFIG = new \stdClass();
 		$CONFIG->db['write']['dbhost'] = $ans['host'];
 		$CONFIG->db['write']['dbuser'] = $ans['user'];
 		$CONFIG->db['write']['dbpass'] = $ans['password'];
 		$CONFIG->db['write']['dbname'] = $ans['database'];
-		$conf = new Elgg_Database_Config($CONFIG);
-		$this->assertEquals($ans, $conf->getConnectionConfig(Elgg_Database_Config::WRITE));
+		$conf = new \Elgg\Database\Config($CONFIG);
+		$this->assertEquals($ans, $conf->getConnectionConfig(\Elgg\Database\Config::WRITE));
 	}
 
 	public function testGetConnectionConfigWithMultipleRead() {
@@ -69,7 +71,7 @@ class Elgg_Database_ConfigTest extends PHPUnit_Framework_TestCase {
 				'database' => 'elgg1',
 			),
 		);
-		$CONFIG = new stdClass();
+		$CONFIG = new \stdClass();
 		$CONFIG->db['read'][0]['dbhost'] = $ans[0]['host'];
 		$CONFIG->db['read'][0]['dbuser'] = $ans[0]['user'];
 		$CONFIG->db['read'][0]['dbpass'] = $ans[0]['password'];
@@ -78,9 +80,9 @@ class Elgg_Database_ConfigTest extends PHPUnit_Framework_TestCase {
 		$CONFIG->db['read'][1]['dbuser'] = $ans[1]['user'];
 		$CONFIG->db['read'][1]['dbpass'] = $ans[1]['password'];
 		$CONFIG->db['read'][1]['dbname'] = $ans[1]['database'];
-		$conf = new Elgg_Database_Config($CONFIG);
+		$conf = new \Elgg\Database\Config($CONFIG);
 
-		$connConf = $conf->getConnectionConfig(Elgg_Database_Config::READ);
+		$connConf = $conf->getConnectionConfig(\Elgg\Database\Config::READ);
 		$this->assertEquals($ans[$connConf['host']], $connConf);
 	}
 
@@ -92,14 +94,14 @@ class Elgg_Database_ConfigTest extends PHPUnit_Framework_TestCase {
 			'password' => 'xxxx',
 			'database' => 'elgg',
 		);
-		$CONFIG = new stdClass();
-		$CONFIG->db['write'] = new stdClass();
+		$CONFIG = new \stdClass();
+		$CONFIG->db['write'] = new \stdClass();
 		$CONFIG->db['write']->dbhost = $ans['host'];
 		$CONFIG->db['write']->dbuser = $ans['user'];
 		$CONFIG->db['write']->dbpass = $ans['password'];
 		$CONFIG->db['write']->dbname = $ans['database'];
-		$conf = new Elgg_Database_Config($CONFIG);
-		$this->assertEquals($ans, $conf->getConnectionConfig(Elgg_Database_Config::WRITE));
+		$conf = new \Elgg\Database\Config($CONFIG);
+		$this->assertEquals($ans, $conf->getConnectionConfig(\Elgg\Database\Config::WRITE));
 	}
 
 	// Elgg < 1.9 used objects to store the config
@@ -118,20 +120,21 @@ class Elgg_Database_ConfigTest extends PHPUnit_Framework_TestCase {
 				'database' => 'elgg1',
 			),
 		);
-		$CONFIG = new stdClass();
-		$CONFIG->db['read'][0] = new stdClass();
+		$CONFIG = new \stdClass();
+		$CONFIG->db['read'][0] = new \stdClass();
 		$CONFIG->db['read'][0]->dbhost = $ans[0]['host'];
 		$CONFIG->db['read'][0]->dbuser = $ans[0]['user'];
 		$CONFIG->db['read'][0]->dbpass = $ans[0]['password'];
 		$CONFIG->db['read'][0]->dbname = $ans[0]['database'];
-		$CONFIG->db['read'][1] = new stdClass();
+		$CONFIG->db['read'][1] = new \stdClass();
 		$CONFIG->db['read'][1]->dbhost = $ans[1]['host'];
 		$CONFIG->db['read'][1]->dbuser = $ans[1]['user'];
 		$CONFIG->db['read'][1]->dbpass = $ans[1]['password'];
 		$CONFIG->db['read'][1]->dbname = $ans[1]['database'];
-		$conf = new Elgg_Database_Config($CONFIG);
+		$conf = new \Elgg\Database\Config($CONFIG);
 
-		$connConf = $conf->getConnectionConfig(Elgg_Database_Config::READ);
+		$connConf = $conf->getConnectionConfig(\Elgg\Database\Config::READ);
 		$this->assertEquals($ans[$connConf['host']], $connConf);
 	}
 }
+

--- a/engine/tests/phpunit/Elgg/DeprecationWrapperTest.php
+++ b/engine/tests/phpunit/Elgg/DeprecationWrapperTest.php
@@ -1,6 +1,7 @@
 <?php
+namespace Elgg;
 
-class Elgg_DeprecationWrapperTest extends PHPUnit_Framework_TestCase {
+class DeprecationWrapperTest extends \PHPUnit_Framework_TestCase {
 
 	public $last_stack_line = '';
 
@@ -29,7 +30,7 @@ class Elgg_DeprecationWrapperTest extends PHPUnit_Framework_TestCase {
 
 	function testWrapString() {
 		$str = 'Hello';
-		$str = new Elgg_DeprecationWrapper($str, 'BAD!', 1.8, array($this, 'report'));
+		$str = new DeprecationWrapper($str, 'BAD!', 1.8, array($this, 'report'));
 		$file = __FILE__;
 		$new_str = "$str"; $line = __LINE__;
 		$this->assertEquals('Hello', $new_str);
@@ -37,8 +38,8 @@ class Elgg_DeprecationWrapperTest extends PHPUnit_Framework_TestCase {
 	}
 
 	function testWrapObject() {
-		$obj = new Elgg_DeprecationWrapperTestObj1();
-		$obj = new Elgg_DeprecationWrapper($obj, 'BAD!', 1.8, array($this, 'report'));
+		$obj = new DeprecationWrapperTestObj1();
+		$obj = new DeprecationWrapper($obj, 'BAD!', 1.8, array($this, 'report'));
 		$file = __FILE__;
 		$foo = $obj->foo; $line = __LINE__;
 		$this->assertEquals($foo, 'foo');
@@ -55,9 +56,9 @@ class Elgg_DeprecationWrapperTest extends PHPUnit_Framework_TestCase {
 
 	function testArrayAccessProxiesObjectArrayAccessMethods() {
 		$file = __FILE__;
-		$obj = new Elgg_DeprecationWrapperTestObj2();
+		$obj = new DeprecationWrapperTestObj2();
 		$obj->data['foo'] = 'test';
-		$wrapper = new Elgg_DeprecationWrapper($obj, 'FOO', 1.9, array($this, 'report'));
+		$wrapper = new DeprecationWrapper($obj, 'FOO', 1.9, array($this, 'report'));
 
 		$foo = $wrapper['foo']; $line = __LINE__;
 		$this->assertEquals('test', $foo);
@@ -80,9 +81,9 @@ class Elgg_DeprecationWrapperTest extends PHPUnit_Framework_TestCase {
 
 	function testArrayAccessProxiesProperties() {
 		$file = __FILE__;
-		$obj = new stdClass();
+		$obj = new \stdClass();
 		$obj->foo = 'test';
-		$wrapper = new Elgg_DeprecationWrapper($obj, 'FOO', 1.9, array($this, 'report'));
+		$wrapper = new DeprecationWrapper($obj, 'FOO', 1.9, array($this, 'report'));
 
 		$foo = $wrapper['foo']; $line = __LINE__;
 		$this->assertEquals('test', $foo);
@@ -94,13 +95,14 @@ class Elgg_DeprecationWrapperTest extends PHPUnit_Framework_TestCase {
 	}
 }
 
-class Elgg_DeprecationWrapperTestObj1 {
+class DeprecationWrapperTestObj1 {
 	public $foo = 'foo';
 	public function foo() { return 'foo'; }
 	public function __toString() { return 'foo'; }
 }
 
-class Elgg_DeprecationWrapperTestObj2 extends ArrayObject {
+
+class DeprecationWrapperTestObj2 extends \ArrayObject {
 	public $data = array();
 	public function offsetSet($offset, $value) {
 		if (is_null($offset)) {
@@ -119,3 +121,4 @@ class Elgg_DeprecationWrapperTestObj2 extends ArrayObject {
 		return isset($this->data[$offset]) ? $this->data[$offset] : null;
 	}
 }
+

--- a/engine/tests/phpunit/Elgg/Di/DiContainerTest.php
+++ b/engine/tests/phpunit/Elgg/Di/DiContainerTest.php
@@ -1,20 +1,23 @@
 <?php
+namespace Elgg\Di;
 
-class Elgg_Di_DiContainerTest extends PHPUnit_Framework_TestCase {
+namespace Elgg\Di;
 
-	const TEST_CLASS = 'Elgg_Di_DiContainerTestObject';
+class DiContainerTest extends \PHPUnit_Framework_TestCase {
 
-	public function getFoo(Elgg_Di_DiContainer $di) {
-		return new Elgg_Di_DiContainerTestObject($di);
+	const TEST_CLASS = '\Elgg\Di\DiContainerTestObject';
+
+	public function getFoo(\Elgg\Di\DiContainer $di) {
+		return new \Elgg\Di\DiContainerTestObject($di);
 	}
 
 	public function testEmptyContainer() {
-		$di = new Elgg_Di_DiContainer();
+		$di = new \Elgg\Di\DiContainer();
 		$this->assertFalse($di->has('foo'));
 	}
 
 	public function testSetValue() {
-		$di = new Elgg_Di_DiContainer();
+		$di = new \Elgg\Di\DiContainer();
 
 		$this->assertSame($di, $di->setValue('foo', 'Foo'));
 		$this->assertTrue($di->has('foo'));
@@ -22,7 +25,7 @@ class Elgg_Di_DiContainerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testSetFactoryShared() {
-		$di = new Elgg_Di_DiContainer();
+		$di = new \Elgg\Di\DiContainer();
 
 		$this->assertSame($di, $di->setFactory('foo', array($this, 'getFoo')));
 		$this->assertTrue($di->has('foo'));
@@ -33,7 +36,7 @@ class Elgg_Di_DiContainerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testSetFactoryUnshared() {
-		$di = new Elgg_Di_DiContainer();
+		$di = new \Elgg\Di\DiContainer();
 
 		$this->assertSame($di, $di->setFactory('foo', array($this, 'getFoo'), false));
 		$this->assertTrue($di->has('foo'));
@@ -44,7 +47,7 @@ class Elgg_Di_DiContainerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testContainerIsPassedToFactory() {
-		$di = new Elgg_Di_DiContainer();
+		$di = new \Elgg\Di\DiContainer();
 		$di->setFactory('foo', array($this, 'getFoo'));
 
 		$foo = $di->foo;
@@ -52,31 +55,31 @@ class Elgg_Di_DiContainerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testSetFactoryLooksUncallable() {
-		$di = new Elgg_Di_DiContainer();
+		$di = new \Elgg\Di\DiContainer();
 
 		$this->setExpectedException('InvalidArgumentException', '$factory must appear callable');
-		$di->setFactory('foo', new stdClass());
+		$di->setFactory('foo', new \stdClass());
 	}
 
 	public function testGetFactoryUncallable() {
-		$di = new Elgg_Di_DiContainer();
+		$di = new \Elgg\Di\DiContainer();
 		$di->setFactory('foo', 'not-a-real-callable');
 
 		$this->setExpectedException(
-			'Elgg_Di_FactoryUncallableException',
+			'\Elgg\Di\FactoryUncallableException',
 			"Factory for 'foo' was uncallable: 'not-a-real-callable'");
 		$di->foo;
 	}
 
 	public function testGetMissingValue() {
-		$di = new Elgg_Di_DiContainer();
+		$di = new \Elgg\Di\DiContainer();
 
-		$this->setExpectedException('Elgg_Di_MissingValueException', "Value or factory was not set for: foo");
+		$this->setExpectedException('\Elgg\Di\MissingValueException', "Value or factory was not set for: foo");
 		$di->foo;
 	}
 
 	public function testRemove() {
-		$di = new Elgg_Di_DiContainer();
+		$di = new \Elgg\Di\DiContainer();
 		$di->setValue('foo', 'Foo');
 
 		$this->assertSame($di, $di->remove('foo'));
@@ -84,7 +87,7 @@ class Elgg_Di_DiContainerTest extends PHPUnit_Framework_TestCase {
 	}
 	
 	public function testSetClassNames() {
-		$di = new Elgg_Di_DiContainer();
+		$di = new \Elgg\Di\DiContainer();
 		$di->setClassName('foo', self::TEST_CLASS);
 
 		$this->assertInstanceOf(self::TEST_CLASS, $di->foo);
@@ -94,7 +97,7 @@ class Elgg_Di_DiContainerTest extends PHPUnit_Framework_TestCase {
 	}
 	
 	public function testSettingInvalidClassNameThrows() {
-		$di = new Elgg_Di_DiContainer();
+		$di = new \Elgg\Di\DiContainer();
 		
 		$euro = "\xE2\x82\xAC";
 		
@@ -110,18 +113,20 @@ class Elgg_Di_DiContainerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testAccessRemovedValue() {
-		$di = new Elgg_Di_DiContainer();
+		$di = new \Elgg\Di\DiContainer();
 		$di->setValue('foo', 'Foo');
 		$di->remove('foo');
 
-		$this->setExpectedException('Elgg_Di_MissingValueException');
+		$this->setExpectedException('\Elgg\Di\MissingValueException');
 		$di->foo;
 	}
 }
 
-class Elgg_Di_DiContainerTestObject {
+
+class DiContainerTestObject {
 	public $di;
 	public function __construct($di = null) {
 		$this->di = $di;
 	}
 }
+

--- a/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
+++ b/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
@@ -1,33 +1,35 @@
 <?php
+namespace Elgg\Di;
 
-class Elgg_Di_ServiceProviderTest extends PHPUnit_Framework_TestCase {
+
+class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testPropertiesReturnCorrectClassNames() {
-		$mgr = $this->getMock('Elgg_AutoloadManager', array(), array(), '', false);
+		$mgr = $this->getMock('\Elgg\AutoloadManager', array(), array(), '', false);
 
-		$sp = new Elgg_Di_ServiceProvider($mgr);
+		$sp = new \Elgg\Di\ServiceProvider($mgr);
 
 		$svcClasses = array(
-			'actions' => 'Elgg_ActionsService',
+			'actions' => '\Elgg\ActionsService',
 			
 			// requires _elgg_get_simplecache_root() to be defined
-			//'amdConfig' => 'Elgg_Amd_Config',
+			//'amdConfig' => '\Elgg\Amd\Config',
 			
-			'autoP' => 'ElggAutoP',
-			'autoloadManager' => 'Elgg_AutoloadManager',
-			'db' => 'Elgg_Database',
-			'events' => 'Elgg_EventsService',
-			'hooks' => 'Elgg_PluginHooksService',
-			'logger' => 'Elgg_Logger',
-			'metadataCache' => 'ElggVolatileMetadataCache',
-			'request' => 'Elgg_Http_Request',
-			'router' => 'Elgg_Router',
+			'autoP' => '\ElggAutoP',
+			'autoloadManager' => '\Elgg\AutoloadManager',
+			'db' => '\Elgg\Database',
+			'events' => '\Elgg\EventsService',
+			'hooks' => '\Elgg\PluginHooksService',
+			'logger' => '\Elgg\Logger',
+			'metadataCache' => '\ElggVolatileMetadataCache',
+			'request' => '\Elgg\Http\Request',
+			'router' => '\Elgg\Router',
 			
 			// Will this start session?
-			//'session' => 'ElggSession'
+			//'session' => '\ElggSession'
 			
-			'views' => 'Elgg_ViewsService',
-			'widgets' => 'Elgg_WidgetsService',
+			'views' => '\Elgg\ViewsService',
+			'widgets' => '\Elgg\WidgetsService',
 		);
 
 		foreach ($svcClasses as $key => $class) {
@@ -38,3 +40,4 @@ class Elgg_Di_ServiceProviderTest extends PHPUnit_Framework_TestCase {
 		}
 	}
 }
+

--- a/engine/tests/phpunit/Elgg/EntityDirLocatorTest.php
+++ b/engine/tests/phpunit/Elgg/EntityDirLocatorTest.php
@@ -1,6 +1,8 @@
 <?php
+namespace Elgg;
 
-class Elgg_EntityDirLocatorTest extends PHPUnit_Framework_TestCase {
+
+class EntityDirLocatorTest extends \PHPUnit_Framework_TestCase {
 	public $guids = array(
 		1,
 		4999,
@@ -15,8 +17,8 @@ class Elgg_EntityDirLocatorTest extends PHPUnit_Framework_TestCase {
 	public function testConstructorGUIDs() {
 		// good guids
 		foreach ($this->guids as $guid) {
-			$dir = new Elgg_EntityDirLocator($guid);
-			$this->assertInstanceOf('Elgg_EntityDirLocator', $dir);
+			$dir = new \Elgg\EntityDirLocator($guid);
+			$this->assertInstanceOf('\Elgg\EntityDirLocator', $dir);
 		}
 
 		// bad guids
@@ -30,15 +32,15 @@ class Elgg_EntityDirLocatorTest extends PHPUnit_Framework_TestCase {
 
 		foreach ($bad_guids as $guid) {
 			$this->setExpectedException('InvalidArgumentException', "GUIDs must be integers > 0.");
-			$dir = new Elgg_EntityDirLocator($guid);
+			$dir = new \Elgg\EntityDirLocator($guid);
 		}
 	}
 
 	public function testGetPath() {
-		$size = Elgg_EntityDirLocator::BUCKET_SIZE;
+		$size = \Elgg\EntityDirLocator::BUCKET_SIZE;
 
 		foreach ($this->guids as $guid) {
-			$test = new Elgg_EntityDirLocator($guid);
+			$test = new \Elgg\EntityDirLocator($guid);
 
 			// we start at 1 since there are no guids of 0
 			if ($guid < 5000) {
@@ -57,7 +59,7 @@ class Elgg_EntityDirLocatorTest extends PHPUnit_Framework_TestCase {
 
 	public function testToString() {
 		$guid = 431;
-		$path = new Elgg_EntityDirLocator($guid);
+		$path = new \Elgg\EntityDirLocator($guid);
 
 		$root = "/tmp/elgg/";
 		$this->assertSame($root . '1/431/', $root . $path);

--- a/engine/tests/phpunit/Elgg/EventsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/EventsServiceTest.php
@@ -1,6 +1,8 @@
 <?php
+namespace Elgg;
 
-class Elgg_EventsServiceTest extends PHPUnit_Framework_TestCase {
+
+class EventsServiceTest extends \PHPUnit_Framework_TestCase {
 
 	public $counter = 0;
 
@@ -9,7 +11,7 @@ class Elgg_EventsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testTriggerCallsRegisteredHandlersAndReturnsTrue() {
-		$events = new Elgg_EventsService();
+		$events = new \Elgg\EventsService();
 
 		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
 		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
@@ -19,9 +21,9 @@ class Elgg_EventsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testFalseStopsPropagationAndReturnsFalse() {
-		$events = new Elgg_EventsService();
+		$events = new \Elgg\EventsService();
 
-		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'returnFalse'));
+		$events->registerHandler('foo', 'bar', array('\Elgg\EventsServiceTest', 'returnFalse'));
 		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
 
 		$this->assertFalse($events->trigger('foo', 'bar'));
@@ -29,9 +31,9 @@ class Elgg_EventsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testNullDoesNotStopPropagation() {
-		$events = new Elgg_EventsService();
+		$events = new \Elgg\EventsService();
 
-		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'returnNull'));
+		$events->registerHandler('foo', 'bar', array('\Elgg\EventsServiceTest', 'returnNull'));
 		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
 
 		$this->assertTrue($events->trigger('foo', 'bar'));
@@ -39,23 +41,23 @@ class Elgg_EventsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testUnstoppableEventsCantBeStoppedAndReturnTrue() {
-		$events = new Elgg_EventsService();
+		$events = new \Elgg\EventsService();
 
-		$events->registerHandler('foo', 'bar', array('Elgg_EventsServiceTest', 'returnFalse'));
+		$events->registerHandler('foo', 'bar', array('\Elgg\EventsServiceTest', 'returnFalse'));
 		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
 
 		$this->assertTrue($events->trigger('foo', 'bar', null, array(
-			Elgg_EventsService::OPTION_STOPPABLE => false
+			\Elgg\EventsService::OPTION_STOPPABLE => false
 		)));
 		$this->assertEquals($this->counter, 1);
 	}
 
 	public function testUncallableHandlersAreLogged() {
-		$events = new Elgg_EventsService();
+		$events = new \Elgg\EventsService();
 
-		$loggerMock = $this->getMock('Elgg_Logger', array(), array(), '', false);
+		$loggerMock = $this->getMock('\Elgg\Logger', array(), array(), '', false);
 		$events->setLogger($loggerMock);
-		$events->registerHandler('foo', 'bar', array(new stdClass(), 'uncallableMethod'));
+		$events->registerHandler('foo', 'bar', array(new \stdClass(), 'uncallableMethod'));
 
 		$expectedMsg = 'handler for event [foo, bar] is not callable: (stdClass)->uncallableMethod';
 		$loggerMock->expects($this->once())->method('warn')->with($expectedMsg);
@@ -80,3 +82,4 @@ class Elgg_EventsServiceTest extends PHPUnit_Framework_TestCase {
 		return;
 	}
 }
+

--- a/engine/tests/phpunit/Elgg/HooksRegistrationService.php
+++ b/engine/tests/phpunit/Elgg/HooksRegistrationService.php
@@ -1,11 +1,13 @@
 <?php
+namespace Elgg;
 
-class Elgg_HooksRegistrationServiceTest extends PHPUnit_Framework_TestCase {
+
+class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
 
 	public function setUp() {
 		parent::setUp();
 
-		$this->mock = $this->getMockForAbstractClass('Elgg_HooksRegistrationService');
+		$this->mock = $this->getMockForAbstractClass('\Elgg\HooksRegistrationService');
 	}
 	
 	public function testCanRegisterHandlers() {
@@ -69,3 +71,4 @@ class Elgg_HooksRegistrationServiceTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame($expected_foo_baz, $this->mock->getOrderedHandlers('foo', 'baz'));
 	}
 }
+

--- a/engine/tests/phpunit/Elgg/Http/MockSessionStorageTest.php
+++ b/engine/tests/phpunit/Elgg/Http/MockSessionStorageTest.php
@@ -1,11 +1,13 @@
 <?php
+namespace Elgg\Http;
 
-class Elgg_Http_MockSessionStorageTest extends PHPUnit_Framework_TestCase {
-	/** @var Elgg_Http_MockSessionStorage */
+
+class MockSessionStorageTest extends \PHPUnit_Framework_TestCase {
+	/** @var \Elgg\Http\MockSessionStorage */
 	protected $storage;
 
 	protected function setUp() {
-		$this->storage = new Elgg_Http_MockSessionStorage();
+		$this->storage = new \Elgg\Http\MockSessionStorage();
 	}
 
 	public function testGetId() {
@@ -21,7 +23,7 @@ class Elgg_Http_MockSessionStorageTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException RuntimeException
+	 * @expectedException \RuntimeException
 	 */
 	public function testSetIdAfterStart() {
 		$this->storage->start();
@@ -66,7 +68,7 @@ class Elgg_Http_MockSessionStorageTest extends PHPUnit_Framework_TestCase {
 
 	protected function setUpAttributes() {
 		$this->data = array(
-			'user' => new stdClass(),
+			'user' => new \stdClass(),
 			'guid' => 64,
 			'msg' => array('success' => 'You are logged in'),
 		);
@@ -75,7 +77,7 @@ class Elgg_Http_MockSessionStorageTest extends PHPUnit_Framework_TestCase {
 
 	public static function provideAttributes() {
 		return array(
-			array('user', new stdClass(), true),
+			array('user', new \stdClass(), true),
 			array('guid', 64, true),
 			array('msg', array('success' => 'You are logged in'), true),
 			array('not_exist', null, false),

--- a/engine/tests/phpunit/Elgg/Http/NativeSessionStorageTest.php
+++ b/engine/tests/phpunit/Elgg/Http/NativeSessionStorageTest.php
@@ -1,4 +1,5 @@
 <?php
+namespace Elgg\Http;
 /**
  * If you make a change in the tests for native storage, update the tests for mock storage
  * 
@@ -6,13 +7,14 @@
  * the session from starting.
  */
 
-class Elgg_Http_NativeSessionStorageTest extends PHPUnit_Framework_TestCase {
 
-	/** @var Elgg_Http_NativeSessionStorage */
+class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase {
+
+	/** @var \Elgg\Http\NativeSessionStorage */
 	protected $storage;
 
 	protected function setUp() {
-		$this->storage = new Elgg_Http_NativeSessionStorage(array(), new Elgg_Http_MockSessionHandler());
+		$this->storage = new \Elgg\Http\NativeSessionStorage(array(), new \Elgg\Http\MockSessionHandler());
 	}
 
 	protected function tearDown() {
@@ -40,7 +42,7 @@ class Elgg_Http_NativeSessionStorageTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException RuntimeException
+	 * @expectedException \RuntimeException
 	 */
 	public function testSetIdAfterStart() {
 		if (headers_sent()) {
@@ -103,7 +105,7 @@ class Elgg_Http_NativeSessionStorageTest extends PHPUnit_Framework_TestCase {
 
 	protected function setUpAttributes() {
 		$this->data = array(
-			'user' => new stdClass(),
+			'user' => new \stdClass(),
 			'guid' => 64,
 			'msg' => array('success' => 'You are logged in'),
 		);
@@ -112,7 +114,7 @@ class Elgg_Http_NativeSessionStorageTest extends PHPUnit_Framework_TestCase {
 
 	public static function provideAttributes() {
 		return array(
-			array('user', new stdClass(), true),
+			array('user', new \stdClass(), true),
 			array('guid', 64, true),
 			array('msg', array('success' => 'You are logged in'), true),
 			array('not_exist', null, false),
@@ -207,3 +209,4 @@ class Elgg_Http_NativeSessionStorageTest extends PHPUnit_Framework_TestCase {
 	}
 
 }
+

--- a/engine/tests/phpunit/Elgg/LoggerTest.php
+++ b/engine/tests/phpunit/Elgg/LoggerTest.php
@@ -1,27 +1,30 @@
 <?php
+namespace Elgg;
 
-class Elgg_LoggerTest extends PHPUnit_Framework_TestCase {
+
+class LoggerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testLoggingOff() {
-		$mock = $this->getMock('Elgg_PluginHooksService', array('trigger'));
+		$mock = $this->getMock('\Elgg\PluginHooksService', array('trigger'));
 		$mock->expects($this->never())->method('trigger');
-		$logger = new Elgg_Logger($mock);
-		$logger->setLevel(Elgg_Logger::OFF);
+		$logger = new \Elgg\Logger($mock);
+		$logger->setLevel(\Elgg\Logger::OFF);
 		$this->assertFalse($logger->log("hello"));
 	}
 
 	public function testLoggingLevelTooLow() {
-		$mock = $this->getMock('Elgg_PluginHooksService', array('trigger'));
+		$mock = $this->getMock('\Elgg\PluginHooksService', array('trigger'));
 		$mock->expects($this->never())->method('trigger');
-		$logger = new Elgg_Logger($mock);
-		$logger->setLevel(Elgg_Logger::WARNING);
-		$this->assertFalse($logger->log("hello", Elgg_Logger::NOTICE));
+		$logger = new \Elgg\Logger($mock);
+		$logger->setLevel(\Elgg\Logger::WARNING);
+		$this->assertFalse($logger->log("hello", \Elgg\Logger::NOTICE));
 	}
 
 	public function testLoggingLevelNotExist() {
-		$mock = $this->getMock('Elgg_PluginHooksService', array('trigger'));
+		$mock = $this->getMock('\Elgg\PluginHooksService', array('trigger'));
 		$mock->expects($this->never())->method('trigger');
-		$logger = new Elgg_Logger($mock);
+		$logger = new \Elgg\Logger($mock);
 		$this->assertFalse($logger->log("hello", 123));
 	}
 }
+

--- a/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
@@ -1,13 +1,15 @@
 <?php
+namespace Elgg\Notifications;
 
-class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_TestCase {
+
+class SubscriptionsServiceTest extends \PHPUnit_Framework_TestCase {
 
 	public function setUp() {
 		$this->containerGuid = 42;
 
-		// mock ElggObject that has a container guid
+		// mock \ElggObject that has a container guid
 		$object = $this->getMock(
-				'ElggObject',
+				'\ElggObject',
 				array('getContainerGUID'),
 				array(),
 				'',
@@ -18,7 +20,7 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 
 		// mock event that holds the mock object
 		$this->event = $this->getMock(
-				'Elgg_Notifications_Event',
+				'\Elgg\Notifications\Event',
 				array('getObject'),
 				array(),
 				'',
@@ -26,7 +28,7 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 		$this->event->expects($this->any())
 				->method('getObject')
 				->will($this->returnValue($object));
-		$this->db = $this->getMock('Elgg_Database',
+		$this->db = $this->getMock('\Elgg\Database',
 				array('getData', 'getTablePrefix', 'sanitizeString'),
 				array(),
 				'',
@@ -40,17 +42,17 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 				->will($this->returnArgument(0));
 
 		// Event class has dependency on elgg_get_logged_in_user_guid()
-		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
+		_elgg_services()->setValue('session', new \ElggSession(new \Elgg\Http\MockSessionStorage()));
 	}
 
 	public function testGetSubscriptionsWithNoMethodsRegistered() {
-		$service = new Elgg_Notifications_SubscriptionsService($this->db);
+		$service = new \Elgg\Notifications\SubscriptionsService($this->db);
 		$this->assertEquals(array(), $service->getSubscriptions($this->event));
 	}
 
 	public function testGetSubscriptionsWithBadObject() {
 		$this->event = $this->getMock(
-				'Elgg_Notifications_Event',
+				'\Elgg\Notifications\Event',
 				array('getObject'),
 				array(),
 				'',
@@ -58,7 +60,7 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 		$this->event->expects($this->any())
 				->method('getObject')
 				->will($this->returnValue(null));
-		$service = new Elgg_Notifications_SubscriptionsService($this->db);
+		$service = new \Elgg\Notifications\SubscriptionsService($this->db);
 		$service->methods = array('one', 'two');
 		$this->assertEquals(array(), $service->getSubscriptions($this->event));
 	}
@@ -73,7 +75,7 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 				->method('getData')
 				->with($this->equalTo($query))
 				->will($this->returnValue(array()));
-		$service = new Elgg_Notifications_SubscriptionsService($this->db);
+		$service = new \Elgg\Notifications\SubscriptionsService($this->db);
 
 		$service->methods = $methods;
 		$this->assertEquals(array(), $service->getSubscriptions($this->event));
@@ -92,7 +94,7 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 		$this->db->expects($this->once())
 				->method('getData')
 				->will($this->returnValue($queryResult));
-		$service = new Elgg_Notifications_SubscriptionsService($this->db);
+		$service = new \Elgg\Notifications\SubscriptionsService($this->db);
 
 		$service->methods = $methods;
 		$this->assertEquals($subscriptions, $service->getSubscriptions($this->event));
@@ -100,7 +102,7 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 
 	public function testGetSubscriptionsForContainerWithNoMethodsRegistered() {
 		$container_guid = 132;
-		$service = new Elgg_Notifications_SubscriptionsService($this->db);
+		$service = new \Elgg\Notifications\SubscriptionsService($this->db);
 		$this->assertEquals(array(), $service->getSubscriptionsForContainer($container_guid));
 	}
 
@@ -119,17 +121,18 @@ class Elgg_Notifications_SubscriptionsServiceTest extends PHPUnit_Framework_Test
 		$this->db->expects($this->once())
 				->method('getData')
 				->will($this->returnValue($queryResult));
-		$service = new Elgg_Notifications_SubscriptionsService($this->db);
+		$service = new \Elgg\Notifications\SubscriptionsService($this->db);
 
 		$service->methods = $methods;
 		$this->assertEquals($subscriptions, $service->getSubscriptionsForContainer($container_guid));
 	}
 
 	protected function createObjectFromArray(array $data) {
-		$obj = new stdClass();
+		$obj = new \stdClass();
 		foreach ($data as $key => $value) {
 			$obj->$key = $value;
 		}
 		return $obj;
 	}
 }
+

--- a/engine/tests/phpunit/Elgg/PersistentLoginTest.php
+++ b/engine/tests/phpunit/Elgg/PersistentLoginTest.php
@@ -1,34 +1,36 @@
 <?php
+namespace Elgg;
 
-class Elgg_PersistentLoginTest extends PHPUnit_Framework_TestCase {
+
+class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 
 	/**
-	 * @var ElggSession
+	 * @var \ElggSession
 	 */
 	protected $session;
 
 	/**
-	 * @var PHPUnit_Framework_MockObject_MockObject
+	 * @var \PHPUnit_Framework_MockObject_MockObject
 	 */
 	protected $dbMock;
 
 	/**
-	 * @var PHPUnit_Framework_MockObject_MockObject
+	 * @var \PHPUnit_Framework_MockObject_MockObject
 	 */
 	protected $cryptoMock;
 
 	/**
-	 * @var Elgg_PersistentLoginService
+	 * @var \Elgg\PersistentLoginService
 	 */
 	protected $svc;
 
 	/**
-	 * @var PHPUnit_Framework_MockObject_MockObject
+	 * @var \PHPUnit_Framework_MockObject_MockObject
 	 */
 	protected $user123;
 
 	/**
-	 * @var ElggCookie
+	 * @var \ElggCookie
 	 */
 	protected $lastCookieSet;
 
@@ -61,10 +63,10 @@ class Elgg_PersistentLoginTest extends PHPUnit_Framework_TestCase {
 
 		$this->user123 = $this->getMockElggUser(123);
 
-		$this->session = new ElggSession(new Elgg_Http_MockSessionStorage());
+		$this->session = new \ElggSession(new \Elgg\Http\MockSessionStorage());
 
 		// mock DB
-		$this->dbMock = $this->getMockBuilder('Elgg_Database')
+		$this->dbMock = $this->getMockBuilder('\Elgg\Database')
 			->disableOriginalConstructor()
 			->getMock();
 		// use addslashes as ->sanitizeString (my local CLI doesn't have MySQL)
@@ -72,7 +74,7 @@ class Elgg_PersistentLoginTest extends PHPUnit_Framework_TestCase {
 			->method('sanitizeString')
 			->will($this->returnCallback(array($this, 'mock_sanitizeString')));
 
-		$this->cryptoMock = $this->getMockBuilder('ElggCrypto')->getMock();
+		$this->cryptoMock = $this->getMockBuilder('\ElggCrypto')->getMock();
 		$this->cryptoMock->expects($this->any())
 			->method('getRandomString')
 			->will($this->returnValue(str_repeat('a', 31)));
@@ -274,9 +276,9 @@ class Elgg_PersistentLoginTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame($this->mockToken, $this->session->get('code'));
 	}
 
-	// mock ElggUser which will return the GUID on ->guid reads
+	// mock \ElggUser which will return the GUID on ->guid reads
 	function getMockElggUser($guid) {
-		$user = $this->getMockBuilder('ElggUser')
+		$user = $this->getMockBuilder('\ElggUser')
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->any())
@@ -293,7 +295,7 @@ class Elgg_PersistentLoginTest extends PHPUnit_Framework_TestCase {
 		return null;
 	}
 
-	function mock_elgg_set_cookie(ElggCookie $cookie) {
+	function mock_elgg_set_cookie(\ElggCookie $cookie) {
 		$this->lastCookieSet = $cookie;
 	}
 
@@ -308,7 +310,7 @@ class Elgg_PersistentLoginTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @param string $cookie_token
-	 * @return Elgg_PersistentLoginService
+	 * @return \Elgg\PersistentLoginService
 	 */
 	protected function getSvcWithCookie($cookie_token = '') {
 		$cookie_config = array(
@@ -321,7 +323,7 @@ class Elgg_PersistentLoginTest extends PHPUnit_Framework_TestCase {
 			'expire' => time() + (30 * 86400),
 		);
 		$time = $this->thirtyDaysAgo + (30 * 86400);
-		$svc = new Elgg_PersistentLoginService(
+		$svc = new \Elgg\PersistentLoginService(
 			$this->dbMock, $this->session, $this->cryptoMock,
 			$cookie_config, $cookie_token, $time);
 

--- a/engine/tests/phpunit/Elgg/PluginHooksServiceTest.php
+++ b/engine/tests/phpunit/Elgg/PluginHooksServiceTest.php
@@ -1,20 +1,22 @@
 <?php
+namespace Elgg;
 
-class Elgg_PluginHooksServiceTest extends PHPUnit_Framework_TestCase {
+
+class PluginHooksServiceTest extends \PHPUnit_Framework_TestCase {
 	
 	public function testTriggerCallsRegisteredHandlers() {
-		$hooks = new Elgg_PluginHooksService();
+		$hooks = new \Elgg\PluginHooksService();
 		
 		$this->setExpectedException('InvalidArgumentException');
 		
-		$hooks->registerHandler('foo', 'bar', array('Elgg_PluginHooksServiceTest', 'throwInvalidArg'));
+		$hooks->registerHandler('foo', 'bar', array('\Elgg\PluginHooksServiceTest', 'throwInvalidArg'));
 
 		$hooks->trigger('foo', 'bar');
 	}
 	
 	public function testCanPassParamsAndChangeReturnValue() {
-		$hooks = new Elgg_PluginHooksService();
-		$hooks->registerHandler('foo', 'bar', array('Elgg_PluginHooksServiceTest', 'changeReturn'));
+		$hooks = new \Elgg\PluginHooksService();
+		$hooks->registerHandler('foo', 'bar', array('\Elgg\PluginHooksServiceTest', 'changeReturn'));
 		
 		$returnval = $hooks->trigger('foo', 'bar', array(
 			'testCase' => $this,
@@ -24,11 +26,11 @@ class Elgg_PluginHooksServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testUncallableHandlersAreLogged() {
-		$hooks = new Elgg_PluginHooksService();
+		$hooks = new \Elgg\PluginHooksService();
 
-		$loggerMock = $this->getMock('Elgg_Logger', array(), array(), '', false);
+		$loggerMock = $this->getMock('\Elgg\Logger', array(), array(), '', false);
 		$hooks->setLogger($loggerMock);
-		$hooks->registerHandler('foo', 'bar', array(new stdClass(), 'uncallableMethod'));
+		$hooks->registerHandler('foo', 'bar', array(new \stdClass(), 'uncallableMethod'));
 
 		$expectedMsg = 'handler for plugin hook [foo, bar] is not callable: (stdClass)->uncallableMethod';
 		$loggerMock->expects($this->once())->method('warn')->with($expectedMsg);
@@ -49,6 +51,7 @@ class Elgg_PluginHooksServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public static function throwInvalidArg() {
-		throw new InvalidArgumentException();
+		throw new \InvalidArgumentException();
 	}
 }
+

--- a/engine/tests/phpunit/Elgg/RouterTest.php
+++ b/engine/tests/phpunit/Elgg/RouterTest.php
@@ -1,14 +1,16 @@
 <?php
+namespace Elgg;
 
-class Elgg_RouterTest extends PHPUnit_Framework_TestCase {
+
+class RouterTest extends \PHPUnit_Framework_TestCase {
 
 	/**
-	 * @var Elgg_PluginHooksService
+	 * @var \Elgg\PluginHooksService
 	 */
 	protected $hooks;
 
 	/**
-	 * @var Elgg_Router
+	 * @var \Elgg\Router
 	 */
 	protected $router;
 
@@ -23,8 +25,8 @@ class Elgg_RouterTest extends PHPUnit_Framework_TestCase {
 	protected $fooHandlerCalls = 0;
 
 	function setUp() {
-		$this->hooks = new Elgg_PluginHooksService();
-		$this->router = new Elgg_Router($this->hooks);
+		$this->hooks = new \Elgg\PluginHooksService();
+		$this->router = new \Elgg\Router($this->hooks);
 		$this->pages = dirname(dirname(__FILE__)) . '/test_files/pages';
 		$this->fooHandlerCalls = 0;
 	}
@@ -42,7 +44,7 @@ class Elgg_RouterTest extends PHPUnit_Framework_TestCase {
 
 		$path = "hello/1/\xE2\x82\xAC"; // euro sign
 		$qs = http_build_query(array('__elgg_uri' => $path));
-		$request = Elgg_Http_Request::create("http://localhost/?$qs");
+		$request = \Elgg\Http\Request::create("http://localhost/?$qs");
 		
 		ob_start();
 		$handled = $this->router->route($request);
@@ -56,7 +58,7 @@ class Elgg_RouterTest extends PHPUnit_Framework_TestCase {
 		$this->router->registerPageHandler('hello', array($this, 'hello_page_handler'));
 		$this->router->unregisterPageHandler('hello');
 		
-		$request = Elgg_Http_Request::create('http://localhost/hello/');
+		$request = \Elgg\Http\Request::create('http://localhost/hello/');
 		
 		ob_start();
 		$handled = $this->router->route($request);
@@ -84,7 +86,7 @@ class Elgg_RouterTest extends PHPUnit_Framework_TestCase {
 		$query = http_build_query(array('__elgg_uri' => 'bar/baz'));
 
 		ob_start();
-		$this->router->route(Elgg_Http_Request::create("http://localhost/?$query"));
+		$this->router->route(\Elgg\Http\Request::create("http://localhost/?$query"));
 		ob_end_clean();
 		
 		$this->assertEquals(1, $this->fooHandlerCalls);
@@ -100,3 +102,4 @@ class Elgg_RouterTest extends PHPUnit_Framework_TestCase {
 		return $value;
 	}
 }
+

--- a/engine/tests/phpunit/Elgg/ViewsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ViewsServiceTest.php
@@ -1,18 +1,20 @@
 <?php
+namespace Elgg;
 
-class Elgg_ViewsServiceTest extends PHPUnit_Framework_TestCase {
+
+class ViewsServiceTest extends \PHPUnit_Framework_TestCase {
 	
 	public function setUp() {
 		$this->viewsDir = dirname(dirname(__FILE__)) . "/test_files/views";
 		
-		$this->hooks = new Elgg_PluginHooksService();
-		$this->logger = $this->getMock('Elgg_Logger', array(), array(), '', false);
+		$this->hooks = new \Elgg\PluginHooksService();
+		$this->logger = $this->getMock('\Elgg\Logger', array(), array(), '', false);
 		
-		$this->views = new Elgg_ViewsService($this->hooks, $this->logger);
+		$this->views = new \Elgg\ViewsService($this->hooks, $this->logger);
 		$this->views->autoregisterViews('', "$this->viewsDir/default", "$this->viewsDir/", 'default');
 
 		// supports deprecation wrapper for $vars['user'] 
-		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
+		_elgg_services()->setValue('session', new \ElggSession(new \Elgg\Http\MockSessionStorage()));
 	}
 	
 	public function testCanExtendViews() {
@@ -69,3 +71,4 @@ class Elgg_ViewsServiceTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($this->views->isCacheableView('js/static.js'));
 	}
 }
+

--- a/engine/tests/phpunit/Elgg/WidgetsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/WidgetsServiceTest.php
@@ -1,13 +1,15 @@
 <?php
+namespace Elgg;
 
-class Elgg_WidgetsServiceTest extends PHPUnit_Framework_TestCase {
+
+class WidgetsServiceTest extends \PHPUnit_Framework_TestCase {
 
 	public function elgg_set_config($key, $val) {
 		//do nothing, that's only for BC
 	}
 	
 	public function testRegisterTypeParametersControl() {
-		$service = new Elgg_WidgetsService(array($this, 'elgg_set_config'));
+		$service = new \Elgg\WidgetsService(array($this, 'elgg_set_config'));
 
 		$this->assertFalse($service->registerType('', 'Widget name', 'Widget description'));
 		$this->assertFalse($service->registerType(0, 'Widget name', 'Widget description'));
@@ -23,7 +25,7 @@ class Elgg_WidgetsServiceTest extends PHPUnit_Framework_TestCase {
 	 * Tests register, exists and unregisrer
 	 */
 	public function testCanRegisterType() {
-		$service = new Elgg_WidgetsService(array($this, 'elgg_set_config'));
+		$service = new \Elgg\WidgetsService(array($this, 'elgg_set_config'));
 		
 		$this->assertFalse($service->validateType('widget_type'));
 		$this->assertFalse($service->validateType('not_registered_widget'));
@@ -46,7 +48,7 @@ class Elgg_WidgetsServiceTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @depends testCanRegisterType
-	 * @param Elgg_WidgetsService $service
+	 * @param \Elgg\WidgetsService $service
 	 */
 	public function testRegistrationParametersPreserveContext($service) {
 		
@@ -76,7 +78,7 @@ class Elgg_WidgetsServiceTest extends PHPUnit_Framework_TestCase {
 	
 	/**
 	 * @depends testRegistrationParametersPreserveContext
-	 * @param Elgg_WidgetsService $service
+	 * @param \Elgg\WidgetsService $service
 	 */
 	public function testRegistrationParametersPreserveMultiple($service) {
 		
@@ -93,7 +95,7 @@ class Elgg_WidgetsServiceTest extends PHPUnit_Framework_TestCase {
 			foreach ($contexts as $context) {
 				$items = $service->getTypes($context, $exact);
 				foreach ($items as $handler => $item) {
-					$this->assertInstanceOf('stdClass', $item);
+					$this->assertInstanceOf('\stdClass', $item);
 					$this->assertNotEmpty($handler);
 					$this->assertInternalType('string', $handler);
 					$this->assertArrayHasKey($handler, $resps);
@@ -107,7 +109,7 @@ class Elgg_WidgetsServiceTest extends PHPUnit_Framework_TestCase {
 	
 	/**
 	 * @depends testRegistrationParametersPreserveMultiple
-	 * @param Elgg_WidgetsService $service
+	 * @param \Elgg\WidgetsService $service
 	 */
 	public function testRegistrationParametersPreserveNameDescription($service) {
 		
@@ -124,7 +126,7 @@ class Elgg_WidgetsServiceTest extends PHPUnit_Framework_TestCase {
 			foreach ($contexts as $context) {
 				$items = $service->getTypes($context, $exact);
 				foreach ($items as $handler => $item) {
-					$this->assertInstanceOf('stdClass', $item);
+					$this->assertInstanceOf('\stdClass', $item);
 					$this->assertNotEmpty($handler);
 					$this->assertInternalType('string', $handler);
 					$this->assertArrayHasKey($handler, $resps);
@@ -140,7 +142,7 @@ class Elgg_WidgetsServiceTest extends PHPUnit_Framework_TestCase {
 	
 	/**
 	 * @depends testRegistrationParametersPreserveNameDescription
-	 * @param Elgg_WidgetsService $service
+	 * @param \Elgg\WidgetsService $service
 	 */
 	public function testCanUnregisterType($service) {
 
@@ -159,3 +161,4 @@ class Elgg_WidgetsServiceTest extends PHPUnit_Framework_TestCase {
 	//TODO get, view, create, canEditLayout, defaultWidgetsInit, createDefault, defaultWidgetsPermissionsOverride
 
 }
+

--- a/engine/tests/phpunit/ElggCommitMessageGitHookTest.php
+++ b/engine/tests/phpunit/ElggCommitMessageGitHookTest.php
@@ -3,7 +3,7 @@
  * Tests the commit message validation shell script used by the git hook and travis
  */
 
-class ElggCommitMessageGitHookTest extends PHPUnit_Framework_TestCase {
+class ElggCommitMessageGitHookTest extends \PHPUnit_Framework_TestCase {
 	protected $scriptsDir;
 	protected $filesDir;
 	protected $validateScript;

--- a/engine/tests/phpunit/ElggCommitMessageTest.php
+++ b/engine/tests/phpunit/ElggCommitMessageTest.php
@@ -5,9 +5,9 @@
 
 require dirname(dirname(dirname(dirname(__FILE__)))) . '/.scripts/ElggCommitMessage.php';
 
-class ElggCommitMessageTest extends PHPUnit_Framework_TestCase {
+class ElggCommitMessageTest extends \PHPUnit_Framework_TestCase {
 	public function assertInvalidCommitMessages(array $msgs) {
-		$msg = new ElggCommitMessage();
+		$msg = new \ElggCommitMessage();
 
 		foreach ($msgs as $text) {
 			$msg->setMsg($text);
@@ -39,7 +39,7 @@ class ElggCommitMessageTest extends PHPUnit_Framework_TestCase {
 	
 	public function assertIgnoreCommitMessages(array $ignored) {
 		foreach ($ignored as $msg) {
-			$msg = new ElggCommitMessage($msg);
+			$msg = new \ElggCommitMessage($msg);
 			$this->assertTrue($msg->shouldIgnore(), $msg);
 		}
 	}
@@ -67,7 +67,7 @@ class ElggCommitMessageTest extends PHPUnit_Framework_TestCase {
 	public function testCanParseMessagesWithoutBody() {
 		$text = "chore(test): Summary";
 		
-		$msg = new ElggCommitMessage($text);
+		$msg = new \ElggCommitMessage($text);
 
 		$this->assertTrue($msg->isValidFormat());
 		$this->assertSame('chore', $msg->getPart('type'));
@@ -78,7 +78,7 @@ class ElggCommitMessageTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanParseMessagesWithOneLineBody() {
 		$text = "chore(test): Summary\nOptional body";
-		$msg = new ElggCommitMessage($text);
+		$msg = new \ElggCommitMessage($text);
 
 		$this->assertTrue($msg->isValidFormat());
 		$this->assertSame('chore', $msg->getPart('type'));
@@ -98,7 +98,7 @@ Refs #789
 ___MSG;
 		$text = "$title\n$body";
 
-		$msg = new ElggCommitMessage($text);
+		$msg = new \ElggCommitMessage($text);
 
 		$this->assertTrue($msg->isValidFormat());
 		$this->assertSame('chore', $msg->getPart('type'));
@@ -109,7 +109,7 @@ ___MSG;
 
 	public function testIsValidLineLengthRejectsLinesOverTheMaxLineLength() {
 		$text = "chore(test): But with long line";
-		$msg = new ElggCommitMessage();
+		$msg = new \ElggCommitMessage();
 		$msg->setMaxLineLength(15);
 		$msg->setMsg($text);
 		$this->assertFalse($msg->isValidLineLength());
@@ -117,10 +117,10 @@ ___MSG;
 
 	public function testFindLengthyLinesFindsLinesOverTheMaxLineLength() {
 		$text = "This text is 33 characters long.";
-		$this->assertSame(array(1), ElggCommitMessage::findLengthyLines($text, 30));
+		$this->assertSame(array(1), \ElggCommitMessage::findLengthyLines($text, 30));
 
 		$text2 = 'This line is only 22.';
-		$this->assertSame(array(), ElggCommitMessage::findLengthyLines($text2, 30));
+		$this->assertSame(array(), \ElggCommitMessage::findLengthyLines($text2, 30));
 
 		$text3 = <<<___TEXT
 This has multiple lines.
@@ -128,7 +128,7 @@ Some of which are not really very long at all.
 Some are.
 ___TEXT;
 
-		$this->assertSame(array(2), ElggCommitMessage::findLengthyLines($text3, 30));
+		$this->assertSame(array(2), \ElggCommitMessage::findLengthyLines($text3, 30));
 	}
 
 	public function testGetLengthyLinesFindsLinesOverTheMaxLineLength() {
@@ -139,17 +139,17 @@ The long line is down here. This line is much longer than the other.
 And this one is short.
 But here we go again with another long line.
 ___MSG;
-		$msg = new ElggCommitMessage();
+		$msg = new \ElggCommitMessage();
 		$msg->setMaxLineLength(40);
 		$msg->setMsg($text);
 		$this->assertSame(array(3, 5), $msg->getLengthyLines());
 	}
 
 	public function testIsValidTypeReturnsTrueForValidTypes() {
-		$types = ElggCommitMessage::getValidTypes();
+		$types = \ElggCommitMessage::getValidTypes();
 
 		foreach ($types as $type) {
-			$msg = new ElggCommitMessage("{$type}(component): Summary");
+			$msg = new \ElggCommitMessage("{$type}(component): Summary");
 			$this->assertTrue($msg->isValidType(), "Invalid type `$type`.");
 		}
 	}
@@ -163,6 +163,6 @@ And more text
 ___TEXT;
 
 		$expected = "These are lines of text\nAnd more text";
-		$this->assertSame($expected, ElggCommitMessage::removeComments($text));
+		$this->assertSame($expected, \ElggCommitMessage::removeComments($text));
 	}
 }

--- a/engine/tests/phpunit/ElggCoreUrlHelpersTest.php
+++ b/engine/tests/phpunit/ElggCoreUrlHelpersTest.php
@@ -4,10 +4,10 @@ $engine = dirname(dirname(dirname(__FILE__)));
 require_once "$engine/lib/mb_wrapper.php";// for elgg_parse_str used by elgg_http_add_url_query_elements
 
 /**
- * @see ElggCoreHelpersTest
+ * @see \ElggCoreHelpersTest
  * @todo migrate similar simpletest tests to this class
  */
-class ElggCoreUrlHelpersTest extends PHPUnit_Framework_TestCase {
+class ElggCoreUrlHelpersTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * Test if elgg_http_add_url_query_elements() preserves original url when no params are passed

--- a/engine/tests/phpunit/ElggCoreViewtypeTest.php
+++ b/engine/tests/phpunit/ElggCoreViewtypeTest.php
@@ -5,7 +5,7 @@ require_once "$engine/lib/views.php";
 require_once "$engine/lib/input.php";
 require_once "$engine/lib/pageowner.php";
 
-class ElggCoreViewtypeTest extends PHPUnit_Framework_TestCase {
+class ElggCoreViewtypeTest extends \PHPUnit_Framework_TestCase {
 
 	protected function setUp() {
 		global $CURRENT_SYSTEM_VIEWTYPE;

--- a/engine/tests/phpunit/ElggCryptoTest.php
+++ b/engine/tests/phpunit/ElggCryptoTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggCryptoTest extends PHPUnit_Framework_TestCase {
+class ElggCryptoTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @var PHPUnit_Framework_MockObject_MockObject
@@ -8,7 +8,7 @@ class ElggCryptoTest extends PHPUnit_Framework_TestCase {
 	protected $stub;
 
 	protected function setUp() {
-		$this->stub = $this->getMockBuilder('ElggCrypto')
+		$this->stub = $this->getMockBuilder('\ElggCrypto')
 			->setMethods(array('getRandomBytes'))
 			->getMock();
 
@@ -29,8 +29,8 @@ class ElggCryptoTest extends PHPUnit_Framework_TestCase {
 	function provider() {
 		return array(
 			array(32, null, 'kwG37f3ds_7awuiaL52mVWXud9dqT1GF'),
-			array(32, ElggCrypto::CHARS_HEX, '9301b7edfdddb3fedac2e89a2f9da655'),
-			array(32, ElggCrypto::CHARS_PASSWORD, 'kl4lmjwyrpyh6rpqct3rkd9zvxwvqww8'),
+			array(32, \ElggCrypto::CHARS_HEX, '9301b7edfdddb3fedac2e89a2f9da655'),
+			array(32, \ElggCrypto::CHARS_PASSWORD, 'kl4lmjwyrpyh6rpqct3rkd9zvxwvqww8'),
 			array(32, "0123456789", "78181215379307389761767024720714"),
 		);
 	}

--- a/engine/tests/phpunit/ElggEntityTest.php
+++ b/engine/tests/phpunit/ElggEntityTest.php
@@ -7,15 +7,15 @@ require_once "$engine/lib/output.php";
  * This requires elgg_get_logged_in_user_guid() in session.php, the access 
  * constants defined in entities.php, and elgg_normalize_url() in output.php
  */
-class ElggEntityTest extends PHPUnit_Framework_TestCase {
+class ElggEntityTest extends \PHPUnit_Framework_TestCase {
 
-	/** @var ElggEntity */
+	/** @var \ElggEntity */
 	protected $obj;
 
 	protected function setUp() {
-		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
-		$this->obj = $this->getMockForAbstractClass('ElggEntity');
-		$reflection = new ReflectionClass('ElggEntity');
+		_elgg_services()->setValue('session', new \ElggSession(new \Elgg\Http\MockSessionStorage()));
+		$this->obj = $this->getMockForAbstractClass('\ElggEntity');
+		$reflection = new ReflectionClass('\ElggEntity');
 		$method = $reflection->getMethod('initializeAttributes');
 		if (method_exists($method, 'setAccessible')) {
 			$method->setAccessible(true);
@@ -124,7 +124,7 @@ class ElggEntityTest extends PHPUnit_Framework_TestCase {
 	 * @expectedException InvalidParameterException
 	 */
 	public function testSaveWithoutType() {
-		$db = $this->getMock('Elgg_Database',
+		$db = $this->getMock('\Elgg\Database',
 			array('getData', 'getTablePrefix', 'sanitizeString'),
 			array(),
 			'',

--- a/engine/tests/phpunit/ElggExtenderTest.php
+++ b/engine/tests/phpunit/ElggExtenderTest.php
@@ -4,21 +4,21 @@
 $engine = dirname(dirname(dirname(__FILE__)));
 require_once "$engine/lib/extender.php";
 
-class ElggExtenderTest extends PHPUnit_Framework_TestCase {
+class ElggExtenderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testSettingAndGettingAttribute() {
-		$obj = $this->getMockForAbstractClass('ElggExtender');
+		$obj = $this->getMockForAbstractClass('\ElggExtender');
 		$obj->name = 'comment';
 		$this->assertEquals('comment', $obj->name);
 	}
 
 	public function testGettingNonexistentAttribute() {
-		$obj = $this->getMockForAbstractClass('ElggExtender');
+		$obj = $this->getMockForAbstractClass('\ElggExtender');
 		$this->assertNull($obj->foo);
 	}
 
 	public function testSettingValueAttribute() {
-		$obj = $this->getMockForAbstractClass('ElggExtender');
+		$obj = $this->getMockForAbstractClass('\ElggExtender');
 		$obj->value = '36';
 		$this->assertSame('36', $obj->value);
 		$this->assertEquals('text', $obj->value_type);
@@ -28,7 +28,7 @@ class ElggExtenderTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testSettingValueExplicitly() {
-		$obj = $this->getMockForAbstractClass('ElggExtender');
+		$obj = $this->getMockForAbstractClass('\ElggExtender');
 		$obj->setValue('36', 'integer');
 		$this->assertSame(36, $obj->value);
 		$this->assertEquals('integer', $obj->value_type);		

--- a/engine/tests/phpunit/ElggGroupTest.php
+++ b/engine/tests/phpunit/ElggGroupTest.php
@@ -1,14 +1,14 @@
 <?php
 
-class ElggGroupTest extends PHPUnit_Framework_TestCase {
+class ElggGroupTest extends \PHPUnit_Framework_TestCase {
 
 	protected function setUp() {
-		// required by ElggEntity when setting the owner/container
-		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
+		// required by \ElggEntity when setting the owner/container
+		_elgg_services()->setValue('session', new \ElggSession(new \Elgg\Http\MockSessionStorage()));
 	}
 
 	public function testCanConstructWithoutArguments() {
-		$this->assertNotNull(new ElggGroup());
+		$this->assertNotNull(new \ElggGroup());
 	}
 
 }

--- a/engine/tests/phpunit/ElggMenuItemTest.php
+++ b/engine/tests/phpunit/ElggMenuItemTest.php
@@ -3,18 +3,18 @@
 /**
  * Depends on elgg_normalize_url() in output.php
  */
-class ElggMenuItemTest extends PHPUnit_Framework_TestCase {
+class ElggMenuItemTest extends \PHPUnit_Framework_TestCase {
 
 	protected function setUp() {
 	}
 
 	public function testFactoryNoNameOrText() {
-		$this->assertNull(ElggMenuItem::factory(array('name' => 'test')));
-		$this->assertNull(ElggMenuItem::factory(array('text' => 'test')));
+		$this->assertNull(\ElggMenuItem::factory(array('name' => 'test')));
+		$this->assertNull(\ElggMenuItem::factory(array('text' => 'test')));
 	}
 
 	public function testFactoryNoHref() {
-		$item = ElggMenuItem::factory(array('name' => 'test','text' => 'test'));
+		$item = \ElggMenuItem::factory(array('name' => 'test','text' => 'test'));
 		$this->assertEquals('', $item->getHref());
 	}
 
@@ -33,7 +33,7 @@ class ElggMenuItemTest extends PHPUnit_Framework_TestCase {
 			'selected' => true,
 			'parent_name' => 'node',
 		);
-		$item = ElggMenuItem::factory($params);
+		$item = \ElggMenuItem::factory($params);
 
 		$this->assertEquals($params['name'], $item->getName());
 		$this->assertEquals($params['text'], $item->getText());
@@ -61,7 +61,7 @@ class ElggMenuItemTest extends PHPUnit_Framework_TestCase {
 				'parent_name' => 'node',
 			),
 		);
-		$item = ElggMenuItem::factory($params);
+		$item = \ElggMenuItem::factory($params);
 
 		$this->assertEquals($params['data']['section'], $item->getSection());
 		$this->assertEquals($params['data']['priority'], $item->getPriority());
@@ -76,19 +76,19 @@ class ElggMenuItemTest extends PHPUnit_Framework_TestCase {
 			'href' => 'test',
 			'context' => array('blog', 'bookmarks'),
 		);
-		$item = ElggMenuItem::factory($params);
+		$item = \ElggMenuItem::factory($params);
 
 		$this->assertEquals($params['context'], $item->getContext());
 	}
 
 	public function testConstructorUrlNormalization() {
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$url = elgg_normalize_url('url');
 		$this->assertEquals($url, $item->getHref());
 	}
 
 	public function testSetDataWithSingleValue() {
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$item->setData('foo', 'value');
 		$this->assertEquals('value', $item->getData('foo'));
 		$item->setData('name', 'new_name');
@@ -98,7 +98,7 @@ class ElggMenuItemTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testSetDataWithArray() {
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$item->setData(array(
 			'priority' => 88,
 			'new' => 64,
@@ -109,31 +109,31 @@ class ElggMenuItemTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetDataNonExistentKey() {
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$this->assertNull($item->getData('blah'));
 	}
 
 	public function testSetContextWithString() {
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$item->setContext('mine');
 		$this->assertEquals(array('mine'), $item->getContext());
 	}
 
 	public function testSetContextWithArray() {
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$item->setContext(array('mine'));
 		$this->assertEquals(array('mine'), $item->getContext());
 	}
 
 	public function testInContextAll() {
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$item->setContext('all');
 		$this->assertTrue($item->inContext('blog'));
 		$this->assertTrue($item->inContext(''));
 	}
 
 	public function testInContextWithParticularContext() {
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$item->setContext(array('blog', 'bookmarks'));
 		$this->assertTrue($item->inContext('blog'));
 		$this->assertFalse($item->inContext('file'));
@@ -142,13 +142,13 @@ class ElggMenuItemTest extends PHPUnit_Framework_TestCase {
 /*
  * This requires elgg_in_context()
 	public function testInContextAgainstRequestContext() {
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$item->setContext(array('blog', 'bookmarks'));
 	}
 */
 
 	public function testSetLinkClassWithString() {
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$item->setLinkClass('elgg-link');
 		$this->assertEquals('elgg-link', $item->getLinkClass());
 		$item->setLinkClass('new-link');
@@ -156,43 +156,43 @@ class ElggMenuItemTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testSetLinkClassWithArray() {
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$item->setLinkClass(array('elgg-link', '2nd-link'));
 		$this->assertEquals('elgg-link 2nd-link', $item->getLinkClass());
 	}
 
 	public function testAddLinkClassWithString() {
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$item->addLinkClass('new-link');
 		$item->addLinkClass('2nd-link');
 		$this->assertEquals('new-link 2nd-link', $item->getLinkClass());
 
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$item->setLinkClass('new-link');
 		$item->addLinkClass('2nd-link');
 		$this->assertEquals('new-link 2nd-link', $item->getLinkClass());
 	}
 
 	public function testAddLinkClassWithArray() {
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$item->setLinkClass('new-link');
 		$item->addLinkClass(array('2nd-link'));
 		$this->assertEquals('new-link 2nd-link', $item->getLinkClass());
 	}
 
 	public function testGetItemClass() {
-		$item = new ElggMenuItem('name', 'text', 'url');
+		$item = new \ElggMenuItem('name', 'text', 'url');
 		$item->setItemClass('new-link');
 		$item->addItemClass(array('2nd-link'));
 		$this->assertEquals('elgg-menu-item-name new-link 2nd-link', $item->getItemClass());
 	}
 
 	public function testGetItemClassNormalizeName() {
-		$item = new ElggMenuItem('name_underscore', 'text', 'url');
+		$item = new \ElggMenuItem('name_underscore', 'text', 'url');
 		$this->assertEquals('elgg-menu-item-name-underscore', $item->getItemClass());
-		$item = new ElggMenuItem('name space', 'text', 'url');
+		$item = new \ElggMenuItem('name space', 'text', 'url');
 		$this->assertEquals('elgg-menu-item-name-space', $item->getItemClass());
-		$item = new ElggMenuItem('name:colon', 'text', 'url');
+		$item = new \ElggMenuItem('name:colon', 'text', 'url');
 		$this->assertEquals('elgg-menu-item-name-colon', $item->getItemClass());
 	}
 }

--- a/engine/tests/phpunit/ElggObjectTest.php
+++ b/engine/tests/phpunit/ElggObjectTest.php
@@ -1,14 +1,14 @@
 <?php
 
-class ElggObjectTest extends PHPUnit_Framework_TestCase {
+class ElggObjectTest extends \PHPUnit_Framework_TestCase {
 
 	protected function setUp() {
-		// required by ElggEntity when setting the owner/container
-		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
+		// required by \ElggEntity when setting the owner/container
+		_elgg_services()->setValue('session', new \ElggSession(new \Elgg\Http\MockSessionStorage()));
 	}
 
 	public function testCanConstructWithoutArguments() {
-		$this->assertNotNull(new ElggObject());
+		$this->assertNotNull(new \ElggObject());
 	}
 
 }

--- a/engine/tests/phpunit/ElggPriorityListTest.php
+++ b/engine/tests/phpunit/ElggPriorityListTest.php
@@ -1,8 +1,8 @@
 <?php
 
-class ElggPriorityListTest extends PHPUnit_Framework_TestCase {
+class ElggPriorityListTest extends \PHPUnit_Framework_TestCase {
 	public function testAdd() {
-		$pl = new ElggPriorityList();
+		$pl = new \ElggPriorityList();
 		$elements = array(
 			'Test value',
 			'Test value 2',
@@ -29,7 +29,7 @@ class ElggPriorityListTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testAddWithPriority() {
-		$pl = new ElggPriorityList();
+		$pl = new \ElggPriorityList();
 
 		$elements = array(
 			10 => 'Test Element 10',
@@ -64,7 +64,7 @@ class ElggPriorityListTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetNextPriority() {
-		$pl = new ElggPriorityList();
+		$pl = new \ElggPriorityList();
 
 		$elements = array(
 			2 => 'Test Element',
@@ -87,11 +87,11 @@ class ElggPriorityListTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testRemove() {
-		$pl = new ElggPriorityList();
+		$pl = new \ElggPriorityList();
 
 		$elements = array();
 		for ($i=0; $i<3; $i++) {
-			$element = new stdClass();
+			$element = new \stdClass();
 			$element->name = "Test Element $i";
 			$element->someAttribute = rand(0, 9999);
 			$elements[] = $element;
@@ -109,7 +109,7 @@ class ElggPriorityListTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testMove() {
-		$pl = new ElggPriorityList();
+		$pl = new \ElggPriorityList();
 
 		$elements = array(
 			-5 => 'Test Element -5',
@@ -140,7 +140,7 @@ class ElggPriorityListTest extends PHPUnit_Framework_TestCase {
 			-5 => 'Test Element -5'
 		);
 
-		$pl = new ElggPriorityList($elements);
+		$pl = new \ElggPriorityList($elements);
 		$test_elements = $pl->getElements();
 
 		$elements_sorted = array(
@@ -156,7 +156,7 @@ class ElggPriorityListTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetPriority() {
-		$pl = new ElggPriorityList();
+		$pl = new \ElggPriorityList();
 
 		$elements = array(
 			'Test element 0',
@@ -174,7 +174,7 @@ class ElggPriorityListTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetElement() {
-		$pl = new ElggPriorityList();
+		$pl = new \ElggPriorityList();
 		$priorities = array();
 
 		$elements = array(
@@ -193,7 +193,7 @@ class ElggPriorityListTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testPriorityCollision() {
-		$pl = new ElggPriorityList();
+		$pl = new \ElggPriorityList();
 		
 		$elements = array(
 			5 => 'Test element 5',
@@ -219,7 +219,7 @@ class ElggPriorityListTest extends PHPUnit_Framework_TestCase {
 			5 => 'Test element 5',
 		);
 		
-		$pl = new ElggPriorityList($elements);
+		$pl = new \ElggPriorityList($elements);
 
 		foreach ($pl as $priority => $element) {
 			$this->assertSame($elements[$priority], $element);
@@ -227,7 +227,7 @@ class ElggPriorityListTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testCountable() {
-		$pl = new ElggPriorityList();
+		$pl = new \ElggPriorityList();
 
 		$this->assertEquals(0, count($pl));
 
@@ -253,7 +253,7 @@ class ElggPriorityListTest extends PHPUnit_Framework_TestCase {
 		$elements_sorted_string = $elements;
 
 		shuffle($elements);
-		$pl = new ElggPriorityList($elements);
+		$pl = new \ElggPriorityList($elements);
 
 		// will sort by priority
 		$test_elements = $pl->getElements();

--- a/engine/tests/phpunit/ElggRelationshipTest.php
+++ b/engine/tests/phpunit/ElggRelationshipTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggRelationshipTest extends PHPUnit_Framework_TestCase {
+class ElggRelationshipTest extends \PHPUnit_Framework_TestCase {
 
 	public function testSettingAndGettingAttribute() {
 		$obj = $this->getRelationshipMock();
@@ -16,6 +16,6 @@ class ElggRelationshipTest extends PHPUnit_Framework_TestCase {
 	protected function getRelationshipMock() {
 		// do not call constructor because it would cause deprecation warnings
 		// and deprecation is not test-friendly yet.
-		return $this->getMockForAbstractClass('ElggRelationship', array(), '', false);
+		return $this->getMockForAbstractClass('\ElggRelationship', array(), '', false);
 	}
 }

--- a/engine/tests/phpunit/ElggSessionTest.php
+++ b/engine/tests/phpunit/ElggSessionTest.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * Many methods for ElggSession pass through to the storage class so we
+ * Many methods for \ElggSession pass through to the storage class so we
  * don't test them here.
  */
 
-class ElggSessionTest extends PHPUnit_Framework_TestCase {
+class ElggSessionTest extends \PHPUnit_Framework_TestCase {
 
 	public function testStart() {
-		$session = new ElggSession(new Elgg_Http_MockSessionStorage());
+		$session = new \ElggSession(new \Elgg\Http\MockSessionStorage());
 		$this->assertTrue($session->start());
 		$this->assertTrue($session->has('__elgg_session'));
 	}
 
 	public function testInvalidate() {
-		$session = new ElggSession(new Elgg_Http_MockSessionStorage());
+		$session = new \ElggSession(new \Elgg\Http\MockSessionStorage());
 		$session->start();
 		$session->set('foo', 5);
 		$id = $session->getId();
@@ -24,7 +24,7 @@ class ElggSessionTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testMigrate() {
-		$session = new ElggSession(new Elgg_Http_MockSessionStorage());
+		$session = new \ElggSession(new \Elgg\Http\MockSessionStorage());
 		$session->start();
 		$session->set('foo', 5);
 		$id = $session->getId();

--- a/engine/tests/phpunit/ElggSiteTest.php
+++ b/engine/tests/phpunit/ElggSiteTest.php
@@ -1,14 +1,14 @@
 <?php
 
-class ElggSiteTest extends PHPUnit_Framework_TestCase {
+class ElggSiteTest extends \PHPUnit_Framework_TestCase {
 
 	protected function setUp() {
-		// required by ElggEntity when setting the owner/container
-		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
+		// required by \ElggEntity when setting the owner/container
+		_elgg_services()->setValue('session', new \ElggSession(new \Elgg\Http\MockSessionStorage()));
 	}
 
 	public function testCanConstructWithoutArguments() {
-		$this->assertNotNull(new ElggSite());
+		$this->assertNotNull(new \ElggSite());
 	}
 
 }

--- a/engine/tests/phpunit/ElggTravisValidateCommitMsgTest.php
+++ b/engine/tests/phpunit/ElggTravisValidateCommitMsgTest.php
@@ -3,7 +3,7 @@
  * Tests the travis shell script
  */
 
-class ElggTravisValidateCommitMsgTest extends ElggCommitMessageGitHookTest {
+class ElggTravisValidateCommitMsgTest extends \ElggCommitMessageGitHookTest {
 	protected $travisScript;
 
 	public function setUp() {

--- a/engine/tests/phpunit/ElggUpgradeTest.php
+++ b/engine/tests/phpunit/ElggUpgradeTest.php
@@ -4,14 +4,14 @@
 $engine = dirname(dirname(dirname(__FILE__)));
 require_once "$engine/lib/languages.php";
 
-class ElggUpgradeTest extends PHPUnit_Framework_TestCase {
+class ElggUpgradeTest extends \PHPUnit_Framework_TestCase {
 	protected $obj;
 
 	protected function setUp() {
-		// required by ElggEntity when setting the owner/container
-		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
+		// required by \ElggEntity when setting the owner/container
+		_elgg_services()->setValue('session', new \ElggSession(new \Elgg\Http\MockSessionStorage()));
 
-		$this->obj = $this->getMockBuilder('ElggUpgrade')
+		$this->obj = $this->getMockBuilder('\ElggUpgrade')
 				->setMethods(null)
 				->getMock();
 
@@ -24,7 +24,7 @@ class ElggUpgradeTest extends PHPUnit_Framework_TestCase {
 
 	public function mock_egefps_with_entities() {
 		return array(
-			new stdClass()
+			new \stdClass()
 		);
 	}
 

--- a/engine/tests/phpunit/ElggUserTest.php
+++ b/engine/tests/phpunit/ElggUserTest.php
@@ -1,18 +1,18 @@
 <?php
 
-class ElggUserTest extends PHPUnit_Framework_TestCase {
+class ElggUserTest extends \PHPUnit_Framework_TestCase {
 
 	protected function setUp() {
-		// required by ElggEntity when setting the owner/container
-		_elgg_services()->setValue('session', new ElggSession(new Elgg_Http_MockSessionStorage()));
+		// required by \ElggEntity when setting the owner/container
+		_elgg_services()->setValue('session', new \ElggSession(new \Elgg\Http\MockSessionStorage()));
 	}
 	
 	public function testCanConstructWithoutArguments() {
-		$this->assertNotNull(new ElggUser());
+		$this->assertNotNull(new \ElggUser());
 	}
 
 	public function testSettingUnsettableAttributes() {
-		$obj = new ElggUser();
+		$obj = new \ElggUser();
 		foreach (array('prev_last_action', 'last_login', 'prev_last_login') as $name) {
 			$obj->$name = 'foo';
 			$this->assertNotEquals('foo', $obj->$name);			

--- a/engine/tests/phpunit/bootstrap.php
+++ b/engine/tests/phpunit/bootstrap.php
@@ -27,5 +27,5 @@ require_once "$engine/lib/autoloader.php";
 // Provide some basic global functions/initialization.
 require_once "$engine/lib/elgglib.php";
 
-// This is required by ElggEntity
+// This is required by \ElggEntity
 require_once "$engine/lib/sessions.php";

--- a/engine/tests/test_files/class_scanner/3.php
+++ b/engine/tests/test_files/class_scanner/3.php
@@ -1,6 +1,6 @@
 <?php
-
 namespace NS3_20130207;
+
 
 interface I3_20130207 {
 
@@ -9,3 +9,4 @@ interface I3_20130207 {
 class C3_20130207 {
 
 }
+

--- a/engine/tests/test_files/class_scanner/4.php
+++ b/engine/tests/test_files/class_scanner/4.php
@@ -1,6 +1,6 @@
 <?php
-
 namespace NS4_20130207;
+
 
 interface I4_20130207 {
 
@@ -13,3 +13,4 @@ class C4_20130207 {
 trait T4_20130207 {
 
 }
+

--- a/engine/tests/test_files/output/autop/typical-post.exp.html
+++ b/engine/tests/test_files/output/autop/typical-post.exp.html
@@ -13,7 +13,7 @@
 </blockquote>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus enim ante, mattis eget imperdiet nec, <a href="http://google.com/">pharetra </a>vel velit. Sed at euismod nibh. Praesent lacus tellus, posuere et convallis a, mollis et tellus.</p>
 <pre><code>&lt;?php
-class DataTest extends PHPUnit_Framework_TestCase
+class DataTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider provider
@@ -55,7 +55,7 @@ class DataTest extends PHPUnit_Framework_TestCase
 </blockquote>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus enim ante, mattis eget imperdiet nec, <a href="http://google.com/">pharetra </a>vel velit. Sed at euismod nibh. Praesent lacus tellus, posuere et convallis a, mollis et tellus.</p>
 <pre><code>&lt;?php
-class DataTest extends PHPUnit_Framework_TestCase
+class DataTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider provider

--- a/engine/tests/test_files/output/autop/typical-post.in.html
+++ b/engine/tests/test_files/output/autop/typical-post.in.html
@@ -13,7 +13,7 @@ Maecenas elit lorem, varius sed condimentum ac, cursus et magna. Nam ut massa id
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus enim ante, mattis eget imperdiet nec, <a href="http://google.com/">pharetra </a>vel velit. Sed at euismod nibh. Praesent lacus tellus, posuere et convallis a, mollis et tellus.
 
 <pre><code>&lt;?php
-class DataTest extends PHPUnit_Framework_TestCase
+class DataTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider provider
@@ -58,7 +58,7 @@ Maecenas elit lorem, varius sed condimentum ac, cursus et magna. Nam ut massa id
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus enim ante, mattis eget imperdiet nec, <a href="http://google.com/">pharetra </a>vel velit. Sed at euismod nibh. Praesent lacus tellus, posuere et convallis a, mollis et tellus.
 
 <pre><code>&lt;?php
-class DataTest extends PHPUnit_Framework_TestCase
+class DataTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider provider

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -241,9 +241,9 @@ function blog_entity_menu_setup($hook, $type, $return, $params) {
  *
  * @param string                          $hook         Hook name
  * @param string                          $type         Hook type
- * @param Elgg_Notifications_Notification $notification The notification to prepare
+ * @param Elgg\Notifications\Notification $notification The notification to prepare
  * @param array                           $params       Hook parameters
- * @return Elgg_Notifications_Notification
+ * @return Elgg\Notifications\Notification
  */
 function blog_prepare_notification($hook, $type, $notification, $params) {
 	$entity = $params['event']->getObject();

--- a/mod/bookmarks/start.php
+++ b/mod/bookmarks/start.php
@@ -192,9 +192,9 @@ function bookmarks_owner_block_menu($hook, $type, $return, $params) {
  * 
  * @param string                          $hook         Hook name
  * @param string                          $type         Hook type
- * @param Elgg_Notifications_Notification $notification The notification to prepare
+ * @param Elgg\Notifications\Notification $notification The notification to prepare
  * @param array                           $params       Hook parameters
- * @return Elgg_Notifications_Notification
+ * @return Elgg\Notifications\Notification
  */
 function bookmarks_prepare_notification($hook, $type, $notification, $params) {
 	$entity = $params['event']->getObject();

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -151,7 +151,7 @@ function developers_log_events($name, $type) {
 	// 1 => call_user_func_array
 	// 2 => hook class trigger
 	$stack = debug_backtrace();
-	if (isset($stack[2]['class']) && $stack[2]['class'] == 'Elgg_EventsService') {
+	if (isset($stack[2]['class']) && $stack[2]['class'] == 'Elgg\EventsService') {
 		$event_type = 'Event';
 	} else {
 		$event_type = 'Plugin hook';

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -187,9 +187,9 @@ function file_register_toggle() {
  * 
  * @param string                          $hook         Hook name
  * @param string                          $type         Hook type
- * @param Elgg_Notifications_Notification $notification The notification to prepare
+ * @param Elgg\Notifications\Notification $notification The notification to prepare
  * @param array                           $params       Hook parameters
- * @return Elgg_Notifications_Notification
+ * @return Elgg\Notifications\Notification
  */
 function file_prepare_notification($hook, $type, $notification, $params) {
 	$entity = $params['event']->getObject();

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -122,13 +122,13 @@ function groups_init() {
  */
 function discussion_notification_email_subject($hook, $type, $returnvalue, $params){
 
-	/** @var Elgg_Notifications_Notification */
+	/** @var Elgg\Notifications\Notification */
 	$notification = elgg_extract('notification', $returnvalue['params']);
 
-	if ($notification instanceof Elgg_Notifications_Notification) {
+	if ($notification instanceof Elgg\Notifications\Notification) {
 
 		$object = elgg_extract('object', $notification->params);
-		/** @var Elgg_Notifications_Event $event */
+		/** @var Elgg\Notifications\Event $event */
 		$event = elgg_extract('event', $notification->params);
 
 		if ($object instanceof ElggEntity) {
@@ -1032,9 +1032,9 @@ function discussion_add_to_river_menu($hook, $type, $return, $params) {
  *
  * @param string                          $hook         Hook name
  * @param string                          $type         Hook type
- * @param Elgg_Notifications_Notification $notification The notification to prepare
+ * @param Elgg\Notifications\Notification $notification The notification to prepare
  * @param array                           $params       Hook parameters
- * @return Elgg_Notifications_Notification
+ * @return Elgg\Notifications\Notification
  */
 function discussion_prepare_notification($hook, $type, $notification, $params) {
 	$entity = $params['event']->getObject();
@@ -1065,9 +1065,9 @@ function discussion_prepare_notification($hook, $type, $notification, $params) {
  *
  * @param string                          $hook         Hook name
  * @param string                          $type         Hook type
- * @param Elgg_Notifications_Notification $notification The notification to prepare
+ * @param Elgg\Notifications\Notification $notification The notification to prepare
  * @param array                           $params       Hook parameters
- * @return Elgg_Notifications_Notification
+ * @return Elgg\Notifications\Notification
  */
 function discussion_prepare_reply_notification($hook, $type, $notification, $params) {
 	$reply = $params['event']->getObject();

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -270,9 +270,9 @@ function pages_entity_menu_setup($hook, $type, $return, $params) {
  * 
  * @param string                          $hook         Hook name
  * @param string                          $type         Hook type
- * @param Elgg_Notifications_Notification $notification The notification to prepare
+ * @param Elgg\Notifications\Notification $notification The notification to prepare
  * @param array                           $params       Hook parameters
- * @return Elgg_Notifications_Notification
+ * @return Elgg\Notifications\Notification
  */
 function pages_prepare_notification($hook, $type, $notification, $params) {
 	$entity = $params['event']->getObject();

--- a/mod/profile/icondirect.php
+++ b/mod/profile/icondirect.php
@@ -58,7 +58,7 @@ if ($mysql_dblink) {
 		if (isset($data_root) && isset($elgg_path)) {
 			require_once $engine_dir . "classes/Elgg/EntityDirLocator.php";
 
-			$locator = new Elgg_EntityDirLocator($guid);
+			$locator = new Elgg\EntityDirLocator($guid);
 			$user_path = $data_root . $locator->getPath();
 
 			$filename = $user_path . "profile/{$guid}{$size}.jpg";

--- a/mod/site_notifications/start.php
+++ b/mod/site_notifications/start.php
@@ -80,7 +80,7 @@ function site_notifications_set_topbar() {
  * @param array  $params Hook parameters
  */
 function site_notifications_send($hook, $type, $result, $params) {
-	/* @var Elgg_Notifications_Notification */
+	/* @var Elgg\Notifications\Notification */
 	$notification = $params['notification'];
 	if ($notification->summary) {
 		$message = $notification->summary;

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -165,9 +165,9 @@ function thewire_set_url($hook, $type, $url, $params) {
  *
  * @param string                          $hook         Hook name
  * @param string                          $type         Hook type
- * @param Elgg_Notifications_Notification $notification The notification to prepare
+ * @param Elgg\Notifications\Notification $notification The notification to prepare
  * @param array                           $params       Hook parameters
- * @return Elgg_Notifications_Notification
+ * @return Elgg\Notifications\Notification
  */
 function thewire_prepare_notification($hook, $type, $notification, $params) {
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -37,7 +37,7 @@ if (strpos($forward_url, '/') !== 0) {
 
 if (get_input('upgrade') == 'upgrade') {
 
-	$upgrader = new Elgg_UpgradeService();
+	$upgrader = new \Elgg\UpgradeService();
 	$result = $upgrader->run();
 	if ($result['failure'] == true) {
 		register_error($result['reason']);
@@ -48,7 +48,7 @@ if (get_input('upgrade') == 'upgrade') {
 	if (!class_exists('ElggRewriteTester')) {
 		require dirname(__FILE__) . '/install/ElggRewriteTester.php';
 	}
-	$rewriteTester = new ElggRewriteTester();
+	$rewriteTester = new \ElggRewriteTester();
 	$url = elgg_get_site_url() . "__testing_rewrite?__testing_rewrite=1";
 	if (!$rewriteTester->runRewriteTest($url)) {
 		// see if there is a problem accessing the site at all

--- a/views/default/admin/upgrades/datadirs.php
+++ b/views/default/admin/upgrades/datadirs.php
@@ -14,7 +14,7 @@ $upgrade = $factory->getUpgradeFromURL('/admin/upgrades/datadirs');
 if ($upgrade->isCompleted()) {
 	$count = 0;
 } else {
-	$helper = new Elgg_Upgrades_Helper2013022000(
+	$helper = new Elgg\Upgrades\Helper2013022000(
 		elgg_get_site_entity()->guid,
 		elgg_get_config('dbprefix')
 	);

--- a/views/default/widgets/control_panel/content.php
+++ b/views/default/widgets/control_panel/content.php
@@ -11,7 +11,7 @@ elgg_register_menu_item('admin_control_panel', array(
 	'link_class' => 'elgg-button elgg-button-action',
 ));
 
-$upgrader = new Elgg_UpgradeService();
+$upgrader = new Elgg\UpgradeService();
 $is_locked = $upgrader->isUpgradeLocked();
 
 if (!$is_locked) {


### PR DESCRIPTION
TODO:
- [x] Revert changes to `lib/system_log.php`
- [x] `*_subtype` instances need fixing.
- [x] Fix `elgg_echo` changes

I believe the only public classes namespaced with underscores were:
- Elgg_Notifications_Notification
- Elgg_Notifications_Event

I added those as extensions of their namespaced counterparts for backwards compatibility.

I used these commands to do it:
##### Convert namespace underscores to backslashes

TODO: details
##### Pull namespaces out of class declaration

```
find engine -type f -print0 | xargs -0 sed -i 's/class \(Elgg\(\\[A-Z][A-Za-z0-9]*\)*\)\\\([A-Z][A-Za-z0-9]*\)/namespace \1;\n\nclass \3/g'
```

Pulled namespaces out of interface declarations manually because there were only 3. Used this to find them:

```
grep -r 'interface \\' engine
```
##### Add global namespace qualifiers `Elgg\Class` => `\Elgg\Class`

```
find engine -type f -print0 | xargs -0 sed -i 's/\([^\\]\)Elgg\\/\1\\Elgg\\/g'
```
##### Remove global qualifiers from namespaces

```
find engine -type f -print0 | xargs -0 sed -i 's/namespace \\Elgg/namespace Elgg/g'
find engine -type f -print0 | xargs -0 sed -i 's/abstract namespace \([A-Za-z0-9\\]*\);\n\nclass/namespace \1;\n\nabstract class/g'          
```
##### TODO: Move namespaces to top

```
.scripts/move_namespaces_to_top.php
```
##### Add global qualifiers to global classes

```
find engine -type f -print0 | xargs -0 sed -i 's/\([^\\]\)PHPUnit_Framework_TestCase/\1\\PHPUnit_Framework_TestCase/g'
find engine -type f -print0 | xargs -0 sed -i 's/new \([A-Za-z]*\)Exception/new \\\1Exception/g'
find engine -type f -print0 | xargs -0 sed -i 's/extends \([A-Za-z]*\)Exception/extends \\\1Exception/g'
find engine -type f -print0 | xargs -0 sed -i 's/implements Iterator\([A-Za-z]+\)/implements \\Iterator\1/g'
find engine -type f -print0 | xargs -0 sed -i 's/, Countable/, \\Countable/g'
find engine -type f -print0 | xargs -0 sed -i 's/\([^\\\-\_A-Za-z\/]\)Elgg\([A-Z][A-Za-z]*\)/\1\\Elgg\2/g'
find engine -type f -print0 | xargs -0 sed -i 's/\([^\\\-\_A-Za-z\/]\)stdClass/\1\\stdClass/g'
find engine -type f -print0 | xargs -0 sed -i 's/\([^\\\-\_A-Za-z\/]\)Array\([A-Z][A-Za-z]*\)/\1\\Array\2/g'
find engine -type f -print0 | xargs -0 sed -i 's/\([^\\\-\_A-Za-z\/]\)\([A-Z][A-Za-z]*\)Iterator/\1\\\2Iterator/g'
find engine -type f -print0 | xargs -0 sed -i 's/class \\/class \1/g'
find engine -type f -print0 | xargs -0 sed -i 's/elgg_echo\(..\)\\/elgg_echo\1/g'
```
##### Fixed lint problems

Did this manually. Most common issue was having a space between the class docblock and the class, which made it look like we didn't write any docblocks for those classes.

The other issue was alightment of properties. The leading namespace character throws things off.
