### PR TITLE
WIP feature(navigation): adds a pagination model that requires no COUNT() query

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -949,7 +949,8 @@ function elgg_view_annotation(\ElggAnnotation $annotation, array $vars = array()
  *
  * @param array $entities Array of entities
  * @param array $vars     Display variables
- *      'count'            The total number of entities across all pages
+ *      'count'            The total number of entities across all pages. If not provided, the pagination
+ *                         will only include the "next" link.
  *      'offset'           The current indexing offset
  *      'limit'            The number of entities to display per page (default from settings)
  *      'full_view'        Display the full view of the entities?
@@ -1652,6 +1653,8 @@ function elgg_views_boot() {
 		);
 		elgg_set_config('icon_sizes', $icon_sizes);
 	}
+
+	_elgg_services()->config->set('pagination_model', 'no_count');
 }
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {

--- a/views/default/navigation/pagination/count.php
+++ b/views/default/navigation/pagination/count.php
@@ -1,0 +1,3 @@
+<?php
+
+echo elgg_view('navigation/pagination', $vars);

--- a/views/default/page/components/gallery.php
+++ b/views/default/page/components/gallery.php
@@ -52,14 +52,30 @@ if (isset($vars['item_class'])) {
 }
 
 $nav = '';
-if ($pagination && $count) {
-	$nav .= elgg_view('navigation/pagination', array(
-		'base_url' => $base_url,
-		'offset' => $offset,
-		'count' => $count,
-		'limit' => $limit,
-		'offset_key' => $offset_key,
-	));
+
+if ($pagination && $limit) {
+	if ($count) {
+		$nav .= elgg_view('navigation/pagination/count', array(
+			'base_url' => $base_url,
+			'offset' => $offset,
+			'count' => $count,
+			'limit' => $limit,
+			'offset_key' => $offset_key,
+		));
+	} else {
+		$nav .= elgg_view('navigation/pagination/no_count', array(
+			'base_url' => $base_url,
+			'offset' => $offset,
+			'has_next' => count($items) > $limit,
+			'limit' => $limit,
+			'offset_key' => $offset_key,
+		));
+	}
+}
+
+if ($limit) {
+	// if using prev_next pagination, we have one too many
+	$items = array_slice($items, 0, $limit);
 }
 
 if ($position == 'before' || $position == 'both') {
@@ -70,8 +86,8 @@ if ($position == 'before' || $position == 'both') {
 <ul class="<?php echo $gallery_class; ?>">
 	<?php
 		foreach ($items as $item) {
-			if (elgg_instanceof($item)) {
-			$id = "elgg-{$item->getType()}-{$item->getGUID()}";
+			if ($item instanceof ElggEntity) {
+				$id = "elgg-{$item->getType()}-{$item->getGUID()}";
 			} else {
 				$id = "item-{$item->getType()}-{$item->id}";
 			}

--- a/views/default/page/components/list.php
+++ b/views/default/page/components/list.php
@@ -53,14 +53,29 @@ if (isset($vars['item_class'])) {
 $html = "";
 $nav = "";
 
-if ($pagination && $count) {
-	$nav .= elgg_view('navigation/pagination', array(
-		'base_url' => $base_url,
-		'offset' => $offset,
-		'count' => $count,
-		'limit' => $limit,
-		'offset_key' => $offset_key,
-	));
+if ($pagination && $limit) {
+	if ($count) {
+		$nav .= elgg_view('navigation/pagination/count', array(
+			'base_url' => $base_url,
+			'offset' => $offset,
+			'count' => $count,
+			'limit' => $limit,
+			'offset_key' => $offset_key,
+		));
+	} else {
+		$nav .= elgg_view('navigation/pagination/no_count', array(
+			'base_url' => $base_url,
+			'offset' => $offset,
+			'has_next' => count($items) > $limit,
+			'limit' => $limit,
+			'offset_key' => $offset_key,
+		));
+	}
+}
+
+if ($limit) {
+	// if using prev_next pagination, we have one too many
+	$items = array_slice($items, 0, $limit);
 }
 
 $html .= "<ul class=\"$list_class\">";
@@ -69,7 +84,7 @@ foreach ($items as $item) {
 	if ($li) {
 		$item_classes = array($item_class);
 		
-		if (elgg_instanceof($item)) {
+		if ($item instanceof ElggEntity) {
 			$id = "elgg-{$item->getType()}-{$item->getGUID()}";
 			
 			$item_classes[] = "elgg-item-" . $item->getType();


### PR DESCRIPTION
This splits the pagination into two models “count” and “no_count”, the latter
being a new model that requires no COUNT() query but lets the user page ahead
only 1 at a time.

(WIP: This sets the default to the new model for easier review)
- [ ] Decide on the look of the "no_count" pagination model (see below)
- [ ] Decide if "model" is the right elgg_list_entities() option for specifying it
- [ ] Currently a plugin can elgg_set_config("pagination_model", "no_count") to turn this on. Is this sufficient, or should we expose it in settings?
