### PR TITLE
Inspector overhaul

### DIFF
--- a/engine/classes/Elgg/Cache/SystemCache.php
+++ b/engine/classes/Elgg/Cache/SystemCache.php
@@ -151,12 +151,7 @@ class SystemCache {
 		}
 		$this->CONFIG->view_types = unserialize($data);
 
-		// don't need these for operation. Inspector can pull from cache
-//		$data = $this->load('view_overrides');
-//		if ($data) {
-//			$data = unserialize($data);
-//			_elgg_services()->views->setOverriddenLocations($data);
-//		}
+		// Note: We don't need view_overrides for operation. Inspector can pull this from the cache
 	
 		$this->CONFIG->system_cache_loaded = true;
 	}

--- a/engine/classes/Elgg/Cache/SystemCache.php
+++ b/engine/classes/Elgg/Cache/SystemCache.php
@@ -34,7 +34,7 @@ class SystemCache {
 	 *
 	 * @return \ElggFileCache
 	 */
-	function get() {
+	function getFileCache() {
 		
 	
 		/**
@@ -55,8 +55,7 @@ class SystemCache {
 	 * @return void
 	 */
 	function reset() {
-		$cache = elgg_get_system_cache();
-		$cache->clear();
+		$this->getFileCache()->clear();
 	}
 	
 	/**
@@ -70,8 +69,7 @@ class SystemCache {
 		
 	
 		if ($this->CONFIG->system_cache_enabled) {
-			$cache = elgg_get_system_cache();
-			return $cache->save($type, $data);
+			return $this->getFileCache()->save($type, $data);
 		}
 	
 		return false;
@@ -87,8 +85,7 @@ class SystemCache {
 		
 	
 		if ($this->CONFIG->system_cache_enabled) {
-			$cache = elgg_get_system_cache();
-			$cached_data = $cache->load($type);
+			$cached_data = $this->getFileCache()->load($type);
 	
 			if ($cached_data) {
 				return $cached_data;
@@ -111,7 +108,7 @@ class SystemCache {
 	
 		_elgg_services()->datalist->set('system_cache_enabled', 1);
 		$this->CONFIG->system_cache_enabled = 1;
-		elgg_reset_system_cache();
+		$this->reset();
 	}
 	
 	/**
@@ -127,7 +124,7 @@ class SystemCache {
 	
 		_elgg_services()->datalist->set('system_cache_enabled', 0);
 		$this->CONFIG->system_cache_enabled = 0;
-		elgg_reset_system_cache();
+		$this->reset();
 	}
 	
 	/**
@@ -142,17 +139,24 @@ class SystemCache {
 		$this->CONFIG->system_cache_loaded = false;
 	
 		$this->CONFIG->views = new \stdClass();
-		$data = elgg_load_system_cache('view_locations');
+		$data = $this->load('view_locations');
 		if (!is_string($data)) {
 			return;
 		}
 		$this->CONFIG->views->locations = unserialize($data);
 		
-		$data = elgg_load_system_cache('view_types');
+		$data = $this->load('view_types');
 		if (!is_string($data)) {
 			return;
 		}
 		$this->CONFIG->view_types = unserialize($data);
+
+		// don't need these for operation. Inspector can pull from cache
+//		$data = $this->load('view_overrides');
+//		if ($data) {
+//			$data = unserialize($data);
+//			_elgg_services()->views->setOverriddenLocations($data);
+//		}
 	
 		$this->CONFIG->system_cache_loaded = true;
 	}
@@ -164,16 +168,23 @@ class SystemCache {
 	 * @access private
 	 */
 	function init() {
+		if (!$this->CONFIG->system_cache_enabled) {
+			return;
+		}
+
 		// cache system data if enabled and not loaded
-		if ($this->CONFIG->system_cache_enabled && !$this->CONFIG->system_cache_loaded) {
-			elgg_save_system_cache('view_locations', serialize($this->CONFIG->views->locations));
-			elgg_save_system_cache('view_types', serialize($this->CONFIG->view_types));
+		if (!$this->CONFIG->system_cache_loaded) {
+			$this->save('view_locations', serialize($this->CONFIG->views->locations));
+			$this->save('view_types', serialize($this->CONFIG->view_types));
+
+			// this is saved just for the inspector and is not loaded in loadAll()
+			$this->save('view_overrides', serialize(_elgg_services()->views->getOverriddenLocations()));
 		}
 	
-		if ($this->CONFIG->system_cache_enabled && !$this->CONFIG->i18n_loaded_from_cache) {
+		if (!$this->CONFIG->i18n_loaded_from_cache) {
 			_elgg_services()->translator->reloadAllTranslations();
 			foreach ($this->CONFIG->translations as $lang => $map) {
-				elgg_save_system_cache("$lang.lang", serialize($map));
+				$this->save("$lang.lang", serialize($map));
 			}
 		}
 	}

--- a/engine/classes/Elgg/Debug/Inspector.php
+++ b/engine/classes/Elgg/Debug/Inspector.php
@@ -1,0 +1,402 @@
+<?php
+namespace Elgg\Debug;
+
+use Elgg\Debug\Inspector\ViewComponent;
+
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ *
+ * @package Elgg.Core
+ * @since   1.11
+ */
+class Inspector {
+
+	/**
+	 * Get Elgg event information
+	 *
+	 * @return array [event,type] => array(handlers)
+	 */
+	public function getEvents() {
+		return $this->buildHandlerTree(_elgg_services()->events->getAllHandlers());
+	}
+
+	/**
+	 * Get Elgg plugin hooks information
+	 *
+	 * @return array [hook,type] => array(handlers)
+	 */
+	public function getPluginHooks() {
+		return $this->buildHandlerTree(_elgg_services()->hooks->getAllHandlers());
+	}
+
+	/**
+	 * Get all view types for known views
+	 *
+	 * @return string[]
+	 */
+	public function getViewtypes() {
+		global $CONFIG;
+
+		return array_keys($CONFIG->views->locations);
+	}
+
+	/**
+	 * Get Elgg view information
+	 *
+	 * @param string $viewtype The Viewtype we wish to inspect
+	 *
+	 * @return array [view] => map of priority to ViewComponent[]
+	 */
+	public function getViews($viewtype = 'default') {
+		global $CONFIG;
+
+		$overrides = null;
+		if ($CONFIG->system_cache_enabled) {
+			$data = _elgg_services()->systemCache->load('view_overrides');
+			if ($data) {
+				$overrides = unserialize($data);
+			}
+		} else {
+			$overrides = _elgg_services()->views->getOverriddenLocations();
+		}
+
+		// maps view name to array of ViewComponent[] with priority as keys
+		$views = array();
+
+		$location = "{$CONFIG->viewpath}{$viewtype}/";
+		$core_file_list = $this->recurseFileTree($location);
+
+		// setup views array before adding extensions and plugin views
+		foreach ($core_file_list as $path) {
+			$component = ViewComponent::fromPaths($path, $location);
+			$views[$component->view] = array(500 => $component);
+		}
+
+		// add plugins and handle overrides
+		foreach ($CONFIG->views->locations[$viewtype] as $view => $location) {
+			$component = new ViewComponent();
+			$component->view = $view;
+			$component->location = "{$location}{$viewtype}/";
+			$views[$view] = array(500 => $component);
+		}
+
+		// now extensions
+		foreach ($CONFIG->views->extensions as $view => $extensions) {
+			$view_list = array();
+			foreach ($extensions as $priority => $ext_view) {
+				if (isset($views[$ext_view])) {
+					$view_list[$priority] = $views[$ext_view][500];
+				}
+			}
+			if (count($view_list) > 0) {
+				$views[$view] = $view_list;
+			}
+		}
+
+		ksort($views);
+
+		// now overrides
+		foreach ($views as $view => $view_list) {
+			if (!empty($overrides[$viewtype][$view])) {
+				$overrides_list = array();
+				foreach ($overrides[$viewtype][$view] as $i => $location) {
+					$component = new ViewComponent();
+					$component->overridden = true;
+					$component->view = $view;
+					$component->location = "{$location}{$viewtype}/";
+					$overrides_list["o:$i"] = $component;
+				}
+				$views[$view] = $overrides_list + $view_list;
+			}
+		}
+
+		// view handlers
+		$handlers = _elgg_services()->hooks->getAllHandlers();
+
+
+		$filtered_views = array();
+		if (!empty($handlers['view'])) {
+			$filtered_views = array_keys($handlers['view']);
+		}
+
+		$global_hooks = array();
+		if (!empty($handlers['view']['all'])) {
+			$global_hooks[] = 'view,all';
+		}
+		if (!empty($handlers['display']['view'])) {
+			$global_hooks[] = 'display,view';
+		}
+		if (!empty($handlers['display']['all'])) {
+			$global_hooks[] = 'display,all';
+		}
+
+		return array(
+			'views' => $views,
+			'global_hooks' => $global_hooks,
+			'filtered_views' => $filtered_views,
+		);
+	}
+
+	/**
+	 * Get Elgg widget information
+	 *
+	 * @return array [widget] => array(name, contexts)
+	 */
+	public function getWidgets() {
+		$tree = array();
+		foreach (_elgg_services()->widgets->getAllTypes() as $handler => $handler_obj) {
+			$tree[$handler] = array($handler_obj->name, implode(',', array_values($handler_obj->context)));
+		}
+
+		ksort($tree);
+
+		return $tree;
+	}
+
+
+	/**
+	 * Get Elgg actions information
+	 *
+	 * returns [action] => array(file, access)
+	 *
+	 * @return array
+	 */
+	public function getActions() {
+		$tree = array();
+		$access = array(
+			'public' => 'public',
+			'logged_in' => 'logged in only',
+			'admin' => 'admin only',
+		);
+		$start = strlen(elgg_get_root_path());
+		foreach (_elgg_services()->actions->getAllActions() as $action => $info) {
+			$info['file'] = substr($info['file'], $start);
+			$tree[$action] = array($info['file'], $access[$info['access']]);
+		}
+		ksort($tree);
+		return $tree;
+	}
+
+	/**
+	 * Get simplecache information
+	 *
+	 * @return array [views]
+	 */
+	public function getSimpleCache() {
+		global $CONFIG;
+
+		$tree = array();
+		foreach ($CONFIG->views->simplecache as $view => $foo) {
+			$tree[$view] = "";
+		}
+
+		ksort($tree);
+
+		return $tree;
+	}
+
+	/**
+	 * Get Elgg web services API methods
+	 *
+	 * @return array [method] => array(function, parameters, call_method, api auth, user auth)
+	 */
+	public function getWebServices() {
+		global $API_METHODS;
+
+		$tree = array();
+		foreach ($API_METHODS as $method => $info) {
+			$params = implode(', ', array_keys($info['parameters']));
+			if (!$params) {
+				$params = 'none';
+			}
+			$tree[$method] = array(
+				$info['function'],
+				"params: $params",
+				$info['call_method'],
+				($info['require_api_auth']) ? 'API authentication required' : 'No API authentication required',
+				($info['require_user_auth']) ? 'User authentication required' : 'No user authentication required',
+			);
+		}
+
+		ksort($tree);
+
+		return $tree;
+	}
+
+	/**
+	 * Get information about registered menus
+	 *
+	 * @return array [menu name] => array(item name => array(text, href, section, parent))
+	 */
+	public function getMenus() {
+
+		$menus = elgg_get_config('menus');
+
+		// get JIT menu items
+		// note that 'river' is absent from this list - hooks attempt to get object/subject entities cause problems
+		$jit_menus = array('annotation', 'entity', 'login', 'longtext', 'owner_block', 'user_hover', 'widget');
+
+		// create generic ElggEntity, ElggAnnotation, ElggUser, ElggWidget
+		$annotation = new \ElggAnnotation();
+		$annotation->id = 999;
+		$annotation->name = 'generic_comment';
+		$annotation->value = 'testvalue';
+
+		$entity = new \ElggObject();
+		$entity->guid = 999;
+		$entity->subtype = 'blog';
+		$entity->title = 'test entity';
+		$entity->access_id = ACCESS_PUBLIC;
+
+		$user = new \ElggUser();
+		$user->guid = 999;
+		$user->name = "Test User";
+		$user->username = 'test_user';
+
+		$widget = new \ElggWidget();
+		$widget->guid = 999;
+		$widget->title = 'test widget';
+
+		// call plugin hooks
+		foreach ($jit_menus as $type) {
+			$params = array('entity' => $entity, 'annotation' => $annotation, 'user' => $user);
+			switch ($type){
+				case 'owner_block':
+				case 'user_hover':
+					$params['entity'] = $user;
+					break;
+				case 'widget':
+					// this does not work because you cannot set a guid on an entity
+					$params['entity'] = $widget;
+					break;
+				default:
+					break;
+			}
+			$menus[$type] = elgg_trigger_plugin_hook('register', "menu:$type", $params, array());
+		}
+
+		// put the menus in tree form for inspection
+		$tree = array();
+
+		foreach ($menus as $menu_name => $attributes) {
+			foreach ($attributes as $item) {
+				/* @var \ElggMenuItem $item */
+				$name = $item->getName();
+				$text = htmlspecialchars($item->getText(), ENT_QUOTES, 'UTF-8', false);
+				$href = $item->getHref();
+				if ($href === false) {
+					$href = 'not a link';
+				} elseif ($href === "") {
+					$href = 'not a direct link - possibly ajax';
+				}
+				$section = $item->getSection();
+				$parent = $item->getParentName();
+				if (!$parent) {
+					$parent = 'none';
+				}
+
+				$tree[$menu_name][$name] = array(
+					"text: $text",
+					"href: $href",
+					"section: $section",
+					"parent: $parent",
+				);
+			}
+		}
+
+		ksort($tree);
+
+		return $tree;
+	}
+
+	/**
+	 * Get a string description of a callback
+	 *
+	 * E.g. "function_name", "Static::method", "(ClassName)->method", "(Closure path/to/file.php:23)"
+	 *
+	 * @param mixed  $callable  The callable value to describe
+	 * @param string $file_root if provided, it will be removed from the beginning of file names
+	 * @return string
+	 */
+	public function describeCallable($callable, $file_root = '') {
+		if (is_string($callable)) {
+			return $callable;
+		}
+		if (is_array($callable) && array_keys($callable) === array(0, 1) && is_string($callable[1])) {
+			if (is_string($callable[0])) {
+				return "{$callable[0]}::{$callable[1]}";
+			}
+			return "(" . get_class($callable[0]) . ")->{$callable[1]}";
+		}
+		if ($callable instanceof \Closure) {
+			$ref = new \ReflectionFunction($callable);
+			$file = $ref->getFileName();
+			$line = $ref->getStartLine();
+
+			if ($file_root && 0 === strpos($file, $file_root)) {
+				$file = substr($file, strlen($file_root));
+			}
+
+			return "(Closure {$file}:{$line})";
+		}
+		if (is_object($callable)) {
+			return "(" . get_class($callable) . ")->__invoke()";
+		}
+		return "(unknown)";
+	}
+
+	/**
+	 * Build a tree of event handlers
+	 *
+	 * @param array $all_handlers Set of handlers from a HooksRegistrationService
+	 *
+	 * @return array
+	 */
+	protected function buildHandlerTree($all_handlers) {
+		$tree = array();
+		$root = elgg_get_root_path();
+
+		foreach ($all_handlers as $hook => $types) {
+			foreach ($types as $type => $handlers) {
+				array_walk($handlers, function (&$callable, $priority) use ($root) {
+					$description = $this->describeCallable($callable, $root);
+					$callable = "$priority: $description";
+				});
+				$tree[$hook . ',' . $type] = $handlers;
+			}
+		}
+
+		ksort($tree);
+
+		return $tree;
+	}
+
+	/**
+	 * Create array of all php files in directory and subdirectories
+	 *
+	 * @param string $dir full path to directory to begin search
+	 * @return array of every php file in $dir or below in file tree
+	 */
+	protected function recurseFileTree($dir) {
+		$view_list = array();
+
+		$handle = opendir($dir);
+		while ($file = readdir($handle)) {
+			if ($file[0] == '.') {
+
+			} else if (is_dir($dir . $file)) {
+				$view_list = array_merge($view_list, $this->recurseFileTree($dir . $file . "/"));
+			} else {
+				$extension = strrchr(trim($file, "/"), '.');
+				if ($extension === ".php") {
+					$view_list[] = $dir . $file;
+				}
+			}
+		}
+		closedir($handle);
+
+		return $view_list;
+	}
+}

--- a/engine/classes/Elgg/Debug/Inspector/ViewComponent.php
+++ b/engine/classes/Elgg/Debug/Inspector/ViewComponent.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Elgg\Debug\Inspector;
+
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * @access private
+ *
+ * @package Elgg.Core
+ * @since   1.11
+ */
+class ViewComponent {
+
+	/**
+	 * @var string View location. E.g. "/path/to/views/default/"
+	 */
+	public $location;
+
+	/**
+	 * @var string View name. E.g. "css/elgg"
+	 */
+	public $view;
+
+	/**
+	 * @var string View file extension, if known. E.g. "php"
+	 */
+	public $extension = null;
+
+	/**
+	 * @var bool Is this component represent an overridden view?
+	 */
+	public $overridden = false;
+
+	/**
+	 * @return string Return the component as a file path
+	 */
+	public function getFile() {
+		$ext = pathinfo($this->view, PATHINFO_EXTENSION);
+		if ($ext) {
+			// view is filename
+			return "{$this->location}{$this->view}";
+		}
+
+		$str = "{$this->location}{$this->view}.{$this->extension}";
+		if ($this->extension === null) {
+			// try to guess from filesystem
+			$files = glob("{$this->location}{$this->view}.*");
+			if (count($files) === 1) {
+				$str = $files[0];
+			} else {
+				$str = "{$this->location}{$this->view}.?";
+			}
+		}
+
+		return $str;
+	}
+
+	/**
+	 * Get a component from the path and location
+	 *
+	 * @param string $path     Full file path
+	 * @param string $location Base location of view
+	 *
+	 * @return ViewComponent
+	 */
+	public static function fromPaths($path, $location) {
+		$component = new self();
+		$component->location = $location;
+
+		// cut location off
+		$file = substr($path, strlen($location));
+		$component->file = $file;
+
+		$basename = basename($file);
+		$period = strpos($basename, '.');
+		if ($period === false) {
+			// file with no extension? shouldn't happen
+			$component->view = $file;
+			$component->extension = '';
+		} else {
+			$cut_off_end = strlen($basename) - $period;
+			$component->view = substr($file, 0, -$cut_off_end);
+			$component->extension = substr($basename, $period + 1);
+		}
+
+		return $component;
+	}
+}

--- a/engine/classes/Elgg/EventsService.php
+++ b/engine/classes/Elgg/EventsService.php
@@ -1,5 +1,6 @@
 <?php
 namespace Elgg;
+use Elgg\Debug\Inspector;
 
 /**
  * Service for Events
@@ -45,8 +46,9 @@ class EventsService extends \Elgg\HooksRegistrationService {
 		foreach ($events as $callback) {
 			if (!is_callable($callback)) {
 				if ($this->logger) {
+					$inspector = new Inspector();
 					$this->logger->warn("handler for event [$event, $type] is not callable: "
-										. $this->describeCallable($callback));
+										. $inspector->describeCallable($callback));
 				}
 				continue;
 			}

--- a/engine/classes/Elgg/HooksRegistrationService.php
+++ b/engine/classes/Elgg/HooksRegistrationService.php
@@ -147,35 +147,5 @@ abstract class HooksRegistrationService {
 
 		return $handlers;
 	}
-
-	/**
-	 * Get a string description of a callback
-	 *
-	 * E.g. "function_name", "Static::method", "(ClassName)->method", "(Closure path/to/file.php:23)"
-	 *
-	 * @param mixed $callable The callable value to describe
-	 * @return string
-	 */
-	protected function describeCallable($callable) {
-		if (is_string($callable)) {
-			return $callable;
-		}
-		if (is_array($callable) && array_keys($callable) === array(0, 1) && is_string($callable[1])) {
-			if (is_string($callable[0])) {
-				return "{$callable[0]}::{$callable[1]}";
-			}
-			return "(" . get_class($callable[0]) . ")->{$callable[1]}";
-		}
-		if ($callable instanceof \Closure) {
-			$ref = new \ReflectionFunction($callable);
-			$file = $ref->getFileName();
-			$line = $ref->getStartLine();
-			return "(Closure {$file}:{$line})";
-		}
-		if (is_object($callable)) {
-			return "(" . get_class($callable) . ")->__invoke()";
-		}
-		return "(unknown)";
-	}
 }
 

--- a/engine/classes/Elgg/PluginHooksService.php
+++ b/engine/classes/Elgg/PluginHooksService.php
@@ -1,5 +1,6 @@
 <?php
 namespace Elgg;
+use Elgg\Debug\Inspector;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -26,8 +27,9 @@ class PluginHooksService extends \Elgg\HooksRegistrationService {
 		foreach ($hooks as $callback) {
 			if (!is_callable($callback)) {
 				if ($this->logger) {
+					$inspector = new Inspector();
 					$this->logger->warn("handler for plugin hook [$hook, $type] is not callable: "
-										. $this->describeCallable($callback));
+										. $inspector->describeCallable($callback));
 				}
 				continue;
 			}

--- a/engine/classes/Elgg/ViewsService.php
+++ b/engine/classes/Elgg/ViewsService.php
@@ -36,6 +36,11 @@ class ViewsService {
 	private $CONFIG;
 
 	/**
+	 * @var array
+	 */
+	private $overriden_locations = array();
+
+	/**
 	 * Constructor
 	 *
 	 * @param \Elgg\PluginHooksService $hooks  The hooks service
@@ -136,6 +141,10 @@ class ViewsService {
 			$this->CONFIG->views->locations[$viewtype] = array($view => $location);
 
 		} else {
+			if (isset($this->CONFIG->views->locations[$viewtype][$view])) {
+				$this->overriden_locations[$viewtype][$view][] = $this->CONFIG->views->locations[$viewtype][$view];
+			}
+
 			$this->CONFIG->views->locations[$viewtype][$view] = $location;
 		}
 	}
@@ -526,5 +535,68 @@ class ViewsService {
 			// Assume not-cacheable by default
 			return false;
 		}
+	}
+
+	/**
+	 * Register a plugin's views
+	 *
+	 * @param string $path       Base path of the plugin
+	 * @param string $failed_dir This var is set to the failed directory if registration fails
+	 * @return bool
+	 *
+	 * @access private
+	 */
+	public function registerPluginViews($path, &$failed_dir = '') {
+		$view_dir = "$path/views/";
+
+		// plugins don't have to have views.
+		if (!is_dir($view_dir)) {
+			return true;
+		}
+
+		// but if they do, they have to be readable
+		$handle = opendir($view_dir);
+		if (!$handle) {
+			$failed_dir = $view_dir;
+			return false;
+		}
+
+		while (false !== ($view_type = readdir($handle))) {
+			$view_type_dir = $view_dir . $view_type;
+
+			if ('.' !== substr($view_type, 0, 1) && is_dir($view_type_dir)) {
+				if ($this->autoregisterViews('', $view_type_dir, $view_dir, $view_type)) {
+					elgg_register_viewtype($view_type);
+				} else {
+					$failed_dir = $view_type_dir;
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get views overridden by setViewLocation() calls.
+	 *
+	 * @return array
+	 *
+	 * @access private
+	 */
+	public function getOverriddenLocations() {
+		return $this->overriden_locations;
+	}
+
+	/**
+	 * Set views overridden by setViewLocation() calls.
+	 *
+	 * @param array $locations
+	 * @return void
+	 *
+	 * @access private
+	 */
+	public function setOverriddenLocations(array $locations) {
+		$this->overriden_locations = $locations;
 	}
 }

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -43,7 +43,7 @@ class ElggPlugin extends \ElggObject {
 	 */
 	public function __construct($path) {
 		if (!$path) {
-			throw new \PluginException("\ElggPlugin cannot be null instantiated. You must pass a full path.");
+			throw new \PluginException("ElggPlugin cannot be null instantiated. You must pass a full path.");
 		}
 
 		if (is_object($path)) {
@@ -63,7 +63,7 @@ class ElggPlugin extends \ElggObject {
 
 			// not a full path, so assume a directory name and use the default path
 			if (strpos($path, $mod_dir) !== 0) {
-				elgg_deprecated_notice("You should pass a full path to \ElggPlugin.", 1.9);
+				elgg_deprecated_notice("You should pass a full path to ElggPlugin.", 1.9);
 				$path = $mod_dir . $path;
 			}
 
@@ -811,39 +811,14 @@ class ElggPlugin extends \ElggObject {
 	 * Registers the plugin's views
 	 *
 	 * @throws PluginException
-	 * @return true
+	 * @return void
 	 */
 	protected function registerViews() {
-		$view_dir = "$this->path/views/";
-
-		// plugins don't have to have views.
-		if (!is_dir($view_dir)) {
-			return true;
-		}
-
-		// but if they do, they have to be readable
-		$handle = opendir($view_dir);
-		if (!$handle) {
+		if (!_elgg_services()->views->registerPluginViews($this->path, $failed_dir)) {
 			$msg = _elgg_services()->translator->translate('ElggPlugin:Exception:CannotRegisterViews',
-							array($this->getID(), $this->guid, $view_dir));
+				array($this->getID(), $this->guid, $failed_dir));
 			throw new \PluginException($msg);
 		}
-
-		while (false !== ($view_type = readdir($handle))) {
-			$view_type_dir = $view_dir . $view_type;
-
-			if ('.' !== substr($view_type, 0, 1) && is_dir($view_type_dir)) {
-				if (autoregister_views('', $view_type_dir, $view_dir, $view_type)) {
-					elgg_register_viewtype($view_type);
-				} else {
-					$msg = _elgg_services()->translator->translate('ElggPlugin:Exception:CannotRegisterViews',
-									array($this->getID(), $view_type_dir));
-					throw new \PluginException($msg);
-				}
-			}
-		}
-
-		return true;
 	}
 
 	/**
@@ -895,7 +870,7 @@ class ElggPlugin extends \ElggObject {
 	public function __get($name) {
 		// rewrite for old and inaccurate plugin:setting
 		if (strstr($name, 'plugin:setting:')) {
-			$msg = 'Direct access of user settings is deprecated. Use \ElggPlugin->getUserSetting()';
+			$msg = 'Direct access of user settings is deprecated. Use ElggPlugin->getUserSetting()';
 			elgg_deprecated_notice($msg, 1.8);
 			$name = str_replace('plugin:setting:', '', $name);
 			$name = _elgg_namespace_plugin_private_setting('user_setting', $name, $this->getID());

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -18,7 +18,7 @@
  * @return \ElggFileCache
  */
 function elgg_get_system_cache() {
-	return _elgg_services()->systemCache->get();
+	return _elgg_services()->systemCache->getFileCache();
 }
 
 /**

--- a/mod/developers/classes/ElggInspector.php
+++ b/mod/developers/classes/ElggInspector.php
@@ -4,7 +4,19 @@
  *
  */
 
+/**
+ * @deprecated 1.11
+ *
+ * @access private
+ */
 class ElggInspector {
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		elgg_deprecated_notice(__CLASS__ . ' is deprecated and should not be used', '1.11');
+	}
 
 	/**
 	 * Get Elgg event information

--- a/mod/developers/languages/en.php
+++ b/mod/developers/languages/en.php
@@ -41,13 +41,16 @@ return array(
 	'developers:inspect:events' => 'Events',
 	'developers:inspect:menus' => 'Menus',
 	'developers:inspect:pluginhooks' => 'Plugin Hooks',
+	'developers:inspect:priority' => 'Priority',
 	'developers:inspect:simplecache' => 'Simple Cache',
 	'developers:inspect:views' => 'Views',
+	'developers:inspect:views:all_filtered' => "<b>Note!</b> All view output is filtered through these Plugin Hooks:",
+	'developers:inspect:views:filtered' => "(filtered by plugin hook: %s)",
 	'developers:inspect:widgets' => 'Widgets',
 	'developers:inspect:webservices' => 'Webservices',
 	'developers:inspect:widgets:context' => 'Context',
 	'developers:inspect:functions' => 'Functions',
-	'developers:inspect:file_location' => 'File location',
+	'developers:inspect:file_location' => 'File path from Elgg root',
 
 	// event logging
 	'developers:event_log_msg' => "%s: '%s, %s' in %s",

--- a/mod/developers/views/default/admin/develop_tools/inspect.php
+++ b/mod/developers/views/default/admin/develop_tools/inspect.php
@@ -7,14 +7,37 @@
 
 $inspect_type = get_input('inspect_type');
 $method = 'get' . str_replace(' ', '', $inspect_type);
+$view_name = "admin/develop_tools/inspect/" . strtolower(str_replace(' ', '', $inspect_type));
+$inspector = new \Elgg\Debug\Inspector();
 
-$inspector = new ElggInspector();
-$inspect_result = '';
-if ($inspector && method_exists($inspector, $method)) {
-	$data = $inspector->$method();
+if (!elgg_view_exists($view_name) || !method_exists($inspector, $method)) {
+	forward('admin', '404');
+}
+
+switch ($inspect_type) {
+	case 'Views':
+		$viewtypes = $inspector->getViewtypes();
+		$viewtype = get_input('type', 'default');
+
+		if (!in_array($viewtype, $viewtypes)) {
+			forward('admin', '404');
+		}
+
+		$data = $inspector->getViews($viewtype);
+		$page = elgg_view($view_name, array(
+			"data" => $data,
+			"viewtypes" => $viewtypes,
+			"viewtype" => $viewtype,
+		));
+		break;
+	default:
+		$data = $inspector->$method();
+		$page = elgg_view($view_name, array(
+			"data" => $data,
+		));
+		break;
 }
 
 echo '<p>' . elgg_echo('developers:inspect:help') . '</p>';
 
-$view_name = strtolower(str_replace(' ', '', $inspect_type));
-echo elgg_view("admin/develop_tools/inspect/$view_name", array("data" => $data));
+echo $page;

--- a/mod/developers/views/default/admin/develop_tools/inspect/events.php
+++ b/mod/developers/views/default/admin/develop_tools/inspect/events.php
@@ -1,26 +1,41 @@
 <?php
 
 $data = elgg_extract("data", $vars);
+$header = elgg_extract("header", $vars);
+
+if (!$header) {
+	$header = elgg_echo('developers:inspect:events');
+}
 
 if (empty($data)) {
 	return;
 }
 
+$make_id = function ($name) {
+	return "z" . md5($name);
+};
+
 echo "<table class='elgg-table-alt'>";
 echo "<tr>";
-echo "<th>" . elgg_echo('developers:inspect:events') . "</th>";
+echo "<th>$header</th>";
+echo "<th width='1%'>" . elgg_echo('developers:inspect:priority') . "</th>";
 echo "<th>" . elgg_echo('developers:inspect:functions') . "</th>";
 echo "</tr>";
 
+$last_key = '';
 foreach ($data as $key => $arr) {
-	echo "<tr>";
-	echo "<td>$key</td>";
-	echo "<td><ul>";
 	foreach ($arr as $subkey => $value) {
-		echo "<li>$value</li>";
+		list($priority, $desc) = explode(': ', $value, 2);
+		echo "<tr>";
+		if ($key !== $last_key) {
+			$id = $make_id($key);
+			echo "<td id='$id' rowspan='" . count($arr) . "'>$key</td>";
+			$last_key = $key;
+		}
+		echo "<td>$priority</td>";
+		echo "<td>$desc</td>";
+		echo "</tr>";
 	}
-	echo "</ul></td>";
-	echo "</tr>";
 }
 
 echo "</table>";

--- a/mod/developers/views/default/admin/develop_tools/inspect/pluginhooks.php
+++ b/mod/developers/views/default/admin/develop_tools/inspect/pluginhooks.php
@@ -1,26 +1,6 @@
 <?php
 
-$data = elgg_extract("data", $vars);
-
-if (empty($data)) {
-	return;
-}
-
-echo "<table class='elgg-table-alt'>";
-echo "<tr>";
-echo "<th>" . elgg_echo('developers:inspect:pluginhooks') . "</th>";
-echo "<th>" . elgg_echo('developers:inspect:functions') . "</th>";
-echo "</tr>";
-
-foreach ($data as $key => $arr) {
-	echo "<tr>";
-	echo "<td>$key</td>";
-	echo "<td><ul>";
-	foreach ($arr as $subkey => $value) {
-		echo "<li>$value</li>";
-	}
-	echo "</ul></td>";
-	echo "</tr>";
-}
-
-echo "</table>";
+echo elgg_view('admin/develop_tools/inspect/events', array(
+	'data' => elgg_extract("data", $vars),
+	'header' => elgg_echo('developers:inspect:pluginhooks'),
+));

--- a/mod/developers/views/default/admin/develop_tools/inspect/simplecache.php
+++ b/mod/developers/views/default/admin/develop_tools/inspect/simplecache.php
@@ -11,10 +11,12 @@ echo "<tr>";
 echo "<th>" . elgg_echo('developers:inspect:simplecache') . "</th>";
 echo "</tr>";
 
-foreach ($data as $key => $arr) {
-	echo "<tr>";
-	echo "<td>$key</td>";
-	echo "</tr>";
+foreach ($data as $view => $arr) {
+	echo "<tr><td>";
+	echo elgg_view('admin/develop_tools/inspect/views/view_link', array(
+		'view' => $view,
+	));
+	echo "</td></tr>";
 }
 
 echo "</table>";

--- a/mod/developers/views/default/admin/develop_tools/inspect/views.php
+++ b/mod/developers/views/default/admin/develop_tools/inspect/views.php
@@ -1,22 +1,106 @@
 <?php
 
 $data = elgg_extract("data", $vars);
-
 if (empty($data)) {
 	return;
+}
+
+$views = $data['views'];
+$global_hooks = $data['global_hooks'];
+$filtered_views = $data['filtered_views'];
+
+$root = elgg_get_root_path();
+$strip = function ($file) use ($root) {
+	return (0 === strpos($file, $root)) ? substr($file, strlen($root)) : $file;
+};
+$make_id = function ($view) {
+	return "z" . md5($view);
+};
+
+$viewtype = elgg_extract("viewtype", $vars);
+$viewtypes = elgg_extract("viewtypes", $vars);
+
+foreach ($viewtypes as $type) {
+	$href = "admin/develop_tools/inspect?inspect_type=Views";
+	if ($type !== "default") {
+		$href .= "&type={$type}";
+	}
+	elgg_register_menu_item('developers_inspect_viewtype', array(
+		'name' => $type,
+		'text' => $type,
+		'href' => $href,
+	));
+}
+
+echo elgg_view_menu('developers_inspect_viewtype', array(
+	'class' => 'elgg-tabs mbm',
+));
+
+if ($global_hooks) {
+	array_walk($global_hooks, function (&$hook) {
+		$id = "z" . md5($hook);
+		$hook = "<a href='?inspect_type=Plugin%20Hooks#$id'>$hook</a>";
+	});
+
+	echo "<p>" . elgg_echo("developers:inspect:views:all_filtered") . " ";
+	echo implode(' | ', $global_hooks);
+	echo "</p>";
 }
 
 echo "<table class='elgg-table-alt'>";
 echo "<tr>";
 echo "<th>" . elgg_echo('developers:inspect:views') . "</th>";
+echo "<th width='1%'>" . elgg_echo('developers:inspect:priority') . "</th>";
 echo "<th>" . elgg_echo('developers:inspect:file_location') . "</th>";
 echo "</tr>";
 
-foreach ($data as $key => $arr) {
-	echo "<tr>";
-	echo "<td>$key</td>";
-	echo "<td>{$arr[0]}</td>";
-	echo "</tr>";
+$last_view = '';
+foreach ($views as $view => $components) {
+	/* @var \Elgg\Debug\Inspector\ViewComponent[] $components */
+
+	$view_id = $make_id($view);
+
+	$rowspan = count($components);
+
+	if (in_array($view, $filtered_views)) {
+		$rowspan += 1;
+		$id = "z" . md5("view,$view");
+		$link = "<a href='?inspect_type=Plugin%20Hooks#$id'>view,$view</a>";
+		$col2 = elgg_echo('developers:inspect:views:filtered', array($link));
+
+		$extra_row = "<tr><td>&nbsp;</td><td>$col2</td></tr>";
+	} else {
+		$extra_row = "";
+	}
+
+	foreach ($components as $priority => $component) {
+		$file = $strip($component->getFile());
+
+		echo "<tr>";
+		if ($view !== $last_view) {
+			echo "<td id='$view_id' rowspan='$rowspan'>$view</td>";
+			$last_view = $view;
+		}
+
+		if (0 === strpos($priority, "o:")) {
+			echo "<td style='opacity:.6'>over</td>";
+			echo "<td style='opacity:.6'><del>$file</del></td>";
+		} elseif ($priority != 500) {
+			$href = $make_id($component->view);
+			echo "<td>$priority</td>";
+			$link = elgg_view('admin/develop_tools/inspect/views/view_link', array(
+				'view' => $component->view,
+				'text' => $file,
+			));
+			echo "<td style='opacity:.6'>$link</td>";
+		} else {
+			echo "<td>$priority</td>";
+			echo "<td>$file</td>";
+		}
+		echo "</tr>";
+	}
+
+	echo $extra_row;
 }
 
 echo "</table>";

--- a/mod/developers/views/default/admin/develop_tools/inspect/views/view_link.php
+++ b/mod/developers/views/default/admin/develop_tools/inspect/views/view_link.php
@@ -1,0 +1,21 @@
+<?php
+
+$view = $vars['view'];
+
+$text = elgg_extract('text', $vars, $view);
+
+$id = "z" . md5($view);
+
+$href = "admin/develop_tools/inspect?inspect_type=Views#{$id}";
+
+if (get_input('inspect_type')) {
+	// don't lose the viewtype
+	$href = elgg_http_add_url_query_elements($href, array(
+		'type' => get_input('type')
+	));
+}
+
+echo elgg_view('output/url', array(
+	'href' => $href,
+	'text' => $text,
+));

--- a/mod/developers/views/default/admin/develop_tools/inspect/widgets.php
+++ b/mod/developers/views/default/admin/develop_tools/inspect/widgets.php
@@ -13,9 +13,15 @@ echo "<th>" . elgg_echo('title') . "</th>";
 echo "<th>" . elgg_echo('developers:inspect:widgets:context') . "</th>";
 echo "</tr>";
 
-foreach ($data as $key => $arr) {
+foreach ($data as $name => $arr) {
+	$view = "widgets/$name/content";
+	$link = elgg_view('admin/develop_tools/inspect/views/view_link', array(
+		'view' => $view,
+		'text' => $name,
+	));
+
 	echo "<tr>";
-	echo "<td>$key</td>";
+	echo "<td>$link</td>";
 	echo "<td>{$arr[0]}</td>";
 	echo "<td>{$arr[1]}</td>";
 	echo "</tr>";


### PR DESCRIPTION
This replaces #7700 which GitHub will no longer let me re-open. What this does:

The install path is stripped from file locations. Events & Hooks show priorities and more usable descriptions for handlers that aren’t global functions. Views show priorities, extensions, overrides, and any plugin hooks that may filter their output.

Users can jump directly to plugin hook or view inspections from the views, simple cache, and widgets listings.

We also move describeCallable() to the inspector.

Also: This moves the logic of sniffing plugin dirs for views into the ViewsService so it’s less coupled to ElggPlugin. Also we add tracking of views whose locations have been overridden. We save them in the system cache but don’t need to load them for requests; that can be done by the views inspector if it needs them.

Fixes #4540
