### PR TITLE
fix(i18n): ckeditor now uses user's own language instead of the site language

### DIFF
--- a/mod/ckeditor/views/default/js/elgg/ckeditor/config.js
+++ b/mod/ckeditor/views/default/js/elgg/ckeditor/config.js
@@ -10,7 +10,7 @@ define(function(require) {
 		removePlugins: 'contextmenu,tabletools,resize',
 		extraPlugins: 'blockimagepaste',
 		defaultLanguage: 'en',
-		language: elgg.config.language,
+		language: elgg.get_language(),
 		skin: 'moono',
 		uiColor: '#EEEEEE',
 		contentsCss: elgg.get_simplecache_url('css', 'elgg/wysiwyg.css'),


### PR DESCRIPTION
Comes from here: https://github.com/Elgg/Elgg/pull/8144
