### PR TITLE
fix(views): improved check on non existing array keys

### DIFF
--- a/views/default/output/tags.php
+++ b/views/default/output/tags.php
@@ -15,17 +15,18 @@ if (isset($vars['entity'])) {
 	unset($vars['entity']);
 }
 
-if (empty($vars['tags']) && (!empty($vars['value']) || $vars['value'] === 0 || $vars['value'] === '0')) {
-	$vars['tags'] = $vars['value'];
+$value = elgg_extract('value', $vars);
+unset($vars['value']);
+if (empty($vars['tags']) && (!empty($value) || $value === 0 || $value === '0')) {
+	$vars['tags'] = $value;
 }
 
-if (empty($vars['tags']) && $vars['value'] !== 0 && $vars['value'] !== '0') {
+if (empty($vars['tags']) && $value !== 0 && $value !== '0') {
 	return;
 }
 
 $tags = $vars['tags'];
 unset($vars['tags']);
-unset($vars['value']);
 
 if (!is_array($tags)) {
 	$tags = array($tags);

--- a/views/default/output/url.php
+++ b/views/default/output/url.php
@@ -17,11 +17,11 @@
  * 
  */
 
-if ($vars['confirm'] && !isset($vars['is_action'])) {
+if (!empty($vars['confirm']) && !isset($vars['is_action'])) {
 	$vars['is_action'] = true;
 }
 
-if ($vars['confirm']) {
+if (!empty($vars['confirm'])) {
 	$vars['data-confirm'] = elgg_extract('confirm', $vars, elgg_echo('question:areyousure'));
 	
 	// if (bool) true use defaults


### PR DESCRIPTION
This prevents your PHP errorlog from overflowing with warnings about
undefined indexes
