### PR TITLE
chore(tests): Enable tests for abstract hooks service

### DIFF
--- a/engine/classes/Elgg/HooksRegistrationService.php
+++ b/engine/classes/Elgg/HooksRegistrationService.php
@@ -122,8 +122,10 @@ abstract class HooksRegistrationService {
 	 * @param string $type The type of the hook
 	 * @return array
 	 * @see \Elgg\HooksRegistrationService::getAllHandlers()
+	 *
+	 * @access private
 	 */
-	protected function getOrderedHandlers($name, $type) {
+	public function getOrderedHandlers($name, $type) {
 		$handlers = array();
 		
 		if (isset($this->handlers[$name][$type])) {
@@ -148,4 +150,3 @@ abstract class HooksRegistrationService {
 		return $handlers;
 	}
 }
-

--- a/engine/tests/phpunit/Elgg/HooksRegistrationServiceTest.php
+++ b/engine/tests/phpunit/Elgg/HooksRegistrationServiceTest.php
@@ -1,8 +1,12 @@
 <?php
 namespace Elgg;
 
-
 class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @var HooksRegistrationService
+	 */
+	public $mock;
 
 	public function setUp() {
 		parent::setUp();
@@ -39,18 +43,19 @@ class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue($this->mock->unregisterHandler('foo', 'bar', 'callback2'));
 
-		$expected = array(
-			'foo' => array(
-				'bar' => array(
-					500 => 'callback1'
-				)
-			)
-		);
-		
-		$this->assertSame($expected, $this->mock->getAllHandlers());
+		$this->assertSame([500 => 'callback1'], $this->mock->getAllHandlers()['foo']['bar']);
 
 		// check unregistering things that aren't registered
 		$this->assertFalse($this->mock->unregisterHandler('foo', 'bar', 'not_valid'));
+	}
+
+	public function testOnlyOneHandlerUnregistered() {
+		$this->mock->registerHandler('foo', 'bar', 'callback');
+		$this->mock->registerHandler('foo', 'bar', 'callback');
+
+		$this->assertTrue($this->mock->unregisterHandler('foo', 'bar', 'callback'));
+
+		$this->assertSame([501 => 'callback'], $this->mock->getAllHandlers()['foo']['bar']);
 	}
 
 	public function testGetOrderedHandlers() {
@@ -71,4 +76,3 @@ class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->assertSame($expected_foo_baz, $this->mock->getOrderedHandlers('foo', 'baz'));
 	}
 }
-


### PR DESCRIPTION
These tests were not in the suite because the filename lacked “Test”. Also makes getOrderedHandlers() public to allow testing, and adds test for unregisterHandler only removing one handler per call.

Fixes #8069
