### PR TITLE
Lists cleanup

### DIFF
--- a/views/default/navigation/pagination.php
+++ b/views/default/navigation/pagination.php
@@ -17,13 +17,17 @@ if (elgg_in_context('widget')) {
 	return true;
 }
 
+$count = (int) elgg_extract('count', $vars, 0);
+if (!$count) {
+	return true;
+}
+
 $offset = abs((int) elgg_extract('offset', $vars, 0));
 // because you can say $vars['limit'] = 0
 if (!$limit = (int) elgg_extract('limit', $vars, elgg_get_config('default_limit'))) {
 	$limit = 10;
 }
 
-$count = (int) elgg_extract('count', $vars, 0);
 $offset_key = elgg_extract('offset_key', $vars, 'offset');
 // some views pass an empty string for base_url
 if (isset($vars['base_url']) && $vars['base_url']) {

--- a/views/default/navigation/pagination.php
+++ b/views/default/navigation/pagination.php
@@ -14,12 +14,12 @@
 
 if (elgg_in_context('widget')) {
 	// widgets do not show pagination
-	return true;
+	return;
 }
 
 $count = (int) elgg_extract('count', $vars, 0);
 if (!$count) {
-	return true;
+	return;
 }
 
 $offset = abs((int) elgg_extract('offset', $vars, 0));
@@ -43,7 +43,7 @@ if (isset($vars['base_url']) && $vars['base_url']) {
 
 if ($count <= $limit && $offset == 0) {
 	// no need for pagination
-	return true;
+	return;
 }
 
 $total_pages = (int) ceil($count / $limit);

--- a/views/default/page/components/gallery.php
+++ b/views/default/page/components/gallery.php
@@ -18,12 +18,8 @@
  */
 
 $items = $vars['items'];
-$offset = $vars['offset'];
-$limit = $vars['limit'];
 $count = $vars['count'];
-$base_url = elgg_extract('base_url', $vars, '');
 $pagination = elgg_extract('pagination', $vars, true);
-$offset_key = elgg_extract('offset_key', $vars, 'offset');
 $position = elgg_extract('position', $vars, 'after');
 $no_results = elgg_extract('no_results', $vars, '');
 
@@ -52,16 +48,7 @@ if (isset($vars['item_class'])) {
 	$item_class = "$item_class {$vars['item_class']}";
 }
 
-$nav = '';
-if ($pagination && $count) {
-	$nav .= elgg_view('navigation/pagination', array(
-		'base_url' => $base_url,
-		'offset' => $offset,
-		'count' => $count,
-		'limit' => $limit,
-		'offset_key' => $offset_key,
-	));
-}
+$nav = ($pagination) ? elgg_view('navigation/pagination', $vars) : '';
 
 if ($position == 'before' || $position == 'both') {
 	echo $nav;

--- a/views/default/page/components/list.php
+++ b/views/default/page/components/list.php
@@ -19,12 +19,8 @@
  */
 
 $items = $vars['items'];
-$offset = elgg_extract('offset', $vars);
-$limit = elgg_extract('limit', $vars);
 $count = elgg_extract('count', $vars);
-$base_url = elgg_extract('base_url', $vars, '');
 $pagination = elgg_extract('pagination', $vars, true);
-$offset_key = elgg_extract('offset_key', $vars, 'offset');
 $position = elgg_extract('position', $vars, 'after');
 $no_results = elgg_extract('no_results', $vars, '');
 
@@ -52,17 +48,7 @@ if (isset($vars['item_class'])) {
 }
 
 $html = "";
-$nav = "";
-
-if ($pagination && $count) {
-	$nav .= elgg_view('navigation/pagination', array(
-		'base_url' => $base_url,
-		'offset' => $offset,
-		'count' => $count,
-		'limit' => $limit,
-		'offset_key' => $offset_key,
-	));
-}
+$nav = ($pagination) ? elgg_view('navigation/pagination', $vars) : '';
 
 $html .= "<ul class=\"$list_class\">";
 foreach ($items as $item) {

--- a/views/default/page/components/list.php
+++ b/views/default/page/components/list.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * View a list of items
  *
@@ -17,7 +18,6 @@
  * @uses $vars['item_view']   Alternative view to render list items
  * @uses $vars['no_results']  Message to display if no results (string|Closure)
  */
-
 $items = $vars['items'];
 $count = elgg_extract('count', $vars);
 $pagination = elgg_extract('pagination', $vars, true);
@@ -37,50 +37,51 @@ if (!is_array($items) || count($items) == 0) {
 	return;
 }
 
-$list_class = 'elgg-list';
+$list_classes = ['elgg-list'];
 if (isset($vars['list_class'])) {
-	$list_class = "$list_class {$vars['list_class']}";
+	$list_classes[] = $vars['list_class'];
 }
 
-$item_class = 'elgg-item';
+$item_classes = ['elgg-item'];
 if (isset($vars['item_class'])) {
-	$item_class = "$item_class {$vars['item_class']}";
+	$item_classes[] = $vars['item_class'];
 }
 
-$html = "";
 $nav = ($pagination) ? elgg_view('navigation/pagination', $vars) : '';
 
-$html .= "<ul class=\"$list_class\">";
+$list_items = '';
 foreach ($items as $item) {
-	$li = elgg_view_list_item($item, $vars);
-	if ($li) {
-		$item_classes = array($item_class);
-		
-		if (elgg_instanceof($item)) {
-			$id = "elgg-{$item->getType()}-{$item->getGUID()}";
-			
-			$item_classes[] = "elgg-item-" . $item->getType();
-			$subtype = $item->getSubType();
-			if ($subtype) {
-				$item_classes[] = "elgg-item-" . $item->getType() . "-" . $subtype;
-			}
-		} else {
-			$id = "item-{$item->getType()}-{$item->id}";
-		}
-		
-		$item_classes = implode(" ", $item_classes);
-		
-		$html .= "<li id=\"$id\" class=\"$item_classes\">$li</li>";
+	$item_view = elgg_view_list_item($item, $vars);
+	if (!$item_view) {
+		continue;
 	}
+
+	$li_attrs = ['class' => $item_classes];
+
+	if ($item instanceof \ElggEntity) {
+		$guid = $item->getGUID();
+		$type = $item->getType();
+		$subtype = $item->getSubtype();
+
+		$li_attrs['id'] = "elgg-$type-$guid";
+
+		$li_attrs['class'][] = "elgg-item-$type";
+		if ($subtype) {
+			$li_attrs['class'][] = "elgg-item-$type-$subtype";
+		}
+	} else if (is_callable(array($item, 'getType'))) {
+		$li_attrs['id'] = "item-{$item->getType()}-{$item->id}";
+	}
+
+	$list_items .= elgg_format_element('li', $li_attrs, $item_view);
 }
-$html .= '</ul>';
 
 if ($position == 'before' || $position == 'both') {
-	$html = $nav . $html;
+	echo $nav;
 }
+
+echo elgg_format_element('ul', ['class' => $list_classes], $list_items);
 
 if ($position == 'after' || $position == 'both') {
-	$html .= $nav;
+	echo $nav;
 }
-
-echo $html;


### PR DESCRIPTION
Moves pagination-specific variable out of the lists/gallery components
Cleans up list HTML rendering to take advantage of elgg_format_element()

Manual tests
- [x] Pagination not shown when not needed
- [x] List / gallery classes are built correctly
- [x] Item classes are built correctly
