### PR TITLE
feature(views): move logged in check to topbar view

### DIFF
--- a/mod/aalborg_theme/views/default/page/default.php
+++ b/mod/aalborg_theme/views/default/page/default.php
@@ -39,18 +39,9 @@ $body = <<<__BODY
 		$messages
 	</div>
 __BODY;
-	
-if (elgg_is_logged_in()) {
-	$topbar = elgg_view('page/elements/topbar', $vars);
 
-	$body .= <<<__BODY
-	<div class="elgg-page-topbar">
-		<div class="elgg-inner">
-			$topbar
-		</div>
-	</div>
-__BODY;
-}
+$body .= elgg_view('page/elements/topbar_wrapper', $vars);
+
 $body .= <<<__BODY
 	<div class="elgg-page-header">
 		<div class="elgg-inner">

--- a/views/default/page/default.php
+++ b/views/default/page/default.php
@@ -39,17 +39,8 @@ $body = <<<__BODY
 	</div>
 __BODY;
 
-if (elgg_is_logged_in()) {
-	$topbar = elgg_view('page/elements/topbar', $vars);
+$body .= elgg_view('page/elements/topbar_wrapper', $vars);
 
-	$body .= <<<__BODY
-	<div class="elgg-page-topbar">
-		<div class="elgg-inner">
-			$topbar
-		</div>
-	</div>
-__BODY;
-}	
 $body .= <<<__BODY
 	<div class="elgg-page-header">
 		<div class="elgg-inner">

--- a/views/default/page/elements/topbar_wrapper.php
+++ b/views/default/page/elements/topbar_wrapper.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Elgg topbar wrapper
+ * Check if the user is logged in and display a topbar
+ * @since 1.10 
+ */
+if (!elgg_is_logged_in()) {
+	return true;
+}
+?>
+<div class="elgg-page-topbar">
+	<div class="elgg-inner">
+		<?php
+		echo elgg_view('page/elements/topbar', $vars);
+		?>
+	</div>
+</div>


### PR DESCRIPTION
Make it easier for theme authors to override topbar behaviour by moving the logged in check to the topbar view

Fixes #6582
