### PR TITLE
fix(output): elgg_normalize_url no longer mistakes querystrings for domains

### DIFF
--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -324,7 +324,7 @@ function elgg_normalize_url($url) {
 		// 'install.php', 'install.php?step=step'
 		return elgg_get_site_url() . $url;
 
-	} elseif (preg_match("#^[^/]*\.#i", $url)) {
+	} elseif (preg_match("#^[^/?]*\.#i", $url)) {
 		// 'example.com', 'example.com/subpage'
 		return "http://$url";
 

--- a/engine/tests/ElggCoreHelpersTest.php
+++ b/engine/tests/ElggCoreHelpersTest.php
@@ -125,6 +125,7 @@ class ElggCoreHelpersTest extends ElggCoreUnitTest {
 			'page/handler?p=v&p2=v2' =>      	elgg_get_site_url() . 'page/handler?p=v&p2=v2',
 			'mod/plugin/file.php' =>            elgg_get_site_url() . 'mod/plugin/file.php',
 			'mod/plugin/file.php?p=v&p2=v2' =>  elgg_get_site_url() . 'mod/plugin/file.php?p=v&p2=v2',
+            'search?foo.bar' =>                 elgg_get_site_url() . 'search?foo.bar',
 			'rootfile.php' =>                   elgg_get_site_url() . 'rootfile.php',
 			'rootfile.php?p=v&p2=v2' =>         elgg_get_site_url() . 'rootfile.php?p=v&p2=v2',
 


### PR DESCRIPTION
The pattern for recognizing domain names in elgg_normalize_url was too
tolerant, resulting in some paths begin seen as domains just because
the querystring contained a period.

Replaces #6590
