### PR TITLE
fix(css): removed datepicker fixed width causing visual bug

### DIFF
--- a/views/default/css/elements/forms.php
+++ b/views/default/css/elements/forms.php
@@ -282,7 +282,6 @@ input[type="radio"] {
 	display: none;
 
 	margin-top: 3px;
-	width: 208px;
 	background-color: white;
 	border: 1px solid #0054A7;
 	border-radius: 6px;


### PR DESCRIPTION
datepicker can handle different font sizes, but changing the font size causes visual issues (too much padding, or text overflow)

fixes #4964

tested the change and has no effect on default, aalborg or custom theme
