### PR TITLE
feature(security): adds events around site secret regeneration

### DIFF
--- a/actions/admin/site/update_advanced.php
+++ b/actions/admin/site/update_advanced.php
@@ -82,12 +82,16 @@ if ('on' === get_input('https_login')) {
 
 $regenerate_site_secret = get_input('regenerate_site_secret', false);
 if ($regenerate_site_secret) {
-	init_site_secret();
-	elgg_reset_system_cache();
+	// if you cancel this even you should present a message to the user
+	if (elgg_trigger_before_event('regenerate_site_secret', 'system')) {
+		init_site_secret();
+		elgg_reset_system_cache();
+		elgg_trigger_after_event('regenerate_site_secret', 'system');
 
-	system_message(elgg_echo('admin:site:secret_regenerated'));
+		system_message(elgg_echo('admin:site:secret_regenerated'));
 
-	elgg_delete_admin_notice('weak_site_key');
+		elgg_delete_admin_notice('weak_site_key');
+	}
 }
 
 if ($site->save()) {

--- a/docs/guides/events-list.rst
+++ b/docs/guides/events-list.rst
@@ -32,6 +32,13 @@ System events
     might not be shown until after the process is completed. This means that any long-running
     processes will still delay the page load.
 
+**regenerate_site_secret:before, system**
+    Return false to cancel regenerating the site secret. You should also provide a message
+    to the user.
+
+**regenerate_site_secret:after, system**
+    Triggered after the site secret has been regenerated.
+
 **log, systemlog**
 	Called for all triggered events. Used internally by ``system_log_default_logger()`` to populate
 	the ``system_log`` table.


### PR DESCRIPTION
Site owners can regenerate a new site secret. This allows plugins to be notified of this change or to prevent it.

Fixes #6252
