### PR TITLE
Missing underscores in docs/guids/helpers.rst

### DIFF
--- a/docs/guides/helpers.rst
+++ b/docs/guides/helpers.rst
@@ -18,8 +18,8 @@ Entity methods
 Entity and context retrieval
 ----------------------------
 
-- ``elgg_get_loggedin_user_entity()`` Returns the ElggUser for the current user
-- ``elgg_get_loggedin_user_guid()`` Returns the GUID of the current user
+- ``elgg_get_logged_in_user_entity()`` Returns the ElggUser for the current user
+- ``elgg_get_logged_in_user_guid()`` Returns the GUID of the current user
 - ``elgg_is_logged_in()`` Is the viewer logged in
 - ``elgg_is_admin_logged_in()`` Is the view an admin and logged in
 - ``elgg_gatekeeper()`` Shorthand for checking if a user is logged in. Forwards user to front page if not

--- a/mod/groups/views/default/forms/groups/invite.php
+++ b/mod/groups/views/default/forms/groups/invite.php
@@ -8,7 +8,7 @@
 $group = $vars['entity'];
 $owner = $group->getOwnerEntity();
 $forward_url = $group->getURL();
-$friends = elgg_get_logged_in_user_entity()->getFriends('', 0);
+$friends = elgg_get_logged_in_user_entity()->getFriends();
 
 if ($friends) {
 	echo elgg_view('input/friendspicker', array('entities' => $friends, 'name' => 'user_guid', 'highlight' => 'all'));


### PR DESCRIPTION
Typos: 

elgg_get_loggedin_user_entity() Returns the ElggUser for the current user
elgg_get_loggedin_user_guid() Returns the GUID of the current user
