### PR TITLE
fix(groups): respect previous modifications to the write access in group context

### DIFF
--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -496,34 +496,41 @@ function groups_create_event_listener($event, $object_type, $object) {
  * Return the write access for the current group if the user has write access to it.
  */
 function groups_write_acl_plugin_hook($hook, $entity_type, $returnvalue, $params) {
-	$page_owner = elgg_get_page_owner_entity();
-	$user_guid = $params['user_id'];
+	
+	$user_guid = sanitise_int(elgg_extract('user_id', $params), false);
 	$user = get_user($user_guid);
-	if (!$user) {
+	if (empty($user)) {
 		return $returnvalue;
 	}
-
-	// only insert group access for current group
-	if ($page_owner instanceof ElggGroup) {
-		if ($page_owner->canWriteToContainer($user_guid)) {
-			if ($page_owner->getContentAccessMode() == ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY) {
-				// Due to group policy allow only the owner or all group members
-				$returnvalue = array(
-					ACCESS_PRIVATE => elgg_echo('PRIVATE'),
-					$page_owner->group_acl => elgg_echo('groups:acl', array($page_owner->name)),
-				);
-			} else {
-				// Leave out other groups, friends and friend collections
-				$returnvalue = array(
-					ACCESS_PRIVATE => elgg_echo('PRIVATE'),
-					ACCESS_LOGGED_IN => elgg_echo('LOGGED_IN'),
-					ACCESS_PUBLIC => elgg_echo('PUBLIC'),
-					$page_owner->group_acl => elgg_echo('groups:acl', array($page_owner->name)),
-				);
-			}
+	
+	$page_owner = elgg_get_page_owner_entity();
+	if (!($page_owner instanceof ElggGroup)) {
+		return $returnvalue;
+	}
+	
+	if (!$page_owner->canWriteToContainer($user_guid)) {
+		return $returnvalue;
+	}
+	
+	// check group content access rules
+	$allowed_access = array(
+		ACCESS_PRIVATE
+	);
+	
+	if ($page_owner->getContentAccessMode() !== ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY) {
+		$allowed_access[] = ACCESS_LOGGED_IN;
+		$allowed_access[] = ACCESS_PUBLIC;
+	}
+	
+	foreach ($returnvalue as $access_id => $access_string) {
+		if (!in_array($access_id, $allowed_access)) {
+			unset($returnvalue[$access_id]);
 		}
 	}
-
+	
+	// add write access to the group
+	$returnvalue[$page_owner->group_acl] = elgg_echo('groups:acl', array($page_owner->name));
+	
 	return $returnvalue;
 }
 


### PR DESCRIPTION
Remove all access write options based on the group content access level.
This will respect other plugins which have already removed access
options.

fixes #8002
