### PR TITLE
feature(icons): allow additional params in ElggEntity::getIconURL

### DIFF
--- a/docs/guides/database.rst
+++ b/docs/guides/database.rst
@@ -168,9 +168,12 @@ EntityType/default.
 Entity Icons
 ~~~~~~~~~~~~
 
-Every entity can be assigned an icon which is retrieved using the ``ElggEntity::getIconURL($size)`` method.
-This method accepts a ``$size`` argument that can be either of the configured icon sizes.  Use
-``elgg_get_config('icon_sizes')`` to get all possible values. The following sizes exist by default:
+Every entity can be assigned an icon which is retrieved using the ``ElggEntity::getIconURL($params)`` method.
+This method accepts a ``$params`` argument that can be either a string specifying on of the configured icon sizes,
+or an array of parameters, that specify the size and provide additional context for the hook to determine the icon
+to serve.
+
+Use ``elgg_get_config('icon_sizes')`` to get all possible values. The following sizes exist by default:
 ``'large'``, ``'medium'``, ``'small'``, ``'tiny'``, and ``'topbar'``. The method triggers the
 ``entity:icon:url`` :ref:`hook <guides/hooks-list#other>`.
 

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1388,12 +1388,18 @@ abstract class ElggEntity extends \ElggData implements
 	 * Plugins can register for the 'entity:icon:url', <type> plugin hook
 	 * to customize the icon for an entity.
 	 *
-	 * @param string $size Size of the icon: tiny, small, medium, large
-	 *
+	 * @param mixed $params A string defining the size of the icon (e.g. tiny, small, medium, large)
+	 *                      or an array of parameters including 'size'
 	 * @return string The URL
 	 * @since 1.8.0
 	 */
-	public function getIconURL($size = 'medium') {
+	public function getIconURL($params = array()) {
+		if (is_array($params)) {
+			$size = elgg_extract('size', $params, 'medium');
+		} else {	
+			$size = is_string($params) ? $params : 'medium';
+			$params = array();
+		}
 		$size = elgg_strtolower($size);
 
 		if (isset($this->icon_override[$size])) {
@@ -1401,11 +1407,10 @@ abstract class ElggEntity extends \ElggData implements
 			return $this->icon_override[$size];
 		}
 
+		$params['entity'] = $this;
+		$params['size'] = $size;
+
 		$type = $this->getType();
-		$params = array(
-			'entity' => $this,
-			'size' => $size,
-		);
 
 		$url = _elgg_services()->hooks->trigger('entity:icon:url', $type, $params, null);
 		if ($url == null) {

--- a/engine/tests/ElggEntityTest.php
+++ b/engine/tests/ElggEntityTest.php
@@ -262,4 +262,24 @@ class ElggCoreEntityTest extends \ElggCoreUnitTest {
 			$this->assertEqual(array_merge($md, $md2), $obj->$name);
 		}
 	}
+
+	public function testElggEntityGetIconURL() {
+
+		elgg_register_plugin_hook_handler('entity:icon:url', 'object', function ($hook, $type, $url, $params) {
+			$size = (string) elgg_extract('size', $params);
+			return "$size.jpg";
+		}, 99999);
+
+		$obj = new \ElggObject();
+		$obj->save();
+
+		// Test default size
+		$this->assertEqual($obj->getIconURL(), elgg_normalize_url('medium.jpg'));
+		// Test size
+		$this->assertEqual($obj->getIconURL('small'), elgg_normalize_url('small.jpg'));
+		// Test mixed params
+		$this->assertEqual($obj->getIconURL('small'), $obj->getIconURL(array('size' => 'small')));
+		// Test bad param
+		$this->assertEqual($obj->getIconURL(new \stdClass), elgg_normalize_url('medium.jpg'));
+	}
 }


### PR DESCRIPTION
Implementation of ElggEntity::getIconSizes() was restrictive and not respective of additional parameters passed to elgg_view_entity_icon().

Motivation is to allow additional context and params that could allow hooks to determine which icon to serve, e.g. we could use this to serve different file icons for image preview and file mimetype.
