### PR TITLE
feature(views): allow providing alternative views for list items

### DIFF
--- a/docs/guides/views.rst
+++ b/docs/guides/views.rst
@@ -295,6 +295,34 @@ If your entity list will display the entity owners, you can improve performance 
 
 See also :doc:`check this page out first </design/database>`.
 
+Since 1.11, you can define an alternative view to render list items using ```'item_view'``` parameter.
+
+In some cases, default entity views may be unsuitable for your needs. Using ```item_view``` allows you to customize the look, while preserving pagination, list's HTML markup etc.
+
+Consider these two examples:
+
+.. code-block:: php
+
+	echo elgg_list_entities_from_relationship(array(
+	    'type' => 'group',
+	    'relationship' => 'member',
+	    'relationship_guid' => elgg_get_logged_in_user_guid(),
+	    'inverse_relationship' => false,
+	    'full_view' => false,
+	));
+
+.. code-block:: php
+
+	echo elgg_list_entities_from_relationship(array(
+	    'type' => 'group',
+	    'relationship' => 'invited',
+	    'relationship_guid' => (int) $user_guid,
+	    'inverse_relationship' => true,
+	    'item_view' => 'group/format/invitationrequest',
+	));
+
+In the first example, we are displaying a list of groups a user is a member of using the default group view. In the second example, we want to display a list of groups the user was invited to. Since invitations are not entities, they do not have their own views and can not be listed using ``elgg_list_*``. We are providing an alternative item view, that will use the group entity to display an invitation that contains a group name and buttons to access or reject the invitation.
+
 Using a different templating system
 ===================================
 

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -568,6 +568,7 @@ function _elgg_get_entity_time_where_sql($table, $time_created_upper = null,
  * @internal If the initial COUNT query returns 0, the $getter will not be called again.
  *
  * @param array    $options Any options from $getter options plus:
+ *                   item_view => STR Optional. Alternative view used to render list items
  *                   full_view => BOOL Display full view of entities (default: false)
  *                   list_type => STR 'list' or 'gallery'
  *                   list_type_toggle => BOOL Display gallery / list switch

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -495,6 +495,7 @@ function _elgg_prefetch_river_entities(array $river_items) {
  * List river items
  *
  * @param array $options Any options from elgg_get_river() plus:
+ *   item_view  => STR         Alternative view to render list items
  *   pagination => BOOL        Display pagination links (true)
  *   no_results => STR|Closure Message to display if no items
  *

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -771,9 +771,6 @@ function elgg_view_menu_item(\ElggMenuItem $item, array $vars = array()) {
  * The entity view is called with the following in $vars:
  *  - \ElggEntity 'entity' The entity being viewed
  *
- * Other common view $vars paramters:
- *  - bool 'full_view' Whether to show a full or condensed view. (Default: true)
- *
  * @tip This function can automatically appends annotations to entities if in full
  * view and a handler is registered for the entity:annotate.  See https://github.com/Elgg/Elgg/issues/964 and
  * {@link elgg_view_entity_annotations()}.
@@ -781,6 +778,8 @@ function elgg_view_menu_item(\ElggMenuItem $item, array $vars = array()) {
  * @param \ElggEntity $entity The entity to display
  * @param array       $vars   Array of variables to pass to the entity view.
  *                            In Elgg 1.7 and earlier it was the boolean $full_view
+ *      'full_view'        Whether to show a full or condensed view. (Default: true)
+ *      'item_view'        Alternative view used to render this entity
  * @param boolean     $bypass If true, will not pass to a custom template handler.
  *                            {@link set_template_handler()}
  * @param boolean     $debug  Complain if views are missing
@@ -813,25 +812,25 @@ function elgg_view_entity(\ElggEntity $entity, $vars = array(), $bypass = false,
 
 	$vars['entity'] = $entity;
 
-
-	// if this entity has a view defined, use it
-	$view = $entity->view;
-	if (is_string($view)) {
-		return elgg_view($view, $vars, $bypass, $debug);
-	}
-
 	$entity_type = $entity->getType();
-
-	$subtype = $entity->getSubtype();
-	if (empty($subtype)) {
-		$subtype = 'default';
+	$entity_subtype = $entity->getSubtype();
+	if (empty($entity_subtype)) {
+		$entity_subtype = 'default';
 	}
+
+	$entity_views = array(
+		elgg_extract('item_view', $vars, ''),
+		$entity->view,
+		"$entity_type/$entity_subtype",
+		"$entity_type/default",
+	);
 
 	$contents = '';
-	if (elgg_view_exists("$entity_type/$subtype")) {
-		$contents = elgg_view("$entity_type/$subtype", $vars, $bypass, $debug);
-	} else {
-		$contents = elgg_view("$entity_type/default", $vars, $bypass, $debug);
+	foreach ($entity_views as $view) {
+		if (elgg_view_exists($view)) {
+			$contents = elgg_view($view, $vars, $bypass, $debug);
+			break;
+		}
 	}
 
 	// Marcus Povey 20090616 : Speculative and low impact approach for fixing #964
@@ -905,6 +904,7 @@ function elgg_view_entity_icon(\ElggEntity $entity, $size = 'medium', $vars = ar
  *
  * @param \ElggAnnotation $annotation The annotation to display
  * @param array           $vars       Variable array for view.
+ *      'item_view'  Alternative view used to render an annotation
  * @param bool            $bypass     If true, will not pass to a custom
  *                                    template handler. {@link set_template_handler()}
  * @param bool            $debug      Complain if views are missing
@@ -934,11 +934,21 @@ function elgg_view_annotation(\ElggAnnotation $annotation, array $vars = array()
 		return false;
 	}
 
-	if (elgg_view_exists("annotation/$name")) {
-		return elgg_view("annotation/$name", $vars, $bypass, $debug);
-	} else {
-		return elgg_view("annotation/default", $vars, $bypass, $debug);
+	$annotation_views = array(
+		elgg_extract('item_view', $vars, ''),
+		"annotation/$name",
+		"annotation/default",
+	);
+
+	$contents = '';
+	foreach ($annotation_views as $view) {
+		if (elgg_view_exists($view)) {
+			$contents = elgg_view($view, $vars, $bypass, $debug);
+			break;
+		}
 	}
+
+	return $contents;
 }
 
 /**
@@ -959,6 +969,7 @@ function elgg_view_annotation(\ElggAnnotation $annotation, array $vars = array()
  *      'full_view'        Display the full view of the entities?
  *      'list_class'       CSS class applied to the list
  *      'item_class'       CSS class applied to the list items
+ *      'item_view'        Alternative view to render list items
  *      'pagination'       Display pagination?
  *      'list_type'        List type: 'list' (default), 'gallery'
  *      'list_type_toggle' Display the list type toggle?
@@ -1040,6 +1051,7 @@ $list_type_toggle = true, $pagination = true) {
  *      'limit'      The number of annotations to display per page
  *      'full_view'  Display the full view of the annotation?
  *      'list_class' CSS Class applied to the list
+ *      'item_view'  Alternative view to render list items
  *      'offset_key' The url parameter key used for offset
  *      'no_results' Message to display if no results (string|Closure)
  *
@@ -1212,7 +1224,7 @@ function elgg_view_module($type, $title, $body, array $vars = array()) {
  *
  * @param \ElggRiverItem $item A river item object
  * @param array          $vars An array of variables for the view
- *
+ *      'item_view'  Alternative view to render the item
  * @return string returns empty string if could not be rendered
  */
 function elgg_view_river_item($item, array $vars = array()) {
@@ -1245,7 +1257,20 @@ function elgg_view_river_item($item, array $vars = array()) {
 
 	$vars['item'] = $item;
 
-	return elgg_view('river/item', $vars);
+	$river_views = array(
+		elgg_extract('item_view', $vars, ''),
+		"river/item",
+	);
+
+	$contents = '';
+	foreach ($river_views as $view) {
+		if (elgg_view_exists($view)) {
+			$contents = elgg_view($view, $vars);
+			break;
+		}
+	}
+
+	return $contents;
 }
 
 /**
@@ -1340,9 +1365,9 @@ function elgg_view_tagcloud(array $options = array()) {
 /**
  * View an item in a list
  *
- * @param mixed $item An entity, an annotation, or a river item to display
- * @param array $vars Additional parameters for the rendering
- *
+ * @param \ElggEntity|\ElggAnnotation $item
+ * @param array  $vars Additional parameters for the rendering
+ *      'item_view' Alternative view used to render list items
  * @return string
  * @since 1.8.0
  * @access private

--- a/views/default/page/components/gallery.php
+++ b/views/default/page/components/gallery.php
@@ -4,7 +4,7 @@
  *
  * Implemented as an unorder list
  *
- * @uses $vars['items']         Array of ElggEntity or ElggAnnotation objects
+ * @uses $vars['items']         Array of ElggEntity, ElggAnnotation or ElggRiverItem objects
  * @uses $vars['offset']        Index of the first list item in complete list
  * @uses $vars['limit']         Number of items per page
  * @uses $vars['count']         Number of items in the complete list
@@ -13,6 +13,7 @@
  * @uses $vars['full_view']     Show the full view of the items (default: false)
  * @uses $vars['gallery_class'] Additional CSS class for the <ul> element
  * @uses $vars['item_class']    Additional CSS class for the <li> elements
+ * @uses $vars['item_view']     Alternative view to render list items
  * @uses $vars['no_results']    Message to display if no results (string|Closure)
  */
 

--- a/views/default/page/components/list.php
+++ b/views/default/page/components/list.php
@@ -4,7 +4,7 @@
  *
  * @package Elgg
  *
- * @uses $vars['items']       Array of ElggEntity or ElggAnnotation objects
+ * @uses $vars['items']       Array of ElggEntity, ElggAnnotation or ElggRiverItem objects
  * @uses $vars['offset']      Index of the first list item in complete list
  * @uses $vars['limit']       Number of items per page. Only used as input to pagination.
  * @uses $vars['count']       Number of items in the complete list
@@ -14,6 +14,7 @@
  * @uses $vars['full_view']   Show the full view of the items (default: false)
  * @uses $vars['list_class']  Additional CSS class for the <ul> element
  * @uses $vars['item_class']  Additional CSS class for the <li> elements
+ * @uses $vars['item_view']   Alternative view to render list items
  * @uses $vars['no_results']  Message to display if no results (string|Closure)
  */
 


### PR DESCRIPTION
Alternative view to render list items can now be passed as 'item_view' parameter to list generating views and functions

Refs #7899
