### PR TITLE
deprecate(i18n): deprecates get_language in favor of get_current_language

### DIFF
--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -794,6 +794,7 @@ class ElggInstaller {
 				'deprecated-1.7.php',
 				'deprecated-1.8.php',
 				'deprecated-1.9.php',
+				'deprecated-1.10.php',
 			);
 
 			foreach ($lib_files as $file) {

--- a/engine/lib/deprecated-1.10.php
+++ b/engine/lib/deprecated-1.10.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Get the language set by the user, by the system, or false if no language is set.
+ *
+ * @return string The language code or false if not set
+ * @deprecated 1.10 Use get_current_language()
+ */
+function get_language() {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use get_current_language()', '1.10');
+	return get_current_language(false);
+}

--- a/engine/load.php
+++ b/engine/load.php
@@ -64,6 +64,7 @@ $lib_files = array(
 	'deprecated-1.7.php',
 	'deprecated-1.8.php',
 	'deprecated-1.9.php',
+	'deprecated-1.10.php',
 );
 
 foreach ($lib_files as $file) {

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -86,8 +86,7 @@ function developers_setup_menu() {
 function developers_clear_strings() {
 	global $CONFIG;
 
-	$language = get_language();
-	$CONFIG->translations[$language] = array();
+	$CONFIG->translations[get_current_language()] = array();
 	$CONFIG->translations['en'] = array();
 }
 


### PR DESCRIPTION
Adds a default argument to get_current_language() so the false-returning behavior of get_language() can be achieved if needed. This also cleans up elgg_echo() a bit.

Fixes #7252
