### PR TITLE
fix(core): deprecation notices thrown at login/logout even if there's no...

### DIFF
--- a/engine/classes/Elgg/EventsService.php
+++ b/engine/classes/Elgg/EventsService.php
@@ -29,7 +29,7 @@ class Elgg_EventsService extends Elgg_HooksRegistrationService {
 			self::OPTION_DEPRECATION_VERSION => '',
 		), $options);
 
-		$events = $this->getOrderedHandlers($event, $type);
+		$events = $this->hasHandler($event, $type);
 		if ($events && $options[self::OPTION_DEPRECATION_MESSAGE]) {
 			elgg_deprecated_notice(
 				$options[self::OPTION_DEPRECATION_MESSAGE],
@@ -38,6 +38,7 @@ class Elgg_EventsService extends Elgg_HooksRegistrationService {
 			);
 		}
 
+		$events = $this->getOrderedHandlers($event, $type);
 		$args = array($event, $type, $object);
 
 		foreach ($events as $callback) {


### PR DESCRIPTION
... valid reason

Stops the wrongly thrown deprecated notices at login/logout for supposed deprecated usage of ['login', 'user'] and ['logout', 'user'] events even if there are no handlers registered for these deprecated events as mentioned in #6493.
