### PR TITLE
chore(release): composer.json can be updated without corruption

### DIFF
--- a/.scripts/release.php
+++ b/.scripts/release.php
@@ -20,15 +20,15 @@ if (!preg_match($regexp, $version, $matches)) {
 function run_commands($commands) {
 	foreach ($commands as $command) {
 		echo "$command\n";
-		passthru($command, $returnVal);
-		if ($returnVal !== 0) {
+		passthru($command, $return_val);
+		if ($return_val !== 0) {
 			echo "Error executing command! Interrupting!\n";
 			exit(2);
 		}
 	}
 }
 
-$elggPath = dirname(__DIR__);
+$elgg_path = dirname(__DIR__);
 
 $branch = "release-$version";
 
@@ -41,7 +41,7 @@ run_commands(array(
 	"node --version",
 	"sphinx-build --version",
 
-	"cd $elggPath",
+	"cd $elgg_path",
 	"git checkout -B $branch",
 ));
 
@@ -56,10 +56,14 @@ run_commands(array(
 ));
 
 // Update version in composer.json
-$composerPath = "$elggPath/composer.json";
-$composerJson = json_decode(file_get_contents($composerPath));
-$composerJson->version = $version;
-file_put_contents($composerPath, json_encode($composerJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+require_once __DIR__ . '/../engine/classes/Elgg/Json/EmptyKeyEncoding.php';
+$encoding = new \Elgg\Json\EmptyKeyEncoding();
+
+$composer_path = "$elgg_path/composer.json";
+$composer_config = $encoding->decode(file_get_contents($composer_path));
+$composer_config->version = $version;
+$json = $encoding->encode($composer_config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+file_put_contents($composer_path, $json);
 
 // Generate changelog
 run_commands(array(

--- a/engine/classes/Elgg/Json/EmptyKeyEncoding.php
+++ b/engine/classes/Elgg/Json/EmptyKeyEncoding.php
@@ -1,0 +1,80 @@
+<?php
+namespace Elgg\Json;
+
+/**
+ * Encode and decode JSON while converting empty string keys to a unique token.
+ *
+ * This gets around PHP's limitation of not allowing empty string object property names.
+ *
+ * @link https://bugs.php.net/bug.php?id=46600
+ *
+ * @package    Elgg.Core
+ * @subpackage Json
+ * @access     private
+ */
+class EmptyKeyEncoding {
+
+	/**
+	 * @var string
+	 */
+	protected $token;
+
+	/**
+	 * Constructor
+	 *
+	 * @param string $empty_key Optional key to replace "" keys with in JSON decode
+	 */
+	public function __construct($empty_key = '') {
+		if (!$empty_key) {
+			$empty_key = sha1(microtime(true) . mt_rand());
+		}
+		$this->token = $empty_key;
+	}
+
+	/**
+	 * Get the key that represents an empty string key in JSON
+	 *
+	 * @return string
+	 */
+	public function getEmptyKey() {
+		return $this->token;
+	}
+
+	/**
+	 * Decode JSON while converting empty keys to a unique token.
+	 *
+	 * @param string $json    JSON string
+	 * @param bool   $assoc   Convert objects to assoc arrays?
+	 * @param int    $depth   Allowed recursion depth
+	 * @param int    $options Bitmask json_decode options
+	 *
+	 * @return mixed
+	 * @see json_decode
+	 */
+	public function decode($json, $assoc = false, $depth = 512, $options = 0) {
+		// Replace empty keys with the unique token
+		$json = preg_replace('~([^"\\\\])""\\s*\\:~', "$1\"{$this->token}\":", $json, -1, $count);
+
+		return json_decode($json, $assoc, $depth, $options);
+	}
+
+	/**
+	 * Encode JSON while converting unique token keys to empty strings
+	 *
+	 * @param mixed $value   Value to encode
+	 * @param int   $options Encoding options
+	 * @param int   $depth   Allowed recursion depth
+	 *
+	 * @return string|false
+	 */
+	public function encode($value, $options = 0, $depth = 512) {
+		$json = json_encode($value, $options, $depth);
+
+		// Replace unique tokens with empty strings
+		if (is_string($json)) {
+			$json = str_replace("\"{$this->token}\"", '""', $json);
+		}
+
+		return $json;
+	}
+}

--- a/engine/tests/phpunit/Elgg/Json/EmptyKeyEncodingTest.php
+++ b/engine/tests/phpunit/Elgg/Json/EmptyKeyEncodingTest.php
@@ -1,0 +1,46 @@
+<?php
+namespace Elgg\Json;
+
+class EmptyKeyEncodingTest extends \PHPUnit_Framework_TestCase {
+
+	function testRoundTrip() {
+		$json = <<<EOL
+{
+    "": [
+    	{
+			"autoload": {
+				"psr-0": {
+					"": "engine/classes/"
+				}
+			}
+    	}
+    ],
+    "foo": true
+}
+EOL;
+
+		$encoding = new EmptyKeyEncoding();
+		$value = $encoding->decode($json);
+		$empty_key = $encoding->getEmptyKey();
+
+		$this->assertTrue(is_array($value->{$empty_key}));
+		$this->assertFalse(property_exists($value, '_empty_'));
+		$this->assertEquals('engine/classes/', $value->{$empty_key}[0]->autoload->{'psr-0'}->{$empty_key});
+
+		$json = $encoding->encode($value, JSON_UNESCAPED_SLASHES);
+		$this->assertContains('"":"engine/classes/"', $json);
+		$this->assertContains('"":[{"autoload"', $json);
+		$this->assertNotContains($empty_key, $json);
+	}
+
+	function testEncodeWithGivenKey() {
+		$key = 'gyufg78r3gyfryu';
+		$value = array(
+			$key => 'foo',
+		);
+		$encoding = new EmptyKeyEncoding($key);
+		$json = $encoding->encode($value);
+
+		$this->assertEquals('{"":"foo"}', $json);
+	}
+}


### PR DESCRIPTION
In the release process, we JSON decode composer.json to update the version then re-encode it. Due to a PHP bug, we now use a new component which converts empty string keys to a unique token in decoded values. This stops json_decode from breaking our autoloader config.

Fixes #7768
