### PR TITLE
WIP: Ideas for schema changes

### DIFF
--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -3,41 +3,78 @@
 --
 
 -- record membership in an access collection
-CREATE TABLE `prefix_access_collection_membership` (
-  `user_guid` int(11) NOT NULL,
-  `access_collection_id` int(11) NOT NULL,
-  PRIMARY KEY (`user_guid`,`access_collection_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+-- Access collections were replaced by ACLs
+-- See https://docs.google.com/a/elgg.org/document/d/1R3v_bYno6fw8mV5_GDW93uTI0pvR9S4yQ-BHMKTz1zs/edit#
+-- Each user-created "friend collection" is now an entity pointing to an ACL
 
 -- define an access collection
-CREATE TABLE `prefix_access_collections` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` text NOT NULL,
-  `owner_guid` bigint(20) unsigned NOT NULL,
-  `site_guid` bigint(20) unsigned NOT NULL DEFAULT '0',
+-- Access collections were replaced by ACLs
+
+-- internal type strings. Think of this as metastrings for code.
+-- e.g. entity type, entity subtype, type of lists (the old relationship name)
+CREATE TABLE `prefix_types` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `type` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
-  KEY `owner_guid` (`owner_guid`),
-  KEY `site_guid` (`site_guid`)
-) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+  UNIQUE KEY `idx_type` (`type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- store an annotation on an entity
-CREATE TABLE `prefix_annotations` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `entity_guid` bigint(20) unsigned NOT NULL,
-  `name_id` int(11) NOT NULL,
-  `value_id` int(11) NOT NULL,
-  `value_type` enum('integer','text') NOT NULL,
-  `owner_guid` bigint(20) unsigned NOT NULL,
-  `access_id` int(11) NOT NULL,
-  `time_created` int(11) NOT NULL,
-  `enabled` enum('yes','no') NOT NULL DEFAULT 'yes',
+-- Annotations are now entities with type=annotation and container=(the annotated entity)
+
+-- lists are ordered GUIDs identified by /GUID/type. e.g. /123/members
+CREATE TABLE `prefix_lists` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `type_id` int(11) NOT NULL,
+  `target_guid` bigint(20) unsigned NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `entity_guid` (`entity_guid`),
-  KEY `name_id` (`name_id`),
-  KEY `value_id` (`value_id`),
-  KEY `owner_guid` (`owner_guid`),
-  KEY `access_id` (`access_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+  UNIQUE KEY `idx` (`type_id`,`target_guid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- items in lists (item can be in a single list no more than once)
+CREATE TABLE `prefix_list_items` (
+  `position` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `list_id` int(11) unsigned NOT NULL,
+  `item_guid` bigint(20) unsigned NOT NULL,
+  `weight` float NOT NULL DEFAULT 1.0,
+  `time_added` int(11) unsigned DEFAULT NULL,
+  PRIMARY KEY (`position`),
+  KEY `idx` (`list_id`,`item_guid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- access control for various types
+
+CREATE TABLE `prefix_acl_grants_entity` (
+  `list_id` int(11) unsigned NOT NULL,
+  `entity_guid` bigint(20) unsigned NOT NULL,
+  KEY `list_id` (`list_id`),
+  KEY `item_guid` (`entity_guid`),
+  UNIQUE KEY `idx` (`list_id`,`entity_guid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `prefix_acl_grants_river` (
+  `list_id` int(11) unsigned NOT NULL,
+  `river_id` bigint(20) unsigned NOT NULL,
+  KEY `list_id` (`list_id`),
+  KEY `river_id` (`river_id`),
+  UNIQUE KEY `idx` (`list_id`,`river_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `prefix_acl_grants_metadata` (
+  `list_id` int(11) unsigned NOT NULL,
+  `metadata_id` bigint(20) unsigned NOT NULL,
+  KEY `list_id` (`list_id`),
+  KEY `metadata_id` (`metadata_id`),
+  UNIQUE KEY `idx` (`list_id`,`metadata_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `prefix_acl_grants_annotations` (
+  `list_id` int(11) unsigned NOT NULL,
+  `annotation_id` bigint(20) unsigned NOT NULL,
+  KEY `list_id` (`list_id`),
+  KEY `annotation_id` (`annotation_id`),
+  UNIQUE KEY `idx` (`list_id`,`annotation_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- api keys for old web services
 CREATE TABLE `prefix_api_users` (
@@ -59,58 +96,38 @@ CREATE TABLE `prefix_config` (
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 -- application specific configuration
-CREATE TABLE `prefix_datalists` (
-  `name` varchar(255) NOT NULL,
-  `value` text NOT NULL,
-  PRIMARY KEY (`name`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+-- Now stored in config
 
 -- primary entity table
 CREATE TABLE `prefix_entities` (
   `guid` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-  `type` enum('object','user','group','site') NOT NULL,
-  `subtype` int(11) DEFAULT NULL,
+  `type_id` int(11) NOT NULL, -- type
+  `subtype_id` int(11) DEFAULT NULL, -- type
+  `title_id` int(11) unsigned NOT NULL, -- metastring
+  `description_id` int(11) unsigned NOT NULL, -- metastring
   `owner_guid` bigint(20) unsigned NOT NULL,
   `site_guid` bigint(20) unsigned NOT NULL,
   `container_guid` bigint(20) unsigned NOT NULL,
-  `access_id` int(11) NOT NULL,
   `time_created` int(11) NOT NULL,
   `time_updated` int(11) NOT NULL,
   `last_action` int(11) NOT NULL DEFAULT '0',
   `enabled` enum('yes','no') NOT NULL DEFAULT 'yes',
   PRIMARY KEY (`guid`),
-  KEY `type` (`type`),
-  KEY `subtype` (`subtype`),
+  KEY `type_id` (`type_id`),
+  KEY `subtype_id` (`subtype_id`),
   KEY `owner_guid` (`owner_guid`),
   KEY `site_guid` (`site_guid`),
   KEY `container_guid` (`container_guid`),
-  KEY `access_id` (`access_id`),
   KEY `time_created` (`time_created`),
   KEY `time_updated` (`time_updated`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- relationships between entities
-CREATE TABLE `prefix_entity_relationships` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `guid_one` bigint(20) unsigned NOT NULL,
-  `relationship` varchar(50) NOT NULL,
-  `guid_two` bigint(20) unsigned NOT NULL,
-  `time_created` int(11) NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `guid_one` (`guid_one`,`relationship`,`guid_two`),
-  KEY `relationship` (`relationship`),
-  KEY `guid_two` (`guid_two`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+-- Relationships are now lists.
+-- See https://docs.google.com/a/elgg.org/document/d/1R3v_bYno6fw8mV5_GDW93uTI0pvR9S4yQ-BHMKTz1zs/edit#
 
 -- entity type/subtype pairs
-CREATE TABLE `prefix_entity_subtypes` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `type` enum('object','user','group','site') NOT NULL,
-  `subtype` varchar(50) NOT NULL,
-  `class` varchar(50) NOT NULL DEFAULT '',
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `type` (`type`,`subtype`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+-- No need to store these. Now "types" and the class is determined by plugin hook.
 
 -- cache lookups of latitude and longitude for place names
 CREATE TABLE `prefix_geocode_cache` (
@@ -123,15 +140,7 @@ CREATE TABLE `prefix_geocode_cache` (
 ) ENGINE=MEMORY DEFAULT CHARSET=utf8;
 
 -- secondary table for group entities
-CREATE TABLE `prefix_groups_entity` (
-  `guid` bigint(20) unsigned NOT NULL,
-  `name` text NOT NULL,
-  `description` text NOT NULL,
-  PRIMARY KEY (`guid`),
-  KEY `name` (`name`(50)),
-  KEY `description` (`description`(50)),
-  FULLTEXT KEY `name_2` (`name`,`description`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+-- No longer needed. Info is in entities
 
 -- cache for hmac signatures for old web services
 CREATE TABLE `prefix_hmac_cache` (
@@ -143,44 +152,42 @@ CREATE TABLE `prefix_hmac_cache` (
 
 -- metadata that describes an entity
 CREATE TABLE `prefix_metadata` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `entity_guid` bigint(20) unsigned NOT NULL,
-  `name_id` int(11) NOT NULL,
-  `value_id` int(11) NOT NULL,
-  `value_type` enum('integer','text') NOT NULL,
-  `owner_guid` bigint(20) unsigned NOT NULL,
-  `access_id` int(11) NOT NULL,
+  `name_id` bigint(20) NOT NULL,
+  `value_id` bigint(20) NOT NULL,
+
+  -- I see no gain in having metadata keep track of whether it's text or integer.
+  -- If you want to store ints, cast the value after read or query the in_value
+  -- column for faster use.
+  `int_value` int(11) NOT NULL,
+
+  -- Access control on metadata causes more problems than solves IMO.
+  -- If you need it, use an entity or annotation
+
   `time_created` int(11) NOT NULL,
   `enabled` enum('yes','no') NOT NULL DEFAULT 'yes',
   PRIMARY KEY (`id`),
   KEY `entity_guid` (`entity_guid`),
   KEY `name_id` (`name_id`),
-  KEY `value_id` (`value_id`),
-  KEY `owner_guid` (`owner_guid`),
-  KEY `access_id` (`access_id`)
+  KEY `value_id` (`value_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- string normalization table for metadata and annotations
 CREATE TABLE `prefix_metastrings` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `string` text NOT NULL,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `string` mediumtext NOT NULL,
   PRIMARY KEY (`id`),
   KEY `string` (`string`(50))
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- secondary table for object entities
-CREATE TABLE `prefix_objects_entity` (
-  `guid` bigint(20) unsigned NOT NULL,
-  `title` text NOT NULL,
-  `description` text NOT NULL,
-  PRIMARY KEY (`guid`),
-  FULLTEXT KEY `title` (`title`,`description`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+-- No longer needed. Info is in entities
 
 -- settings for an entity
 CREATE TABLE `prefix_private_settings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `entity_guid` int(11) NOT NULL,
+  `entity_guid` bigint(20) NOT NULL,
   `name` varchar(128) NOT NULL,
   `value` text NOT NULL,
   PRIMARY KEY (`id`),
@@ -203,22 +210,20 @@ CREATE TABLE `prefix_queue` (
 
 -- activity stream
 CREATE TABLE `prefix_river` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `type` varchar(8) NOT NULL,
   `subtype` varchar(32) NOT NULL,
   `action_type` varchar(32) NOT NULL,
-  `access_id` int(11) NOT NULL,
   `view` text NOT NULL,
-  `subject_guid` int(11) NOT NULL,
-  `object_guid` int(11) NOT NULL,
-  `target_guid` int(11) NOT NULL,
-  `annotation_id` int(11) NOT NULL,
+  `subject_guid` bigint(20) NOT NULL,
+  `object_guid` bigint(20) NOT NULL,
+  `target_guid` bigint(20) NOT NULL,
+  `annotation_id` bigint(20) NOT NULL,
   `posted` int(11) NOT NULL,
   `enabled` enum('yes','no') NOT NULL DEFAULT 'yes',
   PRIMARY KEY (`id`),
   KEY `type` (`type`),
   KEY `action_type` (`action_type`),
-  KEY `access_id` (`access_id`),
   KEY `subject_guid` (`subject_guid`),
   KEY `object_guid` (`object_guid`),
   KEY `target_guid` (`target_guid`),
@@ -227,27 +232,18 @@ CREATE TABLE `prefix_river` (
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- secondary table for site entities
-CREATE TABLE `prefix_sites_entity` (
-  `guid` bigint(20) unsigned NOT NULL,
-  `name` text NOT NULL,
-  `description` text NOT NULL,
-  `url` varchar(255) NOT NULL,
-  PRIMARY KEY (`guid`),
-  UNIQUE KEY `url` (`url`),
-  FULLTEXT KEY `name` (`name`,`description`,`url`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+-- No longer needed. Info is in entities
 
 -- log activity for the admin
 CREATE TABLE `prefix_system_log` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `object_id` int(11) NOT NULL,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `object_id` bigint(20) NOT NULL,
   `object_class` varchar(50) NOT NULL,
   `object_type` varchar(50) NOT NULL,
   `object_subtype` varchar(50) NOT NULL,
   `event` varchar(50) NOT NULL,
-  `performed_by_guid` int(11) NOT NULL,
-  `owner_guid` int(11) NOT NULL,
-  `access_id` int(11) NOT NULL,
+  `performed_by_guid` bigint(20) NOT NULL,
+  `owner_guid` bigint(20) NOT NULL,
   `enabled` enum('yes','no') NOT NULL DEFAULT 'yes',
   `time_created` int(11) NOT NULL,
   `ip_address` varchar(46) NOT NULL,
@@ -258,7 +254,6 @@ CREATE TABLE `prefix_system_log` (
   KEY `object_subtype` (`object_subtype`),
   KEY `event` (`event`),
   KEY `performed_by_guid` (`performed_by_guid`),
-  KEY `access_id` (`access_id`),
   KEY `time_created` (`time_created`),
   KEY `river_key` (`object_type`,`object_subtype`,`event`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
@@ -280,8 +275,6 @@ CREATE TABLE `prefix_users_entity` (
   `guid` bigint(20) unsigned NOT NULL,
   `name` text NOT NULL,
   `username` varchar(128) NOT NULL DEFAULT '',
-  `password` varchar(32) NOT NULL DEFAULT '' COMMENT 'Legacy password hashes',
-  `salt` varchar(8) NOT NULL DEFAULT '' COMMENT 'Legacy password salts',
   -- 255 chars is recommended by PHP.net to hold future hash formats
   `password_hash` varchar(255) NOT NULL DEFAULT '',
   `email` text NOT NULL,
@@ -294,7 +287,6 @@ CREATE TABLE `prefix_users_entity` (
   `prev_last_login` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`guid`),
   UNIQUE KEY `username` (`username`),
-  KEY `password` (`password`),
   KEY `email` (`email`(50)),
   KEY `last_action` (`last_action`),
   KEY `last_login` (`last_login`),


### PR DESCRIPTION
The ideas here are:
- Upgrades metastrings to MEDIUMTEXT (easy fix to problems storing large posts)
- [Unify access control and relationships into "lists"](https://docs.google.com/a/elgg.org/document/d/1R3v_bYno6fw8mV5_GDW93uTI0pvR9S4yQ-BHMKTz1zs/edit#).
- Add title and description to entities. This eliminates the need for several secondary tables (object, group, site) and allows annotations and/or metadata to be promoted to entity types.
- Simplifies metadata to an array of strings with the option of querying their casted integer values. No access control.
- Move datalists to config
