### PR TITLE
fix(notifications): subject of comment notification email always starts with "Re: "

### DIFF
--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -110,42 +110,6 @@ function groups_init() {
 }
 
 /**
- * Set notifications about discussions and their replies to have just thread title as a subject.
- * This is to make more picky email clients happy while groupping messages in threads, as well as to
- * save space in subject line.
- *
- * @param $hook string
- * @param $type string
- * @param $returnvalue array
- * @param $params array
- * @return array
- */
-function discussion_notification_email_subject($hook, $type, $returnvalue, $params){
-
-	/** @var Elgg_Notifications_Notification */
-	$notification = elgg_extract('notification', $returnvalue['params']);
-
-	if ($notification instanceof Elgg_Notifications_Notification) {
-
-		$object = elgg_extract('object', $notification->params);
-		/** @var Elgg_Notifications_Event $event */
-		$event = elgg_extract('event', $notification->params);
-
-		if ($object instanceof ElggEntity) {
-			if ($object->getSubtype() === 'groupforumtopic') {
-				$returnvalue['subject'] = $object->getDisplayName();
-			}
-			$container = $object->getContainerEntity();
-
-			if (($container instanceof ElggEntity) && ($object instanceof ElggComment)) {
-				$returnvalue['subject'] = 'Re: ' . $container->getDisplayName();
-			}
-		}
-	}
-	return $returnvalue;
-}
-
-/**
  * This function loads a set of default fields into the profile, then triggers
  * a hook letting other plugins to edit add and delete fields.
  *
@@ -856,7 +820,6 @@ function discussion_init() {
 	elgg_register_plugin_hook_handler('prepare', 'notification:create:object:groupforumtopic', 'discussion_prepare_notification');
 	elgg_register_notification_event('object', 'discussion_reply');
 	elgg_register_plugin_hook_handler('prepare', 'notification:create:object:discussion_reply', 'discussion_prepare_reply_notification');
-	elgg_register_plugin_hook_handler('email', 'system', 'discussion_notification_email_subject');
 }
 
 /**


### PR DESCRIPTION
Subjects of comment notification emails were starting with `Re:` only when the groups plugin was enabled. This moves the logic out from the groups plugin, so comment notifications use the same subject regardless if the groups plugin is enabled or not.

Fixes #7743
