### PR TITLE
fix(css): stop CSS from overwriting the width and height added in CKEditor

### DIFF
--- a/mod/aalborg_theme/views/default/css/elements/typography.php
+++ b/mod/aalborg_theme/views/default/css/elements/typography.php
@@ -159,7 +159,6 @@ h6 { font-size: 0.8em; }
 	padding: 3px 5px;
 }
 .elgg-output img {
-	width: auto;
 	max-width: 100%;
 	height: auto;
 }

--- a/views/default/css/elements/typography.php
+++ b/views/default/css/elements/typography.php
@@ -162,7 +162,6 @@ h6 { font-size: 0.8em; }
 	padding: 3px 5px;
 }
 .elgg-output img {
-	width: auto;
 	max-width: 100%;
 	height: auto;
 }

--- a/views/default/css/ie8.php
+++ b/views/default/css/ie8.php
@@ -16,3 +16,7 @@
 .elgg-gallery .elgg-avatar > .elgg-icon-hover-menu {
     bottom: 4px;
 }
+/* Maintain the aspect ratio of images. */
+.elgg-output img {
+	width: auto;
+}


### PR DESCRIPTION
Fixes #7269
