### PR TITLE
add missing icon size

### DIFF
--- a/mod/groups/actions/groups/delete.php
+++ b/mod/groups/actions/groups/delete.php
@@ -20,11 +20,11 @@ if (($entity) && ($entity instanceof ElggGroup)) {
 	// delete group icons
 	$owner_guid = $entity->owner_guid;
 	$prefix = "groups/" . $entity->guid;
-	$imagenames = array('.jpg', 'tiny.jpg', 'small.jpg', 'medium.jpg', 'large.jpg', 'master.jpg');
+	$imagenames = elgg_get_config('icon_sizes');
 	$img = new ElggFile();
 	$img->owner_guid = $owner_guid;
-	foreach ($imagenames as $name) {
-		$img->setFilename($prefix . $name);
+	foreach ($imagenames as $name => $value) {
+		$img->setFilename($prefix . $name.'.jpg');
 		$img->delete();
 	}
 

--- a/mod/groups/actions/groups/delete.php
+++ b/mod/groups/actions/groups/delete.php
@@ -20,7 +20,7 @@ if (($entity) && ($entity instanceof ElggGroup)) {
 	// delete group icons
 	$owner_guid = $entity->owner_guid;
 	$prefix = "groups/" . $entity->guid;
-	$imagenames = array('.jpg', 'tiny.jpg', 'small.jpg', 'medium.jpg', 'large.jpg');
+	$imagenames = array('.jpg', 'tiny.jpg', 'small.jpg', 'medium.jpg', 'large.jpg', 'master.jpg');
 	$img = new ElggFile();
 	$img->owner_guid = $owner_guid;
 	foreach ($imagenames as $name) {

--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -192,7 +192,7 @@ if ($has_uploaded_icon) {
 	$filehandler->close();
 	$filename = $filehandler->getFilenameOnFilestore();
 
-	$sizes = array('tiny', 'small', 'medium', 'large');
+	$sizes = array('tiny', 'small', 'medium', 'large', 'master');
 
 	$thumbs = array();
 	foreach ($sizes as $size) {


### PR DESCRIPTION
In groups icon.php line 27:
array('large', 'medium', 'small', 'tiny', 'master', 'topbar');

Why master is missing from action?
- [ ] Adhere to commit message formatting requirements
- [ ] Get sizes via `elgg_get_config('icon_sizes')`
