### PR TITLE
fix(navigation): Links to “Comments” again link directly to the comments section

### DIFF
--- a/views/default/page/elements/comments.php
+++ b/views/default/page/elements/comments.php
@@ -22,6 +22,8 @@ if (!$limit) {
 $id = '';
 if (isset($vars['id'])) {
 	$id = "id=\"{$vars['id']}\"";
+} else {
+	$id = "id=\"comments\"";
 }
 
 $class = 'elgg-comments';


### PR DESCRIPTION
In an earlier redesign of the comments, a separate element with `id="comments"` was removed. This applies the id to the containing DIV element.

Fixes #8227
