### PR TITLE
fix(search): Search treats "0" as a valid query

### DIFF
--- a/actions/user/changepassword.php
+++ b/actions/user/changepassword.php
@@ -25,7 +25,13 @@ if ($password != $password_repeat) {
 
 if (execute_new_password_request($user_guid, $code, $password)) {
 	system_message(elgg_echo('user:password:success'));
-	login(get_entity($user_guid));
+	
+	try {
+		login(get_entity($user_guid));
+	} catch (LoginException $e) {
+		register_error($e->getMessage());
+		forward(REFERER);
+	}
 } else {
 	register_error(elgg_echo('user:password:fail'));
 }

--- a/engine/classes/Elgg/I18n/Translator.php
+++ b/engine/classes/Elgg/I18n/Translator.php
@@ -115,11 +115,13 @@ class Translator {
 	
 		$country_code = strtolower($country_code);
 		$country_code = trim($country_code);
-		if (is_array($language_array) && sizeof($language_array) > 0 && $country_code != "") {
-			if (!isset($this->CONFIG->translations[$country_code])) {
-				$this->CONFIG->translations[$country_code] = $language_array;
-			} else {
-				$this->CONFIG->translations[$country_code] = $language_array + $this->CONFIG->translations[$country_code];
+		if (is_array($language_array) && $country_code != "") {
+			if (sizeof($language_array) > 0) { 
+				if (!isset($this->CONFIG->translations[$country_code])) {
+					$this->CONFIG->translations[$country_code] = $language_array;
+				} else {
+					$this->CONFIG->translations[$country_code] = $language_array + $this->CONFIG->translations[$country_code];
+				}
 			}
 			return true;
 		}
@@ -242,7 +244,7 @@ class Translator {
 	
 			if (in_array($language, $load_language_files) || $load_all) {
 				$result = include_once($path . $language);
-				if (!$result) {
+				if ($result === false) {
 					$return = false;
 					continue;
 				} elseif (is_array($result)) {

--- a/engine/classes/Elgg/Notifications/Event.php
+++ b/engine/classes/Elgg/Notifications/Event.php
@@ -26,13 +26,13 @@ class Event {
 	/**
 	 * Create a notification event
 	 *
-	 * @param \ElggData $object The object of the event (\ElggEntity)
-	 * @param string    $action The name of the action (default: create)
-	 * @param \ElggUser $actor  The user that caused the event (default: logged in user)
+	 * @param \ElggData   $object The object of the event (\ElggEntity)
+	 * @param string      $action The name of the action (default: create)
+	 * @param \ElggEntity $actor  The entity that caused the event (default: logged in user)
 	 * 
 	 * @throws \InvalidArgumentException
 	 */
-	public function __construct(\ElggData $object, $action, \ElggUser $actor = null) {
+	public function __construct(\ElggData $object, $action, \ElggEntity $actor = null) {
 		if (elgg_instanceof($object)) {
 			$this->object_type = $object->getType();
 			$this->object_subtype = $object->getSubtype();
@@ -55,7 +55,7 @@ class Event {
 	/**
 	 * Get the actor of the event
 	 *
-	 * @return \ElggUser
+	 * @return \ElggEntity|false
 	 */
 	public function getActor() {
 		return get_entity($this->actor_guid);

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -359,7 +359,7 @@ function _elgg_notify_user($to, $from, $subject, $message, array $params = null,
 					$handler = $notify_service->getDeprecatedHandler($method);
 					/* @var callable $handler */
 					if (!$handler || !is_callable($handler)) {
-						error_log("No handler registered for the method $method", 'WARNING');
+						elgg_log("No handler registered for the method $method", 'WARNING');
 						continue;
 					}
 

--- a/mod/ckeditor/views/default/js/elgg/ckeditor/config.js
+++ b/mod/ckeditor/views/default/js/elgg/ckeditor/config.js
@@ -10,7 +10,7 @@ define(function(require) {
 		removePlugins: 'contextmenu,tabletools,resize',
 		extraPlugins: 'blockimagepaste',
 		defaultLanguage: 'en',
-		language: elgg.config.language,
+		language: elgg.get_language(),
 		skin: 'moono',
 		uiColor: '#EEEEEE',
 		contentsCss: elgg.get_simplecache_url('css', 'elgg/wysiwyg.css'),

--- a/mod/messageboard/start.php
+++ b/mod/messageboard/start.php
@@ -116,7 +116,7 @@ function messageboard_add($poster, $owner, $message, $access_id = ACCESS_PUBLIC)
 		$body = elgg_echo('messageboard:email:body', array(
 			$poster->name,
 			$message,
-			elgg_get_site_url() . "messageboard/" . $owner->username,
+			elgg_get_site_url() . "messageboard/owner/" . $owner->username,
 			$poster->name,
 			$poster->getURL()
 		), $owner->language);

--- a/mod/search/pages/search/index.php
+++ b/mod/search/pages/search/index.php
@@ -20,7 +20,7 @@ $query = stripslashes(get_input('q', get_input('tag', '')));
 $display_query = _elgg_get_display_query($query);
 
 // check that we have an actual query
-if (!$query) {
+if (empty($query) && $query != "0") {
 	$title = sprintf(elgg_echo('search:results'), "\"$display_query\"");
 	
 	$body = elgg_echo('search:no_query');

--- a/mod/thewire/actions/delete.php
+++ b/mod/thewire/actions/delete.php
@@ -9,7 +9,7 @@ $guid = (int) get_input('guid');
 
 // Make sure we actually have permission to edit
 $thewire = get_entity($guid);
-if ($thewire->getSubtype() == "thewire" && $thewire->canEdit()) {
+if (elgg_instanceof($thewire, 'object', 'thewire') && $thewire->canEdit()) {
 
 	// unset reply metadata on children
 	$children = elgg_get_entities_from_relationship(array(
@@ -37,3 +37,5 @@ if ($thewire->getSubtype() == "thewire" && $thewire->canEdit()) {
 
 	forward("thewire/owner/" . $owner->username);
 }
+
+forward(REFERER);

--- a/views/default/navigation/pagination.php
+++ b/views/default/navigation/pagination.php
@@ -17,13 +17,17 @@ if (elgg_in_context('widget')) {
 	return true;
 }
 
+$count = (int) elgg_extract('count', $vars, 0);
+if (!$count) {
+	return true;
+}
+
 $offset = abs((int) elgg_extract('offset', $vars, 0));
 // because you can say $vars['limit'] = 0
 if (!$limit = (int) elgg_extract('limit', $vars, elgg_get_config('default_limit'))) {
 	$limit = 10;
 }
 
-$count = (int) elgg_extract('count', $vars, 0);
 $offset_key = elgg_extract('offset_key', $vars, 'offset');
 // some views pass an empty string for base_url
 if (isset($vars['base_url']) && $vars['base_url']) {

--- a/views/default/navigation/pagination.php
+++ b/views/default/navigation/pagination.php
@@ -14,12 +14,12 @@
 
 if (elgg_in_context('widget')) {
 	// widgets do not show pagination
-	return true;
+	return;
 }
 
 $count = (int) elgg_extract('count', $vars, 0);
 if (!$count) {
-	return true;
+	return;
 }
 
 $offset = abs((int) elgg_extract('offset', $vars, 0));
@@ -43,7 +43,7 @@ if (isset($vars['base_url']) && $vars['base_url']) {
 
 if ($count <= $limit && $offset == 0) {
 	// no need for pagination
-	return true;
+	return;
 }
 
 $total_pages = (int) ceil($count / $limit);

--- a/views/default/page/components/gallery.php
+++ b/views/default/page/components/gallery.php
@@ -18,12 +18,8 @@
  */
 
 $items = $vars['items'];
-$offset = $vars['offset'];
-$limit = $vars['limit'];
 $count = $vars['count'];
-$base_url = elgg_extract('base_url', $vars, '');
 $pagination = elgg_extract('pagination', $vars, true);
-$offset_key = elgg_extract('offset_key', $vars, 'offset');
 $position = elgg_extract('position', $vars, 'after');
 $no_results = elgg_extract('no_results', $vars, '');
 
@@ -52,16 +48,7 @@ if (isset($vars['item_class'])) {
 	$item_class = "$item_class {$vars['item_class']}";
 }
 
-$nav = '';
-if ($pagination && $count) {
-	$nav .= elgg_view('navigation/pagination', array(
-		'base_url' => $base_url,
-		'offset' => $offset,
-		'count' => $count,
-		'limit' => $limit,
-		'offset_key' => $offset_key,
-	));
-}
+$nav = ($pagination) ? elgg_view('navigation/pagination', $vars) : '';
 
 if ($position == 'before' || $position == 'both') {
 	echo $nav;

--- a/views/default/page/components/list.php
+++ b/views/default/page/components/list.php
@@ -19,12 +19,8 @@
  */
 
 $items = $vars['items'];
-$offset = elgg_extract('offset', $vars);
-$limit = elgg_extract('limit', $vars);
 $count = elgg_extract('count', $vars);
-$base_url = elgg_extract('base_url', $vars, '');
 $pagination = elgg_extract('pagination', $vars, true);
-$offset_key = elgg_extract('offset_key', $vars, 'offset');
 $position = elgg_extract('position', $vars, 'after');
 $no_results = elgg_extract('no_results', $vars, '');
 
@@ -52,17 +48,7 @@ if (isset($vars['item_class'])) {
 }
 
 $html = "";
-$nav = "";
-
-if ($pagination && $count) {
-	$nav .= elgg_view('navigation/pagination', array(
-		'base_url' => $base_url,
-		'offset' => $offset,
-		'count' => $count,
-		'limit' => $limit,
-		'offset_key' => $offset_key,
-	));
-}
+$nav = ($pagination) ? elgg_view('navigation/pagination', $vars) : '';
 
 $html .= "<ul class=\"$list_class\">";
 foreach ($items as $item) {

--- a/views/default/page/components/list.php
+++ b/views/default/page/components/list.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * View a list of items
  *
@@ -17,7 +18,6 @@
  * @uses $vars['item_view']   Alternative view to render list items
  * @uses $vars['no_results']  Message to display if no results (string|Closure)
  */
-
 $items = $vars['items'];
 $count = elgg_extract('count', $vars);
 $pagination = elgg_extract('pagination', $vars, true);
@@ -37,50 +37,51 @@ if (!is_array($items) || count($items) == 0) {
 	return;
 }
 
-$list_class = 'elgg-list';
+$list_classes = ['elgg-list'];
 if (isset($vars['list_class'])) {
-	$list_class = "$list_class {$vars['list_class']}";
+	$list_classes[] = $vars['list_class'];
 }
 
-$item_class = 'elgg-item';
+$item_classes = ['elgg-item'];
 if (isset($vars['item_class'])) {
-	$item_class = "$item_class {$vars['item_class']}";
+	$item_classes[] = $vars['item_class'];
 }
 
-$html = "";
 $nav = ($pagination) ? elgg_view('navigation/pagination', $vars) : '';
 
-$html .= "<ul class=\"$list_class\">";
+$list_items = '';
 foreach ($items as $item) {
-	$li = elgg_view_list_item($item, $vars);
-	if ($li) {
-		$item_classes = array($item_class);
-		
-		if (elgg_instanceof($item)) {
-			$id = "elgg-{$item->getType()}-{$item->getGUID()}";
-			
-			$item_classes[] = "elgg-item-" . $item->getType();
-			$subtype = $item->getSubType();
-			if ($subtype) {
-				$item_classes[] = "elgg-item-" . $item->getType() . "-" . $subtype;
-			}
-		} else {
-			$id = "item-{$item->getType()}-{$item->id}";
-		}
-		
-		$item_classes = implode(" ", $item_classes);
-		
-		$html .= "<li id=\"$id\" class=\"$item_classes\">$li</li>";
+	$item_view = elgg_view_list_item($item, $vars);
+	if (!$item_view) {
+		continue;
 	}
+
+	$li_attrs = ['class' => $item_classes];
+
+	if ($item instanceof \ElggEntity) {
+		$guid = $item->getGUID();
+		$type = $item->getType();
+		$subtype = $item->getSubtype();
+
+		$li_attrs['id'] = "elgg-$type-$guid";
+
+		$li_attrs['class'][] = "elgg-item-$type";
+		if ($subtype) {
+			$li_attrs['class'][] = "elgg-item-$type-$subtype";
+		}
+	} else if (is_callable(array($item, 'getType'))) {
+		$li_attrs['id'] = "item-{$item->getType()}-{$item->id}";
+	}
+
+	$list_items .= elgg_format_element('li', $li_attrs, $item_view);
 }
-$html .= '</ul>';
 
 if ($position == 'before' || $position == 'both') {
-	$html = $nav . $html;
+	echo $nav;
 }
+
+echo elgg_format_element('ul', ['class' => $list_classes], $list_items);
 
 if ($position == 'after' || $position == 'both') {
-	$html .= $nav;
+	echo $nav;
 }
-
-echo $html;


### PR DESCRIPTION
If an object has the valid tag "0", search will return an error if the tag is clicked. This pull request changes search to treat "0" as a valid query.

Disregard previous PR in favor of this one with the correct commit message format, please.
