### PR TITLE
Prevent empty strings as metastring values

### DIFF
--- a/engine/classes/Elgg/Database/MetadataTable.php
+++ b/engine/classes/Elgg/Database/MetadataTable.php
@@ -120,7 +120,8 @@ class MetadataTable {
 		$owner_guid = (int)$owner_guid;
 		$allow_multiple = (boolean)$allow_multiple;
 
-		if (!isset($value)) {
+		// Prevent metadata with empty values (0 is allowed), see #4858
+		if (!isset($value) || $value === '') {
 			return false;
 		}
 


### PR DESCRIPTION
Empty string values cause e.g. group profile fields to show up on the profile page regardless if anything has actually been entered to the fields.

In e1eedeae6a43a5f040402a4ba2c09146877a2672 this was fixed for the user profile save action:

``` php
if (!is_null($value) && ($value !== '')) {
    // only create metadata for non empty values (0 is allowed) to prevent metadata records
    // with empty string values #4858

    ...
}

```

I was about to do the same for groups, but decided to do it in core instead. After all there aren't _any_ entities that have the need for empty strings as metadata value. Right?

P.S. Damn there's still a lot of random trailing whitespace around
