### PR TITLE
First pass at defining some common collection interfaces

### DIFF
--- a/engine/classes/Elgg/Structs/ArrayCollection.php
+++ b/engine/classes/Elgg/Structs/ArrayCollection.php
@@ -1,84 +1,72 @@
 <?php
 namespace Elgg\Structs;
 
-use Exception;
+use ArrayIterator;
 
 /**
- * Uses native PHP array to implement the Collection interface.
- * 
- * @package    Elgg.Core
- * @subpackage Structs
- * @since      1.10
+ * An immutable collection implemented using native PHP arrays.
  *
  * @access private
  */
 final class ArrayCollection implements Collection {
-	/** @var array */
+
+	/* @var array */
 	private $items;
 	
 	/**
 	 * Constructor
 	 * 
-	 * @param array $items The set of items in the collection
+	 * @param array $items The initial collection of items in the collection.
 	 */
-	public function __construct(array $items = array()) {
-		$this->items = $items;
+	public function __construct(array $items = []) {
+		$this->items = array_values($items);
 	}
 	
 	/** @inheritDoc */
 	public function contains($item) {
 		return in_array($item, $this->items, true);
 	}
-
+	
 	/** @inheritDoc */
 	public function count() {
 		return count($this->items);
 	}
 	
 	/** @inheritDoc */
-	public function current() {
-		return current($this->items);
-	}
-	
-	/** @inheritDoc */
 	public function filter(callable $filter) {
-		$results = array();
-		
-		foreach ($this->items as $item) {
-			if ($filter($item)) {
-				$results[] = $item;
-			}
-		}
-		
-		return new ArrayCollection($results);
+		return new self(array_filter($this->items, $filter));
 	}
 	
 	/** @inheritDoc */
-	public function key() {
-		return key($this->items);
+	public function getIterator() {
+		return new ArrayIterator($this->toArray());
+	}
+	
+	/** @inheritDoc */
+	public function isEmpty() {
+		return count($this) > 0;
 	}
 	
 	/** @inheritDoc */
 	public function map(callable $mapper) {
-		$results = array();
+		$items = [];
+		
 		foreach ($this->items as $item) {
-			$results[] = $mapper($item);
+			$items[] = $mapper($item);
 		}
-		return new ArrayCollection($results);
+		
+		return new self($items);
 	}
 	
 	/** @inheritDoc */
-	public function next() {
-		return next($this->items);
+	public function toArray() {
+		return $this->items;
 	}
 	
 	/** @inheritDoc */
-	public function rewind() {
-		reset($this->items);
-	}
-	
-	/** @inheritDoc */
-	public function valid() {
-		return key($this->items) !== NULL;
+	public function where(array $options) {
+		// TODO(ewinslow): Actual implementation plz...
+		return $this;
 	}
 }
+

--- a/engine/classes/Elgg/Structs/Collection.php
+++ b/engine/classes/Elgg/Structs/Collection.php
@@ -1,66 +1,67 @@
 <?php
 namespace Elgg\Structs;
 
-use Countable;
-use Iterator;
+use IteratorAggregate;
 
 /**
- * A read-only interface to a (possibly mutable) group of items.
- * 
- * Read-only provides some nice guarantees that can be harnessed for things
- * like caching, lazy evaluation, respecting HTTP semantics of GET/HEAD, etc.
- * 
- * We do not extend ArrayAccess, because:
- *  * Collections aren't writable by default
- *  * Collections don't have a defined order by default
- *  * Collections aren't all Maps by default ;)
- * 
- * Extensions may provide one or more of these features.
- * 
- * TODO(ewinslow): If PHP had generics support, we'd add that here.
- * 
- * DO NOT EXTEND OR IMPLEMENT this interface outside of this package.
- * Doing so would cause additions to the API to be breaking changes, which is
- * not what we want. You have a couple of options for how to proceed:
- *  * File a feature request
- *  * Submit a PR
- *  * Use composition -- http://en.wikipedia.org/wiki/Composition_over_inheritance
- *
- * @package    Elgg.Core
- * @subpackage Structs
- * @since      1.10
+ * A read-only interface to a group/bag of items.
  *
  * @access private
  */
-interface Collection extends Countable, Iterator {
-	
-	/**
-	 * Returns a new collection only containing the elements which pass the filter.
-	 * 
-	 * @param callable $filter Receives an item. Return true to keep the item.
-	 * 
-	 * @return Collection
-	 */
-	public function filter(callable $filter);
+interface Collection extends Countable, IteratorAggregate {
 	
 	/**
 	 * Returns true iff the item is in this collection at least once.
 	 * 
-	 * @param mixed $item The object or value to check for 
+	 * @param T $item The object or value to check for 
 	 * 
 	 * @return boolean
 	 */
 	public function contains($item);
 
 	/**
-	 * Take items of the collection and return a new collection
-	 * with all the items having the $mapper applied to them.
+	 * Returns a new collection only containing the elements which pass the filter.
 	 * 
-	 * The callable is not guaranteed to execute immediately for each item.
+	 * @param callable $filter Receives an item. Return true to keep the item.
 	 * 
-	 * @param callable $mapper Returns the mapped value
+	 * @return Collection<T>
+	 */
+	public function filter(callable $filter);
+	
+	/**
+	 * Returns a new collection created by applying the $mapper to each item in
+	 * this collection.
 	 * 
-	 * @return Collection
+	 * The callable is not guaranteed to execute immediately for each item, so
+	 * do not pass in a callable with any side effects.
+	 * 
+	 * @param callable $mapper Receives an item and returns the mapped value
+	 * 
+	 * @return Collection<T>
 	 */
 	public function map(callable $mapper);
+	
+	/**
+	 * Returns an array containing all the items in this collection.
+	 * 
+	 * @return T[]
+	 */
+	public function toArray();
+	
+	/**
+	 * Narrows down the collection to based on item properties.
+	 * 
+	 * This only works for collections of object and/or array, not int or string.
+	 * 
+	 * For example:
+	 * ```
+	 * function(Collection $entities) {
+	 * 		return $entities->where(['container_guid' => 12345]);
+	 * }
+	 * 
+	 * @param array $options How properties should be compared
+	 * 
+	 * @return Collection<T>
+	 */
+	public function where(array $options);
 }

--- a/engine/classes/Elgg/Structs/Countable.php
+++ b/engine/classes/Elgg/Structs/Countable.php
@@ -1,0 +1,19 @@
+<?php
+namespace Elgg\Structs;
+
+use Countable as NativeCountable;
+
+/**
+ * Adds a convenience for checking whether a countable has value 0.
+ */
+interface Countable extends NativeCountable {
+	/**
+	 * Indicates whether there are no items in this collection.
+	 * 
+	 * Although this always returns the same result as count($this) == 0,
+	 * it doesn't have to be implemented that way.
+	 * 
+	 * @return boolean
+	 */
+	public function isEmpty();
+}

--- a/engine/classes/Elgg/Structs/DoubleEndedStack.php
+++ b/engine/classes/Elgg/Structs/DoubleEndedStack.php
@@ -1,0 +1,35 @@
+<?php
+namespace Elgg\Structs;
+
+/**
+ * A Stack that allows you to insert/remove from both ends.
+ * 
+ * These operations are push/pop for the "top" or "end" of the stack,
+ * and shift/unshift for the "bottom" or "front" of the stack.
+ * 
+ * This is also known as a Deque or DoubleEndedQueue.
+ * 
+ * @see http://en.wikipedia.org/wiki/Double-ended_queue
+ * 
+ * Generics
+ *  V -- The type of the items
+ * 
+ * @access private
+ */
+interface DoubleEndedStack extends Stack {
+	/**
+	 * Removes an item from the bottom of the stack.
+	 * 
+	 * @return V The removed item
+	 */
+	public function shift();
+	
+	/**
+	 * Inserts the item onto the bottom of the stack.
+	 * 
+	 * @param V $item
+	 * 
+	 * @return void
+	 */
+	public function unshift($item);
+}

--- a/engine/classes/Elgg/Structs/Exception/ItemNotFound.php
+++ b/engine/classes/Elgg/Structs/Exception/ItemNotFound.php
@@ -1,0 +1,4 @@
+<?php
+namespace Elgg\Structs\Exception;
+
+class ItemNotFound extends \Exception {}

--- a/engine/classes/Elgg/Structs/Map.php
+++ b/engine/classes/Elgg/Structs/Map.php
@@ -1,0 +1,61 @@
+<?php
+namespace Elgg\Structs;
+
+/**
+ * A collection of items which all have associated keys.
+ * 
+ * Generics:
+ *  K -- The type of the keys in the map (not just strings!)
+ *  V -- The type of the values in the map
+ * 
+ * @access private
+ */
+interface Map/*<K,V>*/ extends Collection/*<V>*/ {
+	/**
+	 * Gets a collection of the key/value tuples (i.e. [$key, $value]) in this map.
+	 * 
+	 * @return Collection<[K,V]>
+	 */
+	public function entries();
+	
+	/**
+	 * @return Map<K,V> Maintains key associations after filter is applied.
+	 * @inheritDoc
+	 */
+	public function filter(callable $filter);
+
+	/**
+	 * Gets the item associated with a given key.
+	 * 
+	 * Throws an exception if no item can be found or generated for the key.
+	 * 
+	 * @param K $key
+	 * 
+	 * @return V The item.
+	 */
+	public function get($key);
+	
+	/**
+	 * Indicates whether the given key has been set for this map.
+	 * 
+	 * @param K $key
+	 * 
+	 * @return boolean
+	 */
+	public function has($key);
+
+	/**
+	 * Get a set of all the keys that have associated values.
+	 * 
+	 * @return Set<K>
+	 */
+	public function keys();
+
+	/**
+	 * @param callable(V):R $mapper
+	 * 
+	 * @return Map<K,R> Maintains key associations after mapper is applied.
+	 * @inheritDoc
+	 */
+	public function map(callable $mapper);
+}

--- a/engine/classes/Elgg/Structs/MutableArraySequence.php
+++ b/engine/classes/Elgg/Structs/MutableArraySequence.php
@@ -1,0 +1,171 @@
+<?php
+namespace Elgg\Structs;
+
+use ArrayIterator;
+
+/**
+ * A MutableSequence implemented using native PHP arrays.
+ *
+ * @access private
+ */
+final class MutableArraySequence implements MutableSequence {
+
+	/* @var array */
+	private $items;
+	
+	/**
+	 * Create a new sequence
+	 */
+	public function __construct(array $items = []) {
+		$this->items = $items;
+	}
+	
+	/** @inheritDoc */
+	public function add($item) {
+		$this->push($item);
+	}
+	
+	/** @inheritDoc */
+	public function clear() {
+		$this->items = [];
+	}
+	
+	/** @inheritDoc */
+	public function contains($item) {
+		return $this->indexOf($item) != -1;
+	}
+	
+	/** @inheritDoc */
+	public function count() {
+		return count($this->items);
+	}
+	
+	/** @inheritDoc */
+	public function current() {
+		return current($this->items);
+	}
+	
+	/** @inheritDoc */
+	public function filter(callable $filter) {
+		return new ArraySequence(array_filter($this->items, $filter));
+	}
+	
+	/** @inheritDoc */
+	public function first() {
+		return $this->items[0];
+	}
+	
+	/** @inheritDoc */
+	public function indexOf($item) {
+		$index = array_search($item, $this->items, true);
+		return $index === FALSE ? -1 : $index;
+	}
+	
+	/** @inheritDoc */
+	public function isEmpty() {
+		return count($this) == 0;
+	}
+	
+	/** @inheritDoc */
+	public function insertAt($index, $item) {
+		$this->splice($index, 0, [$item]);
+	}
+	
+	/** @inheritDoc */
+	public function getIterator() {
+		return new ArrayIterator($this->toArray());
+	}
+	
+	/** @inheritDoc */
+	public function last() {
+		return $this->items[count($this) - 1];
+	}
+	
+	/** @inheritDoc */
+	public function map(callable $mapper) {
+		$items = [];
+		
+		foreach ($this->items as $item) {
+			$items[] = $mapper($item);
+		}
+		
+		return $items;
+	}
+
+	/** @inheritDoc */
+	public function next() {
+		return next($this->items);
+	}
+	
+	/** @inheritDoc */
+	public function peek() {
+		return $this->last();
+	}
+
+	/** @inheritDoc */
+	public function pop() {
+		return array_pop($this->items);
+	}
+
+	/** @inheritDoc */
+	public function push($item) {
+		array_push($this->items, $item);
+	}
+	
+	/** @inheritDoc */
+	public function remove($item) {
+		$index = $this->indexOf($item);
+		if ($index === -1) {
+			throw new \Exception("Item was not found in this sequence");
+		}
+		
+		$this->removeAt($index);
+	}
+	
+	/** @inheritDoc */
+	public function removeAt($index) {
+		return $this->splice($index, 1)->first();
+	}
+	
+	/** @inheritDoc */
+	public function rewind() {
+		return rewind($this->items);
+	}
+
+	/** @inheritDoc */
+	public function shift() {
+		return array_shift($this->items);
+	}
+	
+	/** @inheritDoc */
+	public function slice($index = 0, $limit = 0) {
+		return new ArraySequence(array_slice($this->items, $index, $limit));
+	}
+	
+	/** @inheritDoc */
+	public function splice($index, $limit = 0, array $replacements = []) {
+		return new ArraySequence(array_splice($this->items, $index, $limit, $replacements));
+	}
+	
+	/** @inheritDoc */
+	public function toArray() {
+		return $this->items;
+	}
+
+	/** @inheritDoc */
+	public function unshift($item) {
+		array_unshift($this->items, $item);
+	}
+	
+	/** @inheritDoc */
+	public function valid() {
+		return key($this) < count($this);
+	}
+
+	/** @inheritDoc */
+	public function where(array $options) {
+		// TODO(ewinslow): Actual implementation plz...
+		return $this;
+	}
+}
+

--- a/engine/classes/Elgg/Structs/MutableCollection.php
+++ b/engine/classes/Elgg/Structs/MutableCollection.php
@@ -1,0 +1,39 @@
+<?php
+namespace Elgg\Structs;
+
+/**
+ * A read-only interface to a group of items.
+ *
+ * @access private
+ */
+interface MutableCollection extends Collection {
+	
+	/**
+	 * Adds the item to the collection.
+	 * 
+	 * Duplicates are allowed unless specified otherwise by a subinterface.
+	 * 
+	 * @param T $item
+	 * 
+	 * @return void
+	 */
+	public function add($item);
+	
+	/**
+	 * Removes all items from this collection.
+	 * 
+	 * The collection is always empty after calling this.
+	 * 
+	 * @return void
+	 */
+	public function clear();
+
+	/**
+	 * Remove a single occurrence of the item from the collection.
+	 * 
+	 * @param T $item
+	 * 
+	 * @return void
+	 */
+	public function remove($item);
+}

--- a/engine/classes/Elgg/Structs/MutableMap.php
+++ b/engine/classes/Elgg/Structs/MutableMap.php
@@ -1,0 +1,29 @@
+<?php
+namespace Elgg\Structs;
+
+/**
+ * A collection of items which all have associated keys.
+ *
+ * @access private
+ */
+interface MutableMap extends Map {
+
+	/**
+	 * Sets the value associated with $key to $item.
+	 * 
+	 * @param K $key
+	 * @param V $item
+	 * 
+	 * @return void
+	 */
+	public function set($key, $item);
+
+	/**
+	 * Removes the key and its associated item from this map.
+	 * 
+	 * @param K $key
+	 * 
+	 * @return V The removed item.
+	 */
+	public function delete($key);
+}

--- a/engine/classes/Elgg/Structs/MutableSequence.php
+++ b/engine/classes/Elgg/Structs/MutableSequence.php
@@ -1,0 +1,44 @@
+<?php
+namespace Elgg\Structs;
+
+
+/**
+ * A sequence that can have items inserted and removed from any index.
+ * 
+ * @access private
+ */
+interface MutableSequence extends DoubleEndedStack, MutableCollection {
+	/**
+	 * Puts an item at the given position in the sequence,
+	 * shifting all items after it over by one position.
+	 * 
+	 * @param int $index
+	 * @param T   $item
+	 * 
+	 * @return void
+	 */
+	public function insertAt($index, $item);
+	
+	/**
+	 * Removes an item at the given position in the sequence,
+	 * shiften all items after it over by one position.
+	 * 
+	 * @param int $index
+	 * 
+	 * @return T $item
+	 */
+	public function removeAt($index);
+	
+	/**
+	 * Removes and inserts items in a single operation.
+	 * 
+	 * TODO(ewinslow): allow collections to be passed in as $replacements
+	 * 
+	 * @param int   $index        Starting at this index
+	 * @param int   $limit        Remove this many items
+	 * @param array $replacements And insert these instead 
+	 * 
+	 * @return Sequence<T> The removed items
+	 */
+	public function splice($index, $limit = 0, array $replacements = []);
+}

--- a/engine/classes/Elgg/Structs/MutableSet.php
+++ b/engine/classes/Elgg/Structs/MutableSet.php
@@ -1,0 +1,9 @@
+<?php
+namespace Elgg\Structs;
+
+/**
+ * A set that can add/remove items.
+ * 
+ * @access private
+ */
+interface MutableSet extends Set, MutableCollection {}

--- a/engine/classes/Elgg/Structs/Queue.php
+++ b/engine/classes/Elgg/Structs/Queue.php
@@ -1,0 +1,34 @@
+<?php
+namespace Elgg\Structs;
+
+/**
+ * A sequence of items that can have items inserted at an end and removed at an end. 
+ * 
+ * The most basic queues will pop items in the same order they are pushed (FIFO,
+ * aka first-in-first-out), but extensions may specify a different behavior.
+ * For example, Stacks are LIFO and PriorityQueues use a custom algorithm.
+ * 
+ * @access private
+ */
+interface Queue {
+	/**
+	 * Takes a look at the next item that will be popped, without removing it.
+	 * 
+	 * @return T
+	 */
+	public function peek();
+	
+	/**
+	 * Removes an item from the queue and returns it.
+	 *
+	 * @return T
+	 */
+	public function pop();
+
+	/**
+	 * Adds an item to the queue.
+	 *
+	 * @param T $item
+	 */
+	public function push($item);
+}

--- a/engine/classes/Elgg/Structs/README.md
+++ b/engine/classes/Elgg/Structs/README.md
@@ -1,0 +1,52 @@
+Elgg Data Structures API
+========================
+
+A library of common data structure interfaces (mostly collections).
+
+Collections differ from PHP's native array in several ways. By default:
+
+ * They aren't mutable/writable (!!)
+ * They don't have keys
+ * They don't ever contain null items or return null values
+ * The items don't have stable indexes
+
+However, subinterfaces may augment the base Collection interface to add one or
+more of the above features, as well as:
+
+ * Sorting, such that iteration passes over items in a consistent order
+   regardless of what order the items are inserted). Items in such a collection
+   cannot be rearranged.
+
+The data structures APIs are designed with the following principles:
+
+ * Exceptions are bad. Instead of throwing for unsupported operations,
+   interfaces should specify only the methods that will actually be
+   implemented. This results in more interfaces, but also more clarity.
+
+ * Null is worse. Throw meaningful exceptions or return empty values
+   instead of returning null. This helps catch errors earlier and minimizes
+   null checks which just add complexity without benefit.
+
+ * Read-only is good. Performance improvements can be made more aggressively
+   when we can guarantee the value won't be modified by clients.
+
+ * Immutable is better. When values can't be modified at their source,
+   clients can make even more performance improvements.
+
+The read-only-by-default philosophy provides some nice guarantees that can be
+harnessed for performance-related things like caching and lazy evaluation.
+
+TODO(ewinslow): If PHP had generics support, we'd add that here.
+
+DO NOT EXTEND OR IMPLEMENT this interface outside of this package.
+Doing so would cause additions to the API to be breaking changes, which is
+not what we want. You have a couple of options for how to proceed:
+ * File a feature request
+ * Submit a PR
+ * Use composition -- http://en.wikipedia.org/wiki/Composition_over_inheritance
+
+
+The important part of some interfaces is the tests that come along with them.
+Any implementation must also run those tests to check for correctness,
+otherwise the interface is just a hint at an implementation detail that
+cannot be otherwise enforced by the type system.

--- a/engine/classes/Elgg/Structs/Sequence.php
+++ b/engine/classes/Elgg/Structs/Sequence.php
@@ -1,0 +1,102 @@
+<?php
+namespace Elgg\Structs;
+
+/**
+ * A collection whose elements are ordered such that it makes
+ * sense to ask which is the "nth" item. Normally this would be called a "List"
+ * but that is a reserved keyword in PHP used for array destructuring.
+ * 
+ * Subinterfaces may provide functionality for reordering items.
+ *
+ * @access private
+ */
+interface Sequence extends Collection {
+	
+	/**
+	 * @return Sequence Maintains relative order of items, but not indexes.
+	 * @inheritDoc
+	 */
+	public function filter(callable $filter);
+	
+	/**
+	 * Returns the first item in the sequence.
+	 * 
+	 * Alias for $this->getAt(0), essentially.
+	 * 
+	 * @return T
+	 */
+	public function first();
+	
+	/**
+	 * Returns the item at the given index.
+	 * 
+	 * Throws an exception for invalid values of index:
+	 *  - Any value less than 0
+	 *  - Any value greater than the size of the collection
+	 * 
+	 * @param int $index
+	 * 
+	 * @return T
+	 */
+	public function getAt($index);
+	
+	/**
+	 * Returns the index of the first occurence of the item in this sequence.
+	 * 
+	 * @param T $item
+	 * 
+	 * @return int Returns -1 if not preset in the set.
+	 */
+	public function indexOf($item);
+	
+	/**
+	 * Returns the last item in a non-empty collection.
+	 * 
+	 * Alias for:
+	 *  - $this->reverse()->getAt(0)
+	 *  - $this->getAt(count($this) - 1)
+	 * 
+	 * @return T
+	 */
+	public function last();
+	
+	/**
+	 * @return Sequence<R> Maintains the order and index of items.
+	 * @inheritDoc
+	 */
+	public function map(callable $mapper);
+
+	/**
+	 * Gets a new sequence with the items sorted from low to high (ascending)
+	 * on the given property.
+	 * 
+	 * @example To get the most recently created items first, assuming time_created
+	 * stores the creation date:
+	 * 
+	 * ```php
+	 * function mostRecent(Sequence $sequence) {
+	 * 	return $sequence->orderBy('time_created')->reverse();
+	 * }
+	 * ```
+	 * 
+	 * @return Sequence<T>
+	 */
+	public function orderBy($property);
+	
+	/**
+	 * Gets a new sequence with all of its items in reverse order of the current one.
+	 * 
+	 * @return Sequence<T>
+	 */
+	public function reverse();
+	
+	/**
+	 * Gets a new Sequence that represents a section (slice) of the current sequence.
+	 * 
+	 * @param int $offset Starting at this index
+	 * @param int $limit  Return this many items
+	 * 
+	 * @return Sequence<T>
+	 */
+	public function slice($offset = 0, $limit = 0);
+}

--- a/engine/classes/Elgg/Structs/Set.php
+++ b/engine/classes/Elgg/Structs/Set.php
@@ -1,0 +1,15 @@
+<?php
+namespace Elgg\Structs;
+
+/**
+ * A collection that only contains each item once.
+ *
+ * @access private
+ */
+interface Set extends Collection {
+	/**
+	 * @return Set<T>
+	 * @inheritDoc
+	 */
+	public function filter(callable $filter);
+}

--- a/engine/classes/Elgg/Structs/Stack.php
+++ b/engine/classes/Elgg/Structs/Stack.php
@@ -1,0 +1,9 @@
+<?php
+namespace Elgg\Structs;
+
+/**
+ * A queue in which elements are popped off the end, rather than the front.
+ *
+ * @access private
+ */
+interface Stack extends Queue {}


### PR DESCRIPTION
Comparison of collection libraries/interfaces

https://docs.google.com/a/elgg.org/spreadsheets/d/1a7krO6pIQPm52Y8tKYr8JOPvOrrTlohty59W7MRz6Fk/edit#gid=0

Believe it or not, I've tried to keep this down to the minimum number of interfaces I think we'd need if we migrated all our array-based interfaces to be collections-based. Because of my philosophy of "promise the least API surface possible", we have lots of fine-grained interfaces which allow us to do just that, which makes this feel a more complicated than just using arrays, but the possibilities for performance and developer appeal are fantastic, I think, compared to arrays.

``` php
// no superfluous arguments
$recentBlogs = $entities->where([
  'type' => 'object',
  'subtype' => 'blog',
])->orderBy('time_created')->reverse();

echo "Count: " . count($recentBlogs);
foreach ($recentBlogs->slice($offset, $limit) as $blog) {
  echo $blog->getTitle();
}
```

I find this significantly cleaner that the current approach:

``` php
$options = [
  'type' => 'object',
  'subtype' => 'blog',
  // Was it order_by or sort_by??? No errors if you get it wrong.
  // Also, SQL formatting sneaking through.
  'order_by' => 'time_created desc',
  'count' => true,
  // Ignore when count = true
  'offset' => 0,
  'limit' => 10,
];

// returns a number
$count = elgg_get_entities($options);
$options['count'] = false;
// returns a different kind of response based on a string key argument... oy...
$blogs = elgg_get_entities($options);
```

TODOs:
- [ ] Commit should mention https://github.com/Elgg/Elgg/issues/2567 and #5071 ...
- [ ] Add clear use-cases for each one of these interfaces.
- [ ] Don't make `Queue` inherit from `Sequence`. This **requires** implementors to provide all the iteration helpers (filter/map/etc.), which we don't necessarily want to do (e.g. see `Elgg\Queue\DatabaseQueue`, which does not need all those things to do its job).

For discussion:
- [ ] Most importantly, do we want to go down this path? Everything is private right now, so it shouldn't really be a huge huge deal, but as soon as we start leaking this API out to plugin devs (which we would eventually want to do, I would think), this will be a rather large library of things to deal with...
- [x] Generics support (i.e. how to place type restrictions on the items in a collection?)
  - Generics will be documentation-only until PHP supports them natively, not runtime enforced.
- [ ] Should the sorting functions (e.g. orderBy) be available on `Collection` instead of just `Sequence`?
  - seems like you should be able to sort any collection of items and end up with a sequence, but then this creates a circular reference b/w `Sequence` and `Collection` interfaces, which feels wrong.
- [x] What should happen when an item is added to a `Set` that already contains it?
  - throw?
  - fail silently?
  - leave it up to implementations? <--- We'll do this, but throwing an exception is within the realm of possibilities, so clients will have to guard against this either way...
  - E.g. if you have an mutable ordered set, and you insert an item at a given index, but the item is already in the set, should you move the item from its position to the new position, or should you throw with an error like "only one instance allowed per set"? 
- [ ] What should the naming convention for `Map` accessors be?
  - get, getKey
  - containsKey, exists, isset, issetKey, keyExists, offsetExists, offsetIsset
  - delete, deleteKey, removeKey, unset, unsetKey, offsetUnset
  - set, setKey, put, putKey, offsetSet
  - Note that other interfaces already have remove($item), contains($item)
- [ ] What should the naming convenion for `Sequence` accessors be?
  - getAt, getNth
  - removeAt, removeNth
  - insertAt, insertNth
  - replaceAt, replaceNth
