### PR TITLE
fix(core): renaming to _elgg_namespace_plugin_private_setting forgotten in unsetAllSettings

### DIFF
--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -354,8 +354,8 @@ class ElggPlugin extends ElggObject {
 	 */
 	public function unsetAllSettings() {
 		$db_prefix = get_config('dbprefix');
-		$us_prefix = elgg_namespace_plugin_private_setting('user_setting', '', $this->getID());
-		$is_prefix = elgg_namespace_plugin_private_setting('internal', '', $this->getID());
+		$us_prefix = _elgg_namespace_plugin_private_setting('user_setting', '', $this->getID());
+		$is_prefix = _elgg_namespace_plugin_private_setting('internal', '', $this->getID());
 
 		$q = "DELETE FROM {$db_prefix}private_settings
 			WHERE entity_guid = $this->guid


### PR DESCRIPTION
Renaming of elgg_namespace_plugin_private_setting() to _elgg_namespace_plugin_private_setting()
had been forgotten in unsetAllSettings() function in engine/classes/ElggPlugin.php

Fixes #7335
