### PR TITLE
chore(mbstring): remove PHP 5.6 notices due to deprecated ini setting

### DIFF
--- a/engine/lib/mb_wrapper.php
+++ b/engine/lib/mb_wrapper.php
@@ -3,7 +3,9 @@
 // if mb functions are available, set internal encoding to UTF8
 if (is_callable('mb_internal_encoding')) {
 	mb_internal_encoding("UTF-8");
-	ini_set("mbstring.internal_encoding", 'UTF-8');
+	if (ini_get("mbstring.internal_encoding")) {
+		ini_set("mbstring.internal_encoding", 'UTF-8');
+	}
 }
 
 /**


### PR DESCRIPTION
In PHP 5.6 the ini setting mbstring.internal_encoding was deprecated. Solution
is to only set it if a value already exists.

Fixes #7244
