### PR TITLE
chore(cleanup): Remove use of logical operator `and` in `output/url` view

### DIFF
--- a/views/default/output/url.php
+++ b/views/default/output/url.php
@@ -14,7 +14,7 @@
  */
 
 $url = elgg_extract('href', $vars, null);
-if (!$url and isset($vars['value'])) {
+if (!$url && isset($vars['value'])) {
 	$url = trim($vars['value']);
 	unset($vars['value']);
 }


### PR DESCRIPTION
This is mostly to make the SensioInsights static analysis tool happy.
Logical operators have precedence that is unfamiliar to most programmers,
so they are best avoided.

Another argument could be made that this was the only instance of the logical operator
that exists in our entire project, so just for consistency's sake, it's best to remove.
