### PR TITLE
fix(style): ordered list markers now always visible

### DIFF
--- a/mod/aalborg_theme/views/default/css/elements/typography.php
+++ b/mod/aalborg_theme/views/default/css/elements/typography.php
@@ -148,6 +148,8 @@ h6 { font-size: 0.8em; }
 }
 .elgg-output ol {
 	list-style-type: decimal;
+	list-style-position: inside;
+	padding-left: .4em;
 }
 .elgg-output table {
 	border: 1px solid #DCDCDC;

--- a/mod/aalborg_theme/views/default/css/maintenance.php
+++ b/mod/aalborg_theme/views/default/css/maintenance.php
@@ -112,6 +112,8 @@ a {
 }
 .elgg-output ol {
 	list-style-type: decimal;
+	list-style-position: inside;
+	padding-left: .4em;
 }
 .elgg-output table {
 	border: 1px solid #DCDCDC;

--- a/mod/ckeditor/views/default/css/elgg/wysiwyg.css
+++ b/mod/ckeditor/views/default/css/elgg/wysiwyg.css
@@ -22,6 +22,8 @@ ul {
 }
 ol {
 	list-style-type: decimal;
+	list-style-position: inside;
+	padding-left: .4em;
 }
 table {
 	border: 1px solid #ccc;

--- a/views/default/css/elements/typography.php
+++ b/views/default/css/elements/typography.php
@@ -151,6 +151,8 @@ h6 { font-size: 0.8em; }
 }
 .elgg-output ol {
 	list-style-type: decimal;
+	list-style-position: inside;
+	padding-left: .4em;
 }
 .elgg-output table {
 	border: 1px solid #ccc;

--- a/views/default/css/maintenance.php
+++ b/views/default/css/maintenance.php
@@ -116,6 +116,8 @@ p:last-child {
 }
 .elgg-output ol {
 	list-style-type: decimal;
+	list-style-position: inside;
+	padding-left: .4em;
 }
 .elgg-output table {
 	border: 1px solid #ccc;


### PR DESCRIPTION
Due to the default list-style-position: outside, list markers would extend
to the left of the elgg-body content and be cut off due to the way that
element is layed out. Here we change the model to inside position.

Fixes #7206
