### PR TITLE
fix(upgrade): fixes erroneous values in the list of processed upgrades

### DIFF
--- a/engine/classes/Elgg/UpgradeService.php
+++ b/engine/classes/Elgg/UpgradeService.php
@@ -94,7 +94,7 @@ class Elgg_UpgradeService {
 			if ($quiet) {
 				// hide include errors as well as any exceptions that might happen
 				try {
-					if (!@include("$upgrade_path/$upgrade")) {
+					if (!@self::includeCode("$upgrade_path/$upgrade")) {
 						$success = false;
 						error_log("Could not include $upgrade_path/$upgrade");
 					}
@@ -103,7 +103,7 @@ class Elgg_UpgradeService {
 					error_log($e->getMessage());
 				}
 			} else {
-				if (!include("$upgrade_path/$upgrade")) {
+				if (!self::includeCode("$upgrade_path/$upgrade")) {
 					$success = false;
 					error_log("Could not include $upgrade_path/$upgrade");
 				}
@@ -126,6 +126,16 @@ class Elgg_UpgradeService {
 		}
 
 		return true;
+	}
+
+	/**
+	 * PHP include a file with a very limited scope
+	 *
+	 * @param string $file File path to include
+	 * @return mixed
+	 */
+	protected static function includeCode($file) {
+		return include $file;
 	}
 
 	/**

--- a/engine/lib/upgrades/2014090900-1.9.0-fix_processed_upgrades-183ad189c71872d8.php
+++ b/engine/lib/upgrades/2014090900-1.9.0-fix_processed_upgrades-183ad189c71872d8.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Elgg 1.9.0 upgrade 2014090900
+ * fix_processed_upgrades
+ *
+ * Fixes incorrect values in the processed_upgrades setting.
+ *
+ * Both the upgrade file name and the class responsible for the actual upgrade
+ * logic had been set as the value of variable called $upgrade. This mistake may
+ * have caused the class to be saved to the list of processed upgrade instead
+ * of the filename. This upgrade replaces the class with the filename.
+ */
+
+$upgrade_data = datalist_get('processed_upgrades');
+$upgrade_data = unserialize($upgrade_data);
+
+foreach ($upgrade_data as $key => $entry) {
+	if (!$entry instanceof ElggUpgrade) {
+		continue;
+	}
+
+	if ($entry->title == 'Comments Upgrade') {
+		$upgrade_data[$key] = '2013010400-1.9.0_dev-comments_to_entities-faba94768b055b08.php';
+	}
+}
+
+datalist_set('processed_upgrades', serialize($upgrade_data));


### PR DESCRIPTION
Code in the upgrade includes was overwriting variables in the upgrade service
resulting in an object being saved to the list of processed upgrade where the
filename should have been. This upgrade replaces the class with the filename and
isolates the scope of the include so upgrades cannot break the process.

Fixes #7198.
