### PR TITLE
fix(js): only show editor toggle link if editor is initialized

### DIFF
--- a/mod/ckeditor/start.php
+++ b/mod/ckeditor/start.php
@@ -38,7 +38,7 @@ function ckeditor_longtext_menu($hook, $type, $items, $vars) {
 
 	$items[] = ElggMenuItem::factory(array(
 		'name' => 'ckeditor_toggler',
-		'link_class' => 'ckeditor-toggle-editor elgg-longtext-control',
+		'link_class' => 'ckeditor-toggle-editor elgg-longtext-control hidden',
 		'href' => "#{$vars['id']}",
 		'text' => elgg_echo('ckeditor:html'),
 	));

--- a/mod/ckeditor/views/default/js/elgg/ckeditor.js
+++ b/mod/ckeditor/views/default/js/elgg/ckeditor.js
@@ -33,6 +33,9 @@ define(function(require) {
 		 * @return void
 		 */
 		init: function() {
+			// show the toggle-editor link which is hidden by default, so it will only show up if the editor is correctly loaded
+			var href = $(editor).attr('id');
+			$('.ckeditor-toggle-editor[href="#' + href + '"]').show();
 		},
 
 		/**


### PR DESCRIPTION
This prevents having a toggle editor link even if there is no editor
(for example if it the browser doesn't support it)

Ref #5686
