### PR TITLE
fix(metadata): metadata values returned in more reliable order

### DIFF
--- a/engine/classes/ElggVolatileMetadataCache.php
+++ b/engine/classes/ElggVolatileMetadataCache.php
@@ -289,7 +289,7 @@ class ElggVolatileMetadataCache {
 				"JOIN {$db_prefix}metastrings n ON n_table.name_id = n.id",
 			),
 			'selects' => array('n.string AS name', 'v.string AS value'),
-			'order_by' => 'n_table.entity_guid, n_table.time_created ASC',
+			'order_by' => 'n_table.entity_guid, n_table.id ASC',
 
 			// @todo don't know why this is necessary
 			'wheres' => array(_elgg_get_access_where_sql(array('table_alias' => 'n_table'))),

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -126,7 +126,7 @@ function _elgg_get_metastring_based_objects($options) {
 		'metastring_ids' => ELGG_ENTITIES_ANY_VALUE,
 
 		// sql
-		'order_by' => 'n_table.time_created asc',
+		'order_by' => 'n_table.id ASC',
 		'limit' => elgg_get_config('default_limit'),
 		'offset' => 0,
 		'count' => false,


### PR DESCRIPTION
Storing multiple values often results in metadata rows with the same
timestamp. Ordering by ID allows these values to be fetched in insertion
order more reliably.

Fixes #5603
