### PR TITLE
perf(annotations): increased performance of egef_annotations

### DIFF
--- a/docs/guides/database.rst
+++ b/docs/guides/database.rst
@@ -122,6 +122,30 @@ By metadata
 The function ``elgg_get_entities_from_metadata`` allows fetching entities
 with metadata in a variety of ways.
 
+By annotation
+~~~~~~~~~~~~~
+
+The function ``elgg_get_entities_from_annotations`` allows fetching entities
+with metadata in a variety of ways.
+
+.. note::
+
+   As of Elgg 1.10 the default behaviour of `elgg_get_entities_from_annotations` was brought inline with the rest of the `elgg_get_entities*` functions.
+   
+   Pre Elgg 1.10 the sorting of the entities was based on the latest addition of an annotation (in $options your could add `$options['order_by'] = 'maxtime ASC'` or `$options['order_by'] = 'maxtime DESC'`. As of Elgg 1.10 this was changed to the creation time of the entity, just like the rest of the `elgg_get_entities*` functions.
+   To get the old behaviour back add the following to your `$options`:
+   
+   .. code:: php
+   
+      $options['selects'] = array('MAX(n_table.time_created) AS maxtime');
+      $options['group_by'] = 'n_table.entity_guid';
+      $options['order_by'] = 'maxtime ASC'
+      
+      or
+      
+      $options['order_by'] = 'maxtime DESC'
+      
+
 Displaying entities
 -------------------
 

--- a/engine/classes/Elgg/Database/Annotations.php
+++ b/engine/classes/Elgg/Database/Annotations.php
@@ -284,9 +284,6 @@ class Annotations {
 	 * Returns entities based upon annotations.  Also accepts all options available
 	 * to elgg_get_entities() and elgg_get_entities_from_metadata().
 	 *
-	 * Entity creation time is selected as maxtime. To sort based upon
-	 * this, pass 'order_by' => 'maxtime asc' || 'maxtime desc'
-	 *
 	 * @see elgg_get_entities
 	 * @see elgg_get_entities_from_metadata
 	 *
@@ -329,9 +326,6 @@ class Annotations {
 			'annotation_created_time_upper'			=>	ELGG_ENTITIES_ANY_VALUE,
 	
 			'annotation_owner_guids'				=>	ELGG_ENTITIES_ANY_VALUE,
-	
-			'order_by'								=>	'maxtime DESC',
-			'group_by'								=>	'a.entity_guid'
 		);
 	
 		$options = array_merge($defaults, $options);
@@ -346,11 +340,34 @@ class Annotations {
 			return false;
 		}
 	
-		// special sorting for annotations
-		//@todo overrides other sorting
-		$options['selects'][] = "MAX(n_table.time_created) AS maxtime";
-		$options['group_by'] = 'n_table.entity_guid';
-	
+		// because of performance issues support for ordering by maxtime has been dropped @see https://github.com/Elgg/Elgg/issues/6638
+		if (isset($options['order_by']) && preg_match('~\bmaxtime\b~i', $options['order_by'])) {
+			// check if the user provided maxtime
+			$deprecated = true;
+			if (isset($options['selects'])) {
+				$selects = $options['selects'];
+				if (!is_array($selects)) {
+					$selects = array($selects);
+				}
+					
+				foreach ($selects as $select) {
+					if (preg_match('~\bmaxtime\b~i', $options['order_by'])) {
+						$deprecated = false;
+						break;
+					}
+				}
+			}
+		
+			// the user didn't provide maxtime
+			if ($deprecated) {
+				// special sorting for annotations
+				elgg_deprecated_notice(__FUNCTION__ . ": no longer orders by annotations by default. If you order by maxtime, you must provide that column via \$options['selects']. See https://github.com/Elgg/Elgg/issues/6638#issuecomment-41562034", "1.10");
+					
+				$options['selects'][] = "MAX(n_table.time_created) AS maxtime";
+				$options['group_by'] = 'n_table.entity_guid';
+			}
+		}
+		
 		$time_wheres = _elgg_get_entity_time_where_sql('a', $options['annotation_created_time_upper'],
 			$options['annotation_created_time_lower']);
 	

--- a/engine/tests/ElggCoreGetEntitiesFromAnnotationsTest.php
+++ b/engine/tests/ElggCoreGetEntitiesFromAnnotationsTest.php
@@ -74,6 +74,66 @@ class ElggCoreGetEntitiesFromAnnotationsTest extends \ElggCoreGetEntitiesBaseTes
 			}
 		}
 	}
+	
+	/**
+	 * This function tests the deprecated behaviour of egef_annotations 
+	 * discussed in https://github.com/Elgg/Elgg/issues/6638
+	 */
+	public function testElggApiGettersEntitiesFromAnnotationOrderByMaxtime() {
+		
+		// grab a few different users to annotation
+		// there will always be at least 2 here because of the construct.
+		$users = elgg_get_entities(array('type' => 'user', 'limit' => 2));
+
+		// create some test annotations
+		$subtypes = $this->getRandomValidSubtypes(array('object'), 1);
+		$subtype = $subtypes[0];
+		$annotation_name = 'test_annotation_name_' . rand();
+		$annotation_value = rand(1000, 9999);
+		$annotation_name2 = 'test_annotation_name_' . rand();
+		$annotation_value2 = rand(1000, 9999);
+		$guids = array();
+
+		// our targets
+		$valid = new \ElggObject();
+		$valid->subtype = $subtype;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+		create_annotation($valid->getGUID(), $annotation_name, $annotation_value, 'integer', $users[0]->getGUID());
+
+		$valid2 = new \ElggObject();
+		$valid2->subtype = $subtype;
+		$valid2->save();
+		$guids[] = $valid2->getGUID();
+		create_annotation($valid2->getGUID(), $annotation_name2, $annotation_value2, 'integer', $users[1]->getGUID());
+
+		$options = array(
+			'annotation_owner_guid' => $users[0]->getGUID(),
+			'annotation_name' => $annotation_name,
+			'selects' => array('MAX(n_table.time_created) AS maxtime'),
+			'group_by' => 'n_table.entity_guid',
+			'order_by' => 'maxtime'
+		);
+
+		$entities = elgg_get_entities_from_annotations($options);
+
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $guids));
+			$annotations = $entity->getAnnotations(array('annotation_name' => $annotation_name));
+			$this->assertEqual(count($annotations), 1);
+
+			$this->assertEqual($annotations[0]->name, $annotation_name);
+			$this->assertEqual($annotations[0]->value, $annotation_value);
+			$this->assertEqual($annotations[0]->owner_guid, $users[0]->getGUID());
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+	
 	public function testElggGetEntitiesFromAnnotationsCalculateX() {
 		$types = array('sum', 'avg', 'min', 'max');
 		$num_entities = 5;


### PR DESCRIPTION
The default behaviour of elgg_get_entities_from_annotations was
different from all other elgg_get_entities_from\* functions.
This also caused a performance issue on large databases

Fixes #6638 

from #6787 
Todo:
- [x] rst docs for how to achieve the old behavior
- [x] add test for this specific case
- [x] resubmit to 1.10 branch
