### PR TITLE
feature(admin): add a warning when a physical robots.txt is present

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -712,6 +712,7 @@ These changes will only affect new users on the site.',
 	'admin:robots.txt:instructions' => "Edit this site's robots.txt file below",
 	'admin:robots.txt:plugins' => "Plugins are adding the following to the robots.txt file",
 	'admin:robots.txt:subdir' => "The robots.txt tool will not work because Elgg is installed in a sub-directory",
+	'admin:robots.txt:physical' => "The robots.txt tool will not work because a physical robots.txt is present",
 
 	'admin:maintenance_mode:default_message' => 'This site is down for maintenance',
 	'admin:maintenance_mode:instructions' => 'Maintenance mode should be used for upgrades and other large changes to the site.

--- a/views/default/admin/configure_utilities/robots.php
+++ b/views/default/admin/configure_utilities/robots.php
@@ -8,4 +8,10 @@ if ('/' !== parse_url(elgg_get_site_url(), PHP_URL_PATH)) {
 	echo "<div class=\"elgg-admin-notices\"><p>$warning</p></div>";
 }
 
+if (file_exists(elgg_get_root_path() . 'robots.txt')) {
+	// a physical robots.txt exists, which will take precedent over the any configuration
+	$warning = elgg_echo('admin:robots.txt:physical');
+	echo "<div class=\"elgg-admin-notices\"><p>$warning</p></div>";
+}
+
 echo elgg_view_form('admin/site/set_robots');


### PR DESCRIPTION
The admin configured robots.txt settings will not work as a physical
file is present

fixes #7067
