### PR TITLE
fix(perf): correctly re-enable querycache after elggbatch run

### DIFF
--- a/engine/classes/ElggBatch.php
+++ b/engine/classes/ElggBatch.php
@@ -327,7 +327,7 @@ class ElggBatch
 			_elgg_services()->db->enableQueryCache();
 			return true;
 		} else {
-			_elgg_services()->db->disableQueryCache();
+			_elgg_services()->db->enableQueryCache();
 			return false;
 		}
 	}


### PR DESCRIPTION
The query cache should always be enabled if a batch ends, otherwise everything after the batch run will not use the query cache.
