### PR TITLE
chore(embed): order embed menu by priority as documented

### DIFF
--- a/mod/embed/views/default/embed/layout.php
+++ b/mod/embed/views/default/embed/layout.php
@@ -5,7 +5,9 @@
 
 $title =  elgg_view_title(elgg_echo('embed:media'));
 
-$menu = elgg_view_menu('embed');
+$menu = elgg_view_menu('embed', array(
+	'sort_by' => 'priority'
+));
 
 $selected = elgg_get_config('embed_tab');
 if ($selected->getData('view')) {


### PR DESCRIPTION
According to the documentation the embed menu (tabs) are ordered by
priority, but they were in fact order by 'text'

fixes #7043
