### PR TITLE
fix(deprecation): visible deprecation warnings aren't displayed to admin anymore

### DIFF
--- a/docs/contribute/code.rst
+++ b/docs/contribute/code.rst
@@ -602,22 +602,18 @@ Function expressions should end with a semi-colon.
 Deprecating APIs
 ================
 
-Occasionally, functions and classes must be deprecated in favor of newer replacements.
-Since 3rd party plugin authors rely on a consistent API,
-backward compatibility must be maintained,
-but will not be maintained indefinitely as
-plugin authors are expected to properly update their plugins.
-In order to maintain backward compatibility,
-deprecated APIs will follow these guidelines:
+Occasionally functions and classes must be deprecated in favor of newer
+replacements. Since 3rd party plugin authors rely on a consistent API,
+backward compatibility must be maintained, but will not be maintained
+indefinitely as plugin authors are expected to properly update their plugins.
+In order to maintain backward compatibility, deprecated APIs will follow
+these guidelines:
 
-* The first minor version (1.7) with a deprecated API must include a wrapper
-  function/class (or otherwise appropriate means) to maintain backward compatibility,
-  including any bugs in the original function/class.
-  This compatibility layer uses ``elgg_deprecated_notice('...', '1.7')``
+* Minor version (1.x) that deprecates an API must include a wrapper
+  function/class (or otherwise appropriate means) to maintain backward
+  compatibility, including any bugs in the original function/class.
+  This compatibility layer uses ``elgg_deprecated_notice('...', '1.11')``
   to log that the function is deprecated.
-
-* The following minor versions (1.8+) maintain the backward compatibility layer,
-  but ``elgg_deprecated_notice()`` will produce a visible warning.
 
 * The next major revision (2.0) removes the compatibility layer.
   Any use of the deprecated API should be corrected before this.

--- a/engine/classes/Elgg/DeprecationService.php
+++ b/engine/classes/Elgg/DeprecationService.php
@@ -38,7 +38,7 @@ class DeprecationService {
 	/**
 	 * Sends a notice about deprecated use of a function, view, etc.
 	 *
-	 * @param string $msg             Message to log / display.
+	 * @param string $msg             Message to log
 	 * @param string $dep_version     Human-readable *release* version: 1.7, 1.8, ...
 	 * @param int    $backtrace_level How many levels back to display the backtrace.
 	 *                                Useful if calling from functions that are called
@@ -47,11 +47,6 @@ class DeprecationService {
 	 * @return bool
 	 */
 	function sendNotice($msg, $dep_version, $backtrace_level = 1) {
-		// if it's a major release behind, visual and logged
-		// if it's a 1 minor release behind, visual and logged
-		// if it's for current minor release, logged.
-		// bugfixes don't matter because we are not deprecating between them
-
 		if (!$dep_version) {
 			return false;
 		}
@@ -65,23 +60,10 @@ class DeprecationService {
 		$dep_major_version = (int)$dep_version_arr[0];
 		$dep_minor_version = (int)$dep_version_arr[1];
 
-		$visual = false;
+		$msg = "Deprecated in $dep_major_version.$dep_minor_version: $msg Called from ";
 
-		if (($dep_major_version < $elgg_major_version) ||
-			($dep_minor_version < $elgg_minor_version)) {
-			$visual = true;
-		}
-
-		$msg = "Deprecated in $dep_major_version.$dep_minor_version: $msg";
-
-		if ($visual && $this->session->isAdminLoggedIn()) {
-			register_error($msg);
-		}
-
-		// Get a file and line number for the log. Never show this in the UI.
-		// Skip over the function that sent this notice and see who called the deprecated
-		// function itself.
-		$msg .= " Called from ";
+		// Get a file and line number for the log. Skip over the function that
+		// sent this notice and see who called the deprecated function itself.
 		$stack = array();
 		$backtrace = debug_backtrace();
 		// never show this call.

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -991,24 +991,9 @@ function elgg_get_version($human_readable = false) {
 }
 
 /**
- * Sends a notice about deprecated use of a function, view, etc.
+ * Log a notice about deprecated use of a function, view, etc.
  *
- * This function either displays or logs the deprecation message,
- * depending upon the deprecation policies in {@link CODING.txt}.
- * Logged messages are sent with the level of 'WARNING'. Only admins
- * get visual deprecation notices. When non-admins are logged in, the
- * notices are sent to PHP's log through elgg_dump().
- *
- * A user-visual message will be displayed if $dep_version is greater
- * than 1 minor releases lower than the current Elgg version, or at all
- * lower than the current Elgg major version.
- *
- * @note This will always at least log a warning.  Don't use to pre-deprecate things.
- * This assumes we are releasing in order and deprecating according to policy.
- *
- * @see CODING.txt
- *
- * @param string $msg             Message to log / display.
+ * @param string $msg             Message to log
  * @param string $dep_version     Human-readable *release* version: 1.7, 1.8, ...
  * @param int    $backtrace_level How many levels back to display the backtrace.
  *                                Useful if calling from functions that are called


### PR DESCRIPTION
We cannot assume all administrators to have the technical skill to upgrade plugin code or even the capability to install a new plugin version that has addressed the deprecation issues. Therefore it is best not to display visible errors at all as they only give the impression that the site is broken even though this is not the case.
