### PR TITLE
feature(views): output readable access level for any access_id

### DIFF
--- a/views/default/output/access.php
+++ b/views/default/output/access.php
@@ -1,17 +1,16 @@
 <?php
+
 /**
- * Displays HTML for entity access levels.
- * Requires an entity because some special logic for containers is used.
+ * Displays HTML with human readable representation of an access level
  *
- * @uses int $vars['entity'] - The entity whose access ID to display.
+ * @uses ElggEntity $vars['entity'] Optional. The entity whose access ID to display. If provided, additional logic is used to determine CSS classes
+ * @uses int        $vars['value']  Optional. Access ID to display.
  */
+$access_class = 'elgg-access';
 
 //sort out the access level for display
 if (isset($vars['entity']) && elgg_instanceof($vars['entity'])) {
 	$access_id = $vars['entity']->access_id;
-	$access_class = 'elgg-access';
-	$access_id_string = get_readable_access_level($access_id);
-	$access_id_string = htmlspecialchars($access_id_string, ENT_QUOTES, 'UTF-8', false);
 
 	// if within a group or shared access collection display group name and open/closed membership status
 	// @todo have a better way to do this instead of checking against subtype / class.
@@ -35,8 +34,21 @@ if (isset($vars['entity']) && elgg_instanceof($vars['entity'])) {
 	} elseif ($access_id == ACCESS_PRIVATE) {
 		$access_class .= ' elgg-access-private';
 	}
-
-	$help_text = elgg_echo('access:help');
-
-	echo "<span title=\"$help_text\" class=\"$access_class\">$access_id_string</span>";
+} else if (isset($vars['value'])) {
+	$access_id = $vars['value'];
 }
+
+if (!isset($access_id)) {
+	return true;
+}
+
+$access_id_string = get_readable_access_level($access_id);
+
+$attributes = array(
+	'title' => elgg_echo('access:help'),
+	'class' => $access_class,
+);
+
+echo elgg_format_element('span', $attributes, $access_id_string, array(
+	'encode_text' => true,
+));


### PR DESCRIPTION
Do not require an entity to display a human readable representation of an access_id

Fixes #7133 

Replaces #7300

Required for #7214
