### PR TITLE
fix(upgrade): reset system cache before upgrade

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -94,6 +94,9 @@ if (get_input('upgrade') == 'upgrade') {
 		'forward' => $forward_url
 	);
 
+	// reset cache to have latest translations available during upgrade
+	elgg_reset_system_cache();
+	
 	echo elgg_view_page(elgg_echo('upgrading'), '', 'upgrade', $vars);
 	exit;
 }


### PR DESCRIPTION
This allows to be able to use new language keys during upgrade.

Fixes #6249
