### PR TITLE
Comments/discussion pagination links jump to comments/replies

### DIFF
--- a/mod/groups/views/default/discussion/replies.php
+++ b/mod/groups/views/default/discussion/replies.php
@@ -16,6 +16,7 @@ $replies = elgg_list_entities(array(
 	'container_guid' => $vars['topic']->getGUID(),
 	'reverse_order_by' => true,
 	'distinct' => false,
+	'url_fragment' => 'group-replies',
 ));
 
 echo $replies;

--- a/views/default/page/components/list.php
+++ b/views/default/page/components/list.php
@@ -5,18 +5,19 @@
  *
  * @package Elgg
  *
- * @uses $vars['items']       Array of ElggEntity, ElggAnnotation or ElggRiverItem objects
- * @uses $vars['offset']      Index of the first list item in complete list
- * @uses $vars['limit']       Number of items per page. Only used as input to pagination.
- * @uses $vars['count']       Number of items in the complete list
- * @uses $vars['base_url']    Base URL of list (optional)
- * @uses $vars['pagination']  Show pagination? (default: true)
- * @uses $vars['position']    Position of the pagination: before, after, or both
- * @uses $vars['full_view']   Show the full view of the items (default: false)
- * @uses $vars['list_class']  Additional CSS class for the <ul> element
- * @uses $vars['item_class']  Additional CSS class for the <li> elements
- * @uses $vars['item_view']   Alternative view to render list items
- * @uses $vars['no_results']  Message to display if no results (string|Closure)
+ * @uses $vars['items']        Array of ElggEntity, ElggAnnotation or ElggRiverItem objects
+ * @uses $vars['offset']       Index of the first list item in complete list
+ * @uses $vars['limit']        Number of items per page. Only used as input to pagination.
+ * @uses $vars['count']        Number of items in the complete list
+ * @uses $vars['base_url']     Base URL of list (optional)
+ * @uses $vars['url_fragment'] URL fragment to add to links if not present in base_url (optional)
+ * @uses $vars['pagination']   Show pagination? (default: true)
+ * @uses $vars['position']     Position of the pagination: before, after, or both
+ * @uses $vars['full_view']    Show the full view of the items (default: false)
+ * @uses $vars['list_class']   Additional CSS class for the <ul> element
+ * @uses $vars['item_class']   Additional CSS class for the <li> elements
+ * @uses $vars['item_view']    Alternative view to render list items
+ * @uses $vars['no_results']   Message to display if no results (string|Closure)
  */
 $items = $vars['items'];
 $count = elgg_extract('count', $vars);

--- a/views/default/page/elements/comments.php
+++ b/views/default/page/elements/comments.php
@@ -19,27 +19,19 @@ if (!$limit) {
 	$limit = elgg_trigger_plugin_hook('config', 'comments_per_page', [], 25);
 }
 
-$id = '';
-if (isset($vars['id'])) {
-	$id = "id=\"{$vars['id']}\"";
-} else {
-	$id = "id=\"comments\"";
-}
-
-$class = 'elgg-comments';
-if (isset($vars['class'])) {
-	$class = "$class {$vars['class']}";
-}
+$attr = [
+	'id' => elgg_extract('id', $vars, 'comments'),
+	'class' => (array) elgg_extract('class', $vars, []),
+];
+$attr['class'][] = 'elgg-comments';
 
 // work around for deprecation code in elgg_view()
 unset($vars['internalid']);
 
-echo "<div $id class=\"$class\">";
-
-$html = elgg_list_entities(array(
+$content = elgg_list_entities(array(
 	'type' => 'object',
 	'subtype' => 'comment',
-	'container_guid' => $vars['entity']->getGUID(),
+	'container_guid' => $vars['entity']->guid,
 	'reverse_order_by' => true,
 	'full_view' => true,
 	'limit' => $limit,
@@ -47,10 +39,8 @@ $html = elgg_list_entities(array(
 	'distinct' => false,
 ));
 
-echo $html;
-
 if ($show_add_form) {
-	echo elgg_view_form('comment/save', array(), $vars);
+	$content .= elgg_view_form('comment/save', array(), $vars);
 }
 
-echo '</div>';
+echo elgg_format_element('div', $attr, $content);

--- a/views/default/page/elements/comments.php
+++ b/views/default/page/elements/comments.php
@@ -37,6 +37,7 @@ $content = elgg_list_entities(array(
 	'limit' => $limit,
 	'preload_owners' => true,
 	'distinct' => false,
+	'url_fragment' => $attr['id'],
 ));
 
 if ($show_add_form) {


### PR DESCRIPTION
This is a refactoring of #8174 to make this UX improvement easily addable to any paginated list.

feature(views): Users can jump directly to content via prev/next links

This adds an option to add a URL fragment to pagination links, jumping the user directly to the paginated content on pages 2 and after. When returning to the first page, the fragment is not included, assuming that the user may actually want to see the full first page.

Should the base_url option contain a fragment, the url_fragment value will not replace it.

feature(comments): Paging through comments/discussion replies jumps to content

Comment and discussion reply listings now include URL fragments that push the user directly to the next set of comments/replies on the new page.

Refs #5041
