### PR TITLE
fix(upgrade): no longer try to process upgrade files from before installation version

### DIFF
--- a/engine/classes/Elgg/UpgradeService.php
+++ b/engine/classes/Elgg/UpgradeService.php
@@ -103,6 +103,13 @@ class UpgradeService {
 			$upgrade_version = $this->getUpgradeFileVersion($upgrade);
 			$success = true;
 
+			if ($upgrade_version <= $version) {
+				// skip upgrade files from before the installation version of Elgg
+				// because the upgrade files from before the installation version aren't
+				// added to the database.
+				continue;
+			}
+			
 			// hide all errors.
 			if ($quiet) {
 				// hide include errors as well as any exceptions that might happen

--- a/engine/tests/phpunit/Elgg/UpdateServiceTest.php
+++ b/engine/tests/phpunit/Elgg/UpdateServiceTest.php
@@ -1,0 +1,40 @@
+<?php
+namespace Elgg;
+
+class UpgradeServiceTest extends \PHPUnit_Framework_TestCase {
+	
+	/**
+	 * @var \Elgg\UpgradeService
+	 */
+	private $service;
+	
+	protected function setUp() {
+		
+		$this->service = new \Elgg\UpgradeService();
+	}
+	
+	protected function tearDown() {
+		// @todo should be re-enabled if test is complete
+		//$this->service->releaseUpgradeMutex();
+	}
+	
+	/**
+	 * This will test an upgrade run, just like calling /upgrade.php
+	 */
+	public function testUpgradeRun() {
+		// marked as incomplete because $CONFIG isn't available
+		$this->markTestIncomplete();
+		
+		try {
+			// running database upgrades can through exceptions
+			$result = $this->service->run();
+			
+			$this->assertTrue(is_array($result));
+			$this->assertArrayHasKey("failure", $result);
+			$this->assertFalse($result["failure"]);
+			
+		} catch (Exception $e) {
+			$this->fail($e->getMessage());
+		}
+	}
+}


### PR DESCRIPTION
The unprocessed upgrade files include everything which isn't listed in
the databse. But on a fresh installation nothing is added to the
database. This skipps all files from before the version in the database.

fixes: #7457

todo
- [x] add UnitTest
