### PR TITLE
feature(events): allows wider variety of callables to be unregistered

### DIFF
--- a/engine/classes/Elgg/CallableMatcher.php
+++ b/engine/classes/Elgg/CallableMatcher.php
@@ -1,0 +1,146 @@
+<?php
+namespace Elgg;
+
+/**
+ * Identify a callable, even if contains an object to which you don't have a reference.
+ */
+class CallableMatcher {
+
+	/**
+	 * @var mixed
+	 */
+	private $spec;
+
+	/**
+	 * Constructor
+	 *
+	 * @param mixed $spec Callable or string specification
+	 *   - A value like "The\ClassName->method" will match an array where element 0 is an instance of The\ClassName
+	 *     and element 1 is "method".
+	 *   - A value like "function /foo/bar.php" will match any anonymous function in any file whose filename ends
+	 *     with "/foo/bar.php" or "\foo\bar.php".
+	 *   - A value like "function /foo/bar.php:120" will additionally require that the anonymous function declaration
+	 *     end on line 120.
+	 *   - A value like "function /foo/bar.php:120+-5" will allow the declaration to end within lines 115 to 125.
+	 *   - Anonymous functions include those created with create_function().
+	 */
+	public function __construct($spec) {
+		$this->spec = $this->normalize($spec);
+	}
+
+	/**
+	 * Does the given callable match the specification?
+	 *
+	 * @param callable $subject Callable to test
+	 * @return bool
+	 */
+	public function matches($subject) {
+		// We don't use the callable type-hint because it unnecessarily autoloads for static methods.
+
+		// shortcut for common case
+		if ($subject === $this->spec) {
+			return true;
+		}
+
+		$subject = $this->normalize($subject);
+
+		// try again
+		if ($subject === $this->spec) {
+			return true;
+		}
+
+		if (is_string($this->spec)) {
+			if (false !== strpos($this->spec, '->')) {
+				list ($type, $method) = explode('->', $this->spec);
+				return is_array($subject)
+					&& ($subject[0] instanceof $type)
+					&& ($subject[1] === $method);
+			}
+
+			if (0 === strpos($this->spec, 'function ')) {
+				if (is_string($subject)) {
+					// allow matching use of create_function()
+					if (0 !== strpos($subject, "\x00lambda_")) {
+						return false;
+					}
+				} elseif (!$subject instanceof \Closure) {
+					return false;
+				}
+
+				$spec_file = substr($this->spec, 9);
+				$acceptable_line_error = 0;
+
+				if (false === strpos($spec_file, ':')) {
+					$spec_line = null;
+				} else {
+					list ($spec_file, $spec_line) = explode(':', $spec_file);
+					if (false !== strpos($spec_line, '+-')) {
+						list ($spec_line, $acceptable_line_error) = explode('+-', $spec_line);
+					}
+				}
+				$spec_file = strtr($spec_file, '\\', '/');
+
+				$reflection = new \ReflectionFunction($subject);
+				$subject_file = $reflection->getFileName();
+
+				if (is_string($subject)) {
+					if (!preg_match('~^(.*?)\((\d+)\) \: runtime~', $subject_file, $m)) {
+						// unrecognized filename
+						return false;
+					}
+
+					$subject_file = $m[1];
+					$subject_line = (int)$m[2];
+				}
+
+				$subject_file = strtr($subject_file, '\\', '/');
+
+				if ($spec_file !== substr($subject_file, -strlen($spec_file))) {
+					return false;
+				}
+
+				if ($spec_line === null) {
+					return true;
+				}
+
+				if (!isset($subject_line)) {
+					$subject_line = $reflection->getEndLine();
+				}
+
+				return (abs($spec_line - $subject_line) <= $acceptable_line_error);
+			}
+
+			if (0 === strpos($this->spec, 'instanceof ')) {
+				$type = substr($this->spec, 11);
+
+				return ($subject instanceof $type);
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Normalizes callables/specs to ease matching.
+	 *
+	 * @param mixed $spec Callable or specification string
+	 * @return mixed
+	 */
+	protected function normalize($spec) {
+		if (is_string($spec) && false !== strpos($spec, '::')) {
+			$spec = explode('::', $spec);
+		}
+
+		if (is_string($spec)) {
+			if (0 !== strpos($spec, 'function ')) {
+				$spec = ltrim($spec, '\\');
+			}
+		} elseif (is_array($spec)) {
+			if (is_string($spec[0])) {
+				$spec[0] = ltrim($spec[0], '\\');
+			}
+		}
+
+		return $spec;
+	}
+}

--- a/engine/classes/Elgg/HooksRegistrationService.php
+++ b/engine/classes/Elgg/HooksRegistrationService.php
@@ -13,7 +13,7 @@ namespace Elgg;
  * @since      1.9.0
  */
 abstract class HooksRegistrationService {
-	
+
 	private $handlers = array();
 
 	/**
@@ -69,20 +69,28 @@ abstract class HooksRegistrationService {
 	/**
 	 * Unregister a handler
 	 *
-	 * @param string   $name
-	 * @param string   $type
-	 * @param callable $callback
+	 * @param string                   $name
+	 * @param string                   $type
+	 * @param callable|CallableMatcher $callback
 	 *
 	 * @return bool
 	 * @access private
 	 */
 	public function unregisterHandler($name, $type, $callback) {
 		if (isset($this->handlers[$name]) && isset($this->handlers[$name][$type])) {
-			foreach ($this->handlers[$name][$type] as $key => $name_callback) {
-				if ($name_callback == $callback) {
-					unset($this->handlers[$name][$type][$key]);
-					return true;
+			foreach ($this->handlers[$name][$type] as $key => $handler) {
+				if ($callback instanceof CallableMatcher) {
+					if (!$callback->matches($handler)) {
+						continue;
+					}
+				} else {
+					if ($handler != $callback) {
+						continue;
+					}
 				}
+
+				unset($this->handlers[$name][$type][$key]);
+				return true;
 			}
 		}
 
@@ -122,8 +130,10 @@ abstract class HooksRegistrationService {
 	 * @param string $type The type of the hook
 	 * @return array
 	 * @see \Elgg\HooksRegistrationService::getAllHandlers()
+	 *
+	 * @access private
 	 */
-	protected function getOrderedHandlers($name, $type) {
+	public function getOrderedHandlers($name, $type) {
 		$handlers = array();
 		
 		if (isset($this->handlers[$name][$type])) {

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -523,9 +523,9 @@ function elgg_register_event_handler($event, $object_type, $callback, $priority 
 /**
  * Unregisters a callback for an event.
  *
- * @param string $event       The event type
- * @param string $object_type The object type
- * @param string $callback    The callback
+ * @param string                         $event       The event type
+ * @param string                         $object_type The object type
+ * @param callable|\Elgg\CallableMatcher $callback    The callback or matcher
  *
  * @return bool true if a handler was found and removed
  * @since 1.7
@@ -707,9 +707,9 @@ function elgg_register_plugin_hook_handler($hook, $type, $callback, $priority = 
 /**
  * Unregister a callback as a plugin hook.
  *
- * @param string   $hook        The name of the hook
- * @param string   $entity_type The name of the type of entity (eg "user", "object" etc)
- * @param callable $callback    The PHP callback to be removed
+ * @param string                         $hook        The name of the hook
+ * @param string                         $entity_type The name of the type of entity (eg "user", "object" etc)
+ * @param callable|\Elgg\CallableMatcher $callback    The callable or matcher
  *
  * @return void
  * @since 1.8.0

--- a/engine/tests/phpunit/Elgg/CallableMatcherTest.php
+++ b/engine/tests/phpunit/Elgg/CallableMatcherTest.php
@@ -1,0 +1,129 @@
+<?php
+namespace Elgg;
+
+class CallableMatcherTest extends \PHPUnit_Framework_TestCase {
+
+	public function testVanillaCallablesMatchAsExpected() {
+		$obj = new \stdClass();
+		$f = function () {};
+
+		$matching_sets = [
+			['\Foo\bar', 'Foo\bar'],
+			['Foo::bar', '\Foo::bar', ['Foo', 'bar'], ['\Foo', 'bar']],
+			[[$obj, 'bar']],
+			[$f],
+		];
+
+		foreach ($matching_sets as $set_key => $set) {
+			foreach ($set as $item_key => $item) {
+				$matcher = new CallableMatcher($item);
+
+				// all set items should match each other
+				for ($i = 0; $i < count($set); $i++) {
+					$message = "spec " . var_export($item, true) . " failed to match " . var_export($set[$i], true);
+					$this->assertTrue($matcher->matches($set[$i]), $message);
+				}
+
+				// no item in set should match items in other sets
+				for ($j = 0; $j < count($matching_sets); $j++) {
+					if ($j == $set_key) {
+						continue;
+					}
+					for ($k = 0; $k < count($matching_sets[$j]); $k++) {
+						$message = "spec " . var_export($item, true) . " matched " . var_export($matching_sets[$j][$k], true);
+						$this->assertFalse($matcher->matches($matching_sets[$j][$k]), $message);
+					}
+				}
+			}
+		}
+	}
+
+	public function testCanMatchDynamicMethodsByType() {
+		$obj = new \stdClass();
+
+		$matcher = new CallableMatcher('\stdClass->bar');
+		$this->assertTrue($matcher->matches([$obj, 'bar']));
+	}
+
+	public function testCanMatchClosures() {
+		$f = function () {
+			$hello = 1;
+		};
+		$line = __LINE__ - 1;
+
+		$matcher = new CallableMatcher('function /Elgg/CallableMatcherTest.php');
+		$this->assertTrue($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function lableMatcherTest.php');
+		$this->assertTrue($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function LableMATCHerTest.php');
+		$this->assertFalse($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function /Elgg/CallableMatcherTest.php:' . $line);
+		$this->assertTrue($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function /Elgg/CallableMatcherTest.php:' . ($line + 1));
+		$this->assertFalse($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function /Elgg/CallableMatcherTest.php:' . ($line - 2) . '+-2');
+		$this->assertTrue($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function /Elgg/CallableMatcherTest.php:' . ($line - 2) . '+-1');
+		$this->assertFalse($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function /Elgg/CallableMatcherTest.php:' . ($line + 2) . '+-2');
+		$this->assertTrue($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function /Elgg/CallableMatcherTest.php:' . ($line + 2) . '+-1');
+		$this->assertFalse($matcher->matches($f));
+	}
+
+	public function testCanMatchOldLambdas() {
+		$f = create_function('', '
+			$hello = 1;
+		');
+		$line = __LINE__ - 1;
+
+		$matcher = new CallableMatcher('function /Elgg/CallableMatcherTest.php');
+		$this->assertTrue($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function lableMatcherTest.php');
+		$this->assertTrue($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function LableMATCHerTest.php');
+		$this->assertFalse($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function /Elgg/CallableMatcherTest.php:' . $line);
+		$this->assertTrue($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function /Elgg/CallableMatcherTest.php:' . ($line + 1));
+		$this->assertFalse($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function /Elgg/CallableMatcherTest.php:' . ($line - 2) . '+-2');
+		$this->assertTrue($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function /Elgg/CallableMatcherTest.php:' . ($line - 2) . '+-1');
+		$this->assertFalse($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function /Elgg/CallableMatcherTest.php:' . ($line + 2) . '+-2');
+		$this->assertTrue($matcher->matches($f));
+
+		$matcher = new CallableMatcher('function /Elgg/CallableMatcherTest.php:' . ($line + 2) . '+-1');
+		$this->assertFalse($matcher->matches($f));
+	}
+
+	public function testCanMatchType() {
+		$invokable = new CallableMatcherTest_invokable();
+
+		$matcher = new CallableMatcher('instanceof CallableMatcherTest_invokable');
+		$this->assertFalse($matcher->matches($invokable));
+
+		$matcher = new CallableMatcher('instanceof Elgg\CallableMatcherTest_invokable');
+		$this->assertTrue($matcher->matches($invokable));
+	}
+}
+
+class CallableMatcherTest_invokable {
+	function __invoke() {}
+}


### PR DESCRIPTION
This adds a class usable for matching anonymous functions, dynamic method callbacks, and invokable objects without the need for an object reference. The matcher can be passed to the event/hook unregister functions to successfully remove such types of handlers.

This also renames the event registration test so it’s actively tested by PHPUnit.

Fixes #7750
Fixes #8069
