### PR TITLE
fix(uservalidationbyemail): makes emailsent page public

### DIFF
--- a/mod/uservalidationbyemail/start.php
+++ b/mod/uservalidationbyemail/start.php
@@ -220,6 +220,7 @@ function uservalidationbyemail_validate_new_admin_user($event, $type, $user) {
  */
 function uservalidationbyemail_public_pages($hook, $type, $return_value, $params) {
 	$return_value[] = 'uservalidationbyemail/confirm';
+	$return_value[] = 'uservalidationbyemail/emailsent';
 	return $return_value;
 }
 


### PR DESCRIPTION
I had the same problem as mentioned in #7334, this confirms that the fix suggested
iionly works.

Marks uservalidationbyemail/emailsent as a public page in walled garden to
ensure that newly registered users receive a understandabe comfirmation page.

Fixes #7334 
