### PR TITLE
fix(views): do not drop elgg-button-submit class when using input/submit

### DIFF
--- a/views/default/input/button.php
+++ b/views/default/input/button.php
@@ -9,15 +9,10 @@
  * @uses $vars['class'] Additional CSS class
  */
 
-if (isset($vars['class'])) {
-	$vars['class'] = "elgg-button {$vars['class']}";
-} else {
-	$vars['class'] = "elgg-button";
-}
+$vars['class'] = (array) elgg_extract('class', $vars, []);
+$vars['class'][] = "elgg-button";
 
-$defaults = array(
-	'type' => 'button',
-);
+$defaults = ['type' => 'button'];
 
 $vars = array_merge($defaults, $vars);
 
@@ -36,5 +31,5 @@ switch ($vars['type']) {
 if (isset($vars['src']) && strpos($vars['src'], elgg_get_site_url()) === false) {
 	$vars['src'] = "";
 }
-?>
-<input <?php echo elgg_format_attributes($vars); ?> />
+
+echo elgg_format_element('input', $vars);

--- a/views/default/input/submit.php
+++ b/views/default/input/submit.php
@@ -5,10 +5,12 @@
  * @package Elgg
  * @subpackage Core
  *
- * @uses $vars['class'] CSS class that replaces elgg-button-submit
+ * @uses $vars['class'] Additional CSS class
  */
 
 $vars['type'] = 'submit';
-$vars['class'] = elgg_extract('class', $vars, 'elgg-button-submit');
+
+$vars['class'] = (array) elgg_extract('class', $vars, []);
+$vars['class'][] = "elgg-button-submit";
 
 echo elgg_view('input/button', $vars);


### PR DESCRIPTION
Also the input/button and input/submit views can now handle $vars['class'] to be an array.

replaces #7931
