### PR TITLE
chore(insight): Fully qualify class names with `use` or leading backslash

### DIFF
--- a/engine/classes/Elgg/CommitMessage.php
+++ b/engine/classes/Elgg/CommitMessage.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elgg;
 
+use UnexpectedValueException;
+
 
 /**
  * Provides a structured format for parsing and examining our commit messages.

--- a/engine/classes/Elgg/Database/AccessCollections.php
+++ b/engine/classes/Elgg/Database/AccessCollections.php
@@ -603,7 +603,7 @@ class AccessCollections {
 	
 		$collection = get_access_collection($collection_id);
 	
-		if (!($user instanceof Elgguser) || !$collection) {
+		if (!($user instanceof \ElggUser) || !$collection) {
 			return false;
 		}
 	
@@ -645,7 +645,7 @@ class AccessCollections {
 	
 		$collection = get_access_collection($collection_id);
 	
-		if (!($user instanceof Elgguser) || !$collection) {
+		if (!($user instanceof \ElggUser) || !$collection) {
 			return false;
 		}
 	
@@ -698,7 +698,7 @@ class AccessCollections {
 	 * @param int  $collection The collection's ID
 	 * @param bool $idonly     If set to true, will only return the members' GUIDs (default: false)
 	 *
-	 * @return ElggUser[]|int[]|false guids or entities if successful, false if not
+	 * @return \ElggUser[]|int[]|false guids or entities if successful, false if not
 	 */
 	function getMembers($collection, $idonly = false) {
 		global $CONFIG;

--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elgg\Database;
 
+use IncompleteEntityException;
+
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
  *

--- a/engine/classes/Elgg/Database/Plugins.php
+++ b/engine/classes/Elgg/Database/Plugins.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elgg\Database;
 
+use Exception;
+
 /**
  * @var array cache used by elgg_get_plugins_provides function
  * @todo move it with all other functions to \Elgg\PluginsService

--- a/engine/classes/Elgg/Notifications/NotificationsService.php
+++ b/engine/classes/Elgg/Notifications/NotificationsService.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elgg\Notifications;
 
+use ElggEntity;
+
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
  *


### PR DESCRIPTION
In general, missing `use` statements can lead to bugs or at least ambiguity.
Better to fully qualify all classes.

See "Missing use statement should be avoided" on this report:
https://insight.sensiolabs.com/projects/0630ff8f-809b-4409-a718-12f7da91367e/analyses/5
