### PR TITLE
deprecate(libraries): End support for `elgg_register_library` and `elgg_load_library`

### DIFF
--- a/engine/lib/deprecated-1.10.php
+++ b/engine/lib/deprecated-1.10.php
@@ -25,3 +25,59 @@ function file_get_general_file_type($mime_type) {
 	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use elgg_get_file_simple_type()', '1.10');
 	return elgg_get_file_simple_type($mime_type);
 }
+
+/**
+ * Register a php library.
+ *
+ * @param string $name     The name of the library
+ * @param string $location The location of the file
+ *
+ * @return void
+ * @since 1.8.0
+ * @deprecated 1.10.0 Use class autoloading instead
+ */
+function elgg_register_library($name, $location) {
+	global $CONFIG;
+
+	if (!isset($CONFIG->libraries)) {
+		$CONFIG->libraries = array();
+	}
+
+	$CONFIG->libraries[$name] = $location;
+}
+
+/**
+ * Load a php library.
+ *
+ * @param string $name The name of the library
+ *
+ * @return void
+ * @throws InvalidParameterException
+ * @since 1.8.0
+ * @deprecated 1.10.0 Use class autoloading instead
+ */
+function elgg_load_library($name) {
+	global $CONFIG;
+
+	static $loaded_libraries = array();
+
+	if (in_array($name, $loaded_libraries)) {
+		return;
+	}
+
+	if (!isset($CONFIG->libraries)) {
+		$CONFIG->libraries = array();
+	}
+
+	if (!isset($CONFIG->libraries[$name])) {
+		$error = $name . " is not a registered library";
+		throw new \InvalidParameterException($error);
+	}
+
+	if (!include_once($CONFIG->libraries[$name])) {
+		$error = "Could not load the " . $name . " library from " . $CONFIG->libraries[$name];
+		throw new \InvalidParameterException($error);
+	}
+
+	$loaded_libraries[] = $name;
+}

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -8,60 +8,6 @@
  */
 
 /**
- * Register a php library.
- *
- * @param string $name     The name of the library
- * @param string $location The location of the file
- *
- * @return void
- * @since 1.8.0
- */
-function elgg_register_library($name, $location) {
-	global $CONFIG;
-
-	if (!isset($CONFIG->libraries)) {
-		$CONFIG->libraries = array();
-	}
-
-	$CONFIG->libraries[$name] = $location;
-}
-
-/**
- * Load a php library.
- *
- * @param string $name The name of the library
- *
- * @return void
- * @throws InvalidParameterException
- * @since 1.8.0
- */
-function elgg_load_library($name) {
-	global $CONFIG;
-
-	static $loaded_libraries = array();
-
-	if (in_array($name, $loaded_libraries)) {
-		return;
-	}
-
-	if (!isset($CONFIG->libraries)) {
-		$CONFIG->libraries = array();
-	}
-
-	if (!isset($CONFIG->libraries[$name])) {
-		$error = $name . " is not a registered library";
-		throw new \InvalidParameterException($error);
-	}
-
-	if (!include_once($CONFIG->libraries[$name])) {
-		$error = "Could not load the " . $name . " library from " . $CONFIG->libraries[$name];
-		throw new \InvalidParameterException($error);
-	}
-
-	$loaded_libraries[] = $name;
-}
-
-/**
  * Forward to $location.
  *
  * Sends a 'Location: $location' header and exists.  If headers have


### PR DESCRIPTION
Class autoloading is better in every way. It's trivial to use static methods
on autoloaded classes rather than `elgg_*_library` with global functions.

This is a "soft" deprecation (no warnings/notices when using the deprecated APIs)
because we're not updating core plugins just yet.
