### PR TITLE
(WIP) feature(i18n): alters elgg_echo to allow using fallback keys without notices

### DIFF
--- a/docs/guides/i18n.rst
+++ b/docs/guides/i18n.rst
@@ -3,7 +3,7 @@ Internationalization
 
 Make your UI translatable into many different languages.
 
-If you’d like to contribute translations to Elgg, see :doc:`the contributors' guide </about/contributing>`.
+If you'd like to contribute translations to Elgg, see :doc:`the contributors' guide </about/contributing>`.
 
 Overview
 ========
@@ -13,27 +13,27 @@ Translations are stored in PHP files in the ``/languages`` directory of your plu
 .. code:: php
 
    <?php
-   
+
    // mod/example/languages/en.php
    return array(
-     ‘example:text’ => ‘Some example text’,
+     'example:text' => 'Some example text',
    );
 
 The default language is “en” for English.
 
-To change the wording of any phrase, provide a new mapping in your plugin’s ``{language}.php`` file for the associated key:
+To change the wording of any phrase, provide a new mapping in your plugin's ``{language}.php`` file for the associated key:
 
 .. code:: php
 
    <?php
 
    return array(
-     ‘example:text’ => ‘This is an example’,
+     'example:text' => 'This is an example',
    );
 
 .. note::
 
-   Unless you are overriding core’s or another plugin’s language strings, it is good practice for the language keys to start with your plugin name. For example: “yourplugin:success,” “yourplugin:title,” etc. This helps avoid conflicts with other language keys.
+   Unless you are overriding core's or another plugin's language strings, it is good practice for the language keys to start with your plugin name. For example: “yourplugin:success,” “yourplugin:title,” etc. This helps avoid conflicts with other language keys.
 
 
 Server-side API
@@ -47,15 +47,15 @@ Example:
 
 .. code:: php
 
-   echo elgg_echo(‘example:text’);
+   echo elgg_echo('example:text');
 
 It also supports variable replacement using sprintf syntax:
 
 .. code:: php
 
-   // ‘welcome’ => ‘Welcome to %s, %s!’
-   echo elgg_echo(‘welcome’, array(
-     elgg_get_config(‘sitename’),
+   // 'welcome' => 'Welcome to %s, %s!'
+   echo elgg_echo('welcome', array(
+     elgg_get_config('sitename'),
      elgg_get_logged_in_user_entity()->name,
    ));
 
@@ -63,9 +63,18 @@ To force which language should be used for translation, set the third parameter:
 
 .. code:: php
 
-   echo elgg_echo(‘welcome’, array(), ‘es’);
+   echo elgg_echo('welcome', array(), 'es');
 
+You can use the ``$quiet`` parameter to allow translation key fallbacks:
 
+.. code:: php
+
+    $key = 'key_that_may_not_exist';
+    $output = elgg_echo($key, array(), '', true);
+    if (false === $output) {
+        $key = 'fallback_key';
+        $output = (string)elgg_echo($key, array(), '', true);
+    }
 
 Javascript API
 ==============
@@ -74,7 +83,7 @@ Javascript API
 
 This function is the exact counterpart to ``elgg_echo`` in PHP.
 
-Client-side translations are loaded asynchronously. This means ``elgg.echo`` will not be ready until after the system is done initializing. 
+Client-side translations are loaded asynchronously. This means ``elgg.echo`` will not be ready until after the system is done initializing.
 
 
 

--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -14,11 +14,14 @@
  * @param array  $args        An array of arguments to pass through vsprintf().
  * @param string $language    Optionally, the standard language code
  *                            (defaults to site/user default, then English)
+ * @param bool   $quiet       If set to true, no notices will be logged about missing translations
+ *                            and the function will return an empty string if no translation is found. This is
+ *                            particularly useful for allowing missing translations with fallback keys.
  *
- * @return string Either the translated string, the English string,
- * or the original language string.
+ * @return string|false Either the translated string, the English string, or the original language string. If
+ *                      $quiet is true, "" may be returned.
  */
-function elgg_echo($message_key, $args = array(), $language = "") {
+function elgg_echo($message_key, $args = array(), $language = "", $quiet = false) {
 	global $CONFIG;
 
 	static $CURRENT_LANGUAGE;
@@ -50,8 +53,13 @@ function elgg_echo($message_key, $args = array(), $language = "") {
 		$string = $CONFIG->translations[$language][$message_key];
 	} else if (isset($CONFIG->translations["en"][$message_key])) {
 		$string = $CONFIG->translations["en"][$message_key];
-		elgg_log(sprintf('Missing %s translation for "%s" language key', $language, $message_key), 'NOTICE');
+		if (!$quiet) {
+			elgg_log(sprintf('Missing %s translation for "%s" language key', $language, $message_key), 'NOTICE');
+		}
 	} else {
+		if ($quiet) {
+			return false;
+		}
 		$string = $message_key;
 		elgg_log(sprintf('Missing English translation for "%s" language key', $message_key), 'NOTICE');
 	}

--- a/views/default/river/elements/summary.php
+++ b/views/default/river/elements/summary.php
@@ -43,11 +43,11 @@ if ($container instanceof ElggGroup) {
 // check summary translation keys.
 // will use the $type:$subtype if that's defined, otherwise just uses $type:default
 $key = "river:$action:$type:$subtype";
-$summary = elgg_echo($key, array($subject_link, $object_link));
-
-if ($summary == $key) {
-	$key = "river:$action:$type:default";
-	$summary = elgg_echo($key, array($subject_link, $object_link));
+$summary = elgg_echo($key, array($subject_link, $object_link), '', true);
+if (false !== $summary) {
+	echo $summary;
+	return;
 }
 
-echo $summary;
+$key = "river:$action:$type:default";
+echo elgg_echo($key, array($subject_link, $object_link), '', true);

--- a/views/default/river/object/comment/create.php
+++ b/views/default/river/object/comment/create.php
@@ -26,10 +26,10 @@ $target_link = elgg_view('output/url', array(
 $type = $target->getType();
 $subtype = $target->getSubtype() ? $target->getSubtype() : 'default';
 $key = "river:comment:$type:$subtype";
-$summary = elgg_echo($key, array($subject_link, $target_link));
-if ($summary == $key) {
+$summary = elgg_echo($key, array($subject_link, $target_link), '', true);
+if (false === $summary) {
 	$key = "river:comment:$type:default";
-	$summary = elgg_echo($key, array($subject_link, $target_link));
+	$summary = (string)elgg_echo($key, array($subject_link, $target_link), '', true);
 }
 
 echo elgg_view('river/elements/layout', array(


### PR DESCRIPTION
This introduces a “quiet” parameter to elgg_echo to have it return false
in case of missing translation, allowing use of fallback keys with 
triggering unwanted NOTICEs.

Fixes #6299
