### PR TITLE
Point all the badges at proper branch for 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Elgg [![Build Status](https://secure.travis-ci.org/Elgg/Elgg.png?branch=master)](https://travis-ci.org/Elgg/Elgg) [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/Elgg/Elgg/badges/quality-score.png?s=ef3560cf83f4fd1ae3abbd6e93c20e5b4832c343)](https://scrutinizer-ci.com/g/Elgg/Elgg/)
+Elgg [![Build Status](https://secure.travis-ci.org/Elgg/Elgg.png?branch=master)](https://travis-ci.org/Elgg/Elgg) [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/Elgg/Elgg/badges/quality-score.png?s=ef3560cf83f4fd1ae3abbd6e93c20e5b4832c343)](https://scrutinizer-ci.com/g/Elgg/Elgg/)  [![Read the docs build status](https://readthedocs.org/projects/elgg/badge/?version=1.9)](http://learn.elgg.org/en/1.9/)
 ====
 
 Copyright (c) 2008-2014, see COPYRIGHT.txt

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Elgg [![Build Status](https://secure.travis-ci.org/Elgg/Elgg.png?branch=master)](https://travis-ci.org/Elgg/Elgg) [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/Elgg/Elgg/badges/quality-score.png?s=ef3560cf83f4fd1ae3abbd6e93c20e5b4832c343)](https://scrutinizer-ci.com/g/Elgg/Elgg/)  [![Read the docs build status](https://readthedocs.org/projects/elgg/badge/?version=1.9)](http://learn.elgg.org/en/1.9/)
+Elgg [![Build Status](https://secure.travis-ci.org/Elgg/Elgg.svg?branch=1.9)](https://travis-ci.org/Elgg/Elgg) [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/Elgg/Elgg/badges/quality-score.png?s=1.9)](https://scrutinizer-ci.com/g/Elgg/Elgg/?branch=1.9) [![Scrutinizer Code Coverage](https://scrutinizer-ci.com/g/Elgg/Elgg/badges/coverage.png?b=1.9)](https://scrutinizer-ci.com/g/Elgg/Elgg/?branch=1.9) [![Read the docs build status](https://readthedocs.org/projects/elgg/badge/?version=1.9)](http://learn.elgg.org/en/1.9/)
 ====
 
 Copyright (c) 2008-2014, see COPYRIGHT.txt


### PR DESCRIPTION
That mostly matters for scrutinizer code coverage that varies a lot between branches as well as for the readthedocs build statuses. Unfortunately it only seems to take html build into account and doesn't indicate pdf build failures which I hoped for.

It looks like we should remember to update branches for current bugfix, 1.x and master to keep badges in context. Readthedocs pretty much gives away configured branch. I don't think we have checklist on creating new branches, so nothing to update at the moment.
