### PR TITLE
chore(i18n): Move 2.0 to its own Transifex project

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,253 +1,253 @@
 [main]
 host = https://www.transifex.com
 
-[elgg-core.engine]
+[elgg-core-2.engine]
 file_filter = languages/<lang>.php
 source_file = languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.install]
+[elgg-core-2.install]
 file_filter = install/languages/<lang>.php
 source_file = install/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.blog]
+[elgg-core-2.blog]
 file_filter = mod/blog/languages/<lang>.php
 source_file = mod/blog/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.bookmarks]
+[elgg-core-2.bookmarks]
 file_filter = mod/bookmarks/languages/<lang>.php
 source_file = mod/bookmarks/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.categories]
+[elgg-core-2.categories]
 file_filter = mod/categories/languages/<lang>.php
 source_file = mod/categories/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.ckeditor]
+[elgg-core-2.ckeditor]
 file_filter = mod/ckeditor/languages/<lang>.php
 source_file = mod/ckeditor/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.custom_index]
+[elgg-core-2.custom_index]
 file_filter = mod/custom_index/languages/<lang>.php
 source_file = mod/custom_index/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.developers]
+[elgg-core-2.developers]
 file_filter = mod/developers/languages/<lang>.php
 source_file = mod/developers/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.diagnostics]
+[elgg-core-2.diagnostics]
 file_filter = mod/diagnostics/languages/<lang>.php
 source_file = mod/diagnostics/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.embed]
+[elgg-core-2.embed]
 file_filter = mod/embed/languages/<lang>.php
 source_file = mod/embed/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.externalpages]
+[elgg-core-2.externalpages]
 file_filter = mod/externalpages/languages/<lang>.php
 source_file = mod/externalpages/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.file]
+[elgg-core-2.file]
 file_filter = mod/file/languages/<lang>.php
 source_file = mod/file/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.garbagecollector]
+[elgg-core-2.garbagecollector]
 file_filter = mod/garbagecollector/languages/<lang>.php
 source_file = mod/garbagecollector/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.groups]
+[elgg-core-2.groups]
 file_filter = mod/groups/languages/<lang>.php
 source_file = mod/groups/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.invitefriends]
+[elgg-core-2.invitefriends]
 file_filter = mod/invitefriends/languages/<lang>.php
 source_file = mod/invitefriends/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.legacy_urls]
+[elgg-core-2.legacy_urls]
 file_filter = mod/legacy_urls/languages/<lang>.php
 source_file = mod/legacy_urls/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.likes]
+[elgg-core-2.likes]
 file_filter = mod/likes/languages/<lang>.php
 source_file = mod/likes/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.logbrowser]
+[elgg-core-2.logbrowser]
 file_filter = mod/logbrowser/languages/<lang>.php
 source_file = mod/logbrowser/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.logrotate]
+[elgg-core-2.logrotate]
 file_filter = mod/logrotate/languages/<lang>.php
 source_file = mod/logrotate/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.members]
+[elgg-core-2.members]
 file_filter = mod/members/languages/<lang>.php
 source_file = mod/members/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.messageboard]
+[elgg-core-2.messageboard]
 file_filter = mod/messageboard/languages/<lang>.php
 source_file = mod/messageboard/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.messages]
+[elgg-core-2.messages]
 file_filter = mod/messages/languages/<lang>.php
 source_file = mod/messages/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.notifications]
+[elgg-core-2.notifications]
 file_filter = mod/notifications/languages/<lang>.php
 source_file = mod/notifications/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.pages]
+[elgg-core-2.pages]
 file_filter = mod/pages/languages/<lang>.php
 source_file = mod/pages/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.profile]
+[elgg-core-2.profile]
 file_filter = mod/profile/languages/<lang>.php
 source_file = mod/profile/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.reportedcontent]
+[elgg-core-2.reportedcontent]
 file_filter = mod/reportedcontent/languages/<lang>.php
 source_file = mod/reportedcontent/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.search]
+[elgg-core-2.search]
 file_filter = mod/search/languages/<lang>.php
 source_file = mod/search/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.site_notifications]
+[elgg-core-2.site_notifications]
 file_filter = mod/site_notifications/languages/<lang>.php
 source_file = mod/web_services/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.tagcloud]
+[elgg-core-2.tagcloud]
 file_filter = mod/tagcloud/languages/<lang>.php
 source_file = mod/tagcloud/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.thewire]
+[elgg-core-2.thewire]
 file_filter = mod/thewire/languages/<lang>.php
 source_file = mod/thewire/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.twitter_api]
+[elgg-core-2.twitter_api]
 file_filter = mod/twitter_api/languages/<lang>.php
 source_file = mod/twitter_api/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.uservalidationbyemail]
+[elgg-core-2.uservalidationbyemail]
 file_filter = mod/uservalidationbyemail/languages/<lang>.php
 source_file = mod/uservalidationbyemail/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.web_services]
+[elgg-core-2.web_services]
 file_filter = mod/web_services/languages/<lang>.php
 source_file = mod/web_services/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core.docs-design]
+[elgg-core-2.docs-design]
 file_filter = docs/locale/<lang>/LC_MESSAGES/design.po
 source_file = docs/locale/pot/design.pot
 source_lang = en
 type = PO
 
-[elgg-core.docs-tutorials]
+[elgg-core-2.docs-tutorials]
 file_filter = docs/locale/<lang>/LC_MESSAGES/tutorials.po
 source_file = docs/locale/pot/tutorials.pot
 source_lang = en
 type = PO
 
-[elgg-core.docs-about]
+[elgg-core-2.docs-about]
 file_filter = docs/locale/<lang>/LC_MESSAGES/about.po
 source_file = docs/locale/pot/about.pot
 source_lang = en
 type = PO
 
-[elgg-core.docs-index]
+[elgg-core-2.docs-index]
 file_filter = docs/locale/<lang>/LC_MESSAGES/index.po
 source_file = docs/locale/pot/index.pot
 source_lang = en
 type = PO
 
-[elgg-core.docs-admin]
+[elgg-core-2.docs-admin]
 file_filter = docs/locale/<lang>/LC_MESSAGES/admin.po
 source_file = docs/locale/pot/admin.pot
 source_lang = en
 type = PO
 
-[elgg-core.docs-contribute]
+[elgg-core-2.docs-contribute]
 file_filter = docs/locale/<lang>/LC_MESSAGES/contribute.po
 source_file = docs/locale/pot/contribute.pot
 source_lang = en
 type = PO
 
-[elgg-core.docs-appendix]
+[elgg-core-2.docs-appendix]
 file_filter = docs/locale/<lang>/LC_MESSAGES/appendix.po
 source_file = docs/locale/pot/appendix.pot
 source_lang = en
 type = PO
 
-[elgg-core.docs-intro]
+[elgg-core-2.docs-intro]
 file_filter = docs/locale/<lang>/LC_MESSAGES/intro.po
 source_file = docs/locale/pot/intro.pot
 source_lang = en
 type = PO
 
-[elgg-core.docs-guides]
+[elgg-core-2.docs-guides]
 file_filter = docs/locale/<lang>/LC_MESSAGES/guides.po
 source_file = docs/locale/pot/guides.pot
 source_lang = en


### PR DESCRIPTION
We need to do this since there will be backwards incompatible changes to language strings in 2.0 most likely and there is no way to keep Transifex from syncing those changes back to 1.x without creating a new project.
