### PR TITLE
feature(webapp): Add support for a basic WebApp Manifest file

### DIFF
--- a/engine/classes/Elgg/Http/WebAppManifestResource.php
+++ b/engine/classes/Elgg/Http/WebAppManifestResource.php
@@ -1,0 +1,43 @@
+<?php
+namespace Elgg\Http;
+
+use ElggSite;
+
+/**
+ * Overview: http://html5doctor.com/web-manifest-specification/
+ * Spec: https://w3c.github.io/manifest/
+ *
+ * Support was added to Chrome 39 and is expected to come to Firefox soon.
+ *
+ * @package    Elgg.Core
+ * @subpackage Http
+ * @since      1.10
+ *
+ * @access private
+ */
+class WebAppManifestResource {
+	/** @var ElggSite */
+	private $site;
+	
+	/**
+	 * Constructor
+	 * 
+	 * @param ElggSite $site The site serving this manifest.
+	 */
+	public function __construct(ElggSite $site) {
+		$this->site = $site;
+	}
+	
+	/**
+	 * Behavior for HTTP GET method
+	 * 
+	 * @return array
+	 */
+	public function get() {
+		return [
+			'display' => 'standalone',
+			'name' => $this->site->getDisplayName(),
+			'start_url' => $this->site->getUrl(),
+		];
+	}
+}

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1900,6 +1900,23 @@ function _elgg_init() {
 	elgg_register_page_handler('css', '_elgg_css_page_handler');
 	elgg_register_page_handler('ajax', '_elgg_ajax_page_handler');
 
+	elgg_register_page_handler('manifest.json', function() {
+		$site = elgg_get_site_entity();
+		$resource = new \Elgg\Http\WebAppManifestResource($site);
+		header('Content-Type: application/json');
+		echo json_encode($resource->get());
+		return true;
+	});
+
+	elgg_register_plugin_hook_handler('head', 'page', function($hook, $type, array $result) {
+		$result['links']['manifest'] = [
+			'rel' => 'manifest',
+			'href' => elgg_normalize_url('/manifest.json'),
+		];
+
+		return $result;
+	});
+
 	elgg_register_js('elgg.autocomplete', 'js/lib/ui.autocomplete.js');
 	elgg_register_js('jquery.ui.autocomplete.html', 'vendors/jquery/jquery.ui.autocomplete.html.js');
 

--- a/engine/tests/phpunit/Elgg/Http/WebAppManifestResourceTest.php
+++ b/engine/tests/phpunit/Elgg/Http/WebAppManifestResourceTest.php
@@ -1,0 +1,18 @@
+<?php
+namespace Elgg\Http;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+class WebAppManifestResourceTest extends TestCase {
+
+	public function testPagesExposeARelManifestLink() {
+		$this->markTestIncomplete();
+		// 1. Load any HTML page (e.g. the homepage)
+		// 2. Find an element matching "link[rel=manifest]"
+		//    - Assert that such an element exists
+		//    - Assert that it has an href value
+		// 3. Fetch the resource at the given href
+		//    - Assert that the resource is a valid web app manifest
+	}
+
+}


### PR DESCRIPTION
Fixes #7493

TODO:
- [x] Choose a component. i.e. `feature(???)`
- [x] Actually register the `init()` callback with Elgg
- [x] Remove the `@flow` annotation
