### PR TITLE
chore(discussion): cleanup old upgrade action

### DIFF
--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -831,8 +831,7 @@ function discussion_init() {
 	elgg_register_action('discussion/delete', "$action_base/delete.php");
 	elgg_register_action('discussion/reply/save', "$action_base/reply/save.php");
 	elgg_register_action('discussion/reply/delete', "$action_base/reply/delete.php");
-	elgg_register_action('discussion/upgrade/2013100401', "$action_base/upgrades/2013100401.php", 'admin');
-
+	
 	// add link to owner block
 	elgg_register_plugin_hook_handler('register', 'menu:owner_block', 'discussion_owner_block_menu');
 
@@ -945,7 +944,7 @@ function discussion_set_topic_url($hook, $type, $url, $params) {
 
 /**
  * We don't want people commenting on topics in the river
- * 
+ *
  * @param string $hook
  * @param string $type
  * @param string $return
@@ -960,7 +959,7 @@ function discussion_comment_override($hook, $type, $return, $params) {
 
 /**
  * Add owner block link
- * 
+ *
  * @param string          $hook    'register'
  * @param string          $type    'menu:owner_block'
  * @param ElggMenuItem[]  $return
@@ -981,10 +980,10 @@ function discussion_owner_block_menu($hook, $type, $return, $params) {
 
 /**
  * Set up menu items for river items
- * 
+ *
  * Add reply button for discussion topic. Remove the possibility
  * to comment on a discussion reply.
- * 
+ *
  * @param string         $hook   'register'
  * @param string         $type   'menu:river'
  * @param ElggMenuItem[] $return
@@ -1114,7 +1113,7 @@ function discussion_get_subscriptions($hook, $type, $subscriptions, $params) {
 
 /**
  * A simple function to see who can edit a group discussion post
- * 
+ *
  * @param ElggComment $entity      the  comment $entity
  * @param ELggUser    $group_owner user who owns the group $group_owner
  * @return boolean
@@ -1144,7 +1143,7 @@ function groups_run_upgrades() {
 
 /**
  * Allow group owner and discussion owner to edit discussion replies.
- * 
+ *
  * @param string  $hook   'permissions_check'
  * @param string  $type   'object'
  * @param boolean $return
@@ -1179,7 +1178,7 @@ function discussion_can_edit_reply($hook, $type, $return, $params) {
 
 /**
  * Allow group members to post to a group discussion
- * 
+ *
  * @param string $hook   'container_permissions_check'
  * @param string $type   'object'
  * @param array  $return
@@ -1204,7 +1203,7 @@ function discussion_reply_container_permissions_override($hook, $type, $return, 
 
 /**
  * Update access_id of discussion replies when topic access_id is updated.
- * 
+ *
  * @param string     $event  'update'
  * @param string     $type   'object'
  * @param ElggObject $object ElggObject
@@ -1233,7 +1232,7 @@ function discussion_update_reply_access_ids($event, $type, $object) {
 
 /**
  * Set up discussion reply entity menu
- * 
+ *
  * @param string          $hook   'register'
  * @param string          $type   'menu:entity'
  * @param ElggMenuItem[]  $return


### PR DESCRIPTION
The action script was moved to a different location, but the
registration was left behind.

fixes: #6932
