### PR TITLE
chore(datalist): Add global vars statement to fix `loadAll()` method

### DIFF
--- a/engine/classes/Elgg/Database/Datalist.php
+++ b/engine/classes/Elgg/Database/Datalist.php
@@ -161,6 +161,8 @@ class Datalist {
 	 * @access private
 	 */
 	function loadAll() {
+		global $DATALIST_CACHE;
+
 		$result = _elgg_services()->db->getData("SELECT * FROM {$this->CONFIG->dbprefix}datalists");
 		if ($result) {
 			foreach ($result as $row) {


### PR DESCRIPTION
This is considered a chore because the issue it fixes was introduced
during development and never released, so it should not go in the changelog.

Refs #7457 
