### PR TITLE
fix(views): use named keys when registering meta tags and links in head

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -465,6 +465,7 @@ function elgg_view_page($title, $body, $page_shell = 'default', $vars = array())
 
 	// head has keys 'title', 'metas', 'links'
 	$head_params = _elgg_views_prepare_head($title);
+
 	$vars['head'] = elgg_trigger_plugin_hook('head', 'page', $vars, $head_params);
 
 	$vars = elgg_trigger_plugin_hook('output:before', 'page', null, $vars);
@@ -502,64 +503,64 @@ function _elgg_views_prepare_head($title) {
 		$params['title'] = $title . ' : ' . elgg_get_config('sitename');
 	}
 
-	$params['metas'][] = array(
+	$params['metas']['content-type'] = array(
 		'http-equiv' => 'Content-Type',
 		'content' => 'text/html; charset=utf-8',
 	);
 
-	$params['metas'][] = array(
+	$params['metas']['description'] = array(
 		'name' => 'description',
 		'content' => elgg_get_config('sitedescription')
 	);
 	
 	// https://developer.chrome.com/multidevice/android/installtohomescreen
-	$data['metas'][] = array(
+	$params['metas']['viewport'] = array(
 		'name' => 'viewport',
 		'content' => 'width=device-width',
 	);    
-	$data['metas'][] = array(
+	$params['metas']['mobile-web-app-capable'] = array(
 		'name' => 'mobile-web-app-capable',
 		'content' => 'yes',
 	);
-	$data['metas'][] = array(
+	$params['metas']['apple-mobile-web-app-capable'] = array(
 		'name' => 'apple-mobile-web-app-capable',
 		'content' => 'yes',
 	);
-	$data['links'][] = array(
+	$params['links']['apple-touch-icon'] = array(
 		'rel' => 'apple-touch-icon',
 		'href' => elgg_normalize_url('_graphics/favicon-128.png'),
 	);
 
 	// favicons
-	$params['links'][] = array(
+	$params['links']['icon-ico'] = array(
 		'rel' => 'icon',
 		'href' => elgg_normalize_url('_graphics/favicon.ico'),
 	);
-	$params['links'][] = array(
+	$params['links']['icon-svg'] = array(
 		'rel' => 'icon',
 		'sizes' => '16x16 32x32 48x48 64x64 128x128',
 		'type' => 'image/svg+xml',
 		'href' => elgg_normalize_url('_graphics/favicon.svg'),
 	);
-	$params['links'][] = array(
+	$params['links']['icon-png-16'] = array(
 		'rel' => 'icon',
 		'sizes' => '16x16',
 		'type' => 'image/png',
 		'href' => elgg_normalize_url('_graphics/favicon-16.png'),
 	);
-	$params['links'][] = array(
+	$params['links']['icon-png-32'] = array(
 		'rel' => 'icon',
 		'sizes' => '32x32',
 		'type' => 'image/png',
 		'href' => elgg_normalize_url('_graphics/favicon-32.png'),
 	);
-	$params['links'][] = array(
+	$params['links']['icon-png-64'] = array(
 		'rel' => 'icon',
 		'sizes' => '64x64',
 		'type' => 'image/png',
 		'href' => elgg_normalize_url('_graphics/favicon-64.png'),
 	);
-	$params['links'][] = array(
+	$params['links']['icon-png-128'] = array(
 		'rel' => 'icon',
 		'sizes' => '128x128',
 		'type' => 'image/png',
@@ -575,7 +576,7 @@ function _elgg_views_prepare_head($title) {
 		} else {
 			$url .= "?view=rss";
 		}
-		$params['links'][] = array(
+		$params['links']['rss'] = array(
 			'rel' => 'alternative',
 			'type' => 'application/rss+xml',
 			'title' => 'RSS',

--- a/mod/aalborg_theme/start.php
+++ b/mod/aalborg_theme/start.php
@@ -105,23 +105,23 @@ function aalborg_theme_pagesetup() {
  * @return array
  */
 function aalborg_theme_setup_head($hook, $type, $data) {
-	$data['metas'][] = array(
+	$data['metas']['viewport'] = array(
 		'name' => 'viewport',
 		'content' => 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0',
 	);
     
     // https://developer.chrome.com/multidevice/android/installtohomescreen
-    $data['metas'][] = array(
+    $data['metas']['mobile-web-app-capable'] = array(
         'name' => 'mobile-web-app-capable',
         'content' => 'yes',
     );
 
-    $data['metas'][] = array(
+    $data['metas']['apple-mobile-web-app-capable'] = array(
         'name' => 'apple-mobile-web-app-capable',
         'content' => 'yes',
     );
 
-	$data['links'][] = array(
+	$data['links']['apple-touch-icon'] = array(
 		'rel' => 'apple-touch-icon',
 		'href' => elgg_normalize_url('mod/aalborg_theme/graphics/homescreen.png'),
 	);


### PR DESCRIPTION
fixes #6609 

also fixes the incorrect use of `$data` instead of `$params`
