### PR TITLE
chore(file): use a hook to fix detected mimetype

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -149,6 +149,12 @@ Views
 **head, page**
     In elgg_view_page(), filters $vars['head']
 
+Files
+=====
+
+**mime_type, file**
+    In ElggFile::detectMimeType, filters the detected mime type
+
 Other
 =====
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -5,6 +5,19 @@ Prepare your plugin for the next version of Elgg.
 
 See the administator guides for :doc:`how to upgrade a live site </admin/upgrading>`.
 
+From 1.9 to 1.10
+================
+
+File uploads
+------------
+
+If your plugin is using a snippet copied from the ``file/upload`` action to fix detected mime types for Microsoft zipped formats, it can now be safely removed.
+
+If your upload action performs other manipulations on detected mime and simple types, it is recommended to make use of available plugin hooks:
+
+- ``'mime_type','file'`` for filtering detected mime types
+- ``'simple_type','file'`` for filtering parsed simple types
+
 From 1.8 to 1.9
 ===============
 

--- a/mod/file/actions/file/upload.php
+++ b/mod/file/actions/file/upload.php
@@ -98,28 +98,6 @@ if (isset($_FILES['upload']['name']) && !empty($_FILES['upload']['name'])) {
 	$file->originalfilename = $_FILES['upload']['name'];
 	$mime_type = $file->detectMimeType($_FILES['upload']['tmp_name'], $_FILES['upload']['type']);
 
-	// hack for Microsoft zipped formats
-	$info = pathinfo($_FILES['upload']['name']);
-	$office_formats = array('docx', 'xlsx', 'pptx');
-	if ($mime_type == "application/zip" && in_array($info['extension'], $office_formats)) {
-		switch ($info['extension']) {
-			case 'docx':
-				$mime_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-				break;
-			case 'xlsx':
-				$mime_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-				break;
-			case 'pptx':
-				$mime_type = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
-				break;
-		}
-	}
-
-	// check for bad ppt detection
-	if ($mime_type == "application/vnd.ms-office" && $info['extension'] == "ppt") {
-		$mime_type = "application/vnd.ms-powerpoint";
-	}
-
 	$file->setMimeType($mime_type);
 	$file->simpletype = file_get_simple_type($mime_type);
 

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -184,7 +184,7 @@ function file_register_toggle() {
 
 /**
  * Prepare a notification message about a new file
- * 
+ *
  * @param string                          $hook         Hook name
  * @param string                          $type         Hook type
  * @param Elgg\Notifications\Notification $notification The notification to prepare
@@ -201,7 +201,7 @@ function file_prepare_notification($hook, $type, $notification, $params) {
 	$descr = $entity->description;
 	$title = $entity->title;
 
-	$notification->subject = elgg_echo('file:notify:subject', array($entity->title), $language); 
+	$notification->subject = elgg_echo('file:notify:subject', array($entity->title), $language);
 	$notification->body = elgg_echo('file:notify:body', array(
 		$owner->name,
 		$title,
@@ -415,7 +415,7 @@ function file_set_icon_url($hook, $type, $url, $params) {
 		} else {
 			$ext = '';
 		}
-		
+
 		$url = "mod/file/graphics/icons/{$type}{$ext}.gif";
 		$url = elgg_trigger_plugin_hook('file:icon:url', 'override', $params, $url);
 		return $url;


### PR DESCRIPTION
Moves mimetype detection logic for Microsoft zipped formats into a plugin hook as to avoid code duplication in file upload actions
