### PR TITLE
feature(views): passes more context info to input/access and access hooks

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -223,7 +223,12 @@ Permission hooks
 	.. warning:: The handler needs to either not use parts of the API that use the access system (triggering the hook again) or to ignore the second call. Otherwise, an infinite loop will be created.
 
 **access:collections:write, user**
-	Filters an array of access IDs that the user ``$params['user_id']`` can write to.
+	Filters an array of access IDs that the user ``$params['user_id']`` can write to. In
+	get_write_access_array(), this hook filters the return value, so it can be used to alter
+	the available options in the input/access view. For core plugins, the value "input_params"
+	has the keys "entity" (ElggEntity|false), "entity_type" (string), "entity_subtype" (string),
+	"container_guid" (int) are provided. An empty entity value generally means the form is to
+	create a new object.
 
 	.. warning:: The handler needs to either not use parts of the API that use the access system (triggering the hook again) or to ignore the second call. Otherwise, an infinite loop will be created.
 
@@ -282,7 +287,11 @@ Other
 =====
 
 **default, access**
-    In ``get_default_access()``, filters the return value.
+	In get_default_access(), this hook filters the return value, so it can be used to alter
+	the default value in the input/access view. For core plugins, the value "input_params" has
+	the keys "entity" (ElggEntity|false), "entity_type" (string), "entity_subtype" (string),
+	"container_guid" (int) are provided. An empty entity value generally means the form is to
+	create a new object.
 
 **entity:icon:url, <entity_type>**
 	Triggered when entity icon URL is requested, see :ref:`entity icons <guides/database#entity-icons>`. Callback should

--- a/engine/classes/Elgg/Database/AccessCollections.php
+++ b/engine/classes/Elgg/Database/AccessCollections.php
@@ -362,13 +362,14 @@ class AccessCollections {
 	 * standard access levels. It does not return access collections that the user
 	 * belongs to such as the access collection for a group.
 	 *
-	 * @param int  $user_guid The user's GUID.
-	 * @param int  $site_guid The current site.
-	 * @param bool $flush     If this is set to true, this will ignore a cached access array
+	 * @param int   $user_guid    The user's GUID.
+	 * @param int   $site_guid    The current site.
+	 * @param bool  $flush        If this is set to true, this will ignore a cached access array
+	 * @param array $input_params Some parameters passed into an input/access view
 	 *
 	 * @return array List of access permissions
 	 */
-	function getWriteAccessArray($user_guid = 0, $site_guid = 0, $flush = false) {
+	function getWriteAccessArray($user_guid = 0, $site_guid = 0, $flush = false, array $input_params = array()) {
 		global $init_finished;
 		$cache = _elgg_services()->accessCache;
 	
@@ -421,10 +422,10 @@ class AccessCollections {
 	
 		$options = array(
 			'user_id' => $user_guid,
-			'site_id' => $site_guid
+			'site_id' => $site_guid,
+			'input_params' => $input_params,
 		);
-		return _elgg_services()->hooks->trigger('access:collections:write', 'user',
-			$options, $access_array);
+		return _elgg_services()->hooks->trigger('access:collections:write', 'user', $options, $access_array);
 	}
 
 	/**

--- a/engine/lib/access.php
+++ b/engine/lib/access.php
@@ -110,11 +110,12 @@ function get_access_array($user_guid = 0, $site_guid = 0, $flush = false) {
  * If want you to change the default access based on group of other information,
  * use the 'default', 'access' plugin hook.
  *
- * @param \ElggUser $user Get the user's default access. Defaults to logged in user.
+ * @param ElggUser $user         The user for whom we're getting default access. Defaults to logged in user.
+ * @param array    $input_params Parameters passed into an input/access view
  *
  * @return int default access id (see ACCESS defines in elgglib.php)
  */
-function get_default_access(\ElggUser $user = null) {
+function get_default_access(ElggUser $user = null, array $input_params = array()) {
 	global $CONFIG;
 
 	// site default access
@@ -134,6 +135,7 @@ function get_default_access(\ElggUser $user = null) {
 	$params = array(
 		'user' => $user,
 		'default_access' => $default_access,
+		'input_params' => $input_params,
 	);
 	return _elgg_services()->hooks->trigger('default', 'access', $params, $default_access);
 }
@@ -257,14 +259,15 @@ function has_access_to_entity($entity, $user = null) {
  * standard access levels. It does not return access collections that the user
  * belongs to such as the access collection for a group.
  *
- * @param int  $user_guid The user's GUID.
- * @param int  $site_guid The current site.
- * @param bool $flush     If this is set to true, this will ignore a cached access array
+ * @param int   $user_guid    The user's GUID.
+ * @param int   $site_guid    The current site.
+ * @param bool  $flush        If this is set to true, this will ignore a cached access array
+ * @param array $input_params Some parameters passed into an input/access view
  *
  * @return array List of access permissions
  */
-function get_write_access_array($user_guid = 0, $site_guid = 0, $flush = false) {
-	return _elgg_services()->accessCollections->getWriteAccessArray($user_guid, $site_guid, $flush);
+function get_write_access_array($user_guid = 0, $site_guid = 0, $flush = false, array $input_params = array()) {
+	return _elgg_services()->accessCollections->getWriteAccessArray($user_guid, $site_guid, $flush, $input_params);
 }
 
 /**

--- a/mod/blog/views/default/forms/blog/save.php
+++ b/mod/blog/views/default/forms/blog/save.php
@@ -102,7 +102,10 @@ $access_label = elgg_echo('access');
 $access_input = elgg_view('input/access', array(
 	'name' => 'access_id',
 	'id' => 'blog_access_id',
-	'value' => $vars['access_id']
+	'value' => $vars['access_id'],
+	'entity' => $vars['entity'],
+	'entity_type' => 'object',
+	'entity_subtype' => 'blog',
 ));
 
 $categories_input = elgg_view('input/categories', $vars);

--- a/mod/bookmarks/views/default/forms/bookmarks/save.php
+++ b/mod/bookmarks/views/default/forms/bookmarks/save.php
@@ -41,7 +41,13 @@ if ($categories) {
 ?>
 <div>
 	<label><?php echo elgg_echo('access'); ?></label><br />
-	<?php echo elgg_view('input/access', array('name' => 'access_id', 'value' => $access_id)); ?>
+	<?php echo elgg_view('input/access', array(
+		'name' => 'access_id',
+		'value' => $access_id,
+		'entity' => get_entity($guid),
+		'entity_type' => 'object',
+		'entity_subtype' => 'bookmarks',
+	)); ?>
 </div>
 <div class="elgg-foot">
 <?php

--- a/mod/file/views/default/forms/file/upload.php
+++ b/mod/file/views/default/forms/file/upload.php
@@ -63,7 +63,13 @@ if ($categories) {
 ?>
 <div>
 	<label><?php echo elgg_echo('access'); ?></label><br />
-	<?php echo elgg_view('input/access', array('name' => 'access_id', 'value' => $access_id)); ?>
+	<?php echo elgg_view('input/access', array(
+		'name' => 'access_id',
+		'value' => $access_id,
+		'entity' => get_entity($guid),
+		'entity_type' => 'object',
+		'entity_subtype' => 'file',
+	)); ?>
 </div>
 <div class="elgg-foot">
 <?php

--- a/mod/groups/views/default/forms/discussion/save.php
+++ b/mod/groups/views/default/forms/discussion/save.php
@@ -40,7 +40,13 @@ $guid = elgg_extract('guid', $vars, null);
 </div>
 <div>
 	<label><?php echo elgg_echo('access'); ?></label><br />
-	<?php echo elgg_view('input/access', array('name' => 'access_id', 'value' => $access_id)); ?>
+	<?php echo elgg_view('input/access', array(
+		'name' => 'access_id',
+		'value' => $access_id,
+		'entity' => get_entity($guid),
+		'entity_type' => 'object',
+		'entity_subtype' => 'groupforumtopic',
+	)); ?>
 </div>
 <div class="elgg-foot">
 <?php

--- a/mod/groups/views/default/groups/edit/access.php
+++ b/mod/groups/views/default/groups/edit/access.php
@@ -47,7 +47,10 @@ $content_access_mode = elgg_extract("content_access_mode", $vars);
 			"name" => "vis",
 			"id" => "groups-vis",
 			"value" => $visibility,
-			"options_values" => $visibility_options
+			"options_values" => $visibility_options,
+			'entity' => $entity,
+			'entity_type' => 'group',
+			'entity_subtype' => '',
 		));
 		?>
 	</div>

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -69,6 +69,8 @@ function pages_init() {
 		'tags' => 'tags',
 		'parent_guid' => 'parent',
 		'access_id' => 'access',
+
+		// TODO change to "access" when input/write_access is removed
 		'write_access_id' => 'write_access',
 	));
 
@@ -77,6 +79,8 @@ function pages_init() {
 	// write permission plugin hooks
 	elgg_register_plugin_hook_handler('permissions_check', 'object', 'pages_write_permission_check');
 	elgg_register_plugin_hook_handler('container_permissions_check', 'object', 'pages_container_permission_check');
+
+	elgg_register_plugin_hook_handler('access:collections:write', 'user', 'pages_write_access_options_hook');
 
 	// icon url override
 	elgg_register_plugin_hook_handler('entity:icon:url', 'object', 'pages_icon_url_override');
@@ -400,4 +404,26 @@ function pages_ecml_views_hook($hook, $entity_type, $return_value, $params) {
  */
 function pages_is_page($value) {
 	return ($value instanceof ElggObject) && in_array($value->getSubtype(), array('page', 'page_top'));
+}
+
+/**
+ * Return options for the write_access_id input
+ *
+ * @param string $hook
+ * @param string $type
+ * @param array  $return_value
+ * @param array  $params
+ *
+ * @return array
+ */
+function pages_write_access_options_hook($hook, $type, $return_value, $params) {
+	if (empty($params['input_params']['entity_subtype'])
+			|| !in_array($params['input_params']['entity_subtype'], array('page', 'page_top'))) {
+		return null;
+	}
+
+	if ($params['input_params']['purpose'] === 'write') {
+		unset($return_value[ACCESS_PUBLIC]);
+		return $return_value;
+	}
 }

--- a/mod/pages/views/default/forms/pages/edit.php
+++ b/mod/pages/views/default/forms/pages/edit.php
@@ -38,11 +38,24 @@ foreach ($variables as $name => $type) {
 			echo '<br />';
 		}
 
-		echo elgg_view($input_view, array(
+		$view_vars = array(
 			'name' => $name,
 			'value' => $vars[$name],
 			'entity' => ($name == 'parent_guid') ? $vars['entity'] : null,
-		));
+		);
+		if ($input_view === 'input/access' || $input_view === 'input/write_access') {
+			$view_vars['entity'] = $entity;
+			$view_vars['entity_type'] = 'object';
+			$view_vars['entity_subtype'] = $vars['parent_guid'] ? 'page': 'page_top';
+			if ($name === 'write_access_id') {
+				$view_vars['purpose'] = 'write';
+				if ($entity) {
+					$view_vars['value'] = $entity->write_access_id;
+				}
+			}
+		}
+
+		echo elgg_view($input_view, $view_vars);
 	?>
 </div>
 <?php

--- a/mod/pages/views/default/input/write_access.php
+++ b/mod/pages/views/default/input/write_access.php
@@ -1,35 +1,5 @@
 <?php
-/**
- * Write access
- *
- * Removes the public option found in input/access
- *
- * @uses $vars['value'] The current value, if any
- * @uses $vars['options_values']
- * @uses $vars['name'] The name of the input field
- * @uses $vars['entity'] Optional. The entity for this access control (uses write_access_id)
- */
 
-$options = get_write_access_array();
-unset($options[ACCESS_PUBLIC]);
+echo elgg_view('input/access', $vars);
 
-$defaults = array(
-	'class' => 'elgg-input-access',
-	'disabled' => FALSE,
-	'value' => get_default_access(),
-	'options_values' => $options,
-);
-
-if (isset($vars['entity'])) {
-	$defaults['value'] = $vars['entity']->write_access_id;
-	unset($vars['entity']);
-}
-
-$vars = array_merge($defaults, $vars);
-
-if ($vars['value'] == ACCESS_DEFAULT) {
-	$vars['value'] = get_default_access();
-}
-$vars['value'] = ($vars['value'] == ACCESS_PUBLIC) ? ACCESS_LOGGED_IN : $vars['value'];
-
-echo elgg_view('input/select', $vars);
+elgg_deprecated_notice("The input/write_access view is deprecated. The pages plugin now uses the ['access:collections:write', 'user'] hook to alter options.", "1.11");

--- a/views/default/input/access.php
+++ b/views/default/input/access.php
@@ -8,51 +8,93 @@
  * @uses $vars['name']           The name of the input field
  * @uses $vars['entity']         Optional. The entity for this access control (uses access_id)
  * @uses $vars['class']          Additional CSS class
+ *
+ * @uses $vars['entity_type']    Optional. Type of the entity
+ * @uses $vars['entity_subtype'] Optional. Subtype of the entity
+ * @uses $vars['container_guid'] Optional. Container GUID of the entity
+ *
  */
 
-if (isset($vars['class'])) {
-	$vars['class'] = "elgg-input-access {$vars['class']}";
-} else {
-	$vars['class'] = "elgg-input-access";
+// bail if set to a unusable value
+if (isset($vars['options_values'])) {
+	if (!is_array($vars['options_values']) || empty($vars['options_values'])) {
+		return;
+	}
 }
 
-$defaults = array(
-	'disabled' => false,
-	'value' => get_default_access(),
-	'options_values' => get_write_access_array(),
+$vars['class'] = trim("elgg-input-access " . elgg_extract('class', $vars, ''));
+
+// this will be passed to plugin hooks ['access:collections:write', 'user'] and ['default', 'access']
+$params = array();
+
+$keys = array(
+	'entity' => null,
+	'entity_type' => null,
+	'entity_subtype' => null,
+	'container_guid' => null,
+	'purpose' => 'read',
 );
+foreach ($keys as $key => $default_value) {
+	$params[$key] = elgg_extract($key, $vars, $default_value);
+	unset($vars[$key]);
+}
 
 /* @var ElggEntity $entity */
-$entity = elgg_extract('entity', $vars);
-unset($vars['entity']);
+$entity = $params['entity'];
+
+if ($entity) {
+	$params['value'] = $entity->access_id;
+	$params['entity_type'] = $entity->type;
+	$params['entity_subtype'] = $entity->getSubtype();
+	$params['container_guid'] = $entity->container_guid;
+}
+
+$container = elgg_get_page_owner_entity();
+if (!$params['container_guid'] && $container) {
+	$params['container_guid'] = $container->guid;
+}
+
+// don't call get_default_access() unless we need it
+if (!isset($vars['value']) || $vars['value'] == ACCESS_DEFAULT) {
+	if ($entity) {
+		$vars['value'] = $entity->access_id;
+	} else {
+		$vars['value'] = get_default_access(null, $params);
+	}
+}
+
+$params['value'] = $vars['value'];
+
+// don't call get_write_access_array() unless we need it
+if (!isset($vars['options_values'])) {
+	$vars['options_values'] = get_write_access_array(0, 0, false, $params);
+}
+
+if (!isset($vars['disabled'])) {
+	$vars['disabled'] = false;
+}
+
+// if access is set to a value not present in the available options, add the option
+if (!isset($vars['options_values'][$vars['value']])) {
+	$acl = get_access_collection($vars['value']);
+	$display = $acl ? $acl->name : elgg_echo('access:missing_name');
+	$vars['options_values'][$vars['value']] = $display;
+}
 
 // should we tell users that public/logged-in access levels will be ignored?
-$container = elgg_get_page_owner_entity();
 if (($container instanceof ElggGroup)
-		&& $container->getContentAccessMode() === ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY
-		&& !elgg_in_context('group-edit')
-		&& !($entity && $entity instanceof ElggGroup)) {
+	&& $container->getContentAccessMode() === ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY
+	&& !elgg_in_context('group-edit')
+	&& !($entity instanceof ElggGroup)) {
 	$show_override_notice = true;
 } else {
 	$show_override_notice = false;
 }
 
-if ($entity) {
-	$defaults['value'] = $entity->access_id;
+if ($show_override_notice) {
+	$vars['data-group-acl'] = $container->group_acl;
 }
-
-$vars = array_merge($defaults, $vars);
-
-if ($vars['value'] == ACCESS_DEFAULT) {
-	$vars['value'] = get_default_access();
-}
-
-if (is_array($vars['options_values']) && sizeof($vars['options_values']) > 0) {
-	if ($show_override_notice) {
-		$vars['data-group-acl'] = $container->group_acl;
-	}
-	echo elgg_view('input/select', $vars);
-	if ($show_override_notice) {
-		echo "<p class='elgg-text-help'>" . elgg_echo('access:overridenotice')  .  "</p>";
-	}
+echo elgg_view('input/select', $vars);
+if ($show_override_notice) {
+	echo "<p class='elgg-text-help'>" . elgg_echo('access:overridenotice')  .  "</p>";
 }


### PR DESCRIPTION
(something messed up my previous PRs for 1.10. I rebased this for 1.x)

Without contextual information about the entity being edited/created,
it's difficult to alter the input/access view in meaningful ways. This
provides the hook parameter to hold that info and alters the core uses
of input/access to provide that info.

Fixes #4695
