### PR TITLE
chore(core): catch login exceptions during password change

### DIFF
--- a/actions/user/changepassword.php
+++ b/actions/user/changepassword.php
@@ -25,7 +25,13 @@ if ($password != $password_repeat) {
 
 if (execute_new_password_request($user_guid, $code, $password)) {
 	system_message(elgg_echo('user:password:success'));
-	login(get_entity($user_guid));
+	
+	try {
+		login(get_entity($user_guid));
+	} catch (LoginException $e) {
+		register_error($e->getMessage());
+		forward(REFERER);
+	}
 } else {
 	register_error(elgg_echo('user:password:fail'));
 }


### PR DESCRIPTION
When a user requested a password change and acts on the confirmation
e-mail, the user is eventualy logged in. But this could trigger an
exception which wasn't caught.

fixes #7948
