### PR TITLE
fix(tags): Corrected cases of tags having leading or trailing spaces.

### DIFF
--- a/engine/classes/Elgg/Database/Annotations.php
+++ b/engine/classes/Elgg/Database/Annotations.php
@@ -71,7 +71,6 @@ class Annotations {
 		$result = false;
 	
 		$entity_guid = (int)$entity_guid;
-		$name = trim($name);
 		$value_type = detect_extender_valuetype($value, $value_type);
 	
 		$owner_guid = (int)$owner_guid;

--- a/engine/classes/Elgg/Database/MetastringsTable.php
+++ b/engine/classes/Elgg/Database/MetastringsTable.php
@@ -114,7 +114,7 @@ class MetastringsTable {
 	 * @return int The identifier for this string
 	 */
 	function add($string) {
-		$escaped_string = $this->db->sanitizeString($string);
+		$escaped_string = $this->db->sanitizeString(trim($string));
 	
 		return $this->db->insertData("INSERT INTO {$this->getTableName()} (string) VALUES ('$escaped_string')");
 	}

--- a/engine/lib/upgrades/2015041400-1.11.0_dev-trim_metastrings-d9a9fdfa28a981a3.php
+++ b/engine/lib/upgrades/2015041400-1.11.0_dev-trim_metastrings-d9a9fdfa28a981a3.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Elgg 1.11.0-dev upgrade 2015041400
+ * trim_metastrings
+ *
+ * Trim all whitespace padding in metastrings
+ */
+
+$prefix = elgg_get_config('dbprefix');
+$q = "SELECT * FROM {$prefix}metastrings WHERE string REXEXP '^[ ]+|[ ]+$'";
+$r = mysql_query($q);
+
+while ($ms = mysql_fetch_assoc($r)) {
+	// find if trimmed version collides with existing MS
+	$string = sanitize_string(trim($ms['string']));
+	$existing = get_data_row("SELECT * FROM {$prefix}metastrings WHERE string = BINARY '$string' LIMIT 1");
+	
+	if ($existing) {
+		// delete the padded string and update MD / annotations to use the existing trimmed one
+		$q = "DELETE FROM {$prefix}metastrings WHERE id = {$ms['id']} LIMIT 1";
+		if (delete_data($q)) {
+			update_data("UPDATE {$prefix}metadata SET name_id = '{$existing->id}' where name_id = '{$ms['id']}'");
+			update_data("UPDATE {$prefix}metadata SET value_id = '{$existing->id}' where value_id = '{$ms['id']}'");
+			
+			update_data("UPDATE {$prefix}annotations SET name_id = '{$existing->id}' where name_id = '{$ms['id']}'");
+			update_data("UPDATE {$prefix}annotations SET value_id = '{$existing->id}' where value_id = '{$ms['id']}'");
+		}
+	} else {
+		update_data("UPDATE {$prefix}metastrings SET string = '$string' where id = '{$ms['id']}'");
+	}
+}

--- a/mod/groups/actions/discussion/save.php
+++ b/mod/groups/actions/discussion/save.php
@@ -50,8 +50,7 @@ $topic->status = $status;
 $topic->access_id = $access_id;
 $topic->container_guid = $container_guid;
 
-$tags = explode(",", $tags);
-$topic->tags = $tags;
+$topic->tags = string_to_tag_array($tags);
 
 $result = $topic->save();
 

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2015031300;
+$version = 2015041400;
 
 $composerJson = file_get_contents(dirname(__FILE__) . "/composer.json");
 if ($composerJson === false) {


### PR DESCRIPTION
Metastrings for annotation and metadata name and values are again trimmed before saving.

Fixes #8123
