### PR TITLE
fix(comments): keep comment access_id in sync with container

### DIFF
--- a/actions/admin/upgrades/upgrade_comments_access.php
+++ b/actions/admin/upgrades/upgrade_comments_access.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Convert comment annotations to entities
+ * 
+ * Run for 2 seconds per request as set by $batch_run_time_in_secs. This includes
+ * the engine loading time.
+ */
+// from engine/start.php
+global $START_MICROTIME;
+$batch_run_time_in_secs = 2;
+
+// if upgrade has run correctly, mark it done
+if (get_input('upgrade_completed')) {
+	// set the upgrade as completed
+	$factory = new ElggUpgrade();
+	$upgrade = $factory->getUpgradeFromPath('admin/upgrades/commentaccess');
+	if ($upgrade instanceof ElggUpgrade) {
+		$upgrade->setCompleted();
+	}
+
+	return true;
+}
+
+// Offset is the total amount of errors so far. We skip these
+// comments to prevent them from possibly repeating the same error.
+$offset = get_input('offset', 0);
+$limit = 50;
+
+$access_status = access_get_show_hidden_status();
+access_show_hidden_entities(true);
+
+$success_count = 0;
+$error_count = 0;
+
+do {
+	$dbprefix = elgg_get_config('dbprefix');
+	$options = array(
+		'type' => 'object',
+		'subtype' => 'comment',
+		'joins' => array(
+			"JOIN {$dbprefix}entities e2 ON e.container_guid = e2.guid"
+		),
+		'wheres' => array(
+			"e.access_id != e2.access_id"
+		),
+		'offset' => $offset,
+		'limit' => $limit,
+		'preload_containers' => true
+	);
+			
+	$comments = elgg_get_entities($options);
+	
+	foreach ($comments as $comment) {
+		$container = $comment->getContainerEntity();
+		
+		if (!$container) {
+			$error_count++;
+			continue;
+		}		
+		
+		$comment->access_id = $container->access_id;
+		
+		if ($comment->save()) {
+			$success_count++;
+		} else {
+			$error_count++;
+		}
+	}
+	
+} while ((microtime(true) - $START_MICROTIME) < $batch_run_time_in_secs);
+
+access_show_hidden_entities($access_status);
+
+// Give some feedback for the UI
+echo json_encode(array(
+	'numSuccess' => $success_count,
+	'numErrors' => $error_count,
+));

--- a/docs/guides/events-list.rst
+++ b/docs/guides/events-list.rst
@@ -116,7 +116,10 @@ Entity events
     Triggered for user, group, object, and site entities after creation. Return false to delete entity.
 
 **update, <entity type>**
-	Triggered before an update for the user, group, object, and site entities. Return false to prevent update.
+    Triggered before an update for the user, group, object, and site entities. Return false to prevent update.
+
+**update:after, <entity type>**
+    Triggered after an update for the user, group, object, and site entities.
 
 **delete, <entity type>**
     Triggered before entity deletion. Return false to prevent deletion.

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1686,6 +1686,7 @@ abstract class ElggEntity extends \ElggData implements
 		unset($persisted_entity);
 
 		if ($allow_edit) {
+			// give old update event a chance to stop the update
 			$allow_edit = _elgg_services()->events->trigger('update', $this->type, $this);
 		}
 
@@ -1711,6 +1712,8 @@ abstract class ElggEntity extends \ElggData implements
 			set owner_guid='$owner_guid', access_id='$access_id',
 			container_guid='$container_guid', time_created='$time_created',
 			time_updated='$time' WHERE guid=$guid");
+		
+		elgg_trigger_after_event('update', $this->type, $this);
 
 		// TODO(evan): Move this to \ElggObject?
 		if ($this instanceof \ElggObject) {

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -231,6 +231,7 @@ function _elgg_admin_init() {
 	elgg_register_action('admin/upgrades/upgrade_comments', '', 'admin');
 	elgg_register_action('admin/upgrades/upgrade_datadirs', '', 'admin');
 	elgg_register_action('admin/upgrades/upgrade_discussion_replies', '', 'admin');
+	elgg_register_action('admin/upgrades/upgrade_comments_access', '', 'admin');
 	elgg_register_action('admin/site/regenerate_secret', '', 'admin');
 
 	elgg_register_action('admin/menu/save', '', 'admin');

--- a/engine/lib/upgrades/2015031300-1.11.0_dev-comment-access-sync-50c9764e5845315c.php
+++ b/engine/lib/upgrades/2015031300-1.11.0_dev-comment-access-sync-50c9764e5845315c.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Elgg 1.11.0-dev upgrade 2015031300
+ * comment-access-sync
+ *
+ * Synchronize comment access_id with the container access_id
+ */
+
+$access_status = access_get_show_hidden_status();
+access_show_hidden_entities(true);
+$ia = elgg_set_ignore_access(true);
+
+// there may be many instances in large databases
+// add \ElggUpgrade object if need to update comments
+$dbprefix = elgg_get_config('dbprefix');
+$options = array(
+	'type' => 'object',
+	'subtype' => 'comment',
+	'joins' => array(
+		"JOIN {$dbprefix}entities e2 ON e.container_guid = e2.guid"
+	),
+	'wheres' => array(
+		"e.access_id != e2.access_id"
+	),
+	'count' => true
+);
+
+if (elgg_get_entities($options)) {
+	$path = "admin/upgrades/commentaccess";
+	$upgrade = new \ElggUpgrade();
+
+	// Create the upgrade if one with the same URL doesn't already exist
+	if (!$upgrade->getUpgradeFromPath($path)) {
+		$upgrade->setPath($path);
+		$upgrade->title = 'Comments Access Upgrade';
+		$upgrade->description = 'Some comments on this system have different access settings than their containers. Run this upgrade to synchronize comment access.';
+		$upgrade->save();
+	}
+}
+
+elgg_set_ignore_access($ia);
+access_show_hidden_entities($access_status);

--- a/engine/tests/ElggCommentTest.php
+++ b/engine/tests/ElggCommentTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Elgg Test \ElggComment
+ *
+ * @package Elgg
+ * @subpackage Test
+ */
+class ElggCoreCommentTest extends \ElggCoreUnitTest {
+	/**
+	 * @var \ElggComment
+	 */
+	protected $comment;
+	
+	/**
+	 * @var \ElggObject
+	 */
+	protected $container;
+
+	/**
+	 * Called before each test method.
+	 */
+	public function setUp() {
+		$this->container = new \ElggObject();
+		$this->container->access_id = ACCESS_PUBLIC;
+		$this->container->save();
+		
+		$this->comment = new \ElggComment();
+		$this->comment->description = 'comment description';
+		$this->comment->container_guid = $this->container->guid;
+		$this->comment->access_id = $this->container->access_id;
+		$this->comment->save();
+	}
+
+	public function testCommentAccessSync() {
+		
+		_elgg_disable_caching_for_entity($this->comment->guid);
+		_elgg_disable_caching_for_entity($this->container->guid);
+		
+		$this->assertEqual($this->comment->access_id, $this->container->access_id);
+		
+		// now change the access of the container
+		$this->container->access_id = ACCESS_LOGGED_IN;
+		$this->container->save();
+		
+		$updated_container = get_entity($this->container->guid);
+		$updated_comment = get_entity($this->comment->guid);
+		
+		$this->assertEqual($updated_comment->access_id, $updated_container->access_id);
+	}
+
+	/**
+	 * Called after each test method.
+	 */
+	public function tearDown() {
+		$this->container->delete();
+		$this->comment->delete();
+	}
+}

--- a/languages/en.php
+++ b/languages/en.php
@@ -1131,6 +1131,7 @@ Once you have logged in, we highly recommend that you change your password.
 	// Strings specific for the comments upgrade
 	'admin:upgrades:comments' => 'Comments upgrade',
 	'upgrade:comment:create_failed' => 'Failed to convert comment id %s to an entity.',
+	'admin:upgrades:commentaccess' => 'Comments Access Upgrade',
 
 	// Strings specific for the datadir upgrade
 	'admin:upgrades:datadirs' => 'Data directory upgrade',

--- a/mod/categories/start.php
+++ b/mod/categories/start.php
@@ -17,7 +17,7 @@ function categories_init() {
 
 	elgg_register_page_handler('categories', 'categories_page_handler');
 
-	elgg_register_event_handler('update', 'all', 'categories_save');
+	elgg_register_event_handler('update:after', 'all', 'categories_save');
 	elgg_register_event_handler('create', 'all', 'categories_save');
 
 	// To keep the category plugins in the settings area and because we have to do special stuff,

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -736,7 +736,7 @@ function discussion_init() {
 	// allow non-owners to add replies to group discussion
 	elgg_register_plugin_hook_handler('container_permissions_check', 'object', 'discussion_reply_container_permissions_override');
 
-	elgg_register_event_handler('update', 'object', 'discussion_update_reply_access_ids');
+	elgg_register_event_handler('update:after', 'object', 'discussion_update_reply_access_ids');
 
 	$action_base = elgg_get_plugins_path() . 'groups/actions/discussion';
 	elgg_register_action('discussion/save', "$action_base/save.php");
@@ -1187,6 +1187,7 @@ function discussion_reply_container_permissions_override($hook, $type, $return, 
  */
 function discussion_update_reply_access_ids($event, $type, $object) {
 	if (elgg_instanceof($object, 'object', 'groupforumtopic')) {
+		$ia = elgg_set_ignore_access(true);
 		$options = array(
 			'type' => 'object',
 			'subtype' => 'discussion_reply',
@@ -1204,6 +1205,8 @@ function discussion_update_reply_access_ids($event, $type, $object) {
 			$reply->access_id = $object->access_id;
 			$reply->save();
 		}
+		
+		elgg_set_ignore_access($ia);
 	}
 }
 

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2014130300;
+$version = 2015031300;
 
 $composerJson = file_get_contents(dirname(__FILE__) . "/composer.json");
 if ($composerJson === false) {

--- a/views/default/admin/upgrades/commentaccess.php
+++ b/views/default/admin/upgrades/commentaccess.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Comment access upgrade page
+ */
+
+// Upgrade also possible hidden comments. This feature gets run
+// by an administrator so there's no need to ignore access.
+$access_status = access_get_show_hidden_status();
+access_show_hidden_entities(true);
+
+$dbprefix = elgg_get_config('dbprefix');
+$options = array(
+	'type' => 'object',
+	'subtype' => 'comment',
+	'joins' => array(
+		"JOIN {$dbprefix}entities e2 ON e.container_guid = e2.guid"
+	),
+	'wheres' => array(
+		"e.access_id != e2.access_id"
+	),
+	'count' => true
+);
+		
+$count = elgg_get_entities($options);
+
+echo elgg_view('admin/upgrades/view', array(
+	'count' => $count,
+	'action' => 'action/admin/upgrades/upgrade_comments_access',
+));
+
+access_show_hidden_entities($access_status);


### PR DESCRIPTION
Fixes #7807, Fixes #7984
### Voting time

Yes let's pull this in:
- Matt
- Evan
- Brett
- Juho

Yes with more:
- Steve (show [UI message](https://github.com/Elgg/Elgg/issues/7807#issuecomment-82495268) when expanding access, don't close #7984)

No let's do something else:
