### PR TITLE
feature(views): allows rendering empty results using an anonymous function

### DIFF
--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -1340,7 +1340,7 @@ $time_created_lower = null, $time_updated_upper = null, $time_updated_lower = nu
  *                   list_type => STR 'list' or 'gallery'
  *                   list_type_toggle => BOOL Display gallery / list switch
  *                   pagination => BOOL Display pagination links
- *                   no_results => STR Message to display when there are no entities
+ *                   no_results => STR|Closure Message to display when there are no entities
  *
  * @param callback $getter  The entity getter function to use to fetch the entities.
  * @param callback $viewer  The function to use to view the entity list.

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -481,8 +481,8 @@ function _elgg_prefetch_river_entities(array $river_items) {
  * List river items
  *
  * @param array $options Any options from elgg_get_river() plus:
- *   pagination => BOOL Display pagination links (true)
- *   no_results => STR Message to display if no items
+ *   pagination => BOOL        Display pagination links (true)
+ *   no_results => STR|Closure Message to display if no items
  *
  * @return string
  * @since 1.8.0

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -943,7 +943,7 @@ function elgg_view_annotation(\ElggAnnotation $annotation, array $vars = array()
  *      'pagination'       Display pagination?
  *      'list_type'        List type: 'list' (default), 'gallery'
  *      'list_type_toggle' Display the list type toggle?
- *      'no_results'       Message to display if no results
+ *      'no_results'       Message to display if no results (string|Closure)
  *
  * @return string The rendered list of entities
  * @access private
@@ -1018,7 +1018,7 @@ $list_type_toggle = true, $pagination = true) {
  *      'full_view'  Display the full view of the annotation?
  *      'list_class' CSS Class applied to the list
  *      'offset_key' The url parameter key used for offset
- *      'no_results' Message to display if no results
+ *      'no_results' Message to display if no results (string|Closure)
  *
  * @return string The list of annotations
  * @access private

--- a/views/default/page/components/gallery.php
+++ b/views/default/page/components/gallery.php
@@ -13,7 +13,7 @@
  * @uses $vars['full_view']     Show the full view of the items (default: false)
  * @uses $vars['gallery_class'] Additional CSS class for the <ul> element
  * @uses $vars['item_class']    Additional CSS class for the <li> elements
- * @uses $vars['no_results']    Message to display if no results
+ * @uses $vars['no_results']    Message to display if no results (string|Closure)
  */
 
 $items = $vars['items'];
@@ -26,6 +26,10 @@ $position = elgg_extract('position', $vars, 'after');
 $no_results = elgg_extract('no_results', $vars, '');
 
 if (!$items && $no_results) {
+	if ($no_results instanceof Closure) {
+		echo $no_results();
+		return;
+	}
 	echo "<p>$no_results</p>";
 	return;
 }

--- a/views/default/page/components/list.php
+++ b/views/default/page/components/list.php
@@ -14,7 +14,7 @@
  * @uses $vars['full_view']   Show the full view of the items (default: false)
  * @uses $vars['list_class']  Additional CSS class for the <ul> element
  * @uses $vars['item_class']  Additional CSS class for the <li> elements
- * @uses $vars['no_results']  Message to display if no results
+ * @uses $vars['no_results']  Message to display if no results (string|Closure)
  */
 
 $items = $vars['items'];
@@ -28,6 +28,10 @@ $position = elgg_extract('position', $vars, 'after');
 $no_results = elgg_extract('no_results', $vars, '');
 
 if (!$items && $no_results) {
+	if ($no_results instanceof Closure) {
+		echo $no_results();
+		return;
+	}
 	echo "<p>$no_results</p>";
 	return;
 }


### PR DESCRIPTION
If you want the no_results message to not be wrapped by P tags, or you don’t
want to always incur the cost of rendering a view for backup content, you
can now provide a Closure whose output will be echoed by the view.

TODO:
- [ ] Agree to limit this to Closures for now
