### PR TITLE
fix(tests): Allows autoloader to load from tests/phpunit

### DIFF
--- a/engine/tests/phpunit/bootstrap.php
+++ b/engine/tests/phpunit/bootstrap.php
@@ -18,3 +18,5 @@ $CONFIG = (object) array(
 );
 
 require_once "$engine/load.php";
+
+_elgg_services()->autoloadManager->getLoader()->addFallback(__DIR__);


### PR DESCRIPTION
The tests fail on my system due to failing to autoload Elgg\Cache\PoolTestCase, I don't know how they run on Travis.
