### PR TITLE
fix(core): don't trigger delete event when you can't edit the entity

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1987,14 +1987,19 @@ abstract class ElggEntity extends \ElggData implements
 			return false;
 		}
 		
-		if (!_elgg_services()->events->trigger('delete', $this->type, $this)) {
-			return false;
-		}
-		
+		// first check if we have edit access to this entity
+		// NOTE: in Elgg <= 1.10.3 this was after the delete event, 
+		// which could potentially remove some content if the user didn't have access
 		if (!$this->canEdit()) {
 			return false;
 		}
 
+		// now trigger an event to let others know this entity is about to be deleted
+		// so they can prevent it or take their own actions
+		if (!_elgg_services()->events->trigger('delete', $this->type, $this)) {
+			return false;
+		}
+		
 		_elgg_invalidate_cache_for_entity($guid);
 		
 		// If memcache is available then delete this entry from the cache


### PR DESCRIPTION
No longer first trigger the delete event and then check if you canEdit()
the entity. This could cause data to be lost.

example use case:
$group->delete();
the groups plugin listens to this event and removes the group_acl
but if ->canEdit() results in false the access collection is removed but the group still exists, meaning nobody can access any content shared with the group
