### PR TITLE
fix(notifications): correctly unregister the default notifications save function

### DIFF
--- a/mod/notifications/start.php
+++ b/mod/notifications/start.php
@@ -16,7 +16,7 @@ function notifications_plugin_init() {
 	elgg_register_event_handler('pagesetup', 'system', 'notifications_plugin_pagesetup');
 
 	// Unset the default notification settings
-	elgg_unregister_plugin_hook_handler('usersettings:save', 'user', 'notification_user_settings_save');
+	elgg_unregister_plugin_hook_handler('usersettings:save', 'user', '_elgg_save_notification_user_settings');
 	elgg_unextend_view('forms/account/settings', 'core/settings/account/notifications');
 
 	// update notifications based on relationships changing


### PR DESCRIPTION
The name of the default notifications save function was changed, but the
new name wasn't set in the notifications plugin.

this causes a php warning
"Invalid argument supplied for foreach()" in file /engine/lib/notification.php (line 687)
