### PR TITLE
fix(plugins): Eliminates deprecation notice on file plugin objects

### DIFF
--- a/engine/lib/objects.php
+++ b/engine/lib/objects.php
@@ -10,7 +10,7 @@
 /**
  * Return the object specific details of a object by a row.
  *
- * @param int $guid The guid to retreive
+ * @param int $guid The guid to retrieve
  *
  * @return bool
  * @access private

--- a/mod/file/classes/FilePluginFile.php
+++ b/mod/file/classes/FilePluginFile.php
@@ -2,15 +2,26 @@
 
 /**
  * Override the ElggFile
+ *
+ * @note When extending an ElggEntity, one should always register a unique type/subtype
+ *       combination. We failed to do so here, so get_entity() and friends will always return
+ *       these objects as ElggFile. We leave it this way just for BC.
  */
 class FilePluginFile extends ElggFile {
 	protected function  initializeAttributes() {
 		parent::initializeAttributes();
 
+		// This should have been a unique subtype (see above)
 		$this->attributes['subtype'] = "file";
 	}
 
 	public function __construct($guid = null) {
+		if ($guid && !is_object($guid)) {
+			// Loading entities via __construct(GUID) is deprecated, so we give it the entity row and the
+			// attribute loader will finish the job. This is necessary due to not using a custom
+			// subtype (see above).
+			$guid = get_entity_as_row($guid);
+		}
 		parent::__construct($guid);
 	}
 


### PR DESCRIPTION
FilePluginFile fails to register a custom subtype. Due to this, we need to
catch the use of __construct(GUID) and instead pass a DB row to the parent
ElggFile constructor.

Fixes #7761
