### PR TITLE
fix(pages): add canEdit to page deletion permission check

### DIFF
--- a/mod/pages/actions/pages/delete.php
+++ b/mod/pages/actions/pages/delete.php
@@ -10,8 +10,9 @@
 $guid = get_input('guid');
 $page = get_entity($guid);
 if (pages_is_page($page)) {
+	elgg_load_library('elgg:pages');
 	// only allow owners and admin to delete
-	if (elgg_is_admin_logged_in() || elgg_get_logged_in_user_guid() == $page->getOwnerGuid()) {
+	if (elgg_is_admin_logged_in() || elgg_get_logged_in_user_guid() == $page->getOwnerGuid()||pages_can_delete_page($page)) {
 		$container = get_entity($page->container_guid);
 
 		// Bring all child elements forward

--- a/mod/pages/lib/pages.php
+++ b/mod/pages/lib/pages.php
@@ -150,3 +150,24 @@ function pages_register_navigation_tree($container) {
 		}
 	}
 }
+
+/**
+ * Function checking delete permission
+ *
+ * @package ElggPages
+ * @param mixed $value
+ *
+ * @return bool
+ */
+function pages_can_delete_page($page) {
+	if (! $page) {
+		return false;
+	} else {
+		$container = get_entity($page->container_guid);
+		if ($container->canEdit()) {
+			return true;
+                } else {
+			return false;
+		}
+	}
+}

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -239,6 +239,7 @@ function pages_entity_menu_setup($hook, $type, $return, $params) {
 		return $return;
 	}
 
+	elgg_load_library('elgg:pages');
 	$entity = $params['entity'];
 	$handler = elgg_extract('handler', $params, false);
 	if ($handler != 'pages') {
@@ -246,7 +247,7 @@ function pages_entity_menu_setup($hook, $type, $return, $params) {
 	}
 
 	// remove delete if not owner or admin
-	if (!elgg_is_admin_logged_in() && elgg_get_logged_in_user_guid() != $entity->getOwnerGuid()) {
+	if (!elgg_is_admin_logged_in() && elgg_get_logged_in_user_guid() != $entity->getOwnerGuid()&& ! pages_can_delete_page($entity)) {
 		foreach ($return as $index => $item) {
 			if ($item->getName() == 'delete') {
 				unset($return[$index]);


### PR DESCRIPTION
Description: using canEdit allows plugins to override the delete permission check (e.g. groups owners in the group_tools plugin). I did not mark the function pages_can_delete_page in lib/pages as private since it could be used by other plugins.

Fixes #7007

Duplicate of pull request #7012 
