### PR TITLE
fix(groups): Hides the like button for groups

### DIFF
--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -421,7 +421,7 @@ function groups_entity_menu_setup($hook, $type, $return, $params) {
 
 	/* @var ElggMenuItem $item */
 	foreach ($return as $index => $item) {
-		if (in_array($item->getName(), array('access', 'likes', 'edit', 'delete'))) {
+		if (in_array($item->getName(), array('access', 'like', 'edit', 'delete'))) {
 			unset($return[$index]);
 		}
 	}


### PR DESCRIPTION
This was exposed by accident when the likes plugin changed the name of
its menu item.

Fixes #7724
