### PR TITLE
WIP feature(amd): Allow AMD modules to be decorated by plugins

### DIFF
--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -22,8 +22,8 @@ Defining and loading a module in Elgg 1.9 takes two steps:
 
 You can define a module by creating a view or registering a URL.
 
-Defining modules as a view
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Defining a module as a JS view
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Modules defined by creating views are immediately available for use and require no registration.
 To register a module named ``my/module``, create the view ``views/default/js/my/module.js``.
@@ -43,8 +43,23 @@ A basic module could look like this:
 		};
 	});
 
+Defining a module as a PHP view
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Although this is discouraged in favor of JavaScript files, you may register PHP views as AMD
+modules.
+
+To register a module named ``my/module``, create the view ``views/default/js/my/module.js.php``
+(note the extension ``.js.php``). You must also manually register your view as an external
+resource:
+
+.. code-block:: php
+
+    // note the view name includes the .js extension, but not .php
+    elgg_register_external_view('js/my/module.js', true);
+
 Define your module via a URL
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can define an existing AMD module using ``elgg_define_js()``. Traditional (browser-globals)
 JavaScript files can also be defined as AMD modules if you shim them by setting ``exports`` and
@@ -74,6 +89,35 @@ optionally ``deps``.
 			'exports' => 'jQuery.fn.ajaxForm',
 		));
 	}
+
+Altering the return values of other modules
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can do this by using a "decorator" module, which accepts the original module value and returns
+the modified value.
+
+Let's say you want to alter the module ``elgg/ckeditor/config``. First create your decorator module:
+
+.. code-block:: javascript
+
+    // myplugin/views/default/js/myplugin/decorator/elgg/ckeditor/config.js
+	define(function(require) {
+		var config = require("elgg/ckeditor/config");
+
+		// change some properties...
+
+		return config;
+	});
+
+Now you must register your decorator in PHP:
+
+.. code-block:: php
+
+    elgg_decorate_js('elgg/ckeditor/config', 'myplugin');
+
+This will set up the system so that the original module value will be passed through your decorator
+module automatically and transparently. Devs can continue to require the original module without
+modifying their code.
 
 Some things to note
 ^^^^^^^^^^^^^^^^^^^

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -202,6 +202,20 @@ function elgg_require_js($name) {
 	_elgg_services()->amdConfig->addDependency($name);
 }
 
+/**
+ * Register a module as a decorator for another module
+ *
+ * First create the module "$plugin_id/decorator/$name", have it depend on and return "$name". When
+ * other modules depend on "$name" they will receive what you returned in your decorator module.
+ *
+ * @param string $name      The AMD module name
+ * @param string $plugin_id The plugin ID
+ * @return void
+ * @since 1.11.0
+ */
+function elgg_decorate_js($name, $plugin_id) {
+	_elgg_services()->amdConfig->decorateModule($name, $plugin_id);
+}
 
 /**
  * Get the JavaScript URLs that are loaded

--- a/engine/tests/phpunit/Elgg/Amd/ConfigTest.php
+++ b/engine/tests/phpunit/Elgg/Amd/ConfigTest.php
@@ -113,5 +113,98 @@ class ConfigTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($amdConfig->hasModule('jquery.form'));
 		$this->assertFalse($amdConfig->hasShim('jquery.form'));
 	}
+
+	public function testMultiplePluginsCanDecorate() {
+		$amdConfig = new \Elgg\Amd\Config();
+
+		$this->assertEmpty($amdConfig->getConfig()['map']);
+
+		$amdConfig->decorateModule('ckeditor/config', 'foo');
+
+		$this->assertEquals([], $amdConfig->getConfig()['paths']);
+		$this->assertEquals([], $amdConfig->getConfig()['map']);
+
+		$amdConfig->applyDecorations();
+
+		$expected_paths = [
+			'_alias/ckeditor/config' => ['ckeditor/config'],
+		];
+		$expected_map = [
+			'foo/decorator/ckeditor/config' => [
+				'ckeditor/config' => '_alias/ckeditor/config',
+			],
+			'*' => [
+				'ckeditor/config' => 'foo/decorator/ckeditor/config',
+			],
+		];
+
+		$this->assertEquals($expected_paths, $amdConfig->getConfig()['paths']);
+		$this->assertEquals($expected_map, $amdConfig->getConfig()['map']);
+
+		$amdConfig->decorateModule('ckeditor/config', 'bar');
+
+		$expected_map['bar/decorator/ckeditor/config'] = [
+			'ckeditor/config' => 'foo/decorator/ckeditor/config',
+		];
+		$expected_map['*'] = [
+			'ckeditor/config' => 'bar/decorator/ckeditor/config',
+		];
+
+		$amdConfig->applyDecorations();
+
+		$this->assertEquals($expected_paths, $amdConfig->getConfig()['paths']);
+		$this->assertEquals($expected_map, $amdConfig->getConfig()['map']);
+	}
+
+	public function testDecorationCanHandleShimsAndPaths() {
+		$amdConfig = new \Elgg\Amd\Config();
+
+		$amdConfig->decorateModule('module1', 'foo');
+		$amdConfig->decorateModule('module2', 'foo');
+		$amdConfig->decorateModule('module2', 'bar');
+
+		$amdConfig->addPath('module1', 'module1_path');
+		$amdConfig->addModule('module2', [
+			'url' => 'module2_path',
+		]);
+
+		$amdConfig->applyDecorations();
+
+		$expected_paths = [
+			'module1' => ['module1_path'],
+			'module2' => ['module2_path'],
+			'_alias/module1' => ['module1_path'],
+			'_alias/module2' => ['module2_path'],
+		];
+		$expected_map = [
+			'foo/decorator/module1' => [
+				'module1' => '_alias/module1',
+			],
+			'foo/decorator/module2' => [
+				'module2' => '_alias/module2',
+			],
+			'bar/decorator/module2' => [
+				'module2' => 'foo/decorator/module2',
+			],
+			'*' => [
+				'module1' => 'foo/decorator/module1',
+				'module2' => 'bar/decorator/module2',
+			],
+		];
+
+		$this->assertEquals($expected_paths, $amdConfig->getConfig()['paths']);
+		$this->assertEquals($expected_map, $amdConfig->getConfig()['map']);
+	}
+
+	/**
+	 * @expectedException \RuntimeException
+	 */
+	public function testForbidsDecoratingSameModuleTwice() {
+		$amdConfig = new \Elgg\Amd\Config();
+
+		$amdConfig->decorateModule('module', 'foo');
+		$amdConfig->decorateModule('module', 'foo');
+		$amdConfig->applyDecorations();
+	}
 }
 

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -19,6 +19,8 @@ elgg_register_event_handler('init', 'system', 'blog_init');
  */
 function blog_init() {
 
+	elgg_decorate_js('elgg/ckeditor/config', 'blog');
+
 	elgg_register_library('elgg:blog', elgg_get_plugins_path() . 'blog/lib/blog.php');
 
 	// add a site navigation item

--- a/mod/blog/views/default/js/blog/decorator/elgg/ckeditor/config.js
+++ b/mod/blog/views/default/js/blog/decorator/elgg/ckeditor/config.js
@@ -1,0 +1,7 @@
+define(function (require) {
+	var config = require('elgg/ckeditor/config');
+
+	config.toolbar = [['Bold', 'Italic', 'Underline', 'RemoveFormat']];
+
+	return config;
+});

--- a/mod/ckeditor/README.md
+++ b/mod/ckeditor/README.md
@@ -3,10 +3,11 @@ CKEditor WYSIWYG plugin
 
 Configuration options
 ----------------------
-CKEditor configuration is set in the view js/ckeditor. The configuration object
-is elgg.ckeditor.config. A plugin can modify the configuration object by registering
-a function to run before the ckeditor.init function on the 'init', 'system' hook.
-This is where toolbar options and the skin are set.
+CKEditor configuration defines toolbar options and skinning. A plugin can modify the
+configuration object by decorating the AMD module elgg/ckeditor/config. See
+``elgg_decorate_js()``.
+
+See http://docs.ckeditor.com/#!/api/CKEDITOR.config for options documentation.
 
 Content CSS
 ------------

--- a/views/default/js/elgg/require_config.php
+++ b/views/default/js/elgg/require_config.php
@@ -1,6 +1,14 @@
 <?php
 
-$amdConfig = _elgg_services()->amdConfig->getConfig();
+$amd = _elgg_services()->amdConfig;
+
+try {
+	$amd->applyDecorations();
+} catch (RuntimeException $e) {
+	echo "console.log(" . json_encode($e->getMessage()) . ");\n";
+}
+
+$amdConfig = $amd->getConfig();
 
 // Deps are loaded in page/elements/foot with require([...])
 unset($amdConfig['deps']);


### PR DESCRIPTION
Includes [docs](https://github.com/mrclay/Elgg-leaf/blob/08f75b8b2291f6cc8e47c81843bf519c37a6a5af/docs/guides/javascript.rst#altering-the-return-values-of-other-modules).

To see it working I extended elgg/ckeditor/config in the blog plugin. The JS error CKEditor creates is not caused by this change.

Fixes #8082
