### PR TITLE
WIP perf(plugins): Adds plugin settings cache and optimized loading

### DIFF
--- a/engine/classes/Elgg/Cache/PluginSettingsCache.php
+++ b/engine/classes/Elgg/Cache/PluginSettingsCache.php
@@ -1,0 +1,168 @@
+<?php
+namespace Elgg\Cache;
+
+use Elgg\Database;
+
+/**
+ * In memory cache of (non-user-specific, non-internal) plugin settings
+ *
+ * @access private
+ */
+class PluginSettingsCache {
+
+	/**
+	 * The cached values.
+	 *
+	 * @var array GUID => string[]
+	 */
+	private $values = array();
+
+	/**
+	 * GUIDs of plugins for which we will later load settings
+	 *
+	 * @var int[]
+	 */
+	private $plugin_guids = array();
+
+	/**
+	 * @var Database
+	 */
+	private $db;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Database $db Elgg Database
+	 */
+	public function __construct(Database $db) {
+		$this->db = $db;
+	}
+
+	/**
+	 * Set the settings for a plugin in the cache
+	 *
+	 * Note this does NOT invalidate any other part of the cache.
+	 *
+	 * @param int   $entity_guid The GUID of the entity
+	 * @param array $values      The settings to cache
+	 * @return void
+	 *
+	 * @access private For testing only
+	 */
+	public function inject($entity_guid, array $values) {
+		$this->values[$entity_guid] = $values;
+	}
+
+	/**
+	 * Get all the non-user, non-internal settings for a plugin
+	 *
+	 * @param int $entity_guid The GUID of the entity
+	 *
+	 * @return null|string[] null if settings are not loaded for this entity
+	 */
+	public function getAll($entity_guid) {
+		$this->lazyLoad();
+		return isset($this->values[$entity_guid]) ? $this->values[$entity_guid] : null;
+	}
+
+	/**
+	 * Clear cache for an entity
+	 *
+	 * @param int $entity_guid The GUID of the entity
+	 * @return void
+	 */
+	public function clear($entity_guid) {
+		unset($this->values[$entity_guid]);
+	}
+
+	/**
+	 * Clear entire cache
+	 *
+	 * @return void
+	 */
+	public function clearAll() {
+		$this->values = [];
+		$this->plugin_guids = [];
+	}
+
+	/**
+	 * Populate the cache from a set of plugins
+	 *
+	 * @param int|array $guids Array of GUIDs
+	 * @return void
+	 */
+	public function populateFromPlugins(array $guids) {
+		$this->plugin_guids = $guids;
+	}
+
+	/**
+	 * Lazy-load settings
+	 *
+	 * @return void
+	 */
+	protected function lazyLoad() {
+		if (!$this->plugin_guids) {
+			return;
+		}
+
+		$guids = $this->getCacheableGuids($this->plugin_guids);
+
+		$db_prefix = $this->db->getTablePrefix();
+		$data = $this->db->getData("
+			SELECT entity_guid, `name`, `value`
+			FROM {$db_prefix}private_settings
+			WHERE entity_guid IN (" . implode(',', $guids) . ")
+			  AND name NOT LIKE 'plugin:user_setting:%'
+			  AND name NOT LIKE 'elgg:internal:%'
+			ORDER BY entity_guid
+		");
+
+		// make sure we show all entities as loaded
+		foreach ($guids as $guid) {
+			$this->values[$guid] = array();
+		}
+
+		foreach ($data as $i => $row) {
+			$this->values[$row->entity_guid][$row->name] = $row->value;
+		}
+
+		$this->plugin_guids = [];
+	}
+
+	/**
+	 * Filter a set of plugin GUIDs to those having less than a preset number of settings
+	 *
+	 * If a plugin has a lot of settings, we don't bother preloading them
+	 *
+	 * @param array $guids Plugin GUIDs
+	 * @param int   $limit Limit to number of settings
+	 *
+	 * @return int[]
+	 */
+	protected function getCacheableGuids(array $guids, $limit = 30) {
+		if (!$guids) {
+			return [];
+		}
+
+		$limit = (int)($limit);
+		$db_prefix = $this->db->getTablePrefix();
+
+		$sql = "
+			SELECT entity_guid
+			FROM {$db_prefix}private_settings
+			WHERE entity_guid IN (" . implode(',', $guids) . ")
+			  AND name NOT LIKE 'plugin:user_setting:%'
+			  AND name NOT LIKE 'elgg:internal:%'
+			GROUP BY entity_guid
+			HAVING COUNT(*) > $limit
+		";
+		$callback = function ($row) {
+			return (int)$row->entity_guid;
+		};
+
+		$unsuitable_guids = $this->db->getData($sql, $callback);
+		$guids = array_values($guids);
+
+		return array_diff($guids, $unsuitable_guids);
+	}
+}

--- a/engine/classes/Elgg/Database/Plugins.php
+++ b/engine/classes/Elgg/Database/Plugins.php
@@ -2,6 +2,8 @@
 namespace Elgg\Database;
 
 use Exception;
+use Elgg\Cache\Pool;
+use Elgg\Cache\PluginSettingsCache;
 
 /**
  * @var array cache used by elgg_get_plugins_provides function
@@ -24,28 +26,34 @@ global $ELGG_PLUGINS_PROVIDES_CACHE;
 class Plugins {
 
 	/**
-	 * @var string[] Active plugin IDs with IDs as the array keys. Missing keys imply inactive plugins.
+	 * @var string[] Active plugins, with plugin ID => GUID. Missing keys imply inactive plugins.
 	 */
-	protected $active_ids = array();
+	private $active_guids = array();
 
 	/**
-	 * @var bool Has $active_ids been populated?
+	 * @var bool Has $active_guids been populated?
 	 */
-	protected $active_ids_known = false;
+	private $active_guids_known = false;
 
 	/**
-	 * @var \Elgg\Cache\MemoryPool
+	 * @var Pool
 	 */
-	protected $plugins_by_id;
+	private $plugins_by_id;
+
+	/**
+	 * @var PluginSettingsCache
+	 */
+	private $settings_cache;
 
 	/**
 	 * Constructor
 	 *
-	 * @param \Elgg\EventsService    $events Events service
-	 * @param \Elgg\Cache\MemoryPool $pool   Cache for referencing plugins by ID
+	 * @param Pool                $pool           Cache for referencing plugins by ID
+	 * @param PluginSettingsCache $settings_cache Plugin settings cache
 	 */
-	public function __construct(\Elgg\EventsService $events, \Elgg\Cache\MemoryPool $pool) {
+	public function __construct(Pool $pool, PluginSettingsCache $settings_cache) {
 		$this->plugins_by_id = $pool;
+		$this->settings_cache = $settings_cache;
 	}
 
 	/**
@@ -275,9 +283,9 @@ class Plugins {
 	function isActive($plugin_id, $site_guid = null) {
 		$current_site_guid = elgg_get_site_entity()->guid;
 
-		if ($this->active_ids_known
+		if ($this->active_guids_known
 				&& ($site_guid === null || $site_guid == $current_site_guid)) {
-			return isset($this->active_ids[$plugin_id]);
+			return isset($this->active_guids[$plugin_id]);
 		}
 
 		if ($site_guid) {
@@ -335,28 +343,38 @@ class Plugins {
 		if (elgg_get_config('i18n_loaded_from_cache')) {
 			$start_flags = $start_flags & ~ELGG_PLUGIN_REGISTER_LANGUAGES;
 		}
-	
-		$return = true;
+
 		$plugins = $this->find('active');
-		if ($plugins) {
-			foreach ($plugins as $plugin) {
-				$id = $plugin->getID();
-				try {
-					$plugin->start($start_flags);
-					$this->active_ids[$id] = true;
-				} catch (Exception $e) {
-					$plugin->deactivate();
-					$msg = _elgg_services()->translator->translate('PluginException:CannotStart',
-									array($id, $plugin->guid, $e->getMessage()));
-					elgg_add_admin_notice("cannot_start $id", $msg);
-					$return = false;
-	
-					continue;
-				}
+		if (!$plugins) {
+			$this->active_guids_known = true;
+			return true;
+		}
+
+		// preload settings early because some plugins call them early
+		$guids = [];
+		foreach ($plugins as $plugin) {
+			$guids[] = $plugin->guid;
+		}
+		$this->settings_cache->populateFromPlugins($guids);
+
+		$return = true;
+		foreach ($plugins as $plugin) {
+			$id = $plugin->getID();
+			try {
+				$plugin->start($start_flags);
+				$this->active_guids[$id] = $plugin->guid;
+			} catch (Exception $e) {
+				$plugin->deactivate();
+				$msg = _elgg_services()->translator->translate('PluginException:CannotStart',
+								array($id, $plugin->guid, $e->getMessage()));
+				elgg_add_admin_notice("cannot_start $id", $msg);
+				$return = false;
+
+				continue;
 			}
 		}
 
-		$this->active_ids_known = true;
+		$this->active_guids_known = true;
 		return $return;
 	}
 	
@@ -609,8 +627,8 @@ class Plugins {
 	 * @access private
 	 */
 	public function invalidateIsActiveCache() {
-		$this->active_ids = array();
-		$this->active_ids_known = false;
+		$this->active_guids = array();
+		$this->active_guids_known = false;
 	}
 	
 	/**

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -40,6 +40,7 @@ use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
  * @property-read \Elgg\PasswordService                    $passwords
  * @property-read \Elgg\PersistentLoginService             $persistentLogin
  * @property-read \Elgg\Database\Plugins                   $plugins
+ * @property-read \Elgg\Cache\PluginSettingsCache          $pluginSettingsCache
  * @property-read \Elgg\Database\QueryCounter              $queryCounter
  * @property-read \Elgg\Http\Request                       $request
  * @property-read \Elgg\Database\RelationshipsTable        $relationshipsTable
@@ -182,7 +183,12 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		});
 
 		$this->setFactory('plugins', function(ServiceProvider $c) {
-			return new \Elgg\Database\Plugins($c->events, new \Elgg\Cache\MemoryPool());
+			$pool = new \Elgg\Cache\MemoryPool();
+			return new \Elgg\Database\Plugins($pool, $c->pluginSettingsCache);
+		});
+
+		$this->setFactory('pluginSettingsCache', function (ServiceProvider $c) {
+			return new \Elgg\Cache\PluginSettingsCache($c->db);
 		});
 
 		$this->setFactory('queryCounter', function(ServiceProvider $c) {

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -275,6 +275,11 @@ class ElggPlugin extends \ElggObject {
 	 * @return mixed
 	 */
 	public function getSetting($name, $default = null) {
+		$values = _elgg_services()->pluginSettingsCache->getAll($this->guid);
+		if ($values !== null) {
+			return isset($values[$name]) ? $values[$name] : null;
+		}
+
 		$val = $this->$name;
 		return $val !== null ? $val : $default;
 	}
@@ -289,6 +294,11 @@ class ElggPlugin extends \ElggObject {
 	public function getAllSettings() {
 		if (!$this->guid) {
 			return false;
+		}
+
+		$values = _elgg_services()->pluginSettingsCache->getAll($this->guid);
+		if ($values !== null) {
+			return $values;
 		}
 
 		$db_prefix = _elgg_services()->config->get('dbprefix');
@@ -361,6 +371,8 @@ class ElggPlugin extends \ElggObject {
 	 * @return bool
 	 */
 	public function unsetAllSettings() {
+		_elgg_services()->pluginSettingsCache->clear($this->guid);
+
 		$db_prefix = _elgg_services()->configTable->get('dbprefix');
 		$us_prefix = _elgg_namespace_plugin_private_setting('user_setting', '', $this->getID());
 		$is_prefix = _elgg_namespace_plugin_private_setting('internal', '', $this->getID());

--- a/engine/lib/private_settings.php
+++ b/engine/lib/private_settings.php
@@ -342,6 +342,8 @@ function get_all_private_settings($entity_guid) {
 function set_private_setting($entity_guid, $name, $value) {
 	global $CONFIG;
 
+	_elgg_services()->pluginSettingsCache->clear($entity_guid);
+
 	$entity_guid = (int) $entity_guid;
 	$name = sanitise_string($name);
 	$value = sanitise_string($value);
@@ -368,6 +370,8 @@ function set_private_setting($entity_guid, $name, $value) {
  */
 function remove_private_setting($entity_guid, $name) {
 	global $CONFIG;
+
+	_elgg_services()->pluginSettingsCache->clear($entity_guid);
 
 	$entity_guid = (int) $entity_guid;
 
@@ -396,6 +400,8 @@ function remove_private_setting($entity_guid, $name) {
  */
 function remove_all_private_settings($entity_guid) {
 	global $CONFIG;
+
+	_elgg_services()->pluginSettingsCache->clear($entity_guid);
 
 	$entity_guid = (int) $entity_guid;
 

--- a/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
+++ b/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
@@ -38,6 +38,7 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
 			'metastringsTable' => '\Elgg\Database\MetastringsTable',
 			'passwords' => '\Elgg\PasswordService',
 			'plugins' => '\Elgg\Database\Plugins',
+			'pluginSettingsCache' => '\Elgg\Cache\PluginSettingsCache',
 			'request' => '\Elgg\Http\Request',
 			'relationshipsTable' => '\Elgg\Database\RelationshipsTable',
 			'router' => '\Elgg\Router',


### PR DESCRIPTION
This caches non-user/non-internal plugin settings and lazily loads all settings in a couple queries when the first one is requested. Many bundled plugins don’t use settings on every request so this avoids the overhead on those requests.
- [ ] write tests
