### PR TITLE
chore(tests): Remove notice in entity preloader simpletest

### DIFF
--- a/engine/tests/ElggEntityPreloaderIntegrationTest.php
+++ b/engine/tests/ElggEntityPreloaderIntegrationTest.php
@@ -50,7 +50,7 @@ class ElggEntityPreloaderIntegrationTest extends ElggCoreUnitTest {
 class MockEntityPreloader20140623 extends Elgg\EntityPreloader {
 	public $preloaded;
 
-	public function preload($objects) {
+	public function preload($objects, array $guid_properties) {
 		$this->preloaded = $objects;
 	}
 }


### PR DESCRIPTION
The mock’s preload() didn’t match the signature.
