### PR TITLE
fix(views): prevent output of empty heading when there is no page title

### DIFF
--- a/views/default/page/elements/title.php
+++ b/views/default/page/elements/title.php
@@ -6,6 +6,10 @@
  * @uses $vars['class'] Optional class for heading
  */
 
+if (!isset($vars['title'])) {
+	return;
+}
+
 $class= '';
 if (isset($vars['class'])) {
 	$class = " class=\"{$vars['class']}\"";


### PR DESCRIPTION
fixes #7387
