### PR TITLE
fix(plugins): trigger plugin hooks when saving plugin settings

### DIFF
--- a/actions/plugins/settings/save.php
+++ b/actions/plugins/settings/save.php
@@ -30,7 +30,7 @@ if (elgg_action_exists("$plugin_id/settings/save")) {
 	action("$plugin_id/settings/save");
 } else {
 	foreach ($params as $k => $v) {
-		$result = $plugin->set($k, $v);
+		$result = $plugin->$k = $v;
 		if (!$result) {
 			register_error(elgg_echo('plugins:settings:save:fail', array($plugin_name)));
 			forward(REFERER);

--- a/actions/plugins/settings/save.php
+++ b/actions/plugins/settings/save.php
@@ -30,7 +30,7 @@ if (elgg_action_exists("$plugin_id/settings/save")) {
 	action("$plugin_id/settings/save");
 } else {
 	foreach ($params as $k => $v) {
-		$result = $plugin->setSetting($k, $v);
+		$result = $plugin->set($k, $v);
 		if (!$result) {
 			register_error(elgg_echo('plugins:settings:save:fail', array($plugin_name)));
 			forward(REFERER);


### PR DESCRIPTION
$plugin->setPrivateSetting doesn't trigger plugin hooks. 

Calling $plugin->set instead trigger plugin hooks and internally calls $plugin->setPrivateSetting

Fixes: #6820

TODO:
- [x] Document why `setSetting()` is replace with a key = value pair
- [ ] Update commit message to match Elgg standards, remove semicolon after Fixes
