### PR TITLE
fix(relationships): distinct ege* results when relationship_guid is not ...

### DIFF
--- a/engine/lib/relationships.php
+++ b/engine/lib/relationships.php
@@ -343,6 +343,10 @@ function elgg_get_entities_from_relationship($options) {
 		$select = array('r.id');
 
 		$options['selects'] = array_merge($options['selects'], $select);
+		
+		if (!isset($options['group_by'])) {
+			$options['group_by'] = $clauses['group_by'];
+		}
 	}
 
 	return elgg_get_entities_from_metadata($options);
@@ -374,6 +378,7 @@ $relationship_guid = null, $inverse_relationship = false) {
 
 	$wheres = array();
 	$joins = array();
+	$group_by = '';
 
 	if ($inverse_relationship) {
 		$joins[] = "JOIN {$CONFIG->dbprefix}entity_relationships r on r.guid_one = $column";
@@ -391,11 +396,15 @@ $relationship_guid = null, $inverse_relationship = false) {
 		} else {
 			$wheres[] = "r.guid_one = '$relationship_guid'";
 		}
+	} else {
+		// See #5775. Queries that do not include a relationship_guid must be grouped by entity table alias,
+		// otherwise the result set is not unique
+		$group_by = $column;
 	}
 
 	if ($where_str = implode(' AND ', $wheres)) {
 
-		return array('wheres' => array("($where_str)"), 'joins' => $joins);
+		return array('wheres' => array("($where_str)"), 'joins' => $joins, 'group_by' => $group_by);
 	}
 
 	return '';

--- a/engine/tests/ElggCoreGetEntitiesFromRelationshipTest.php
+++ b/engine/tests/ElggCoreGetEntitiesFromRelationshipTest.php
@@ -191,5 +191,81 @@ class ElggCoreGetEntitiesFromRelationshipTest extends ElggCoreGetEntitiesBaseTes
 			}
 		}
 	}
+	
+	/**
+	 * Make sure elgg_get_entities_from_relationship() returns distinct (unique) results when relationship_guid is not set
+	 * See #5775
+	 * @covers elgg_get_entities_from_relationship()
+	 */
+	public function testElggApiGettersEntityRelationshipDistinctResult() {
+
+		$obj1 = new ElggObject();
+		$obj1->save();
+
+		$obj2 = new ElggObject();
+		$obj2->save();
+
+		$obj3 = new ElggObject();
+		$obj3->save();
+
+		add_entity_relationship($obj2->guid, 'test_5775', $obj1->guid);
+		add_entity_relationship($obj3->guid, 'test_5775', $obj1->guid);
+
+		$options = array(
+			'relationship' => 'test_5775',
+			'inverse_relationship' => false,
+			'count' => true,
+		);
+		
+		$count = elgg_get_entities_from_relationship($options);
+		$this->assertIdentical($count, 1);
+
+		unset($options['count']);
+		$objects = elgg_get_entities_from_relationship($options);
+		$this->assertTrue(is_array($objects));
+		$this->assertIdentical(count($objects), 1);
+		
+		$obj1->delete();
+		$obj2->delete();
+		$obj3->delete();
+	}
+	
+	/**
+	 * Make sure changes related to #5775 do not affect inverse relationship queries
+	 * @covers elgg_get_entities_from_relationship()
+	 */
+	public function testElggApiGettersEntityRelationshipDistinctResultInverse() {
+
+		
+		$obj1 = new ElggObject();
+		$obj1->save();
+
+		$obj2 = new ElggObject();
+		$obj2->save();
+
+		$obj3 = new ElggObject();
+		$obj3->save();
+
+		add_entity_relationship($obj2->guid, 'test_5775_inverse', $obj1->guid);
+		add_entity_relationship($obj3->guid, 'test_5775_inverse', $obj1->guid);
+
+		$options = array(
+			'relationship' => 'test_5775_inverse',
+			'inverse_relationship' => true,
+			'count' => true,
+		);
+		
+		$count = elgg_get_entities_from_relationship($options);
+		$this->assertIdentical($count, 2);
+
+		unset($options['count']);
+		$objects = elgg_get_entities_from_relationship($options);
+		$this->assertTrue(is_array($objects));
+		$this->assertIdentical(count($objects), 2);
+		
+		$obj1->delete();
+		$obj2->delete();
+		$obj3->delete();
+	}
 
 }


### PR DESCRIPTION
...set

elgg_get_entities_from_relationship() was returning duplicate entities when relationship_guid was not set. This was likely caused by MySQL optimizing the query and using a different index to fulfill the r.id select.

Specifying group_by in cases where relationship_guid is not set fixes the issue.

Fixes #5775
