### PR TITLE
feature(navigation): add hook to filter breadcrumbs

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -110,6 +110,11 @@ System hooks
 		<user_guid2> => array('email', 'sms', 'ajax')
 	);
 
+**prepare, breadcrumbs**
+    In elgg_get_breadcrumbs(), this filters the registered breadcrumbs before
+    returning them, allowing a plugin to alter breadcrumb strategy site-wide.
+
+**add, river**
 
 User hooks
 ==========

--- a/engine/tests/phpunit/ElggBreadcrumbsTest.php
+++ b/engine/tests/phpunit/ElggBreadcrumbsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+class ElggBreadcrumbsTest extends \PHPUnit_Framework_TestCase {
+
+//	public function setUp() {
+//		// TODO run each test in better isolation
+//		static $have_run;
+//		if (!$have_run) {
+//			_elgg_nav_init();
+//			$have_run = true;
+//		}
+//	}
+
+	public function testCrumbsCanBePushed() {
+		elgg_push_breadcrumb('title 1');
+
+		elgg_push_breadcrumb('title 2', 'path2');
+
+		$this->assertEquals(array(
+			array('title' => 'title 1', 'link' => null),
+			array('title' => 'title 2', 'link' => 'path2')
+		), elgg_get_breadcrumbs());
+	}
+
+	public function testCrumbsCanBePopped() {
+		elgg_push_breadcrumb('title 1');
+
+		elgg_push_breadcrumb('title 2', 'path2');
+
+		$this->assertEquals(array('title' => 'title 2', 'link' => 'path2'), elgg_pop_breadcrumb());
+
+		$this->assertEquals(array(
+			array('title' => 'title 1', 'link' => null),
+		), elgg_get_breadcrumbs());
+
+		$this->assertEquals(array('title' => 'title 1', 'link' => null), elgg_pop_breadcrumb());
+
+		$this->assertEquals(array(), elgg_get_breadcrumbs());
+	}
+
+	public function testCanAlterCrumbsViaHook() {
+		elgg_push_breadcrumb(str_repeat('abcd ', 100));
+
+		elgg_unregister_plugin_hook_handler('prepare', 'breadcrumbs', 'elgg_prepare_breadcrumbs');
+
+		$this->assertEquals(array(
+			array(
+				'title' => str_repeat('abcd ', 100),
+				'link' => null,
+			),
+		), elgg_get_breadcrumbs());
+	}
+
+	public function testCrumbsAreExcerpted() {
+		$this->markTestIncomplete('Needs DB');
+
+		elgg_push_breadcrumb(str_repeat('abcd ', 100));
+
+		$this->assertEquals(array(
+			array(
+				'title' => elgg_get_excerpt(str_repeat('abcd ', 100), 100),
+				'link' => null,
+			),
+		), elgg_get_breadcrumbs());
+	}
+
+	public function testCrumbTitlesAreEscaped() {
+		$this->markTestIncomplete('Needs DB');
+
+		// TODO make this unnecessary
+		elgg_set_view_location('output/url', __DIR__ . '/../../../views/');
+		elgg_set_view_location('navigation/breadcrumbs', __DIR__ . '/../../../views/');
+
+		elgg_push_breadcrumb('Me < &amp; you');
+		$escaped = 'Me &lt; &amp; you';
+		$html = elgg_view('navigation/breadcrumbs');
+		$this->assertNotFalse(strpos($html, $escaped));
+
+		// links uses different view
+		elgg_pop_breadcrumb();
+		elgg_push_breadcrumb('Me < &amp; you', 'link');
+
+		$html = elgg_view('navigation/breadcrumbs');
+		$this->assertNotFalse(strpos($html, $escaped));
+	}
+
+	public function testCrumbLinksAreNormalized() {
+		$this->markTestIncomplete('Needs DB');
+
+		// TODO make this unnecessary
+		elgg_set_view_location('output/url', __DIR__ . '/../../../views/');
+		elgg_set_view_location('navigation/breadcrumbs', __DIR__ . '/../../../views/');
+
+		elgg_push_breadcrumb('test', 'link');
+		$html = elgg_view('navigation/breadcrumbs');
+		$this->assertNotFalse(strpos($html, '"http://localhost/link"'));
+	}
+}

--- a/views/default/navigation/breadcrumbs.php
+++ b/views/default/navigation/breadcrumbs.php
@@ -9,6 +9,7 @@
  * @uses $vars['class']
  *
  * @see elgg_push_breadcrumb
+ * @see elgg_get_breadcrumbs
  */
 
 if (isset($vars['breadcrumbs'])) {
@@ -26,14 +27,17 @@ if ($additional_class) {
 if (is_array($breadcrumbs) && count($breadcrumbs) > 0) {
 	echo "<ul class=\"$class\">";
 	foreach ($breadcrumbs as $breadcrumb) {
+		// Why need to escape titles? Titles in core plugins are escaped on input, but we can't
+		// guarantee other users of this view and of elgg_push_breadcrumb() will safely escape text.
 		if (!empty($breadcrumb['link'])) {
 			$crumb = elgg_view('output/url', array(
 				'href' => $breadcrumb['link'],
 				'text' => $breadcrumb['title'],
+				'encode_text' => true,
 				'is_trusted' => true,
 			));
 		} else {
-			$crumb = $breadcrumb['title'];
+			$crumb = htmlspecialchars($breadcrumb['title'], ENT_QUOTES, 'UTF-8', false);
 		}
 		echo "<li>$crumb</li>";
 	}


### PR DESCRIPTION
(replaces #7262)

This also makes sure crumb titles are escaped in the view, and moves the
elgg_get_excerpt call to a hook handler, allowing it to be disabled.

Fixes #6419
