### PR TITLE
feature(settings): serialize arrays passed as plugin/user settings by de...

### DIFF
--- a/actions/plugins/settings/save.php
+++ b/actions/plugins/settings/save.php
@@ -30,6 +30,9 @@ if (elgg_action_exists("$plugin_id/settings/save")) {
 	action("$plugin_id/settings/save");
 } else {
 	foreach ($params as $k => $v) {
+		if (is_array($v)) {
+			$v = serialize($v);
+		}
 		$result = $plugin->setSetting($k, $v);
 		if (!$result) {
 			register_error(elgg_echo('plugins:settings:save:fail', array($plugin_name)));

--- a/actions/plugins/usersettings/save.php
+++ b/actions/plugins/usersettings/save.php
@@ -44,6 +44,9 @@ if (elgg_action_exists("$plugin_id/usersettings/save")) {
 } else {
 	foreach ($params as $k => $v) {
 		// Save
+		if (is_array($v)) {
+			$v = serialize($v);
+		}
 		$result = $plugin->setUserSetting($k, $v, $user->guid);
 
 		// Error?

--- a/docs/guides/settings.rst
+++ b/docs/guides/settings.rst
@@ -30,6 +30,10 @@ An example ``settings.php`` would look like:
 
    You cannot use form components that send no value when "off." These include radio inputs and check boxes.
 
+.. note::
+
+   Array values will be stored serialized
+
 User settings
 -------------
 
@@ -59,6 +63,10 @@ where:
 - ``$name`` Is the value you want to retrieve
 - ``$user_guid`` Is the user you want to retrieve these for (defaults to the currently logged in user)
 - ``$plugin_name`` Is the name of the plugin (detected if run from within a plugin)
+
+.. note::
+
+   Settings stored as an array will be returned as the serialized value.  Developers are expected to unserialize such settings on retrieval.
 
 Setting values while in code
 ----------------------------


### PR DESCRIPTION
...fault

Allows developers to use arrays in plugin settings/user settings with the magic $params system and have it stored as a serialized string

Fixes #8081
