### PR TITLE
feature(cache): allows using ints as keys in Cache\Pool

### DIFF
--- a/engine/classes/Elgg/Cache/Pool.php
+++ b/engine/classes/Elgg/Cache/Pool.php
@@ -20,8 +20,8 @@ interface Pool {
 	/**
 	 * Fetches a value from the cache, calculating on miss via $callback.
 	 * 
-	 * @param string   $key      A plain string ID for the cache entry
-	 * @param callable $callback Logic for calculating the cache entry on miss
+	 * @param string|int $key      A plain string ID for the cache entry
+	 * @param callable   $callback Logic for calculating the cache entry on miss
 	 * 
 	 * @return mixed The cache value
 	 */
@@ -34,7 +34,7 @@ interface Pool {
 	 *  * Immediately consider the value stale
 	 *  * Recalculate the value at the next opportunity
 	 * 
-	 * @param string $key A plain string ID for the cache entry to invalidate.
+	 * @param string|int $key A plain string ID for the cache entry to invalidate.
 	 * 
 	 * @return void
 	 */
@@ -47,8 +47,8 @@ interface Pool {
 	 * For example, when a list of rows is fetched from the database, you can
 	 * prime the cache for each individual result.
 	 * 
-	 * @param string $key   A plain string ID for the cache entry
-	 * @param mixed  $value The cache value
+	 * @param string|int $key   A plain string ID for the cache entry
+	 * @param mixed      $value The cache value
 	 * 
 	 * @return void
 	 */

--- a/engine/classes/Elgg/Cache/StashPool.php
+++ b/engine/classes/Elgg/Cache/StashPool.php
@@ -30,9 +30,9 @@ final class StashPool implements Pool {
 
 	/** @inheritDoc */
 	public function get($key, callable $callback) {
-		assert(is_string($key));
+		assert(is_string($key) || is_int($key));
 
-		$item = $this->stash->getItem($key);
+		$item = $this->stash->getItem((string)$key);
 
 		$result = $item->get();
 
@@ -49,16 +49,16 @@ final class StashPool implements Pool {
 
 	/** @inheritDoc */
 	public function invalidate($key) {
-		assert(is_string($key));
+		assert(is_string($key) || is_int($key));
 		
-		$this->stash->getItem($key)->clear();
+		$this->stash->getItem((string)$key)->clear();
 	}
 	
 	/** @inheritDoc */
 	public function put($key, $value) {
-		assert(is_string($key));
+		assert(is_string($key) || is_int($key));
 
-		$this->stash->getItem($key)->set($value);
+		$this->stash->getItem((string)$key)->set($value);
 	}
 	
 	/**

--- a/engine/tests/phpunit/Elgg/Cache/StashPoolTest.php
+++ b/engine/tests/phpunit/Elgg/Cache/StashPoolTest.php
@@ -32,6 +32,52 @@ class StashPoolTest extends TestCase implements PoolTestCase {
 		$this->assertEquals(2, $result);
 	}
 
+	public function testAcceptsStringAndIntKeys() {
+		$pool = StashPool::createEphemeral();
+
+		foreach (array('123', 123) as $key) {
+			$pool->put($key, 'foo');
+			$pool->get($key, function () { return 'foo'; });
+			$pool->invalidate($key);
+		}
+	}
+
+	/**
+	 * @dataProvider invalidKeyProvider
+	 */
+	public function testPutComplainsAboutInvalidKeys($key) {
+		$pool = StashPool::createEphemeral();
+		$this->setExpectedException('PHPUnit_Framework_Error_Warning', 'assert(): Assertion failed');
+		$pool->put($key, 'foo');
+	}
+
+	/**
+	 * @dataProvider invalidKeyProvider
+	 */
+	public function testGetComplainsAboutInvalidKeys($key) {
+		$pool = StashPool::createEphemeral();
+		$this->setExpectedException('PHPUnit_Framework_Error_Warning', 'assert(): Assertion failed');
+		$pool->get($key, function () { return 'foo'; });
+	}
+
+	/**
+	 * @dataProvider invalidKeyProvider
+	 */
+	public function testInvalidateComplainsAboutInvalidKeys($key) {
+		$pool = StashPool::createEphemeral();
+		$this->setExpectedException('PHPUnit_Framework_Error_Warning', 'assert(): Assertion failed');
+		$pool->invalidate($key);
+	}
+
+	public function invalidKeyProvider() {
+		return array(
+			array(123.1),
+			array(true),
+			array(array()),
+			array(new \stdClass()),
+		);
+	}
+
 	/**
 	 * Stash recommends always calling $item->lock() on miss to make sure that
 	 * the caching is as performant as possible by avoiding multiple


### PR DESCRIPTION
Keying based on GUIDs is a common case, we should not require devs to
explicitly cast when using pool. There’s too much risk for errors to
auto-casting floats/bools though.
