### PR TITLE
fix(actions): action scripts can return falsey values without causing errors

### DIFF
--- a/engine/classes/Elgg/ActionsService.php
+++ b/engine/classes/Elgg/ActionsService.php
@@ -64,10 +64,11 @@ class ActionsService {
 		} elseif (!_elgg_services()->session->isLoggedIn() && ($this->actions[$action]['access'] !== 'public')) {
 			register_error(_elgg_services()->translator->translate('actionloggedout'));
 		} else {
-			// Returning falsy doesn't produce an error
-			// We assume this will be handled in the hook itself.
+			// To quietly cancel the action file, return a falsey value in the "action" hook.
 			if (_elgg_services()->hooks->trigger('action', $action, null, true)) {
-				if (!include($this->actions[$action]['file'])) {
+				if (is_file($this->actions[$action]['file']) && is_readable($this->actions[$action]['file'])) {
+					self::includeFile($this->actions[$action]['file']);
+				} else {
 					register_error(_elgg_services()->translator->translate('actionnotfound', array($action)));
 				}
 			}
@@ -75,6 +76,16 @@ class ActionsService {
 	
 		$forwarder = empty($forwarder) ? REFERER : $forwarder;
 		forward($forwarder);
+	}
+
+	/**
+	 * Include an action file with isolated scope
+	 *
+	 * @param string $file File to be interpreted by PHP
+	 * @return void
+	 */
+	protected static function includeFile($file) {
+		include $file;
 	}
 	
 	/**

--- a/engine/tests/phpunit/Elgg/ActionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ActionsServiceTest.php
@@ -71,6 +71,10 @@ class ActionsServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->markTestIncomplete("Can't test execution due to missing configuration.php dependencies");
 // 		$actions->execute('test/not_registered');
 	}
+
+	public function testActionReturnValuesAreIgnored() {
+		$this->markTestIncomplete();
+	}
 	
 	//TODO call non existing
 


### PR DESCRIPTION
We were testing the return value of "include", but this caused a false-
positive error if the script uses "return;". Now we actually test for
ability to read the script and include it with isolated scope.

Fixes #7209

TODO:
- [x] Add test case (at least an empty one)
