### PR TITLE
perf(engine): only autodetect viewtype once

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -97,14 +97,16 @@ function elgg_get_viewtype() {
 
 	$viewtype = get_input('view', '', false);
 	if (_elgg_is_valid_viewtype($viewtype)) {
-		return $viewtype;
+		$CURRENT_SYSTEM_VIEWTYPE = $viewtype;
+		return $CURRENT_SYSTEM_VIEWTYPE;
 	}
 
 	if (isset($CONFIG->view) && _elgg_is_valid_viewtype($CONFIG->view)) {
-		return $CONFIG->view;
+		$CURRENT_SYSTEM_VIEWTYPE = $CONFIG->view;
+		return $CURRENT_SYSTEM_VIEWTYPE;
 	}
-
-	return 'default';
+	$CURRENT_SYSTEM_VIEWTYPE = 'default';
+	return $CURRENT_SYSTEM_VIEWTYPE;
 }
 
 /**


### PR DESCRIPTION
before this fix Elgg autodetects viewtype for every view that is requested. This fix stores the autodetected value in the appropriate variable.

Benefits:
on a basic page 107 time this function is called. Before the fix it took 70ms cumulative for this function. After just 1 ms. On the total page time it was a 3-5% gain.
