### PR TITLE
fix(comments): allow comments hook to return empty strings

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1153,7 +1153,7 @@ function elgg_view_comments($entity, $add_comment = true, array $vars = array())
 	$vars['class'] = elgg_extract('class', $vars, "{$entity->getSubtype()}-comments");
 
 	$output = elgg_trigger_plugin_hook('comments', $entity->getType(), $vars, false);
-	if ($output) {
+	if ($output !== false) {
 		return $output;
 	} else {
 		return elgg_view('page/elements/comments', $vars);


### PR DESCRIPTION
Falsy values returned by hook handlers for comments result in default form being displayed. This checks to see if the false value passed as default to the hook has been altered, and only displays the default comments form if not.
