### PR TITLE
fix(forms): Removes icon and title links from autocomplete results

### DIFF
--- a/engine/lib/input.php
+++ b/engine/lib/input.php
@@ -339,7 +339,9 @@ function input_livesearch_page_handler($page) {
 
 						$output = elgg_view_list_item($entity, array(
 							'use_hover' => false,
+							'use_link' => false,
 							'class' => 'elgg-autocomplete-item',
+							'title' => $entity->name, // Default title would be a link
 						));
 
 						$icon = elgg_view_entity_icon($entity, 'tiny', array(
@@ -389,6 +391,8 @@ function input_livesearch_page_handler($page) {
 							'use_hover' => false,
 							'class' => 'elgg-autocomplete-item',
 							'full_view' => false,
+							'href' => false,
+							'title' => $entity->name, // Default title would be a link
 						));
 
 						$icon = elgg_view_entity_icon($entity, 'tiny', array(
@@ -430,7 +434,9 @@ function input_livesearch_page_handler($page) {
 						
 						$output = elgg_view_list_item($entity, array(
 							'use_hover' => false,
+							'use_link' => false,
 							'class' => 'elgg-autocomplete-item',
+							'title' => $entity->name, // Default title would be a link
 						));
 
 						$icon = elgg_view_entity_icon($entity, 'tiny', array(

--- a/mod/groups/views/default/group/default.php
+++ b/mod/groups/views/default/group/default.php
@@ -7,7 +7,7 @@
 
 $group = $vars['entity'];
 
-$icon = elgg_view_entity_icon($group, 'tiny');
+$icon = elgg_view_entity_icon($group, 'tiny', $vars);
 
 $metadata = elgg_view_menu('entity', array(
 	'entity' => $group,

--- a/views/default/user/default.php
+++ b/views/default/user/default.php
@@ -4,6 +4,7 @@
  *
  * @uses $vars['entity'] ElggUser entity
  * @uses $vars['size']   Size of the icon
+ * @uses $vars['title']  Optional override for the title
  */
 
 $entity = $vars['entity'];
@@ -11,15 +12,22 @@ $size = elgg_extract('size', $vars, 'tiny');
 
 $icon = elgg_view_entity_icon($entity, $size, $vars);
 
-// Simple XFN
-$rel = '';
-if (elgg_get_logged_in_user_guid() == $entity->guid) {
-	$rel = 'rel="me"';
-} elseif (check_entity_relationship(elgg_get_logged_in_user_guid(), 'friend', $entity->guid)) {
-	$rel = 'rel="friend"';
-}
+$title = elgg_extract('title', $vars);
+if (!$title) {
+	$link_params = array(
+		'href' => $entity->getUrl(),
+		'text' => $entity->name,
+	);
 
-$title = "<a href=\"" . $entity->getUrl() . "\" $rel>" . $entity->name . "</a>";
+	// Simple XFN, see http://gmpg.org/xfn/
+	if (elgg_get_logged_in_user_guid() == $entity->guid) {
+		$link_params['rel'] = 'me';
+	} elseif (check_entity_relationship(elgg_get_logged_in_user_guid(), 'friend', $entity->guid)) {
+		$link_params['rel'] = 'friend';
+	}
+
+	$title = elgg_view('output/url', $link_params);
+}
 
 $metadata = elgg_view_menu('entity', array(
 	'entity' => $entity,


### PR DESCRIPTION
Removes the links from all three search options:
- groups
- friends
- users

As a side effect also makes it possible to override:
- Title used in user/default view
- Icon params for groups/default view

Fixes #5583
