### PR TITLE
feature(i18n): allows passing multiple message keys to elgg_echo()

### DIFF
--- a/docs/guides/i18n.rst
+++ b/docs/guides/i18n.rst
@@ -65,6 +65,17 @@ To force which language should be used for translation, set the third parameter:
 
    echo elgg_echo(‘welcome’, array(), ‘es’);
 
+If you want to automatically fallback to different message keys, give an array
+of them as ``$key``. The function will try all of them and return ``false`` if no
+translation can be found.
+
+.. code:: php
+
+    $keys = array('key_that_may_not_exist', 'fallback_key');
+    $translation = elgg_echo($keys);
+    if ($translation === false) {
+        // no translation was available, including in English
+    }
 
 
 Javascript API

--- a/engine/tests/phpunit/ElggEchoTest.php
+++ b/engine/tests/phpunit/ElggEchoTest.php
@@ -1,0 +1,64 @@
+<?php
+
+class ElggEchoTest extends \PHPUnit_Framework_TestCase {
+
+	protected $key1 = '__echo_test_key1';
+	protected $key2 = '__echo_test_key2';
+	protected $realLog;
+
+	public function setUp() {
+		$this->realLog = _elgg_services()->logger;
+		_elgg_services()->setValue('logger', $this->getMock('Elgg\\Logger', array(), array(), '', false));
+
+		add_translation('xx', array(
+			$this->key1 => 'xx1 %s',
+		));
+		add_translation('en', array(
+			$this->key1 => 'en1 %s',
+			$this->key2 => 'en2 %s',
+		));
+	}
+
+	public function tearDown() {
+		_elgg_services()->setValue('logger', $this->realLog);
+	}
+
+	public function testCanTranslate() {
+		$this->assertEquals('xx1 %s', elgg_echo($this->key1, array(), 'xx'));
+		$this->assertEquals('xx1 z', elgg_echo($this->key1, array('z'), 'xx'));
+	}
+
+	public function testFallsBackToEnglish() {
+		$mock = _elgg_services()->logger;
+		/* @var PHPUnit_Framework_MockObject_MockObject $mock */
+		$mock->expects($this->exactly(2))->method('log');
+
+		$this->assertEquals('en2 %s', elgg_echo($this->key2, array(), 'xx'));
+		$this->assertEquals('en2 z', elgg_echo($this->key2, array('z'), 'xx'));
+	}
+
+	public function testStringKeyFallsBackToKey() {
+		$key = __METHOD__;
+
+		$mock = _elgg_services()->logger;
+		/* @var PHPUnit_Framework_MockObject_MockObject $mock */
+		$mock->expects($this->once())->method('log');
+
+		$this->assertEquals($key, elgg_echo($key));
+	}
+
+	public function testCanAcceptMultipleKeys() {
+		$keys = array(__METHOD__, $this->key2);
+		$this->assertEquals('en2 z', elgg_echo($keys, array('z'), 'xx'));
+	}
+
+	public function testArrayKeyFallsBackToFalse() {
+		$key = __METHOD__;
+
+		$mock = _elgg_services()->logger;
+		/* @var PHPUnit_Framework_MockObject_MockObject $mock */
+		$mock->expects($this->never())->method('log');
+
+		$this->assertFalse(elgg_echo(array($key)));
+	}
+}

--- a/views/default/river/elements/summary.php
+++ b/views/default/river/elements/summary.php
@@ -6,6 +6,7 @@
  */
 
 $item = $vars['item'];
+/* @var ElggRiverItem $item */
 
 $subject = $item->getSubjectEntity();
 $object = $item->getObjectEntity();
@@ -42,12 +43,8 @@ if ($container instanceof ElggGroup) {
 
 // check summary translation keys.
 // will use the $type:$subtype if that's defined, otherwise just uses $type:default
-$key = "river:$action:$type:$subtype";
-$summary = elgg_echo($key, array($subject_link, $object_link));
-
-if ($summary == $key) {
-	$key = "river:$action:$type:default";
-	$summary = elgg_echo($key, array($subject_link, $object_link));
-}
-
-echo $summary;
+$keys = array(
+	"river:$action:$type:$subtype",
+	"river:$action:$type:default",
+);
+echo elgg_echo($keys, array($subject_link, $object_link));

--- a/views/default/river/object/comment/create.php
+++ b/views/default/river/object/comment/create.php
@@ -26,12 +26,12 @@ $target_link = elgg_view('output/url', array(
 
 $type = $target->getType();
 $subtype = $target->getSubtype() ? $target->getSubtype() : 'default';
-$key = "river:comment:$type:$subtype";
-$summary = elgg_echo($key, array($subject_link, $target_link));
-if ($summary == $key) {
-	$key = "river:comment:$type:default";
-	$summary = elgg_echo($key, array($subject_link, $target_link));
-}
+
+$keys = array(
+	"river:comment:$type:$subtype",
+	"river:comment:$type:default",
+);
+$summary = elgg_echo($keys, array($subject_link, $target_link));
 
 echo elgg_view('river/elements/layout', array(
 	'item' => $vars['item'],


### PR DESCRIPTION
When an array of keys are passed, it looks for each translation (including
English versions) and returns false if none are found. No notices are
emitted.

Fixes #6299

/cc @ewinslow @juho-jaakkola @jdalsem 

TODO:
- [ ] Rebase and add to new `I18n\Translator` class
- [ ] Split into a separate function from `elgg_echo`?
