### PR TITLE
deprecate(access): deprecates elgg_get_access_object() and refactors access lib

### DIFF
--- a/engine/classes/Elgg/Access.php
+++ b/engine/classes/Elgg/Access.php
@@ -63,6 +63,8 @@ class Access {
 	 * @return bool Previous setting
 	 */
 	public function setIgnoreAccess($ignore = true) {
+		_elgg_services()->accessCache->clear();
+
 		$prev = $this->ignore_access;
 		$this->ignore_access = $ignore;
 

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -7,7 +7,10 @@ namespace Elgg\Di;
  * We extend the container because it allows us to document properties in the PhpDoc, which assists
  * IDEs to auto-complete properties and understand the types returned. Extension allows us to keep
  * the container generic.
- * 
+ *
+ * @property-read \Elgg\Access                             $access
+ * @property-read \Elgg\Database\AccessCollections         $accessCollections
+ * @property-read \ElggStaticVariableCache                 $accessCache
  * @property-read \Elgg\ActionsService                     $actions
  * @property-read \Elgg\Database\AdminNotices              $adminNotices
  * @property-read \Elgg\Amd\Config                         $amdConfig
@@ -60,7 +63,12 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 	public function __construct(\Elgg\AutoloadManager $autoload_manager) {
 		$this->setValue('autoloadManager', $autoload_manager);
 
-		$this->setClassName('accessCollections', '\Elgg\Database\AccessCollections');
+		$this->setClassName('access', '\Elgg\Access');
+
+		$this->setFactory('accessCollections', function(ServiceProvider $c) {
+			return new \Elgg\Database\AccessCollections($c->config->get('site_guid'));
+		});
+
 		$this->setClassName('actions', '\Elgg\ActionsService');
 		$this->setClassName('adminNotices', '\Elgg\Database\AdminNotices');
 		$this->setFactory('amdConfig', array($this, 'getAmdConfig'));
@@ -106,6 +114,10 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setFactory('views', array($this, 'getViews'));
 		$this->setClassName('widgets', '\Elgg\WidgetsService');
 		$this->setFactory('notifications', array($this, 'getNotifications'));
+
+		$this->setFactory('accessCache', function(ServiceProvider $c) {
+			return new \ElggStaticVariableCache('access');
+		});
 	}
 
 	/**
@@ -247,8 +259,7 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		// @todo move queue in service provider
 		$queue = new \Elgg\Queue\DatabaseQueue(\Elgg\Notifications\NotificationsService::QUEUE_NAME, $c->db);
 		$sub = new \Elgg\Notifications\SubscriptionsService($c->db);
-		$access = elgg_get_access_object();
-		return new \Elgg\Notifications\NotificationsService($sub, $queue, $c->hooks, $access);
+		return new \Elgg\Notifications\NotificationsService($sub, $queue, $c->hooks, $c->access);
 	}
 
 	/**

--- a/engine/lib/access.php
+++ b/engine/lib/access.php
@@ -41,10 +41,7 @@
  * @see elgg_get_ignore_access()
  */
 function elgg_set_ignore_access($ignore = true) {
-	$cache = _elgg_get_access_cache();
-	$cache->clear();
-	$elgg_access = elgg_get_access_object();
-	return $elgg_access->setIgnoreAccess($ignore);
+	return _elgg_services()->access->setIgnoreAccess($ignore);
 }
 
 /**
@@ -55,27 +52,7 @@ function elgg_set_ignore_access($ignore = true) {
  * @see elgg_set_ignore_access()
  */
 function elgg_get_ignore_access() {
-	return elgg_get_access_object()->getIgnoreAccess();
-}
-
-/**
- * Return an \ElggCache static variable cache for the access caches
- *
- * @staticvar \ElggStaticVariableCache $access_cache
- * @return \ElggStaticVariableCache
- * @access private
- */
-function _elgg_get_access_cache() {
-	/**
-	 * A default filestore cache using the dataroot.
-	 */
-	static $access_cache;
-
-	if (!$access_cache) {
-		$access_cache = new \ElggStaticVariableCache('access');
-	}
-
-	return $access_cache;
+	return _elgg_services()->access->getIgnoreAccess();
 }
 
 /**
@@ -522,7 +499,7 @@ function get_readable_access_level($entity_access_id) {
 
 	// Entity access id is a custom access collection
 	// Check if the user has write access to it and can see it's label
-	$write_access_array = get_write_access_array();
+	$write_access_array = _elgg_services()->accessCollections->getWriteAccessArray();
 
 	if (array_key_exists($access, $write_access_array)) {
 		return $write_access_array[$access];
@@ -554,27 +531,7 @@ function elgg_check_access_overrides($user_guid = 0) {
 		$is_admin = elgg_is_admin_user($user_guid);
 	}
 
-	return ($is_admin || elgg_get_ignore_access());
-}
-
-/**
- * Returns the \Elgg\Access object.
- *
- * // @todo comment is incomplete
- * This is used to
- *
- * @return \Elgg\Access
- * @since 1.7.0
- * @access private
- */
-function elgg_get_access_object() {
-	static $elgg_access;
-
-	if (!$elgg_access) {
-		$elgg_access = new \Elgg\Access();
-	}
-
-	return $elgg_access;
+	return ($is_admin || _elgg_services()->access->getIgnoreAccess());
 }
 
 /**

--- a/engine/lib/deprecated-1.10.php
+++ b/engine/lib/deprecated-1.10.php
@@ -25,3 +25,16 @@ function file_get_general_file_type($mime_type) {
 	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use elgg_get_file_simple_type()', '1.10');
 	return elgg_get_file_simple_type($mime_type);
 }
+
+/**
+ * Returns the \Elgg\Access object.
+ *
+ * @return \Elgg\Access
+ * @since 1.7.0
+ * @access private
+ * @deprecated 1.10 Use elgg_get_ignore_access or elgg_set_ignore_access
+ */
+function elgg_get_access_object() {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use elgg_get/set_ignore_access()', '1.10');
+	return _elgg_services()->access;
+}

--- a/engine/tests/ElggCoreAccessCollectionsTest.php
+++ b/engine/tests/ElggCoreAccessCollectionsTest.php
@@ -260,8 +260,7 @@ class ElggCoreAccessCollectionsTest extends \ElggCoreUnitTest {
 		$user->save();
 
 		foreach (array('get_access_list', 'get_access_array') as $func) {
-			$cache = _elgg_get_access_cache();
-			$cache->clear();
+			_elgg_services()->accessCache->clear();
 
 			// admin users run tests, so disable access
 			elgg_set_ignore_access(true);

--- a/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
+++ b/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
@@ -10,6 +10,8 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
 		$sp = new \Elgg\Di\ServiceProvider($mgr);
 
 		$svcClasses = array(
+			'access' => '\Elgg\Access',
+			'accessCache' => '\ElggStaticVariableCache',
 			'accessCollections' => '\Elgg\Database\AccessCollections',
 			'actions' => '\Elgg\ActionsService',
 			'adminNotices' => '\Elgg\Database\AdminNotices',

--- a/engine/tests/phpunit/bootstrap.php
+++ b/engine/tests/phpunit/bootstrap.php
@@ -15,6 +15,7 @@ $CONFIG = (object) array(
 	'dbprefix' => 'elgg_',
 	'boot_complete' => false,
 	'wwwroot' => 'http://localhost/',
+	'site_guid' => 1,
 );
 
 require_once "$engine/load.php";


### PR DESCRIPTION
This moves the access object and access cache to be served from the service
provider, and refactors AccessCollections to remove the need for $CONFIG.
