### PR TITLE
docs(travis): Added validation of translated docs sources for es language to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
        - phpcs --standard=../elgg-coding-standards/elgg.xml --warning-severity=0 --ignore=*/tests/*,*/upgrades/*,*/deprecated* engine/classes engine/lib
        - npm test
        - sphinx-build -b html -nW docs docs/_build/html
+       - sphinx-build -b latex -nW docs docs/_build/latex
          # Flags used here, not in `make html`:
          #  -n   Run in nit-picky mode. Currently, this generates warnings for all missing references.
          #  -W   Turn warnings into errors. This means that the build stops at the first warning and sphinx-build exits with exit status 1.

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
        - phpenv rehash
        - npm install
        - sudo easy_install "Sphinx==1.1.3"
+       - sudo easy_install "sphinx-intl"
        - wget https://scrutinizer-ci.com/ocular.phar
       script:
        - bash .scripts/travis/check_commit_msgs.sh
@@ -34,6 +35,8 @@ matrix:
          # Flags used here, not in `make html`:
          #  -n   Run in nit-picky mode. Currently, this generates warnings for all missing references.
          #  -W   Turn warnings into errors. This means that the build stops at the first warning and sphinx-build exits with exit status 1.
+       - sphinx-intl --locale-dir=docs/locale/ build
+       - sphinx-build -b html -D language=es -n docs docs/_build/html
        - phpunit --coverage-clover=coverage.clover
        - composer validate
       after_script:

--- a/docs/appendix/roadmap.rst
+++ b/docs/appendix/roadmap.rst
@@ -62,7 +62,7 @@ The best we can do is tell you to look out for what features
 existing developers have expressed interest in working on.
 
 The best way to ensure a feature gets implemented is to discuss it with the core team and implement it yourself.
-See our :doc:`/about/contributing` guide if you're interested. We love new contributors!
+See our :doc:`/contribute/index` guide if you're interested. We love new contributors!
 
 Do not rely on future enhancements if you're on the fence as to whether to use Elgg.
 Evaluate it given the current feature set.

--- a/docs/contribute/code.rst
+++ b/docs/contribute/code.rst
@@ -18,11 +18,10 @@ Pull requests
 Pull requests (PRs) are the best way to get code contributed to Elgg core.
 The core development team uses them even for the most trivial changes.
 
-For new features, `submit a feature request <issues.html>`__ or `talk to us`_ first and make
+For new features, `submit a feature request <https://github.com/Elgg/Elgg/issues>`__ or `talk to us`_ first and make
 sure the core team approves of your direction before spending lots of time on code.
 
 .. _talk to us: http://community.elgg.org/groups/profile/211069/feedback-and-planning
-
 
 Checklists
 ----------

--- a/docs/design/amd.rst
+++ b/docs/design/amd.rst
@@ -49,10 +49,10 @@ We like the edit-refresh cycle of web development. We wanted to make sure everyo
 Elgg could continue experiencing that joy. Synchronous module formats like Closure or CommonJS just
 weren't an option for us. But even though AMD doesn't require a build step, *it is still very
 build-friendly*. Because of the ``define()`` wrapper, it's possible to concatenate multiple modules
-into a single file and ship them all at once in a production environment. [*]_
+into a single file and ship them all at once in a production environment. [#]_
 
 AMD is a battle-tested and well thought out module loading system for the web today. We're very
 thankful for the work that has gone into it, and are excited to offer it as the standard solution
 for JavaScript development in Elgg starting with Elgg 1.9.
 
-.. [*] This is not currently supported by Elgg core, but we'll be looking into it since reducing round-trips is critical for a good first-view experience, especially on mobile devices.
+.. [#] This is not currently supported by Elgg core, but we'll be looking into it since reducing round-trips is critical for a good first-view experience, especially on mobile devices.

--- a/docs/design/database.rst
+++ b/docs/design/database.rst
@@ -709,21 +709,17 @@ The following rules govern write access:
    does not mean that the owner of a group can edit anything therein)
 -  Admins can edit anything
 
-You can override this behaviour using a `plugin hook`_ called
+You can override this behaviour using a :ref:`plugin hook <design/events#plugin-hooks>` called
 ``permissions_check``, which passes the entity in question to any
 function that has announced it wants to be referenced. Returning
 ``true`` will allow write access; returning ``false`` will deny it. See
-`the plugin hook reference for permissions\_check`_ for more details.
+:ref:`the plugin hook reference for permissions\_check <guides/hooks-list#permission-hooks>` for more details.
 
 Also see
 --------
 
--  `Engine reference`_
 -  `Access library reference`_
 
-.. _plugin hook: PluginHooks
-.. _the plugin hook reference for permissions\_check: PluginHooks#permissions_check
-.. _Engine reference : Engine
 .. _Access library reference: http://reference.elgg.org/engine_2lib_2access_8php.html
 
 Schema

--- a/docs/design/events.rst
+++ b/docs/design/events.rst
@@ -152,6 +152,7 @@ Parameters:
 The function will return ``false`` if any of the selected handlers returned
 ``false`` and the event is stoppable, otherwise it will return ``true``.
 
+.. _design/events#plugin-hooks:
 
 Plugin Hooks
 ============

--- a/docs/guides/database.rst
+++ b/docs/guides/database.rst
@@ -121,7 +121,7 @@ with metadata in a variety of ways.
 Displaying entities
 -------------------
 
-In order for entities to be displayed in `listing functions`_ you need
+In order for entities to be displayed in listing functions you need
 to provide a view for the entity in the views system.
 
 To display an entity, create a view EntityType/subtype where EntityType
@@ -132,10 +132,10 @@ user: for entities derived from ElggUser
 site: for entities derived from ElggSite
 group: for entities derived from ElggGroup
 
-.. _listing functions: Views#Listing_entities
-
 A default view for all entities has already been created, this is called
 EntityType/default.
+
+.. _guides/database#entity-icons:
 
 Entity Icons
 ~~~~~~~~~~~~
@@ -144,7 +144,7 @@ Every entity can be assigned an icon which is retrieved using the ``ElggEntity::
 This method accepts a ``$size`` argument that can be either of the configured icon sizes.  Use
 ``elgg_get_config('icon_sizes')`` to get all possible values. The following sizes exist by default:
 ``'large'``, ``'medium'``, ``'small'``, ``'tiny'``, and ``'topbar'``. The method triggers the
-``entity:icon:url`` hook_.
+``entity:icon:url`` :ref:`hook <guides/hooks-list#other>`.
 
 Use ``elgg_view_entity_icon($entity, $size, $vars)`` to render an icon. This will scan the following
 locations for a view and include the first match.
@@ -165,8 +165,6 @@ $subtype
 By convention entities that have an uploaded avatar or icon will have the ``icontime`` property
 assigned. This means that you can use ``$entity->icontime`` to check if an icon exists for the given
 entity.
-
-.. _hook: hooks-list.rst#other
 
 Adding, reading and deleting annotations
 ----------------------------------------

--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -171,6 +171,8 @@ Action hooks
 **forward, <reason>**
 	Filter the URL to forward a user to when ``forward($url, $reason)`` is called.
 
+.. _guides/hooks-list#permission-hooks:
+
 Permission hooks
 ================
 
@@ -237,6 +239,8 @@ Permission hooks
 **get_sql, access**
     Filters the SQL clauses used in ``_elgg_get_access_where_sql()``.
 
+.. _guides/hooks-list#views:
+
 Views
 =====
 
@@ -252,6 +256,8 @@ Views
 **head, page**
     In ``elgg_view_page()``, filters ``$vars['head']``
 
+.. _guides/hooks-list#other:
+
 Other
 =====
 
@@ -259,16 +265,16 @@ Other
     In ``get_default_access()``, filters the return value.
 
 **entity:icon:url, <entity_type>**
-	Triggered when entity icon URL is requested, see `entity icons`_. Callback should
+	Triggered when entity icon URL is requested, see :ref:`entity icons <guides/database#entity-icons>`. Callback should
 	return URL for the icon of size ``$params['size']`` for the entity ``$params['entity']``.
 	Following parameters are available through the ``$params`` array:
 
 	entity
 		Entity for which icon url is requested.
 	viewtype
-		The type of `view`_ e.g. ``'default'`` or ``'json'``.
+		The type of :ref:`view <guides/views#listing-entities>` e.g. ``'default'`` or ``'json'``.
 	size
-		Size requested, see `entity icons`_ for possible values.
+		Size requested, see :ref:`entity icons <guides/database#entity-icons>` for possible values.
 
 	Example on how one could default to a Gravatar icon for users that
 	have not yet uploaded an avatar:
@@ -303,9 +309,6 @@ Other
 		// Produce URL used to retrieve icon
 		return "http://www.gravatar.com/avatar/$hash?s=$size";
 	}
-
-.. _entity icons: database.rst#entity-icons
-.. _view: views.rst#listing-entities
 
 **entity:url, <entity_type>**
 	Return the URL for the entity ``$params['entity']``. Note: Generally it is better to override the

--- a/docs/guides/menus.rst
+++ b/docs/guides/menus.rst
@@ -40,7 +40,7 @@ Examples
 Advanced usage
 ==============
 
-You can get more control over menus by using `plugin hooks </design/events.html#plugin-hooks>`_
+You can get more control over menus by using :doc:`plugin hooks </design/events>`
 and the public methods provided by the ElggMenuItem__ class.
 
 There are two hooks that can be used to modify a menu:

--- a/docs/guides/notifications.rst
+++ b/docs/guides/notifications.rst
@@ -12,7 +12,7 @@ The generic method to send a notification to a user is via the function `notify_
 It is normally used when we want to notify only a single user. Notification like
 this might for example inform that someone has liked or commented the user's post.
 
-The function usually gets called in an `action <actions.html>`__ file.
+The function usually gets called in an :doc:`action <actions>` file.
 
 __ http://reference.elgg.org/notification_8php.html#a9d8de7faa63baf2dcd5d42eb8f76eaa1
 
@@ -91,7 +91,7 @@ Tell Elgg to send notifications when a new object of subtype "photo" is created:
 .. note::
 
 	In order to send the event-based notifications you must have the one-minute
-	`CRON <admin/cron.html>`__ interval configured.
+	:doc:`CRON </admin/cron>` interval configured.
 
 Contents of the notification message can be defined with the
 ``'prepare', 'notification:[action]:[type]:[subtype]'`` hook.

--- a/docs/guides/river.rst
+++ b/docs/guides/river.rst
@@ -41,7 +41,7 @@ River views
 ===========
 
 In order for events to appear in the river you need to provide a corresponding
-`view <views.html>`__ with the name specified in the function above.
+:doc:`view <views>` with the name specified in the function above.
 
 We recommend ``/river/{type}/{subtype}/{action}``, where:
 

--- a/docs/guides/views.rst
+++ b/docs/guides/views.rst
@@ -73,11 +73,13 @@ Again, the best way to override views is to place them in the appropriate place 
 
 .. note::
 
-	When considering long-term maintenance, overriding views in the core and bundled plugins has a cost: Upgrades may bring changes in views, and if you have overridden them, you will not get those changes. You may want to use `post processing <views#post-processing-views>`__ if the change you're making can be easily made with string replacement methods.
+	When considering long-term maintenance, overriding views in the core and bundled plugins has a cost: Upgrades may bring changes in views, and if you have overridden them, you will not get those changes. You may want to use :ref:`post processing <guides/views#post-processing-views>` if the change you're making can be easily made with string replacement methods.
 
 .. note::
 
 	Elgg caches view locations. This means that you should disable the system cache while working with views. When you install the changes to a production environment you mush flush the caches.
+
+.. _guides/views#viewtypes:
 
 Viewtypes
 =========
@@ -148,17 +150,19 @@ Note that if you extend the core css view like this:
 
 You **must** do so within code that is executed by engine/start.php (normally this would mean your plugin's init code).  Because the core css view is loaded separately via a ``<link>`` tag, any extensions you add will not have the same context as the rest of your page.
 
+.. _guides/views#post-processing-views:
+
 Post processing views
 =====================
 
 Sometimes it is preferable to process or rewrite the output of a view instead of overriding it.
 
-The output of each view is run through the `plugin hook <guides/events.html#post-plugin-hooks>`__ ``[view, view_name]`` before being returned by ``elgg_view()``. Each registered handler function is passed these arguments:
+The output of each view is run through the :ref:`plugin hook <guides/hooks-list#views>` ``[view, view_name]`` before being returned by ``elgg_view()``. Each registered handler function is passed these arguments:
 
 * ``$hook`` - the string ``"view"``
 * ``$type`` - the view name being rendered (the first argument passed to ``elgg_view()``)
 * ``$returnvalue`` - the rendered output of the view (or the return value of the last handler)
-* ``$params`` - an array containing the key ``viewtype`` with value being the `viewtype <views.html#viewtypes>`__ being rendered
+* ``$params`` - an array containing the key ``viewtype`` with value being the :ref:`viewtype <guides/views#viewtypes>` being rendered
 
 To alter the view output, the handler just needs to alter ``$returnvalue`` and return a new string.
 
@@ -208,6 +212,8 @@ Full and partial entity views
 * ``$full_view`` - Whether to display a *full* version of the entity. (Defaults to false.)
 
 This last parameter is passed to the view as ``$vars['full_view']``. It's up to you what you do with it; the usual behaviour is to only display comments and similar information if this is set to true.
+
+.. _guides/views#listing-entities:
 
 Listing entities
 ================

--- a/docs/guides/web-services.rst
+++ b/docs/guides/web-services.rst
@@ -135,7 +135,7 @@ http://yoursite.com/services/api/rest/xml/?method=users.active&api_key=1140321cb
 Signature-based authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The `HMAC Authentication`_ is similar to what is used with `OAuth`_ or
+The HMAC Authentication is similar to what is used with OAuth or
 Amazon's S3 service. This involves both the public and private key. If
 you want to be very sure that the API calls are coming from the
 developer you think they are coming from and you want to make sure the
@@ -147,12 +147,9 @@ authentication.
 OAuth
 ~~~~~
 
-With the addition of the `OAuth`_ plugin, Elgg also fully supports the
+With the addition of the OAuth plugin, Elgg also fully supports the
 OAuth 1.0a authorization standard. Clients can then use standard OAuth
 libraries to make any API calls to the site.
-
-.. _HMAC Authentication: HMAC Authentication
-.. _OAuth: OAuth
 
 User authentication
 -------------------

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -375,8 +375,6 @@ if you find a ``.htaccess`` file inside the installation path, but you
 are still getting 404 error, make sure the contents of ``.htaccess`` are
 same as that of ``htaccess_dist``.
 
-`Instructions for testing mod\_rewrite`_
-
 **``mod_rewrite`` isn't installed.**
 
 Check your ``httpd.conf`` to make sure that this module is being loaded
@@ -386,7 +384,6 @@ if the module is being loaded.
 
 **The rules in ``.htaccess`` aren't being obeyed.**
 
-.. _Instructions for testing mod\_rewrite: mod_rewrite_test
 .. _PHP info: http://uk.php.net/manual/en/function.phpinfo.php
 
 In your virtual host configuration settings (which may be contained


### PR DESCRIPTION
It will fail due to invalid translations that break references format.

See: https://github.com/Elgg/Elgg/issues/7034
