### PR TITLE
fix(engine): eliminated potential deadloops in MenuBuilder::setupTrees

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -84,6 +84,9 @@ return array(
 	
 	'ElggPlugin:Dependencies:ActiveDependent' => 'There are other plugins that list %s as a dependency.  You must disable the following plugins before disabling this one: %s',
 
+	'ElggMenuBuilder:Trees:NoParents' => 'Menu items found without parents to link them to',
+	'ElggMenuBuilder:Trees:OrphanedChild' => 'Menu item [%s] found with a missing parent[%s]',
+	'ElggMenuBuilder:Trees:DuplicateChild' => 'Duplicate registration found for menu item [%s]',
 
 	'RegistrationException:EmptyPassword' => 'The password fields cannot be empty',
 	'RegistrationException:PasswordMismatch' => 'Passwords must match',


### PR DESCRIPTION
removed the need for $iteration < 20 check that should prevent deadloop by validating in $all_menu_items.
This will also prevent php warnings if you are having menu items with missing parents ($current_gen could be null).

also tried to make it more readable

previous work (and discussion) in #6175

related (already merged) change #7373 for #5570
- [x] move error log text to translation file
- [x] fix missing double linkage
