### PR TITLE
fix(aalborg_theme): moves unextend/extend view into init

### DIFF
--- a/mod/aalborg_theme/start.php
+++ b/mod/aalborg_theme/start.php
@@ -14,6 +14,9 @@ function aalborg_theme_init() {
 	// theme specific CSS
 	elgg_extend_view('css/elgg', 'aalborg_theme/css');
 
+	elgg_unextend_view('page/elements/header', 'search/header');
+	elgg_extend_view('page/elements/sidebar', 'search/header', 0);
+	
 	elgg_register_plugin_hook_handler('head', 'page', 'aalborg_theme_setup_head');
 
 	// non-members do not get visible links to RSS feeds
@@ -27,9 +30,6 @@ function aalborg_theme_init() {
  * Rearrange menu items
  */
 function aalborg_theme_pagesetup() {
-
-	elgg_unextend_view('page/elements/header', 'search/header');
-	elgg_extend_view('page/elements/sidebar', 'search/header', 0);
 
 	if (elgg_is_logged_in()) {
 


### PR DESCRIPTION
Fixes #8105
