### PR TITLE
fix(views): deprecated notice no longer shows up in the wrong version

### DIFF
--- a/views/default/output/confirmlink.php
+++ b/views/default/output/confirmlink.php
@@ -13,7 +13,7 @@
  * @uses $vars['encode_text'] Run $vars['text'] through htmlspecialchars() (false)
  */
 
-elgg_deprecated_notice('The view output/confirmlink has been deprecated, please use output/url', 1.10);
+elgg_deprecated_notice('The view output/confirmlink has been deprecated, please use output/url', '1.10');
 
 if (!isset($vars['confirm'])) {
 	$vars['confirm'] = true;


### PR DESCRIPTION
Because the version was a float it results in version 1.1 and the
deprecated notice always shows up.
