### PR TITLE
fix(js): correctly init datepicker when ajax loaded

### DIFF
--- a/views/default/input/date.php
+++ b/views/default/input/date.php
@@ -54,3 +54,7 @@ if (is_numeric($vars['value'])) {
 
 $attributes = elgg_format_attributes($vars);
 echo "<input type=\"text\" $attributes />";
+
+if (elgg_is_xhr()) {
+	echo elgg_format_element('script', null, 'elgg.ui.initDatePicker();');
+}


### PR DESCRIPTION
fixes #3850 

needed to do this with elgg_is_xhr and call the function, as currently this is bound to core js/lib/ui.js and thus cannot be deprecated to an amd module (very easily). I went for the easy fix.

There is no conflict if double init (normal init + ajaxed later)

rebased version of #7957
