### PR TITLE
fix(css): prevent select box from overflowing its container

### DIFF
--- a/mod/aalborg_theme/views/default/css/elements/forms.php
+++ b/mod/aalborg_theme/views/default/css/elements/forms.php
@@ -74,6 +74,10 @@ input[type="radio"] {
 	display: inline;
 	padding-right: 10px;
 }
+select {
+	max-width: 100%;
+	padding: 4px; 
+}
 .elgg-form-account {
 	margin-bottom: 15px;
 }


### PR DESCRIPTION
Fixes #7290
