### PR TITLE
chore(docs): minor change to test the PHP syntax highlighting

### DIFF
--- a/docs/guides/i18n.rst
+++ b/docs/guides/i18n.rst
@@ -10,7 +10,7 @@ Overview
 
 Translations are stored in PHP files in the ``/languages`` directory of your plugin. Each file corresponds to a language. The format is ``/languages/{language-code}.php`` where ``{language-code}`` is the ISO 639-1 short code for the language. For example:
 
-.. code:: php
+.. code-block:: php
 
    <?php
    


### PR DESCRIPTION
I'm not sure what exactly triggers code syntax highlighting at readthedocs when it comes to PHP, so I'll just try it out in practice.

Refs #6700
