### PR TITLE
fix(settings): It's again possible to set user specific setting for a plugin

### DIFF
--- a/engine/classes/Elgg/Database/Plugins.php
+++ b/engine/classes/Elgg/Database/Plugins.php
@@ -783,7 +783,7 @@ class Plugins {
 	 * @return bool
 	 * @see \ElggPlugin::setUserSetting()
 	 */
-	function setUserSettings($name, $value, $user_guid = 0, $plugin_id = null) {
+	function setUserSetting($name, $value, $user_guid = 0, $plugin_id = null) {
 		if ($plugin_id) {
 			$plugin = elgg_get_plugin_from_id($plugin_id);
 		} else {

--- a/engine/tests/phpunit/Elgg/Database/Plugins.php
+++ b/engine/tests/phpunit/Elgg/Database/Plugins.php
@@ -1,0 +1,24 @@
+<?php
+namespace Elgg\Database;
+
+class PluginsTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * Check that plugins service is able to handle plugin user settings
+	 */
+	public function testSetGetAndUnsetUserSetting() {
+		// TODO Use these once the class becomes testable:
+		/*
+		$plugins = new \Elgg\Database\Plugins();
+		$user_guid = 123;
+
+		$plugins->setUserSetting('foo', 'bar', $user_guid, 'plugin_id');
+		$this->assertSame('bar', $plugins->getUserSetting('foo', $user_guid, 'plugin_id'));
+
+		$plugins->unsetUserSetting('foo', $user_guid, 'plugin_id');
+		$this->assertSame(null, $plugins->getUserSetting('foo', $user_guid, 'plugin_id'));
+		*/
+
+		$this->markTestIncomplete();
+	}
+}


### PR DESCRIPTION
Fixes the method name from `setUserSettings()`  to `setUserSetting()`.
