### PR TITLE
perf(plugins): removes DB query to determine if a plugin is active

### DIFF
--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -171,7 +171,9 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			return new \Elgg\PasswordService();
 		});
 
-		$this->setClassName('plugins', '\Elgg\Database\Plugins');
+		$this->setFactory('plugins', function(ServiceProvider $c) {
+			return new \Elgg\Database\Plugins($c->events, new \Elgg\Cache\MemoryPool());
+		});
 
 		$this->setFactory('queryCounter', function(ServiceProvider $c) {
 			return new \Elgg\Database\QueryCounter($c->db);

--- a/engine/lib/plugins.php
+++ b/engine/lib/plugins.php
@@ -513,6 +513,13 @@ function _elgg_plugins_init() {
 	// deactivation due to error may have already occurred
 	elgg_register_event_handler('deactivate', 'plugin', '_plugins_deactivate_dependency_check');
 
+	/**
+	 * @see \Elgg\Database\Plugins::invalidateIsActiveCache
+	 */
+	$svc = _elgg_services()->plugins;
+	elgg_register_event_handler('deactivate', 'plugin', array($svc, 'invalidateIsActiveCache'));
+	elgg_register_event_handler('activate', 'plugin', array($svc, 'invalidateIsActiveCache'));
+
 	elgg_register_action("plugins/settings/save", '', 'admin');
 	elgg_register_action("plugins/usersettings/save");
 

--- a/engine/tests/phpunit/Elgg/Database/PluginsTest.php
+++ b/engine/tests/phpunit/Elgg/Database/PluginsTest.php
@@ -1,0 +1,18 @@
+<?php
+namespace Elgg\Database;
+
+
+class PluginsTest extends \PHPUnit_Framework_TestCase {
+
+	public function testAfterPluginLoadActiveCheckIsFree() {
+		$this->markTestIncomplete();
+	}
+
+	public function testPluginActivateAltersIsActive() {
+		$this->markTestIncomplete();
+	}
+
+	public function testPluginDeactivateAltersIsActive() {
+		$this->markTestIncomplete();
+	}
+}


### PR DESCRIPTION
This also modernizes the plugin_id to object map to use a MemoryPool.

Fixes #7661
