### PR TITLE
ui.datepicker refactored for better handling of locale settings

### DIFF
--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -308,10 +308,46 @@ elgg.ui.getLocaleSettings = function(language){
             break;
         case 'nl':
             url += 'jquery.ui.datepicker-nl.js';
+            break;
         case 'de':
             url += 'jquery.ui.datepicker-de.js';
+            break;
         case 'es':
-            url += 'jquery.ui.datepicker-es';
+            url += 'jquery.ui.datepicker-es.js';
+            break;
+        case 'fi': 
+            url += 'jquery.ui.datepicker-fi.js';
+            break;
+        case 'ru':
+            url += 'jquery.ui.datepicker-ru.js';
+            break;
+        case 'ca':
+            url += 'jquery.ui.datepicker-ca.js';
+            break;
+        case 'cmn':
+            url += 'jquery.ui.datepicker-zh-CN.js';
+            break;
+        case 'gl':
+            url += 'jquery.ui.datepicker-gl.js';
+            break;
+        case 'ja':
+            url += 'jquery.ui.datepicker-ja.js';
+            break;
+        case 'da':
+            url += 'jquery.ui.datepicker-da.js';
+            break;
+        case 'pl':
+            url += 'jquery.ui.datepicker-pl.js';
+            break;
+        case 'it':
+            url += 'jquery.ui.datepicker-it.js';
+            break;
+        case 'fa':
+            url += 'jquery.ui.datepicker-fa.js';
+            break;
+        case 'el':
+            url += 'jquery.ui.datepicker-el.js';
+            break;
         default:
             return;
     }

--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -291,66 +291,22 @@ elgg.ui.initDatePicker = function(){
 
 /**
  * Get the jquery i18n locale configuration for datepicker
- * accordingly with the current language set for the system.
+ * according to the current language set for the system.
  * 
  * @param {string} language
  * @returns {void}
  */
-elgg.ui.getLocaleSettings = function(language){
+elgg.ui.getLocaleSettings = function(locale){
     var url = elgg.config.wwwroot + 'vendors/jquery/i18n/';
+
+    var localeMap = {
+        'pt_br': 'pt-BR',
+        'cmn': 'zh-CN',
+    };
     
-    switch(language){
-        case 'pt_br':
-            url += 'jquery.ui.datepicker-pt-BR.js';
-            break;
-        case 'fr':
-            url += 'jquery.ui.datepicker-fr.js';
-            break;
-        case 'nl':
-            url += 'jquery.ui.datepicker-nl.js';
-            break;
-        case 'de':
-            url += 'jquery.ui.datepicker-de.js';
-            break;
-        case 'es':
-            url += 'jquery.ui.datepicker-es.js';
-            break;
-        case 'fi': 
-            url += 'jquery.ui.datepicker-fi.js';
-            break;
-        case 'ru':
-            url += 'jquery.ui.datepicker-ru.js';
-            break;
-        case 'ca':
-            url += 'jquery.ui.datepicker-ca.js';
-            break;
-        case 'cmn':
-            url += 'jquery.ui.datepicker-zh-CN.js';
-            break;
-        case 'gl':
-            url += 'jquery.ui.datepicker-gl.js';
-            break;
-        case 'ja':
-            url += 'jquery.ui.datepicker-ja.js';
-            break;
-        case 'da':
-            url += 'jquery.ui.datepicker-da.js';
-            break;
-        case 'pl':
-            url += 'jquery.ui.datepicker-pl.js';
-            break;
-        case 'it':
-            url += 'jquery.ui.datepicker-it.js';
-            break;
-        case 'fa':
-            url += 'jquery.ui.datepicker-fa.js';
-            break;
-        case 'el':
-            url += 'jquery.ui.datepicker-el.js';
-            break;
-        default:
-            return;
-    }
+    var file = localeMap[locale] || locale;
+
+    url += 'jquery.ui.datepicker-' + file + '.js';
 
     elgg.get({
         url: url,

--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -269,41 +269,58 @@ elgg.ui.loginHandler = function(hook, type, params, options) {
  * @return void
  * @requires jqueryui.datepicker
  */
-elgg.ui.initDatePicker = function() {
-	function loadDatePicker() {
-		$('.elgg-input-date').datepicker({
-			// ISO-8601
-			dateFormat: 'yy-mm-dd',
-			onSelect: function(dateText) {
-				if ($(this).is('.elgg-input-timestamp')) {
-					// convert to unix timestamp
-					var dateParts = dateText.split("-");
-					var timestamp = Date.UTC(dateParts[0], dateParts[1] - 1, dateParts[2]);
-					timestamp = timestamp / 1000;
+elgg.ui.initDatePicker = function(){
+    
+    if(elgg.get_language() !== 'en'){
+        elgg.ui.getLocaleSettings(elgg.get_language());
+    }
 
-					var id = $(this).attr('id');
-					$('input[name="' + id + '"]').val(timestamp);
-				}
-			}
-		});
-	}
+    $('.elgg-input-date').datepicker({
+        onSelect: function(dateText){
+            if($(this).is('.elgg-input-timestamp')){
+                var timestamp = $.datepicker.formatDate("@", new Date(dateText));
 
-	if (!$('.elgg-input-date').length) {
-		return;
-	}
+                //javascript handles time in miliseconds. Timestamp is given in seconds
+                timestamp = timestamp / 1000;
+                var id = $(this).attr('id');
+                $('input[name="' + id + '"]').val(timestamp);
+            }
+        }
+    });
+};
 
-	if (elgg.get_language() == 'en') {
-		loadDatePicker();
-	} else {
-		// load language first
-		elgg.get({
-			url: elgg.config.wwwroot + 'vendors/jquery/i18n/jquery.ui.datepicker-'+ elgg.get_language() +'.js',
-			dataType: "script",
-			cache: true,
-			success: loadDatePicker,
-			error: loadDatePicker // english language is already loaded.
-		});
-	}
+/**
+ * Get the jquery i18n locale configuration for datepicker
+ * accordingly with the current language set for the system.
+ * 
+ * @param {string} language
+ * @returns {void}
+ */
+elgg.ui.getLocaleSettings = function(language){
+    var url = elgg.config.wwwroot + 'vendors/jquery/i18n/';
+    
+    switch(language){
+        case 'pt_br':
+            url += 'jquery.ui.datepicker-pt-BR.js';
+            break;
+        case 'fr':
+            url += 'jquery.ui.datepicker-fr.js';
+            break;
+        case 'nl':
+            url += 'jquery.ui.datepicker-nl.js';
+        case 'de':
+            url += 'jquery.ui.datepicker-de.js';
+        case 'es':
+            url += 'jquery.ui.datepicker-es';
+        default:
+            return;
+    }
+
+    elgg.get({
+        url: url,
+        dataType: "script",
+        cache: true
+    });
 };
 
 /**


### PR DESCRIPTION
As stated in the issue https://github.com/Elgg/Elgg/issues/7476. Also timestamp creation now uses datepicker.parseDate method as a less clumsy way of generating timestamp.
- [ ] Adhere to required commit message format
- [x] Describe how the change was tested
