### PR TITLE
fix(plugins): discussion replies no longer missing/reversed order on river

### DIFF
--- a/docs/guides/views.rst
+++ b/docs/guides/views.rst
@@ -231,7 +231,9 @@ This is then used in the provided listing functions. To automatically display a 
 	    'subtype' => 'blog',
 	));
 
-This function checks to see if there are any entities; if there are, it first displays the ``navigation/pagination`` view in order to display a way to move from page to page. It then repeatedly calls ``elgg_view_entity`` on each entity, before returning the result. 
+This function checks to see if there are any entities; if there are, it first displays the ``navigation/pagination`` view in order to display a way to move from page to page. It then repeatedly calls ``elgg_view_entity`` on each entity, before returning the result.
+
+Note that ``elgg_list_entities`` allows the URL to set its ``limit`` and ``offset`` options, so set those explicitly if you need particular values (e.g. if you're not using it for pagination).
 
 Because it does this, Elgg knows that it can automatically supply an RSS feed - it extends the ``metatags`` view (which is called by the header) in order to provide RSS autodiscovery, which is why you can see the orange RSS icon on those pages.
 

--- a/mod/groups/views/default/river/elements/discussion_replies.php
+++ b/mod/groups/views/default/river/elements/discussion_replies.php
@@ -16,18 +16,18 @@ $options = array(
 $count = elgg_get_entities($options);
 
 if ($count) {
-
-	$list_options = array(
+	$replies = elgg_get_entities(array_merge($options, [
 		'order_by' => 'e.time_created desc',
-		'list_class' => 'elgg-river-comments',
-		'pagination' => false,
 		'count' => false,
 		'limit' => 3,
-	);
+	]));
 
-	$options = array_merge($options, $list_options);
+	// why is this reversing it? because we're asking for the 3 latest
+	// comments by sorting desc and limiting by 3, but we want to display
+	// these comments with the latest at the bottom.
+	$replies = array_reverse($replies);
 
-	echo elgg_list_entities($options);
+	echo elgg_view_entity_list($replies, array('list_class' => 'elgg-river-comments'));
 
 	if ($count > 3) {
 		$more_count = $count - 3;


### PR DESCRIPTION
A switch to elgg_list_entities() caused the URL offset param to influence the display of inline replies, causing the river not to show the latest on later pages. Here we move back to ege() but we add a warning in the docs for ele() about this behavior. This also reverses the order of the replies so it matches the river comments.

Fixes #7801, #7668
