### PR TITLE
fix(database): More robust sql script execution.

### DIFF
--- a/docs/guides/database.rst
+++ b/docs/guides/database.rst
@@ -327,3 +327,45 @@ developing for a pre-1.8 version of Elgg.
 elgg\_get\_entities\_from\_metadata(): This function is new in 1.8. It
 deprecates get\_entities\_from\_metadata(), which you should use if
 developing for a pre-1.8 version of Elgg.
+
+Custom database functionality
+=============================
+
+It is strongly recommended to use entities wherever possible. However, Elgg
+supports custom SQL queries using the database API.
+
+Example: Run SQL script on plugin activation
+--------------------------------------------
+
+This example shows how you can populate your database on plugin activation.
+
+my_plugin/activate.php:
+
+.. code:: php
+
+    if (!elgg_get_plugin_setting('database_version', 'my_plugin') {
+        run_sql_script(__DIR__ . '/sql/activate.sql');
+        elgg_set_plugin_setting('database_version', 1, 'my_plugin');
+    }
+
+
+my_plugin/sql/activate.sql:
+
+.. code:: sql
+
+    -- Create some table
+    CREATE TABLE prefix_custom_table(
+        id INTEGER AUTO_INCREMENT,
+        name VARCHAR(32),
+        description VARCHAR(32),
+        PRIMARY KEY (id)
+    );
+
+    -- Insert initial values for table
+    INSERT INTO prefix_custom_table (name, description)
+    VALUES ('Peter', 'Some guy'), ('Lisa', 'Some girl');
+
+Note that Elgg execute statements through PHPs built-in functions and have
+limited support for comments. I.e. only single line comments are supported
+and must be prefixed by "-- " or "# ". A comment must start at the very beginning
+of a line.

--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -375,10 +375,14 @@ class Elgg_Database {
 	 *
 	 * The file specified should be a standard SQL file as created by
 	 * mysqldump or similar.  Statements must be terminated with ;
-	 * and a newline character (\n or \r\n) with only one statement per line.
+	 * and a newline character (\n or \r\n).
 	 *
 	 * The special string 'prefix_' is replaced with the database prefix
 	 * as defined in {@link $this->tablePrefix}.
+	 *
+	 * @warning Only single line comments are supported. A comment
+	 * must start with '-- ' or '# ', where the comment sign is at the
+	 * very beginning of each line.
 	 *
 	 * @warning Errors do not halt execution of the script.  If a line
 	 * generates an error, the error message is saved and the
@@ -396,11 +400,11 @@ class Elgg_Database {
 
 			$errors = array();
 
-			// Remove MySQL -- style comments
-			$script = preg_replace('/\-\-.*\n/', '', $script);
+			// Remove MySQL '-- ' and '# ' style comments
+			$script = preg_replace('/^(?:--|#) .*$/m', '', $script);
 
 			// Statements must end with ; and a newline
-			$sql_statements = preg_split('/;[\n\r]+/', $script);
+			$sql_statements = preg_split('/;[\n\r]+/', "$script\n");
 
 			foreach ($sql_statements as $statement) {
 				$statement = trim($statement);

--- a/engine/tests/phpunit/Elgg/DatabaseTest.php
+++ b/engine/tests/phpunit/Elgg/DatabaseTest.php
@@ -1,0 +1,106 @@
+<?php
+
+class Elgg_DatabaseTest extends PHPUnit_Framework_TestCase {
+	
+	private $dbClass, $configClass;
+
+	/**
+	 * Inspect instances in DI container to get correct classnames for
+	 * Database API.
+	 */
+	public function setUp() {
+		// Database class
+		// Cannot user _elgg_services() because ElggEntityTest replace
+		// the database instance with a mock.
+		$db = _elgg_create_service_provider()->db;
+		$this->dbClass = get_class($db);
+		
+		// Config class
+		$reflectionClass = new ReflectionClass($db);
+		$reflectionProperty = $reflectionClass->getProperty('config');
+		if (method_exists($reflectionProperty, 'setAccessible')) {
+			$reflectionProperty->setAccessible(true);
+			$config = $reflectionProperty->getValue($db);
+			$this->configClass = get_class($config);
+		} else {
+			$this->configClass = 'Elgg_Database_Config';
+		}
+	}
+	
+	/**
+	 * @dataProvider scriptsWithOneStatement
+	 */
+	public function test_runSqlScript_withOneStatement($script) {
+		$db = $this->getDbMock();
+		$db->expects($this->exactly(1))
+			->method('updateData')
+			->with($this->matchesRegularExpression("/^INSERT INTO test_sometable \(`key`\)\sVALUES \('Value(?: -- not a comment)?'\)$/"));
+		$db->runSqlScript($this->getFixture($script));
+	}
+
+	public function scriptsWithOneStatement() {
+		return array(
+			array('one_statement.sql'),
+			array('one_statement_multiline.sql'),
+			array('one_statement_with_comments.sql'),
+		);
+	}
+	
+	/**
+	 * @dataProvider scriptsWithMultipleStatements
+	 * @todo Use @see withConsecutive() to test consecutive method calls after upgrading to PHPUnit 4.
+	 */
+	public function test_runSqlScript_withMultipleStatements($script) {
+		// Verify that exactly three statements are executed
+		$db1 = $this->getDbMock();
+		$db1->expects($this->exactly(3))->method('updateData');
+		$db1->runSqlScript($this->getFixture($script));
+
+		// Verify that executed statements matches fixtures
+		$db2 = $this->getDbMock();
+		$this->expectExecutedStatement($db2, 0, $this->matches("INSERT INTO test_sometable (`key`) VALUES ('Value 1')"));
+		$this->expectExecutedStatement($db2, 1, $this->matchesRegularExpression("/^UPDATE test_sometable\s+SET `key` = 'Value 2'\s+WHERE `key` = 'Value 1'$/"));
+		$this->expectExecutedStatement($db2, 2, $this->matches("INSERT INTO test_sometable (`key`) VALUES ('Value 3')"));
+		$db2->runSqlScript($this->getFixture($script));
+	}
+	
+	public function scriptsWithMultipleStatements() {
+		return array(
+			array('multiple_statements.sql'),
+			array('multiple_statements_with_comments.sql'),
+		);
+	}
+
+	private function getFixture($filename) {
+		return dirname(__FILE__) .
+			DIRECTORY_SEPARATOR . '..' .
+			DIRECTORY_SEPARATOR . 'test_files' .
+			DIRECTORY_SEPARATOR . 'sql' .
+			DIRECTORY_SEPARATOR . $filename;
+	}
+	
+	/**
+	 * @return PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function getDbMock()
+	{
+		return $this->getMock(
+			$this->dbClass,
+			array('updateData'),
+			array(
+				 new $this->configClass((object) array('dbprefix' => 'test_')),
+				_elgg_services()->logger
+			)
+		);
+	}
+		
+	/**
+	 * @param PHPUnit_Framework_MockObject_MockObject $db
+	 * @param int $index
+	 * @param PHPUnit_Framework_MockObject_Matcher $matcher
+	 */
+	private function expectExecutedStatement($db, $index, $matcher)
+	{
+		$db->expects($this->at($index))->method('updateData')->with($matcher);
+	}
+}

--- a/engine/tests/phpunit/test_files/sql/multiple_statements.sql
+++ b/engine/tests/phpunit/test_files/sql/multiple_statements.sql
@@ -1,0 +1,3 @@
+INSERT INTO prefix_sometable (`key`) VALUES ('Value 1');
+UPDATE prefix_sometable SET `key` = 'Value 2' WHERE `key` = 'Value 1';
+INSERT INTO prefix_sometable (`key`) VALUES ('Value 3');

--- a/engine/tests/phpunit/test_files/sql/multiple_statements_with_comments.sql
+++ b/engine/tests/phpunit/test_files/sql/multiple_statements_with_comments.sql
@@ -1,0 +1,13 @@
+-- Insert first value
+INSERT INTO prefix_sometable (`key`) VALUES ('Value 1');
+
+-- Update first value
+UPDATE prefix_sometable
+    SET `key` = 'Value 2'
+    WHERE `key` = 'Value 1'
+;
+
+# And some other comment
+
+-- Insert third value
+INSERT INTO prefix_sometable (`key`) VALUES ('Value 3');

--- a/engine/tests/phpunit/test_files/sql/one_statement.sql
+++ b/engine/tests/phpunit/test_files/sql/one_statement.sql
@@ -1,0 +1,1 @@
+INSERT INTO prefix_sometable (`key`) VALUES ('Value');

--- a/engine/tests/phpunit/test_files/sql/one_statement_multiline.sql
+++ b/engine/tests/phpunit/test_files/sql/one_statement_multiline.sql
@@ -1,0 +1,2 @@
+INSERT INTO prefix_sometable (`key`)
+VALUES ('Value');

--- a/engine/tests/phpunit/test_files/sql/one_statement_with_comments.sql
+++ b/engine/tests/phpunit/test_files/sql/one_statement_with_comments.sql
@@ -1,0 +1,3 @@
+-- This is the first comment
+INSERT INTO prefix_sometable (`key`) VALUES ('Value -- not a comment');
+-- This is another comment


### PR DESCRIPTION
Implemented tests for various formats of SQL input and fixed a bug that caused
text inside SQL strings to be interpreted as comments.

Example of input that would cause a problem:

``` SQL
    -- Input with a comment
    INSERT INTO x VALUES ('Some string -- not a comment');
```

``` PHP
    // Operations in runSqlScript
    // Fatal error
    $this->updateData("INSERT INTO x VALUES ('Some value ");
```

By the additonal demand that all comments must start at the beginning of a line,
this problem is solved. Compared to the previous version, there is one case
that potentially could cause problems:

``` SQL
    -- Input with comment suffix
    INSERT INTO x VALUES ('Some value'); -- Comment
```

``` PHP
    // Operations in runSqlScript
    // No problem, we can pass comments into PHP MySQL API
    $this->updateData("INSERT INTO x VALUES ('Some value'); -- Comment");
```

Luckily, the preceding example will execute as normal, so there should be no side-effects. The following example summarize supported comment formats in SQL files for patch.

``` MYSQL
    -- Supported comment will be stripped before executing statements
    # Supported comment will be stripped before executing statements
    /* Disregarded comment, will not be stripped, but is ignored by MySQL, should not be a problem */
   INSERT INTO x VALUES ('Actual statement');
```
