### PR TITLE
fix(plugins): trigger plugin hooks when saving plugin settings

### DIFF
--- a/actions/plugins/settings/save.php
+++ b/actions/plugins/settings/save.php
@@ -30,7 +30,8 @@ if (elgg_action_exists("$plugin_id/settings/save")) {
 	action("$plugin_id/settings/save");
 } else {
 	foreach ($params as $k => $v) {
-		$result = $plugin->setSetting($k, $v);
+		// We must use __set() so the plugin hooks are triggered
+		$result = $plugin->$k = $v;
 		if (!$result) {
 			register_error(elgg_echo('plugins:settings:save:fail', array($plugin_name)));
 			forward(REFERER);


### PR DESCRIPTION
The introduction of setPrivateSetting led to failing to trigger the plugin hooks.
Only property sets result in the hooks being triggered so we return to that method.

Fixes #6820
