### PR TITLE
fix(notifications): Verifies that a notification method is registered before using it

### DIFF
--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -448,14 +448,20 @@ function notify_user($to, $from, $subject, $message, array $params = array(), $m
 		$methods_override = array($methods_override);
 	}
 
+	$result = array();
+
+	$available_methods = _elgg_services()->notifications->getMethods();
+	if (!$available_methods) {
+		// There are no notifications methods to use
+		return $result;
+	}
+
 	// temporary backward compatibility for 1.8 and earlier notifications
 	$event = null;
 	if (isset($params['object']) && isset($params['action'])) {
 		$event = new Elgg_Notifications_Event($params['object'], $params['action'], $sender);
 	}
 	$params['event'] = $event;
-
-	$result = array();
 
 	foreach ($to as $guid) {
 		// Results for a user are...
@@ -478,6 +484,11 @@ function notify_user($to, $from, $subject, $message, array $params = array(), $m
 			if ($methods) {
 				// Deliver
 				foreach ($methods as $method) {
+					if (!in_array($method, $available_methods)) {
+						// This method was available the last time the user saved their
+						// notification settings. It's however currently disabled.
+						continue;
+					}
 
 					if (_elgg_services()->hooks->hasHandler('send', "notification:$method")) {
 						// 1.9 style notification handler


### PR DESCRIPTION
Instantly sent notifications now respect the registered notification methods instead of assuming that a method is available only because it can be found from user's notification settings.

Fixes #7647
