### PR TITLE
feature(application): adds services to Application and adds elgg()

### DIFF
--- a/engine/classes/Elgg/CacheHandler.php
+++ b/engine/classes/Elgg/CacheHandler.php
@@ -32,7 +32,7 @@ class CacheHandler {
 	 * @return void
 	 */
 	public function handleRequest($get_vars, $server_vars) {
-		$config = $this->application->getConfig();
+		$config = $this->application->config;
 
 		if (empty($get_vars['request'])) {
 			$this->send403();
@@ -143,7 +143,7 @@ class CacheHandler {
 	 */
 	protected function setupSimplecache() {
 		// we can't use Elgg\Config::get yet. It fails before the core is booted
-		$config = $this->application->getConfig();
+		$config = $this->application->config;
 		$config->loadSettingsFile();
 
 		if ($config->getVolatile('dataroot') && $config->getVolatile('simplecache_enabled') !== null) {
@@ -246,7 +246,7 @@ class CacheHandler {
 		}
 
 		// disable error reporting so we don't cache problems
-		$this->application->getConfig()->set('debug', null);
+		$this->application->config->set('debug', null);
 
 		// @todo elgg_view() checks if the page set is done (isset($CONFIG->pagesetupdone)) and
 		// triggers an event if it's not. Calling elgg_view() here breaks submenus
@@ -254,7 +254,7 @@ class CacheHandler {
 		// contexts can be correctly set (since this is called before page_handler()).
 		// To avoid this, lie about $CONFIG->pagehandlerdone to force
 		// the trigger correctly when the first view is actually being output.
-		$this->application->getConfig()->set('pagesetupdone', true);
+		$this->application->config->set('pagesetupdone', true);
 
 		return elgg_view($view);
 	}

--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -3,13 +3,9 @@ namespace Elgg;
 
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * Access to configuration values
  *
- * @access private
- *
- * @package    Elgg.Core
- * @subpackage Config
- * @since      1.10.0
+ * @since 1.10.0
  */
 class Config {
 	/**
@@ -26,6 +22,8 @@ class Config {
 
 	/**
 	 * Constructor
+	 *
+	 * @internal Access this object via Elgg\Application::$config
 	 *
 	 * @param \stdClass $config     Elgg's $CONFIG object
 	 * @param bool      $set_global Copy the config object to global $CONFIG
@@ -105,6 +103,9 @@ class Config {
 
 	/**
 	 * Get an Elgg configuration value, possibly loading it from the DB's config table
+	 *
+	 * Before application boot, it may be unsafe to call get() for some values. You should use
+	 * getVolatile() before system boot.
 	 *
 	 * @param string $name      Name of the configuration value
 	 * @param int    $site_guid null for installation setting, 0 for default site

--- a/engine/classes/Elgg/Context.php
+++ b/engine/classes/Elgg/Context.php
@@ -2,10 +2,8 @@
 namespace Elgg;
 
 /**
- * PRIVATE CLASS. API IN FLUX. DO NOT USE DIRECTLY.
- * 
- * PLUGIN DEVELOPERS SHOULD USE elgg_*_context FUNCTIONS INSTEAD.
- * 
+ * Manages a global stack of strings for sharing information about the current execution context
+ *
  * Views can modify their output based on the local context. You may want to
  * display a list of blogs on a blog page or in a small widget. The rendered
  * output could be different for those two contexts ('blog' vs 'widget').
@@ -19,10 +17,9 @@ namespace Elgg;
  *
  * @warning The context is not available until the page_handler runs (after
  * the 'init, system' event processing has completed).
- * 
- * @package Elgg.Core
- * @access  private
- * @since   1.10.0
+ *
+ * @access private
+ * @since 1.10.0
  */
 final class Context {
 	

--- a/engine/classes/Elgg/EventsService.php
+++ b/engine/classes/Elgg/EventsService.php
@@ -61,4 +61,70 @@ class EventsService extends \Elgg\HooksRegistrationService {
 
 		return true;
 	}
+
+	/**
+	 * Trigger a "Before event" indicating a process is about to begin.
+	 *
+	 * Like regular events, a handler returning false will cancel the process and false
+	 * will be returned.
+	 *
+	 * To register for a before event, append ":before" to the event name when registering.
+	 *
+	 * @param string $event       The event type. The fired event type will be appended with ":before".
+	 * @param string $object_type The object type
+	 * @param string $object      The object involved in the event
+	 *
+	 * @return bool False if any handler returned false, otherwise true
+	 *
+	 * @see trigger
+	 * @see triggerAfter
+	 * @since 2.0.0
+	 */
+	function triggerBefore($event, $object_type, $object = null) {
+		return $this->trigger("$event:before", $object_type, $object);
+	}
+
+	/**
+	 * Trigger an "After event" indicating a process has finished.
+	 *
+	 * Unlike regular events, all the handlers will be called, their return values ignored.
+	 *
+	 * To register for an after event, append ":after" to the event name when registering.
+	 *
+	 * @param string $event       The event type. The fired event type will be appended with ":after".
+	 * @param string $object_type The object type
+	 * @param string $object      The object involved in the event
+	 *
+	 * @return true
+	 *
+	 * @see triggerBefore
+	 * @since 2.0.0
+	 */
+	public function triggerAfter($event, $object_type, $object = null) {
+		$options = array(
+			self::OPTION_STOPPABLE => false,
+		);
+		return $this->trigger("$event:after", $object_type, $object, $options);
+	}
+
+	/**
+	 * Trigger an event normally, but send a notice about deprecated use if any handlers are registered.
+	 *
+	 * @param string $event       The event type
+	 * @param string $object_type The object type
+	 * @param string $object      The object involved in the event
+	 * @param string $message     The deprecation message
+	 * @param string $version     Human-readable *release* version: 1.9, 1.10, ...
+	 *
+	 * @return bool
+	 *
+	 * @see trigger
+	 */
+	function triggerDeprecated($event, $object_type, $object = null, $message, $version) {
+		$options = array(
+			self::OPTION_DEPRECATION_MESSAGE => $message,
+			self::OPTION_DEPRECATION_VERSION => $version,
+		);
+		return $this->trigger($event, $object_type, $object, $options);
+	}
 }

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -8,6 +8,16 @@
  */
 
 /**
+ * Get a reference to the global Application object
+ *
+ * @return Elgg\Application
+ * @since 2.0.0
+ */
+function elgg() {
+	return Elgg\Application::$_instance;
+}
+
+/**
  * Register a PHP file as a library.
  *
  * @see elgg_load_library
@@ -592,7 +602,7 @@ function elgg_trigger_event($event, $object_type, $object = null) {
  * @see elgg_trigger_after_event
  */
 function elgg_trigger_before_event($event, $object_type, $object = null) {
-	return _elgg_services()->events->trigger("$event:before", $object_type, $object);
+	return _elgg_services()->events->triggerBefore($event, $object_type, $object);
 }
 
 /**
@@ -611,10 +621,7 @@ function elgg_trigger_before_event($event, $object_type, $object = null) {
  * @see elgg_trigger_before_event
  */
 function elgg_trigger_after_event($event, $object_type, $object = null) {
-	$options = array(
-		\Elgg\EventsService::OPTION_STOPPABLE => false,
-	);
-	return _elgg_services()->events->trigger("$event:after", $object_type, $object, $options);
+	return _elgg_services()->events->triggerAfter($event, $object_type, $object);
 }
 
 /**
@@ -631,11 +638,7 @@ function elgg_trigger_after_event($event, $object_type, $object = null) {
  * @see elgg_trigger_event
  */
 function elgg_trigger_deprecated_event($event, $object_type, $object = null, $message, $version) {
-	$options = array(
-		\Elgg\EventsService::OPTION_DEPRECATION_MESSAGE => $message,
-		\Elgg\EventsService::OPTION_DEPRECATION_VERSION => $version,
-	);
-	return _elgg_services()->events->trigger($event, $object_type, $object, $options);
+	return _elgg_services()->events->triggerDeprecated($event, $object_type, $object, $message, $version);
 }
 
 /**

--- a/engine/lib/sites.php
+++ b/engine/lib/sites.php
@@ -12,25 +12,22 @@
  *
  * @param int $site_guid Optional. Site GUID.
  *
- * @return \ElggSite
+ * @return \ElggSite|false
  * @since 1.8.0
  */
 function elgg_get_site_entity($site_guid = 0) {
 	global $CONFIG;
 
-	$result = false;
-	
 	if ($site_guid == 0) {
-		$site = $CONFIG->site;
-	} else {
-		$site = get_entity($site_guid);
-	}
-	
-	if ($site instanceof \ElggSite) {
-		$result = $site;
+		return $CONFIG->site;
 	}
 
-	return $result;
+	$site = _elgg_services()->entityTable->get($site_guid);
+	if (!$site instanceof \ElggSite) {
+		return false;
+	}
+
+	return $site;
 }
 
 /**

--- a/engine/tests/phpunit/Elgg/ApplicationTest.php
+++ b/engine/tests/phpunit/Elgg/ApplicationTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace Elgg;
+
+class ApplicationTest extends \PHPUnit_Framework_TestCase {
+
+	function testElggReturnsApp() {
+		$app = _elgg_testing_application();
+
+		$this->assertSame($app, elgg());
+	}
+
+	function testStartsTimer() {
+		unset($GLOBALS['START_MICROTIME']);
+		new Application(_elgg_services());
+
+		$this->assertTrue(is_float($GLOBALS['START_MICROTIME']));
+	}
+
+	function testServices() {
+		$services = _elgg_services();
+		$app = new Application($services);
+
+		$names = [
+			'config',
+		];
+
+		foreach	($names as $name) {
+			$this->assertSame($services->{$name}, $app->{$name});
+		}
+	}
+
+	function testCanLoadSettings() {
+		$this->markTestIncomplete();
+	}
+
+	function testCanGetDb() {
+		$this->markTestIncomplete();
+	}
+
+	function testGettingDbLoadsSettings() {
+		$this->markTestIncomplete();
+	}
+
+	function testCanLoadCore() {
+		$this->markTestIncomplete();
+	}
+
+	function testCanBootCore() {
+		$this->markTestIncomplete();
+	}
+
+	function testBootLoadsCore() {
+		$this->markTestIncomplete();
+	}
+
+	function testRunCanRouteCliServer() {
+		$this->markTestIncomplete();
+	}
+
+	function testRunBootsAndRoutes() {
+		$this->markTestIncomplete();
+	}
+}
+

--- a/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
+++ b/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
@@ -5,10 +5,10 @@ namespace Elgg\Di;
 class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testPropertiesReturnCorrectClassNames() {
-		$sp = _elgg_testing_application()->getServices();
+		$sp = _elgg_services();
 
 		$sp->setValue('session', \ElggSession::getMock());
-		
+
 		$svcClasses = array(
 			'accessCache' => '\ElggStaticVariableCache',
 			'accessCollections' => '\Elgg\Database\AccessCollections',

--- a/mod/profile/icondirect.php
+++ b/mod/profile/icondirect.php
@@ -35,7 +35,7 @@ $app = new \Elgg\Application();
 $app->loadSettings();
 
 $data_root = call_user_func(function () use ($app) {
-	$dataroot = $app->getConfig()->getVolatile('dataroot');
+	$dataroot = $app->config->getVolatile('dataroot');
 	if ($dataroot) {
 		return $dataroot;
 	}


### PR DESCRIPTION
elgg() provides access to the booted Application instance which will provide access to future public API service objects (instead of global functions).

As a first step, this adds only the “config” service, which is needed to use the method getVolatile() before site boot.

For #8238
