### PR TITLE
chore(pages): edit form no longer uses global config for form elements

### DIFF
--- a/mod/pages/actions/pages/edit.php
+++ b/mod/pages/actions/pages/edit.php
@@ -5,27 +5,20 @@
  * @package ElggPages
  */
 
-$variables = elgg_get_config('pages');
-$input = array();
-foreach ($variables as $name => $type) {
-	if ($name == 'title') {
-		$input[$name] = htmlspecialchars(get_input($name, '', false), ENT_QUOTES, 'UTF-8');
-	} else {
-		$input[$name] = get_input($name);
-	}
-	if ($type == 'tags') {
-		$input[$name] = string_to_tag_array($input[$name]);
-	}
-}
-
-// Get guids
-$page_guid = (int)get_input('page_guid');
-$container_guid = (int)get_input('container_guid');
-$parent_guid = (int)get_input('parent_guid');
-
 elgg_make_sticky_form('page');
 
-if (!$input['title']) {
+$title = htmlspecialchars(get_input('title', '', false), ENT_QUOTES, 'UTF-8');
+$description = get_input('description');
+$access_id = (int) get_input('access_id');
+$write_access_id = (int) get_input('write_access_id');
+$tags = string_to_tag_array(get_input('tags'));
+
+// Get guids
+$page_guid = (int) get_input('page_guid');
+$container_guid = (int) get_input('container_guid');
+$parent_guid = (int) get_input('parent_guid');
+
+if (!$title) {
 	register_error(elgg_echo('pages:error:no_title'));
 	forward(REFERER);
 }
@@ -47,25 +40,20 @@ if ($page_guid) {
 	$new_page = true;
 }
 
-if (sizeof($input) > 0) {
-	// don't change access if not an owner/admin
-	$user = elgg_get_logged_in_user_entity();
-	$can_change_access = true;
+$page->title = $title;
+$page->description = $description;
+$page->tags = $tags;
 
-	if ($user && $page) {
-		$can_change_access = $user->isAdmin() || $user->getGUID() == $page->owner_guid;
-	}
-	
-	foreach ($input as $name => $value) {
-		if (($name == 'access_id' || $name == 'write_access_id') && !$can_change_access) {
-			continue;
-		}
-		if ($name == 'parent_guid') {
-			continue;
-		}
+// don't change access if not an owner/admin
+$user = elgg_get_logged_in_user_entity();
+$can_change_access = true;
+if ($user && $page) {
+	$can_change_access = $user->isAdmin() || $user->getGUID() == $page->owner_guid;
+}
 
-		$page->$name = $value;
-	}
+if ($can_change_access) {
+	$page->access_id = $access_id;
+	$page->write_access_id = $write_access_id;
 }
 
 // need to add check to make sure user can write to container

--- a/mod/pages/languages/da.php
+++ b/mod/pages/languages/da.php
@@ -58,7 +58,6 @@ Se og kommenter på den nye side:
 
 	'pages:title' => 'Side titel',
 	'pages:description' => 'Side indhold',
-	'pages:tags' => 'Tags',
 	'pages:parent_guid' => 'Parent page',
 	'pages:access_id' => 'Læseadgang',
 	'pages:write_access_id' => 'Skriveadgang',

--- a/mod/pages/languages/de.php
+++ b/mod/pages/languages/de.php
@@ -58,7 +58,6 @@ Schau Dir die neue Coop-Seite an und schreibe einen Kommentar:
 
 	'pages:title' => 'Titel der Coop-Seite',
 	'pages:description' => 'Seitentext',
-	'pages:tags' => 'Tags',
 	'pages:parent_guid' => 'Übergeordnete Coop-Seite',
 	'pages:access_id' => 'Zugangslevel',
 	'pages:write_access_id' => 'Schreibberechtigung',

--- a/mod/pages/languages/en.php
+++ b/mod/pages/languages/en.php
@@ -58,7 +58,6 @@ View and comment on the page:
 
 	'pages:title' => 'Page title',
 	'pages:description' => 'Page text',
-	'pages:tags' => 'Tags',
 	'pages:parent_guid' => 'Parent page',
 	'pages:access_id' => 'Read access',
 	'pages:write_access_id' => 'Write access',

--- a/mod/pages/languages/es.php
+++ b/mod/pages/languages/es.php
@@ -59,7 +59,6 @@ Ver y comentar:
 
 	'pages:title' => 'T&iacute;tulo de la p&aacute;gina',
 	'pages:description' => 'Contenido',
-	'pages:tags' => 'Etiquetas',
 	'pages:parent_guid' => 'Página antecesora',
 	'pages:access_id' => 'S&oacute;lo lectura',
 	'pages:write_access_id' => 'Acceso de escritura',

--- a/mod/pages/languages/fi.php
+++ b/mod/pages/languages/fi.php
@@ -58,7 +58,6 @@ Voit lukea sivun täällä:
 
 	'pages:title' => 'Sivun otsikko',
 	'pages:description' => 'Sivun sisältö',
-	'pages:tags' => 'Tagit',
 	'pages:parent_guid' => 'Yläsivu',
 	'pages:access_id' => 'Lukuoikeus',
 	'pages:write_access_id' => 'Kirjoitusoikeus',

--- a/mod/pages/languages/fr.php
+++ b/mod/pages/languages/fr.php
@@ -58,7 +58,6 @@ Voir et commenter cette page:
 
 	'pages:title' => 'Titre de la page',
 	'pages:description' => 'Texte de la page',
-	'pages:tags' => 'Tags',
 	'pages:parent_guid' => 'Page Parente',
 	'pages:access_id' => 'Accès en lecture',
 	'pages:write_access_id' => 'Accès en écriture',

--- a/mod/pages/languages/gl.php
+++ b/mod/pages/languages/gl.php
@@ -58,7 +58,6 @@ Vexa e deixe un comentario na páxina:
 
 	'pages:title' => 'Títul',
 	'pages:description' => 'Text',
-	'pages:tags' => 'Etiquetas',
 	'pages:parent_guid' => 'Páxina superior',
 	'pages:access_id' => 'Lectura',
 	'pages:write_access_id' => 'Escritura',

--- a/mod/pages/languages/ja.php
+++ b/mod/pages/languages/ja.php
@@ -58,7 +58,6 @@ return array(
 
 	'pages:title' => 'タイトル',
 	'pages:description' => '本文',
-	'pages:tags' => 'タグ',
 	'pages:parent_guid' => '親ページ',
 	'pages:access_id' => '公開範囲',
 	'pages:write_access_id' => '書込許可',

--- a/mod/pages/languages/nl.php
+++ b/mod/pages/languages/nl.php
@@ -58,7 +58,6 @@ Bekijk en reageer op de pagina:
 
 	'pages:title' => 'Pagina titel',
 	'pages:description' => 'Jouw tekst',
-	'pages:tags' => 'Tags',
 	'pages:parent_guid' => 'Hoofdpagina',
 	'pages:access_id' => 'Toegang',
 	'pages:write_access_id' => 'Schrijf toegang',

--- a/mod/pages/languages/pl.php
+++ b/mod/pages/languages/pl.php
@@ -58,7 +58,6 @@ Wyświetl i skomentuj nową stronę:
 
 	'pages:title' => 'Tytuł strony',
 	'pages:description' => 'Treść strony',
-	'pages:tags' => 'Tagi',
 	'pages:parent_guid' => 'Strona nadrzędna',
 	'pages:access_id' => 'Uprawnienia odczytu',
 	'pages:write_access_id' => 'Uprawnienia zapisu',

--- a/mod/pages/languages/pt_BR.php
+++ b/mod/pages/languages/pt_BR.php
@@ -58,7 +58,6 @@ Veja e comente a página:
 
 	'pages:title' => 'Título da página',
 	'pages:description' => 'Texto da página',
-	'pages:tags' => 'Tags',
 	'pages:parent_guid' => 'Página principal',
 	'pages:access_id' => 'Acesso para leitura',
 	'pages:write_access_id' => 'Acesso para escrita',

--- a/mod/pages/languages/ru.php
+++ b/mod/pages/languages/ru.php
@@ -58,7 +58,6 @@ return array(
 
 	'pages:title' => 'Заголовок документа',
 	'pages:description' => 'Содержимое документа',
-	'pages:tags' => 'Теги',
 	'pages:parent_guid' => 'Родительствий документ',
 	'pages:access_id' => 'Доступ',
 	'pages:write_access_id' => 'Доступ на запись',

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -61,17 +61,6 @@ function pages_init() {
 	//add a widget
 	elgg_register_widget_type('pages', elgg_echo('pages'), elgg_echo('pages:widget:description'));
 
-	// Language short codes must be of the form "pages:key"
-	// where key is the array key below
-	elgg_set_config('pages', array(
-		'title' => 'text',
-		'description' => 'longtext',
-		'tags' => 'tags',
-		'parent_guid' => 'parent',
-		'access_id' => 'access',
-		'write_access_id' => 'write_access',
-	));
-
 	elgg_register_plugin_hook_handler('register', 'menu:owner_block', 'pages_owner_block_menu');
 
 	// write permission plugin hooks

--- a/mod/pages/views/default/forms/pages/edit.php
+++ b/mod/pages/views/default/forms/pages/edit.php
@@ -5,7 +5,6 @@
  * @package ElggPages
  */
 
-$variables = elgg_get_config('pages');
 $user = elgg_get_logged_in_user_entity();
 $entity = elgg_extract('entity', $vars);
 $can_change_access = true;
@@ -13,40 +12,59 @@ if ($user && $entity) {
 	$can_change_access = ($user->isAdmin() || $user->getGUID() == $entity->owner_guid);
 }
 
-foreach ($variables as $name => $type) {
-	// don't show read / write access inputs for non-owners or admin when editing
-	if (($type == 'access' || $type == 'write_access') && !$can_change_access) {
-		continue;
-	}
-	
-	// don't show parent picker input for top or new pages.
-	if ($name == 'parent_guid' && (!$vars['parent_guid'] || !$vars['guid'])) {
-		continue;
-	}
+echo '<div>';
+echo '<label>' . elgg_echo('pages:title') . '</label><br />';
+echo elgg_view('input/text', array(
+	'name' => 'title',
+	'value' => elgg_extract('title', $vars),
+));
+echo '</div>';
 
-	if ($type == 'parent') {
-		$input_view = "pages/input/$type";
-	} else {
-		$input_view = "input/$type";
-	}
+echo '<div>';
+echo '<label>' . elgg_echo('pages:description') . '</label>';
+echo elgg_view('input/longtext', array(
+	'name' => 'description',
+	'value' => elgg_extract('description', $vars)
+));
+echo '</div>';
 
-?>
-<div>
-	<label><?php echo elgg_echo("pages:$name") ?></label>
-	<?php
-		if ($type != 'longtext') {
-			echo '<br />';
-		}
+echo '<div>';
+echo '<label>' . elgg_echo('tags') . '</label><br />';
+echo elgg_view('input/tags', array(
+	'name' => 'tags',
+	'value' => elgg_extract('tags', $vars)
+));
+echo '</div>';
 
-		echo elgg_view($input_view, array(
-			'name' => $name,
-			'value' => $vars[$name],
-			'entity' => ($name == 'parent_guid') ? $vars['entity'] : null,
-		));
-	?>
-</div>
-<?php
+if (!$vars['parent_guid'] && !$vars['guid']) {
+	echo '<div>';
+	echo '<label>' . elgg_echo('pages:parent_guid') . '</label><br />';
+	echo elgg_view('pages/input/parent', array(
+		'name' => 'parent_guid',
+		'value' => elgg_extract('parent_guid', $vars),
+		'entity' => $entity
+	));
+	echo '</div>';
 }
+
+echo '<div>';
+echo '<label>' . elgg_echo('pages:access_id') . '</label><br />';
+echo elgg_view('input/access', array(
+	'name' => 'access_id',
+	'value' => elgg_extract('access_id', $vars)
+));
+echo '</div>';
+
+echo '<div>';
+echo '<label>' . elgg_echo('pages:write_access_id') . '</label><br />';
+echo elgg_view('input/write_access', array(
+	'name' => 'write_access_id',
+	'value' => elgg_extract('write_access_id', $vars)
+));
+echo '</div>';
+
+// deprecated way of form extension
+echo elgg_view("pages/input/deprecated", $vars);
 
 $cats = elgg_view('input/categories', $vars);
 if (!empty($cats)) {

--- a/mod/pages/views/default/pages/input/deprecated.php
+++ b/mod/pages/views/default/pages/input/deprecated.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This view outputs the deprecated way of extending the pages form elements.
+ * 
+ * DON'T extend or overrule this view as it will be removed in Elgg 1.11
+ * 
+ * @package ElggPages
+ * @deprecated Elgg 1.11
+ */
+
+$variables = elgg_get_config('pages');
+if (!$variables) {
+	return;
+}
+
+elgg_deprecated_notice("Using \$CONFIG->pages to extend the form elements was deprecated. 
+		To extend the form please overrule the view forms/pages/edit", "1.10");
+
+$can_change_access = true;
+if ($user && $entity) {
+	$can_change_access = ($user->isAdmin() || $user->getGUID() == $entity->owner_guid);
+}
+
+foreach ($variables as $name => $type) {
+	// don't show read / write access inputs for non-owners or admin when editing
+	if (($type == 'access' || $type == 'write_access') && !$can_change_access) {
+		continue;
+	}
+
+	// don't show parent picker input for top or new pages.
+	if ($name == 'parent_guid' && (!$vars['parent_guid'] || !$vars['guid'])) {
+		continue;
+	}
+
+	if ($type == 'parent') {
+		$input_view = "pages/input/$type";
+	} else {
+		$input_view = "input/$type";
+	}
+
+	?>
+<div>
+	<label><?php echo elgg_echo("pages:$name") ?></label>
+	<?php
+		if ($type != 'longtext') {
+			echo '<br />';
+		}
+
+		echo elgg_view($input_view, array(
+			'name' => $name,
+			'value' => $vars[$name],
+			'entity' => ($name == 'parent_guid') ? $vars['entity'] : null,
+		));
+	?>
+</div>
+<?php
+}


### PR DESCRIPTION
The pages edit form used a global config for it's form elements. This
was very confusing and not as extendable as expected.

fixes: #4490
