### PR TITLE
fix(tests): fix failing SystemMessagesServiceTest

### DIFF
--- a/engine/tests/phpunit/Elgg/SystemMessagesServiceTest.php
+++ b/engine/tests/phpunit/Elgg/SystemMessagesServiceTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace Elgg;
 
-use Elgg\Http\MockSessionStorage;
-
 class SystemMessagesServiceTest extends \PHPUnit_Framework_TestCase {
 
 	/**
@@ -16,7 +14,7 @@ class SystemMessagesServiceTest extends \PHPUnit_Framework_TestCase {
 	protected $session;
 
 	function setup() {
-		$this->session = new \ElggSession(new MockSessionStorage());
+		$this->session = \ElggSession::getMock();
 		$this->svc = new SystemMessagesService($this->session);
 	}
 


### PR DESCRIPTION
We merged the switch to Symfony’s mock session but this feature/test
was merged without verifying it still worked.
