### PR TITLE
chore(cache): reworks ElggMemcache and its core usage and adds a null cache to simplify logic

### DIFF
--- a/engine/classes/Elgg/Database/MetadataTable.php
+++ b/engine/classes/Elgg/Database/MetadataTable.php
@@ -204,15 +204,8 @@ class MetadataTable {
 		}
 	
 		// If memcached then we invalidate the cache for this entry
-		static $metabyname_memcache;
-		if ((!$metabyname_memcache) && (is_memcache_available())) {
-			$metabyname_memcache = new \ElggMemcache('metabyname_memcache');
-		}
-	
-		if ($metabyname_memcache) {
-			// @todo fix memcache (name_id is not a property of \ElggMetadata)
-			$metabyname_memcache->delete("{$md->entity_guid}:{$md->name_id}");
-		}
+		// @todo fix memcache (name_id is not a property of \ElggMetadata)
+		_elgg_get_memcache('metabyname_memcache')->delete("{$md->entity_guid}:{$md->name_id}");
 	
 		$value_type = detect_extender_valuetype($value, $this->db->sanitizeString(trim($value_type)));
 	

--- a/engine/classes/Elgg/Database/UsersTable.php
+++ b/engine/classes/Elgg/Database/UsersTable.php
@@ -98,14 +98,7 @@ class UsersTable {
 				}
 	
 				// invalidate memcache for this user
-				static $newentity_cache;
-				if ((!$newentity_cache) && (is_memcache_available())) {
-					$newentity_cache = new \ElggMemcache('new_entity_cache');
-				}
-	
-				if ($newentity_cache) {
-					$newentity_cache->delete($user_guid);
-				}
+				_elgg_get_memcache('new_entity_cache')->delete($user_guid);
 	
 				// Set ban flag
 				$query = "UPDATE {$this->CONFIG->dbprefix}users_entity set banned='yes' where guid=$user_guid";
@@ -137,15 +130,7 @@ class UsersTable {
 				create_metadata($user_guid, 'ban_reason', '', '', 0, ACCESS_PUBLIC);
 	
 				// invalidate memcache for this user
-				static $newentity_cache;
-				if ((!$newentity_cache) && (is_memcache_available())) {
-					$newentity_cache = new \ElggMemcache('new_entity_cache');
-				}
-	
-				if ($newentity_cache) {
-					$newentity_cache->delete($user_guid);
-				}
-	
+				_elgg_get_memcache('new_entity_cache')->delete($user_guid);
 	
 				$query = "UPDATE {$this->CONFIG->dbprefix}users_entity set banned='no' where guid=$user_guid";
 				return _elgg_services()->db->updateData($query);
@@ -172,18 +157,11 @@ class UsersTable {
 		if (($user) && ($user instanceof \ElggUser) && ($user->canEdit())) {
 			if (_elgg_services()->events->trigger('make_admin', 'user', $user)) {
 	
-				// invalidate memcache for this user
-				static $newentity_cache;
-				if ((!$newentity_cache) && (is_memcache_available())) {
-					$newentity_cache = new \ElggMemcache('new_entity_cache');
-				}
-	
-				if ($newentity_cache) {
-					$newentity_cache->delete($user_guid);
-				}
-	
 				$r = _elgg_services()->db->updateData("UPDATE {$this->CONFIG->dbprefix}users_entity set admin='yes' where guid=$user_guid");
+
 				_elgg_invalidate_cache_for_entity($user_guid);
+				_elgg_invalidate_memcache_for_entity($user_guid);
+
 				return $r;
 			}
 	
@@ -209,17 +187,11 @@ class UsersTable {
 			if (_elgg_services()->events->trigger('remove_admin', 'user', $user)) {
 	
 				// invalidate memcache for this user
-				static $newentity_cache;
-				if ((!$newentity_cache) && (is_memcache_available())) {
-					$newentity_cache = new \ElggMemcache('new_entity_cache');
-				}
-	
-				if ($newentity_cache) {
-					$newentity_cache->delete($user_guid);
-				}
-	
 				$r = _elgg_services()->db->updateData("UPDATE {$this->CONFIG->dbprefix}users_entity set admin='no' where guid=$user_guid");
+
 				_elgg_invalidate_cache_for_entity($user_guid);
+				_elgg_invalidate_memcache_for_entity($user_guid);
+
 				return $r;
 			}
 	

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -28,6 +28,7 @@ namespace Elgg\Di;
  * @property-read \Elgg\PluginHooksService                 $hooks
  * @property-read \Elgg\Http\Input                         $input
  * @property-read \Elgg\Logger                             $logger
+ * @property-read \Stash\Pool|null                         $memcacheStashPool
  * @property-read \ElggVolatileMetadataCache               $metadataCache
  * @property-read \Elgg\Database\MetadataTable             $metadataTable
  * @property-read \Elgg\Database\MetastringsTable          $metastringsTable
@@ -126,6 +127,22 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 
 		$this->setFactory('logger', function(ServiceProvider $c) {
 			return $this->resolveLoggerDependencies('logger');
+		});
+
+		$this->setFactory('memcacheStashPool', function(ServiceProvider $c) {
+			if (!$c->config->get('memcache')) {
+				return null;
+			}
+
+			$servers = $c->config->get('memcache_servers');
+			if (!$servers) {
+				return null;
+			}
+			$driver = new \Stash\Driver\Memcache();
+			$driver->setOptions(array(
+				'servers' => $servers,
+			));
+			return new \Stash\Pool($driver);
 		});
 
 		$this->setClassName('metadataCache', '\ElggVolatileMetadataCache');

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1715,13 +1715,7 @@ abstract class ElggEntity extends \ElggData implements
 		}
 
 		// If memcache is available then delete this entry from the cache
-		static $newentity_cache;
-		if ((!$newentity_cache) && (is_memcache_available())) {
-			$newentity_cache = new \ElggMemcache('new_entity_cache');
-		}
-		if ($newentity_cache) {
-			$newentity_cache->delete($guid);
-		}
+		_elgg_invalidate_memcache_for_entity($guid);
 
 		if ($ret !== false) {
 			$this->attributes['time_updated'] = $time;
@@ -1996,15 +1990,7 @@ abstract class ElggEntity extends \ElggData implements
 		}
 
 		_elgg_invalidate_cache_for_entity($guid);
-		
-		// If memcache is available then delete this entry from the cache
-		static $newentity_cache;
-		if ((!$newentity_cache) && (is_memcache_available())) {
-			$newentity_cache = new \ElggMemcache('new_entity_cache');
-		}
-		if ($newentity_cache) {
-			$newentity_cache->delete($guid);
-		}
+		_elgg_invalidate_memcache_for_entity($guid);
 
 		// Delete contained owned and otherwise releated objects (depth first)
 		if ($recursive) {

--- a/engine/classes/ElggMemcache.php
+++ b/engine/classes/ElggMemcache.php
@@ -4,120 +4,64 @@
  *
  * @package    Elgg.Core
  * @subpackage Memcache
+ *
+ * @deprecated 1.10 This is a legacy API that will be eventually replaced by something
+ *             implementing the Elgg\Cache\Pool interface. Until then, this class has
+ *             been turned into a wrapper around a 3rd party cache library.
  */
 class ElggMemcache extends \ElggSharedMemoryCache {
-	/**
-	 * Global Elgg configuration
-	 * 
-	 * @var \stdClass
-	 */
-	private $CONFIG;
 
 	/**
-	 * Minimum version of memcached needed to run
+	 * TTL of saved items (default timeout after a day to prevent anything getting too stale)
+	 */
+	private $ttl = 86400;
+
+	/**
+	 * @var \Stash\Pool
+	 */
+	private $stash_pool;
+
+	/**
+	 * Constructor
 	 *
-	 */
-	private static $MINSERVERVERSION = '1.1.12';
-
-	/**
-	 * Memcache object
-	 */
-	private $memcache;
-
-	/**
-	 * Expiry of saved items (default timeout after a day to prevent anything getting too stale)
-	 */
-	private $expires = 86400;
-
-	/**
-	 * The version of memcache running
-	 */
-	private $version = 0;
-
-	/**
-	 * Connect to memcache.
+	 * @internal Use _elgg_get_memcache() instead of direct construction.
 	 *
-	 * @param string $namespace The namespace for this cache to write to -
-	 * note, namespaces of the same name are shared!
+	 * @param string      $namespace The namespace for this cache to write to
+	 * @param \Stash\Pool $pool      The cache pool to use. Default is memcache.
+	 * @param int         $ttl       The TTL in seconds. Default is from $CONFIG->memcache_expires.
 	 *
 	 * @throws ConfigurationException
+	 *
+	 * @see _elgg_get_memcache()
 	 */
-	public function __construct($namespace = 'default') {
-		global $CONFIG;
-		$this->CONFIG = $CONFIG;
-
+	public function __construct($namespace = 'default', \Stash\Pool $pool = null, $ttl = null) {
 		$this->setNamespace($namespace);
 
-		// Do we have memcache?
-		if (!class_exists('Memcache')) {
-			throw new \ConfigurationException('PHP memcache module not installed, you must install php5-memcache');
-		}
-
-		// Create memcache object
-		$this->memcache	= new Memcache;
-
-		// Now add servers
-		if (!$this->CONFIG->memcache_servers) {
-			throw new \ConfigurationException('No memcache servers defined, please populate the $this->CONFIG->memcache_servers variable');
-		}
-
-		if (is_callable(array($this->memcache, 'addServer'))) {
-			foreach ($this->CONFIG->memcache_servers as $server) {
-				if (is_array($server)) {
-					$this->memcache->addServer(
-						$server[0],
-						isset($server[1]) ? $server[1] : 11211,
-						isset($server[2]) ? $server[2] : false,
-						isset($server[3]) ? $server[3] : 1,
-						isset($server[4]) ? $server[4] : 1,
-						isset($server[5]) ? $server[5] : 15,
-						isset($server[6]) ? $server[6] : true
-					);
-
-				} else {
-					$this->memcache->addServer($server, 11211);
-				}
-			}
-		} else {
-			// don't use _elgg_services()->translator->translate() here because most of the config hasn't been loaded yet
-			// and it caches the language, which is hard coded in $this->CONFIG->language as en.
-			// overriding it with real values later has no effect because it's already cached.
-			_elgg_services()->logger->error("This version of the PHP memcache API doesn't support multiple servers.");
-
-			$server = $this->CONFIG->memcache_servers[0];
-			if (is_array($server)) {
-				$this->memcache->connect($server[0], $server[1]);
-			} else {
-				$this->memcache->addServer($server, 11211);
+		if (!$pool) {
+			$pool = _elgg_services()->memcacheStashPool;
+			if (!$pool) {
+				throw new \ConfigurationException('No memcache servers defined, please populate the $this->CONFIG->memcache_servers variable');
 			}
 		}
+		$this->stash_pool = $pool;
 
-		// Get version
-		$this->version = $this->memcache->getVersion();
-		if (version_compare($this->version, \ElggMemcache::$MINSERVERVERSION, '<')) {
-			$msg = vsprintf('Memcache needs at least version %s to run, you are running %s',
-				array(\ElggMemcache::$MINSERVERVERSION,
-				$this->version
-			));
-
-			throw new \ConfigurationException($msg);
+		if ($ttl === null) {
+			$ttl = _elgg_services()->config->get('memcache_expires');
 		}
-
-		// Set some defaults
-		if (isset($this->CONFIG->memcache_expires)) {
-			$this->expires = $this->CONFIG->memcache_expires;
+		if (isset($ttl)) {
+			$this->ttl = $ttl;
 		}
 	}
 
 	/**
-	 * Set the default expiry.
+	 * Set the default TTL.
 	 *
-	 * @param int $expires The lifetime as a unix timestamp or time from now. Defaults forever.
+	 * @param int $ttl The TTL in seconds from now. Default is no expiration.
 	 *
 	 * @return void
 	 */
-	public function setDefaultExpiry($expires = 0) {
-		$this->expires = $expires;
+	public function setDefaultExpiry($ttl = 0) {
+		$this->ttl = $ttl;
 	}
 
 	/**
@@ -141,24 +85,26 @@ class ElggMemcache extends \ElggSharedMemoryCache {
 	/**
 	 * Saves a name and value to the cache
 	 *
-	 * @param string  $key     Name
-	 * @param string  $data    Value
-	 * @param integer $expires Expires (in seconds)
+	 * @param string  $key  Name
+	 * @param string  $data Value
+	 * @param integer $ttl  TTL of cache item (seconds), 0 for no expiration, null for default.
 	 *
 	 * @return bool
 	 */
-	public function save($key, $data, $expires = null) {
+	public function save($key, $data, $ttl = null) {
 		$key = $this->makeMemcacheKey($key);
 
-		if ($expires === null) {
-			$expires = $this->expires;
+		if ($ttl === null) {
+			$ttl = $this->expires;
 		}
 
-		$result = $this->memcache->set($key, $data, null, $expires);
-		if ($result === false) {
-			_elgg_services()->logger->error("MEMCACHE: SAVE FAIL $key");
-		} else {
+		$item = $this->stash_pool->getItem($key);
+		$result = $item->set($data, $ttl);
+
+		if ($result) {
 			_elgg_services()->logger->info("MEMCACHE: SAVE SUCCESS $key");
+		} else {
+			_elgg_services()->logger->error("MEMCACHE: SAVE FAIL $key");
 		}
 
 		return $result;
@@ -168,22 +114,25 @@ class ElggMemcache extends \ElggSharedMemoryCache {
 	 * Retrieves data.
 	 *
 	 * @param string $key    Name of data to retrieve
-	 * @param int    $offset Offset
-	 * @param int    $limit  Limit
+	 * @param int    $offset Unused
+	 * @param int    $limit  Unused
 	 *
 	 * @return mixed
 	 */
 	public function load($key, $offset = 0, $limit = null) {
 		$key = $this->makeMemcacheKey($key);
 
-		$result = $this->memcache->get($key);
-		if ($result === false) {
+		$item = $this->stash_pool->getItem($key);
+		$value = $item->get();
+
+		if ($item->isMiss()) {
 			_elgg_services()->logger->info("MEMCACHE: LOAD MISS $key");
-		} else {
-			_elgg_services()->logger->info("MEMCACHE: LOAD HIT $key");
+			return false;
 		}
 
-		return $result;
+		_elgg_services()->logger->info("MEMCACHE: LOAD HIT $key");
+
+		return $value;
 	}
 
 	/**
@@ -196,20 +145,19 @@ class ElggMemcache extends \ElggSharedMemoryCache {
 	public function delete($key) {
 		$key = $this->makeMemcacheKey($key);
 
-		return $this->memcache->delete($key, 0);
+		return $this->stash_pool->getItem($key)->clear();
 	}
 
 	/**
-	 * Clears the entire cache?
-	 *
-	 * @todo write or remove.
+	 * Clears the entire cache (does not work)
 	 *
 	 * @return true
+	 *
+	 * @deprecated 1.10 This functionality is not available
 	 */
 	public function clear() {
-		// DISABLE clearing for now - you must use delete on a specific key.
-		return true;
+		elgg_deprecated_notice(__METHOD__ . ' no longer works and will be removed.', '1.10');
 
-		// @todo Namespaces as in #532
+		return true;
 	}
 }

--- a/engine/classes/ElggNullCache.php
+++ b/engine/classes/ElggNullCache.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * A "Null" version of ElggMemcache for use on sites without memcache setup
+ *
+ * This will eventually be replaced by something like Elgg\Cache\NullPool.
+ *
+ * @access private
+ *
+ * @package    Elgg.Core
+ * @subpackage Memcache
+ */
+class ElggNullCache extends \ElggSharedMemoryCache {
+
+	/**
+	 * Saves a name and value to the cache
+	 *
+	 * @param string  $key  Unused
+	 * @param string  $data Unused
+	 * @param integer $ttl  Unused
+	 *
+	 * @return bool
+	 */
+	public function save($key, $data, $ttl = null) {
+		return true;
+	}
+
+	/**
+	 * Retrieves data.
+	 *
+	 * @param string $key    Unused
+	 * @param int    $offset Unused
+	 * @param int    $limit  Unused
+	 *
+	 * @return mixed
+	 */
+	public function load($key, $offset = 0, $limit = null) {
+		return false;
+	}
+
+	/**
+	 * Delete data
+	 *
+	 * @param string $key Unused
+	 *
+	 * @return bool
+	 */
+	public function delete($key) {
+		return true;
+	}
+
+	/**
+	 * Clears the entire cache (does not work)
+	 *
+	 * @return true
+	 */
+	public function clear() {
+		return true;
+	}
+}

--- a/engine/lib/memcache.php
+++ b/engine/lib/memcache.php
@@ -14,26 +14,7 @@
  * @return bool
  */
 function is_memcache_available() {
-	global $CONFIG;
-
-	static $memcache_available;
-
-	if ((!isset($CONFIG->memcache)) || (!$CONFIG->memcache)) {
-		return false;
-	}
-
-	// If we haven't set variable to something
-	if (($memcache_available !== true) && ($memcache_available !== false)) {
-		try {
-			$tmp = new \ElggMemcache();
-			// No exception thrown so we have memcache available
-			$memcache_available = true;
-		} catch (Exception $e) {
-			$memcache_available = false;
-		}
-	}
-
-	return $memcache_available;
+	return (bool) _elgg_services()->memcacheStashPool;
 }
 
 /**
@@ -45,13 +26,37 @@ function is_memcache_available() {
  * @access private
  */
 function _elgg_invalidate_memcache_for_entity($entity_guid) {
-	static $newentity_cache;
-	
-	if ((!$newentity_cache) && (is_memcache_available())) {
-		$newentity_cache = new \ElggMemcache('new_entity_cache');
+	_elgg_get_memcache('new_entity_cache')->delete($entity_guid);
+}
+
+/**
+ * Get a namespaced ElggMemcache object (if memcache is available) or a null cache
+ *
+ * @param string $namespace Namespace to add to all keys used
+ *
+ * @return ElggMemcache|ElggNullCache
+ * @access private
+ * @since 1.10
+ */
+function _elgg_get_memcache($namespace = 'default') {
+	static $cache_pool = 'initial';
+	static $null_cache;
+	static $objects = array();
+
+	// can't use null because the service may be null
+	if ($cache_pool === 'initial') {
+		$cache_pool = _elgg_services()->memcacheStashPool;
 	}
-	
-	if ($newentity_cache) {
-		$newentity_cache->delete($entity_guid);
+
+	if (!$cache_pool) {
+		if ($null_cache === null) {
+			$null_cache = new ElggNullCache();
+		}
+		return $null_cache;
 	}
+
+	if (!isset($objects[$namespace])) {
+		$objects[$namespace] = new ElggMemcache($namespace, $cache_pool);
+	}
+	return $objects[$namespace];
 }

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -635,15 +635,8 @@ function _elgg_delete_metastring_based_object_by_id($id, $type) {
 		// Tidy up if memcache is enabled.
 		// @todo only metadata is supported
 		if ($type == 'metadata') {
-			static $metabyname_memcache;
-			if ((!$metabyname_memcache) && (is_memcache_available())) {
-				$metabyname_memcache = new \ElggMemcache('metabyname_memcache');
-			}
-
-			if ($metabyname_memcache) {
-				// @todo why name_id? is that even populated?
-				$metabyname_memcache->delete("{$obj->entity_guid}:{$obj->name_id}");
-			}
+			// @todo why name_id? is that even populated?
+			_elgg_get_memcache('metabyname_memcache')->delete("{$obj->entity_guid}:{$obj->name_id}");
 		}
 
 		if ($obj->canEdit()) {

--- a/engine/tests/ElggCoreMetadataAPITest.php
+++ b/engine/tests/ElggCoreMetadataAPITest.php
@@ -47,7 +47,7 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 	}
 
 	public function testElggGetEntitiesFromMetadata() {
-		global $CONFIG, $METASTRINGS_CACHE;
+		global $METASTRINGS_CACHE;
 		$METASTRINGS_CACHE = array();
 
 		$this->object->title = 'Meta Unit Test';
@@ -212,6 +212,8 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 	protected function delete_metastrings($string) {
 		global $CONFIG, $METASTRINGS_CACHE;
 		$METASTRINGS_CACHE = array();
+
+		_elgg_get_memcache('metastrings_memcache')->delete($string);
 
 		$string = sanitise_string($string);
 		mysql_query("DELETE FROM {$CONFIG->dbprefix}metastrings WHERE string = BINARY '$string'");

--- a/mod/garbagecollector/start.php
+++ b/mod/garbagecollector/start.php
@@ -142,11 +142,7 @@ function garbagecollector_orphaned_metastrings() {
 
 		$dead = get_data($select_query);
 		if ($dead) {
-			static $metastrings_memcache;
-			
-			if (!$metastrings_memcache) {
-				$metastrings_memcache = new \ElggMemcache('metastrings_memcache');
-			}
+			$metastrings_memcache = _elgg_get_memcache('metastrings_memcache');
 
 			foreach ($dead as $d) {
 				$metastrings_memcache->delete($d->string);

--- a/mod/pages/actions/pages/delete.php
+++ b/mod/pages/actions/pages/delete.php
@@ -23,7 +23,6 @@ if (pages_is_page($page)) {
 		if ($children) {
 			$db_prefix = elgg_get_config('dbprefix');
 			$subtype_id = (int)get_subtype_id('object', 'page_top');
-			$newentity_cache = is_memcache_available() ? new ElggMemcache('new_entity_cache') : null;
 
 			foreach ($children as $child) {
 				if ($parent) {
@@ -41,9 +40,7 @@ if (pages_is_page($page)) {
 					));
 
 					_elgg_invalidate_cache_for_entity($child_guid);
-					if ($newentity_cache) {
-						$newentity_cache->delete($child_guid);
-					}
+					_elgg_invalidate_memcache_for_entity($child_guid);
 				}
 			}
 		}


### PR DESCRIPTION
The goal here was to leave the ElggMemcache API as is, and simplify its use in core without requiring a radical (bug inducing) refactoring.

The big benefit here is that, since this uses a Stash pool internally, a dev could easily set this up to use APC, files, or any other Stash storage model.
- [ ] Get tested by someone with a working memcache setup
