### PR TITLE
deprecate(view): deprecate output/confirmlink for consolidated output/ur...

### DIFF
--- a/docs/guides/actions.rst
+++ b/docs/guides/actions.rst
@@ -399,7 +399,6 @@ A few views and functions automatically generate security tokens:
 .. code:: php
 
    elgg_view('output/url', array('is_action' => TRUE));
-   elgg_view('output/confirmlink');
    elgg_view('input/securitytoken');
    $url = elgg_add_action_tokens_to_url("http://localhost/elgg/action/example");
 

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -80,10 +80,8 @@
  *                          item_class  => STR  A class or classes for the <li> tag
  *
  *                          Additional options that the view output/url takes can be
- *							passed in the array. If the 'confirm' key is passed, the
- *							menu link uses the 'output/confirmlink' view. Custom
- *							options can be added by using the 'data' key with the
- *							value being an associative array.
+ *							passed in the array. Custom options can be added by using
+ *							the 'data' key with the	value being an associative array.
  *
  * @return bool
  * @since 1.8.0

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -907,7 +907,7 @@ function elgg_user_hover_menu($hook, $type, $return, $params) {
 			$url = elgg_add_action_tokens_to_url($url);
 			$item = new ElggMenuItem($action, elgg_echo($action), $url);
 			$item->setSection('admin');
-			$item->setLinkClass('elgg-requires-confirmation');
+			$item->setConfirmText(true);
 
 			$return[] = $item;
 		}

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -733,9 +733,6 @@ function elgg_view_menu_item(ElggMenuItem $item, array $vars = array()) {
 
 	if ($item->getConfirmText()) {
 		$vars['confirm'] = $item->getConfirmText();
-		return elgg_view('output/confirmlink', $vars);
-	} else {
-		unset($vars['confirm']);
 	}
 
 	return elgg_view('output/url', $vars);

--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -22,7 +22,10 @@ elgg.ui.init = function () {
 
 	$('.elgg-menu-page .elgg-menu-parent').live('click', elgg.ui.toggleMenu);
 
-	$('.elgg-requires-confirmation').live('click', elgg.ui.requiresConfirmation);
+    $('*[data-confirm], .elgg-requires-confirmation').live('click', elgg.ui.requiresConfirmation);
+    if ($('.elgg-requires-confirmation').length > 0) {
+        elgg.deprecated_notice('Use of .elgg-requires-confirmation is deprecated by data-confirm', '1.10');
+    }
 
 	$('.elgg-autofocus').focus();
 	if ($('.elgg-autofocus').length > 0) {

--- a/mod/blog/views/default/forms/blog/save.php
+++ b/mod/blog/views/default/forms/blog/save.php
@@ -20,10 +20,11 @@ $preview_button = '';
 if ($vars['guid']) {
 	// add a delete button if editing
 	$delete_url = "action/blog/delete?guid={$vars['guid']}";
-	$delete_link = elgg_view('output/confirmlink', array(
+	$delete_link = elgg_view('output/url', array(
 		'href' => $delete_url,
 		'text' => elgg_echo('delete'),
-		'class' => 'elgg-button elgg-button-delete float-alt'
+		'class' => 'elgg-button elgg-button-delete float-alt',
+		'confirm' => true,
 	));
 }
 

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -497,9 +497,10 @@ function groups_user_entity_menu_setup($hook, $type, $return, $params) {
 
 		// Add remove link if we can edit the group, and if we're not trying to remove the group owner
 		if ($group->canEdit() && $group->getOwnerGUID() != $entity->guid) {
-			$remove = elgg_view('output/confirmlink', array(
+			$remove = elgg_view('output/url', array(
 				'href' => "action/groups/remove?user_guid={$entity->guid}&group_guid={$group->guid}",
 				'text' => elgg_echo('groups:removeuser'),
+				'confirm' => true,
 			));
 
 			$options = array(
@@ -538,7 +539,7 @@ function groups_annotation_menu_setup($hook, $type, $return, $params) {
 			'href' => $url,
 			'text' => "<span class=\"elgg-icon elgg-icon-delete\"></span>",
 			'confirm' => elgg_echo('deleteconfirm'),
-			'encode_text' => false
+			'encode_text' => false,
 		);
 		$return[] = ElggMenuItem::factory($options);
 

--- a/mod/groups/views/default/forms/groups/edit.php
+++ b/mod/groups/views/default/forms/groups/edit.php
@@ -36,7 +36,7 @@ echo elgg_view("input/submit", array("value" => elgg_echo("save")));
 
 if ($entity) {
 	$delete_url = "action/groups/delete?guid=" . $entity->getGUID();
-	echo elgg_view("output/confirmlink", array(
+	echo elgg_view("output/url", array(
 		"text" => elgg_echo("groups:delete"),
 		"href" => $delete_url,
 		"confirm" => elgg_echo("groups:deletewarning"),

--- a/mod/groups/views/default/groups/invitationrequests.php
+++ b/mod/groups/views/default/groups/invitationrequests.php
@@ -27,7 +27,7 @@ if (!empty($vars['invitations']) && is_array($vars['invitations'])) {
 			));
 
 			$url = "action/groups/killinvitation?user_guid={$user->getGUID()}&group_guid={$group->getGUID()}";
-			$delete_button = elgg_view('output/confirmlink', array(
+			$delete_button = elgg_view('output/url', array(
 					'href' => $url,
 					'confirm' => elgg_echo('groups:invite:remove:check'),
 					'text' => elgg_echo('delete'),

--- a/mod/groups/views/default/groups/membershiprequests.php
+++ b/mod/groups/views/default/groups/membershiprequests.php
@@ -27,7 +27,7 @@ if (!empty($vars['requests']) && is_array($vars['requests'])) {
 		));
 
 		$url = 'action/groups/killrequest?user_guid=' . $user->guid . '&group_guid=' . $vars['entity']->guid;
-		$delete_button = elgg_view('output/confirmlink', array(
+		$delete_button = elgg_view('output/url', array(
 				'href' => $url,
 				'confirm' => elgg_echo('groups:joinrequest:remove:check'),
 				'text' => elgg_echo('delete'),

--- a/mod/likes/views/default/annotation/likes.php
+++ b/mod/likes/views/default/annotation/likes.php
@@ -28,7 +28,7 @@ $likes_string = elgg_echo('likes:this');
 $friendlytime = elgg_view_friendly_time($like->time_created);
 
 if ($like->canEdit()) {
-	$delete_button = elgg_view("output/confirmlink",array(
+	$delete_button = elgg_view("output/url",array(
     	'href' => "action/likes/delete?id={$like->id}",
     	'text' => "<span class=\"elgg-icon elgg-icon-delete float-alt\"></span>",
     	'confirm' => elgg_echo('likes:delete:confirm'),

--- a/mod/messageboard/views/default/messageboard/js.php
+++ b/mod/messageboard/views/default/messageboard/js.php
@@ -7,12 +7,12 @@ elgg.messageboard.init = function() {
 
 	// remove the default binding for confirmation since we're doing extra stuff.
 	// @todo remove if we add a hook to the requires confirmation callback
-	form.parent().find('a.elgg-requires-confirmation')
+	form.parent().find('*[data-confirm]')
 		.click(elgg.messageboard.deletePost)
 
 		// double whammy for in case the load order changes.
 		.unbind('click', elgg.ui.requiresConfirmation)
-		.removeClass('elgg-requires-confirmation');
+		.removeAttr('data-confirm');
 };
 
 elgg.messageboard.submit = function(e) {

--- a/mod/messages/views/default/forms/messages/process.php
+++ b/mod/messages/views/default/forms/messages/process.php
@@ -23,8 +23,9 @@ echo '<div class="elgg-foot messages-buttonbank">';
 echo elgg_view('input/submit', array(
 	'value' => elgg_echo('delete'),
 	'name' => 'delete',
-	'class' => 'elgg-button-delete elgg-requires-confirmation',
+	'class' => 'elgg-button-delete',
 	'title' => elgg_echo('deleteconfirm:plural'),
+	'data-confirm' => elgg_echo('deleteconfirm:plural')
 ));
 
 if ($vars['folder'] == "inbox") {

--- a/mod/messages/views/default/object/messages.php
+++ b/mod/messages/views/default/object/messages.php
@@ -64,7 +64,7 @@ $subject_info .= elgg_view('output/url', array(
 	'is_trusted' => true,
 ));
 
-$delete_link = elgg_view("output/confirmlink", array(
+$delete_link = elgg_view("output/url", array(
 						'href' => "action/messages/delete?guid=" . $message->getGUID(),
 						'text' => "<span class=\"elgg-icon elgg-icon-delete float-alt\"></span>",
 						'confirm' => elgg_echo('deleteconfirm'),

--- a/mod/uservalidationbyemail/views/default/uservalidationbyemail/unvalidated_user.php
+++ b/mod/uservalidationbyemail/views/default/uservalidationbyemail/unvalidated_user.php
@@ -16,19 +16,19 @@ $checkbox = elgg_view('input/checkbox', array(
 
 $created = elgg_echo('uservalidationbyemail:admin:user_created', array(elgg_view_friendly_time($user->time_created)));
 
-$validate = elgg_view('output/confirmlink', array(
+$validate = elgg_view('output/url', array(
 	'confirm' => elgg_echo('uservalidationbyemail:confirm_validate_user', array($user->username)),
 	'href' => "action/uservalidationbyemail/validate/?user_guids[]=$user->guid",
 	'text' => elgg_echo('uservalidationbyemail:admin:validate')
 ));
 
-$resend_email = elgg_view('output/confirmlink', array(
+$resend_email = elgg_view('output/url', array(
 	'confirm' => elgg_echo('uservalidationbyemail:confirm_resend_validation', array($user->username)),
 	'href' => "action/uservalidationbyemail/resend_validation/?user_guids[]=$user->guid",
 	'text' => elgg_echo('uservalidationbyemail:admin:resend_validation')
 ));
 
-$delete = elgg_view('output/confirmlink', array(
+$delete = elgg_view('output/url', array(
 	'confirm' => elgg_echo('uservalidationbyemail:confirm_delete', array($user->username)),
 	'href' => "action/uservalidationbyemail/delete/?user_guids[]=$user->guid",
 	'text' => elgg_echo('delete')

--- a/views/default/admin/appearance/profile_fields.php
+++ b/views/default/admin/appearance/profile_fields.php
@@ -6,7 +6,7 @@
 $add = elgg_view_form('profile/fields/add', array('class' => 'elgg-form-settings'), array());
 $list = elgg_view('admin/appearance/profile_fields/list');
 
-$reset = elgg_view('output/confirmlink', array(
+$reset = elgg_view('output/url', array(
 	'text' => elgg_echo('reset'),
 	'href' => 'action/profile/fields/reset',
 	'title' => elgg_echo('profile:resetdefault'),

--- a/views/default/core/friends/collection.php
+++ b/views/default/core/friends/collection.php
@@ -21,11 +21,12 @@ echo "<li><h2>";
 //as collections are private, check that the logged in user is the owner
 if ($coll->owner_guid == elgg_get_logged_in_user_guid()) {
 	echo "<div class=\"friends_collections_controls\">";
-	echo elgg_view('output/confirmlink', array(
+	echo elgg_view('output/url', array(
 			'href' => 'action/friends/collections/delete?collection=' . $coll->id,
 			'class' => 'delete_collection',
 			'text' => elgg_view_icon('delete'),
 			'encode_text' => false,
+			'confirm' => true,
 		));
 	echo "</div>";
 }

--- a/views/default/output/confirmlink.php
+++ b/views/default/output/confirmlink.php
@@ -13,35 +13,9 @@
  * @uses $vars['encode_text'] Run $vars['text'] through htmlspecialchars() (false)
  */
 
-$vars['data-confirm'] = elgg_extract('confirm', $vars, elgg_echo('question:areyousure'));
+elgg_deprecated_notice('The view output/confirmlink has been deprecated, please use output/url', 1.10);
 
-$encode = elgg_extract('encode_text', $vars, false);
-
-// always generate missing action tokens
-$vars['href'] = elgg_add_action_tokens_to_url(elgg_normalize_url($vars['href']), true);
-
-$text = elgg_extract('text', $vars, '');
-if ($encode) {
-	$text = htmlspecialchars($text, ENT_QUOTES, 'UTF-8', false);
+if (!isset($vars['confirm'])) {
+	$vars['confirm'] = true;
 }
-
-if (!isset($vars['title']) && isset($vars['confirm'])) {
-	$vars['title'] = $vars['confirm'];
-}
-
-if (isset($vars['class'])) {
-	if (!is_array($vars['class'])) {
-		$vars['class'] = array($vars['class']);
-	}
-	$vars['class'][] = 'elgg-requires-confirmation';
-} else {
-	$vars['class'] = 'elgg-requires-confirmation';
-}
-
-unset($vars['encode_text']);
-unset($vars['text']);
-unset($vars['confirm']);
-unset($vars['is_trusted']);
-
-$attributes = elgg_format_attributes($vars);
-echo "<a $attributes>$text</a>";
+echo elgg_view('output/url', $vars);

--- a/views/default/output/url.php
+++ b/views/default/output/url.php
@@ -11,7 +11,24 @@
  * @uses bool   $vars['encode_text'] Run $vars['text'] through htmlspecialchars() (false)
  * @uses bool   $vars['is_action']   Is this a link to an action (false)
  * @uses bool   $vars['is_trusted']  Is this link trusted (false)
+ * @uses mixed  $vars['confirm']     Confirmation dialog text | (bool) true
+ * 
+ * Note: if confirm is set to true or has dialog text 'is_action' will default to true
+ * 
  */
+
+if ($vars['confirm'] && !isset($vars['is_action'])) {
+	$vars['is_action'] = true;
+}
+
+if ($vars['confirm']) {
+	$vars['data-confirm'] = elgg_extract('confirm', $vars, elgg_echo('question:areyousure'));
+	
+	// if (bool) true use defaults
+	if ($vars['data-confirm'] === true) {
+		$vars['data-confirm'] = elgg_echo('question:areyousure');
+	}
+}
 
 $url = elgg_extract('href', $vars, null);
 if (!$url and isset($vars['value'])) {
@@ -49,8 +66,13 @@ if ($url) {
 	$vars['href'] = $url;
 }
 
+if (!isset($vars['title']) && isset($vars['data-confirm'])) {
+	$vars['title'] = $vars['data-confirm'];
+}
+
 unset($vars['is_action']);
 unset($vars['is_trusted']);
+unset($vars['confirm']);
 
 $attributes = elgg_format_attributes($vars);
 echo "<a $attributes>$text</a>";


### PR DESCRIPTION
...l with 'confirm' option

Fixes #5810
- [x] whitespace fixes
- [x] trailing commas in arrays
- [x] select on data-confirm attribute
- [x] deprecate use of .elgg-requires-confirmation
- [x] replace all core usage of .elgg-requires-confirmation 
