### PR TITLE
chore(views): clean up icon views

### DIFF
--- a/mod/file/views/default/icon/object/file.php
+++ b/mod/file/views/default/icon/object/file.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * File icon view
  *
@@ -8,47 +9,19 @@
  * @uses $vars['img_class']  Optional CSS class added to img
  * @uses $vars['link_class'] Optional CSS class added to link
  */
-
-$entity = $vars['entity'];
-
-$sizes = array('small', 'medium', 'large', 'tiny', 'master', 'topbar');
-// Get size
-if (!in_array($vars['size'], $sizes)) {
-	$vars['size'] = "medium";
+$entity = elgg_extract('entity', $vars);
+if (!$entity instanceof \ElggFile) {
+	return;
 }
 
-$title = $entity->title;
-$title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8', false);
-
-$url = $entity->getURL();
-if (isset($vars['href'])) {
-	$url = $vars['href'];
-}
-
-$class = '';
-if (isset($vars['img_class'])) {
-	$class = $vars['img_class'];
-}
+$class = array();
 if ($entity->thumbnail) {
-	$class = "class=\"elgg-photo $class\"";
-} else if ($class) {
-	$class = "class=\"$class\"";
+	$class[] = 'elgg-photo';
+}
+if (isset($vars['img_class'])) {
+	$class[] = $vars['img_class'];
 }
 
-$img_src = $entity->getIconURL($vars['size']);
-$img_src = elgg_format_url($img_src);
-$img = "<img $class src=\"$img_src\" alt=\"$title\" />";
+$vars['img_class'] = implode(' ', $class);
 
-if ($url) {
-	$params = array(
-		'href' => $url,
-		'text' => $img,
-		'is_trusted' => true,
-	);
-	if (isset($vars['link_class'])) {
-		$params['class'] = $vars['link_class'];
-	}
-	echo elgg_view('output/url', $params);
-} else {
-	echo $img;
-}
+echo elgg_view('icon/default', $vars);

--- a/mod/pages/views/default/pages/icon.php
+++ b/mod/pages/views/default/pages/icon.php
@@ -10,16 +10,17 @@
  * @uses $vars['annotation']
  */
 
-$annotation = $vars['annotation'];
-$entity = get_entity($annotation->entity_guid);
-
-// Get size
-if (!in_array($vars['size'], array('small', 'medium', 'large', 'tiny', 'master', 'topbar'))) {
-	$vars['size'] = "medium";
+$annotation = elgg_extract('annotation', $vars);
+if (!$annotation instanceof \ElggAnnotation) {
+	return;
 }
 
-?>
+$entity = $annotation->getEntity();
+if (!$entity) {
+	return;
+}
 
-<a href="<?php echo $annotation->getURL(); ?>">
-	<img alt="<?php echo $entity->title; ?>" src="<?php echo $entity->getIconURL($vars['size']); ?>" />
-</a>
+$vars['entity'] = $entity;
+$vars['href'] = $annotation->getURL();
+
+echo elgg_view('icon/default', $vars);

--- a/views/default/icon/default.php
+++ b/views/default/icon/default.php
@@ -12,68 +12,39 @@
  * @uses $vars['link_class'] Optional CSS class for the link
  */
 
-$entity = $vars['entity'];
+$entity = elgg_extract('entity', $vars);
+if (!$entity instanceof \ElggEntity) {
+	return;
+}
 
 $icon_sizes = elgg_get_config('icon_sizes');
-// Get size
-$size = elgg_extract('size', $vars, 'medium');
-if (!array_key_exists($size, $icon_sizes)) {
-	$size = "medium";
-}
-$vars['size'] = $size;
-
-$class = elgg_extract('img_class', $vars, '');
-
-if (isset($entity->name)) {
-	$title = $entity->name;
-} else {
-	$title = $entity->title;
-}
-$title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8', false);
-
-$url = $entity->getURL();
-if (isset($vars['href'])) {
-	$url = $vars['href'];
+if (!isset($vars['size']) || !array_key_exists($vars['size'], $icon_sizes)) {
+	$vars['size'] = 'medium';
 }
 
-if (!isset($vars['width'])) {
-	$vars['width'] = $size != 'master' ? $icon_sizes[$size]['w'] : null;
-}
-if (!isset($vars['height'])) {
-	$vars['height'] = $size != 'master' ? $icon_sizes[$size]['h'] : null;
-}
-
-$img_params = array(
-	'src' => $entity->getIconURL($size),
-	'alt' => $title,	
-);
-
-if (!empty($class)) {
-	$img_params['class'] = $class;
+if ($vars['size'] != 'master') {
+	$dimensions = elgg_extract($vars['size'], $icon_sizes, array());
+	$width = elgg_extract('w', $dimensions);
+	$height = elgg_extract('h', $dimensions);
 }
 
-if (!empty($vars['width'])) {
-	$img_params['width'] = $vars['width'];
-}
+$img = elgg_view('output/img', array(
+	'src' => $entity->getIconURL($vars),
+	'alt' => $entity->getDisplayName(),
+	'class' => elgg_extract('img_class', $vars),
+	'width' => elgg_extract('width', $vars, $width),
+	'height' => elgg_extract('height', $vars, $height),
+));
 
-if (!empty($vars['height'])) {
-	$img_params['height'] = $vars['height'];
-}
-
-$img = elgg_view('output/img', $img_params);
+$url = elgg_extract('href', $vars, $entity->getURL());
 
 if ($url) {
-	$params = array(
+	echo elgg_view('output/url', array(
 		'href' => $url,
 		'text' => $img,
 		'is_trusted' => true,
-	);
-	$class = elgg_extract('link_class', $vars, '');
-	if ($class) {
-		$params['class'] = $class;
-	}
-
-	echo elgg_view('output/url', $params);
+		'class' => elgg_extract('link_class', $vars),
+	));
 } else {
 	echo $img;
 }

--- a/views/default/icon/user/default.php
+++ b/views/default/icon/user/default.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Elgg user icon
  *
@@ -14,36 +15,27 @@
  * @uses $vars['link_class'] Optional CSS class for the link
  * @uses $vars['href']       Optional override of the link href
  */
-
-$user = elgg_extract('entity', $vars, elgg_get_logged_in_user_entity());
-$size = elgg_extract('size', $vars, 'medium');
-$icon_sizes = elgg_get_config('icon_sizes');
-if (!array_key_exists($size, $icon_sizes)) {
-	$size = 'medium';
-}
-
-if (!($user instanceof ElggUser)) {
+$user = elgg_extract('entity', $vars);
+if (!$user instanceof \ElggUser) {
 	return;
 }
 
-$name = htmlspecialchars($user->name, ENT_QUOTES, 'UTF-8', false);
-$username = $user->username;
+$icon_sizes = elgg_get_config('icon_sizes');
+if (!isset($vars['size']) || !array_key_exists($vars['size'], $icon_sizes)) {
+	$vars['size'] = 'medium';
+}
 
-$class = "elgg-avatar elgg-avatar-$size";
+$name = array($user->getDisplayName());
+
+$class = array('elgg-avatar', "elgg-avatar-{$vars['size']}");
 if (isset($vars['class'])) {
-	$class = "$class {$vars['class']}";
+	$class[] = $vars['class'];
 }
+
 if ($user->isBanned()) {
-	$class .= ' elgg-state-banned';
+	$class[] = 'elgg-state-banned';
 	$banned_text = elgg_echo('banned');
-	$name .= " ($banned_text)";
-}
-
-$use_link = elgg_extract('use_link', $vars, true);
-
-$icontime = $user->icontime;
-if (!$icontime) {
-	$icontime = "default";
+	$name[] = "($banned_text)";
 }
 
 $js = elgg_extract('js', $vars, '');
@@ -51,56 +43,50 @@ if ($js) {
 	elgg_deprecated_notice("Passing 'js' to icon views is deprecated.", 1.8, 5);
 }
 
-$img_class = '';
-if (isset($vars['img_class'])) {
-	$img_class = $vars['img_class'];
-}
-
-
-$use_hover = elgg_extract('use_hover', $vars, true);
 if (isset($vars['override'])) {
 	elgg_deprecated_notice("Use 'use_hover' rather than 'override' with user avatars", 1.8, 5);
-	$use_hover = false;
+	$vars['use_hover'] = false;
+	unset($vars['hover']);
 }
+
 if (isset($vars['hover'])) {
 	// only 1.8.0 was released with 'hover' as the key
-	$use_hover = $vars['hover'];
+	$vars['use_hover'] = $vars['hover'];
+	unset($vars['hover']);
 }
 
 $icon = elgg_view('output/img', array(
 	'src' => $user->getIconURL($size),
 	'alt' => $name,
-	'title' => $name,
-	'class' => $img_class,
-));
+	'class' => elgg_extract('img_class', $vars),
+		));
 
+$avatar = '';
+
+$use_hover = elgg_extract('use_hover', $vars, true);
 $show_menu = $use_hover && (elgg_is_admin_logged_in() || !$user->isBanned());
-
-?>
-<div class="<?php echo $class; ?>">
-<?php
-
 if ($show_menu) {
-	$params = array(
+	$avatar = elgg_view_icon('hover-menu');
+	$avatar .= elgg_view_menu('user_hover', array(
 		'entity' => $user,
-		'username' => $username,
-		'name' => $name,
-	);
-	echo elgg_view_icon('hover-menu');
-	echo elgg_view_menu('user_hover', $params);
+		'username' => $user->username,
+		'name' => $user->name,
+	));
 }
 
+$use_link = elgg_extract('use_link', $vars, true);
 if ($use_link) {
-	$class = elgg_extract('link_class', $vars, '');
-	$url = elgg_extract('href', $vars, $user->getURL());
-	echo elgg_view('output/url', array(
-		'href' => $url,
+	$avatar .= elgg_view('output/url', array(
+		'href' => elgg_extract('href', $vars, $user->getURL()),
 		'text' => $icon,
+		'title' => $name,
 		'is_trusted' => true,
-		'class' => $class,
+		'class' => elgg_extract('link_class', $vars),
 	));
 } else {
-	echo "<a>$icon</a>";
+	$avatar .= elgg_format_element('a', array(), $icon);
 }
-?>
-</div>
+
+echo elgg_format_element('div', array(
+	'class' => $class,
+		), $avatar);


### PR DESCRIPTION
Adds instance checks, removes escaping that is done by default by the output lib, removes variable duplication
- [x] Needs #7901
- [ ] File icon sizes (is useing system wide dimensions a BC break) ?
- [ ] Add css classes for `elgg-$type-icon`, `elgg-$type-$subtype-icon` ?
