### PR TITLE
fix(datepicker): Prevents month navigation links from overlapping with other elements

### DIFF
--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -296,7 +296,9 @@ elgg.ui.initDatePicker = function() {
 					var id = $(this).attr('id');
 					$('input[name="' + id + '"]').val(timestamp);
 				}
-			}
+			},
+			nextText: '&#xBB;',
+			prevText: '&#xAB;'
 		});
 	}
 

--- a/mod/aalborg_theme/views/default/css/elements/forms.php
+++ b/mod/aalborg_theme/views/default/css/elements/forms.php
@@ -281,7 +281,6 @@ select {
 	display: none;
 
 	margin-top: 3px;
-	width: 208px;
 	background-color: #FFF;
 	border: 1px solid #0054A7;
 	border-radius: 3px;
@@ -304,14 +303,21 @@ select {
 }
 .ui-datepicker-prev, .ui-datepicker-next {
 	position: absolute;
-	top: 5px;
+	top: 3px;
 	cursor: pointer;
+	border: 1px solid #fff;
+	border-radius: 3px;
+	padding: 1px 7px;
+}
+.ui-datepicker-prev:hover,
+.ui-datepicker-next:hover {
+	text-decoration: none;
 }
 .ui-datepicker-prev {
-	left: 6px;
+	left: 3px;
 }
 .ui-datepicker-next {
-	right: 6px;
+	right: 3px;
 }
 .ui-datepicker-title {
 	line-height: 1.8em;


### PR DESCRIPTION
It is difficult to predict how much translatable strings need space in each language. This
replaces the textual representation with icons to make sure that the Next and Previous
links do not take up too much space.

Fixes #7542
- [x] Add better styles for the icons
