### PR TITLE
perf(languages): improved js caching of languages by using simplecache

### DIFF
--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -236,3 +236,23 @@ function get_language_completeness($language) {
 function get_missing_language_keys($language) {
 	return _elgg_services()->translator->getMissingLanguageKeys($language);
 }
+
+/**
+ * Initializes simplecache views for translations
+ * 
+ * @return void
+ */
+function _elgg_translations_init() {
+	$translations = _elgg_services()->translator->getInstalledTranslations();
+	foreach ($translations as $key => $language) {
+		// make the js view available for each language
+		elgg_extend_view("js/languages/$key.js", "js/languages");
+		
+		// register the js view for use in simplecache
+		elgg_register_simplecache_view("js/languages/$key.js");
+	}
+}
+
+return function(\Elgg\EventsService $events) {
+	$events->registerHandler('init', 'system', '_elgg_translations_init');
+};

--- a/views/default/js/elgg.php
+++ b/views/default/js/elgg.php
@@ -64,12 +64,7 @@ elgg.security.interval = <?php echo (int)_elgg_services()->actions->getActionTok
 elgg.config.language = '<?php echo (empty($CONFIG->language) ? 'en' : $CONFIG->language); ?>';
 
 !function () {
-	var languagesUrl = elgg.config.wwwroot + 'ajax/view/js/languages?language=' + elgg.get_language();
-	if (elgg.config.simplecache_enabled) {
-		languagesUrl += '&lc=' + elgg.config.lastcache;
-	}
-
-	define('elgg', ['jquery', languagesUrl], function($, translations) {
+	define('elgg', ['jquery', 'languages/' + elgg.get_language()], function($, translations) {
 		elgg.add_translation(elgg.get_language(), translations);
 
 		$(function() {

--- a/views/default/js/languages.php
+++ b/views/default/js/languages.php
@@ -1,33 +1,30 @@
 <?php
 /**
  * @uses $vars['language']
- * @uses $vars['lc'] if present, client will be sent long expires headers
  */
 
-$language = $vars['language'];
-$lastcache = elgg_extract('lc', $vars, 0);
+$language = elgg_extract('language', $vars);
 
-// @todo add server-side caching
-if ($lastcache) {
-	// we're relying on lastcache changes to predict language changes
-	$etag = '"' . md5("$language|$lastcache") .  '"';
+if (empty($language)) {
+	// try to detect it
+	preg_match("/\/js\/languages\/(.*?).js+/", current_page_url(), $matches);
+	
+	if (!empty($matches) && isset($matches[1])) {
+		$language = $matches[1];
+	}	
+}
 
-	header('Expires: ' . gmdate('D, d M Y H:i:s \G\M\T', strtotime("+6 months")), true);
-	header("Pragma: public", true);
-	header("Cache-Control: public", true);
-	header("ETag: $etag");
-
-	if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) === $etag) {
-		header("HTTP/1.1 304 Not Modified");
-		exit;
-	}
+if (empty($language)) {
+	// fallback to 'en'
+	$language = 'en';
 }
 
 $all_translations = elgg_get_config('translations');
 $translations = $all_translations['en'];
 
-if ($language != 'en') {
+if ($language != 'en' && isset($all_translations[$language])) {
 	$translations = array_merge($translations, $all_translations[$language]);
 }
+
 ?>
 define(<?php echo json_encode($translations); ?>);

--- a/views/default/js/languages/en.php
+++ b/views/default/js/languages/en.php
@@ -1,2 +1,3 @@
 <?php
+// @todo This view is no longer need for Core. Can be removed in 2.0
 echo elgg_view('js/languages', array('language' => 'en'));


### PR DESCRIPTION
fixes #7458

This replaces the ajax language views which booted the engine every view to only report a 304 not modified... this fix replaces this with just a few milliseconds and a normal cacheable .js file if you use tools like Varnish
