### PR TITLE
chore(tests): throw ElggUpgrade exceptions untranslated to get rid of li...

### DIFF
--- a/engine/classes/ElggUpgrade.php
+++ b/engine/classes/ElggUpgrade.php
@@ -40,12 +40,12 @@ class ElggUpgrade extends ElggObject {
 		parent::initializeAttributes();
 
 		$this->attributes['subtype'] = 'elgg_upgrade';
-		
-		// unowned 
+
+		// unowned
 		$this->attributes['site_guid'] = 0;
 		$this->attributes['container_guid'] = 0;
 		$this->attributes['owner_guid'] = 0;
-		
+
 		$this->is_completed = 0;
 	}
 
@@ -77,13 +77,13 @@ class ElggUpgrade extends ElggObject {
 	 */
 	public function setPath($path) {
 		if (!$path) {
-			throw new InvalidArgumentException(elgg_echo('ElggUpgrade:error:url_invalid'));
+			throw new InvalidArgumentException('Invalid value for URL path.');
 		}
 
 		$path = ltrim($path, '/');
 
 		if ($this->getUpgradeFromPath($path)) {
-			throw new InvalidArgumentException(elgg_echo('ElggUpgrade:error:url_not_unique'));
+			throw new InvalidArgumentException('Upgrade URL paths must be unique.');
 		}
 
 		$this->upgrade_url = $path;
@@ -130,7 +130,7 @@ class ElggUpgrade extends ElggObject {
 	public function save() {
 		foreach ($this->requiredProperties as $prop) {
 			if (!$this->$prop) {
-				throw new UnexpectedValueException(elgg_echo("ElggUpgrade:error:{$prop}_required"));
+				throw new UnexpectedValueException("ElggUpgrade objects must have a value for the $prop property.");
 			}
 		}
 

--- a/engine/tests/phpunit/ElggUpgradeTest.php
+++ b/engine/tests/phpunit/ElggUpgradeTest.php
@@ -1,9 +1,5 @@
 <?php
 
-// Exceptions are translated
-$engine = dirname(dirname(dirname(__FILE__)));
-require_once "$engine/lib/languages.php";
-
 class ElggUpgradeTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * @var ElggUpgrade
@@ -73,7 +69,7 @@ class ElggUpgradeTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @expectedException UnexpectedValueException
-	 * @expectedExceptionMessage ElggUpgrade:error:upgrade_url_required
+	 * @expectedExceptionMessage ElggUpgrade objects must have a value for the upgrade_url property.
 	 */
 	public function testThrowsOnSaveWithoutPath() {
 		$this->obj->description = 'Test';
@@ -83,7 +79,7 @@ class ElggUpgradeTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @expectedException UnexpectedValueException
-	 * @expectedExceptionMessage ElggUpgrade:error:title_required
+	 * @expectedExceptionMessage ElggUpgrade objects must have a value for the title property.
 	 */
 	public function testThrowsOnSaveWithoutTitle() {
 		$this->obj->setPath('test');
@@ -93,7 +89,7 @@ class ElggUpgradeTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @expectedException UnexpectedValueException
-	 * @expectedExceptionMessage ElggUpgrade:error:description_required
+	 * @expectedExceptionMessage ElggUpgrade objects must have a value for the description property.
 	 */
 	public function testThrowsOnSaveWithoutDesc() {
 		$this->obj->setPath('test');

--- a/languages/en.php
+++ b/languages/en.php
@@ -1101,12 +1101,6 @@ Once you have logged in, we highly recommend that you change your password.
 	'upgrade:site_secret_warning:moderate' => "You are encouraged to regenerate your site key to improve system security. See Configure &gt; Settings &gt; Advanced",
 	'upgrade:site_secret_warning:weak' => "You are strongly encouraged to regenerate your site key to improve system security. See Configure &gt; Settings &gt; Advanced",
 
-	'ElggUpgrade:error:url_invalid' => 'Invalid value for URL path.',
-	'ElggUpgrade:error:url_not_unique' => 'Upgrade URL paths must be unique.',
-	'ElggUpgrade:error:title_required' => 'ElggUpgrade objects must have a title.',
-	'ElggUpgrade:error:description_required' => 'ElggUpgrade objects must have a description.',
-	'ElggUpgrade:error:upgrade_url_required' => 'ElggUpgrade objects must have an upgrade URL path.',
-
 	'deprecated:function' => '%s() was deprecated by %s()',
 
 	'admin:pending_upgrades' => 'The site has pending upgrades that require your immediate attention.',


### PR DESCRIPTION
...brary dependencies

ElggUpgrade was translating its exception messages which required ElggUpgradeTest to include the languages library. Use of the libraries is prone to cause dependency chains, so it's better not to translate the exceptions at all for now.

Fixes #7276
