### PR TITLE
chore(input): Pull `get_input` and `set_input` into an OO service

### DIFF
--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -16,6 +16,7 @@ namespace Elgg\Di;
  * @property-read \Elgg\Database                           $db
  * @property-read \Elgg\EventsService                      $events
  * @property-read \Elgg\PluginHooksService                 $hooks
+ * @property-read \Elgg\Http\Input                         $input
  * @property-read \Elgg\Logger                             $logger
  * @property-read \ElggVolatileMetadataCache               $metadataCache
  * @property-read \Elgg\Notifications\NotificationsService $notifications
@@ -49,6 +50,7 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setFactory('db', array($this, 'getDatabase'));
 		$this->setFactory('events', array($this, 'getEvents'));
 		$this->setFactory('hooks', array($this, 'getHooks'));
+		$this->setClassName('input', 'Elgg\Http\Input');
 		$this->setFactory('logger', array($this, 'getLogger'));
 		$this->setClassName('metadataCache', '\ElggVolatileMetadataCache');
 		$this->setFactory('persistentLogin', array($this, 'getPersistentLogin'));

--- a/engine/classes/Elgg/Http/Input.php
+++ b/engine/classes/Elgg/Http/Input.php
@@ -1,0 +1,92 @@
+<?php
+namespace Elgg\Http;
+
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * 
+ * Provides unified access to the $_GET and $_POST inputs.
+ *
+ * @package    Elgg.Core
+ * @subpackage Http
+ * @since      1.10.0
+ * @access private
+ */
+class Input {
+	/**
+	 * Sets an input value that may later be retrieved by get_input
+	 *
+	 * Note: this function does not handle nested arrays (ex: form input of param[m][n])
+	 *
+	 * @param string          $variable The name of the variable
+	 * @param string|string[] $value    The value of the variable
+	 *
+	 * @return void
+	 */
+	public function set($variable, $value) {
+		global $CONFIG;
+		if (!isset($CONFIG->input)) {
+			$CONFIG->input = array();
+		}
+	
+		if (is_array($value)) {
+			array_walk_recursive($value, create_function('&$v, $k', '$v = trim($v);'));
+			$CONFIG->input[trim($variable)] = $value;
+		} else {
+			$CONFIG->input[trim($variable)] = trim($value);
+		}
+	}
+	
+	
+	/**
+	 * Get some input from variables passed submitted through GET or POST.
+	 *
+	 * If using any data obtained from get_input() in a web page, please be aware that
+	 * it is a possible vector for a reflected XSS attack. If you are expecting an
+	 * integer, cast it to an int. If it is a string, escape quotes.
+	 *
+	 * Note: this function does not handle nested arrays (ex: form input of param[m][n])
+	 * because of the filtering done in htmlawed from the filter_tags call.
+	 * @todo Is this ^ still true?
+	 *
+	 * @param string $variable      The variable name we want.
+	 * @param mixed  $default       A default value for the variable if it is not found.
+	 * @param bool   $filter_result If true, then the result is filtered for bad tags.
+	 *
+	 * @return mixed
+	 */
+	function get($variable, $default = null, $filter_result = true) {
+			
+		global $CONFIG;
+	
+		$result = $default;
+	
+		elgg_push_context('input');
+	
+		if (isset($CONFIG->input[$variable])) {
+			// a plugin has already set this variable
+			$result = $CONFIG->input[$variable];
+			if ($filter_result) {
+				$result = filter_tags($result);
+			}
+		} else {
+			$request = _elgg_services()->request;
+			$value = $request->get($variable);
+			if ($value !== null) {
+				$result = $value;
+				if (is_string($result)) {
+					// @todo why trim
+					$result = trim($result);
+				}
+	
+				if ($filter_result) {
+					$result = filter_tags($result);
+				}
+			}
+		}
+	
+		elgg_pop_context();
+	
+		return $result;
+
+	}
+}

--- a/engine/lib/input.php
+++ b/engine/lib/input.php
@@ -25,38 +25,7 @@
  * @return mixed
  */
 function get_input($variable, $default = null, $filter_result = true) {
-
-	global $CONFIG;
-
-	$result = $default;
-
-	elgg_push_context('input');
-
-	if (isset($CONFIG->input[$variable])) {
-		// a plugin has already set this variable
-		$result = $CONFIG->input[$variable];
-		if ($filter_result) {
-			$result = filter_tags($result);
-		}
-	} else {
-		$request = _elgg_services()->request;
-		$value = $request->get($variable);
-		if ($value !== null) {
-			$result = $value;
-			if (is_string($result)) {
-				// @todo why trim
-				$result = trim($result);
-			}
-
-			if ($filter_result) {
-				$result = filter_tags($result);
-			}
-		}
-	}
-
-	elgg_pop_context();
-
-	return $result;
+	return _elgg_services()->input->get($variable, $default, $filter_result);
 }
 
 /**
@@ -70,17 +39,7 @@ function get_input($variable, $default = null, $filter_result = true) {
  * @return void
  */
 function set_input($variable, $value) {
-	global $CONFIG;
-	if (!isset($CONFIG->input)) {
-		$CONFIG->input = array();
-	}
-
-	if (is_array($value)) {
-		array_walk_recursive($value, create_function('&$v, $k', '$v = trim($v);'));
-		$CONFIG->input[trim($variable)] = $value;
-	} else {
-		$CONFIG->input[trim($variable)] = trim($value);
-	}
+	_elgg_services()->input->set($variable, $value);
 }
 
 /**

--- a/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
+++ b/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
@@ -20,6 +20,7 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
 			'db' => '\Elgg\Database',
 			'events' => '\Elgg\EventsService',
 			'hooks' => '\Elgg\PluginHooksService',
+			'input' => '\Elgg\Http\Input',
 			'logger' => '\Elgg\Logger',
 			'metadataCache' => '\ElggVolatileMetadataCache',
 			'request' => '\Elgg\Http\Request',

--- a/engine/tests/phpunit/Elgg/Http/InputTest.php
+++ b/engine/tests/phpunit/Elgg/Http/InputTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace Elgg\Http;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+class InputTest extends TestCase {
+	
+	public function testGetInputDefaultsToProvidedDefaultValue() {
+		$this->markTestIncomplete();
+	}
+	
+	public function testGetInputTriggersValidateInputHookIfAndOnlyIfFilteringIsEnabled() {
+		$this->markTestIncomplete();
+	}
+	
+	public function testGetInputCanBeOverriddenBySetInput() {
+		$this->markTestIncomplete();
+	}
+	
+	public function testGetInputChecksBothPostAndGetParams() {
+		$this->markTestIncomplete();
+	}
+	
+	public function testGetInputPushesInputContextDuringFiltering() {
+		$this->markTestIncomplete();
+	}
+	
+	public function testFilterTagsGlobal() {
+		$this->markTestIncomplete();
+	}
+}


### PR DESCRIPTION
Also adds test stubs to be implemented when the global state is removed.

Fixes #7091

This is basically a more modest version of #7100 to just get the lazy-loading and OO facade without all the fancy refactoring or unrelated Http\Url class.
