### PR TITLE
fix(filestore): Fixed a crash when forms had a file input but no file was provided

### DIFF
--- a/engine/lib/filestore.php
+++ b/engine/lib/filestore.php
@@ -47,6 +47,10 @@ function get_uploaded_file($input_name) {
 	}
 
 	$file = $files->get($input_name);
+	if (empty($file)) {
+		// a file input was provided but no file uploaded
+		return false;
+	}
 	if ($file->getError() !== 0) {
 		return false;
 	}
@@ -74,8 +78,12 @@ $square = false, $upscale = false) {
 	if (!$files->has($input_name)) {
 		return false;
 	}
+	
 	$file = $files->get($input_name);
-
+	if (empty($file)) {
+		// a file input was provided but no file uploaded
+		return false;
+	}
 	if ($file->getError() !== 0) {
 		return false;
 	}


### PR DESCRIPTION
If a form has an input/file, but no file was uploaded the system could
crash because of incorrect checks
