### PR TITLE
fix(upgrade): Rechecks that all annotation comments have been migrated to entities

### DIFF
--- a/actions/admin/upgrades/upgrade_discussion_replies.php
+++ b/actions/admin/upgrades/upgrade_discussion_replies.php
@@ -51,14 +51,6 @@ do {
 
 	if (!$annotations) {
 		// no annotations left
-
-		// set the upgrade as completed
-		$factory = new ElggUpgrade();
-		$upgrade = $factory->getUpgradeFromPath('admin/upgrades/comments');
-		if ($upgrade instanceof ElggUpgrade) {
-			$upgrade->setCompleted();
-		}
-
 		break;
 	}
 
@@ -107,7 +99,7 @@ do {
 				$error_count++;
 			}
 
-			// set the time_updated and last_action for this comment
+			// set the time_updated and last_action for this reply
 			// to the original time_created
 			$fix_ts_query = "
 				UPDATE {$db_prefix}entities
@@ -137,16 +129,16 @@ do {
 		delete_data($delete_query);
 	}
 
-	// update the last action on containers to be the max of all its comments
+	// update the last action on containers to be the max of all its replies
 	// or its own last action
-	$comment_subtype_id = get_subtype_id('object', 'discussion_reply');
+	$reply_subtype_id = get_subtype_id('object', 'discussion_reply');
 
 	foreach (array_unique($container_guids) as $guid) {
 		// can't use a subquery in an update clause without hard to read tricks.
 		$max = get_data_row("SELECT MAX(time_updated) as max_time_updated
 					FROM {$db_prefix}entities e
 					WHERE e.container_guid = $guid
-					AND e.subtype = $comment_subtype_id");
+					AND e.subtype = $reply_subtype_id");
 
 		$query = "
 		UPDATE {$db_prefix}entities

--- a/engine/lib/upgrades/2014111600-1.9.4-recheck_comments_upgrade-9da270072a5b0cad.php
+++ b/engine/lib/upgrades/2014111600-1.9.4-recheck_comments_upgrade-9da270072a5b0cad.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Elgg 1.9.4 upgrade 2014111600
+ * recheck_comments_upgrade
+ *
+ * The discussion reply upgrade had a bug that caused it to mark also the
+ * comments upgrade as completed. This rechecks whether there still are
+ * unmigrated comment annotations left and marks the upgrade as incomplete
+ * if annotations are found.
+ */
+
+$access_status = access_get_show_hidden_status();
+access_show_hidden_entities(true);
+$ia = elgg_set_ignore_access(true);
+
+$comments = elgg_get_annotations(array(
+	'annotation_names' => 'generic_comment',
+	'count' => true
+));
+
+if ($comments) {
+	$factory = new ElggUpgrade();
+
+	$upgrade = $factory->getUpgradeFromPath("admin/upgrades/comments");
+
+	if ($upgrade) {
+		$upgrade->setPrivateSetting('is_completed', 0);
+
+		_elgg_create_notice_of_pending_upgrade(null, null, $upgrade);
+	}
+}
+
+elgg_set_ignore_access($ia);
+access_show_hidden_entities($access_status);


### PR DESCRIPTION
The discussion reply upgrade had a bug that caused it to mark also the comments upgrade as completed. This rechecks whether there still are unmigrated comment annotations left and marks the comment upgrade as incomplete if annotations are found.

Fixes #7486
