### PR TITLE
perf(entities): adds preload_containers option to elgg_get_entities

### DIFF
--- a/docs/guides/database.rst
+++ b/docs/guides/database.rst
@@ -281,9 +281,9 @@ Entity loading performance
 
 ``elgg_get_entities`` has a couple options that can sometimes be useful to improve performance.
 
-* **preload_owners**: If the entities fetched will be displayed in a list with the owner information, you can set this option to ``true`` to efficiently load the owner users of the fetched entities.
-
-* **distinct**: When Elgg fetches entities using an SQL query, Elgg must be sure that each entity row appears only once in the result set. By default it includes a ``DISTINCT`` modifier on the GUID column to enforce this, but some queries naturally return unique entities. Setting the ``distinct`` option to false will remove this modifier, and rely on the query to enforce its own uniqueness.
+- **preload_owners**: If the entities fetched will be displayed in a list with the owner information, you can set this option to ``true`` to efficiently load the owner users of the fetched entities.
+- **preload_containers**: If the entities fetched will be displayed in a list using info from their containers, you can set this option to ``true`` to efficiently load them.
+- **distinct**: When Elgg fetches entities using an SQL query, Elgg must be sure that each entity row appears only once in the result set. By default it includes a ``DISTINCT`` modifier on the GUID column to enforce this, but some queries naturally return unique entities. Setting the ``distinct`` option to false will remove this modifier, and rely on the query to enforce its own uniqueness.
 
 The internals of Elgg entity queries is a complex subject and it's recommended to seek help on the Elgg Community site before using the ``distinct`` option.
 

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -27,6 +27,7 @@ use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
  * @property-read \Elgg\Database\Datalist                  $datalist
  * @property-read \Elgg\Database                           $db
  * @property-read \Elgg\DeprecationService                 $deprecation
+ * @property-read \Elgg\EntityPreloader                    $entityPreloader
  * @property-read \Elgg\Database\EntityTable               $entityTable
  * @property-read \Elgg\EventsService                      $events
  * @property-read \Elgg\Assets\ExternalFiles               $externalFiles
@@ -37,7 +38,6 @@ use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
  * @property-read \Elgg\Database\MetadataTable             $metadataTable
  * @property-read \Elgg\Database\MetastringsTable          $metastringsTable
  * @property-read \Elgg\Notifications\NotificationsService $notifications
- * @property-read \Elgg\EntityPreloader                    $ownerPreloader
  * @property-read \Elgg\PasswordService                    $passwords
  * @property-read \Elgg\PersistentLoginService             $persistentLogin
  * @property-read \Elgg\Database\Plugins                   $plugins
@@ -120,6 +120,8 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			return new \Elgg\DeprecationService($c->session, $c->logger);
 		});
 
+		$this->setClassName('entityPreloader', '\Elgg\EntityPreloader');
+
 		$this->setClassName('entityTable', '\Elgg\Database\EntityTable');
 
 		$this->setFactory('events', function(ServiceProvider $c) {
@@ -158,10 +160,6 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			$queue = new \Elgg\Queue\DatabaseQueue($queue_name, $c->db);
 			$sub = new \Elgg\Notifications\SubscriptionsService($c->db);
 			return new \Elgg\Notifications\NotificationsService($sub, $queue, $c->hooks, $c->access);
-		});
-
-		$this->setFactory('ownerPreloader', function(ServiceProvider $c) {
-			return new \Elgg\EntityPreloader(array('owner_guid'));
 		});
 
 		$this->setFactory('persistentLogin', function(ServiceProvider $c) {

--- a/engine/classes/Elgg/EntityPreloader.php
+++ b/engine/classes/Elgg/EntityPreloader.php
@@ -12,28 +12,16 @@ namespace Elgg;
 class EntityPreloader {
 
 	/**
-	 * @var string[]
-	 */
-	protected $properties;
-
-	/**
-	 * Configure the preloader to check these properties of fetched objects for GUIDs.
-	 *
-	 * @param array $guid_properties e.g. array("owner_guid")
-	 */
-	public function __construct(array $guid_properties) {
-		$this->properties = $guid_properties;
-	}
-
-	/**
 	 * Preload entities based on the given objects
 	 *
-	 * @param object[] $objects Objects--e.g. loaded from an Elgg query--from which we can pluck GUIDs to preload
+	 * @param object[] $objects         Objects--e.g. loaded from an Elgg query--from which we can
+	 *                                  pluck GUIDs to preload
+	 * @param string[] $guid_properties e.g. array("owner_guid")
 	 *
 	 * @return void
 	 */
-	public function preload($objects) {
-		$guids = $this->getGuidsToLoad($objects);
+	public function preload($objects, array $guid_properties) {
+		$guids = $this->getGuidsToLoad($objects, $guid_properties);
 		// If only 1 to load, not worth the overhead of elgg_get_entities(),
 		// get_entity() will handle it later.
 		if (count($guids) > 1) {
@@ -48,17 +36,18 @@ class EntityPreloader {
 	 *
 	 * To simplify the user API, this function accepts non-arrays and arrays containing non-objects
 	 *
-	 * @param object[] $objects Objects from which to pluck GUIDs
+	 * @param object[] $objects         Objects from which to pluck GUIDs
+	 * @param string[] $guid_properties e.g. array("owner_guid")
 	 * @return int[]
 	 */
-	protected function getGuidsToLoad($objects) {
+	protected function getGuidsToLoad($objects, array $guid_properties) {
 		if (!is_array($objects) || count($objects) < 2) {
 			return array();
 		}
 		$preload_guids = array();
 		foreach ($objects as $object) {
 			if (is_object($object)) {
-				foreach ($this->properties as $property) {
+				foreach ($guid_properties as $property) {
 					if (empty($object->{$property})) {
 						continue;
 					}

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -973,7 +973,7 @@ function _elgg_entities_test($hook, $type, $value) {
 	$value[] = $CONFIG->path . 'engine/tests/ElggCoreGetEntitiesFromPrivateSettingsTest.php';
 	$value[] = $CONFIG->path . 'engine/tests/ElggCoreGetEntitiesFromRelationshipTest.php';
 	$value[] = $CONFIG->path . 'engine/tests/ElggCoreGetEntitiesFromAttributesTest.php';
-	$value[] = $CONFIG->path . 'engine/tests/ElggOwnerPreloaderIntegrationTest.php';
+	$value[] = $CONFIG->path . 'engine/tests/ElggEntityPreloaderIntegrationTest.php';
 	return $value;
 }
 

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -324,7 +324,7 @@ function _elgg_get_metastring_based_objects($options) {
 		$dt = get_data($query, $options['callback']);
 
 		if ($options['preload_owners'] && is_array($dt) && count($dt) > 1) {
-			_elgg_services()->ownerPreloader->preload($dt);
+			_elgg_services()->entityPreloader->preload($dt, ['owner_guid']);
 		}
 
 		return $dt;

--- a/engine/tests/ElggEntityPreloaderIntegrationTest.php
+++ b/engine/tests/ElggEntityPreloaderIntegrationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggOwnerPreloaderIntegrationTest extends ElggCoreUnitTest {
+class ElggEntityPreloaderIntegrationTest extends ElggCoreUnitTest {
 
 	protected $realPreloader;
 
@@ -10,14 +10,14 @@ class ElggOwnerPreloaderIntegrationTest extends ElggCoreUnitTest {
 	protected $mockPreloader;
 
 	public function setUp() {
-		$this->realPreloader = _elgg_services()->ownerPreloader;
+		$this->realPreloader = _elgg_services()->entityPreloader;
 
-		$this->mockPreloader = new MockEntityPreloader20140623(array('owner_guid'));
-		_elgg_services()->setValue('ownerPreloader', $this->mockPreloader);
+		$this->mockPreloader = new MockEntityPreloader20140623();
+		_elgg_services()->setValue('entityPreloader', $this->mockPreloader);
 	}
 
 	public function tearDown() {
-		_elgg_services()->setValue('ownerPreloader', $this->realPreloader);
+		_elgg_services()->setValue('entityPreloader', $this->realPreloader);
 	}
 
 	public function testEGECanUsePreloader() {

--- a/engine/tests/phpunit/Elgg/EntityPreloaderTest.php
+++ b/engine/tests/phpunit/Elgg/EntityPreloaderTest.php
@@ -14,7 +14,7 @@ class EntityPreloaderTest extends \PHPUnit_Framework_TestCase {
 	public $obj;
 
 	public function setup() {
-		$this->obj = new EntityPreloader(array('foo', 'bar'));
+		$this->obj = new EntityPreloader();
 		$dependency = new PreloaderMock_20140623();
 		$this->obj->_callable_cache_checker = array($dependency, 'isCached');
 		$this->obj->_callable_entity_loader = array($dependency, 'load');
@@ -34,7 +34,7 @@ class EntityPreloaderTest extends \PHPUnit_Framework_TestCase {
 		$this->obj->_callable_cache_checker = array($this->mock, 'isCached');
 		$this->mock->expects($this->once())->method('isCached')->with(123);
 		foreach ($inputs as $input) {
-			$this->obj->preload($input);
+			$this->obj->preload($input, array('foo', 'bar'));
 		}
 	}
 
@@ -45,7 +45,7 @@ class EntityPreloaderTest extends \PHPUnit_Framework_TestCase {
 			(object)array('foo' => 23,),
 			(object)array('bar' => 234,),
 			(object)array('bar' => 345,),
-		));
+		), array('foo', 'bar'));
 	}
 
 	public function testOnlyLoadsIfMoreThanOne() {
@@ -54,7 +54,7 @@ class EntityPreloaderTest extends \PHPUnit_Framework_TestCase {
 		$this->obj->preload(array(
 			(object)array('foo' => 23,),
 			(object)array('bar' => 234,),
-		));
+		), array('foo', 'bar'));
 	}
 
 	public function testQuietlyIgnoresMissingProperty() {
@@ -64,7 +64,7 @@ class EntityPreloaderTest extends \PHPUnit_Framework_TestCase {
 			(object)array('foo' => 234),
 			(object)array(),
 			(object)array('bar' => 345)
-		));
+		), array('foo', 'bar'));
 	}
 }
 

--- a/mod/blog/lib/blog.php
+++ b/mod/blog/lib/blog.php
@@ -93,6 +93,7 @@ function blog_get_page_content_list($container_guid = NULL) {
 			$return['filter_context'] = 'none';
 		}
 	} else {
+		$options['preload_containers'] = true;
 		$return['filter_context'] = 'all';
 		$return['title'] = elgg_echo('blog:title:all_blogs');
 		elgg_pop_breadcrumb();
@@ -139,6 +140,7 @@ function blog_get_page_content_friends($user_guid) {
 		'relationship_join_on' => 'container_guid',
 		'no_results' => elgg_echo('blog:none'),
 		'preload_owners' => true,
+		'preload_containers' => true,
 	);
 
 	$return['content'] = elgg_list_entities_from_relationship($options);

--- a/mod/bookmarks/pages/bookmarks/all.php
+++ b/mod/bookmarks/pages/bookmarks/all.php
@@ -17,6 +17,7 @@ $content = elgg_list_entities(array(
 	'view_toggle_type' => false,
 	'no_results' => elgg_echo('bookmarks:none'),
 	'preload_owners' => true,
+	'preload_containers' => true,
 	'distinct' => false,
 ));
 

--- a/mod/bookmarks/pages/bookmarks/friends.php
+++ b/mod/bookmarks/pages/bookmarks/friends.php
@@ -26,6 +26,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo('bookmarks:none'),
 	'preload_owners' => true,
+	'preload_containers' => true,
 ));
 
 $params = array(

--- a/mod/file/pages/file/friends.php
+++ b/mod/file/pages/file/friends.php
@@ -27,6 +27,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo("file:none"),
 	'preload_owners' => true,
+	'preload_containers' => true,
 ));
 
 $sidebar = file_get_type_cloud($owner->guid, true);

--- a/mod/file/pages/file/world.php
+++ b/mod/file/pages/file/world.php
@@ -17,6 +17,7 @@ $content = elgg_list_entities(array(
 	'full_view' => false,
 	'no_results' => elgg_echo("file:none"),
 	'preload_owners' => true,
+	'preload_containers' => true,
 	'distinct' => false,
 ));
 

--- a/mod/groups/lib/discussion.php
+++ b/mod/groups/lib/discussion.php
@@ -19,6 +19,7 @@ function discussion_handle_all_page() {
 		'full_view' => false,
 		'no_results' => elgg_echo('discussion:none'),
 		'preload_owners' => true,
+		'preload_containers' => true,
 	));
 
 	$title = elgg_echo('discussion:latest');

--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -37,6 +37,7 @@ function groups_handle_all_page() {
 				'full_view' => false,
 				'no_results' => elgg_echo('discussion:none'),
 				'distinct' => false,
+				'preload_containers' => true,
 			));
 			break;
 		case 'featured':

--- a/mod/pages/pages/pages/friends.php
+++ b/mod/pages/pages/pages/friends.php
@@ -26,6 +26,7 @@ $content = elgg_list_entities_from_relationship(array(
 	'relationship_join_on' => 'container_guid',
 	'no_results' => elgg_echo('pages:none'),
 	'preload_owners' => true,
+	'preload_containers' => true,
 ));
 
 $params = array(

--- a/mod/pages/pages/pages/world.php
+++ b/mod/pages/pages/pages/world.php
@@ -18,6 +18,7 @@ $content = elgg_list_entities(array(
 	'full_view' => false,
 	'no_results' => elgg_echo('pages:none'),
 	'preload_owners' => true,
+	'preload_containers' => true,
 ));
 
 $body = elgg_view_layout('content', array(


### PR DESCRIPTION
This allows devs to preload the containing entities of a fetched list. It
refactors the EntityPreloader a bit to support both use cases, and adds
container preloading to lists of group discussions.

Fixes #7663 

Where discussions appear across different groups, this save ~ 10 queries.
