### PR TITLE
chore(php): Remove PHP 7 support for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ php:
  - 5.4
  - 5.5
  - 5.6
- - 7.0
 
 branches:
   except:

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "type": "project",
     "require": {
-        "php": "~5.4 | ~7.0",
+        "php": "~5.4",
         "ext-mysql": "*",
         "ext-gd": "*",
         "ext-json": "*",


### PR DESCRIPTION
Breaking changes are happening too fast and causing us overhead.
We will need to modernize Elgg's core and then we can turn it back on.
