### PR TITLE
(WIP) Implements entity rendering based on "format" string

### DIFF
--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -1331,16 +1331,20 @@ $time_created_lower = null, $time_updated_upper = null, $time_updated_lower = nu
  *
  * @tip Pagination is handled automatically.
  *
+ * @see elgg_view_entity() This function is used for rendering, hence here we accept the "format" and "full_view"
+ *      options. For BC purposes this function sets a default only for the "full_view" option.
+ *
  * @internal This also provides the views for elgg_view_annotation().
  *
  * @internal If the initial COUNT query returns 0, the $getter will not be called again.
  *
  * @param array    $options Any options from $getter options plus:
- *                   full_view => BOOL Display full view of entities (default: false)
- *                   list_type => STR 'list' or 'gallery'
- *                   list_type_toggle => BOOL Display gallery / list switch
- *                   pagination => BOOL Display pagination links
- *                   no_results => STR Message to display when there are no entities
+ *     format => STR The format in which to render entities. {@link elgg_view_entity()}
+ *     full_view => BOOL Legacy method to specify format. {@link elgg_view_entity()}
+ *     list_type => STR 'list' or 'gallery'
+ *     list_type_toggle => BOOL Display gallery / list switch
+ *     pagination => BOOL Display pagination links
+ *     no_results => STR Message to display when there are no entities
  *
  * @param callback $getter  The entity getter function to use to fetch the entities.
  * @param callback $viewer  The function to use to view the entity list.

--- a/views/default/group/default/link.php
+++ b/views/default/group/default/link.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * ElggGroup rendered as a link
+ *
+ * @package Elgg
+ * @subpackage Core
+ */
+
+$entity = $vars['entity'];
+/* @var ElggGroup $entity */
+
+echo elgg_view('output/url', array(
+	'text' => $entity->getDisplayName(),
+	'href' => $entity->getURL(),
+	'is_trusted' => true,
+	'class' => 'elgg-format-link elgg-format-link-group',
+));

--- a/views/default/object/default/link.php
+++ b/views/default/object/default/link.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * ElggObject rendered as a link
+ *
+ * @package Elgg
+ * @subpackage Core
+ */
+
+$entity = $vars['entity'];
+/* @var ElggObject $entity */
+
+$title = $entity->getDisplayName();
+if ($title === '') {
+	$title = get_class($object);
+}
+
+echo elgg_view('output/url', array(
+	'text' => $title,
+	'href' => $entity->getURL(),
+	'is_trusted' => true,
+	'class' => 'elgg-format-link elgg-format-link-object',
+));

--- a/views/default/user/default/link.php
+++ b/views/default/user/default/link.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * ElggUser rendered as a link
+ *
+ * @package Elgg
+ * @subpackage Core
+ */
+
+$entity = $vars['entity'];
+/* @var ElggUser $entity */
+
+echo elgg_view('output/url', array(
+	'text' => $entity->getDisplayName(),
+	'href' => $entity->getURL(),
+	'is_trusted' => true,
+	'class' => 'elgg-format-link elgg-format-link-user',
+));


### PR DESCRIPTION
For #2815. This adds the "format" option to elgg_view_entity() in a BC way (all site listings use this function and nothing seemed to break), adds RST docs, and adds useful comments to elgg_list_entities() (obviously there are other functions that could use this). It also adds a few sample "link" format views, but no code that uses them.
