### PR TITLE
perf(system): do not load deprecated api by default

### DIFF
--- a/docs/info/config.php
+++ b/docs/info/config.php
@@ -343,16 +343,24 @@ $CONFIG->lastcache;
 /**
  * This is an optional script used to override Elgg's default handling of
  * uncaught exceptions.
- * 
+ *
  * This should be an absolute file path to a php script that will be called
  * any time an uncaught exception is thrown.
- * 
+ *
  * The script will have access to the following variables as part of the scope
  * global $CONFIG
  * $exception - the unhandled exception
- * 
+ *
  * @warning - the database may not be available
- * 
+ *
  * @global string $CONFIG->exception_include
  */
 $CONFIG->exception_include = '';
+
+/**
+ * A flag to optionally load APIs that have been deprecated and removed from core according
+ * to deprecation policy
+ *
+ * @global boolean $CONFIG->load_legacy_apis
+ */
+$CONFIG->load_legacy_apis;

--- a/engine/load.php
+++ b/engine/load.php
@@ -1,11 +1,12 @@
 <?php
 /**
  * This file is used to make all of Elgg's code available without going through
- * the boot process. Useful for internal testing purposes. 
- * 
+ * the boot process. Useful for internal testing purposes.
+ *
  * @access private
  */
 
+global $CONFIG;
 
 $lib_dir = __DIR__ . "/lib";
 
@@ -16,7 +17,7 @@ $lib_files = array(
 	// These need to be loaded first to correctly bootstrap
 	'autoloader.php',
 	'elgglib.php',
-	
+
 	// The order of these doesn't matter, so keep them alphabetical
 	'access.php',
 	'actions.php',
@@ -61,10 +62,13 @@ $lib_files = array(
 	'widgets.php',
 
 	// backward compatibility
-	'deprecated-1.7.php',
-	'deprecated-1.8.php',
 	'deprecated-1.9.php',
 );
+
+if ($CONFIG->load_legacy_apis === true) {
+	$lib_files[] = 'deprecated-1.7.php';
+	$lib_files[] = 'deprecated-1.8.php';
+}
 
 foreach ($lib_files as $file) {
 	require_once("$lib_dir/$file");


### PR DESCRIPTION
Stop loading deprecated APIs and ddd a config flag for site owners to load legacy APIs if needed
