### PR TITLE
security(passwords): switches password hashing to password_hash()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "ext-xml": "*",
         "mrclay/minify": "2.*",
         "knplabs/gaufrette": "0.1.*",
-        "tedivm/stash": "~0.12"
+        "tedivm/stash": "~0.12",
+        "ircmaxell/password-compat": "1.*"
     },
     "suggest": {
         "ext-mbstring": "*"

--- a/engine/classes/Elgg/Database/UsersTable.php
+++ b/engine/classes/Elgg/Database/UsersTable.php
@@ -239,20 +239,9 @@ class UsersTable {
 	 * @return \ElggUser|false
 	 */
 	function get($guid) {
-		// Fixes "Exception thrown without stack frame" when db_select fails
-		if (!empty($guid)) {
-			$result = get_entity($guid);
-		}
-	
-		if ((!empty($result)) && (!($result instanceof \ElggUser))) {
-			return false;
-		}
-	
-		if (!empty($result)) {
-			return $result;
-		}
-	
-		return false;
+		$result = _elgg_services()->entityTable->get($guid);
+
+		return ($result instanceof \ElggUser) ? $result : false;
 	}
 	
 	/**
@@ -383,135 +372,7 @@ class UsersTable {
 			'order_by' => "u.last_action desc",
 		));
 	}
-	
-	/**
-	 * Generate and send a password request email to a given user's registered email address.
-	 *
-	 * @param int $user_guid User GUID
-	 *
-	 * @return bool
-	 */
-	function sendNewPasswordRequest($user_guid) {
-		$user_guid = (int)$user_guid;
-	
-		$user = get_entity($user_guid);
-		if ($user instanceof \ElggUser) {
-			// generate code
-			$code = generate_random_cleartext_password();
-			$user->setPrivateSetting('passwd_conf_code', $code);
-			$user->setPrivateSetting('passwd_conf_time', time());
-	
-			// generate link
-			$link = _elgg_services()->config->getSiteUrl() . "changepassword?u=$user_guid&c=$code";
-	
-			// generate email
-			$ip_address = _elgg_services()->request->getClientIp();
-			$email = _elgg_services()->translator->translate('email:changereq:body', array($user->name, $ip_address, $link));
-	
-			return notify_user($user->guid, elgg_get_site_entity()->guid,
-				_elgg_services()->translator->translate('email:changereq:subject'), $email, array(), 'email');
-		}
-	
-		return false;
-	}
-	
-	/**
-	 * Low level function to reset a given user's password.
-	 *
-	 * This can only be called from execute_new_password_request().
-	 *
-	 * @param int    $user_guid The user.
-	 * @param string $password  Text (which will then be converted into a hash and stored)
-	 *
-	 * @return bool
-	 */
-	function forcePasswordReset($user_guid, $password) {
-		$user = get_entity($user_guid);
-		if ($user instanceof \ElggUser) {
-			$ia = elgg_set_ignore_access();
-	
-			$user->salt = _elgg_generate_password_salt();
-			$hash = generate_user_password($user, $password);
-			$user->password = $hash;
-			$result = (bool)$user->save();
-	
-			elgg_set_ignore_access($ia);
-	
-			return $result;
-		}
-	
-		return false;
-	}
-	
-	/**
-	 * Validate and change password for a user.
-	 *
-	 * @param int    $user_guid The user id
-	 * @param string $conf_code Confirmation code as sent in the request email.
-	 * @param string $password  Optional new password, if not randomly generated.
-	 *
-	 * @return bool True on success
-	 */
-	function executeNewPasswordReset($user_guid, $conf_code, $password = null) {
-	
-		$user_guid = (int)$user_guid;
-		$user = get_entity($user_guid);
-	
-		if ($password === null) {
-			$password = generate_random_cleartext_password();
-			$reset = true;
-		}
-	
-		if (!elgg_instanceof($user, 'user')) {
-			return false;
-		}
-	
-		$saved_code = $user->getPrivateSetting('passwd_conf_code');
-		$code_time = (int) $user->getPrivateSetting('passwd_conf_time');
-	
-		if (!$saved_code || $saved_code != $conf_code) {
-			return false;
-		}
-	
-		// Discard for security if it is 24h old
-		if (!$code_time || $code_time < time() - 24 * 60 * 60) {
-			return false;
-		}
-	
-		if (force_user_password_reset($user_guid, $password)) {
-			remove_private_setting($user_guid, 'passwd_conf_code');
-			remove_private_setting($user_guid, 'passwd_conf_time');
-			// clean the logins failures
-			reset_login_failure_count($user_guid);
-	
-			$ns = $reset ? 'resetpassword' : 'changepassword';
-	
-			notify_user($user->guid,
-				elgg_get_site_entity()->guid,
-				_elgg_services()->translator->translate("email:$ns:subject"),
-				_elgg_services()->translator->translate("email:$ns:body", array($user->username, $password)),
-				array(),
-				'email'
-			);
-	
-			return true;
-		}
-	
-		return false;
-	}
-	
-	/**
-	 * Hash a password for storage. Currently salted MD5.
-	 *
-	 * @param \ElggUser $user     The user this is being generated for.
-	 * @param string    $password Password in clear text
-	 *
-	 * @return string
-	 */
-	function generatePassword(\ElggUser $user, $password) {
-		return md5($password . $user->salt);
-	}
-	
+
 	/**
 	 * Registers a user, returning false if the username already exists
 	 *
@@ -523,7 +384,7 @@ class UsersTable {
 	 *                                      registered multiple times?
 	 *
 	 * @return int|false The new user's GUID; false on failure
-	 * @throws RegistrationException
+	 * @throws \RegistrationException
 	 */
 	function register($username, $password, $name, $email, $allow_multiple_emails = false) {
 	
@@ -539,7 +400,7 @@ class UsersTable {
 				|| empty($email)) {
 			return false;
 		}
-	
+
 		// Make sure a user with conflicting details hasn't registered and been disabled
 		$access_status = access_get_show_hidden_status();
 		access_show_hidden_entities(true);
@@ -572,8 +433,7 @@ class UsersTable {
 		$user->email = $email;
 		$user->name = $name;
 		$user->access_id = ACCESS_PUBLIC;
-		$user->salt = _elgg_generate_password_salt();
-		$user->password = generate_user_password($user, $password);
+		$user->setPassword($password);
 		$user->owner_guid = 0; // Users aren't owned by anyone, even if they are admin created.
 		$user->container_guid = 0; // Users aren't contained by anyone, even if they are admin created.
 		$user->language = _elgg_services()->translator->getCurrentLanguage();

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -33,6 +33,7 @@ namespace Elgg\Di;
  * @property-read \Elgg\Database\MetastringsTable          $metastringsTable
  * @property-read \Elgg\Notifications\NotificationsService $notifications
  * @property-read \Elgg\EntityPreloader                    $ownerPreloader
+ * @property-read \Elgg\PasswordService                    $passwords
  * @property-read \Elgg\PersistentLoginService             $persistentLogin
  * @property-read \Elgg\Database\Plugins                   $plugins
  * @property-read \Elgg\Database\QueryCounter              $queryCounter
@@ -160,6 +161,14 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			$cookie_token = $c->request->cookies->get($cookie_name, '');
 			return new \Elgg\PersistentLoginService(
 				$c->db, $c->session, $c->crypto, $cookie_config, $cookie_token);
+		});
+
+		$this->setFactory('passwords', function (ServiceProvider $c) {
+			if (!function_exists('password_hash')) {
+				$root = $c->config->getRootPath();
+				require "{$root}vendor/ircmaxell/password-compat/lib/password.php";
+			}
+			return new \Elgg\PasswordService();
 		});
 
 		$this->setClassName('plugins', '\Elgg\Database\Plugins');

--- a/engine/classes/Elgg/PasswordService.php
+++ b/engine/classes/Elgg/PasswordService.php
@@ -1,0 +1,185 @@
+<?php
+namespace Elgg;
+
+/**
+ * PRIVATE CLASS. API IN FLUX. DO NOT USE DIRECTLY.
+ * 
+ * @package Elgg.Core
+ * @access  private
+ * @since   1.10.0
+ */
+final class PasswordService {
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		if (!function_exists('password_hash')) {
+			throw new \RuntimeException("password_hash and associated functions are required.");
+		}
+	}
+
+	/**
+	 * Determine if the password hash needs to be rehashed
+	 *
+	 * If the answer is true, after validating the password using password_verify, rehash it.
+	 *
+	 * @param string $hash The hash to test
+	 *
+	 * @return boolean True if the password needs to be rehashed.
+	 */
+	function needsRehash($hash) {
+		return password_needs_rehash($hash, PASSWORD_DEFAULT);
+	}
+
+	/**
+	 * Verify a password against a hash using a timing attack resistant approach
+	 *
+	 * @param string $password The password to verify
+	 * @param string $hash     The hash to verify against
+	 *
+	 * @return boolean If the password matches the hash
+	 */
+	function verify($password, $hash) {
+		return password_verify($password, $hash);
+	}
+
+	/**
+	 * Hash a password for storage using password_hash()
+	 *
+	 * @param string $password Password in clear text
+	 *
+	 * @return string
+	 */
+	function generateHash($password) {
+		return password_hash($password, PASSWORD_DEFAULT);
+	}
+
+	/**
+	 * Hash a password for storage. Currently salted MD5.
+	 *
+	 * @param \ElggUser $user     The user this is being generated for.
+	 * @param string    $password Password in clear text
+	 *
+	 * @return string
+	 */
+	function generateLegacyHash(\ElggUser $user, $password) {
+		return md5($password . $user->salt);
+	}
+
+	/**
+	 * Generate and send a password request email to a given user's registered email address.
+	 *
+	 * @param int $user_guid User GUID
+	 *
+	 * @return bool
+	 */
+	function sendNewPasswordRequest($user_guid) {
+		$user_guid = (int)$user_guid;
+
+		$user = _elgg_services()->entityTable->get($user_guid);
+		if (!$user instanceof \ElggUser) {
+			return false;
+		}
+
+		// generate code
+		$code = generate_random_cleartext_password();
+		$user->setPrivateSetting('passwd_conf_code', $code);
+		$user->setPrivateSetting('passwd_conf_time', time());
+
+		// generate link
+		$link = _elgg_services()->config->getSiteUrl() . "changepassword?u=$user_guid&c=$code";
+
+		// generate email
+		$ip_address = _elgg_services()->request->getClientIp();
+		$message = _elgg_services()->translator->translate(
+			'email:changereq:body', array($user->name, $ip_address, $link), $user->language);
+		$subject = _elgg_services()->translator->translate(
+			'email:changereq:subject', array(), $user->language);
+
+		return notify_user($user->guid, elgg_get_site_entity()->guid, $subject, $message, array(), 'email');
+	}
+
+	/**
+	 * Set a user's new password and save the entity.
+	 *
+	 * This can only be called from execute_new_password_request().
+	 *
+	 * @param \ElggUser|int $user     The user GUID or entity
+	 * @param string        $password Text (which will then be converted into a hash and stored)
+	 *
+	 * @return bool
+	 */
+	function forcePasswordReset($user, $password) {
+		if (!$user instanceof \ElggUser) {
+			$user = _elgg_services()->usersTable->get($user);
+			if (!$user) {
+				return false;
+			}
+		}
+
+		$user->setPassword($password);
+
+		$ia = elgg_set_ignore_access(true);
+		$result = (bool)$user->save();
+		elgg_set_ignore_access($ia);
+
+		return $result;
+	}
+
+	/**
+	 * Validate and change password for a user.
+	 *
+	 * @param int    $user_guid The user id
+	 * @param string $conf_code Confirmation code as sent in the request email.
+	 * @param string $password  Optional new password, if not randomly generated.
+	 *
+	 * @return bool True on success
+	 */
+	function executeNewPasswordReset($user_guid, $conf_code, $password = null) {
+		$user_guid = (int)$user_guid;
+		$user = get_entity($user_guid);
+
+		if ($password === null) {
+			$password = generate_random_cleartext_password();
+			$reset = true;
+		} else {
+			$reset = false;
+		}
+
+		if (!$user instanceof \ElggUser) {
+			return false;
+		}
+
+		$saved_code = $user->getPrivateSetting('passwd_conf_code');
+		$code_time = (int) $user->getPrivateSetting('passwd_conf_time');
+
+		if (!$saved_code || $saved_code != $conf_code) {
+			return false;
+		}
+
+		// Discard for security if it is 24h old
+		if (!$code_time || $code_time < time() - 24 * 60 * 60) {
+			return false;
+		}
+
+		if (!$this->forcePasswordReset($user, $password)) {
+			return false;
+		}
+
+		remove_private_setting($user_guid, 'passwd_conf_code');
+		remove_private_setting($user_guid, 'passwd_conf_time');
+		// clean the logins failures
+		reset_login_failure_count($user_guid);
+
+		$ns = $reset ? 'resetpassword' : 'changepassword';
+
+		$message = _elgg_services()->translator->translate(
+			"email:$ns:body", array($user->username, $password), $user->language);
+		$subject = _elgg_services()->translator->translate("email:$ns:subject", array(), $user->language);
+
+		notify_user($user->guid, elgg_get_site_entity()->guid, $subject, $message, array(), 'email');
+
+		return true;
+	}
+}

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -7,14 +7,15 @@
  * @package    Elgg.Core
  * @subpackage DataModel.User
  * 
- * @property string $name     The display name that the user will be known by in the network
- * @property string $username The short, reference name for the user in the network
- * @property string $email    The email address to which Elgg will send email notifications
- * @property string $language The language preference of the user (ISO 639-1 formatted)
- * @property string $banned   'yes' if the user is banned from the network, 'no' otherwise
- * @property string $admin    'yes' if the user is an administrator of the network, 'no' otherwise
- * @property string $password The hashed password of the user
- * @property string $salt     The salt used to secure the password before hashing
+ * @property      string $name          The display name that the user will be known by in the network
+ * @property      string $username      The short, reference name for the user in the network
+ * @property      string $email         The email address to which Elgg will send email notifications
+ * @property      string $language      The language preference of the user (ISO 639-1 formatted)
+ * @property      string $banned        'yes' if the user is banned from the network, 'no' otherwise
+ * @property      string $admin         'yes' if the user is an administrator of the network, 'no' otherwise
+ * @property-read string $password      The legacy (salted MD5) password hash of the user
+ * @property-read string $salt          The salt used to create the legacy password hash
+ * @property-read string $password_hash The hashed password of the user
  */
 class ElggUser extends \ElggEntity
 	implements Friendable {
@@ -33,6 +34,7 @@ class ElggUser extends \ElggEntity
 		$this->attributes['username'] = null;
 		$this->attributes['password'] = null;
 		$this->attributes['salt'] = null;
+		$this->attributes['password_hash'] = null;
 		$this->attributes['email'] = null;
 		$this->attributes['language'] = null;
 		$this->attributes['banned'] = "no";
@@ -130,12 +132,13 @@ class ElggUser extends \ElggEntity
 		$username = sanitize_string($this->username);
 		$password = sanitize_string($this->password);
 		$salt = sanitize_string($this->salt);
+		$password_hash = sanitize_string($this->password_hash);
 		$email = sanitize_string($this->email);
 		$language = sanitize_string($this->language);
 
 		$query = "INSERT into {$CONFIG->dbprefix}users_entity
-			(guid, name, username, password, salt, email, language)
-			values ($guid, '$name', '$username', '$password', '$salt', '$email', '$language')";
+			(guid, name, username, password, salt, password_hash, email, language)
+			values ($guid, '$name', '$username', '$password', '$salt', '$password_hash', '$email', '$language')";
 
 		$result = $this->getDatabase()->insertData($query);
 		if ($result === false) {
@@ -161,12 +164,13 @@ class ElggUser extends \ElggEntity
 		$username = sanitize_string($this->username);
 		$password = sanitize_string($this->password);
 		$salt = sanitize_string($this->salt);
+		$password_hash = sanitize_string($this->password_hash);
 		$email = sanitize_string($this->email);
 		$language = sanitize_string($this->language);
 
 		$query = "UPDATE {$CONFIG->dbprefix}users_entity
 			SET name='$name', username='$username', password='$password', salt='$salt',
-			email='$email', language='$language'
+			password_hash='$password_hash', email='$email', language='$language'
 			WHERE guid = $guid";
 
 		return $this->getDatabase()->updateData($query) !== false;
@@ -209,23 +213,41 @@ class ElggUser extends \ElggEntity
 	 * {@inheritdoc}
 	 */
 	public function __set($name, $value) {
-		if (array_key_exists($name, $this->attributes)) {
-			switch ($name) {
-				case 'prev_last_action':
-				case 'last_login':
-				case 'prev_last_login':
-					if ($value !== null) {
-						$this->attributes[$name] = (int)$value;
-					} else {
-						$this->attributes[$name] = null;
-					}
-					break;
-				default:
-					parent::__set($name, $value);
-					break;
-			}
-		} else {
+		if (!array_key_exists($name, $this->attributes)) {
 			parent::__set($name, $value);
+			return;
+		}
+
+		switch ($name) {
+			case 'prev_last_action':
+			case 'last_login':
+			case 'prev_last_login':
+				if ($value !== null) {
+					$this->attributes[$name] = (int)$value;
+				} else {
+					$this->attributes[$name] = null;
+				}
+				break;
+
+			case 'salt':
+			case 'password':
+				elgg_deprecated_notice("Setting salt/password directly is deprecated. Use ElggUser::setPassword().", "1.10");
+				$this->attributes[$name] = $value;
+
+				// this is emptied so that the user is not left with two usable hashes
+				$this->attributes['password_hash'] = '';
+
+				break;
+
+			// setting this not supported
+			case 'password_hash':
+				_elgg_services()->logger->error("password_hash is now an attribute of ElggUser and cannot be set.");
+				return;
+				break;
+
+			default:
+				parent::__set($name, $value);
+				break;
 		}
 	}
 
@@ -759,5 +781,21 @@ class ElggUser extends \ElggEntity
 			return $result;
 		}
 		return false;
+	}
+
+	/**
+	 * Set the necessary attributes to store a hash of the user's password. Also removes
+	 * the legacy hash/salt values.
+	 *
+	 * @tip You must save() to persist the attributes
+	 *
+	 * @param string $password The password to be hashed
+	 * @return void
+	 * @since 1.10.0
+	 */
+	public function setPassword($password) {
+		$this->attributes['salt'] = "";
+		$this->attributes['password'] = "";
+		$this->attributes['password_hash'] = _elgg_services()->passwords->generateHash($password);
 	}
 }

--- a/engine/lib/deprecated-1.10.php
+++ b/engine/lib/deprecated-1.10.php
@@ -38,3 +38,18 @@ function elgg_get_access_object() {
 	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use elgg_get/set_ignore_access()', '1.10');
 	return _elgg_services()->access;
 }
+
+/**
+ * Create a legacy password hash (salted MD5).
+ *
+ * @param \ElggUser $user     The user this is being generated for.
+ * @param string    $password Password in clear text
+ *
+ * @return string
+ * @access private
+ * @deprecated 1.10.0 The password hashing API is not public
+ */
+function generate_user_password(\ElggUser $user, $password) {
+	elgg_deprecated_notice(__FUNCTION__ . " is deprecated and will not be replaced.", "1.10");
+	return _elgg_services()->passwords->generateLegacyHash($user, $password);
+}

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -163,16 +163,37 @@ function pam_auth_userpass(array $credentials = array()) {
 
 	$user = get_user_by_username($credentials['username']);
 	if (!$user) {
-		throw new \LoginException(elgg_echo('LoginException:UsernameFailure'));
+		throw new \LoginException(_elgg_services()->translator->translate('LoginException:UsernameFailure'));
 	}
 
 	if (check_rate_limit_exceeded($user->guid)) {
-		throw new \LoginException(elgg_echo('LoginException:AccountLocked'));
+		throw new \LoginException(_elgg_services()->translator->translate('LoginException:AccountLocked'));
 	}
 
-	if ($user->password !== generate_user_password($user, $credentials['password'])) {
+	$password_svc = _elgg_services()->passwords;
+	$password = $credentials['password'];
+	$hash = $user->password_hash;
+
+	if (!$hash) {
+		// try legacy hash
+		$legacy_hash = $password_svc->generateLegacyHash($user, $password);
+		if ($user->password !== $legacy_hash) {
+			log_login_failure($user->guid);
+			throw new \LoginException(_elgg_services()->translator->translate('LoginException:PasswordFailure'));
+		}
+
+		// migrate password
+		$password_svc->forcePasswordReset($user, $password);
+		return true;
+	}
+
+	if (!$password_svc->verify($password, $hash)) {
 		log_login_failure($user->guid);
-		throw new \LoginException(elgg_echo('LoginException:PasswordFailure'));
+		throw new \LoginException(_elgg_services()->translator->translate('LoginException:PasswordFailure'));
+	}
+
+	if ($password_svc->needsRehash($hash)) {
+		$password_svc->forcePasswordReset($user, $password);
 	}
 
 	return true;

--- a/engine/lib/upgrades/2014111800-1.10.0-add_new_hash_column-536087bbb2dbc82b.php
+++ b/engine/lib/upgrades/2014111800-1.10.0-add_new_hash_column-536087bbb2dbc82b.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Elgg 1.10.0 upgrade 2014111800
+ * add_new_hash_column
+ *
+ * Upgrades user entity schema to support new password hashes
+ */
+
+$db = _elgg_services()->db;
+$prefix = $db->getTablePrefix();
+
+$db->updateData("
+	ALTER TABLE {$prefix}users_entity
+	ADD `password_hash` varchar(255) NOT NULL DEFAULT ''
+	AFTER `salt`
+");

--- a/engine/lib/user_settings.php
+++ b/engine/lib/user_settings.php
@@ -51,9 +51,9 @@ function _elgg_set_user_password() {
 
 		if ($result) {
 			if ($password == $password2) {
-				$user->salt = _elgg_generate_password_salt();
-				$user->password = generate_user_password($user, $password);
+				$user->setPassword($password);
 				_elgg_services()->persistentLogin->handlePasswordChange($user, elgg_get_logged_in_user_entity());
+
 				if ($user->save()) {
 					system_message(elgg_echo('user:password:success'));
 					return true;

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -151,7 +151,7 @@ function find_active_users($options = array(), $limit = 10, $offset = 0, $count 
  * @return bool
  */
 function send_new_password_request($user_guid) {
-	return _elgg_services()->usersTable->sendNewPasswordRequest($user_guid);
+	return _elgg_services()->passwords->sendNewPasswordRequest($user_guid);
 }
 
 /**
@@ -165,7 +165,7 @@ function send_new_password_request($user_guid) {
  * @return bool
  */
 function force_user_password_reset($user_guid, $password) {
-	return _elgg_services()->usersTable->forcePasswordReset($user_guid, $password);
+	return _elgg_services()->passwords->forcePasswordReset($user_guid, $password);
 }
 
 /**
@@ -178,7 +178,7 @@ function force_user_password_reset($user_guid, $password) {
  * @return bool True on success
  */
 function execute_new_password_request($user_guid, $conf_code, $password = null) {
-	return _elgg_services()->usersTable->executeNewPasswordReset($user_guid, $conf_code, $password);
+	return _elgg_services()->passwords->executeNewPasswordReset($user_guid, $conf_code, $password);
 }
 
 /**
@@ -190,27 +190,7 @@ function generate_random_cleartext_password() {
 	return _elgg_services()->crypto->getRandomString(12, \ElggCrypto::CHARS_PASSWORD);
 }
 
-/**
- * Generate an 8 character Base64 URL salt for the password
- *
- * @return string
- * @access private
- */
-function _elgg_generate_password_salt() {
-	return _elgg_services()->crypto->getRandomString(8);
-}
 
-/**
- * Hash a password for storage. Currently salted MD5.
- *
- * @param \ElggUser $user     The user this is being generated for.
- * @param string    $password Password in clear text
- *
- * @return string
- */
-function generate_user_password(\ElggUser $user, $password) {
-	return md5($password . $user->salt);
-}
 
 /**
  * Simple function which ensures that a username contains only valid characters.

--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -280,8 +280,10 @@ CREATE TABLE `prefix_users_entity` (
   `guid` bigint(20) unsigned NOT NULL,
   `name` text NOT NULL,
   `username` varchar(128) NOT NULL DEFAULT '',
-  `password` varchar(32) NOT NULL DEFAULT '',
-  `salt` varchar(8) NOT NULL DEFAULT '',
+  `password` varchar(32) NOT NULL DEFAULT '' COMMENT 'Legacy password hashes',
+  `salt` varchar(8) NOT NULL DEFAULT '' COMMENT 'Legacy password salts',
+  -- 255 chars is recommended by PHP.net to hold future hash formats
+  `password_hash` varchar(255) NOT NULL DEFAULT '',
   `email` text NOT NULL,
   `language` varchar(6) NOT NULL DEFAULT '',
   `banned` enum('yes','no') NOT NULL DEFAULT 'no',

--- a/engine/tests/ElggCoreAccessCollectionsTest.php
+++ b/engine/tests/ElggCoreAccessCollectionsTest.php
@@ -22,8 +22,7 @@ class ElggCoreAccessCollectionsTest extends \ElggCoreUnitTest {
 		$user->email = 'fake_email@fake.com' . rand();
 		$user->name = 'fake user';
 		$user->access_id = ACCESS_PUBLIC;
-		$user->salt = _elgg_generate_password_salt();
-		$user->password = generate_user_password($user, rand());
+		$user->setPassword(rand());
 		$user->owner_guid = 0;
 		$user->container_guid = 0;
 		$user->save();
@@ -85,8 +84,7 @@ class ElggCoreAccessCollectionsTest extends \ElggCoreUnitTest {
 		$user->email = 'fake_email@fake.com' . rand();
 		$user->name = 'fake user';
 		$user->access_id = ACCESS_PUBLIC;
-		$user->salt = _elgg_generate_password_salt();
-		$user->password = generate_user_password($user, rand());
+		$user->setPassword(rand());
 		$user->owner_guid = 0;
 		$user->container_guid = 0;
 		$user->save();

--- a/engine/tests/ElggCoreAccessSQLTest.php
+++ b/engine/tests/ElggCoreAccessSQLTest.php
@@ -21,8 +21,7 @@ class ElggCoreAccessSQLTest extends \ElggCoreUnitTest {
 		$this->user->email = 'fake_email@fake.com' . rand();
 		$this->user->name = 'fake user ' . rand();
 		$this->user->access_id = ACCESS_PUBLIC;
-		$this->user->salt = _elgg_generate_password_salt();
-		$this->user->password = generate_user_password($this->user, rand());
+		$this->user->setPassword(rand());
 		$this->user->owner_guid = 0;
 		$this->user->container_guid = 0;
 		$this->user->save();

--- a/engine/tests/ElggUserTest.php
+++ b/engine/tests/ElggUserTest.php
@@ -56,6 +56,7 @@ class ElggCoreUserTest extends \ElggCoreUnitTest {
 		$attributes['username'] = null;
 		$attributes['password'] = null;
 		$attributes['salt'] = null;
+		$attributes['password_hash'] = null;
 		$attributes['email'] = null;
 		$attributes['language'] = null;
 		$attributes['banned'] = 'no';

--- a/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
+++ b/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
@@ -37,6 +37,7 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
 			'metadataCache' => '\ElggVolatileMetadataCache',
 			'metadataTable' => '\Elgg\Database\MetadataTable',
 			'metastringsTable' => '\Elgg\Database\MetastringsTable',
+			'passwords' => '\Elgg\PasswordService',
 			'plugins' => '\Elgg\Database\Plugins',
 			'request' => '\Elgg\Http\Request',
 			'relationshipsTable' => '\Elgg\Database\RelationshipsTable',

--- a/mod/twitter_api/actions/twitter_api/interstitial_settings.php
+++ b/mod/twitter_api/actions/twitter_api/interstitial_settings.php
@@ -38,8 +38,7 @@ if ($email) {
 }
 
 if ($password_1) {
-	$user->salt = _elgg_generate_password_salt();
-	$user->password = generate_user_password($user, $password_1);
+	$user->setPassword($password_1);
 }
 
 if (!$user->save()) {

--- a/mod/twitter_api/lib/twitter_api.php
+++ b/mod/twitter_api/lib/twitter_api.php
@@ -216,8 +216,7 @@ function twitter_api_create_user($twitter) {
 	$user->username = $username;
 	$user->name = $name;
 	$user->access_id = ACCESS_PUBLIC;
-	$user->salt = _elgg_generate_password_salt();
-	$user->password = generate_user_password($user, $password);
+	$user->setPassword($password);
 	$user->owner_guid = 0;
 	$user->container_guid = 0;
 

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2014050600;
+$version = 2014111800;
 
 $composerJson = file_get_contents(dirname(__FILE__) . "/composer.json");
 if ($composerJson === false) {


### PR DESCRIPTION
(replaces #7495)

This gradually migrates users to modern hashes as they log in; deprecates
setting the salt/password attributes in favor of a new setPassword() method
(setting salt/password continues to work but will revert the user to the
legacy MD5 hashing); and moves core password functionality to a
PasswordService object.

Fixes #4665.
