### PR TITLE
feature(developers): show total DB queries in the developer screen log

### DIFF
--- a/mod/developers/languages/en.php
+++ b/mod/developers/languages/en.php
@@ -20,7 +20,7 @@ return array(
 	'developers:label:display_errors' => 'Display fatal PHP errors',
 	'developers:help:display_errors' => "By default, Elgg's .htaccess file supresses the display of fatal errors.",
 	'developers:label:screen_log' => "Log to the screen",
-	'developers:help:screen_log' => "This displays elgg_log() and elgg_dump() output on the web page.",
+	'developers:help:screen_log' => "This displays elgg_log() and elgg_dump() output and a DB query count.",
 	'developers:label:show_strings' => "Show raw translation strings",
 	'developers:help:show_strings' => "This displays the translation strings used by elgg_echo().",
 	'developers:label:wrap_views' => "Wrap views",
@@ -54,6 +54,7 @@ return array(
 
 	// event logging
 	'developers:event_log_msg' => "%s: '%s, %s' in %s",
+	'developers:log_queries' => "%s DB queries (does not include the shutdown event)",
 
 	// theme sandbox
 	'theme_sandbox:intro' => 'Introduction',

--- a/mod/developers/views/default/developers/log.php
+++ b/mod/developers/views/default/developers/log.php
@@ -6,13 +6,15 @@
 $cache = elgg_get_config('log_cache');
 $items = $cache->get();
 
-echo '<div class="developers-log">';
+$pres = array();
 if ($items) {
 	foreach ($items as $item) {
-		echo '<pre>';
-		print_r($item);
-		echo '</pre>';
+		$pres[] = '<pre>' . print_r($item, true) . '</pre>';
 	}
 }
 
-echo '</div>';
+// Add query count to top.
+$msg = elgg_echo('developers:log_queries', array(_elgg_services()->db->getQueryCount()));
+array_unshift($pres, "<pre>$msg</pre>");
+
+echo '<div class="developers-log">' . implode('', $pres) . '</div>';


### PR DESCRIPTION
This adds the “total” queries to the developers plugin visible log area. For practical purposes this only includes queries run before the log is output, but this is late enough to be a useful metric.

This idea was formerly abandoned because it's really hard to capture any shutdown queries, but this imperfect count is still _much_ better than nothing.
