### PR TITLE
Links in comment/reply notification emails now take directly to the correct page

### DIFF
--- a/actions/comment/save.php
+++ b/actions/comment/save.php
@@ -68,7 +68,7 @@ if ($comment_guid) {
 				$entity->title,
 				$user->name,
 				$comment_text,
-				$entity->getURL(),
+				$comment->getURL(),
 				$user->name,
 				$user->getURL()
 			), $owner->language),

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -1058,7 +1058,7 @@ function discussion_prepare_reply_notification($hook, $type, $notification, $par
 		$topic->title,
 		$group->name,
 		$reply->description,
-		$topic->getURL(),
+		$reply->getURL(),
 	), $language);
 	$notification->summary = elgg_echo('discussion:reply:notify:summary', array($topic->title), $language);
 


### PR DESCRIPTION
Refs #7940
