### PR TITLE
docs(menus): improve docs for menu item factory

### DIFF
--- a/engine/classes/ElggMenuItem.php
+++ b/engine/classes/ElggMenuItem.php
@@ -4,6 +4,10 @@
  *
  * To create a menu item that is not a link, pass false for $href.
  *
+ * Any undocumented properties set will be passed to the output/url view during rendering. E.g.
+ * to give a menu item a "target" attribute, set $item->target, or include a "target" key in
+ * the options array for factory().
+ *
  * @package    Elgg.Core
  * @subpackage Navigation
  * @since      1.8.0
@@ -85,12 +89,28 @@ class ElggMenuItem {
 	}
 
 	/**
-	 * ElggMenuItem factory method
-	 *
-	 * This static method creates an ElggMenuItem from an associative array.
-	 * Required keys are name, text, and href.
+	 * Create an ElggMenuItem from an associative array. Required keys are name, text, and href.
 	 *
 	 * @param array $options Option array of key value pairs
+	 *
+	 *    name        => STR  Menu item identifier (required)
+	 *    text        => STR  Menu item display text as HTML (required)
+	 *    href        => STR  Menu item URL (required) (false for non-links.
+	 *                        @warning If you disable the href the <a> tag will
+	 *                        not appear, so the link_class will not apply. If you
+	 *                        put <a> tags in manually through the 'text' option
+	 *                        the default CSS selector .elgg-menu-$menu > li > a
+	 *                        may affect formatting. Wrap in a <span> if it does.)
+	 *
+	 *    section     => STR  Menu section identifier
+	 *    link_class  => STR  A class or classes for the <a> tag
+	 *    item_class  => STR  A class or classes for the <li> tag
+	 *    parent_name => STR  Identifier of the parent menu item
+	 *    contexts    => ARR  Page context strings
+	 *    title       => STR  Menu item tooltip
+	 *    selected    => BOOL Is this menu item currently selected?
+	 *    confirm     => STR  If set, the link will be drawn with the output/confirmlink view instead of output/url.
+	 *    data        => ARR  Custom attributes stored in the menu item.
 	 *
 	 * @return ElggMenuItem or null on error
 	 */

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -60,32 +60,14 @@
  * @see elgg_view_menu() for the plugin hooks available for modifying a menu as
  * it is being rendered.
  *
+ * @see ElggMenuItem::factory() is used to turn an array value of $menu_item into an
+ * ElggMenuItem object.
+ *
  * @param string $menu_name The name of the menu: site, page, userhover,
  *                          userprofile, groupprofile, or any custom menu
- * @param mixed  $menu_item A ElggMenuItem object or an array of options in format:
- *                          name        => STR  Menu item identifier (required)
- *                          text        => STR  Menu item display text as HTML (required)
- *                          href        => STR  Menu item URL (required) (false for non-links.
- *                                              @warning If you disable the href the <a> tag will
- *                                              not appear, so the link_class will not apply. If you
- *                                              put <a> tags in manually through the 'text' option
- *                                              the default CSS selector .elgg-menu-$menu > li > a
- *                                              may affect formatting. Wrap in a <span> if it does.)
- *                          contexts    => ARR  Page context strings
- *                          section     => STR  Menu section identifier
- *                          title       => STR  Menu item tooltip
- *                          selected    => BOOL Is this menu item currently selected
- *                          parent_name => STR  Identifier of the parent menu item
- *                          link_class  => STR  A class or classes for the <a> tag
- *                          item_class  => STR  A class or classes for the <li> tag
+ * @param mixed  $menu_item An ElggMenuItem or options for ElggMenuItem::factory()
  *
- *                          Additional options that the view output/url takes can be
- *							passed in the array. If the 'confirm' key is passed, the
- *							menu link uses the 'output/confirmlink' view. Custom
- *							options can be added by using the 'data' key with the
- *							value being an associative array.
- *
- * @return bool
+ * @return bool False if the item could not be added
  * @since 1.8.0
  */
 function elgg_register_menu_item($menu_name, $menu_item) {
@@ -169,7 +151,7 @@ function elgg_is_menu_item_registered($menu_name, $item_name) {
  * @param string $menu_name The name of the menu
  * @param string $item_name The unique identifier for this menu item
  *
- * @return ElggMenuItem
+ * @return ElggMenuItem|null
  * @since 1.9.0
  */
 function elgg_get_menu_item($menu_name, $item_name) {


### PR DESCRIPTION
Clarifies that the 2nd argument for elgg_register_menu_item() is used
as the arguments for ElggMenuItem::factory() and the options PHPdocs
are moved to factory().
