### PR TITLE
perf(views): remove unneeded view calls in river/elements/body view

### DIFF
--- a/views/default/river/elements/body.php
+++ b/views/default/river/elements/body.php
@@ -21,7 +21,13 @@ $menu = elgg_view_menu('river', array(
 // river item header
 $timestamp = elgg_view_friendly_time($item->getTimePosted());
 
-$summary = elgg_extract('summary', $vars, elgg_view('river/elements/summary', array('item' => $vars['item'])));
+$summary = elgg_extract('summary', $vars);
+if ($summary === null) {
+	$summary = elgg_view('river/elements/summary', array(
+		'item' => $vars['item'],
+	));
+}
+
 if ($summary === false) {
 	$subject = $item->getSubjectEntity();
 	$summary = elgg_view('output/url', array(


### PR DESCRIPTION
Since item summaries are commonly set, we now only render the default
summary view when the summary is really missing. This also reduces the
number of NOTICEs about missing translation keys.

(Mitigates #6299 but doesn't solve it.)
- [x] Fix "Yoda condition"
