### PR TITLE
chore(docs): fixes broken links in Views and Contribute documentation

### DIFF
--- a/docs/contribute/code.rst
+++ b/docs/contribute/code.rst
@@ -18,11 +18,10 @@ Pull requests
 Pull requests (PRs) are the best way to get code contributed to Elgg core.
 The core development team uses them even for the most trivial changes.
 
-For new features, `submit a feature request`_ or `talk to us`_ first and make
+For new features, `submit a feature request <issues.html>`__ or `talk to us`_ first and make
 sure the core team approves of your direction before spending lots of time on code.
 
 .. _talk to us: http://community.elgg.org/groups/profile/211069/feedback-and-planning
-.. _submit a feature request: :doc:`/contribute/issues`
 
 
 Checklists

--- a/docs/guides/views.rst
+++ b/docs/guides/views.rst
@@ -153,12 +153,12 @@ Post processing views
 
 Sometimes it is preferable to process or rewrite the output of a view instead of overriding it.
 
-The output of each view is run through the `plugin hook <guides/events#post-plugin-hooks>`__ ``[view, view_name]`` before being returned by ``elgg_view()``. Each registered handler function is passed these arguments:
+The output of each view is run through the `plugin hook <guides/events.html#post-plugin-hooks>`__ ``[view, view_name]`` before being returned by ``elgg_view()``. Each registered handler function is passed these arguments:
 
 * ``$hook`` - the string ``"view"``
 * ``$type`` - the view name being rendered (the first argument passed to ``elgg_view()``)
 * ``$returnvalue`` - the rendered output of the view (or the return value of the last handler)
-* ``$params`` - an array containing the key ``viewtype`` with value being the `viewtype <views#viewtypes>`__ being rendered
+* ``$params`` - an array containing the key ``viewtype`` with value being the `viewtype <views.html#viewtypes>`__ being rendered
 
 To alter the view output, the handler just needs to alter ``$returnvalue`` and return a new string.
 


### PR DESCRIPTION
For some reason the Views doc links worked in my local environment but not in http://learn.elgg.org/en/1.9/guides/views.html

Fixes also #6954 
