### PR TITLE
resolve getFriends call without array

### DIFF
--- a/mod/groups/views/default/forms/groups/invite.php
+++ b/mod/groups/views/default/forms/groups/invite.php
@@ -8,7 +8,7 @@
 $group = $vars['entity'];
 $owner = $group->getOwnerEntity();
 $forward_url = $group->getURL();
-$friends = elgg_get_logged_in_user_entity()->getFriends('', 0);
+$friends = elgg_get_logged_in_user_entity()->getFriends(array(''), 0);
 
 if ($friends) {
 	echo elgg_view('input/friendspicker', array('entities' => $friends, 'name' => 'user_guid', 'highlight' => 'all'));


### PR DESCRIPTION
Deprecated in 1.9: \ElggUser::getFriends takes an options array
- [ ] commit message like: `chore(groups): fixes deprecated use of getFriends() method`
- [ ] call getFriends() with an array with limit => false.
