### PR TITLE
chore(js): Don't use assignment expression value in control flow

### DIFF
--- a/js/lib/elgglib.js
+++ b/js/lib/elgglib.js
@@ -510,7 +510,7 @@ elgg.parse_str = function(string) {
 		re = /([^&=]+)=?([^&]*)/g,
 		re2 = /\[\]$/;
 
-	while (result = re.exec(string)) {
+	for (result = re.exec(string); result; result = re.exec(string)) {
 		key = decodeURIComponent(result[1].replace(/\+/g, ' '));
 		value = decodeURIComponent(result[2].replace(/\+/g, ' '));
 


### PR DESCRIPTION
It's very hard to tell whether it's intentional or a bug, so we avoid it.
