### PR TITLE
chore(tests): Add engine/classes as target for PHPUnit tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,8 @@
 <phpunit bootstrap="./engine/tests/phpunit/bootstrap.php">
-    <testsuites>
+	<testsuites>
 		<testsuite name="All Tests">
-    			<directory>./engine/tests/phpunit/</directory>
+			<directory>./engine/tests/phpunit/</directory>
+			<directory>./engine/classes/</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>


### PR DESCRIPTION
This allows you to temporarily move the test file next to its source file
when you are actively developing and testing with it so that it's easier
to switch between two (which happens frequently in TDD).

The test should still be moved back to engine/tests/phpunit when committed.

Refs #7112
