### PR TITLE
fix(menus): allow max depth of 20 to prevent losing menu items

### DIFF
--- a/engine/classes/ElggMenuBuilder.php
+++ b/engine/classes/ElggMenuBuilder.php
@@ -123,7 +123,7 @@ class ElggMenuBuilder {
 			$iteration = 0;
 			$current_gen = $parents;
 			$next_gen = null;
-			while (count($children) && $iteration < 5) {
+			while (count($children) && $iteration < 20) {
 				foreach ($children as $index => $menu_item) {
 					$parent_name = $menu_item->getParentName();
 					if (array_key_exists($parent_name, $current_gen)) {


### PR DESCRIPTION
fixes #5570 

this (minimal) fix makes the edge cases less frequent, but still has deadloop protection
