### PR TITLE
fix(likes): Uses getDisplayName() instead of assuming the object has value in title property

### DIFF
--- a/mod/likes/actions/likes/add.php
+++ b/mod/likes/actions/likes/add.php
@@ -44,7 +44,7 @@ if ($entity->owner_guid != $user->guid) {
 
 	$annotation = elgg_get_annotation_from_id($annotation_id);
 
-	$title_str = $entity->title;
+	$title_str = $entity->getDisplayName();
 	if (!$title_str) {
 		$title_str = elgg_get_excerpt($entity->description);
 	}


### PR DESCRIPTION
I got notifications with empty title strings because the liked object had neither title nor description, but had overridden the `getDisplayName()` to generate a custom title.
