### PR TITLE
fix(output): fewer view $vars will be output by accident

### DIFF
--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -132,6 +132,8 @@ function elgg_format_bytes($size, $precision = 2) {
  *
  * @note usually for HTML, but could be useful for XML too...
  *
+ * @note Key names containing "_" will be ignored.
+ *
  * @param array $attrs An associative array of attr => val pairs
  *
  * @return string HTML attributes to be inserted into a tag (e.g., <tag $attrs>)
@@ -155,6 +157,11 @@ function elgg_format_attributes(array $attrs = array()) {
 	}
 
 	foreach ($attrs as $attr => $val) {
+		if (false !== strpos($attr, '_')) {
+			// this is probably a view $vars variable not meant for output
+			continue;
+		}
+
 		$attr = strtolower($attr);
 
 		if ($val === true) {


### PR DESCRIPTION
A general problem is views passing along arbitrary $vars values to views like output/url, which treat unrecognized $vars as HTML attributes. This at least strips keys with underscores, which are definitely not meant to be HTML attributes.

Fixes #8218
- [ ] Passthrough attributes starting with `data-`
