### PR TITLE
perf(engine): Reduce method calls when fetching from service provider

### DIFF
--- a/engine/tests/phpunit/Elgg/Di/DiContainerTest.php
+++ b/engine/tests/phpunit/Elgg/Di/DiContainerTest.php
@@ -137,6 +137,32 @@ class DiContainerTest extends \PHPUnit_Framework_TestCase {
 		$this->setExpectedException('\Elgg\Di\MissingValueException');
 		$di->foo;
 	}
+
+	public function testNamesCannotEndWithUnderscore() {
+		$di = new \Elgg\Di\DiContainer();
+
+		try {
+			$di->setValue('foo_', 'foo');
+			$this->fail('setValue did not throw');
+		} catch (\InvalidArgumentException $e) {}
+
+		$this->assertFalse($di->has('foo_'));
+
+		try {
+			$di->setFactory('foo_', function () {});
+			$this->fail('setFactory did not throw');
+		} catch (\InvalidArgumentException $e) {}
+
+		try {
+			$di->remove('foo_');
+			$this->fail('remove did not throw');
+		} catch (\InvalidArgumentException $e) {}
+
+		try {
+			$di->_foo;
+			$this->fail('->_foo did not throw');
+		} catch (MissingValueException $e) {}
+	}
 }
 
 


### PR DESCRIPTION
Instead of a private array, we store shared values as simple dynamic properties on the container. Hence, values already built or set are just returned by PHP rather than triggering a __get() call.

On a stock site this eliminated 7461 __get() method calls on the container, and reduced request time by 14ms. I assume the improvement is better for sites with lots of plugins.
