### PR TITLE
fix(plugins): pages with no annotation no longer cause fatal errors

### DIFF
--- a/mod/pages/views/default/object/page_top.php
+++ b/mod/pages/views/default/object/page_top.php
@@ -35,6 +35,9 @@ if ($revision) {
 	));
 	if ($annotation) {
 		$annotation = $annotation[0];
+	} else {
+		elgg_log("Failed to access annotation for page with GUID {$page->guid}", 'WARNING');
+		return;
 	}
 }
 


### PR DESCRIPTION
Fixes #7793
