### PR TITLE
IDEA(views): API for deferring the rendering of views

### DIFF
--- a/engine/classes/Elgg/Context.php
+++ b/engine/classes/Elgg/Context.php
@@ -98,4 +98,25 @@ final class Context {
 	public function contains($context) {
 		return in_array($context, $this->stack);
 	}
+
+	/**
+	 * Get the entire context stack (e.g. for backing it up)
+	 *
+	 * @return string[]
+	 * @access private
+	 */
+	public function getAll() {
+		return $this->stack;
+	}
+
+	/**
+	 * Set the entire context stack
+	 *
+	 * @param string[] $stack All contexts to be placed on the stack
+	 * @access private
+	 * @return void
+	 */
+	public function setAll(array $stack) {
+		$this->stack = $stack;
+	}
 }

--- a/engine/classes/Elgg/DeferredViewService.php
+++ b/engine/classes/Elgg/DeferredViewService.php
@@ -1,0 +1,81 @@
+<?php
+namespace Elgg;
+
+use Elgg\DeferredViews\View;
+
+/**
+ * Manager of deferred rendering views. This keeps track of views that have been deferred.
+ */
+class DeferredViewService {
+
+	static protected $global_counter = 0;
+
+	/**
+	 * @var View[]
+	 */
+	protected $views = array();
+
+	/**
+	 * @var string
+	 */
+	protected $placeholder_format = '';
+
+	/**
+	 * Constructor
+	 *
+	 * @param string $unique_token Unique alphanumeric token. If end users can guess this they may trick the system
+	 *                             into rendering a view where it was not intended.
+	 */
+	public function __construct($unique_token) {
+		$this->placeholder_format = "{$unique_token}z%dz";
+	}
+
+	/**
+	 * Get a token that will be later replaced by the output of the renderer
+	 *
+	 * @param string $view_name Name of the view we're deferring
+	 * @param array  $args      Args passed to the view
+	 * @param string $viewtype  The viewtype for elgg_view()
+	 *
+	 * @return string Token
+	 */
+	public function defer($view_name, array $args = array(), $viewtype = '') {
+		self::$global_counter += 1;
+		$placeholder = sprintf($this->placeholder_format, self::$global_counter);
+
+		// we need to capture the viewtype now, when the placeholder is created.
+		if (!$viewtype) {
+			$viewtype = elgg_get_viewtype();
+		}
+
+		$view = new View($view_name, $args, $viewtype);
+		$this->views[$placeholder] = $view;
+
+		return $placeholder;
+	}
+
+	/**
+	 * Replace all deferred view placeholders in $input
+	 *
+	 * @param string $output The current output containing view placeholders
+	 *
+	 * @return string
+	 */
+	public function resolveAll($output) {
+		foreach ($this->views as $placeholder => $view) {
+
+			if (false === strpos($output, $placeholder)) {
+				// no placeholder, let's put off rendering it. maybe we won't have to!
+				continue;
+			}
+
+			$output = str_replace($placeholder, $view->render(), $output, $count);
+			if ($count) {
+				// we can forget views once they're resolved
+				unset($this->views[$placeholder]);
+			}
+		}
+
+		return $output;
+	}
+}

--- a/engine/classes/Elgg/DeferredViews/RiverComments.php
+++ b/engine/classes/Elgg/DeferredViews/RiverComments.php
@@ -1,0 +1,130 @@
+<?php
+namespace Elgg\DeferredViews;
+
+/**
+ * This example model supplies data to the river/elements/responses view and is designed to
+ * be "prepared" ahead of time to expect particular calls. This way we can batch fetch the
+ * results in few queries.
+ */
+class RiverComments {
+
+	const NUM_COMMENTS = 'num_comments';
+	const LATEST_COMMENTS = 'latest_comments';
+
+	protected $expectations = array();
+
+	protected $results = array();
+
+	protected $is_resolved = false;
+
+	/**
+	 * @param int $guid
+	 * @return void
+	 */
+	public function prepareNumComments($guid) {
+		$this->expectations[self::NUM_COMMENTS][$guid] = true;
+	}
+
+	/**
+	 * @param int $guid
+	 * @return int
+	 */
+	public function numComments($guid) {
+		return $this->call(self::NUM_COMMENTS, $guid);
+	}
+
+	/**
+	 * @param int $guid
+	 * @return void
+	 */
+	public function prepareLatestComments($guid) {
+		$this->expectations[self::LATEST_COMMENTS][$guid] = true;
+	}
+
+	/**
+	 * @param int $guid
+	 * @return \ElggComment[]
+	 */
+	public function latestComments($guid) {
+		return $this->call(self::LATEST_COMMENTS, $guid);
+	}
+
+	protected function call($method_name, $args = null) {
+		if (!$this->is_resolved) {
+			$this->computeAll();
+			$this->is_resolved = true;
+		}
+		if (isset($this->results[$method_name]) && array_key_exists($args, $this->results[$method_name])) {
+			return $this->results[$method_name][$args];
+		}
+		$this->computeOne($method_name, $args);
+		return $this->results[$method_name][$args];
+	}
+
+	/**
+	 * Attempt to efficiently compute the responses to all expected API calls
+	 */
+	protected function computeAll() {
+		// look at expectations and try to compute
+		// results as quickly as possible
+
+		if (!empty($this->expectations[self::NUM_COMMENTS])) {
+			$container_guids = array_keys($this->expectations[self::NUM_COMMENTS]);
+
+			// initialize
+			foreach ($container_guids as $guid) {
+				$this->results[self::NUM_COMMENTS][$guid] = 0;
+			}
+
+			// override
+			$rows = elgg_get_entities(array(
+				'type' => 'object',
+				'subtype' => 'comment',
+				'container_guid' => $container_guids,
+				'group_by' => 'e.container_guid',
+				'selects' => array('COUNT(1) AS cnt'),
+				'callback' => false,
+			));
+			foreach ($rows as $row) {
+				$this->results[self::NUM_COMMENTS][$row->container_guid] = (int)$row->cnt;
+			}
+		}
+
+		if (!empty($this->expectations[self::LATEST_COMMENTS])) {
+			$container_guids = array_keys($this->expectations[self::LATEST_COMMENTS]);
+
+			foreach ($container_guids as $i => $guid) {
+				if (isset($this->results[self::NUM_COMMENTS][$guid])
+						&& $this->results[self::NUM_COMMENTS][$guid] == 0) {
+					$this->results[self::LATEST_COMMENTS][$guid] = array();
+					unset($container_guids[$i]);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Compute and store the result of an unexpected API call
+	 *
+	 * @param string $method_name API method name
+	 * @param string $args        Comma-separated arguments as string
+	 */
+	protected function computeOne($method_name, $args = '') {
+		$this->results[$method_name][$args] = null;
+
+		if ($method_name === self::NUM_COMMENTS) {
+			$object = get_entity($args);
+			if ($object) {
+				$this->results[$method_name][$args] = $object->countComments();
+			}
+		} elseif ($method_name === self::LATEST_COMMENTS) {
+			$this->results[$method_name][$args] = elgg_get_entities(array(
+				'type' => 'object',
+				'subtype' => 'comment',
+				'container_guid' => $args,
+				'limit' => 3,
+				'order_by' => 'e.time_created desc'
+			));
+		}
+	}
+}

--- a/engine/classes/Elgg/DeferredViews/View.php
+++ b/engine/classes/Elgg/DeferredViews/View.php
@@ -1,0 +1,64 @@
+<?php
+namespace Elgg\DeferredViews;
+
+/**
+ * A single unresolved view rendering. It outputs a token during initial rendering but when
+ * forced to resolve, it can render itself and replace instances of the token.
+ */
+class View {
+
+	/**
+	 * @var string The view name
+	 */
+	protected $view;
+
+	/**
+	 * @var array
+	 */
+	protected $args;
+
+	/**
+	 * @var string
+	 */
+	protected $viewtype;
+
+	/**
+	 * @var string[]
+	 */
+	protected $contexts;
+
+	/**
+	 * Constructor
+	 *
+	 * @param string $view     Name of the view we're deferring
+	 * @param array  $args     Args passed to the view or the callable object
+	 * @param string $viewtype The viewtype for elgg_view()
+	 */
+	public function __construct($view, array $args, $viewtype) {
+		$this->view = $view;
+		$this->args = $args;
+		$this->viewtype = $viewtype;
+
+		$this->contexts = _elgg_services()->context->getAll();
+	}
+
+	/**
+	 * Render the deferred view
+	 *
+	 * @return string
+	 */
+	public function render() {
+		$context_svc = _elgg_services()->context;
+		$old_contexts = $context_svc->getAll();
+
+		// restore context when placeholder was rendered
+		$context_svc->setAll($this->contexts);
+
+		$output = elgg_view($this->view, $this->args, false, null, $this->viewtype);
+
+		// restore global context
+		$context_svc->setAll($old_contexts);
+
+		return $output;
+	}
+}

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -22,6 +22,7 @@ namespace Elgg\Di;
  * @property-read \Elgg\Database\ConfigTable               $configTable
  * @property-read \Elgg\Context                            $context
  * @property-read \Elgg\Database\Datalist                  $datalist
+ * @property-read \Elgg\DeferredViewService                $deferredViews
  * @property-read \Elgg\Database                           $db
  * @property-read \Elgg\DeprecationService                 $deprecation
  * @property-read \Elgg\Database\EntityTable               $entityTable
@@ -41,6 +42,7 @@ namespace Elgg\Di;
  * @property-read \Elgg\Database\QueryCounter              $queryCounter
  * @property-read \Elgg\Http\Request                       $request
  * @property-read \Elgg\Database\RelationshipsTable        $relationshipsTable
+ * @property-read \Elgg\DeferredViews\RiverComments        $riverComments
  * @property-read \Elgg\Router                             $router
  * @property-read \ElggSession                             $session
  * @property-read \Elgg\Cache\SimpleCache                  $simpleCache
@@ -114,6 +116,13 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 
 		$this->setFactory('deprecation', function(ServiceProvider $c) {
 			return new \Elgg\DeprecationService($c->session, $c->logger);
+		});
+
+		$this->setClassName('riverComments', '\Elgg\DeferredViews\RiverComments');
+
+		$this->setFactory('deferredViews', function(ServiceProvider $c) {
+			$token = $c->crypto->getHmac(__FILE__ . time());
+			return new \Elgg\DeferredViewService($token);
 		});
 
 		$this->setClassName('entityTable', '\Elgg\Database\EntityTable');

--- a/engine/classes/Elgg/ViewsService.php
+++ b/engine/classes/Elgg/ViewsService.php
@@ -599,4 +599,16 @@ class ViewsService {
 	public function setOverriddenLocations(array $locations) {
 		$this->overriden_locations = $locations;
 	}
+
+	/**
+	 * Get a placeholder to be replaced later by the deferred view
+	 *
+	 * @param string $view The view name
+	 * @param array  $args Args passed to the view
+	 *
+	 * @return string The placeholder
+	 */
+	public function deferView($view, array $args = array()) {
+		return _elgg_services()->deferredViews->defer($view, $args);
+	}
 }

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1551,7 +1551,11 @@ function _elgg_ajax_page_handler($page) {
 				break;
 		}
 
-		echo elgg_view($view, $vars);
+		$output = elgg_view($view, $vars);
+
+		$output = _elgg_services()->deferredViews->resolveAll($output);
+
+		echo $output;
 		return true;
 	}
 	return false;

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -476,7 +476,12 @@ function elgg_view_page($title, $body, $page_shell = 'default', $vars = array())
 	$vars['page_shell'] = $page_shell;
 
 	// Allow plugins to modify the output
-	return elgg_trigger_plugin_hook('output', 'page', $vars, $output);
+	$output = elgg_trigger_plugin_hook('output', 'page', $vars, $output);
+
+	// Resolve any deferred views
+	$output = _elgg_services()->deferredViews->resolveAll($output);
+
+	return $output;
 }
 
 /**

--- a/views/default/river/elements/responses/content.php
+++ b/views/default/river/elements/responses/content.php
@@ -1,0 +1,37 @@
+<?php
+
+$entity = $vars['entity'];
+/* @var ElggObject $entity */
+
+$model = $vars['model'];
+/* @var \Elgg\DeferredViews\RiverComments $model */
+
+// This first call will batch fetch all comment counts for the whole river view.
+$comment_count = $model->numComments($entity->guid);
+if (!$comment_count) {
+	return;
+}
+
+$comments = $model->latestComments($entity->guid);
+if (!$comments) {
+	return;
+}
+
+// why is this reversing it? because we're asking for the 3 latest
+// comments by sorting desc and limiting by 3, but we want to display
+// these comments with the latest at the bottom.
+$comments = array_reverse($comments);
+
+echo elgg_view_entity_list($comments, array('list_class' => 'elgg-river-comments'));
+
+if ($comment_count > count($comments)) {
+	$num_more_comments = $comment_count - count($comments);
+	$url = $entity->getURL();
+	$params = array(
+		'href' => $url,
+		'text' => elgg_echo('river:comments:more', array($num_more_comments)),
+		'is_trusted' => true,
+	);
+	$link = elgg_view('output/url', $params);
+	echo "<div class=\"elgg-river-more\">$link</div>";
+}


### PR DESCRIPTION
A proof-of-concept. See #6940. This uses the new API to prefetch comment counts on river items, removing 14 queries when displaying 20 items. If someone bumps the river to 50, 30 queries are saved.
