### PR TITLE
WIP: feature(db): Allow getting row iterator from get_data()

### DIFF
--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elgg;
 use Elgg\Database\Config;
+use Elgg\Database\ResultIterator;
 
 /**
  * An object representing a single Elgg database.
@@ -165,14 +166,21 @@ class Database {
 	 * argument to $callback.  If no callback function is defined, the
 	 * entire result set is returned as an array.
 	 *
-	 * @param mixed  $query    The query being passed.
-	 * @param string $callback Optionally, the name of a function to call back to on each row
+	 * @param mixed  $query       The query being passed.
+	 * @param string $callback    Optionally, the name of a function to call back to on each row
+	 * @param bool   $as_iterator If true, a ResultIterator will be returned. Rows will be fetched from the MySQL
+	 *                            client one-by-one, saving memory, and query caching/logging will not occur.
 	 *
 	 * @return array An array of database result objects or callback function results. If the query
 	 *               returned nothing, an empty array.
 	 * @throws \DatabaseException
 	 */
-	public function getData($query, $callback = '') {
+	public function getData($query, $callback = '', $as_iterator = false) {
+		if ($as_iterator) {
+			$result = $this->executeQuery("$query", $this->getLink('read'));
+			return new ResultIterator($result, $callback);
+		}
+
 		return $this->getResults($query, $callback, false);
 	}
 

--- a/engine/classes/Elgg/Database/ResultIterator.php
+++ b/engine/classes/Elgg/Database/ResultIterator.php
@@ -1,0 +1,140 @@
+<?php
+namespace Elgg\Database;
+
+use Elgg\Database;
+
+/**
+ * Iterate over a DB result set, returning stdClass objects optionally filtered through a callable.
+ */
+final class ResultIterator implements \Countable, \Iterator {
+
+	/**
+	 * @var int
+	 */
+	private $position = -1;
+
+	/**
+	 * @var resource
+	 */
+	private $result;
+
+	/**
+	 * @var int
+	 */
+	private $num_rows;
+
+	/**
+	 * @var \stdClass
+	 */
+	private $row;
+
+	/**
+	 * @var bool
+	 */
+	private $is_valid = false;
+
+	/**
+	 * @var callable
+	 */
+	private $callback;
+
+	/**
+	 * Constructor
+	 *
+	 * @param resource $result   MySQL result set
+	 * @param callable $callback Callable applied to each row
+	 *
+	 * @internal Devs should not use this class directly
+	 * @access private
+	 */
+	public function __construct($result, $callback = null) {
+		if (!is_resource($result) || get_resource_type($result) !== 'mysql result') {
+			throw new \InvalidArgumentException('$result must be a MySQL result');
+		}
+		$this->result = $result;
+
+		if ($callback && !is_callable($callback)) {
+			throw new \InvalidArgumentException('If given, $callback must be a callable');
+		}
+		$this->callback = $callback;
+
+		$this->num_rows = mysql_num_rows($result);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function rewind() {
+		if (!$this->num_rows) {
+			return;
+		}
+
+		mysql_data_seek($this->result, 0);
+		$this->position = -1;
+		$this->fetch();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function current() {
+		return $this->row;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function key() {
+		return $this->position;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function next() {
+		$this->fetch();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function valid() {
+		return $this->is_valid;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function count() {
+		return $this->num_rows;
+	}
+
+	/**
+	 * Destructor
+	 *
+	 * @return void
+	 */
+	public function __destruct() {
+		if (is_resource($this->result)) {
+			mysql_free_result($this->result);
+		}
+	}
+
+	/**
+	 * Fetch the next row
+	 *
+	 * @return void
+	 */
+	private function fetch() {
+		if (!$this->num_rows) {
+			return;
+		}
+
+		$this->row = mysql_fetch_object($this->result);
+		$this->is_valid = ($this->row !== false);
+		if ($this->callback) {
+			$this->row = call_user_func($this->callback, $this->row);
+		}
+		$this->position += 1;
+	}
+}

--- a/engine/lib/database.php
+++ b/engine/lib/database.php
@@ -41,14 +41,16 @@ function execute_delayed_read_query($query, $handler = "") {
  * argument to $callback.  If no callback function is defined, the
  * entire result set is returned as an array.
  *
- * @param mixed  $query    The query being passed.
- * @param string $callback Optionally, the name of a function to call back to on each row
+ * @param mixed  $query       The query being passed.
+ * @param string $callback    Optionally, the name of a function to call back to on each row
+ * @param bool   $as_iterator If true, a ResultIterator will be returned. Rows will be fetched from the MySQL
+ *                            client one-by-one, saving memory, and query caching/logging will not occur.
  *
  * @return array An array of database result objects or callback function results. If the query
  *               returned nothing, an empty array.
  */
-function get_data($query, $callback = "") {
-	return _elgg_services()->db->getData($query, $callback);
+function get_data($query, $callback = "", $as_iterator = false) {
+	return _elgg_services()->db->getData($query, $callback, $as_iterator);
 }
 
 /**


### PR DESCRIPTION
This is for large queries where you don’t want to pull the full results into memory (or cache them). Users have to use ext/mysql directly to do this now.
- [ ] new function for get_data_iterator() ?
- [ ] tests
- [ ] docs

cc @brettp 
