### PR TITLE
(WIP) feature(i18n): adds function to sniff translation keys before use

### DIFF
--- a/docs/guides/i18n.rst
+++ b/docs/guides/i18n.rst
@@ -65,6 +65,18 @@ To force which language should be used for translation, set the third parameter:
 
    echo elgg_echo(‘welcome’, array(), ‘es’);
 
+``elgg_get_echo_language($key, $language)``
+
+Find the language the translation key is available in. This can be used to test for keys before use:
+
+.. code:: php
+
+    $key = 'key_that_may_not_exist';
+    $lang = elgg_get_echo_language($key);
+    if (!$lang) {
+        $key = 'fallback_key';
+    }
+    $translation = elgg_echo($key, array(), $lang);
 
 
 Javascript API

--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -66,6 +66,45 @@ function elgg_echo($message_key, $args = array(), $language = "") {
 }
 
 /**
+ * Get the language in which the translation key exists. This is for checking keys before
+ * use in elgg_echo().
+ *
+ * Like elgg_echo(), if language is not "en" then this also checks for an English translation. The
+ * developer can then decide whether or not to accept an English translation.
+ *
+ * @param string $key      The translation key to search for
+ * @param string $language The language code to check first. Defaults to get_current_language()
+ *
+ * @return string The language code in which the translation key was found, or empty string.
+ *
+ * @see get_current_language
+ * @see elgg_echo
+ * @since 1.10
+ */
+function elgg_get_echo_language($key, $language = "") {
+	global $CONFIG;
+
+	if (!isset($CONFIG->translations)) {
+		// this means we probably had an exception before translations were initialized
+		register_translations(dirname(dirname(dirname(__FILE__))) . "/languages/");
+	}
+
+	if (!$language) {
+		$language = get_current_language();
+	}
+
+	if (isset($CONFIG->translations[$language][$key])) {
+		return $language;
+	}
+
+	if ($language !== 'en' && isset($CONFIG->translations['en'][$key])) {
+		return 'en';
+	}
+
+	return '';
+}
+
+/**
  * Add a translation.
  *
  * Translations are arrays in the Zend Translation array format, eg:

--- a/views/default/river/elements/summary.php
+++ b/views/default/river/elements/summary.php
@@ -6,6 +6,7 @@
  */
 
 $item = $vars['item'];
+/* @var ElggRiverItem $item */
 
 $subject = $item->getSubjectEntity();
 $object = $item->getObjectEntity();
@@ -43,11 +44,15 @@ if ($container instanceof ElggGroup) {
 // check summary translation keys.
 // will use the $type:$subtype if that's defined, otherwise just uses $type:default
 $key = "river:$action:$type:$subtype";
-$summary = elgg_echo($key, array($subject_link, $object_link));
-
-if ($summary == $key) {
+$lang = elgg_get_echo_language($key);
+if (!$lang) {
 	$key = "river:$action:$type:default";
-	$summary = elgg_echo($key, array($subject_link, $object_link));
+
+	$lang = elgg_get_echo_language($key);
+	if (!$lang) {
+		return;
+	}
 }
+$summary = elgg_echo($key, array($subject_link, $object_link), $lang);
 
 echo $summary;

--- a/views/default/river/object/comment/create.php
+++ b/views/default/river/object/comment/create.php
@@ -25,12 +25,13 @@ $target_link = elgg_view('output/url', array(
 
 $type = $target->getType();
 $subtype = $target->getSubtype() ? $target->getSubtype() : 'default';
+
 $key = "river:comment:$type:$subtype";
-$summary = elgg_echo($key, array($subject_link, $target_link));
-if ($summary == $key) {
+$lang = elgg_get_echo_language($key);
+if (!$lang) {
 	$key = "river:comment:$type:default";
-	$summary = elgg_echo($key, array($subject_link, $target_link));
 }
+$summary = elgg_echo($key, array($subject_link, $target_link), $lang);
 
 echo elgg_view('river/elements/layout', array(
 	'item' => $vars['item'],


### PR DESCRIPTION
This introduces a function to check translation key availability and provides
a workflow for using elgg_echo with fallback keys without triggering unwanted
NOTICEs.

Fixes #6299
- [ ] rewrite for current 1.x
- [ ] basic test
