### PR TITLE
Fixes 2 bugs relating to rel="toggle"

### DIFF
--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -50,17 +50,23 @@ elgg.ui.init = function () {
  */
 elgg.ui.toggles = function(event) {
 	event.preventDefault();
-	var target = $(this).data().toggleSelector;
+	var $this = $(this),
+		target = $this.data().toggleSelector;
 	
 	if (!target) {
-		target = elgg.getSelectorFromUrlFragment($(this).attr('href')); 
+		// @todo we can switch to elgg.getSelectorFromUrlFragment() in 1.x if
+		// we also extend it to support href=".some-class"
+		target = $this.attr('href');
 	}
-	
+
+	$this.toggleClass('elgg-state-active');
+
 	$(target).each(function(index, elem) {
-		if ($(elem).data().toggleSlide != false) {
-			$(elem).slideToggle('medium');
+		var $elem = $(elem);
+		if ($elem.data().toggleSlide != false) {
+			$elem.slideToggle('medium');
 		} else {
-			$(elem).toggle();
+			$elem.toggle();
 		}
 	});
 };

--- a/mod/aalborg_theme/views/default/page/elements/navbar.php
+++ b/mod/aalborg_theme/views/default/page/elements/navbar.php
@@ -9,7 +9,7 @@ echo elgg_view('core/account/login_dropdown');
 
 ?>
 
-<a class="elgg-button-nav" rel="toggle" href=".elgg-nav-collapse">
+<a class="elgg-button-nav" rel="toggle" data-toggle-selector=".elgg-nav-collapse" href="#">
 	<span class="icon-bar"></span>
 	<span class="icon-bar"></span>
 	<span class="icon-bar"></span>


### PR DESCRIPTION
fix(js): fixes aalborg site menu by restoring 1.9 toggle behavior.

We used to use the raw href attribute as the selector for rel=“toggle” elements, which supported hrefs like “.class-name”. In 1.10 we switched to using elgg.getSelectorFromUrlFragment(), which does not support this format, so we are switching back to maintain BC.

Fixes #7790

fix(ui): using site menu too early no longer results in 404 page.

Before elgg.ui.init binds events for toggles, the user may click the hamburger menu in aalborg, which was a link to a non-existent page. This repoints the link to “#” and sets the toggle selector via the new data- attribute.

Fixes #7861
