### PR TITLE
System cache should support regional designators in language codes

### DIFF
--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -249,7 +249,10 @@ function reload_all_translations() {
 		$cache_dir = $cache->getVariable("cache_path");
 		$filenames = elgg_get_file_list($cache_dir, array(), array(), array(".lang"));
 		foreach ($filenames as $filename) {
-			if (preg_match('/([a-z]+)\.[^.]+$/', $filename, $matches)) {
+			// Look for files matching for example 'en.lang', 'cmn.lang' or 'pt_br.lang'.
+			// Note that this regex is just for the system cache. The original language
+			// files are allowed to have uppercase letters (e.g. pt_BR.php).
+			if (preg_match('/(([a-z]{2,3})(_[a-z]{2})?)\.lang$/', $filename, $matches)) {
 				$language = $matches[1];
 				$data = elgg_load_system_cache("$language.lang");
 				if ($data) {

--- a/languages/en.php
+++ b/languages/en.php
@@ -1234,7 +1234,7 @@ You cannot reply to this email.",
 	'js:security:token_refreshed' => 'Connection to %s restored!',
 
 /**
- * Languages according to ISO 639-1
+ * Languages according to ISO 639-1 (with a couple of exceptions)
  */
 	"aa" => "Afar",
 	"ab" => "Abkhazian",
@@ -1253,6 +1253,7 @@ You cannot reply to this email.",
 	"bo" => "Tibetan",
 	"br" => "Breton",
 	"ca" => "Catalan",
+	"cmn" => "Mandarin Chinese", // ISO 639-3
 	"co" => "Corsican",
 	"cs" => "Czech",
 	"cy" => "Welsh",
@@ -1329,6 +1330,7 @@ You cannot reply to this email.",
 	"pl" => "Polish",
 	"ps" => "Pashto / Pushto",
 	"pt" => "Portuguese",
+	"pt_br" => 'Brazilian Portuguese',
 	"qu" => "Quechua",
 	"rm" => "Rhaeto-Romance",
 	"rn" => "Kirundi",


### PR DESCRIPTION
Name of a cached language file can now have the following structure:
- language code (2-3 lowercase alphabets)
- underscore followed by regional designator (2 lowercase alphabets)

Fixes #7187
