### PR TITLE
feature(api): allow convenience methods to return ElggBatch as a result

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -843,6 +843,8 @@ abstract class ElggEntity extends \ElggData implements
 	 *
 	 * @param array  $options Array of options for elgg_get_annotations() except guid. This
 	 *               may be passed a string annotation name, but this usage is deprecated.
+	 *               'elggbatch' will return an ElggBatch instance for the query for existing
+	 *               entities only
 	 * @param int    $limit   Limit (deprecated)
 	 * @param int    $offset  Offset (deprecated)
 	 * @param string $order   Order by time: asc or desc (deprecated)
@@ -869,6 +871,17 @@ abstract class ElggEntity extends \ElggData implements
 				}
 			} else {
 				$options['guid'] = $this->guid;
+			}
+			
+			if ($options['elggbatch']) {
+				$batch_defaults = array(
+					'elggbatch_callback' => null,
+					'elggbatch_size' => 25,
+					'elggbatch_inc_offset' => true
+				);
+				$options = array_merge($batch_defaults, $options);
+				$batch = new ElggBatch('elgg_get_annotations', $options, $options['elggbatch_callback'], $options['elggbatch_size'], $options['elggbatch_inc_offset']);
+				return $batch;
 			}
 
 			return elgg_get_annotations($options);
@@ -986,6 +999,7 @@ abstract class ElggEntity extends \ElggData implements
 	 * @param array $options Options array. See elgg_get_entities_from_relationship()
 	 *                       for a list of options. 'relationship_guid' is set to
 	 *                       this entity.
+	 *                       'elggbatch' will return an ElggBatch for the query
 	 * @param bool  $inverse Is this an inverse relationship? (deprecated)
 	 * @param int   $limit   Number of elements to return (deprecated)
 	 * @param int   $offset  Indexing offset (deprecated)
@@ -996,6 +1010,17 @@ abstract class ElggEntity extends \ElggData implements
 	public function getEntitiesFromRelationship($options = array(), $inverse = false, $limit = 50, $offset = 0) {
 		if (is_array($options)) {
 			$options['relationship_guid'] = $this->getGUID();
+			
+			if ($options['elggbatch']) {
+				$batch_defaults = array(
+					'elggbatch_callback' => null,
+					'elggbatch_size' => 25,
+					'elggbatch_inc_offset' => true
+				);
+				$options = array_merge($batch_defaults, $options);
+				$batch = new ElggBatch('elgg_get_entities_from_relationship', $options, $options['elggbatch_callback'], $options['elggbatch_size'], $options['elggbatch_inc_offset']);
+				return $batch;
+			}
 			return elgg_get_entities_from_relationship($options);
 		} else {
 			elgg_deprecated_notice("\ElggEntity::getEntitiesFromRelationship takes an options array", 1.9);

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -318,8 +318,9 @@ class ElggGroup extends \ElggEntity
 	 * @param array $options Options array. See elgg_get_entities_from_relationships
 	 *                       for a complete list. Common ones are 'limit', 'offset',
 	 *                       and 'count'. Options set automatically are 'relationship',
-	 *                       'relationship_guid', 'inverse_relationship', and 'type'. This argument
-	 *                       used to set the limit (deprecated usage)
+	 *                       'relationship_guid', 'inverse_relationship', and 'type'. 
+	 *                       'elggbatch' will return an ElggBatch instance for the query
+	 *                       This argument used to set the limit (deprecated usage)
 	 * @param int   $offset  Offset (deprecated)
 	 * @param bool  $count   Count (deprecated)
 	 *
@@ -344,6 +345,17 @@ class ElggGroup extends \ElggEntity
 			$options['type'] = 'user';
 		}
 
+		if ($options['elggbatch']) {
+			$batch_defaults = array(
+				'elggbatch_callback' => null,
+				'elggbatch_size' => 25,
+				'elggbatch_inc_offset' => true
+			);
+			$options = array_merge($batch_defaults, $options);
+			$batch = new ElggBatch('elgg_get_entities_from_relationship', $options, $options['elggbatch_callback'], $options['elggbatch_size'], $options['elggbatch_inc_offset']);
+			return $batch;
+		}
+		
 		return elgg_get_entities_from_relationship($options);
 	}
 

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -333,6 +333,7 @@ class ElggSite extends \ElggEntity {
 	 * @param array $options Options array for elgg_get_entities_from_relationship()
 	 *                       Parameters set automatically by this method:
 	 *                       'relationship', 'relationship_guid', 'inverse_relationship'
+	 *                       'elggbatch' will return an ElggBatch for the query
 	 * @return array
 	 */
 	public function getEntities(array $options = array()) {
@@ -341,6 +342,17 @@ class ElggSite extends \ElggEntity {
 		$options['inverse_relationship'] = true;
 		if (!isset($options['site_guid']) || !isset($options['site_guids'])) {
 			$options['site_guids'] = ELGG_ENTITIES_ANY_VALUE;
+		}
+		
+		if ($options['elggbatch']) {
+			$batch_defaults = array(
+				'elggbatch_callback' => null,
+				'elggbatch_size' => 25,
+				'elggbatch_inc_offset' => true
+			);
+			$options = array_merge($batch_defaults, $options);
+			$batch = new ElggBatch('elgg_get_entities_from_relationship', $options, $options['elggbatch_callback'], $options['elggbatch_size'], $options['elggbatch_inc_offset']);
+			return $batch;
 		}
 
 		return elgg_get_entities_from_relationship($options);

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -476,6 +476,7 @@ class ElggUser extends \ElggEntity
 	 * @param array $options Options array. See elgg_get_entities_from_relationship()
 	 *                       for a list of options. 'relationship_guid' is set to
 	 *                       this entity, relationship name to 'friend' and type to 'user'.
+	 *                       'elggbatch' will return an ElggBatch instance for the query
 	 * @param int   $limit   The number of users to retrieve (deprecated)
 	 * @param int   $offset  Indexing offset, if any (deprecated)
 	 *
@@ -486,6 +487,17 @@ class ElggUser extends \ElggEntity
 			$options['relationship'] = 'friend';
 			$options['relationship_guid'] = $this->getGUID();
 			$options['type'] = 'user';
+			
+			if ($options['elggbatch']) {
+				$batch_defaults = array(
+					'elggbatch_callback' => null,
+					'elggbatch_size' => 25,
+					'elggbatch_inc_offset' => true
+				);
+				$options = array_merge($batch_defaults, $options);
+				$batch = new ElggBatch('elgg_get_entities_from_relationship', $options, $options['elggbatch_callback'], $options['elggbatch_size'], $options['elggbatch_inc_offset']);
+				return $batch;
+			}
 			return elgg_get_entities_from_relationship($options);
 		} else {
 			elgg_deprecated_notice("\ElggUser::getFriends takes an options array", 1.9);
@@ -507,6 +519,7 @@ class ElggUser extends \ElggEntity
 	 *                       for a list of options. 'relationship_guid' is set to
 	 *                       this entity, relationship name to 'friend', type to 'user'
 	 *                       and inverse_relationship to true.
+	 *                       'elggbatch' will return an ElggBatch instance for the query
 	 * @param int   $limit   The number of users to retrieve (deprecated)
 	 * @param int   $offset  Indexing offset, if any (deprecated)
 	 *
@@ -518,6 +531,18 @@ class ElggUser extends \ElggEntity
 			$options['relationship_guid'] = $this->getGUID();
 			$options['inverse_relationship'] = true;
 			$options['type'] = 'user';
+			
+			if ($options['elggbatch']) {
+				$batch_defaults = array(
+					'elggbatch_callback' => null,
+					'elggbatch_size' => 25,
+					'elggbatch_inc_offset' => true
+				);
+				$options = array_merge($batch_defaults, $options);
+				$batch = new ElggBatch('elgg_get_entities_from_relationship', $options, $options['elggbatch_callback'], $options['elggbatch_size'], $options['elggbatch_inc_offset']);
+				return $batch;
+			}
+			
 			return elgg_get_entities_from_relationship($options);
 		} else {
 			elgg_deprecated_notice("\ElggUser::getFriendsOf takes an options array", 1.9);
@@ -591,6 +616,17 @@ class ElggUser extends \ElggEntity
 			$options['relationship'] = 'member';
 			$options['relationship_guid'] = $this->guid;
 		}
+		
+		if ($options['elggbatch']) {
+			$batch_defaults = array(
+				'elggbatch_callback' => null,
+				'elggbatch_size' => 25,
+				'elggbatch_inc_offset' => true
+			);
+			$options = array_merge($batch_defaults, $options);
+			$batch = new ElggBatch('elgg_get_entities_from_relationship', $options, $options['elggbatch_callback'], $options['elggbatch_size'], $options['elggbatch_inc_offset']);
+			return $batch;
+		}
 
 		return elgg_get_entities_from_relationship($options);
 	}
@@ -628,6 +664,7 @@ class ElggUser extends \ElggEntity
 	 *
 	 * @param array $options Options array. See elgg_get_entities() for a list of options.
 	 *                       'type' is set to object and owner_guid to this entity.
+	 *                       'elggbatch' will return an ElggBatch instance for the query
 	 * @param int   $limit   Number of results to return (deprecated)
 	 * @param int   $offset  Any indexing offset (deprecated)
 	 *
@@ -637,6 +674,17 @@ class ElggUser extends \ElggEntity
 		if (is_array($options)) {
 			$options['type'] = 'object';
 			$options['owner_guid'] = $this->getGUID();
+			
+			if ($options['elggbatch']) {
+				$batch_defaults = array(
+					'elggbatch_callback' => null,
+					'elggbatch_size' => 25,
+					'elggbatch_inc_offset' => true
+				);
+				$options = array_merge($batch_defaults, $options);
+				$batch = new ElggBatch('elgg_get_entities', $options, $options['elggbatch_callback'], $options['elggbatch_size'], $options['elggbatch_inc_offset']);
+				return $batch;
+			}
 			return elgg_get_entities($options);
 		} else {
 			elgg_deprecated_notice("\ElggUser::getObjects takes an options array", 1.9);
@@ -657,6 +705,7 @@ class ElggUser extends \ElggEntity
 	 *                       for a list of options. 'relationship_guid' is set to
 	 *                       this entity, type to 'object', relationship name to 'friend'
 	 *                       and relationship_join_on to 'container_guid'.
+	 *                       'elggbatch' will return an ElggBatch instance for the query
 	 * @param int   $limit   Number of results to return (deprecated)
 	 * @param int   $offset  Any indexing offset (deprecated)
 	 *
@@ -668,6 +717,17 @@ class ElggUser extends \ElggEntity
 			$options['relationship'] = 'friend';
 			$options['relationship_guid'] = $this->getGUID();
 			$options['relationship_join_on'] = 'container_guid';
+			
+			if ($options['elggbatch']) {
+				$batch_defaults = array(
+					'elggbatch_callback' => null,
+					'elggbatch_size' => 25,
+					'elggbatch_inc_offset' => true
+				);
+				$options = array_merge($batch_defaults, $options);
+				$batch = new ElggBatch('elgg_get_entities_from_relationship', $options, $options['elggbatch_callback'], $options['elggbatch_size'], $options['elggbatch_inc_offset']);
+				return $batch;
+			}
 			return elgg_get_entities_from_relationship($options);
 		} else {
 			elgg_deprecated_notice("\ElggUser::getFriendsObjects takes an options array", 1.9);


### PR DESCRIPTION
Fixes #6676 - allows developers to pass a flag in the options to return an ElggBatch from convenience methods when they need to iterate through large sets

TODO
- [ ] Tests
