### PR TITLE
chore(thewire): improved error handling when removing a wire post

### DIFF
--- a/mod/thewire/actions/delete.php
+++ b/mod/thewire/actions/delete.php
@@ -9,7 +9,7 @@ $guid = (int) get_input('guid');
 
 // Make sure we actually have permission to edit
 $thewire = get_entity($guid);
-if ($thewire->getSubtype() == "thewire" && $thewire->canEdit()) {
+if (elgg_instanceof($thewire, 'object', 'thewire') && $thewire->canEdit()) {
 
 	// unset reply metadata on children
 	$children = elgg_get_entities_from_relationship(array(
@@ -37,3 +37,5 @@ if ($thewire->getSubtype() == "thewire" && $thewire->canEdit()) {
 
 	forward("thewire/owner/" . $owner->username);
 }
+
+forward(REFERER);


### PR DESCRIPTION
Make sure we have a correct entity type before removing it from the
database

fixes #7003
