### PR TITLE
fix(router): add original params to route hook

### DIFF
--- a/engine/classes/Elgg/Router.php
+++ b/engine/classes/Elgg/Router.php
@@ -60,7 +60,7 @@ class Elgg_Router {
 			'handler' => $identifier, // backward compatibility
 			'segments' => $segments,
 		);
-		$result = $this->hooks->trigger('route', $identifier, null, $result);
+		$result = $this->hooks->trigger('route', $identifier, $result, $result);
 		if ($result === false) {
 			return true;
 		}


### PR DESCRIPTION
fixes #7284 

this allows a hook handler to look at the original params instead of the current return value
