### PR TITLE
fix(friends): show friends collections menu item in friend context

### DIFF
--- a/engine/lib/friends.php
+++ b/engine/lib/friends.php
@@ -30,6 +30,7 @@ function _elgg_friends_init() {
 	elgg_register_widget_type('friends', elgg_echo('friends'), elgg_echo('friends:widget:description'));
 
 	elgg_register_event_handler('pagesetup', 'system', '_elgg_friends_page_setup');
+	elgg_register_event_handler('pagesetup', 'system', '_elgg_setup_collections_menu');
 	elgg_register_plugin_hook_handler('register', 'menu:user_hover', '_elgg_friends_setup_user_hover_menu');
 	elgg_register_event_handler('create', 'friend', '_elgg_send_friend_notification');
 }
@@ -127,10 +128,6 @@ function _elgg_friends_page_handler($segments, $handler) {
 		return false;
 	}
 
-	if (elgg_get_logged_in_user_guid() == elgg_get_page_owner_guid()) {
-		_elgg_setup_collections_menu();
-	}
-
 	switch ($handler) {
 		case 'friends':
 			require_once(dirname(dirname(dirname(__FILE__))) . "/pages/friends/index.php");
@@ -159,7 +156,7 @@ function _elgg_collections_page_handler($page_elements) {
 		switch ($page_elements[0]) {
 			case 'add':
 				elgg_set_page_owner_guid(elgg_get_logged_in_user_guid());
-				_elgg_setup_collections_menu();
+				
 				require_once "{$base}pages/friends/collections/add.php";
 				return true;
 				break;
@@ -167,9 +164,7 @@ function _elgg_collections_page_handler($page_elements) {
 				$user = get_user_by_username($page_elements[1]);
 				if ($user) {
 					elgg_set_page_owner_guid($user->getGUID());
-					if (elgg_get_logged_in_user_guid() == elgg_get_page_owner_guid()) {
-						_elgg_setup_collections_menu();
-					}
+					
 					require_once "{$base}pages/friends/collections/view.php";
 					return true;
 				}
@@ -186,14 +181,17 @@ function _elgg_collections_page_handler($page_elements) {
  * @access private
  */
 function _elgg_setup_collections_menu() {
-
-	$user = elgg_get_logged_in_user_entity();
-
-	elgg_register_menu_item('page', array(
-		'name' => 'friends:view:collections',
-		'text' => elgg_echo('friends:collections'),
-		'href' => "collections/owner/$user->username",
-	));
+	
+	if (elgg_get_logged_in_user_guid() == elgg_get_page_owner_guid()) {
+		$user = elgg_get_page_owner_entity();
+		
+		elgg_register_menu_item('page', array(
+			'name' => 'friends:view:collections',
+			'text' => elgg_echo('friends:collections'),
+			'href' => "collections/owner/$user->username",
+			'contexts' => array('friends')
+		));
+	}
 }
 
 /**


### PR DESCRIPTION
Not on all pages related to friends the menu item for friends
collections was shown. It now shows more consistently.

fixes: #4810
