### PR TITLE
perf(river): only fetch comments if comment_count > 0

### DIFF
--- a/views/default/river/elements/responses.php
+++ b/views/default/river/elements/responses.php
@@ -24,15 +24,15 @@ if ($item->annotation_id != 0 || !$object || elgg_instanceof($target, 'object', 
 
 $comment_count = $object->countComments();
 
-$comments = elgg_get_entities(array(
-	'type' => 'object',
-	'subtype' => 'comment',
-	'container_guid' => $object->getGUID(),
-	'limit' => 3,
-	'order_by' => 'e.time_created desc'
-));
-
-if ($comments) {
+if ($comment_count) {
+	$comments = elgg_get_entities(array(
+		'type' => 'object',
+		'subtype' => 'comment',
+		'container_guid' => $object->getGUID(),
+		'limit' => 3,
+		'order_by' => 'e.time_created desc'
+	));
+	
 	// why is this reversing it? because we're asking for the 3 latest
 	// comments by sorting desc and limiting by 3, but we want to display
 	// these comments with the latest at the bottom.


### PR DESCRIPTION
fixes #6951
