### PR TITLE
fix(css): removes padding and margin from elgg-menu-entity items (moved to 1.9)

### DIFF
--- a/mod/aalborg_theme/views/default/css/elements/components.php
+++ b/mod/aalborg_theme/views/default/css/elements/components.php
@@ -204,10 +204,10 @@
 .elgg-river-comments li:last-child {
 	border-radius-bottomleft: 0 0 5px 5px;
 }
-.elgg-river-comments li {
+.elgg-river-comments > li {
 	background-color: #EEE;
 	border-bottom: none;
-	padding: 4px 4px 4px 10px;
+	padding: 4px 10px;
 	margin-bottom: 2px;
 }
 .elgg-river-comments li .elgg-output {

--- a/views/default/css/elements/components.php
+++ b/views/default/css/elements/components.php
@@ -198,7 +198,7 @@
 .elgg-river-comments li:last-child {
 	border-radius-bottomleft: 0 0 5px 5px;
 }
-.elgg-river-comments li {
+.elgg-river-comments > li {
 	background-color: #EEE;
 	border-bottom: none;
 	padding: 4px;


### PR DESCRIPTION
This is a cherry-pick from 1.x. I assume this would still allow 1.9 to merge clean into 1.x?

Fixes #7150
