### PR TITLE
feature(groups): make it easier for plugins to work with group sidebars

### DIFF
--- a/mod/groups/views/default/groups/profile/sidebar.php
+++ b/mod/groups/views/default/groups/profile/sidebar.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Group profile sidebar
+ *
+ * @package ElggGroups
+ *
+ * @uses $vars['entity'] Group entity
+ */
+
+$group = elgg_extract('entity', $vars);
+if (!$group instanceof \ElggGroup) {
+	return;
+}
+
+if (elgg_group_gatekeeper(false, $group->guid)) {
+	echo elgg_view('groups/sidebar/my_status', $vars);
+	echo elgg_view('groups/sidebar/search', $vars);
+	echo elgg_view('groups/sidebar/members', $vars);
+}

--- a/mod/groups/views/default/groups/sidebar/featured.php
+++ b/mod/groups/views/default/groups/sidebar/featured.php
@@ -5,20 +5,18 @@
  * @package ElggGroups
  */
 
-$featured_groups = elgg_get_entities_from_metadata(array(
+elgg_push_context('widgets');
+
+$featured_groups = elgg_list_entities_from_metadata(array(
 	'metadata_name' => 'featured_group',
 	'metadata_value' => 'yes',
 	'type' => 'group',
-));
+	'full_view' => false,
+	'pagination' => false,
+		));
 
 if ($featured_groups) {
-
-	elgg_push_context('widgets');
-	$body = '';
-	foreach ($featured_groups as $group) {
-		$body .= elgg_view_entity($group, array('full_view' => false));
-	}
-	elgg_pop_context();
-
-	echo elgg_view_module('aside', elgg_echo("groups:featured"), $body);
+	echo elgg_view_module('aside', elgg_echo("groups:featured"), $featured_groups);
 }
+
+elgg_pop_context();

--- a/mod/groups/views/default/groups/sidebar/members.php
+++ b/mod/groups/views/default/groups/sidebar/members.php
@@ -8,17 +8,22 @@
  * @uses $vars['limit']  The number of members to display
  */
 
+$group = elgg_extract('entity', $vars);
+if (!$group instanceof \ElggGroup) {
+	return;
+}
+
 $limit = elgg_extract('limit', $vars, 14);
 
 $all_link = elgg_view('output/url', array(
-	'href' => 'groups/members/' . $vars['entity']->guid,
+	'href' => 'groups/members/' . $group->guid,
 	'text' => elgg_echo('groups:members:more'),
 	'is_trusted' => true,
 ));
 
 $body = elgg_list_entities_from_relationship(array(
 	'relationship' => 'member',
-	'relationship_guid' => $vars['entity']->guid,
+	'relationship_guid' => $group->guid,
 	'inverse_relationship' => true,
 	'type' => 'user',
 	'limit' => $limit,

--- a/mod/groups/views/default/groups/sidebar/my_status.php
+++ b/mod/groups/views/default/groups/sidebar/my_status.php
@@ -8,55 +8,23 @@
  */
 
 $group = elgg_extract('entity', $vars);
+if (!$group instanceof \ElggGroup) {
+	return;
+}
+
 $user = elgg_get_logged_in_user_entity();
+if (!$user) {
+	return;
+}
+
 $subscribed = elgg_extract('subscribed', $vars);
 
-if (!elgg_is_logged_in()) {
-	return true;
+$body = elgg_view_menu('groups:my_status', array(
+	'entity' => $group,
+	'user' => $user,
+	'subscribed' => $subscribed,
+));
+
+if($body) {
+	echo elgg_view_module('aside', elgg_echo('groups:my_status'), $body);
 }
-
-// membership status
-$is_member = $group->isMember($user);
-$is_owner = $group->getOwnerEntity() == $user;
-
-if ($is_owner) {
-	elgg_register_menu_item('groups:my_status', array(
-		'name' => 'membership_status',
-		'text' => '<a>' . elgg_echo('groups:my_status:group_owner') . '</a>',
-		'href' => false
-	));
-} elseif ($is_member) {
-	elgg_register_menu_item('groups:my_status', array(
-		'name' => 'membership_status',
-		'text' => '<a>' . elgg_echo('groups:my_status:group_member') . '</a>',
-		'href' => false
-	));
-} else {
-	elgg_register_menu_item('groups:my_status', array(
-		'name' => 'membership_status',
-		'text' => elgg_echo('groups:join'),
-		'href' => "/action/groups/join?group_guid={$group->getGUID()}",
-		'is_action' => true
-	));
-}
-
-// notification info
-if (elgg_is_active_plugin('notifications') && $is_member) {
-	if ($subscribed) {
-		elgg_register_menu_item('groups:my_status', array(
-			'name' => 'subscription_status',
-			'text' => elgg_echo('groups:subscribed'),
-			'href' => "notifications/group/$user->username",
-			'is_action' => true
-		));
-	} else {
-		elgg_register_menu_item('groups:my_status', array(
-			'name' => 'subscription_status',
-			'text' => elgg_echo('groups:unsubscribed'),
-			'href' => "notifications/group/$user->username"
-		));
-	}
-}
-
-$body = elgg_view_menu('groups:my_status');
-echo elgg_view_module('aside', elgg_echo('groups:my_status'), $body);

--- a/mod/groups/views/default/groups/sidebar/search.php
+++ b/mod/groups/views/default/groups/sidebar/search.php
@@ -5,6 +5,15 @@
  * @uses vars['entity'] ElggGroup
  */
 
+if (!elgg_is_active_plugin('search')) {
+	return;
+}
+
+$group = elgg_extract('entity', $vars);
+if (!$group instanceof \ElggGroup) {
+	return;
+}
+
 $url = elgg_get_site_url() . 'search';
 $body = elgg_view_form('groups/search', array(
 	'action' => $url,


### PR DESCRIPTION
Group sidebar modules are now view extensions
My status menu is built with a plugin hook
Adds groups_is_user_subscribed() function to check if the user is subscribed to group notifications
Adds missing action token to join item in My status menu
- [x] Find a cleaner way for notifications methods
- [x] Add a wrapper view that will check group_gatekeeper()
- [ ] Needs  #5911
