### PR TITLE
fix(plugins): ckeditor now prevents image drag/drop/paste in editor

### DIFF
--- a/mod/ckeditor/languages/en.php
+++ b/mod/ckeditor/languages/en.php
@@ -2,4 +2,5 @@
 return array(
 	'ckeditor:html' => "Edit HTML",
 	'ckeditor:visual' => "Visual editor",
+	'ckeditor:blockimagepaste' => "Direct image paste is not allowed.",
 );

--- a/mod/ckeditor/views/default/js/elgg/ckeditor.js
+++ b/mod/ckeditor/views/default/js/elgg/ckeditor.js
@@ -3,6 +3,8 @@ define(function(require) {
 	var $ = require('jquery'); require('jquery.ckeditor');
 	var CKEDITOR = require('ckeditor');
 
+	CKEDITOR.plugins.addExternal('blockimagepaste', elgg.get_site_url() + 'mod/ckeditor/views/default/js/elgg/ckeditor/blockimagepaste.js', '');
+	
 	var elggCKEditor = {
 
 		/**

--- a/mod/ckeditor/views/default/js/elgg/ckeditor/blockimagepaste.js
+++ b/mod/ckeditor/views/default/js/elgg/ckeditor/blockimagepaste.js
@@ -1,0 +1,43 @@
+// originaly copied from http://www.isummation.com/blog/block-drag-drop-image-or-direct-image-paste-into-ckeditor-using-firefox/
+
+CKEDITOR.plugins.add( 'blockimagepaste', {
+        init : function(editor) {
+ 
+	        function replaceImgText(html) {
+	            var ret = html.replace( /<img[^>]*src="data:image\/(bmp|dds|gif|jpg|jpeg|png|psd|pspimage|tga|thm|tif|tiff|yuv|ai|eps|ps|svg);base64,.*?"[^>]*>/gi, function( img ){
+                    alert(elgg.echo('ckeditor:blockimagepaste'));
+                    return '';
+                 });
+	            return ret;
+	        }
+	             
+	        function chkImg() {
+	            // don't execute code if the editor is readOnly
+	            if (editor.readOnly) {
+	                return;
+	            }
+	            
+	            setTimeout(function() {
+	                editor.document.$.body.innerHTML = replaceImgText(editor.document.$.body.innerHTML);
+	            }, 100);
+	        }
+	         
+	        editor.on('contentDom', function() {
+	            // For Firefox
+	            editor.document.on('drop', chkImg);
+	            // For IE
+	            editor.document.getBody().on('drop', chkImg);
+	        });
+	         
+	        editor.on('paste', function(e) {
+	 
+	            var html = e.data.dataValue;
+                if (!html) {
+                    return;
+                }
+	 
+	            e.data.dataValue = replaceImgText(html);
+            });
+             
+        } //Init
+});

--- a/mod/ckeditor/views/default/js/elgg/ckeditor/config.js
+++ b/mod/ckeditor/views/default/js/elgg/ckeditor/config.js
@@ -8,6 +8,7 @@ define(function(require) {
 		allowedContent: true,
 		baseHref: elgg.config.wwwroot,
 		removePlugins: 'contextmenu,tabletools,resize',
+		extraPlugins: 'blockimagepaste',
 		defaultLanguage: 'en',
 		language: elgg.config.language,
 		skin: 'moono',


### PR DESCRIPTION
fixes #4970

code snippet is added as an external source, so it will not interfere with the default ckeditor code folder

TODOs:
- [x] Change message to `fix(ckeditor)`
- [x] Move custom JS out of `vendors` and into an AMD file.
