### PR TITLE
chore(core): do not use deprecated methods in ElggEntity

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -2148,8 +2148,8 @@ abstract class ElggEntity extends \ElggData implements
 	 * @todo Unimplemented
 	 */
 	public function setLatLong($lat, $long) {
-		$this->set('geo:lat', $lat);
-		$this->set('geo:long', $long);
+		$this->{"geo:lat"} = $lat;
+		$this->{"geo:long"} = $long;
 	}
 
 	/**
@@ -2159,7 +2159,7 @@ abstract class ElggEntity extends \ElggData implements
 	 * @todo Unimplemented
 	 */
 	public function getLatitude() {
-		return (float)$this->get('geo:lat');
+		return (float)$this->{"geo:lat"};
 	}
 
 	/**
@@ -2169,7 +2169,7 @@ abstract class ElggEntity extends \ElggData implements
 	 * @todo Unimplemented
 	 */
 	public function getLongitude() {
-		return (float)$this->get('geo:long');
+		return (float)$this->{"geo:long"};
 	}
 
 	/*

--- a/engine/tests/phpunit/ElggEntityTest.php
+++ b/engine/tests/phpunit/ElggEntityTest.php
@@ -141,4 +141,16 @@ class ElggEntityTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals($keys, $object_keys);
 	}
+
+	public function testLatLong() {
+
+		// Coordinates for Elgg, Switzerland
+		$lat = 47.483333;
+		$long = 8.866667;
+
+		$this->obj->setLatLong($lat, $long);
+
+		$this->assertEquals($this->obj->getLatitude(), $lat);
+		$this->assertEquals($this->obj->getLongitude(), $long);
+	}
 }


### PR DESCRIPTION
Uses metadata assignment instead of ->set() and ->get() methods for latitude
and longitude methods
