### PR TITLE
perf(scripts): Load all scripts in foot regardless of registered location

### DIFF
--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -122,12 +122,13 @@ Load a library on the current page with ``elgg_load_js``:
 
 This will include and execute the linked code.
 
-.. tip::
+.. warning::
 
-   Using inline scripts is strongly discouraged because:
+   Using inline scripts is NOT SUPPORTED because:
     * They are not testable (maintainability)
     * They are not cacheable (performance)
-    * Doing so forces some scripts to be loaded in ``<head>`` (performance)
+    * They prevent use of Content-Security-Policy (security) 
+    * They prevent scripts from being loaded with ``defer`` or ``async`` (performance)
 
    Inline scripts in core or bundled plugins are considered legacy bugs.
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -12,6 +12,11 @@ See the administrator guides for :doc:`how to upgrade a live site </admin/upgrad
 From 1.11 to 2.0
 ================
 
+All scripts moved to bottom of page
+-----------------------------------
+This was done for performance reasons but breaks any inline scripts in views.
+Convert your inline scripts to external scripts and load them with ``elgg_load_js``.
+
 Removed Functions
 -----------------
 

--- a/views/default/page/elements/foot.php
+++ b/views/default/page/elements/foot.php
@@ -2,14 +2,20 @@
 
 echo elgg_view_deprecated('footer/analytics', array(), "Extend page/elements/foot instead", 1.8);
 
-$js = elgg_get_loaded_js('footer');
-foreach ($js as $script) { ?>
-	<script src="<?php echo htmlspecialchars($script, ENT_QUOTES, 'UTF-8'); ?>"></script>
-<?php
+$elgg_init = elgg_view('js/initialize_elgg');
+echo "<script>$elgg_init</script>";
+
+// TODO(evan): "head" JS and "footer" JS distinction doesn't make sense anymore
+// TODO(evan): Introduce new "async" location for scripts allowed in head?
+$js = elgg_get_loaded_js('head');
+foreach ($js as $url) {
+	echo elgg_format_element('script', array('src' => $url));
 }
 
-$deps = _elgg_services()->amdConfig->getDependencies();
-?>
-<script>
-require(<?php echo json_encode($deps); ?>);
-</script>
+$js = elgg_get_loaded_js('footer');
+foreach ($js as $url) {
+	echo elgg_format_element('script', array('src' => $url));
+}
+
+$requires = json_encode(_elgg_services()->amdConfig->getDependencies());
+echo "<script>require($requires)</script>";

--- a/views/default/page/elements/head.php
+++ b/views/default/page/elements/head.php
@@ -28,9 +28,7 @@ foreach ($links as $attributes) {
 	echo elgg_format_element('link', $attributes);
 }
 
-$js = elgg_get_loaded_js('head');
 $css = elgg_get_loaded_css();
-$elgg_init = elgg_view('js/initialize_elgg');
 
 $html5shiv_url = elgg_normalize_url('vendors/html5shiv.js');
 $ie_url = elgg_get_simplecache_url('css', 'ie');
@@ -52,11 +50,7 @@ foreach ($css as $url) {
 		<link rel="stylesheet" href="<?php echo $ie_url; ?>" />
 	<![endif]-->
 
-	<script><?php echo $elgg_init; ?></script>
 <?php
-foreach ($js as $url) {
-	echo elgg_format_element('script', array('src' => $url));
-}
 
 echo elgg_view_deprecated('page/elements/shortcut_icon', array(), "Use the 'head', 'page' plugin hook.", 1.9);
 


### PR DESCRIPTION
BREAKING CHANGE:
If you use any inline scripts that depend on scripts in head,
you'll need to change them to external AMD modules and
load them with `elgg_require_js`.

Fixes #2718
