### PR TITLE
fix(blog): correctly handle the archive listing if there is no archive

### DIFF
--- a/mod/blog/views/default/blog/sidebar/archives.php
+++ b/mod/blog/views/default/blog/sidebar/archives.php
@@ -14,9 +14,11 @@ if (elgg_instanceof($page_owner, 'user')) {
 
 // This is a limitation of the URL schema.
 if ($page_owner && $vars['page'] != 'friends') {
-	$dates = array_reverse(get_entity_dates('object', 'blog', $page_owner->getGUID()));
+	$dates = get_entity_dates('object', 'blog', $page_owner->getGUID());
 
 	if ($dates) {
+		$dates = array_reverse($dates);
+		
 		$title = elgg_echo('blog:archives');
 		$content = '<ul class="blog-archives">';
 		foreach ($dates as $date) {


### PR DESCRIPTION
If a user/group doesn't have any blogs the archive threw a php warning.

"array_reverse() expects parameter 1 to be array, boolean given" in file /mod/blog/views/default/blog/sidebar/archives.php (line 17)
