### PR TITLE
feature(test): Added rewrite rules for builtin PHP cli server execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,21 @@ matrix:
        - sphinx-build -b latex -nW docs docs/_build/latex
        - sphinx-intl --locale-dir=docs/locale/ build
        - sphinx-build -b html -D language=es -n docs docs/_build/html
-      
+
+    # End to end tests
+    - php: 5.6
+      env: E2E=true
+      install:
+       - composer install
+       - mysql -e 'create database elgg;'
+       - echo "USE mysql; UPDATE user SET password=PASSWORD('password') WHERE user='root'; FLUSH PRIVILEGES;" | mysql -u root
+       - mkdir "${HOME}/elgg_data/"
+       - php -f ./install/cli/travis_installer.php
+       - php -S localhost:8888 index.php &
+       - sleep 3 # give Web server some time to bind to sockets, etc
+      script:
+       - curl -o - http://localhost:8888/ | grep "<title>Elgg Travis Site</title>"
+
 services: 
  - mysql
 

--- a/index.php
+++ b/index.php
@@ -6,6 +6,44 @@
  * @subpackage Core
  */
 
+/*
+ * Rewrite rules for PHP cli webserver used for testing. Do not use on production sites
+ * as normal web server replacement.
+ *
+ * You need to explicitly point to index.php in order for router to work properly:
+ *
+ * <code>php -S localhost:8888 index.php</code>
+ */
+if (php_sapi_name() === 'cli-server') {
+	$urlPath = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
+
+	if (preg_match('/^\/cache\/(.*)$/', $urlPath, $matches)) {
+		$_GET['request'] = $matches[1];
+		require('engine/handlers/cache_handler.php');
+		exit;
+	} else if (preg_match('/^\/export\/([A-Za-z]+)\/([0-9]+)\/?$/', $urlPath, $matches)) {
+		$_GET['view'] = $matches[1];
+		$_GET['guid'] = $matches[2];
+		require('engine/handlers/export_handler.php');
+		exit;
+	} else if (preg_match('/^\/export\/([A-Za-z]+)\/([0-9]+)\/([A-Za-z]+)\/([A-Za-z0-9\_]+)\/$/', $urlPath, $matches)) {
+		$_GET['view'] = $matches[1];
+		$_GET['guid'] = $matches[2];
+		$_GET['type'] = $matches[3];
+		$_GET['idname'] = $matches[4];
+		require('engine/handlers/export_handler.php');
+		exit;
+	} else if (preg_match("/^\/rewrite.php$/", $urlPath, $matches)) {
+		require('install.php');
+		exit;
+	} else if ($urlPath !== '/' && file_exists(__DIR__ . $urlPath)) {
+		// serve the requested resource as-is.
+		return false;
+	} else {
+		$_GET['__elgg_uri'] = $urlPath;
+	}
+}
+
 // allow testing from the upgrade page before the site is upgraded.
 if (isset($_GET['__testing_rewrite'])) {
 	if (isset($_GET['__elgg_uri']) && false !== strpos($_GET['__elgg_uri'], '__testing_rewrite')) {

--- a/install/cli/travis_installer.php
+++ b/install/cli/travis_installer.php
@@ -35,7 +35,7 @@ $params = array(
 	// site settings
 	'sitename' => 'Elgg Travis Site',
 	'siteemail' => 'no_reply@travis.elgg.org',
-	'wwwroot' => 'http://travis.elgg.org/',
+	'wwwroot' => 'http://localhost:8888/',
 	'dataroot' => getenv('HOME') . '/elgg_data/',
 
 	// admin account


### PR DESCRIPTION
This does not test much at the moment, but it's a working stub that performs local HTTP request to the Elgg installed on Travis. It also introduces ability to run Elgg using PHP builtin cli server. Important is to indicate `index.php` as the router script, otherwise some URLs are not routed properly. 
