### PR TITLE
fix(forms): Login and account forms widened and centered by default

### DIFF
--- a/mod/aalborg_theme/views/default/css/elements/forms.php
+++ b/mod/aalborg_theme/views/default/css/elements/forms.php
@@ -82,7 +82,8 @@ select {
 	margin-bottom: 15px;
 }
 .elgg-form-login, .elgg-form-account {
-	max-width: 450px;
+	max-width: 475px;
+	margin: 0 auto;
 }
 
 /* ***************************************

--- a/views/default/css/elements/forms.php
+++ b/views/default/css/elements/forms.php
@@ -83,7 +83,8 @@ input[type="radio"] {
 }
 
 .elgg-form-login, .elgg-form-account {
-	max-width: 450px;
+	max-width: 475px;
+	margin: 0 auto;
 }
 
 /* ***************************************


### PR DESCRIPTION
Fixes #6456
