### PR TITLE
fix(views): elgg_view_menu_item shows no link for items with null href

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -716,7 +716,7 @@ function elgg_view_menu_item(\ElggMenuItem $item, array $vars = array()) {
 		$vars['class'] .= ' ' . $item->getLinkClass();
 	}
 
-	if ($item->getHref() === false) {
+	if ($item->getHref() === false || $item->getHref() === null) {
 		$text = $item->getText();
 
 		// if contains elements, don't wrap


### PR DESCRIPTION
fixes #5023

previous PR in #7341

TODOs:
- [ ] Consider switching to something more generic, like `== false`
