### PR TITLE
fix(views): always add the user guid param to the usersettings/save form

### DIFF
--- a/views/default/core/settings/account/name.php
+++ b/views/default/core/settings/account/name.php
@@ -17,5 +17,6 @@ if ($user) {
 	echo elgg_view_module('info', $title, $content);
 
 	// need the user's guid to make sure the correct user gets updated
+	// TODO: remove the hidden input in 2.0. See #8001
 	echo elgg_view('input/hidden', array('name' => 'guid', 'value' => $user->guid));
 }

--- a/views/default/forms/usersettings/save.php
+++ b/views/default/forms/usersettings/save.php
@@ -5,10 +5,18 @@
  * Plugins should extend "forms/account/settings" to add to the settings.
  */
 
-$form_body = elgg_view("forms/account/settings", $vars);
+$user = elgg_get_page_owner_entity();
 
-$form_body .= '<div class="elgg-foot">';
-$form_body .= elgg_view('input/submit', array('value' => elgg_echo('save')));
-$form_body .= '</div>';
+$form_body = elgg_view('forms/account/settings', $vars);
+
+$submit = elgg_view('input/submit', ['value' => elgg_echo('save')]);
+$hidden = '';
+
+if ($user) {
+	// we need to include the user GUID so that admins can edit the settings of other users
+	$hidden = elgg_view('input/hidden', ['name' => 'guid', 'value' => $user->guid]);
+}
+
+$form_body .= elgg_format_element('div', ['class' => 'elgg-foot'], $submit . $hidden);
 
 echo $form_body;


### PR DESCRIPTION
This fixes the issue where you can not change the password (of other users) if you unextend the `settings/account/name` view which was the only view that had the guid param available when submitting the form. This fix adds it to the default of the usersettings/save form, so it is always available.

Unfortunately i can not remove it from the `core/settings/account/name` view for BC reasons, so there now is a dupe param in the form, but that is not a problem.
