### PR TITLE
Fixes erronous values in the list of processed upgrades

### DIFF
--- a/engine/classes/Elgg/UpgradeService.php
+++ b/engine/classes/Elgg/UpgradeService.php
@@ -94,7 +94,7 @@ class Elgg_UpgradeService {
 			if ($quiet) {
 				// hide include errors as well as any exceptions that might happen
 				try {
-					if (!@include("$upgrade_path/$upgrade")) {
+					if (!@self::includeCode("$upgrade_path/$upgrade")) {
 						$success = false;
 						error_log("Could not include $upgrade_path/$upgrade");
 					}
@@ -103,23 +103,21 @@ class Elgg_UpgradeService {
 					error_log($e->getMessage());
 				}
 			} else {
-				if (!include("$upgrade_path/$upgrade")) {
+				if (!self::includeCode("$upgrade_path/$upgrade")) {
 					$success = false;
 					error_log("Could not include $upgrade_path/$upgrade");
 				}
 			}
 
 			if ($success) {
-				// incrementally set upgrade so we know where to start if something fails.
-				$processed_upgrades[] = $upgrade;
-
 				// don't set the version to a lower number in instances where an upgrade
 				// has been merged from a lower version of Elgg
 				if ($upgrade_version > $version) {
 					datalist_set('version', $upgrade_version);
 				}
 
-				$this->setProcessedUpgrades($processed_upgrades);
+				// incrementally set upgrade so we know where to start if something fails.
+				$this->setProcessedUpgrade($upgrade);
 			} else {
 				return false;
 			}
@@ -129,13 +127,25 @@ class Elgg_UpgradeService {
 	}
 
 	/**
-	 * Saves the processed upgrades to a dataset.
+	 * PHP include a file with a very limited scope
 	 *
-	 * @param array $processed_upgrades An array of processed upgrade filenames
-	 *                                  (not the path, just the file)
+	 * @param string $file File path to include
+	 * @return mixed
+	 */
+	protected static function includeCode($file) {
+		return include $file;
+	}
+
+	/**
+	 * Saves a processed upgrade to a dataset.
+	 *
+	 * @param string $upgrade Filename of the processed upgrade
+	 *                        (not the path, just the file)
 	 * @return bool
 	 */
-	protected function setProcessedUpgrades(array $processed_upgrades) {
+	protected function setProcessedUpgrade($upgrade) {
+		$processed_upgrades = $this->getProcessedUpgrades();
+		$processed_upgrades[] = $upgrade;
 		$processed_upgrades = array_unique($processed_upgrades);
 		return datalist_set('processed_upgrades', serialize($processed_upgrades));
 	}
@@ -298,11 +308,9 @@ class Elgg_UpgradeService {
 
 			// this has already been run in a previous 1.7.X -> 1.7.X upgrade
 			if ($upgrade_version < $db_version) {
-				$processed_upgrades[] = $upgrade_file;
+				$this->setProcessedUpgrade($upgrade_file);
 			}
 		}
-
-		return $this->setProcessedUpgrades($processed_upgrades);
 	}
 
 	/**

--- a/engine/lib/upgrades/2014090900-1.9.0-fix_processed_upgrades-183ad189c71872d8.php
+++ b/engine/lib/upgrades/2014090900-1.9.0-fix_processed_upgrades-183ad189c71872d8.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Elgg 1.9.0 upgrade 2014090900
+ * fix_processed_upgrades
+ *
+ * Fixes incorrect values in the processed_upgrades setting.
+ *
+ * Both the upgrade file name and the class responsible for the actual upgrade
+ * logic had been set as the value of variable called $upgrade. This mistake may
+ * have caused the class to be saved to the list of processed upgrade instead
+ * of the filename. This upgrade replaces the class with the filename.
+ */
+
+$upgrade_data = datalist_get('processed_upgrades');
+$upgrade_data = unserialize($upgrade_data);
+
+foreach ($upgrade_data as $key => $entry) {
+	if (!$entry instanceof ElggUpgrade) {
+		continue;
+	}
+
+	if ($entry->title == 'Comments Upgrade') {
+		$upgrade_data[$key] = '2013010400-1.9.0_dev-comments_to_entities-faba94768b055b08.php';
+	}
+}
+
+datalist_set('processed_upgrades', serialize($upgrade_data));


### PR DESCRIPTION
Both the upgrade file name and the class responsible for the actual upgrade logic had been set as the
value of variable called $upgrade. This mistake may have caused the class to be saved to the list of
processed upgrade instead of the filename. This upgrade replaces the class with the filename.

Fixes #7198
