### PR TITLE
fix(metadata): metadata cache is invalidated on session user change

### DIFF
--- a/engine/classes/Elgg/Access.php
+++ b/engine/classes/Elgg/Access.php
@@ -1,5 +1,8 @@
 <?php
 namespace Elgg;
+
+use Elgg\Access\AccessState;
+
 /**
  * Class used to determine if access is being ignored.
  *
@@ -69,6 +72,18 @@ class Access {
 		$this->ignore_access = $ignore;
 
 		return $prev;
+	}
+
+	/**
+	 * Get a snapshot of the current state of access control
+	 *
+	 * @return AccessState
+	 */
+	public function getState() {
+		$state = new AccessState();
+		$state->ignored = $this->ignore_access;
+		$state->current_user_guid = _elgg_services()->session->getLoggedInUserGuid();
+		return $state;
 	}
 }
 

--- a/engine/classes/Elgg/Access/AccessState.php
+++ b/engine/classes/Elgg/Access/AccessState.php
@@ -1,0 +1,14 @@
+<?php
+namespace Elgg\Access;
+
+/**
+ * Snapshot of the current state of access control
+ */
+class AccessState {
+	public $ignored = false;
+	public $current_user_guid = 0;
+
+	public function __toString() {
+		return "{$this->current_user_guid}" . ($this->ignored ? 'i' : '');
+	}
+}

--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -491,7 +491,8 @@ class EntityTable {
 
 		if ($guids) {
 			// there were entities in the result set, preload metadata for them
-			_elgg_services()->metadataCache->populateFromEntities($guids);
+			$access = _elgg_services()->access->getState();
+			_elgg_services()->metadataCache->populateFromEntities($guids, $access);
 		}
 
 		if (count($results) > 1) {

--- a/engine/classes/Elgg/Database/MetadataTable.php
+++ b/engine/classes/Elgg/Database/MetadataTable.php
@@ -168,8 +168,9 @@ class MetadataTable {
 			if ($id !== false) {
 				$obj = $this->get($id);
 				if ($this->events->trigger('create', 'metadata', $obj)) {
-	
-					$this->cache->save($entity_guid, $name, $value, $allow_multiple);
+
+					$access = _elgg_services()->access->getState();
+					$this->cache->save($entity_guid, $name, $value, $allow_multiple, $access);
 	
 					return $id;
 				} else {
@@ -245,8 +246,9 @@ class MetadataTable {
 	
 		$result = $this->db->updateData($query);
 		if ($result !== false) {
-	
-			$this->cache->save($md->entity_guid, $name, $value);
+
+			$access_key = _elgg_services()->access->getState();
+			$this->cache->save($md->entity_guid, $name, $value, false, $access_key);
 	
 			// @todo this event tells you the metadata has been updated, but does not
 			// let you do anything about it. What is needed is a plugin hook before
@@ -348,7 +350,7 @@ class MetadataTable {
 	
 		// This moved last in case an object's constructor sets metadata. Currently the batch
 		// delete process has to create the entity to delete its metadata. See #5214
-		$this->cache->invalidateByOptions('delete', $options);
+		$this->cache->invalidateByOptions('delete', $options, _elgg_services()->access->getState());
 	
 		return $result;
 	}
@@ -366,7 +368,7 @@ class MetadataTable {
 			return false;
 		}
 	
-		$this->cache->invalidateByOptions('disable', $options);
+		$this->cache->invalidateByOptions('disable', $options, _elgg_services()->access->getState());
 	
 		// if we can see hidden (disabled) we need to use the offset
 		// otherwise we risk an infinite loop if there are more than 50
@@ -392,7 +394,7 @@ class MetadataTable {
 			return false;
 		}
 	
-		$this->cache->invalidateByOptions('enable', $options);
+		$this->cache->invalidateByOptions('enable', $options, _elgg_services()->access->getState());
 	
 		$options['metastring_type'] = 'metadata';
 		return _elgg_batch_metastring_based_objects($options, 'elgg_batch_enable_callback');

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -314,13 +314,15 @@ abstract class ElggEntity extends \ElggData implements
 		// upon first cache miss, just load/cache all the metadata and retry.
 		// if this works, the rest of this function may not be needed!
 		$cache = _elgg_services()->metadataCache;
-		if ($cache->isKnown($guid, $name)) {
-			return $cache->load($guid, $name);
+		$access = _elgg_services()->access->getState();
+
+		if ($cache->isKnown($guid, $name, $access)) {
+			return $cache->load($guid, $name, $access);
 		} else {
-			$cache->populateFromEntities(array($guid));
+			$cache->populateFromEntities(array($guid), $access);
 			// in case ignore_access was on, we have to check again...
-			if ($cache->isKnown($guid, $name)) {
-				return $cache->load($guid, $name);
+			if ($cache->isKnown($guid, $name, $access)) {
+				return $cache->load($guid, $name, $access);
 			}
 		}
 
@@ -341,7 +343,7 @@ abstract class ElggEntity extends \ElggData implements
 			$value = metadata_array_to_values($md);
 		}
 
-		$cache->save($guid, $name, $value);
+		$cache->save($guid, $name, $value, false, $access);
 
 		return $value;
 	}

--- a/engine/classes/ElggMetadata.php
+++ b/engine/classes/ElggMetadata.php
@@ -102,7 +102,8 @@ class ElggMetadata extends \ElggExtender {
 		if ($success) {
 			// we mark unknown here because this deletes only one value
 			// under this name, and there may be others remaining.
-			_elgg_services()->metadataCache->markUnknown($this->entity_guid, $this->name);
+			$access = _elgg_services()->access->getState();
+			_elgg_services()->metadataCache->markUnknown($this->entity_guid, $this->name, $access);
 		}
 		return $success;
 	}
@@ -118,7 +119,8 @@ class ElggMetadata extends \ElggExtender {
 		if ($success) {
 			// we mark unknown here because this disables only one value
 			// under this name, and there may be others remaining.
-			_elgg_services()->metadataCache->markUnknown($this->entity_guid, $this->name);
+			$access = _elgg_services()->access->getState();
+			_elgg_services()->metadataCache->markUnknown($this->entity_guid, $this->name, $access);
 		}
 		return $success;
 	}
@@ -132,7 +134,8 @@ class ElggMetadata extends \ElggExtender {
 	public function enable() {
 		$success = _elgg_set_metastring_based_object_enabled_by_id($this->id, 'yes', 'metadata');
 		if ($success) {
-			_elgg_services()->metadataCache->markUnknown($this->entity_guid, $this->name);
+			$access = _elgg_services()->access->getState();
+			_elgg_services()->metadataCache->markUnknown($this->entity_guid, $this->name, $access);
 		}
 		return $success;
 	}

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -72,7 +72,8 @@ function _elgg_invalidate_cache_for_entity($guid) {
 		// have caused a bunch of unnecessary purges at every shutdown. Doing it this way we have no way
 		// to know that the expunged entity will be GCed (might be another reference living), but that's
 		// OK; the metadata will reload if necessary.
-		_elgg_services()->metadataCache->clear($guid);
+		$access = _elgg_services()->access->getState();
+		_elgg_services()->metadataCache->clear($guid, $access);
 	}
 }
 

--- a/engine/lib/metadata.php
+++ b/engine/lib/metadata.php
@@ -385,20 +385,22 @@ function metadata_update($event, $object_type, $object) {
 function _elgg_invalidate_metadata_cache($action, array $options) {
 	// remove as little as possible, optimizing for common cases
 	$cache = _elgg_services()->metadataCache;
+	$access = _elgg_services()->access->getState();
+
 	if (empty($options['guid'])) {
 		// safest to clear everything unless we want to make this even more complex :(
 		$cache->flush();
 	} else {
 		if (empty($options['metadata_name'])) {
 			// safest to clear the whole entity
-			$cache->clear($options['guid']);
+			$cache->clear($options['guid'], $access);
 		} else {
 			switch ($action) {
 				case 'delete':
-					$cache->markEmpty($options['guid'], $options['metadata_name']);
+					$cache->markEmpty($options['guid'], $options['metadata_name'], $access);
 					break;
 				default:
-					$cache->markUnknown($options['guid'], $options['metadata_name']);
+					$cache->markUnknown($options['guid'], $options['metadata_name'], $access);
 			}
 		}
 	}

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -332,12 +332,14 @@ function login(\ElggUser $user, $persistent = false) {
 	// #5933: set logged in user early so code in login event will be able to
 	// use elgg_get_logged_in_user_entity().
 	$session->setLoggedInUser($user);
+	_elgg_services()->metadataCache->flush();
 
 	// deprecate event
 	$message = "The 'login' event was deprecated. Register for 'login:before' or 'login:after'";
 	$version = "1.9";
 	if (!elgg_trigger_deprecated_event('login', 'user', $user, $message, $version)) {
 		$session->removeLoggedInUser();
+		_elgg_services()->metadataCache->flush();
 		throw new \LoginException(elgg_echo('LoginException:Unknown'));
 	}
 
@@ -392,6 +394,7 @@ function logout() {
 	// pass along any messages into new session
 	$old_msg = $session->get('msg');
 	$session->invalidate();
+	_elgg_services()->metadataCache->flush();
 	$session->set('msg', $old_msg);
 
 	elgg_trigger_after_event('logout', 'user', $user);
@@ -420,16 +423,19 @@ function _elgg_session_boot() {
 		if (!$user) {
 			// OMG user has been deleted.
 			$session->invalidate();
+			_elgg_services()->metadataCache->flush();
 			forward('');
 		}
 
 		$session->setLoggedInUser($user);
+		_elgg_services()->metadataCache->flush();
 
 		_elgg_services()->persistentLogin->replaceLegacyToken($user);
 	} else {
 		$user = _elgg_services()->persistentLogin->bootSession();
 		if ($user) {
 			$session->setLoggedInUser($user);
+			_elgg_services()->metadataCache->flush();
 		}
 	}
 

--- a/engine/tests/ElggCoreMetadataAPITest.php
+++ b/engine/tests/ElggCoreMetadataAPITest.php
@@ -249,12 +249,12 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 
 		// ignore access bypasses the MD cache, so we try it both ways
 		elgg_set_ignore_access(false);
-		_elgg_services()->metadataCache->clear($obj->guid);
+		_elgg_services()->metadataCache->clear($obj->guid, _elgg_services()->access->getState());
 		$md_values = $obj->test_md;
 		$this->assertEqual($md_values, [1, 2, 3]);
 
 		elgg_set_ignore_access(true);
-		_elgg_services()->metadataCache->clear($obj->guid);
+		_elgg_services()->metadataCache->clear($obj->guid, _elgg_services()->access->getState());
 		$md_values = $obj->test_md;
 		$this->assertEqual($md_values, [1, 2, 3]);
 


### PR DESCRIPTION
Metadata access depends on the session user but we were not flushing the cache when that changed. This became apparent when #7665 started loading the user and site metadata before the user’s session was booted.
- [ ] tests
