### PR TITLE
fix(i18n): translate notification messages to the recipient's language

### DIFF
--- a/actions/admin/user/resetpassword.php
+++ b/actions/admin/user/resetpassword.php
@@ -25,8 +25,8 @@ if (($user instanceof ElggUser) && ($user->canEdit())) {
 
 		notify_user($user->guid,
 			elgg_get_site_entity()->guid,
-			elgg_echo('email:resetpassword:subject'),
-			elgg_echo('email:resetpassword:body', array($user->username, $password)),
+			elgg_echo('email:resetpassword:subject', array(), $user->language),
+			elgg_echo('email:resetpassword:body', array($user->username, $password), $user->language),
 			array(),
 			'email');
 	} else {

--- a/actions/comment/save.php
+++ b/actions/comment/save.php
@@ -59,9 +59,11 @@ if ($comment_guid) {
 
 	// Notify if poster wasn't owner
 	if ($entity->owner_guid != $user->guid) {
-		notify_user($entity->owner_guid,
+		$owner = $entity->getOwnerEntity();
+
+		notify_user($owner->guid,
 			$user->guid,
-			elgg_echo('generic_comment:email:subject'),
+			elgg_echo('generic_comment:email:subject', array(), $owner->language),
 			elgg_echo('generic_comment:email:body', array(
 				$entity->title,
 				$user->name,
@@ -69,7 +71,7 @@ if ($comment_guid) {
 				$entity->getURL(),
 				$user->name,
 				$user->getURL()
-			)),
+			), $owner->language),
 			array(
 				'object' => $comment,
 				'action' => 'create',

--- a/actions/useradd.php
+++ b/actions/useradd.php
@@ -47,14 +47,14 @@ try {
 		// @todo ugh, saving a guid as metadata!
 		$new_user->created_by_guid = elgg_get_logged_in_user_guid();
 
-		$subject = elgg_echo('useradd:subject');
+		$subject = elgg_echo('useradd:subject', array(), $new_user->language);
 		$body = elgg_echo('useradd:body', array(
 			$name,
 			elgg_get_site_entity()->name,
 			elgg_get_site_entity()->url,
 			$username,
 			$password,
-		));
+		), $new_user->language);
 
 		notify_user($new_user->guid, elgg_get_site_entity()->guid, $subject, $body);
 

--- a/engine/lib/friends.php
+++ b/engine/lib/friends.php
@@ -210,9 +210,19 @@ function _elgg_send_friend_notification($event, $type, $object) {
 	$user_one = get_entity($object->guid_one);
 	/* @var ElggUser $user_one */
 
-	return notify_user($object->guid_two,
-			$object->guid_one,
-			elgg_echo('friend:newfriend:subject', array($user_one->name)),
-			elgg_echo("friend:newfriend:body", array($user_one->name, $user_one->getURL()))
-	);
+	$user_two = get_entity($object->guid_two);
+	/* @var ElggUser $user_two */
+
+	// Notification subject
+	$subject = elgg_echo('friend:newfriend:subject', array(
+		$user_one->name
+	), $user_two->language);
+
+	// Notification body
+	$body = elgg_echo("friend:newfriend:body", array(
+		$user_one->name,
+		$user_one->getURL()
+	), $user_two->language);
+
+	return notify_user($user_two->guid, $object->guid_one, $subject, $body);
 }

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -393,15 +393,24 @@ function send_new_password_request($user_guid) {
 		$user->setPrivateSetting('passwd_conf_code', $code);
 		$user->setPrivateSetting('passwd_conf_time', time());
 
-		// generate link
+		// email subject
+		$subject = elgg_echo('email:changereq:subject', array(), $user->language);
+
+		// link for changing the password
 		$link = elgg_get_site_url() . "changepassword?u=$user_guid&c=$code";
 
-		// generate email
+		// IP address of the current user
 		$ip_address = _elgg_services()->request->getClientIp();
-		$email = elgg_echo('email:changereq:body', array($user->name, $ip_address, $link));
+
+		// email message body
+		$email = elgg_echo('email:changereq:body', array(
+			$user->name,
+			$ip_address,
+			$link
+		), $user->language);
 
 		return notify_user($user->guid, elgg_get_site_entity()->guid,
-			elgg_echo('email:changereq:subject'), $email, array(), 'email');
+			$subject, $email, array(), 'email');
 	}
 
 	return false;
@@ -480,8 +489,8 @@ function execute_new_password_request($user_guid, $conf_code, $password = null) 
 
 		notify_user($user->guid,
 			elgg_get_site_entity()->guid,
-			elgg_echo("email:$ns:subject"),
-			elgg_echo("email:$ns:body", array($user->username, $password)),
+			elgg_echo("email:$ns:subject", array(), $user->language),
+			elgg_echo("email:$ns:body", array($user->username, $password), $user->language),
 			array(),
 			'email'
 		);
@@ -545,7 +554,7 @@ function validate_username($username) {
 		$msg = elgg_echo('registration:usernametooshort', array($CONFIG->minusername));
 		throw new RegistrationException($msg);
 	}
-	
+
 	// username in the database has a limit of 128 characters
 	if (strlen($username) > 128) {
 		$msg = elgg_echo('registration:usernametoolong', array(128));
@@ -1094,7 +1103,7 @@ function users_pagesetup() {
 	$owner = elgg_get_page_owner_entity();
 	$viewer = elgg_get_logged_in_user_entity();
 
-	if ($owner) {		
+	if ($owner) {
 		elgg_register_menu_item('page', array(
 			'name' => 'edit_avatar',
 			'href' => "avatar/edit/{$owner->username}",

--- a/mod/groups/actions/groups/membership/add.php
+++ b/mod/groups/actions/groups/membership/add.php
@@ -23,14 +23,16 @@ if (sizeof($user_guid)) {
 			if (!$group->isMember($user)) {
 				if (groups_join_group($group, $user)) {
 
-					// send welcome email to user
-					notify_user($user->getGUID(), $group->owner_guid,
-							elgg_echo('groups:welcome:subject', array($group->name)),
-							elgg_echo('groups:welcome:body', array(
-								$user->name,
-								$group->name,
-								$group->getURL())
-							));
+					$subject = elgg_echo('groups:welcome:subject', array($group->name), $user->language);
+
+					$body = elgg_echo('groups:welcome:body', array(
+						$user->name,
+						$group->name,
+						$group->getURL(),
+					), $user->language);
+
+					// Send welcome notification to user
+					notify_user($user->getGUID(), $group->owner_guid, $subject, $body);
 
 					system_message(elgg_echo('groups:addedtogroup'));
 				}
@@ -40,7 +42,7 @@ if (sizeof($user_guid)) {
 			}
 			else {
 				$errors[] = elgg_echo('groups:add:alreadymember', array($user->name));
-				
+
 				// if an invitation is still pending clear it up, we don't need it
 				remove_entity_relationship($group->guid, 'invited', $user->guid);
 			}

--- a/mod/groups/actions/groups/membership/invite.php
+++ b/mod/groups/actions/groups/membership/invite.php
@@ -34,17 +34,23 @@ if (count($user_guids) > 0 && elgg_instanceof($group, 'group') && $group->canEdi
 		// Create relationship
 		add_entity_relationship($group->guid, 'invited', $user->guid);
 
-		// Send notification
 		$url = elgg_normalize_url("groups/invitations/$user->username");
-		$result = notify_user($user->getGUID(), $group->owner_guid,
-				elgg_echo('groups:invite:subject', array($user->name, $group->name)),
-				elgg_echo('groups:invite:body', array(
-					$user->name,
-					$logged_in_user->name,
-					$group->name,
-					$url,
-				)),
-				NULL);
+
+		$subject = elgg_echo('groups:invite:subject', array(
+			$user->name,
+			$group->name
+		), $user->language);
+
+		$body = elgg_echo('groups:invite:body', array(
+			$user->name,
+			$logged_in_user->name,
+			$group->name,
+			$url,
+		), $user->language);
+
+		// Send notification
+		$result = notify_user($user->getGUID(), $group->owner_guid, $subject, $body, NULL);
+
 		if ($result) {
 			system_message(elgg_echo("groups:userinvited"));
 		} else {

--- a/mod/groups/actions/groups/membership/join.php
+++ b/mod/groups/actions/groups/membership/join.php
@@ -6,7 +6,7 @@
  * open group so user joins
  * closed group so request sent to group owner
  * closed group with invite so user joins
- * 
+ *
  * @package ElggGroups
  */
 
@@ -46,20 +46,25 @@ if ($user && ($group instanceof ElggGroup)) {
 	} else {
 		add_entity_relationship($user->guid, 'membership_request', $group->guid);
 
-		// Notify group owner
+		$owner = $group->getOwnerEntity();
+
 		$url = "{$CONFIG->url}groups/requests/$group->guid";
+
 		$subject = elgg_echo('groups:request:subject', array(
 			$user->name,
 			$group->name,
-		));
+		), $owner->language);
+
 		$body = elgg_echo('groups:request:body', array(
 			$group->getOwnerEntity()->name,
 			$user->name,
 			$group->name,
 			$user->getURL(),
 			$url,
-		));
-		if (notify_user($group->owner_guid, $user->getGUID(), $subject, $body)) {
+		), $owner->language);
+
+		// Notify group owner
+		if (notify_user($owner->guid, $user->getGUID(), $subject, $body)) {
 			system_message(elgg_echo("groups:joinrequestmade"));
 		} else {
 			register_error(elgg_echo("groups:joinrequestnotmade"));

--- a/mod/likes/actions/likes/add.php
+++ b/mod/likes/actions/likes/add.php
@@ -52,18 +52,22 @@ if ($entity->owner_guid != $user->guid) {
 	$site = elgg_get_site_entity();
 
 	$subject = elgg_echo('likes:notifications:subject', array(
-					$user->name,
-					$title_str
-				));
+			$user->name,
+			$title_str
+		),
+		$owner->language
+	);
 
 	$body = elgg_echo('likes:notifications:body', array(
-					$owner->name,
-					$user->name,
-					$title_str,
-					$site->name,
-					$entity->getURL(),
-					$user->getURL()
-				));
+			$owner->name,
+			$user->name,
+			$title_str,
+			$site->name,
+			$entity->getURL(),
+			$user->getURL()
+		),
+		$owner->language
+	);
 
 	notify_user(
 		$entity->owner_guid,

--- a/mod/messageboard/start.php
+++ b/mod/messageboard/start.php
@@ -108,16 +108,18 @@ function messageboard_add($poster, $owner, $message, $access_id = ACCESS_PUBLIC)
 		'annotation_id' => $result_id,
 	));
 
-	// only send notification if not self
+	// Send notification only if poster isn't the owner
 	if ($poster->guid != $owner->guid) {
-		$subject = elgg_echo('messageboard:email:subject');
+
+		$subject = elgg_echo('messageboard:email:subject', array(), $owner->language);
+
 		$body = elgg_echo('messageboard:email:body', array(
-						$poster->name,
-						$message,
-						elgg_get_site_url() . "messageboard/" . $owner->username,
-						$poster->name,
-						$poster->getURL()
-						));
+			$poster->name,
+			$message,
+			elgg_get_site_url() . "messageboard/" . $owner->username,
+			$poster->name,
+			$poster->getURL()
+		), $owner->language);
 
 		notify_user($owner->guid, $poster->guid, $subject, $body);
 	}

--- a/mod/uservalidationbyemail/lib/functions.php
+++ b/mod/uservalidationbyemail/lib/functions.php
@@ -48,9 +48,22 @@ function uservalidationbyemail_request_validation($user_guid, $admin_requested =
 		// Get email to show in the next page
 		elgg_get_session()->set('emailsent', $user->email);
 
+		$subject = elgg_echo('email:validate:subject', array(
+				$user->name,
+				$site->name
+			), $user->language
+		);
+
+		$body = elgg_echo('email:validate:body', array(
+				$user->name,
+				$site->name,
+				$link,
+				$site->name,
+				$site->url
+			), $user->language
+		);
+
 		// Send validation email
-		$subject = elgg_echo('email:validate:subject', array($user->name, $site->name));
-		$body = elgg_echo('email:validate:body', array($user->name, $site->name, $link, $site->name, $site->url));
 		$result = notify_user($user->guid, $site->guid, $subject, $body, array(), 'email');
 
 		return $result;


### PR DESCRIPTION
Fixes #7241 

This list should cover everything:
- [x] Likes
- [x] Messageboard
- [x] User validation by email (Some sites may allow selecting language already on registration)
- [x] Groups:
  - [x] Add member
  - [x] Invite member
  - [x] Membership request
- [x] Core
  - [x] Add user (admin action)
  - [x] Request new password
  - [x] Change password
  - [x] Reset password (admin action)
  - [x] Add friend
  - [x] Comment
