### PR TITLE
fix(views): input/userpicker can now remove all users on edit

### DIFF
--- a/views/default/input/userpicker.php
+++ b/views/default/input/userpicker.php
@@ -50,6 +50,13 @@ $limit = (int)elgg_extract('limit', $vars, 0);
 		}
 		?>
 	</ul>
+	<?php
+	if (empty($guids)) {
+		echo elgg_view('input/hidden', array(
+			'name' => $vars['name'],
+		));
+	}
+	?>
 </div>
 <script>
 require(['elgg/UserPicker'], function (UserPicker) {


### PR DESCRIPTION
We must provide an empty input in case all users are removed. Otherwise
no value will be submitted.

Fixes #6982
