### PR TITLE
fix(search): Search treats "0" as a valid query

### DIFF
--- a/mod/search/pages/search/index.php
+++ b/mod/search/pages/search/index.php
@@ -20,7 +20,7 @@ $query = stripslashes(get_input('q', get_input('tag', '')));
 $display_query = _elgg_get_display_query($query);
 
 // check that we have an actual query
-if (!$query) {
+if (empty($query) && $query != "0") {
 	$title = sprintf(elgg_echo('search:results'), "\"$display_query\"");
 	
 	$body = elgg_echo('search:no_query');


### PR DESCRIPTION
If an object has the valid tag "0", search will return an error if the tag is clicked. This pull request changes search to treat "0" as a valid query.

Disregard previous PR in favor of this one with the correct commit message format, please.

Third time is the charm.
