### PR TITLE
fix(http): don’t allow plugins to bypass a forward() call

### DIFF
--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -92,10 +92,8 @@ function forward($location = "", $reason = 'system') {
 
 		if ($location) {
 			header("Location: {$location}");
-			exit;
-		} else if ($location === '') {
-			exit;
 		}
+		exit;
 	} else {
 		throw new \SecurityException("Redirect could not be issued due to headers already being sent. Halting execution for security. "
 			. "Output started in file $file at line $line. Search http://learn.elgg.org/ for more information.");


### PR DESCRIPTION
If a “forward” hook handler returns false, execution will no longer continue past the forward() call.

Fixes #7637 (please see that ticket)
