### PR TITLE
fix(views): account for null access id value

### DIFF
--- a/views/default/input/access.php
+++ b/views/default/input/access.php
@@ -66,7 +66,7 @@ if (!$params['container_guid'] && $container) {
 }
 
 // don't call get_default_access() unless we need it
-if (!isset($vars['value']) || $vars['value'] == ACCESS_DEFAULT) {
+if (!isset($vars['value']) || is_null($vars['value']) || $vars['value'] == ACCESS_DEFAULT) {
 	if ($entity) {
 		$vars['value'] = $entity->access_id;
 	} else {


### PR DESCRIPTION
The access input view only checks if the value is set before populating the value. This makes sure we populate the value when value passed to the view is null.
