### PR TITLE
feature(db): remove access collection (membership) when an entity is removed

### DIFF
--- a/engine/classes/Elgg/Database/AccessCollections.php
+++ b/engine/classes/Elgg/Database/AccessCollections.php
@@ -707,7 +707,7 @@ class AccessCollections {
 	 *
 	 * @return array|false
 	 */
-	function getUserCollections($owner_guid, $site_guid = 0) {
+	function getEntityCollections($owner_guid, $site_guid = 0) {
 		$owner_guid = (int) $owner_guid;
 		$site_guid = (int) $site_guid;
 	
@@ -761,5 +761,35 @@ class AccessCollections {
 		}
 	
 		return $collection_members;
-	}	
+	}
+	
+	/**
+	 * Return an array of database row objects of the access collections $entity_guid is a member of.
+	 * 
+	 * @param int $member_guid The entity guid
+	 * @param int $site_guid   The GUID of the site (default: current site).
+	 * 
+	 * @return array|false
+	 */
+	function getCollectionsByMember($member_guid, $site_guid = 0) {
+		$member_guid = (int) $member_guid;
+		$site_guid = (int) $site_guid;
+		
+		if (($site_guid == 0) && $this->site_guid) {
+			$site_guid = $this->site_guid;
+		}
+		
+		$db = _elgg_services()->db;
+		$prefix = $db->getTablePrefix();
+		
+		$query = "SELECT ac.* FROM {$prefix}access_collections ac
+				JOIN {$prefix}access_collection_membership m ON ac.id = m.access_collection_id
+				WHERE m.user_guid = {$member_guid}
+				AND ac.site_guid = {$site_guid}
+				ORDER BY name ASC";
+		
+		$collections = $db->getData($query);
+		
+		return $collections;
+	}
 }

--- a/engine/lib/access.php
+++ b/engine/lib/access.php
@@ -403,7 +403,7 @@ function remove_user_from_access_collection($user_guid, $collection_id) {
  * @see get_members_of_access_collection()
  */
 function get_user_access_collections($owner_guid, $site_guid = 0) {
-	return _elgg_services()->accessCollections->getUserCollections($owner_guid, $site_guid);
+	return _elgg_services()->accessCollections->getEntityCollections($owner_guid, $site_guid);
 }
 
 /**

--- a/engine/tests/ElggCoreAccessCollectionsTest.php
+++ b/engine/tests/ElggCoreAccessCollectionsTest.php
@@ -271,4 +271,26 @@ class ElggCoreAccessCollectionsTest extends \ElggCoreUnitTest {
 
 		$user->delete();
 	}
+	
+	public function testAddMemberToACLRemoveMember() {
+		// create a new user to check against
+		$user = new \ElggUser();
+		$user->username = 'access_test_user';
+		$user->save();
+		
+		$acl_id = create_access_collection('test acl');
+
+		$result = add_user_to_access_collection($user->guid, $acl_id);
+		$this->assertTrue($result);
+
+		if ($result) {
+			$this->assertTrue($user->delete());
+			
+			// since there are no more members this should return false
+			$acl_members = get_members_of_access_collection($acl_id, true);
+			$this->assertFalse($acl_members);
+		}
+
+		delete_access_collection($acl_id);
+	}
 }

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -94,9 +94,6 @@ function groups_init() {
 	// Register a handler for create groups
 	elgg_register_event_handler('create', 'group', 'groups_create_event_listener');
 
-	// Register a handler for delete groups
-	elgg_register_event_handler('delete', 'group', 'groups_delete_event_listener');
-	
 	elgg_register_event_handler('join', 'group', 'groups_user_join_event_listener');
 	elgg_register_event_handler('leave', 'group', 'groups_user_leave_event_listener');
 	elgg_register_event_handler('pagesetup', 'system', 'groups_setup_sidebar_menus');
@@ -573,15 +570,6 @@ function groups_write_acl_plugin_hook($hook, $entity_type, $returnvalue, $params
 	}
 
 	return $returnvalue;
-}
-
-/**
- * Groups deleted, so remove access lists.
- */
-function groups_delete_event_listener($event, $object_type, $object) {
-	delete_access_collection($object->group_acl);
-
-	return true;
 }
 
 /**


### PR DESCRIPTION
Cleanup the access collections and access collection memberships if an
entity is removed from the database. This prevents database overhead.

fixes #5557
- [x] add tests
