### PR TITLE
fix(engine): return original val if not a string for string_to_tag_array

### DIFF
--- a/engine/lib/tags.php
+++ b/engine/lib/tags.php
@@ -13,17 +13,18 @@
  *
  * @param string $string Comma-separated tag string
  *
- * @return array|false An array of strings, or false on failure
+ * @return mixed An array of strings or the original data if input was not a string
  */
 function string_to_tag_array($string) {
-	if (is_string($string)) {
-		$ar = explode(",", $string);
-		$ar = array_map('trim', $ar);
-		$ar = array_filter($ar, 'is_not_null');
-		$ar = array_map('strip_tags', $ar);
-		return $ar;
+	if (!is_string($string)) {
+		return $string;
 	}
-	return false;
+	
+	$ar = explode(",", $string);
+	$ar = array_map('trim', $ar);
+	$ar = array_filter($ar, 'is_not_null');
+	$ar = array_map('strip_tags', $ar);
+	return $ar;	
 }
 
 /**

--- a/engine/tests/phpunit/Elgg/TagsTest.php
+++ b/engine/tests/phpunit/Elgg/TagsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+class Elgg_TagsTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * When providing a string to the string_to_tag_array function it should explode it based on a comma and return an array
+	 */
+	public function testStringToTagArrayReturnsArray() {
+		
+		// test if it returns an array with 1 item
+		$single_tag = string_to_tag_array("a");
+		$this->assertCount(1, $single_tag);		
+		
+		// test if it returns an array with 3 item
+		$multiple_tags = string_to_tag_array("a,b,c");
+		$this->assertCount(3, $multiple_tags);
+	}
+	
+	/**
+	 * When providing a non-string the string_to_tag_array function should return the original value
+	 */
+	public function testStringToTagArrayReturnsOriginalValue() {
+		
+		// test if the original value (int) 1 is returned
+		$result = string_to_tag_array(1);
+		$this->assertEquals(1, $result);
+	}
+
+}


### PR DESCRIPTION
fixes #7391
- [x] add test
