### PR TITLE
chore(services): cleanup service provider and remove 5.2 support

### DIFF
--- a/engine/classes/Elgg/Di/DiContainer.php
+++ b/engine/classes/Elgg/Di/DiContainer.php
@@ -37,7 +37,6 @@ class DiContainer {
 	 */
 	protected $cache = array();
 
-	const CLASS_NAME_PATTERN_52 = '/^[a-z_\x7f-\xff][a-z0-9_\x7f-\xff]*$/i';
 	const CLASS_NAME_PATTERN_53 = '/^(\\\\?[a-z_\x7f-\xff][a-z0-9_\x7f-\xff]*)+$/i';
 
 	/**
@@ -134,11 +133,13 @@ class DiContainer {
 	 * @throws \InvalidArgumentException
 	 */
 	public function setClassName($name, $class_name, $shared = true) {
-		$classname_pattern = version_compare(PHP_VERSION, '5.3', '<') ? self::CLASS_NAME_PATTERN_52 : self::CLASS_NAME_PATTERN_53;
+		$classname_pattern = self::CLASS_NAME_PATTERN_53;
 		if (!is_string($class_name) || !preg_match($classname_pattern, $class_name)) {
 			throw new \InvalidArgumentException('Class names must be valid PHP class names');
 		}
-		$func = create_function('', "return new $class_name();");
+		$func = function () use ($class_name) {
+			return new $class_name();
+		};
 		return $this->setFactory($name, $func, $shared);
 	}
 

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -65,109 +65,155 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 
 		$this->setClassName('access', '\Elgg\Access');
 
+		$this->setFactory('accessCache', function(ServiceProvider $c) {
+			return new \ElggStaticVariableCache('access');
+		});
+
 		$this->setFactory('accessCollections', function(ServiceProvider $c) {
 			return new \Elgg\Database\AccessCollections($c->config->get('site_guid'));
 		});
 
 		$this->setClassName('actions', '\Elgg\ActionsService');
+
 		$this->setClassName('adminNotices', '\Elgg\Database\AdminNotices');
-		$this->setFactory('amdConfig', array($this, 'getAmdConfig'));
+
+		$this->setFactory('amdConfig', function(\Elgg\Di\ServiceProvider $c) {
+			$obj = new \Elgg\Amd\Config();
+			$obj->setBaseUrl($c->simpleCache->getRoot() . "js/");
+			return $obj;
+		});
+
 		$this->setClassName('annotations', '\Elgg\Database\Annotations');
+
 		$this->setClassName('autoP', '\ElggAutoP');
+
 		$this->setClassName('config', '\Elgg\Config');
+
 		$this->setClassName('configTable', '\Elgg\Database\ConfigTable');
-		$this->setValue('context', new \Elgg\Context());
+
+		$this->setClassName('context', '\Elgg\Context');
+
 		$this->setClassName('crypto', '\ElggCrypto');
 
-		$this->setFactory('datalist', function(ServiceProvider $c) {
+		$this->setFactory('datalist', function(\Elgg\Di\ServiceProvider $c) {
 			// TODO(ewinslow): Add back memcached support
 			$dbprefix = $c->config->get('dbprefix');
 			return new \Elgg\Database\Datalist(
 				new \Elgg\Cache\MemoryPool(), $c->db, $c->logger, "{$dbprefix}datalists");
 		});
 
-		$this->setFactory('db', array($this, 'getDatabase'));
+		$this->setFactory('db', function(\Elgg\Di\ServiceProvider $c) {
+			global $CONFIG;
+			return new \Elgg\Database(new \Elgg\Database\Config($CONFIG), $c->logger);
+		});
+
 		$this->setClassName('entityTable', '\Elgg\Database\EntityTable');
-		$this->setFactory('events', array($this, 'getEvents'));
+
 		$this->setClassName('externalFiles', '\Elgg\Assets\ExternalFiles');
-		$this->setFactory('hooks', array($this, 'getHooks'));
+
+		$this->setFactory('events', function(\Elgg\Di\ServiceProvider $c) {
+			return $this->resolveLoggerDependencies('events');
+		});
+
+		$this->setFactory('hooks', function(\Elgg\Di\ServiceProvider $c) {
+			return $this->resolveLoggerDependencies('hooks');
+		});
+
 		$this->setClassName('input', 'Elgg\Http\Input');
-		$this->setFactory('logger', array($this, 'getLogger'));
+
+		$this->setFactory('logger', function(\Elgg\Di\ServiceProvider $c) {
+			return $this->resolveLoggerDependencies('logger');
+		});
+
 		$this->setClassName('metadataCache', '\ElggVolatileMetadataCache');
+
 		$this->setFactory('metadataTable', function(ServiceProvider $c) {
 			// TODO(ewinslow): Use Elgg\Cache\Pool instead of MetadataCache
 			return new \Elgg\Database\MetadataTable(
 				$c->metadataCache, $c->db, $c->entityTable,
 				$c->events, $c->metastringsTable, $c->session);
 		});
+
 		$this->setFactory('metastringsTable', function(ServiceProvider $c) {
 			// TODO(ewinslow): Use memcache-based Pool if available...
 			return new \Elgg\Database\MetastringsTable(
 				new \Elgg\Cache\MemoryPool(), $c->db);
 		});
-		$this->setFactory('persistentLogin', array($this, 'getPersistentLogin'));
-		$this->setClassName('plugins', '\Elgg\Database\Plugins');
-		$this->setFactory('ownerPreloader', array($this, 'getOwnerPreloader'));
-		$this->setFactory('queryCounter', array($this, 'getQueryCounter'), false);
-		$this->setFactory('request', array($this, 'getRequest'));
-		$this->setClassName('relationshipsTable', '\Elgg\Database\RelationshipsTable');
-		$this->setFactory('router', array($this, 'getRouter'));
-		$this->setFactory('session', array($this, 'getSession'));
-		$this->setClassName('simpleCache', '\Elgg\Cache\SimpleCache');
-		$this->setClassName('siteSecret', '\Elgg\Database\SiteSecret');
-		$this->setClassName('stickyForms', 'Elgg\Forms\StickyForms');
-		$this->setClassName('subtypeTable', '\Elgg\Database\SubtypeTable');
-		$this->setClassName('systemCache', '\Elgg\Cache\SystemCache');
-		$this->setClassName('translator', '\Elgg\I18n\Translator');
-		$this->setClassName('usersTable', '\Elgg\Database\UsersTable');
-		$this->setFactory('views', array($this, 'getViews'));
-		$this->setClassName('widgets', '\Elgg\WidgetsService');
-		$this->setFactory('notifications', array($this, 'getNotifications'));
 
-		$this->setFactory('accessCache', function(ServiceProvider $c) {
-			return new \ElggStaticVariableCache('access');
+		$this->setFactory('notifications', function(\Elgg\Di\ServiceProvider $c) {
+			// @todo move queue in service provider
+			$queue = new \Elgg\Queue\DatabaseQueue(\Elgg\Notifications\NotificationsService::QUEUE_NAME, $c->db);
+			$sub = new \Elgg\Notifications\SubscriptionsService($c->db);
+			$access = elgg_get_access_object();
+			return new \Elgg\Notifications\NotificationsService($sub, $queue, $c->hooks, $access);
 		});
-	}
 
-	/**
-	 * Database factory
-	 *
-	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
-	 * @return \Elgg\Database
-	 */
-	protected function getDatabase(\Elgg\Di\ServiceProvider $c) {
-		global $CONFIG;
-		return new \Elgg\Database(new \Elgg\Database\Config($CONFIG), $c->logger);
-	}
+		$this->setFactory('ownerPreloader', function(\Elgg\Di\ServiceProvider $c) {
+			return new \Elgg\EntityPreloader(array('owner_guid'));
+		});
 
-	/**
-	 * Events service factory
-	 *
-	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
-	 * @return \Elgg\EventsService
-	 */
-	protected function getEvents(\Elgg\Di\ServiceProvider $c) {
-		return $this->resolveLoggerDependencies('events');
-	}
+		$this->setFactory('persistentLogin', function(\Elgg\Di\ServiceProvider $c) {
+			$cookies_config = _elgg_services()->config->get('cookies');
+			$remember_me_cookies_config = $cookies_config['remember_me'];
+			$cookie_name = $remember_me_cookies_config['name'];
+			$cookie_token = $c->request->cookies->get($cookie_name, '');
+			return new \Elgg\PersistentLoginService($c->db, $c->session, $c->crypto, $remember_me_cookies_config, $cookie_token);
+		});
 
-	/**
-	 * Logger factory
-	 * 
-	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
-	 * @return \Elgg\Logger
-	 */
-	protected function getLogger(\Elgg\Di\ServiceProvider $c) {
-		return $this->resolveLoggerDependencies('logger');
-	}
+		$this->setClassName('plugins', '\Elgg\Database\Plugins');
 
-	/**
-	 * Plugin hooks service factory
-	 *
-	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
-	 * @return \Elgg\PluginHooksService
-	 */
-	protected function getHooks(\Elgg\Di\ServiceProvider $c) {
-		return $this->resolveLoggerDependencies('hooks');
+		$this->setFactory('queryCounter', function(\Elgg\Di\ServiceProvider $c) {
+			return new \Elgg\Database\QueryCounter($c->db);
+		}, false);
+
+		$this->setClassName('relationshipsTable', '\Elgg\Database\RelationshipsTable');
+
+		$this->setFactory('request', '\Elgg\Http\Request::createFromGlobals');
+
+		$this->setFactory('router', function(\Elgg\Di\ServiceProvider $c) {
+			// TODO(evan): Init routes from plugins or cache
+			return new \Elgg\Router($c->hooks);
+		});
+
+		$this->setFactory('session', function(\Elgg\Di\ServiceProvider $c) {
+			global $CONFIG;
+
+			// account for difference of session_get_cookie_params() and ini key names
+			$params = $CONFIG->cookies['session'];
+			foreach ($params as $key => $value) {
+				if (in_array($key, array('path', 'domain', 'secure', 'httponly'))) {
+					$params["cookie_$key"] = $value;
+					unset($params[$key]);
+				}
+			}
+
+			$handler = new \Elgg\Http\DatabaseSessionHandler($c->db);
+			$storage = new \Elgg\Http\NativeSessionStorage($params, $handler);
+			$session = new \ElggSession($storage);
+
+			return $session;
+		});
+
+		$this->setClassName('simpleCache', '\Elgg\Cache\SimpleCache');
+
+		$this->setClassName('siteSecret', '\Elgg\Database\SiteSecret');
+
+		$this->setClassName('stickyForms', 'Elgg\Forms\StickyForms');
+
+		$this->setClassName('subtypeTable', '\Elgg\Database\SubtypeTable');
+
+		$this->setClassName('systemCache', '\Elgg\Cache\SystemCache');
+
+		$this->setClassName('translator', '\Elgg\I18n\Translator');
+
+		$this->setClassName('usersTable', '\Elgg\Database\UsersTable');
+
+		$this->setFactory('views', function(\Elgg\Di\ServiceProvider $c) {
+			return new \Elgg\ViewsService($c->hooks, $c->logger);
+		});
+
+		$this->setClassName('widgets', '\Elgg\WidgetsService');
+
 	}
 
 	/**
@@ -189,120 +235,4 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		}
 		return $svcs[$service_needed];
 	}
-
-	/**
-	 * Views service factory
-	 * 
-	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
-	 * @return \Elgg\ViewsService
-	 */
-	protected function getViews(\Elgg\Di\ServiceProvider $c) {
-		return new \Elgg\ViewsService($c->hooks, $c->logger);
-	}
-
-	/**
-	 * AMD Config factory
-	 * 
-	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
-	 * @return \Elgg\Amd\Config
-	 */
-	protected function getAmdConfig(\Elgg\Di\ServiceProvider $c) {
-		$obj = new \Elgg\Amd\Config();
-		$obj->setBaseUrl(_elgg_get_simplecache_root() . "js/");
-		return $obj;
-	}
-
-	/**
-	 * Session factory
-	 * 
-	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
-	 * @return \ElggSession
-	 */
-	protected function getSession(\Elgg\Di\ServiceProvider $c) {
-		global $CONFIG;
-
-		// account for difference of session_get_cookie_params() and ini key names
-		$params = $CONFIG->cookies['session'];
-		foreach ($params as $key => $value) {
-			if (in_array($key, array('path', 'domain', 'secure', 'httponly'))) {
-				$params["cookie_$key"] = $value;
-				unset($params[$key]);
-			}
-		}
-
-		$handler = new \Elgg\Http\DatabaseSessionHandler($c->db);
-		$storage = new \Elgg\Http\NativeSessionStorage($params, $handler);
-		$session = new \ElggSession($storage);
-
-		return $session;
-	}
-
-	/**
-	 * Request factory
-	 * 
-	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
-	 * @return \Elgg\Http\Request
-	 */
-	protected function getRequest(\Elgg\Di\ServiceProvider $c) {
-		return \Elgg\Http\Request::createFromGlobals();
-	}
-
-	/**
-	 * Router factory
-	 * 
-	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
-	 * @return \Elgg\Router
-	 */
-	protected function getRouter(\Elgg\Di\ServiceProvider $c) {
-		// TODO(evan): Init routes from plugins or cache
-		return new \Elgg\Router($c->hooks);
-	}
-
-	/**
-	 * Notification service factory
-	 * 
-	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
-	 * @return \Elgg\Notifications\NotificationsService
-	 */
-	protected function getNotifications(\Elgg\Di\ServiceProvider $c) {
-		// @todo move queue in service provider
-		$queue = new \Elgg\Queue\DatabaseQueue(\Elgg\Notifications\NotificationsService::QUEUE_NAME, $c->db);
-		$sub = new \Elgg\Notifications\SubscriptionsService($c->db);
-		return new \Elgg\Notifications\NotificationsService($sub, $queue, $c->hooks, $c->access);
-	}
-
-	/**
-	 * Persistent login service factory
-	 *
-	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
-	 * @return \Elgg\PersistentLoginService
-	 */
-	protected function getPersistentLogin(\Elgg\Di\ServiceProvider $c) {
-		$cookies_config = _elgg_services()->config->get('cookies');
-		$remember_me_cookies_config = $cookies_config['remember_me'];
-		$cookie_name = $remember_me_cookies_config['name'];
-		$cookie_token = $c->request->cookies->get($cookie_name, '');
-		return new \Elgg\PersistentLoginService($c->db, $c->session, $c->crypto, $remember_me_cookies_config, $cookie_token);
-	}
-
-	/**
-	 * Owner preloader factory
-	 *
-	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
-	 * @return \Elgg\EntityPreloader
-	 */
-	protected function getOwnerPreloader(\Elgg\Di\ServiceProvider $c) {
-		return new \Elgg\EntityPreloader(array('owner_guid'));
-	}
-
-	/**
-	 * Query counter factory
-	 *
-	 * @param \Elgg\Di\ServiceProvider $c Dependency injection container
-	 * @return \Elgg\Database\QueryCounter
-	 */
-	protected function getQueryCounter(\Elgg\Di\ServiceProvider $c) {
-		return new \Elgg\Database\QueryCounter($c->db);
-	}
 }
-


### PR DESCRIPTION
This removes uses of create_function() and moves all SP factories inline and orders the declarations more cleanly (IMO).
