### PR TITLE
feature(settings): adds setting for default number of items per page

### DIFF
--- a/actions/admin/site/update_advanced.php
+++ b/actions/admin/site/update_advanced.php
@@ -9,89 +9,91 @@
  * @subpackage Administration.Site
  */
 
-if ($site = elgg_get_site_entity()) {
-	if (!($site instanceof ElggSite)) {
-		throw new InstallationException("Passing a non-ElggSite to an ElggSite constructor!");
-	}
-
-	$site->url = rtrim(get_input('wwwroot', '', false), '/') . '/';
-
-	datalist_set('path', sanitise_filepath(get_input('path', '', false)));
-	$dataroot = sanitise_filepath(get_input('dataroot', '', false));
-
-	// check for relative paths
-	if (stripos(PHP_OS, 'win') === 0) {
-		if (strpos($dataroot, ':') !== 1) {
-			$msg = elgg_echo('admin:configuration:dataroot:relative_path', array($dataroot));
-			register_error($msg);
-			forward(REFERER);
-		}
-	} else {
-		if (strpos($dataroot, '/') !== 0) {
-			$msg = elgg_echo('admin:configuration:dataroot:relative_path', array($dataroot));
-			register_error($msg);
-			forward(REFERER);
-		}
-	}
-
-	datalist_set('dataroot', $dataroot);
-
-	if ('on' === get_input('simplecache_enabled')) {
-		elgg_enable_simplecache();
-	} else {
-		elgg_disable_simplecache();
-	}
-
-	set_config('simplecache_minify_js', 'on' === get_input('simplecache_minify_js'), $site->getGUID());
-	set_config('simplecache_minify_css', 'on' === get_input('simplecache_minify_css'), $site->getGUID());
-
-	if ('on' === get_input('system_cache_enabled')) {
-		elgg_enable_system_cache();
-	} else {
-		elgg_disable_system_cache();
-	}
-
-	set_config('default_access', get_input('default_access', ACCESS_PRIVATE), $site->getGUID());
-
-	$user_default_access = ('on' === get_input('allow_user_default_access'));
-	set_config('allow_user_default_access', $user_default_access, $site->getGUID());
-
-	$debug = get_input('debug');
-	if ($debug) {
-		set_config('debug', $debug, $site->getGUID());
-	} else {
-		unset_config('debug', $site->getGUID());
-	}
-
-	// allow new user registration?
-	$allow_registration = ('on' === get_input('allow_registration', false));
-	set_config('allow_registration', $allow_registration, $site->getGUID());
-
-	// setup walled garden
-	$walled_garden = ('on' === get_input('walled_garden', false));
-	set_config('walled_garden', $walled_garden, $site->getGUID());
-
-	if ('on' === get_input('https_login')) {
-		set_config('https_login', 1, $site->getGUID());
-	} else {
-		unset_config('https_login', $site->getGUID());
-	}
-
-	$regenerate_site_secret = get_input('regenerate_site_secret', false);
-	if ($regenerate_site_secret) {
-		init_site_secret();
-		elgg_reset_system_cache();
-
-		system_message(elgg_echo('admin:site:secret_regenerated'));
-
-		elgg_delete_admin_notice('weak_site_key');
-	}
-
-	if ($site->save()) {
-		system_message(elgg_echo("admin:configuration:success"));
-	} else {
-		register_error(elgg_echo("admin:configuration:fail"));
-	}
-
-	forward(REFERER);
+$site = elgg_get_site_entity();
+if (!$site) {
+	throw new InstallationException("The system is missing an ElggSite entity!");
 }
+if (!($site instanceof ElggSite)) {
+	throw new InstallationException("Passing a non-ElggSite to an ElggSite constructor!");
+}
+
+$site->url = rtrim(get_input('wwwroot', '', false), '/') . '/';
+
+datalist_set('path', sanitise_filepath(get_input('path', '', false)));
+$dataroot = sanitise_filepath(get_input('dataroot', '', false));
+
+// check for relative paths
+if (stripos(PHP_OS, 'win') === 0) {
+	if (strpos($dataroot, ':') !== 1) {
+		$msg = elgg_echo('admin:configuration:dataroot:relative_path', array($dataroot));
+		register_error($msg);
+		forward(REFERER);
+	}
+} else {
+	if (strpos($dataroot, '/') !== 0) {
+		$msg = elgg_echo('admin:configuration:dataroot:relative_path', array($dataroot));
+		register_error($msg);
+		forward(REFERER);
+	}
+}
+
+datalist_set('dataroot', $dataroot);
+
+if ('on' === get_input('simplecache_enabled')) {
+	elgg_enable_simplecache();
+} else {
+	elgg_disable_simplecache();
+}
+
+set_config('simplecache_minify_js', 'on' === get_input('simplecache_minify_js'), $site->getGUID());
+set_config('simplecache_minify_css', 'on' === get_input('simplecache_minify_css'), $site->getGUID());
+
+if ('on' === get_input('system_cache_enabled')) {
+	elgg_enable_system_cache();
+} else {
+	elgg_disable_system_cache();
+}
+
+set_config('default_access', get_input('default_access', ACCESS_PRIVATE), $site->getGUID());
+
+$user_default_access = ('on' === get_input('allow_user_default_access'));
+set_config('allow_user_default_access', $user_default_access, $site->getGUID());
+
+$debug = get_input('debug');
+if ($debug) {
+	set_config('debug', $debug, $site->getGUID());
+} else {
+	unset_config('debug', $site->getGUID());
+}
+
+// allow new user registration?
+$allow_registration = ('on' === get_input('allow_registration', false));
+set_config('allow_registration', $allow_registration, $site->getGUID());
+
+// setup walled garden
+$walled_garden = ('on' === get_input('walled_garden', false));
+set_config('walled_garden', $walled_garden, $site->getGUID());
+
+if ('on' === get_input('https_login')) {
+	set_config('https_login', 1, $site->getGUID());
+} else {
+	unset_config('https_login', $site->getGUID());
+}
+
+$regenerate_site_secret = get_input('regenerate_site_secret', false);
+if ($regenerate_site_secret) {
+	init_site_secret();
+	elgg_reset_system_cache();
+
+	system_message(elgg_echo('admin:site:secret_regenerated'));
+
+	elgg_delete_admin_notice('weak_site_key');
+}
+
+if ($site->save()) {
+	system_message(elgg_echo("admin:configuration:success"));
+} else {
+	register_error(elgg_echo("admin:configuration:fail"));
+}
+
+forward(REFERER);

--- a/actions/admin/site/update_basic.php
+++ b/actions/admin/site/update_basic.php
@@ -10,18 +10,28 @@
  * @subpackage Administration.Site
  */
 
-if ($site = elgg_get_site_entity()) {
-	if (!($site instanceof ElggSite)) {
-		throw new InstallationException("Passing a non-ElggSite to an ElggSite constructor!");
-	}
-
-	$site->description = get_input('sitedescription');
-	$site->name = strip_tags(get_input('sitename'));
-	$site->email = get_input('siteemail');
-	$site->save();
-
-	set_config('language', get_input('language'), $site->getGUID());
+$site = elgg_get_site_entity();
+if (!$site) {
+	throw new InstallationException("The system is missing an ElggSite entity!");
 }
+if (!($site instanceof ElggSite)) {
+	throw new InstallationException("Passing a non-ElggSite to an ElggSite constructor!");
+}
+
+$site->description = get_input('sitedescription');
+$site->name = strip_tags(get_input('sitename'));
+$site->email = get_input('siteemail');
+$site->save();
+
+set_config('language', get_input('language'), $site->guid);
+
+$default_limit = (int)get_input('default_limit');
+if ($default_limit < 1) {
+	register_error(elgg_echo('admin:configuration:default_limit'));
+	forward(REFERER);
+}
+
+set_config('default_limit', $default_limit, $site->guid);
 
 system_message(elgg_echo('admin:configuration:success'));
 forward(REFERER);

--- a/docs/info/config.php
+++ b/docs/info/config.php
@@ -171,6 +171,13 @@ $CONFIG->sitedescription;
 $CONFIG->siteemail;
 
 /**
+ * The default "limit" used in site queries.
+ *
+ * @global int $CONFIG->default_limit
+ */
+$CONFIG->default_limit;
+
+/**
  * The current view type
  *
  * View types determin the location of view files that are used to draw pages.

--- a/engine/classes/ElggBatch.php
+++ b/engine/classes/ElggBatch.php
@@ -199,7 +199,7 @@ class ElggBatch
 
 		// store these so we can compare later
 		$this->offset = elgg_extract('offset', $options, 0);
-		$this->limit = elgg_extract('limit', $options, 10);
+		$this->limit = elgg_extract('limit', $options, elgg_get_config('default_limit'));
 
 		// if passed a callback, create a new \ElggBatch with the same options
 		// and pass each to the callback.

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -1465,6 +1465,7 @@ class ElggInstaller {
 		set_config('allow_registration', TRUE, $site->getGUID());
 		set_config('walled_garden', FALSE, $site->getGUID());
 		set_config('allow_user_default_access', '', $site->getGUID());
+		set_config('default_limit', 10, $site->getGUID());
 
 		$this->setSubtypeClasses();
 

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -746,7 +746,7 @@ function elgg_enable_entity($guid, $recursive = true) {
  *
  *  reverse_order_by => BOOL Reverse the default order by clause
  *
- * 	limit => null (10)|INT SQL limit clause (0 means no limit)
+ * 	limit => null (from settings)|INT SQL limit clause (0 means no limit)
  *
  * 	offset => null (0)|INT SQL offset clause
  *
@@ -799,7 +799,7 @@ function elgg_get_entities(array $options = array()) {
 		'reverse_order_by'		=>	false,
 		'order_by' 				=>	'e.time_created desc',
 		'group_by'				=>	ELGG_ENTITIES_ANY_VALUE,
-		'limit'					=>	10,
+		'limit'					=>	elgg_get_config('default_limit'),
 		'offset'				=>	0,
 		'count'					=>	false,
 		'selects'				=>	array(),
@@ -1360,7 +1360,7 @@ function elgg_list_entities(array $options = array(), $getter = 'elgg_get_entiti
 
 	$defaults = array(
 		'offset' => (int) max(get_input($offset_key, 0), 0),
-		'limit' => (int) max(get_input('limit', 10), 0),
+		'limit' => (int) max(get_input('limit', elgg_get_config('default_limit')), 0),
 		'full_view' => false,
 		'list_type_toggle' => false,
 		'pagination' => true,

--- a/engine/lib/input.php
+++ b/engine/lib/input.php
@@ -311,7 +311,7 @@ function input_livesearch_page_handler($page) {
 		$owner_where = '';
 	}
 
-	$limit = sanitise_int(get_input('limit', 10));
+	$limit = sanitise_int(get_input('limit', elgg_get_config('default_limit')));
 
 	// grab a list of entities and send them in json.
 	$results = array();

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -241,7 +241,7 @@ function _elgg_get_metastring_based_objects($options) {
 
 		// sql
 		'order_by' => 'n_table.time_created asc',
-		'limit' => 10,
+		'limit' => elgg_get_config('default_limit'),
 		'offset' => 0,
 		'count' => false,
 		'selects' => array(),

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -493,7 +493,7 @@ function elgg_list_river(array $options = array()) {
 
 	$defaults = array(
 		'offset'     => (int) max(get_input('offset', 0), 0),
-		'limit'      => (int) max(get_input('limit', 20), 0),
+		'limit'      => (int) max(get_input('limit', max(20, elgg_get_config('default_limit'))), 0),
 		'pagination' => true,
 		'list_class' => 'elgg-list-river',
 		'no_results' => '',

--- a/engine/lib/system_log.php
+++ b/engine/lib/system_log.php
@@ -18,7 +18,7 @@
  * @param string    $class      The class of object it effects.
  * @param string    $type       The type
  * @param string    $subtype    The subtype.
- * @param int       $limit      Maximum number of responses to return.
+ * @param int       $limit      Maximum number of responses to return. (default from settings)
  * @param int       $offset     Offset of where to start.
  * @param bool      $count      Return count or not
  * @param int       $timebefore Lower time limit
@@ -27,7 +27,7 @@
  * @param string    $ip_address The IP address.
  * @return mixed
  */
-function get_system_log($by_user = "", $event = "", $class = "", $type = "", $subtype = "", $limit = 10,
+function get_system_log($by_user = "", $event = "", $class = "", $type = "", $subtype = "", $limit = null,
 						$offset = 0, $count = false, $timebefore = 0, $timeafter = 0, $object_id = 0,
 						$ip_address = "") {
 
@@ -47,6 +47,9 @@ function get_system_log($by_user = "", $event = "", $class = "", $type = "", $su
 	$type = sanitise_string($type);
 	$subtype = sanitise_string($subtype);
 	$ip_address = sanitise_string($ip_address);
+	if ($limit === null) {
+		$limit = elgg_get_config('default_limit');
+	}
 	$limit = (int)$limit;
 	$offset = (int)$offset;
 

--- a/engine/lib/tags.php
+++ b/engine/lib/tags.php
@@ -37,7 +37,7 @@ function string_to_tag_array($string) {
  *
  * 	tag_names => array() metadata tag names - must be registered tags
  *
- * 	limit => INT number of tags to return
+ * 	limit => INT number of tags to return (default from settings)
  *
  *  types => null|STR entity type (SQL: type = '$type')
  *
@@ -74,7 +74,7 @@ function elgg_get_tags(array $options = array()) {
 	$defaults = array(
 		'threshold' => 1,
 		'tag_names' => array(),
-		'limit' => 10,
+		'limit' => elgg_get_config('default_limit'),
 
 		'types' => ELGG_ENTITIES_ANY_VALUE,
 		'subtypes' => ELGG_ENTITIES_ANY_VALUE,

--- a/engine/lib/upgrades/2014102000-1.10.0-add_default_limit-fcef9e7ce01e26a4.php
+++ b/engine/lib/upgrades/2014102000-1.10.0-add_default_limit-fcef9e7ce01e26a4.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Elgg 1.10.0 upgrade 2014102000
+ * add_default_limit
+ *
+ * Adds the default_limit site config value
+ */
+
+set_config('default_limit', 10, elgg_get_site_entity()->guid);

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -312,7 +312,7 @@ function get_user_by_email($email) {
  * @param array $options Array of options with keys:
  *
  *   seconds (int)  => Length of period (default 600 = 10min)
- *   limit   (int)  => Limit (default 10)
+ *   limit   (int)  => Limit (default from settings)
  *   offset  (int)  => Offset (default 0)
  *   count   (bool) => Return a count instead of users? (default false)
  *
@@ -324,7 +324,7 @@ function get_user_by_email($email) {
  *
  * @return \ElggUser[]|int
  */
-function find_active_users($options = array(), $limit = 10, $offset = 0, $count = false) {
+function find_active_users($options = array(), $limit = null, $offset = 0, $count = false) {
 
 	$seconds = 600; //default value
 
@@ -334,6 +334,10 @@ function find_active_users($options = array(), $limit = 10, $offset = 0, $count 
 			$options = $seconds; //assign default value
 		}
 		$options = array('seconds' => $options);
+	}
+
+	if ($limit === null) {
+		$limit = elgg_get_config('default_limit');
 	}
 
 	$options = array_merge(array(

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -936,7 +936,7 @@ function elgg_view_annotation(\ElggAnnotation $annotation, array $vars = array()
  * @param array $vars     Display variables
  *      'count'            The total number of entities across all pages
  *      'offset'           The current indexing offset
- *      'limit'            The number of entities to display per page
+ *      'limit'            The number of entities to display per page (default from settings)
  *      'full_view'        Display the full view of the entities?
  *      'list_class'       CSS class applied to the list
  *      'item_class'       CSS class applied to the list items
@@ -948,7 +948,7 @@ function elgg_view_annotation(\ElggAnnotation $annotation, array $vars = array()
  * @return string The rendered list of entities
  * @access private
  */
-function elgg_view_entity_list($entities, $vars = array(), $offset = 0, $limit = 10, $full_view = true,
+function elgg_view_entity_list($entities, $vars = array(), $offset = 0, $limit = null, $full_view = true,
 $list_type_toggle = true, $pagination = true) {
 
 	if (!is_int($offset)) {
@@ -980,6 +980,10 @@ $list_type_toggle = true, $pagination = true) {
 	} else {
 		// old function parameters
 		elgg_deprecated_notice("Please update your use of elgg_view_entity_list()", 1.8);
+
+		if ($limit === null) {
+			$limit = elgg_get_config('default_limit');
+		}
 
 		$vars = array(
 			'items' => $entities,

--- a/engine/start.php
+++ b/engine/start.php
@@ -57,6 +57,10 @@ if (!is_readable("$engine_dir/settings.php")) {
 }
 
 require_once "$engine_dir/settings.php";
+
+// This will be overridden by the DB value but may be needed before the upgrade script can be run.
+$CONFIG->default_limit = 10;
+
 require_once "$engine_dir/load.php";
 
 // Connect to database, load language files, load configuration, init session

--- a/languages/en.php
+++ b/languages/en.php
@@ -448,6 +448,7 @@ return array(
 	'admin:configuration:success' => "Your settings have been saved.",
 	'admin:configuration:fail' => "Your settings could not be saved.",
 	'admin:configuration:dataroot:relative_path' => 'Cannot set "%s" as the dataroot because it is not an absolute path.',
+	'admin:configuration:default_limit' => 'The number of items per page must be at least 1.',
 
 	'admin:unknown_section' => 'Invalid Admin Section.',
 
@@ -1054,6 +1055,7 @@ Once you have logged in, we highly recommend that you change your password.
 	'installation:view' => "Enter the view which will be used as the default for your site or leave this blank for the default view (if in doubt, leave as default):",
 
 	'installation:siteemail' => "Site email address (used when sending system emails):",
+	'installation:default_limit' => "Default number of items per page",
 
 	'admin:site:access:warning' => "This is the privacy setting suggested to users when they create new content. Changing it does not change access to content.",
 	'installation:allow_user_default_access:description' => "Enable this to allow users to set their own suggested privacy setting that overrides the system suggestion.",

--- a/mod/blog/views/default/blog/sidebar/revisions.php
+++ b/mod/blog/views/default/blog/sidebar/revisions.php
@@ -23,7 +23,7 @@ if (elgg_instanceof($blog, 'object', 'blog') && $blog->canEdit()) {
 	// count(FALSE) == 1!  AHHH!!!
 	$saved_revisions = $blog->getAnnotations(array(
 		'annotation_name' => 'blog_revision',
-		'limit' => 10,
+		'limit' => elgg_get_config('default_limit'),
 		'reverse_order_by' => true,
 	));
 	if ($saved_revisions) {

--- a/mod/categories/pages/categories/listing.php
+++ b/mod/categories/pages/categories/listing.php
@@ -5,7 +5,7 @@
  * @package ElggCategories
  */
 
-$limit = get_input("limit", 10);
+$limit = get_input("limit", elgg_get_config('default_limit'));
 $offset = get_input("offset", 0);
 $category = get_input("category");
 $owner_guid = get_input("owner_guid", ELGG_ENTITIES_ANY_VALUE);

--- a/mod/developers/views/default/theme_sandbox/navigation/pagination.php
+++ b/mod/developers/views/default/theme_sandbox/navigation/pagination.php
@@ -1,7 +1,7 @@
 <?php
 $params = array(
 	'count' => 1000,
-	'limit' => 10,
+	'limit' => elgg_get_config('default_limit'),
 	'offset' => 230,
 );
 

--- a/mod/file/pages/file/search.php
+++ b/mod/file/pages/file/search.php
@@ -69,7 +69,7 @@ if ($friends && elgg_instanceof($owner, 'user')) {
 	$page_owner_guid = $friend_guids;
 }
 
-$limit = 10;
+$limit = elgg_get_config('default_limit');
 if ($listtype == "gallery") {
 	$limit = 12;
 }

--- a/mod/groups/lib/discussion.php
+++ b/mod/groups/lib/discussion.php
@@ -15,7 +15,7 @@ function discussion_handle_all_page() {
 		'type' => 'object',
 		'subtype' => 'groupforumtopic',
 		'order_by' => 'e.last_action desc',
-		'limit' => 20,
+		'limit' => max(20, elgg_get_config('default_limit')),
 		'full_view' => false,
 		'no_results' => elgg_echo('discussion:none'),
 		'preload_owners' => true,
@@ -59,7 +59,7 @@ function discussion_handle_list_page($guid) {
 	$options = array(
 		'type' => 'object',
 		'subtype' => 'groupforumtopic',
-		'limit' => 20,
+		'limit' => max(20, elgg_get_config('default_limit')),
 		'order_by' => 'e.last_action desc',
 		'container_guid' => $guid,
 		'full_view' => false,

--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -383,7 +383,7 @@ function groups_handle_members_page($guid) {
 		'relationship_guid' => $group->guid,
 		'inverse_relationship' => true,
 		'type' => 'user',
-		'limit' => (int)get_input('limit', 20, false),
+		'limit' => (int)get_input('limit', max(20, elgg_get_config('default_limit')), false),
 		'joins' => array("JOIN {$db_prefix}users_entity u ON e.guid=u.guid"),
 		'order_by' => 'u.name ASC',
 	));

--- a/mod/groups/views/default/groups/sidebar/featured.php
+++ b/mod/groups/views/default/groups/sidebar/featured.php
@@ -9,7 +9,7 @@ $featured_groups = elgg_get_entities_from_metadata(array(
 	'metadata_name' => 'featured_group',
 	'metadata_value' => 'yes',
 	'type' => 'group',
-	'limit' => 10,
+	'limit' => elgg_get_config('default_limit'),
 ));
 
 if ($featured_groups) {

--- a/mod/messages/start.php
+++ b/mod/messages/start.php
@@ -348,14 +348,14 @@ function count_unread_messages() {
  * Returns the unread messages in a user's inbox
  *
  * @param int  $user_guid GUID of user whose inbox we're counting (0 for logged in user)
- * @param int  $limit     Number of unread messages to return (default = 10)
+ * @param int  $limit     Number of unread messages to return (default from settings)
  * @param int  $offset    Start at a defined offset (for listings)
  * @param bool $count     Switch between entities array or count mode
  *
  * @return array, int (if $count = true)
  * @since 1.9
  */
-function messages_get_unread($user_guid = 0, $limit = 10, $offset = 0, $count = false) {
+function messages_get_unread($user_guid = 0, $limit = null, $offset = 0, $count = false) {
 	if (!$user_guid) {
 		$user_guid = elgg_get_logged_in_user_guid();
 	}
@@ -368,6 +368,10 @@ function messages_get_unread($user_guid = 0, $limit = 10, $offset = 0, $count = 
 	foreach ($strings as $string) {
 		$id = elgg_get_metastring_id($string);
 		$map[$string] = $id;
+	}
+
+	if ($limit === null) {
+		$limit = elgg_get_config('default_limit');
 	}
 
 	$options = array(

--- a/mod/pages/pages/pages/history.php
+++ b/mod/pages/pages/pages/history.php
@@ -33,7 +33,7 @@ $title = $page->title . ": " . elgg_echo('pages:history');
 $content = elgg_list_annotations(array(
 	'guid' => $page_guid,
 	'annotation_name' => 'page',
-	'limit' => 20,
+	'limit' => max(20, elgg_get_config('default_limit')),
 	'order_by' => "n_table.time_created desc",
 ));
 

--- a/mod/pages/views/default/pages/sidebar/history.php
+++ b/mod/pages/views/default/pages/sidebar/history.php
@@ -11,7 +11,7 @@ if ($vars['page']) {
 	$options = array(
 		'guid' => $vars['page']->guid,
 		'annotation_name' => 'page',
-		'limit' => 20,
+		'limit' => max(20, elgg_get_config('default_limit')),
 		'reverse_order_by' => true
 	);
 	elgg_push_context('widgets');

--- a/mod/search/pages/search/index.php
+++ b/mod/search/pages/search/index.php
@@ -35,7 +35,7 @@ if (!$query) {
 
 // get limit and offset.  override if on search dashboard, where only 2
 // of each most recent entity types will be shown.
-$limit = ($search_type == 'all') ? 2 : get_input('limit', 10);
+$limit = ($search_type == 'all') ? 2 : get_input('limit', elgg_get_config('default_limit'));
 $offset = ($search_type == 'all') ? 0 : get_input('offset', 0);
 
 $entity_type = get_input('entity_type', ELGG_ENTITIES_ANY_VALUE);

--- a/mod/thewire/pages/thewire/thread.php
+++ b/mod/thewire/pages/thewire/thread.php
@@ -15,7 +15,7 @@ $content = elgg_list_entities_from_metadata(array(
 	"metadata_value" => $thread_id,
 	"type" => "object",
 	"subtype" => "thewire",
-	"limit" => 20,
+	"limit" => max(20, elgg_get_config('default_limit')),
 	'preload_owners' => true,
 ));
 

--- a/mod/uservalidationbyemail/views/default/forms/uservalidationbyemail/bulk_action.php
+++ b/mod/uservalidationbyemail/views/default/forms/uservalidationbyemail/bulk_action.php
@@ -6,7 +6,7 @@
  * @subpackage UserValidationByEmail.Administration
  */
 
-$limit = get_input('limit', 10);
+$limit = get_input('limit', elgg_get_config('default_limit'));
 $offset = get_input('offset', 0);
 
 // can't use elgg_list_entities() and friends because we don't use the default view for users.

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2014050600;
+$version = 2014102000;
 
 $composerJson = file_get_contents(dirname(__FILE__) . "/composer.json");
 if ($composerJson === false) {

--- a/views/default/forms/admin/site/update_basic.php
+++ b/views/default/forms/admin/site/update_basic.php
@@ -4,7 +4,7 @@
  */
 $form_body = "";
 
-foreach (array('sitename','sitedescription', 'siteemail') as $field) {
+foreach (array('sitename','sitedescription', 'siteemail', 'default_limit') as $field) {
 	$form_body .= "<div>";
 	$form_body .= elgg_echo('installation:' . $field) . "<br />";
 	$warning = elgg_echo('installation:warning:' . $field);

--- a/views/default/navigation/pagination.php
+++ b/views/default/navigation/pagination.php
@@ -19,7 +19,7 @@ if (elgg_in_context('widget')) {
 
 $offset = abs((int) elgg_extract('offset', $vars, 0));
 // because you can say $vars['limit'] = 0
-if (!$limit = (int) elgg_extract('limit', $vars, 10)) {
+if (!$limit = (int) elgg_extract('limit', $vars, elgg_get_config('default_limit'))) {
 	$limit = 10;
 }
 


### PR DESCRIPTION
Most queries that default to 10 now use the setting, whose valid range
is, for now, 2 to 5000. In order to keep this simple, queries that
default to 20 items will continue showing at least 20 items; the setting
is used only if it’s greater than 20.

Fixes #2650
- [x] Add upgrade script
- [ ] Address reviewer comments
