### PR TITLE
feature(ckeditor): add "clear formatting" button

### DIFF
--- a/mod/ckeditor/views/default/js/elgg/ckeditor/config.js
+++ b/mod/ckeditor/views/default/js/elgg/ckeditor/config.js
@@ -3,7 +3,7 @@ define(function(require) {
 	var $ = require('jquery');
 
 	return {
-		toolbar: [['Bold', 'Italic', 'Underline'], ['Strike', 'NumberedList', 'BulletedList', 'Undo', 'Redo', 'Link', 'Unlink', 'Image', 'Blockquote', 'Paste', 'PasteFromWord', 'Maximize']],
+		toolbar: [['Bold', 'Italic', 'Underline', 'RemoveFormat'], ['Strike', 'NumberedList', 'BulletedList', 'Undo', 'Redo', 'Link', 'Unlink', 'Image', 'Blockquote', 'Paste', 'PasteFromWord', 'Maximize']],
 		removeButtons: 'Subscript,Superscript', // To have Underline back
 		allowedContent: true,
 		baseHref: elgg.config.wwwroot,


### PR DESCRIPTION
Adds a button that can be used to reset styles e.g. after copy-pasting content from somewhere else.

Fixes #7105
