### PR TITLE
feature(fielstore): add elgg_get_file_simple_type() to core API

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -155,6 +155,11 @@ Files
 **mime_type, file**
     In ElggFile::detectMimeType, filters the detected mime type
 
+**simple_type, file**
+    In ``elgg_file_get_simple_type()``, filters the return value
+    The hook uses ``$params['mime_type']`` (e.g. ``application/pdf`` or ``image/jpeg``) and determines the corresponding simple (overall) type (e.g. ``document`` or ``image``)
+    Bundled file plugin and other-third party plugins usually store ``simpletype`` metadata on file entities and makes use of it when serving icons and constructing ``ege*`` filters and menus
+
 Other
 =====
 
@@ -198,12 +203,6 @@ Other
 
 Plugins
 =======
-
-File
-----
-
-**simple_type, file**
-    In file_get_simple_type(), filters the return value
 
 Embed
 -----

--- a/engine/lib/deprecated-1.10.php
+++ b/engine/lib/deprecated-1.10.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Returns an overall file type from the mimetype
+ *
+ * @param string $mimetype The MIME type
+ * @return string The overall type
+ * @deprecated 1.10 Use elgg_get_file_simple_type()
+ */
+function file_get_simple_type($mimetype) {
+	elgg_deprecated_notice('Use elgg_get_file_simple_type() instead of file_get_simple_type()', '1.10');
+	return elgg_get_file_simple_type($mimetype);
+}
+
+/**
+ * Returns an overall file type from the mimetype
+ *
+ * @param string $mimetype The MIME type
+ *
+ * @return string The overall type
+ * @deprecated 1.10 Use elgg_get_file_simple_type()
+ */
+function file_get_general_file_type($mimetype) {
+	elgg_deprecated_notice('Use elgg_get_file_simple_type() instead of file_get_general_file_type()', '1.10');
+	return elgg_get_file_simple_type($mimetype);
+}
+

--- a/engine/lib/deprecated-1.8.php
+++ b/engine/lib/deprecated-1.8.php
@@ -4727,3 +4727,17 @@ function retrieve_cached_entity($guid) {
 	elgg_deprecated_notice('retrieve_cached_entity() is a private function and should not be used.', 1.8);
 	return _elgg_retrieve_cached_entity($guid);
 }
+
+
+/**
+ * Returns an overall file type from the mimetype
+ *
+ * @param string $mimetype The MIME type
+ *
+ * @return string The overall type
+ * @deprecated 1.8 Use elgg_get_file_simple_type()
+ */
+function get_general_file_type($mimetype) {
+	elgg_deprecated_notice('Use elgg_file_get_simple_type() instead of get_general_file_type()', '1.8');
+	return elgg_get_file_simple_type($mimetype);
+}

--- a/engine/lib/filestore.php
+++ b/engine/lib/filestore.php
@@ -355,47 +355,6 @@ function file_delete($guid) {
 }
 
 /**
- * Returns an overall file type from the mimetype
- *
- * @param string $mimetype The MIME type
- *
- * @return string The overall type
- */
-function file_get_general_file_type($mimetype) {
-	switch ($mimetype) {
-
-		case "application/msword":
-			return "document";
-			break;
-		case "application/pdf":
-			return "document";
-			break;
-	}
-
-	if (substr_count($mimetype, 'text/')) {
-		return "document";
-	}
-
-	if (substr_count($mimetype, 'audio/')) {
-		return "audio";
-	}
-
-	if (substr_count($mimetype, 'image/')) {
-		return "image";
-	}
-
-	if (substr_count($mimetype, 'video/')) {
-		return "video";
-	}
-
-	if (substr_count($mimetype, 'opendocument')) {
-		return "document";
-	}
-
-	return "general";
-}
-
-/**
  * Delete a directory and all its contents
  *
  * @param string $directory Directory to delete

--- a/engine/lib/filestore.php
+++ b/engine/lib/filestore.php
@@ -105,7 +105,7 @@ $square = false, $upscale = false) {
  * @return false|mixed The contents of the resized image, or false on failure
  */
 function get_resized_image_from_existing_file($input_name, $maxwidth, $maxheight, $square = false,
-$x1 = 0, $y1 = 0, $x2 = 0, $y2 = 0, $upscale = false) {
+		$x1 = 0, $y1 = 0, $x2 = 0, $y2 = 0, $upscale = false) {
 
 	// Get the size information from the image
 	$imgsizearray = getimagesize($input_name);
@@ -160,8 +160,8 @@ $x1 = 0, $y1 = 0, $x2 = 0, $y2 = 0, $upscale = false) {
 
 	// color transparencies white (default is black)
 	imagefilledrectangle(
-		$new_image, 0, 0, $params['newwidth'], $params['newheight'],
-		imagecolorallocate($new_image, 255, 255, 255)
+			$new_image, 0, 0, $params['newwidth'], $params['newheight'],
+			imagecolorallocate($new_image, 255, 255, 255)
 	);
 
 	$rtn_code = imagecopyresampled(	$new_image,
@@ -362,7 +362,7 @@ function file_delete($guid) {
  * @return string The overall type
  */
 function file_get_general_file_type($mimetype) {
-	switch($mimetype) {
+	switch ($mimetype) {
 
 		case "application/msword":
 			return "document";
@@ -486,6 +486,18 @@ function set_default_filestore(\ElggFilestore $filestore) {
 }
 
 /**
+ * Returns a simple (overall) file type from the mimetype
+ * 
+ * @param string $mimetype The MIME type
+ * @return string The overall type: 'general' (default), 'document', 'audio' or 'video'
+ * @since 1.10
+ */
+function elgg_get_file_simple_type($mimetype) {
+	$params = array('mime_type' => $mimetype);
+	return elgg_trigger_plugin_hook('simple_type', 'file', $params, 'general');
+}
+
+/**
  * Initialize the file library.
  * Listens to system init and configures the default filestore
  *
@@ -502,6 +514,9 @@ function _elgg_filestore_init() {
 
 	// Fix mimetype detection for Microsoft zipped formats
 	elgg_register_plugin_hook_handler('mime_type', 'file', '_elgg_filestore_detect_mimetype');
+	
+	// Parse overall simpletype from mimetype
+	elgg_register_plugin_hook_handler('simple_type', 'file', '_elgg_filestore_parse_simpletype');
 
 	// Unit testing
 	elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_filestore_test');
@@ -545,6 +560,50 @@ function _elgg_filestore_detect_mimetype($hook, $type, $mime_type, $params) {
 	}
 
 	return $mime_type;
+}
+
+/**
+ * Parse overall file type from mimetype
+ *
+ * @param string $hook        Hook name
+ * @param string $type        Hook type
+ * @param string $simple_type The overall type
+ * @param array  $params      Hook parameters
+ * @uses string @params['mime_type'] Mimetype
+ * @return string
+ * @access private
+ */
+function _elgg_filestore_parse_simpletype($hook, $type, $simple_type, $params) {
+
+	$mime_type = elgg_extract('mime_type', $params);
+
+	switch ($mime_type) {
+		case "application/msword":
+		case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+			$simple_type = "document";
+			break;
+		case "application/pdf":
+			$simple_type = "document";
+			break;
+		case "application/ogg":
+			$simple_type = "audio";
+			break;
+		default:
+			if (substr_count($mime_type, 'text/')) {
+				$simple_type = "document";
+			} elseif (substr_count($mime_type, 'audio/')) {
+				$simple_type = "audio";
+			} elseif (substr_count($mime_type, 'image/')) {
+				$simple_type = "image";
+			} elseif (substr_count($mime_type, 'video/')) {
+				$simple_type = "video";
+			} elseif (substr_count($mime_type, 'opendocument')) {
+				$simple_type = "document";
+			}
+			break;
+	}
+
+	return $simple_type;
 }
 
 /**

--- a/engine/load.php
+++ b/engine/load.php
@@ -64,6 +64,7 @@ $lib_files = array(
 	'deprecated-1.7.php',
 	'deprecated-1.8.php',
 	'deprecated-1.9.php',
+	'deprecated-1.10.php',
 );
 
 foreach ($lib_files as $file) {

--- a/engine/tests/ElggCoreFilestoreTest.php
+++ b/engine/tests/ElggCoreFilestoreTest.php
@@ -73,6 +73,30 @@ class ElggCoreFilestoreTest extends \ElggCoreUnitTest {
 		$user->delete();
 	}
 
+	function testElggGetFileSimpletype() {
+
+		$tests = array(
+			'x-world/x-svr' => 'general',
+			'application/msword' => 'document',
+			'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'document',
+			'application/vnd.oasis.opendocument.text' => 'document',
+			'application/pdf' => 'document',
+			'application/ogg' => 'audio',
+			'text/css' => 'document',
+			'text/plain' => 'document',
+			'audio/midi' => 'audio',
+			'audio/mpeg' => 'audio',
+			'image/jpeg' => 'image',
+			'image/bmp' => 'image',
+			'video/mpeg' => 'video',
+			'video/quicktime' => 'video',
+		);
+
+		foreach ($tests as $mime_type => $simple_type) {
+			$this->assertEqual($simple_type, elgg_get_file_simple_type($mime_type));
+		}
+	}
+
 	protected function createTestUser($username = 'fileTest') {
 		$user = new \ElggUser();
 		$user->username = $username;

--- a/mod/file/actions/file/upload.php
+++ b/mod/file/actions/file/upload.php
@@ -99,7 +99,7 @@ if (isset($_FILES['upload']['name']) && !empty($_FILES['upload']['name'])) {
 	$mime_type = $file->detectMimeType($_FILES['upload']['tmp_name'], $_FILES['upload']['type']);
 
 	$file->setMimeType($mime_type);
-	$file->simpletype = file_get_simple_type($mime_type);
+	$file->simpletype = elgg_get_file_simple_type($mime_type);
 
 	// Open the file to guarantee the directory exists
 	$file->open("write");

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -233,54 +233,6 @@ function file_owner_block_menu($hook, $type, $return, $params) {
 }
 
 /**
- * Returns an overall file type from the mimetype
- *
- * @param string $mimetype The MIME type
- * @return string The overall type
- */
-function file_get_simple_type($mimetype) {
-
-	$simple_type = null;
-
-	switch ($mimetype) {
-		case "application/msword":
-		case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-			$simple_type = "document";
-			break;
-		case "application/pdf":
-			$simple_type = "document";
-			break;
-		case "application/ogg":
-			$simple_type = "audio";
-			break;
-		default:
-			if (substr_count($mimetype, 'text/')) {
-				$simple_type = "document";
-			} elseif (substr_count($mimetype, 'audio/')) {
-				$simple_type = "audio";
-			} elseif (substr_count($mimetype, 'image/')) {
-				$simple_type = "image";
-			} elseif (substr_count($mimetype, 'video/')) {
-				$simple_type = "video";
-			} elseif (substr_count($mimetype, 'opendocument')) {
-				$simple_type = "document";
-			} else {
-				$simple_type = "general";
-			}
-			break;
-	}
-
-	$params = array('mime_type' => $mimetype);
-	return elgg_trigger_plugin_hook('simple_type', 'file', $params, $simple_type);
-}
-
-// deprecated and will be removed
-function get_general_file_type($mimetype) {
-	elgg_deprecated_notice('Use file_get_simple_type() instead of get_general_file_type()', 1.8);
-	return file_get_simple_type($mimetype);
-}
-
-/**
  * Returns a list of filetypes
  *
  * @param int       $container_guid The GUID of the container of the files


### PR DESCRIPTION
Add elgg_file_get_simple_type() to core API and clean up the mess related to simple type parsing across core and file plugin
