### PR TITLE
fix(messageboard): provide correct link to users messageboard

### DIFF
--- a/mod/messageboard/start.php
+++ b/mod/messageboard/start.php
@@ -116,7 +116,7 @@ function messageboard_add($poster, $owner, $message, $access_id = ACCESS_PUBLIC)
 		$body = elgg_echo('messageboard:email:body', array(
 			$poster->name,
 			$message,
-			elgg_get_site_url() . "messageboard/" . $owner->username,
+			elgg_get_site_url() . "messageboard/owner/" . $owner->username,
 			$poster->name,
 			$poster->getURL()
 		), $owner->language);


### PR DESCRIPTION
In the notification the link to the users messagboard was wrong

fixes #8170
