### PR TITLE
fix(views): Revert erroneous changes made to input/userpicker

### DIFF
--- a/views/default/input/userpicker.php
+++ b/views/default/input/userpicker.php
@@ -50,13 +50,6 @@ $limit = (int)elgg_extract('limit', $vars, 0);
 		}
 		?>
 	</ul>
-	<?php
-	if (empty($guids)) {
-		echo elgg_view('input/hidden', array(
-			'name' => $vars['name'],
-		));
-	}
-	?>
 </div>
 <script>
 require(['elgg/UserPicker'], function (UserPicker) {


### PR DESCRIPTION
This reverts commit 4cf113ab60f6e3c5e0d445f70fdd8cd530917642 which caused the
friends picker to stop working when there were no existing values selected.
