### PR TITLE
fix(plugins): re-hides the likes button for groups

### DIFF
--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -385,7 +385,7 @@ function groups_entity_menu_setup($hook, $type, $return, $params) {
 
 	/* @var ElggMenuItem $item */
 	foreach ($return as $index => $item) {
-		if (in_array($item->getName(), array('access', 'likes', 'edit', 'delete'))) {
+		if (in_array($item->getName(), array('access', 'likes', 'unlike', 'edit', 'delete'))) {
 			unset($return[$index]);
 		}
 	}

--- a/mod/likes/start.php
+++ b/mod/likes/start.php
@@ -39,7 +39,7 @@ function likes_entity_menu_setup($hook, $type, $return, $params) {
 		
 		// Always register both. That makes it super easy to toggle with javascript
 		$return[] = ElggMenuItem::factory(array(
-			'name' => 'like',
+			'name' => 'likes',
 			'href' => elgg_add_action_tokens_to_url("/action/likes/add?guid={$entity->guid}"),
 			'text' => elgg_view_icon('thumbs-up'),
 			'title' => elgg_echo('likes:likethis'),
@@ -105,7 +105,7 @@ function likes_river_menu_setup($hook, $type, $return, $params) {
 
 	// Always register both. That makes it super easy to toggle with javascript
 	$return[] = ElggMenuItem::factory(array(
-		'name' => 'like',
+		'name' => 'likes',
 		'href' => elgg_add_action_tokens_to_url("/action/likes/add?guid={$object->guid}"),
 		'text' => elgg_view_icon('thumbs-up'),
 		'title' => elgg_echo('likes:likethis'),


### PR DESCRIPTION
(replaces #7725)

The name of the likes menu item was mistakenly changed, causing like buttons
to appear for groups. This changes it back. Also this removes the hidden
“unlike” menu item that serves no purpose on groups.

Fixes #7724
