### PR TITLE
IDEA(boot): more formally separate libs and their initializers

### DIFF
--- a/engine/lib/access.php
+++ b/engine/lib/access.php
@@ -624,12 +624,14 @@ function access_test($hook, $type, $value, $params) {
 	return $value;
 }
 
-// Tell the access functions the system has booted, plugins are loaded,
-// and the user is logged in so it can start caching
-elgg_register_event_handler('ready', 'system', 'access_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	// Tell the access functions the system has booted, plugins are loaded,
+	// and the user is logged in so it can start caching
+	$events->registerHandler('ready', 'system', 'access_init');
 
-// For overrided permissions
-elgg_register_plugin_hook_handler('permissions_check', 'all', 'elgg_override_permissions');
-elgg_register_plugin_hook_handler('container_permissions_check', 'all', 'elgg_override_permissions');
+	// For overrided permissions
+	$hooks->registerHandler('permissions_check', 'all', 'elgg_override_permissions');
+	$hooks->registerHandler('container_permissions_check', 'all', 'elgg_override_permissions');
 
-elgg_register_plugin_hook_handler('unit_test', 'system', 'access_test');
+	$hooks->registerHandler('unit_test', 'system', 'access_test');
+};

--- a/engine/lib/actions.php
+++ b/engine/lib/actions.php
@@ -295,4 +295,6 @@ function actions_init() {
 	elgg_register_plugin_hook_handler('forward', 'all', 'ajax_forward_hook');
 }
 
-elgg_register_event_handler('init', 'system', 'actions_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', 'actions_init');
+};

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -835,4 +835,6 @@ function _elgg_add_admin_widgets($event, $type, $user) {
 	elgg_set_ignore_access(false);
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_admin_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_admin_init');
+};

--- a/engine/lib/annotations.php
+++ b/engine/lib/annotations.php
@@ -337,4 +337,6 @@ function _elgg_annotations_init() {
 	elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_annotations_test');
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_annotations_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_annotations_init');
+};

--- a/engine/lib/autoloader.php
+++ b/engine/lib/autoloader.php
@@ -7,12 +7,6 @@
  * @subpackage Autoloader
  */
 
-$autoload_path = dirname(dirname(__DIR__)) . '/vendor/autoload.php';
-$autoload_available = include_once($autoload_path);	
-if (!$autoload_available) {
-	die("Couldn't include '$autoload_path'. Did you run `composer install`?");
-}
-
 /**
  * @return \Elgg\Di\ServiceProvider
  * @access private
@@ -117,8 +111,7 @@ function elgg_register_class($class, $location) {
 	return true;
 }
 
-// set up autoloading and DIC
-_elgg_services();
-
-_elgg_services()->events->registerHandler('shutdown', 'system', '_elgg_save_autoload_cache', 1000);
-_elgg_services()->events->registerHandler('upgrade', 'all', '_elgg_delete_autoload_cache');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('shutdown', 'system', '_elgg_save_autoload_cache', 1000);
+	$events->registerHandler('upgrade', 'all', '_elgg_delete_autoload_cache');
+};

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -232,4 +232,6 @@ function _elgg_cache_init() {
 	_elgg_services()->systemCache->init();
 }
 
-elgg_register_event_handler('ready', 'system', '_elgg_cache_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('ready', 'system', '_elgg_cache_init');
+};

--- a/engine/lib/comments.php
+++ b/engine/lib/comments.php
@@ -7,8 +7,6 @@
  * @since 1.9
  */
 
-elgg_register_event_handler('init', 'system', '_elgg_comments_init');
-
 /**
  * Comments initialization function
  *
@@ -193,3 +191,7 @@ function _elgg_comments_permissions_override($hook, $type, $return, $params) {
 	
 	return $return;
 }
+
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_comments_init');
+};

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -373,4 +373,6 @@ function _elgg_config_test($hook, $type, $tests) {
 	return $tests;
 }
 
-elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_config_test');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$hooks->registerHandler('unit_test', 'system', '_elgg_config_test');
+};

--- a/engine/lib/cron.php
+++ b/engine/lib/cron.php
@@ -113,4 +113,6 @@ function _elgg_cron_public_pages($hook, $type, $pages, $params) {
 	return $pages;
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_cron_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_cron_init');
+};

--- a/engine/lib/database.php
+++ b/engine/lib/database.php
@@ -226,4 +226,6 @@ function _elgg_db_init() {
 	register_shutdown_function('_elgg_db_log_profiling_data');
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_db_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_db_init');
+};

--- a/engine/lib/deprecated-1.9.php
+++ b/engine/lib/deprecated-1.9.php
@@ -3018,9 +3018,6 @@ function _export_init() {
 	elgg_register_action("import/opendd");
 }
 
-// Register a startup event
-elgg_register_event_handler('init', 'system', '_export_init', 100);
-
 /**
  * Returns the name of views for in a directory.
  *
@@ -3745,20 +3742,6 @@ function import_relationship_plugin_hook($hook, $entity_type, $returnvalue, $par
 	return $tmp;
 }
 
-/** Register the import hook */
-elgg_register_plugin_hook_handler("import", "all", "import_entity_plugin_hook", 0);
-elgg_register_plugin_hook_handler("import", "all", "import_extender_plugin_hook", 2);
-elgg_register_plugin_hook_handler("import", "all", "import_relationship_plugin_hook", 3);
-
-/** Register the hook, ensuring entities are serialised first */
-elgg_register_plugin_hook_handler("export", "all", "export_entity_plugin_hook", 0);
-elgg_register_plugin_hook_handler("export", "all", "export_annotation_plugin_hook", 2);
-elgg_register_plugin_hook_handler("export", "all", "export_metadata_plugin_hook", 2);
-elgg_register_plugin_hook_handler("export", "all", "export_relationship_plugin_hook", 3);
-
-/** Hook to get certain named bits of volatile data about an entity */
-elgg_register_plugin_hook_handler('volatile', 'metadata', 'volatile_data_export_plugin_hook');
-
 /**
  * Returns the SQL where clause for a table with access_id and enabled columns.
  *
@@ -3844,3 +3827,22 @@ function elgg_get_calling_plugin_entity() {
 
 	return false;
 }
+
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	// Register a startup event
+	$events->registerHandler('init', 'system', '_export_init', 100);
+
+	/** Register the import hook */
+	$hooks->registerHandler("import", "all", "import_entity_plugin_hook", 0);
+	$hooks->registerHandler("import", "all", "import_extender_plugin_hook", 2);
+	$hooks->registerHandler("import", "all", "import_relationship_plugin_hook", 3);
+
+	/** Register the hook, ensuring entities are serialised first */
+	$hooks->registerHandler("export", "all", "export_entity_plugin_hook", 0);
+	$hooks->registerHandler("export", "all", "export_annotation_plugin_hook", 2);
+	$hooks->registerHandler("export", "all", "export_metadata_plugin_hook", 2);
+	$hooks->registerHandler("export", "all", "export_relationship_plugin_hook", 3);
+
+	/** Hook to get certain named bits of volatile data about an entity */
+	$hooks->registerHandler('volatile', 'metadata', 'volatile_data_export_plugin_hook');
+};

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -2072,8 +2072,10 @@ define('REFERRER', -1);
  */
 define('REFERER', -1);
 
-elgg_register_event_handler('init', 'system', '_elgg_init');
-elgg_register_event_handler('boot', 'system', '_elgg_engine_boot', 1);
-elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_api_test');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_init');
+	$events->registerHandler('boot', 'system', '_elgg_engine_boot', 1);
+	$hooks->registerHandler('unit_test', 'system', '_elgg_api_test');
 
-elgg_register_event_handler('init', 'system', '_elgg_walled_garden_init', 1000);
+	$events->registerHandler('init', 'system', '_elgg_walled_garden_init', 1000);
+};

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -988,4 +988,6 @@ function _elgg_entities_init() {
 	elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_entities_test');
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_entities_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_entities_init');
+};

--- a/engine/lib/filestore.php
+++ b/engine/lib/filestore.php
@@ -574,4 +574,6 @@ function _elgg_filestore_test($hook, $type, $value) {
 	return $value;
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_filestore_init', 100);
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_filestore_init', 100);
+};

--- a/engine/lib/friends.php
+++ b/engine/lib/friends.php
@@ -8,8 +8,6 @@
  * @subpackage Friends
  */
 
-elgg_register_event_handler('init', 'system', '_elgg_friends_init');
-
 /**
  * Init friends library
  *
@@ -224,3 +222,7 @@ function _elgg_send_friend_notification($event, $type, $object) {
 
 	return notify_user($user_two->guid, $object->guid_one, $subject, $body);
 }
+
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_friends_init');
+};

--- a/engine/lib/group.php
+++ b/engine/lib/group.php
@@ -124,4 +124,6 @@ function _elgg_groups_init() {
 	elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_groups_test');
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_groups_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_groups_init');
+};

--- a/engine/lib/input.php
+++ b/engine/lib/input.php
@@ -477,4 +477,6 @@ function _elgg_input_init() {
 	}
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_input_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_input_init');
+};

--- a/engine/lib/mb_wrapper.php
+++ b/engine/lib/mb_wrapper.php
@@ -1,12 +1,10 @@
 <?php
-
-// if mb functions are available, set internal encoding to UTF8
-if (is_callable('mb_internal_encoding')) {
-	mb_internal_encoding("UTF-8");
-	if (ini_get("mbstring.internal_encoding")) {
-		ini_set("mbstring.internal_encoding", 'UTF-8');
-	}
-}
+/**
+ * Elgg UTF-8 string functions
+ *
+ * @package Elgg
+ * @subpackage Core
+ */
 
 /**
  * Parses a string using mb_parse_str() if available.
@@ -27,8 +25,6 @@ function elgg_parse_str($str) {
 
 	return $results;
 }
-
-
 
 /**
  * Wrapper function for mb_split(). Falls back to split() if
@@ -233,3 +229,13 @@ function elgg_substr() {
 	}
 	return call_user_func_array('substr', $args);
 }
+
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	// if mb functions are available, set internal encoding to UTF8
+	if (is_callable('mb_internal_encoding')) {
+		mb_internal_encoding("UTF-8");
+		if (ini_get("mbstring.internal_encoding")) {
+			ini_set("mbstring.internal_encoding", 'UTF-8');
+		}
+	}
+};

--- a/engine/lib/metadata.php
+++ b/engine/lib/metadata.php
@@ -404,9 +404,6 @@ function _elgg_invalidate_metadata_cache($action, array $options) {
 	}
 }
 
-/** Call a function whenever an entity is updated **/
-elgg_register_event_handler('update', 'all', 'metadata_update');
-
 /**
  * Metadata unit test
  *
@@ -425,4 +422,9 @@ function _elgg_metadata_test($hook, $type, $value, $params) {
 	return $value;
 }
 
-elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_metadata_test');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	/** Call a function whenever an entity is updated **/
+	$events->registerHandler('update', 'all', 'metadata_update');
+
+	$hooks->registerHandler('unit_test', 'system', '_elgg_metadata_test');
+};

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -741,4 +741,6 @@ function _elgg_metastrings_test($hook, $type, $value) {
 	return $value;
 }
 
-elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_metastrings_test');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$hooks->registerHandler('unit_test', 'system', '_elgg_metastrings_test');
+};

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -555,4 +555,6 @@ function _elgg_nav_init() {
 	)));
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_nav_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_nav_init');
+};

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -294,10 +294,6 @@ function _elgg_notifications_init() {
 	elgg_register_plugin_hook_handler('usersettings:save', 'user', '_elgg_save_notification_user_settings');
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_notifications_init');
-
-
-
 /**
  * Notify a user via their preferences.
  *
@@ -713,4 +709,8 @@ function _elgg_notifications_test($hook, $type, $tests) {
 	return $tests;
 }
 
-elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_notifications_test');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_notifications_init');
+
+	$hooks->registerHandler('unit_test', 'system', '_elgg_notifications_test');
+};

--- a/engine/lib/objects.php
+++ b/engine/lib/objects.php
@@ -39,4 +39,6 @@ function _elgg_objects_test($hook, $type, $value, $params) {
 	return $value;
 }
 
-elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_objects_test');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$hooks->registerHandler('unit_test', 'system', '_elgg_objects_test');
+};

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -594,4 +594,6 @@ function _elgg_output_init() {
 	elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_output_unit_test');
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_output_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_output_init');
+};

--- a/engine/lib/pagehandler.php
+++ b/engine/lib/pagehandler.php
@@ -296,4 +296,6 @@ function _elgg_page_handler_init() {
 	elgg_register_plugin_hook_handler('forward', '404', 'elgg_error_page_handler', 600);
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_page_handler_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_page_handler_init');
+};

--- a/engine/lib/pageowner.php
+++ b/engine/lib/pageowner.php
@@ -275,4 +275,6 @@ function page_owner_boot() {
 	}
 }
 
-elgg_register_event_handler('boot', 'system', 'page_owner_boot');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('boot', 'system', 'page_owner_boot');
+};

--- a/engine/lib/plugins.php
+++ b/engine/lib/plugins.php
@@ -526,4 +526,6 @@ function _elgg_plugins_init() {
 	elgg_register_library('elgg:markdown', elgg_get_root_path() . 'vendors/markdown/markdown.php');
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_plugins_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_plugins_init');
+};

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -829,6 +829,8 @@ function _elgg_river_init() {
 	elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_river_test');
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_river_init');
-elgg_register_event_handler('disable:after', 'all', '_elgg_river_disable');
-elgg_register_event_handler('enable:after', 'all', '_elgg_river_enable');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_river_init');
+	$events->registerHandler('disable:after', 'all', '_elgg_river_disable');
+	$events->registerHandler('enable:after', 'all', '_elgg_river_enable');
+};

--- a/engine/lib/sites.php
+++ b/engine/lib/sites.php
@@ -86,4 +86,6 @@ function _elgg_sites_test($hook, $type, $value, $params) {
 	return $value;
 }
 
-elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_sites_test');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$hooks->registerHandler('unit_test', 'system', '_elgg_sites_test');
+};

--- a/engine/lib/statistics.php
+++ b/engine/lib/statistics.php
@@ -119,5 +119,6 @@ function statistics_init() {
 	elgg_extend_view('core/settings/statistics', 'core/settings/statistics/numentities');
 }
 
-/// Register init function
-elgg_register_event_handler('init', 'system', 'statistics_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', 'statistics_init');
+};

--- a/engine/lib/system_log.php
+++ b/engine/lib/system_log.php
@@ -322,8 +322,10 @@ function system_log_listener($event, $object_type, $object) {
 	return true;
 }
 
-/** Register event to listen to all events **/
-elgg_register_event_handler('all', 'all', 'system_log_listener', 400);
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	/** Register event to listen to all events **/
+	$events->registerHandler('all', 'all', 'system_log_listener', 400);
 
-/** Register a default system log handler */
-elgg_register_event_handler('log', 'systemlog', 'system_log_default_logger', 999);
+	/** Register a default system log handler */
+	$events->registerHandler('log', 'systemlog', 'system_log_default_logger', 999);
+};

--- a/engine/lib/tags.php
+++ b/engine/lib/tags.php
@@ -242,4 +242,6 @@ function _elgg_tags_init() {
 	elgg_register_tag_metadata_name('tags');
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_tags_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_tags_init');
+};

--- a/engine/lib/user_settings.php
+++ b/engine/lib/user_settings.php
@@ -417,4 +417,6 @@ function _elgg_user_settings_init() {
 	elgg_extend_view('forms/account/settings', 'core/settings/account/default_access', 100);
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_user_settings_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_user_settings_init');
+};

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -805,7 +805,9 @@ function users_test($hook, $type, $value, $params) {
 	return $value;
 }
 
-elgg_register_event_handler('init', 'system', 'users_init', 0);
-elgg_register_event_handler('init', 'system', 'elgg_profile_fields_setup', 10000); // Ensure this runs after other plugins
-elgg_register_event_handler('pagesetup', 'system', 'users_pagesetup', 0);
-elgg_register_plugin_hook_handler('unit_test', 'system', 'users_test');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', 'users_init', 0);
+	$events->registerHandler('init', 'system', 'elgg_profile_fields_setup', 10000); // Ensure this runs after other plugins
+	$events->registerHandler('pagesetup', 'system', 'users_pagesetup', 0);
+	$hooks->registerHandler('unit_test', 'system', 'users_test');
+};

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1650,6 +1650,8 @@ function elgg_views_boot() {
 	}
 }
 
-elgg_register_event_handler('boot', 'system', 'elgg_views_boot');
-elgg_register_event_handler('init', 'system', 'elgg_views_handle_deprecated_views');
-elgg_register_event_handler('ready', 'system', '_elgg_views_deprecate_removed_views');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('boot', 'system', 'elgg_views_boot');
+	$events->registerHandler('init', 'system', 'elgg_views_handle_deprecated_views');
+	$events->registerHandler('ready', 'system', '_elgg_views_deprecate_removed_views');
+};

--- a/engine/lib/widgets.php
+++ b/engine/lib/widgets.php
@@ -293,5 +293,7 @@ function _elgg_default_widgets_permissions_override($hook, $type, $return, $para
 	return null;
 }
 
-elgg_register_event_handler('init', 'system', '_elgg_widgets_init');
-elgg_register_event_handler('ready', 'system', '_elgg_default_widgets_init');
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	$events->registerHandler('init', 'system', '_elgg_widgets_init');
+	$events->registerHandler('ready', 'system', '_elgg_default_widgets_init');
+};


### PR DESCRIPTION
This is an idea for separating the initialization of the "libraries" from their code. Benefits:
1. A library can be included in a unit test without forcing the initialization to happen.
2. The initialization is testable by passing test doubles in for the hooks/events.
3. Adds a place to standardize init handlers
4. including any lib file doesn't run any procedural code (though it may set some local/global vars), to (mostly) be in compliance with PSR-1.

See #5777. cc @ewinslow 
