### PR TITLE
fix(breadcrumbs): hide the last breadcrumb if it’s not a link

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -3,11 +3,34 @@ Upgrading Plugins
 
 Prepare your plugin for the next version of Elgg.
 
-See the administator guides for :doc:`how to upgrade a live site </admin/upgrading>`.
+See the administrator guides for :doc:`how to upgrade a live site </admin/upgrading>`.
 
 .. contents:: Contents
    :local:
    :depth: 2
+
+From 1.11 to 2.0
+================
+
+Breadcrumb display now removes the last item if it does not contain a link. To restore the previous behavior,
+replace the plugin hook handler ``elgg_prepare_breadcrumbs`` with your own:
+
+.. code:: php
+
+    elgg_unregister_plugin_hook_handler('prepare', 'breadcrumbs', 'elgg_prepare_breadcrumbs');
+    elgg_register_plugin_hook_handler('prepare', 'breadcrumbs', 'myplugin_prepare_breadcrumbs');
+
+    function myplugin_prepare_breadcrumbs($hook, $type, $breadcrumbs, $params) {
+        // just apply excerpt to titles
+        foreach (array_keys($breadcrumbs) as $i) {
+            $breadcrumbs[$i]['title'] = elgg_get_excerpt($breadcrumbs[$i]['title'], 100);
+        }
+        return $breadcrumbs;
+    }
+
+
+From 1.10 to 1.11
+=================
 
 From 1.9 to 1.10
 ================

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -297,8 +297,8 @@ function elgg_get_breadcrumbs() {
 }
 
 /**
- * Hook handler to turn titles into 100-character excerpts. To remove this behavior, unregister this
- * function from the [prepare, breadcrumbs] hook.
+ * Prepare breadcrumbs before display. This turns titles into 100-character excerpts, and also
+ * removes the last crumb if it's not a link.
  *
  * @param string $hook        "prepare"
  * @param string $type        "breadcrumbs"
@@ -309,6 +309,13 @@ function elgg_get_breadcrumbs() {
  * @since 1.11
  */
 function elgg_prepare_breadcrumbs($hook, $type, $breadcrumbs, $params) {
+	// remove last crumb if not a link
+	$last_crumb = end($breadcrumbs);
+	if (empty($last_crumb['link'])) {
+		array_pop($breadcrumbs);
+	}
+
+	// apply excerpt to titles
 	foreach (array_keys($breadcrumbs) as $i) {
 		$breadcrumbs[$i]['title'] = elgg_get_excerpt($breadcrumbs[$i]['title'], 100);
 	}

--- a/engine/tests/phpunit/ElggBreadcrumbsTest.php
+++ b/engine/tests/phpunit/ElggBreadcrumbsTest.php
@@ -95,4 +95,17 @@ class ElggBreadcrumbsTest extends \PHPUnit_Framework_TestCase {
 		$html = elgg_view('navigation/breadcrumbs');
 		$this->assertNotFalse(strpos($html, '"http://localhost/link"'));
 	}
+
+	public function testTrailingNonLinkIsRemoved() {
+		$this->markTestIncomplete('Needs DB');
+
+		// TODO make this unnecessary
+		elgg_set_view_location('output/url', __DIR__ . '/../../../views/');
+		elgg_set_view_location('navigation/breadcrumbs', __DIR__ . '/../../../views/');
+
+		elgg_push_breadcrumb('Foo', 'foo');
+		elgg_push_breadcrumb('Bar');
+		$html = elgg_view('navigation/breadcrumbs');
+		$this->assertFalse(strpos($html, 'Bar'));
+	}
 }


### PR DESCRIPTION
Fixes #6419 (breaks BC)
