### PR TITLE
feature(api): allow convenience methods to return ElggBatch as a result

### DIFF
--- a/engine/classes/Elgg/BatchInterface.php
+++ b/engine/classes/Elgg/BatchInterface.php
@@ -1,0 +1,61 @@
+<?php
+namespace Elgg;
+
+/**
+ * Specifies a countable iterator, usually of result rows from a DB
+ *
+ * @package    Elgg.Core
+ * @subpackage DataModel
+ * @since      1.11
+ */
+interface BatchInterface {
+
+	/**
+	 * Return the current element
+	 *
+	 * @see \Iterator::current()
+	 * @return mixed
+	 */
+	public function current();
+
+	/**
+	 * Move forward to the next element
+	 *
+	 * @see \Iterator::next()
+	 * @return void
+	 */
+	public function next();
+
+	/**
+	 * Return the key of the current element
+	 *
+	 * @see \Iterator::key()
+	 * @return mixed scalar on success, or null on failure.
+	 */
+	public function key();
+
+	/**
+	 * Is the current position valid?
+	 *
+	 * @see \Iterator::valid()
+	 * @return bool
+	 * Returns true on success or false on failure.
+	 */
+	public function valid();
+
+	/**
+	 * Rewind the set to the first element
+	 *
+	 * @see \Iterator::rewind()
+	 * @return void
+	 */
+	public function rewind();
+
+	/**
+	 * Count elements in the set. Note the "set" is a DB query, so this may change at any moment!
+	 *
+	 * @see \Countable::count()
+	 * @return int
+	 */
+	public function count();
+}

--- a/engine/classes/ElggBatch.php
+++ b/engine/classes/ElggBatch.php
@@ -1,10 +1,18 @@
 <?php
 /**
- * Efficiently run operations on batches of results for any function
- * that supports an options array.
+ * A lazy-loading proxy for a result array from a fetching function
  *
- * This is usually used with elgg_get_entities() and friends,
- * elgg_get_annotations(), and elgg_get_metadata().
+ * A batch can be counted or iterated over via foreach, where the batch will
+ * internally fetch results several rows at a time. This allows you to efficiently
+ * work on large result sets without loading all results in memory.
+ *
+ * A batch can run operations for any function that supports an options array
+ * and supports the keys "offset", "limit", and "count". This is usually used
+ * with elgg_get_entities() and friends, elgg_get_annotations(), and
+ * elgg_get_metadata(). In fact, those functions will return results as
+ * batches by passing in "batch" as true.
+ *
+ * Unlike a real array, direct access of results is not supported.
  *
  * If you pass a valid PHP callback, all results will be run through that
  * callback. You can still foreach() through the result set after.  Valid
@@ -38,16 +46,21 @@
  * $batch->setIncrementOffset(false);
  *
  * foreach ($batch as $entity) {
- * 	$entity->disable();
+ * 	   $entity->disable();
  * }
  *
  * // using both a callback
  * $callback = function($result, $getter, $options) {
- * 	var_dump("Looking at annotation id: $result->id");
- *  return true;
+ * 	   var_dump("Looking at annotation id: $result->id");
+ *     return true;
  * }
  *
  * $batch = new \ElggBatch('elgg_get_annotations', array('guid' => 2), $callback);
+ *
+ * // get a batch from an Elgg getter function
+ * $batch = elgg_get_entities([
+ *     'batch' => true,
+ * ]);
  * </code>
  *
  * @package    Elgg.Core
@@ -55,10 +68,10 @@
  * @since      1.8
  */
 class ElggBatch
-	implements \Iterator {
+	implements \Iterator, \Countable, \Elgg\BatchInterface {
 
 	/**
-	 * The objects to interator over.
+	 * The objects to iterate over.
 	 *
 	 * @var array
 	 */
@@ -67,9 +80,16 @@ class ElggBatch
 	/**
 	 * The function used to get results.
 	 *
-	 * @var mixed A string, array, or closure, or lamda function
+	 * @var callable
 	 */
 	private $getter = null;
+
+	/**
+	 * The given $options to alter and pass to the getter.
+	 *
+	 * @var array
+	 */
+	private $options = array();
 
 	/**
 	 * The number of results to grab at a time.
@@ -81,7 +101,7 @@ class ElggBatch
 	/**
 	 * A callback function to pass results through.
 	 *
-	 * @var mixed A string, array, or closure, or lamda function
+	 * @var callable
 	 */
 	private $callback = null;
 
@@ -348,10 +368,7 @@ class ElggBatch
 	 */
 
 	/**
-	 * PHP Iterator Interface
-	 *
-	 * @see Iterator::rewind()
-	 * @return void
+	 * {@inheritdoc}
 	 */
 	public function rewind() {
 		$this->resultIndex = 0;
@@ -366,30 +383,21 @@ class ElggBatch
 	}
 
 	/**
-	 * PHP Iterator Interface
-	 *
-	 * @see Iterator::current()
-	 * @return mixed
+	 * {@inheritdoc}
 	 */
 	public function current() {
 		return current($this->results);
 	}
 
 	/**
-	 * PHP Iterator Interface
-	 *
-	 * @see Iterator::key()
-	 * @return int
+	 * {@inheritdoc}
 	 */
 	public function key() {
 		return $this->processedResults;
 	}
 
 	/**
-	 * PHP Iterator Interface
-	 *
-	 * @see Iterator::next()
-	 * @return mixed
+	 * {@inheritdoc}
 	 */
 	public function next() {
 		// if we'll be at the end.
@@ -418,10 +426,7 @@ class ElggBatch
 	}
 
 	/**
-	 * PHP Iterator Interface
-	 *
-	 * @see Iterator::valid()
-	 * @return bool
+	 * {@inheritdoc}
 	 */
 	public function valid() {
 		if (!is_array($this->results)) {
@@ -429,5 +434,58 @@ class ElggBatch
 		}
 		$key = key($this->results);
 		return ($key !== null && $key !== false);
+	}
+
+	/**
+	 * Count the total results available at this moment.
+	 *
+	 * As this performs a separate query, the count returned may not match the number of results you can
+	 * fetch via iteration on a very active DB.
+	 *
+	 * @see Countable::count()
+	 * @return int
+	 */
+	public function count() {
+		if (!is_callable($this->getter)) {
+			$inspector = new \Elgg\Debug\Inspector();
+			throw new RuntimeException("Getter is not callable: " . $inspector->describeCallable($this->getter));
+		}
+
+		$options = $this->options + ['count' => true];
+
+		return call_user_func($this->getter, $options);
+	}
+
+	/**
+	 * Read a property
+	 *
+	 * @param string $name
+	 * @return mixed
+	 * @access private
+	 */
+	public function __get($name) {
+		if ($name === 'options') {
+			elgg_deprecated_notice("The ElggBatch 'options' property is private and should not be used", "1.11");
+			return $this->options;
+		}
+
+		_elgg_services()->logger->warn("Read of non-existent property '$name'");
+		return null;
+	}
+
+	/**
+	 * Write a property
+	 *
+	 * @param string $name
+	 * @param mixed  $value
+	 * @return void
+	 * @access private
+	 */
+	public function __set($name, $value) {
+		if ($name === 'options') {
+			elgg_deprecated_notice("The ElggBatch 'options' property is private and should not be used", "1.11");
+		}
+
+		$this->{$name} = $value;
 	}
 }

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -137,12 +137,26 @@ function _elgg_get_metastring_based_objects($options) {
 		'distinct' => true,
 		'preload_owners' => false,
 		'callback' => $callback,
+
+		'batch' => false,
+		'batch_inc_offset' => true,
+		'batch_size' => 25,
 	);
 
 	// @todo Ignore site_guid right now because of #2910
 	$options['site_guid'] = ELGG_ENTITIES_ANY_VALUE;
 
 	$options = array_merge($defaults, $options);
+
+	if ($options['batch'] && !$options['count']) {
+		$batch_size = $options['batch_size'];
+		$batch_inc_offset = $options['batch_inc_offset'];
+
+		// clean batch keys from $options.
+		unset($options['batch'], $options['batch_size'], $options['batch_inc_offset']);
+
+		return new \ElggBatch('_elgg_get_metastring_based_objects', $options, null, $batch_size, $batch_inc_offset);
+	}
 
 	// can't use helper function with type_subtype_pair because
 	// it's already an array...just need to merge it

--- a/engine/tests/ElggBatchTest.php
+++ b/engine/tests/ElggBatchTest.php
@@ -167,6 +167,44 @@ class ElggBatchTest extends \ElggCoreUnitTest {
 		delete_data("DELETE FROM {$db_prefix}objects_entity WHERE guid IN (" . implode(',', $guids) . ")");
 	}
 
+	public function testBatchCanCount() {
+		$getter = function ($options) {
+			if ($options['count']) {
+				return 20;
+			}
+			return false;
+		};
+		$options = [];
+
+		$count1 = count(new ElggBatch($getter, $options));
+		$count2 = $getter($options + ['count' => true]);
+
+		$this->assertEqual($count1, $count2);
+	}
+
+	public function testCanGetBatchFromAnEntityGetter() {
+		$options = [
+			'type' => 'plugin',
+			'limit' => 5,
+			'callback' => function ($row) {
+				return $row->guid;
+			},
+		];
+		$guids1 = elgg_get_entities($options);
+
+		$batch = elgg_get_entities($options + ['batch' => true]);
+
+		$this->assertIsA($batch, 'Elgg\\BatchInterface');
+		/* @var ElggBatch $batch */
+
+		$guids2 = [];
+		foreach ($batch as $val) {
+			$guids2[] = $val;
+		}
+
+		$this->assertEqual($guids1, $guids2);
+	}
+
 	public static function elgg_batch_callback_test($options, $reset = false) {
 		static $count = 1;
 


### PR DESCRIPTION
Allows developers to pass a flag in the options to return an ElggBatch from convenience methods when they need to iterate through large sets

Fixes #6676

(PR replaces #7719)
- [ ] extend Countable and Iterator for Elgg\BatchInterface
- [ ] fix doc on EntityTable:299
