### PR TITLE
fix(core): getFilenameOnFilestore() returns empty string if an ElggFile ...

### DIFF
--- a/engine/classes/ElggDiskFilestore.php
+++ b/engine/classes/ElggDiskFilestore.php
@@ -215,6 +215,11 @@ class ElggDiskFilestore extends ElggFilestore {
 			throw new InvalidParameterException($msg);
 		}
 
+		$filename = $file->getFilename();
+		if (!$filename) {
+			return '';
+		}
+
 		$dir = new Elgg_EntityDirLocator($owner_guid);
 
 		return $this->dir_root . $dir . $file->getFilename();


### PR DESCRIPTION
...object has no filename set

Fixes #7517.
