### PR TITLE
fix(notifications): correctly use elgg_log instead of error_log

### DIFF
--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -359,7 +359,7 @@ function _elgg_notify_user($to, $from, $subject, $message, array $params = null,
 					$handler = $notify_service->getDeprecatedHandler($method);
 					/* @var callable $handler */
 					if (!$handler || !is_callable($handler)) {
-						error_log("No handler registered for the method $method", 'WARNING');
+						elgg_log("No handler registered for the method $method", 'WARNING');
 						continue;
 					}
 


### PR DESCRIPTION
the use was probably meant to be elgg_log

fixes #8039
