### PR TITLE
fix(js): correctly define amd dependencies for input/userpicker

### DIFF
--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1899,6 +1899,11 @@ function _elgg_init() {
 	elgg_register_js('elgg.autocomplete', 'js/lib/ui.autocomplete.js');
 	elgg_register_js('jquery.ui.autocomplete.html', 'vendors/jquery/jquery.ui.autocomplete.html.js');
 
+	elgg_define_js('jquery.ui.autocomplete.html', array(
+		'src' => '/vendors/jquery/jquery.ui.autocomplete.html.js',
+		'deps' => array('jquery.ui')
+	));
+	
 	elgg_register_external_view('js/elgg/UserPicker.js', true);
 
 	elgg_register_js('elgg.friendspicker', 'js/lib/ui.friends_picker.js');

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1624,6 +1624,10 @@ function elgg_views_boot() {
 		'deps' => array('jquery'),
 		'exports' => 'jQuery.fn.ajaxForm',
 	));
+	elgg_define_js('jquery.ui', array(
+		'src' => '/vendors/jquery/jquery-ui-1.10.4.min.js',
+		'deps' => array('jquery'),
+	));
 
 	$elgg_js_url = elgg_get_simplecache_url('js', 'elgg');
 	elgg_register_js('elgg', $elgg_js_url, 'head');

--- a/views/default/input/userpicker.php
+++ b/views/default/input/userpicker.php
@@ -17,8 +17,6 @@
  * When this happens, a hidden input is created to return the GUID in the array with the form
  */
 
-elgg_load_js('jquery.ui.autocomplete.html');
-
 if (empty($vars['name'])) {
 	$vars['name'] = 'members';
 }

--- a/views/default/js/elgg/UserPicker.js
+++ b/views/default/js/elgg/UserPicker.js
@@ -1,7 +1,6 @@
 /** @module elgg/UserPicker */
 
-define(['jquery', 'elgg'], function ($, elgg) {
-
+define(['jquery', 'elgg', 'jquery.ui.autocomplete.html'], function ($, elgg) {
 	/**
 	 * @param {HTMLElement} wrapper outer div
 	 * @constructor


### PR DESCRIPTION
fixes #5296 

additionally defines jquery.ui and jquery.ui.autocomplete.html for use in AMD.

There is no conflict if you mix loading js with elgg_load_js and a requirement/dependency in requirejs.

Any comments on this @ewinslow?
