### PR TITLE
feature(navigation): add hook to filter breadcrumbs

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -110,6 +110,11 @@ System hooks
 		<user_guid2> => array('email', 'sms', 'ajax')
 	);
 
+**prepare, breadcrumbs**
+    In elgg_get_breadcrumbs(), this filters the registered breadcrumbs before
+    returning them, allowing a plugin to alter breadcrumb strategy site-wide.
+
+**add, river**
 
 User hooks
 ==========

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -231,11 +231,15 @@ function elgg_register_title_button($handler = null, $name = 'add') {
 /**
  * Adds a breadcrumb to the breadcrumbs stack.
  *
- * @param string $title The title to display
- * @param string $link  Optional. The link for the title.
+ * See elgg_get_breadcrumbs() and the navigation/breadcrumbs view.
+ *
+ * @param string $title The title to display. During rendering this is HTML encoded.
+ * @param string $link  Optional. The link for the title. During rendering links are
+ *                      normalized via elgg_normalize_url().
  *
  * @return void
  * @since 1.8.0
+ * @see elgg_get_breadcrumbs
  */
 function elgg_push_breadcrumb($title, $link = null) {
 	global $CONFIG;
@@ -243,40 +247,72 @@ function elgg_push_breadcrumb($title, $link = null) {
 		$CONFIG->breadcrumbs = array();
 	}
 
-	// avoid key collisions.
-	$CONFIG->breadcrumbs[] = array('title' => elgg_get_excerpt($title, 100), 'link' => $link);
+	$CONFIG->breadcrumbs[] = array('title' => $title, 'link' => $link);
 }
 
 /**
  * Removes last breadcrumb entry.
  *
- * @return array popped item.
+ * @return array popped breadcrumb array or empty array
  * @since 1.8.0
  */
 function elgg_pop_breadcrumb() {
 	global $CONFIG;
 
-	if (is_array($CONFIG->breadcrumbs)) {
-		return array_pop($CONFIG->breadcrumbs);
+	if (empty($CONFIG->breadcrumbs) || !is_array($CONFIG->breadcrumbs)) {
+		return array();
 	}
-
-	return false;
+	return array_pop($CONFIG->breadcrumbs);
 }
 
 /**
- * Returns all breadcrumbs as an array of array('title' => 'Readable Title', 'link' => 'URL')
+ * Returns all breadcrumbs as an array of array('title' => 'Title', 'link' => 'URL')
+ *
+ * Since 1.11, breadcrumbs are filtered through the plugin hook [prepare, breadcrumbs] before
+ * being returned.
  *
  * @return array Breadcrumbs
  * @since 1.8.0
+ * @see elgg_prepare_breadcrumbs
  */
 function elgg_get_breadcrumbs() {
 	global $CONFIG;
 
+	// if no crumbs set, still allow hook to populate it
 	if (isset($CONFIG->breadcrumbs) && is_array($CONFIG->breadcrumbs)) {
-		return $CONFIG->breadcrumbs;
+		$breadcrumbs = $CONFIG->breadcrumbs;
+	} else {
+		$breadcrumbs = array();
 	}
 
-	return array();
+	$params = array(
+		'breadcrumbs' => $breadcrumbs,
+	);
+	$breadcrumbs = elgg_trigger_plugin_hook('prepare', 'breadcrumbs', $params, $breadcrumbs);
+	if (!is_array($breadcrumbs)) {
+		return array();
+	}
+
+	return $breadcrumbs;
+}
+
+/**
+ * Hook handler to turn titles into 100-character excerpts. To remove this behavior, unregister this
+ * function from the [prepare, breadcrumbs] hook.
+ *
+ * @param string $hook        "prepare"
+ * @param string $type        "breadcrumbs"
+ * @param array  $breadcrumbs Breadcrumbs to be altered
+ * @param array  $params      Hook parameters
+ *
+ * @return array
+ * @since 1.11
+ */
+function elgg_prepare_breadcrumbs($hook, $type, $breadcrumbs, $params) {
+	foreach (array_keys($breadcrumbs) as $i) {
+		$breadcrumbs[$i]['title'] = elgg_get_excerpt($breadcrumbs[$i]['title'], 100);
+	}
+	return $breadcrumbs;
 }
 
 /**
@@ -540,6 +576,8 @@ function _elgg_login_menu_setup($hook, $type, $return, $params) {
  * @access private
  */
 function _elgg_nav_init() {
+	elgg_register_plugin_hook_handler('prepare', 'breadcrumbs', 'elgg_prepare_breadcrumbs');
+
 	elgg_register_plugin_hook_handler('prepare', 'menu:site', '_elgg_site_menu_setup');
 	elgg_register_plugin_hook_handler('register', 'menu:river', '_elgg_river_menu_setup');
 	elgg_register_plugin_hook_handler('register', 'menu:entity', '_elgg_entity_menu_setup');

--- a/engine/tests/phpunit/ElggBreadcrumbsTest.php
+++ b/engine/tests/phpunit/ElggBreadcrumbsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+class ElggBreadcrumbsTest extends \PHPUnit_Framework_TestCase {
+
+//	public function setUp() {
+//		// TODO run each test in better isolation
+//		static $have_run;
+//		if (!$have_run) {
+//			_elgg_nav_init();
+//			$have_run = true;
+//		}
+//	}
+
+	public function testCrumbsCanBePushed() {
+		elgg_push_breadcrumb('title 1');
+
+		elgg_push_breadcrumb('title 2', 'path2');
+
+		$this->assertEquals(array(
+			array('title' => 'title 1', 'link' => null),
+			array('title' => 'title 2', 'link' => 'path2')
+		), elgg_get_breadcrumbs());
+	}
+
+	public function testCrumbsCanBePopped() {
+		elgg_push_breadcrumb('title 1');
+
+		elgg_push_breadcrumb('title 2', 'path2');
+
+		$this->assertEquals(array('title' => 'title 2', 'link' => 'path2'), elgg_pop_breadcrumb());
+
+		$this->assertEquals(array(
+			array('title' => 'title 1', 'link' => null),
+		), elgg_get_breadcrumbs());
+
+		$this->assertEquals(array('title' => 'title 1', 'link' => null), elgg_pop_breadcrumb());
+
+		$this->assertEquals(array(), elgg_get_breadcrumbs());
+	}
+
+	public function testCanAlterCrumbsViaHook() {
+		elgg_push_breadcrumb(str_repeat('abcd ', 100));
+
+		elgg_unregister_plugin_hook_handler('prepare', 'breadcrumbs', 'elgg_prepare_breadcrumbs');
+
+		$this->assertEquals(array(
+			array(
+				'title' => str_repeat('abcd ', 100),
+				'link' => null,
+			),
+		), elgg_get_breadcrumbs());
+	}
+
+	public function testCrumbsAreExcerpted() {
+		$this->markTestIncomplete('Needs DB');
+
+		elgg_push_breadcrumb(str_repeat('abcd ', 100));
+
+		$this->assertEquals(array(
+			array(
+				'title' => elgg_get_excerpt(str_repeat('abcd ', 100), 100),
+				'link' => null,
+			),
+		), elgg_get_breadcrumbs());
+	}
+
+	public function testCrumbTitlesAreEscaped() {
+		$this->markTestIncomplete('Needs DB');
+
+		// TODO make this unnecessary
+		elgg_set_view_location('output/url', __DIR__ . '/../../../views/');
+		elgg_set_view_location('navigation/breadcrumbs', __DIR__ . '/../../../views/');
+
+		elgg_push_breadcrumb('Me < &amp; you');
+		$escaped = 'Me &lt; &amp; you';
+		$html = elgg_view('navigation/breadcrumbs');
+		$this->assertNotFalse(strpos($html, $escaped));
+
+		// links uses different view
+		elgg_pop_breadcrumb();
+		elgg_push_breadcrumb('Me < &amp; you', 'link');
+
+		$html = elgg_view('navigation/breadcrumbs');
+		$this->assertNotFalse(strpos($html, $escaped));
+	}
+
+	public function testCrumbLinksAreNormalized() {
+		$this->markTestIncomplete('Needs DB');
+
+		// TODO make this unnecessary
+		elgg_set_view_location('output/url', __DIR__ . '/../../../views/');
+		elgg_set_view_location('navigation/breadcrumbs', __DIR__ . '/../../../views/');
+
+		elgg_push_breadcrumb('test', 'link');
+		$html = elgg_view('navigation/breadcrumbs');
+		$this->assertNotFalse(strpos($html, '"http://localhost/link"'));
+	}
+}

--- a/views/default/navigation/breadcrumbs.php
+++ b/views/default/navigation/breadcrumbs.php
@@ -9,6 +9,7 @@
  * @uses $vars['class']
  *
  * @see elgg_push_breadcrumb
+ * @see elgg_get_breadcrumbs
  */
 
 if (isset($vars['breadcrumbs'])) {
@@ -26,14 +27,18 @@ if ($additional_class) {
 if (is_array($breadcrumbs) && count($breadcrumbs) > 0) {
 	echo "<ul class=\"$class\">";
 	foreach ($breadcrumbs as $breadcrumb) {
+		// We have to escape text (without double-encoding). Titles in core plugins are HTML escaped
+		// on input, but we can't guarantee that other users of this view and of elgg_push_breadcrumb()
+		// will do so.
 		if (!empty($breadcrumb['link'])) {
 			$crumb = elgg_view('output/url', array(
 				'href' => $breadcrumb['link'],
 				'text' => $breadcrumb['title'],
+				'encode_text' => true,
 				'is_trusted' => true,
 			));
 		} else {
-			$crumb = $breadcrumb['title'];
+			$crumb = htmlspecialchars($breadcrumb['title'], ENT_QUOTES, 'UTF-8', false);
 		}
 		echo "<li>$crumb</li>";
 	}


### PR DESCRIPTION
(replaces #7599)

This also makes sure crumb titles are escaped in the view, and moves the
elgg_get_excerpt call to a hook handler, allowing it to be disabled.

Fixes #6419
