### PR TITLE
fix(profile): adds the prepare hook for the profile page’s owner menu

### DIFF
--- a/mod/profile/views/default/profile/owner_block.php
+++ b/mod/profile/views/default/profile/owner_block.php
@@ -21,6 +21,13 @@ $icon = elgg_view_entity_icon($user, 'large', array(
 $menu = elgg_trigger_plugin_hook('register', "menu:user_hover", array('entity' => $user), array());
 $builder = new ElggMenuBuilder($menu);
 $menu = $builder->getMenu();
+$menu = elgg_trigger_plugin_hook('prepare', "menu:user_hover", array(
+	'menu' => $menu,
+	'entity' => $user,
+	'username' => $user->username,
+	'name' => 'user_hover',
+), $menu);
+
 $actions = elgg_extract('action', $menu, array());
 $admin = elgg_extract('admin', $menu, array());
 


### PR DESCRIPTION
In 4c94f8809f1131e2d8e073518195b6b65b26aceb the prepare hook was added to elgg_view_menu, but in the manual rendering on the profile page this hook was forgotten. This adds it so plugins can reorder/alter the profile page menus.

Fixes #6085

This has some BC implications. Currently handlers for the (prepare, menu:user_hover) are _not_ called to build the profile page and with this they would be. So this "fix" could have unexpected (and unwanted) results.
