### PR TITLE
adds several reported content features + fix button size in admin CSS

### DIFF
--- a/mod/reportedcontent/actions/reportedcontent/add.php
+++ b/mod/reportedcontent/actions/reportedcontent/add.php
@@ -9,31 +9,32 @@ $description = get_input('description');
 $address = get_input('address');
 $access = ACCESS_PRIVATE; //this is private and only admins can see it
 
-if ($title && $address) {
-
-	$report = new ElggObject;
-	$report->subtype = "reported_content";
-	$report->owner_guid = elgg_get_logged_in_user_guid();
-	$report->title = $title;
-	$report->address = $address;
-	$report->description = $description;
-	$report->access_id = $access;
-
-	if ($report->save()) {
-		if (!elgg_trigger_plugin_hook('reportedcontent:add', 'system', array('report' => $report), true)) {
-			$report->delete();
-			register_error(elgg_echo('reportedcontent:failed'));
-		} else {
-			system_message(elgg_echo('reportedcontent:success'));
-			$report->state = "active";
-		}
-		forward($address);
-	} else {
-		register_error(elgg_echo('reportedcontent:failed'));
-		forward($address);
-	}
-} else {
-
+$fail = function () use ($address) {
 	register_error(elgg_echo('reportedcontent:failed'));
 	forward($address);
+};
+
+if (!$title || !$address) {
+	$fail();
 }
+
+$report = new ElggObject;
+$report->subtype = "reported_content";
+$report->owner_guid = elgg_get_logged_in_user_guid();
+$report->title = $title;
+$report->address = $address;
+$report->description = $description;
+$report->access_id = $access;
+
+if (!$report->save()) {
+	$fail();
+}
+
+if (!elgg_trigger_plugin_hook('reportedcontent:add', 'system', array('report' => $report), true)) {
+	$report->delete();
+	$fail();
+}
+
+system_message(elgg_echo('reportedcontent:success'));
+$report->state = "active";
+forward($address);

--- a/mod/reportedcontent/actions/reportedcontent/archive.php
+++ b/mod/reportedcontent/actions/reportedcontent/archive.php
@@ -8,20 +8,19 @@
 $guid = (int) get_input('guid');
 
 $report = get_entity($guid);
-
-// Make sure we actually have permission to edit
-if ($report->getSubtype() == "reported_content" && $report->canEdit()) {
-
-	// allow another plugin to override
-	if (!elgg_trigger_plugin_hook('reportedcontent:archive', 'system', array('report' => $report), TRUE)) {
-		system_message(elgg_echo("reportedcontent:notarchived"));
-		forward(REFERER);
-	}
-
-	// change the state
-	$report->state = "archived";
-
-	system_message(elgg_echo("reportedcontent:archived"));
-
+if (!$report || $report->getSubtype() !== "reported_content" || !$report->canEdit()) {
+	register_error(elgg_echo("reportedcontent:notarchived"));
 	forward(REFERER);
 }
+
+// allow another plugin to override
+if (!elgg_trigger_plugin_hook('reportedcontent:archive', 'system', ['report' => $report], true)) {
+	register_error(elgg_echo("reportedcontent:notarchived"));
+	forward(REFERER);
+}
+
+// change the state
+$report->state = "archived";
+
+system_message(elgg_echo("reportedcontent:archived"));
+forward(REFERER);

--- a/mod/reportedcontent/actions/reportedcontent/delete.php
+++ b/mod/reportedcontent/actions/reportedcontent/delete.php
@@ -8,21 +8,21 @@
 $guid = (int) get_input('guid');
 
 $report = get_entity($guid);
-
-// Make sure we actually have permission to delete
-if ($report->getSubtype() == "reported_content" && $report->canEdit()) {
-
-	// give another plugin a chance to override
-	if (!elgg_trigger_plugin_hook('reportedcontent:delete', 'system', array('report' => $report), TRUE)) {
-		register_error(elgg_echo("reportedcontent:notdeleted"));
-		forward(REFERER);
-	}
-
-	if ($report->delete()) {
-		system_message(elgg_echo("reportedcontent:deleted"));
-	} else {
-		register_error(elgg_echo("reportedcontent:notdeleted"));
-	}
-	
+if (!$report || $report->getSubtype() !== "reported_content" || !$report->canEdit()) {
+	register_error(elgg_echo("reportedcontent:notdeleted"));
 	forward(REFERER);
 }
+
+// give another plugin a chance to override
+if (!elgg_trigger_plugin_hook('reportedcontent:delete', 'system', array('report' => $report), true)) {
+	register_error(elgg_echo("reportedcontent:notdeleted"));
+	forward(REFERER);
+}
+
+if ($report->delete()) {
+	system_message(elgg_echo("reportedcontent:deleted"));
+} else {
+	register_error(elgg_echo("reportedcontent:notdeleted"));
+}
+
+forward(REFERER);

--- a/mod/reportedcontent/languages/en.php
+++ b/mod/reportedcontent/languages/en.php
@@ -23,6 +23,7 @@ return array(
 	'reportedcontent:address' => 'Location of the item',
 	'reportedcontent:success' => 'Your report has been sent to the site admin',
 	'reportedcontent:failing' => 'Your report could not be sent',
+	'reportedcontent:refresh' => 'Refresh this listing',
 	'reportedcontent:report' => 'Report this',
 	'reportedcontent:instructions' => 'This report will be sent to the administrators of this site for review.',
 	'reportedcontent:numbertodisplay' => 'Number of reports to display',

--- a/mod/reportedcontent/start.php
+++ b/mod/reportedcontent/start.php
@@ -19,19 +19,19 @@ function reportedcontent_init() {
 	elgg_extend_view('css/elgg', 'reportedcontent/css');
 	elgg_extend_view('css/admin', 'reportedcontent/admin_css');
 
-	// Extend footer with report content link
+
 	if (elgg_is_logged_in()) {
-		$href = "javascript:elgg.forward('reportedcontent/add'";
-		$href .= "+'?address='+encodeURIComponent(location.href)";
-		$href .= "+'&title='+encodeURIComponent(document.title));";
-		
+		elgg_require_js('elgg/reportedcontent');
+
+		// Extend footer with report content link
 		elgg_register_menu_item('extras', array(
 			'name' => 'report_this',
-			'href' => $href,
+			'href' => 'reportedcontent/add',
 			'title' => elgg_echo('reportedcontent:this:tooltip'),
 			'text' => elgg_view_icon('report-this'),
 			'priority' => 500,
 			'section' => 'default',
+			'link_class' => 'elgg-lightbox',
 		));
 	}
 
@@ -66,6 +66,11 @@ function reportedcontent_page_handler($page) {
 	// only logged in users can report things
 	elgg_gatekeeper();
 
+	if (elgg_extract(0, $page) === 'add' && elgg_is_xhr()) {
+		echo elgg_view('resources/reportedcontent/add_form');
+		return true;
+	}
+
 	$title = elgg_echo('reportedcontent:this');
 	
 	$content = elgg_view_form('reportedcontent/add');
@@ -87,6 +92,7 @@ function reportedcontent_page_handler($page) {
  */
 function reportedcontent_user_hover_menu($hook, $type, $return, $params) {
 	$user = $params['entity'];
+	/* @var ElggUser $user */
 
 	$profile_url = urlencode($user->getURL());
 	$name = urlencode($user->name);
@@ -98,6 +104,7 @@ function reportedcontent_user_hover_menu($hook, $type, $return, $params) {
 				elgg_echo('reportedcontent:user'),
 				$url);
 		$item->setSection('action');
+		$item->addLinkClass('elgg-lightbox');
 		$return[] = $item;
 	}
 

--- a/mod/reportedcontent/views/default/admin/administer_utilities/reportedcontent.php
+++ b/mod/reportedcontent/views/default/admin/administer_utilities/reportedcontent.php
@@ -5,7 +5,15 @@
  * @package ElggReportedContent
  */
 
-$list = elgg_list_entities(array('type' => 'object', 'subtype' => 'reported_content'));
+$list = elgg_list_entities_from_metadata([
+	'type' => 'object',
+	'subtype' => 'reported_content',
+	'order_by_metadata' => [
+		'name' => 'state',
+		'direction' => 'ASC',
+		'as' => 'text',
+	],
+]);
 if (!$list) {
 	$list = '<p class="mtm">' . elgg_echo('reportedcontent:none') . '</p>';
 }

--- a/mod/reportedcontent/views/default/forms/reportedcontent/add.php
+++ b/mod/reportedcontent/views/default/forms/reportedcontent/add.php
@@ -29,11 +29,11 @@ $owner = elgg_get_logged_in_user_entity();
 	<label>
 		<?php
 			echo elgg_echo('reportedcontent:address');
-			echo elgg_view('input/url', array(
-					'name' => 'address',
-							'value' => $address,
-					));
-			
+			echo elgg_view('input/url', [
+				'name' => 'address',
+				'value' => $address,
+				'readonly' => (bool)$address,
+			]);
 			?>
 	</label>
 </div>
@@ -42,7 +42,7 @@ $owner = elgg_get_logged_in_user_entity();
 		<?php 	echo elgg_echo('reportedcontent:description'); ?>
 	</label>
 	<?php
-		echo elgg_view('input/longtext',array(
+		echo elgg_view('input/plaintext',array(
 			'name' => 'description',
 			'value' => $description,
 		));
@@ -53,5 +53,9 @@ $owner = elgg_get_logged_in_user_entity();
 		echo elgg_view('input/submit', array(
 			'value' => elgg_echo('reportedcontent:report'),
 		));
+		echo elgg_view('input/button', [
+			'class' => 'elgg-button-cancel mls',
+			'value' => elgg_echo('cancel'),
+		]);
 	?>
 </div>

--- a/mod/reportedcontent/views/default/js/elgg/reportedcontent.js
+++ b/mod/reportedcontent/views/default/js/elgg/reportedcontent.js
@@ -1,0 +1,71 @@
+define(function (require) {
+	var elgg = require('elgg'),
+		$ = require('jquery');
+
+	$('.elgg-menu-item-report-this a, .elgg-menu-item-reportuser a').each(function () {
+		if (!/address=/.test(this.href)) {
+			this.href += '?address=' + encodeURIComponent(location.href) +
+						'&title=' + encodeURIComponent(document.title);
+		}
+	});
+
+	$(document).on('submit', '.elgg-form-reportedcontent-add', function (e) {
+		e.preventDefault();
+		var $form = $(this);
+		elgg.action($form[0].action, {
+			data: $form.serialize(),
+			success: function (data) {
+				if (data.status == 0) {
+					elgg.ui.lightbox.close();
+				}
+			}
+		});
+	});
+
+	$(document).on('click', '.elgg-form-reportedcontent-add .elgg-button-cancel', function (e) {
+		if ($(this).is('#colorbox *')) {
+			elgg.ui.lightbox.close();
+		} else {
+			if (history.length > 1) {
+				history.go(-1);
+			} else {
+				location.href = elgg.get_site_url();
+			}
+		}
+		return false;
+	});
+
+	$(document).on('click', '.elgg-item-object-reported_content', function (e) {
+		var $clicked = $(e.target),
+			$li = $(this);
+
+		if (!$clicked.is('button[data-elgg-action]')) {
+			return;
+		}
+
+		var action = $clicked.data('elggAction');
+		elgg.action(action.name, {
+			data: action.data,
+			success: function (data) {
+				if (data.status == -1) {
+					return;
+				}
+
+				if (action.name === 'reportedcontent/delete') {
+					$li.slideUp();
+				} else {
+					$clicked.fadeOut();
+					$li.find('.reported-content-active')
+						.removeClass('reported-content-active')
+						.addClass('reported-content-archived');
+				}
+
+				if (!$('.reported-content-refresh').length) {
+					$li.parent().after('<p class="reported-content-refresh mtm ptm elgg-divide-top center">' +
+						'<a href="">' + elgg.echo('reportedcontent:refresh') + '</a></p>');
+				}
+			}
+		});
+		return false;
+	})
+});

--- a/mod/reportedcontent/views/default/object/reported_content.php
+++ b/mod/reportedcontent/views/default/object/reported_content.php
@@ -6,10 +6,8 @@
  */
 
 $report = $vars['entity'];
+/* @var ElggObject $report */
 $reporter = $report->getOwnerEntity();
-
-$archive_url = elgg_get_site_url() . "action/reportedcontent/archive?guid=$report->guid";
-$delete_url = elgg_get_site_url() . "action/reportedcontent/delete?guid=$report->guid";
 
 //find out if the report is current or archive
 if ($report->state == 'archived') {
@@ -25,60 +23,54 @@ if ($report->state == 'archived') {
 		<div class="clearfix controls">
 <?php
 	if ($report->state != 'archived') {
-		$params = array(
-			'href' => $archive_url,
-			'text' => elgg_echo('reportedcontent:archive'),
-			'is_action' => true,
-			'is_trusted' => true,
+		$attrs = [
 			'class' => 'elgg-button elgg-button-action',
-		);
-		echo elgg_view('output/url', $params);
+			'data-elgg-action' => json_encode([
+				'name' => 'reportedcontent/archive',
+				'data' => [
+					'guid' => $report->guid,
+				]
+			]),
+		];
+		echo elgg_format_element('button', $attrs, elgg_echo('reportedcontent:archive'));
 	}
-	$params = array(
-		'href' => $delete_url,
-		'text' => elgg_echo('reportedcontent:delete'),
-		'is_action' => true,
-		'is_trusted' => true,
+	$attrs = [
 		'class' => 'elgg-button elgg-button-action',
-	);
-	echo elgg_view('output/url', $params);
+		'data-elgg-action' => json_encode([
+			'name' => 'reportedcontent/delete',
+			'data' => [
+				'guid' => $report->guid,
+			]
+		]),
+	];
+	echo elgg_format_element('button', $attrs, elgg_echo('reportedcontent:delete'));
 ?>
 		</div>
-		<p>
-			<b><?php echo elgg_echo('reportedcontent:by'); ?>:</b>
-			<?php echo elgg_view('output/url', array(
+		<h3 class="mbm">
+			<?php echo elgg_view('output/url', [
+				'text' => $report->title,
+				'href' => $report->address,
+				'is_trusted' => true,
+				'class' => 'elgg-reported-content-address elgg-lightbox',
+				'data-colorbox-opts' => json_encode([
+					'width' => '85%',
+					'height' => '85%',
+					'iframe' => true,
+				]),
+			]);
+			?>
+		</h3>
+		<p><b><?php echo elgg_echo('reportedcontent:by') ?></b>
+			<?php echo elgg_view('output/url', [
 				'href' => $reporter->getURL(),
 				'text' => $reporter->name,
 				'is_trusted' => true,
-			));
-			?>,
-			<?php echo elgg_view_friendly_time($report->time_created); ?>
-		</p>
-		<p>
-			<b><?php echo elgg_echo('title'); ?>:</b>
-			<?php echo $report->title; ?>
-		<p>
-			<b><?php echo elgg_echo('reportedcontent:objecturl'); ?>:</b>
-			<?php echo elgg_view('output/url', array(
-				'href' => $report->address,
-				'text' => elgg_echo('reportedcontent:visit'),
-				'is_trusted' => true,
-			));
+			]);
+			echo " " . elgg_view_friendly_time($report->time_created);
 			?>
 		</p>
-		<p>
-			<?php echo elgg_view('output/url', array(
-				'href' => "#report-$report->guid",
-				'text' => elgg_echo('more_info'),
-				'rel' => "toggle",
-			));
-			?>
-		</p>
-	</div>
-	<div class="report-details hidden" id="report-<?php echo $report->getGUID();?>">
-		<p>
-			<b><?php echo elgg_echo('reportedcontent:reason'); ?>:</b>
-			<?php echo $report->description; ?>
-		</p>
+		<?php if ($report->description): ?>
+			<p><?php echo $report->description; ?></p>
+		<?php endif; ?>
 	</div>
 </div>

--- a/mod/reportedcontent/views/default/resources/reportedcontent/add_form.php
+++ b/mod/reportedcontent/views/default/resources/reportedcontent/add_form.php
@@ -1,0 +1,3 @@
+<?php
+
+echo elgg_view_form('reportedcontent/add');

--- a/mod/reportedcontent/views/default/widgets/reportedcontent/content.php
+++ b/mod/reportedcontent/views/default/widgets/reportedcontent/content.php
@@ -3,12 +3,17 @@
  * List the latest reports
  */
 
-$list = elgg_list_entities(array(
+$list = elgg_list_entities_from_metadata([
 	'type' => 'object',
 	'subtype' => 'reported_content',
 	'limit' => $vars['entity']->num_display,
 	'pagination' => false,
-));
+	'order_by_metadata' => [
+		'name' => 'state',
+		'direction' => 'ASC',
+		'as' => 'text',
+	],
+]);
 if (!$list) {
 	$list = '<p class="mtm">' . elgg_echo('reportedcontent:none') . '</p>';
 }

--- a/views/default/css/admin.php
+++ b/views/default/css/admin.php
@@ -525,6 +525,7 @@ select {
 }
 
 .elgg-button {
+	font-size: 100%;
 	text-decoration: none;
 	border-radius: 3px;
 	width: auto;


### PR DESCRIPTION
Ajaxifies the reporting form (form page still BC) and delete/archive
actions. Sorts un-archived reports at the top of results. More compact
report display, and clicking reported link opens page in an iframe
in colorbox.

Fixes #5379, #6082, #5380

This doesn't solve all problems but I think would be a step forward. Potential issue: when deleting/archiving, the list doesn't refresh (several ways to do this and couldn't decide on the best within Elgg's limited framework), so, e.g., you could delete 4 out of the widget and it would show none until you refreshed the page.
