### PR TITLE
chore(views): Entity/annotation views no longer rely on ->view

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -51,6 +51,13 @@ Plugin Messages
 
 Messages will no longer get the metadata 'msg' for newly created messages. This means you can not rely on that metadata to exist.
 
+Specifying View via Properties
+------------------------------
+
+The metadata ``$entity->view`` no longer specifies the view used to render in ``elgg_view_entity()``.
+
+Similarly the property ``$annotation->view`` no longer has an effect within ``elgg_view_annotation()``.
+
 From 1.10 to 1.11
 =================
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -823,7 +823,6 @@ function elgg_view_entity(\ElggEntity $entity, $vars = array(), $bypass = false,
 
 	$entity_views = array(
 		elgg_extract('item_view', $vars, ''),
-		$entity->view,
 		"$entity_type/$entity_subtype",
 		"$entity_type/default",
 	);
@@ -924,13 +923,6 @@ function elgg_view_annotation(\ElggAnnotation $annotation, array $vars = array()
 
 	$vars = array_merge($defaults, $vars);
 	$vars['annotation'] = $annotation;
-
-	// @todo setting the view on an annotation is not advertised anywhere
-	// do we want to keep this?
-	$view = $annotation->view;
-	if (is_string($view)) {
-		return elgg_view($view, $vars, $bypass, $debug);
-	}
 
 	$name = $annotation->name;
 	if (empty($name)) {


### PR DESCRIPTION
Elgg no longer allows $entity->view metadata nor $annotation->view to influence the view used for rendering.

Fixes #8017
