### PR TITLE
feature(js): Adds temporary require() shim for deferring inline scripts

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -15,10 +15,38 @@ From 1.11 to 2.0
 All scripts moved to bottom of page
 -----------------------------------
 
-All inline scripts must be converted to :doc:`AMD </guides/javascript>` or to external scripts loaded with
-``elgg_load_js``. For performance reasons, Elgg no longer loads its core scripts in the ``head`` element,
-and ``elgg_register_js`` no longer honors ``$location == 'head'``, instead outputting all scripts at the
-end of the ``body`` element.
+You should test your plugin **with the JavaScript error console visible**. For performance reasons, Elgg no longer
+supports ``script`` elements in the ``head`` element or in HTML views. ``elgg_register_js`` will now load *all*
+scripts at the end of the ``body`` element.
+
+You must convert inline scripts to :doc:`AMD </guides/javascript>` or to external scripts loaded with
+``elgg_load_js``.
+
+Early in the page, Elgg provides a shim of the RequireJS ``require()`` function that simply queues code until
+the AMD ``elgg`` and ``jQuery`` modules are defined. This provides a straightforward way to convert many inline
+scripts to use ``require()``.
+
+Inline code which will fail because the stack is not yet loaded:
+
+.. code:: html
+
+    <script>
+    $(function () {
+        // code using $ and elgg
+    });
+    </script>
+
+This should work in Elgg 2.0:
+
+.. code:: html
+
+    <script>
+    require(['elgg', 'jquery'], function (elgg, $) {
+        $(function () {
+            // code using $ and elgg
+        });
+    });
+    </script>
 
 Removed Functions
 -----------------

--- a/mod/ckeditor/views/default/ckeditor/init.php
+++ b/mod/ckeditor/views/default/ckeditor/init.php
@@ -7,12 +7,14 @@
 
 ?>
 <script>
-// This global variable must be set before the editor script loading.
-CKEDITOR_BASEPATH = elgg.config.wwwroot + 'mod/ckeditor/vendors/ckeditor/';
+require(['elgg'], function (elgg) {
+	// This global variable must be set before the editor script loading.
+	CKEDITOR_BASEPATH = elgg.config.wwwroot + 'mod/ckeditor/vendors/ckeditor/';
 
-require(['elgg/ckeditor', 'jquery', 'jquery.ckeditor'], function(elggCKEditor, $) {
-	$('.elgg-input-longtext:not([data-cke-init])')
-		.attr('data-cke-init', true)
-		.ckeditor(elggCKEditor.init, elggCKEditor.config);
+	require(['elgg/ckeditor', 'jquery', 'jquery.ckeditor'], function(elggCKEditor, $) {
+		$('.elgg-input-longtext:not([data-cke-init])')
+			.attr('data-cke-init', true)
+			.ckeditor(elggCKEditor.init, elggCKEditor.config);
+	});
 });
 </script>

--- a/mod/developers/views/default/theme_sandbox/modules/widgets.php
+++ b/mod/developers/views/default/theme_sandbox/modules/widgets.php
@@ -52,17 +52,19 @@ echo '</div>';
 
 ?>
 </div>
-<script type="text/javascript">
+<script>
+require(['elgg', 'jquery'], function (elgg, $) {
 	// widgets do not have guids so we override the edit toggle and delete button
 	$(function() {
 		$('.elgg-widget-edit-button').unbind('click');
-		$('.elgg-widget-edit-button').click(function() {
+		$('.elgg-widget-edit-button').on('click', function() {
 			$(this).closest('.elgg-module-widget').find('.elgg-widget-edit').slideToggle('medium');
 			return false;
 		});
-		$('.elgg-widget-delete-button').click(function() {
+		$('.elgg-widget-delete-button').on('click', function() {
 			$(this).closest('.elgg-module-widget').remove();
 			return false;
 		});
 	});
+});
 </script>

--- a/mod/notifications/views/default/notifications/subscriptions/collections.php
+++ b/mod/notifications/views/default/notifications/subscriptions/collections.php
@@ -7,19 +7,17 @@
 $user = $vars['user'];
 
 //@todo JS 1.8: no ?>
-<script type="text/javascript">
-	
+<script>
 	function setCollection(members, method, id) {
 		for ( var i in members ) {
 			var checked = $('#' + method + 'collections' + id).children("INPUT[type='checkbox']").attr('checked');
-			if ($("#"+method+members[i]).children("INPUT[type='checkbox']").attr('checked') != checked) {  
+			if ($("#"+method+members[i]).children("INPUT[type='checkbox']").attr('checked') != checked) {
 				$("#"+method+members[i]).children("INPUT[type='checkbox']").attr('checked', checked);
 				functioncall = 'adjust' + method + '_alt("'+method+members[i]+'");';
 				eval(functioncall);
 			}
-		} 
+		}
 	}
-	
 </script>
 <div class="elgg-module elgg-module-info">
 	<div class="elgg-head">

--- a/mod/notifications/views/default/notifications/subscriptions/forminternals.php
+++ b/mod/notifications/views/default/notifications/subscriptions/forminternals.php
@@ -137,28 +137,29 @@ if (!isset($vars['replacement'])) {
 	if ($formtarget) {
 ?>
 <?php //@todo JS 1.8: no ?>
-	<script language="text/javascript">
-		$(function() { // onload...do
-		$('#collectionMembersForm<?php echo $friendspicker; ?>').submit(function() {
-			var inputs = [];
-			$(':input', this).each(function() {
-				if (this.type != 'checkbox' || (this.type == 'checkbox' && this.checked != false)) {
-					inputs.push(this.name + '=' + escape(this.value));
-				}
-			});
-			jQuery.ajax({
-				type: "POST",
-				data: inputs.join('&'),
-				url: this.action,
-				success: function(){
-					$('a.collectionmembers<?php echo $friendspicker; ?>').click();
-				}
+	<script>
+	require(['jquery'], function($) {
+		$(function () {
+			$('#collectionMembersForm<?php echo $friendspicker; ?>').submit(function() {
+				var inputs = [];
+				$(':input', this).each(function() {
+					if (this.type != 'checkbox' || (this.type == 'checkbox' && this.checked != false)) {
+						inputs.push(this.name + '=' + escape(this.value));
+					}
+				});
+				$.ajax({
+					type: "POST",
+					data: inputs.join('&'),
+					url: this.action,
+					success: function(){
+						$('a.collectionmembers<?php echo $friendspicker; ?>').click();
+					}
 
+				});
+				return false;
 			});
-			return false;
-		})
-	})
-
+		});
+	});
 	</script>
 
 <?php
@@ -307,26 +308,26 @@ if (!$callback) {
 if (!isset($vars['replacement'])) {
 ?>
 <?php //@todo JS 1.8: no ?>
-<script type="text/javascript">
+<script>
+require(['elgg', 'jquery'], function(elgg, $) {
+	$(function () {
 		// initialise picker
 		$("div#friends-picker<?php echo $friendspicker; ?>").friendsPicker(<?php echo $friendspicker; ?>);
-</script>
-<script type="text/javascript">
-	$(function () {
-	// manually add class to corresponding tab for panels that have content
-<?php
-	if (sizeof($activeletters) > 0) {
-		$chararray .= "*";
-		foreach($activeletters as $letter) {
-			$tab = elgg_strpos($chararray, $letter) + 1;
-?>
-	$("div#friends-picker-navigation<?php echo $friendspicker; ?> li.tab<?php echo $tab; ?> a").addClass("tabHasContent");
-<?php
-		}
-	}
 
-?>
+		// manually add class to corresponding tab for panels that have content
+		<?php
+			if (sizeof($activeletters) > 0) {
+				$chararray .= "*";
+				foreach($activeletters as $letter) {
+					$tab = elgg_strpos($chararray, $letter) + 1;
+		?>
+		$("div#friends-picker-navigation<?php echo $friendspicker; ?> li.tab<?php echo $tab; ?> a").addClass("tabHasContent");
+		<?php
+				}
+			}
+		?>
 	});
+});
 </script>
 
 <?php

--- a/mod/notifications/views/default/notifications/subscriptions/jsfuncs.php
+++ b/mod/notifications/views/default/notifications/subscriptions/jsfuncs.php
@@ -4,30 +4,27 @@ $NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecated
 
 ?> 
 <?php //@todo JS 1.8: no ?>
-<script type="text/javascript">
+<script>
+require(['jquery'], function($) {
+	$(function () {
+		<?php
+		foreach($NOTIFICATION_HANDLERS as $method => $foo) {
+		?>
+		$('input[type=checkbox]:checked').parent("a.<?php echo $method; ?>toggleOff").each(function(){
+			$(this).removeClass('<?php echo $method; ?>toggleOff').addClass('<?php echo $method; ?>toggleOn');
+		});
 
-$(document).ready(function () {
-<?php 
-foreach($NOTIFICATION_HANDLERS as $method => $foo) {
-?>
-	$('input[type=checkbox]:checked').parent("a.<?php echo $method; ?>toggleOff").each(function(){
-		$(this).removeClass('<?php echo $method; ?>toggleOff').addClass('<?php echo $method; ?>toggleOn');
+		<?php
+		}
+		?>
 	});
-	
-<?php
-}
-?>
-
 });
-
-	clickflag = 0;
-
 <?php 
 foreach($NOTIFICATION_HANDLERS as $method => $foo) {
 ?>
 function adjust<?php echo $method; ?>(linkId) {
 	var obj = $(this).prev("a");
-	
+
 	if (obj.className == "<?php echo $method; ?>toggleOff") {
 		obj.className = "<?php echo $method; ?>toggleOn";
 	} else {

--- a/mod/zaudio/views/default/zaudio/audioplayer.php
+++ b/mod/zaudio/views/default/zaudio/audioplayer.php
@@ -11,13 +11,13 @@ $mp3_url = elgg_get_site_url() . "mod/file/download.php?file_guid={$vars['file_g
 
 ?>
 <?php //@todo JS 1.8: no ?>
-<script type="text/javascript">
+<script>
 	AudioPlayer.setup("<?php echo $swf_url; ?>", {width: 290});
 </script>
 
 <div class="zaudio">
 	<p id="zaudioplayer"></p>
-	<script type="text/javascript">
+	<script>
 		AudioPlayer.embed("zaudioplayer", {soundFile: "<?php echo $mp3_url; ?>"});
 	</script>
 </div>

--- a/views/default/core/friends/collection.php
+++ b/views/default/core/friends/collection.php
@@ -51,11 +51,14 @@ if ($friends) {
 	));
 ?>
 <?php //@todo JS 1.8: no ?>
-	<script type="text/javascript">
-	$(function () {
-
-			$('#friends-picker_placeholder<?php echo $vars['friendspicker']; ?>').load(elgg.config.wwwroot + 'pages/friends/collections/pickercallback.php?username=<?php echo elgg_get_logged_in_user_entity()->username; ?>&type=list&collection=<?php echo $vars['collection']->id; ?>');
-
+	<script>
+	require(['elgg', 'jquery'], function(elgg, $) {
+		$(function () {
+			var url = elgg.config.wwwroot + 'pages/friends/collections/pickercallback.php' +
+				'?username=<?php echo elgg_get_logged_in_user_entity()->username; ?>' +
+				'&type=list&collection=<?php echo $vars['collection']->id; ?>';
+			$('#friends-picker_placeholder<?php echo $vars['friendspicker']; ?>').load(url);
+		});
 	});
 	</script>
 	<?php

--- a/views/default/core/friends/collections.php
+++ b/views/default/core/friends/collections.php
@@ -30,10 +30,11 @@ if (is_array($vars['collections']) && sizeof($vars['collections'])) {
 ?>
 <?php //@todo JS 1.8: no ?>
 <script>
-$(function(){
-	$('#friends_collections_accordian h2').click(function () {
-		$(this.parentNode).children("[class=friends-picker-main-wrapper]").slideToggle("fast");
-		//return false;
+require(['jquery'], function($) {
+	$(function () {
+		$('#friends_collections_accordian h2').on('click', function () {
+			$(this.parentNode).children("[class=friends-picker-main-wrapper]").slideToggle("fast");
+		});
 	});
 });
 </script>

--- a/views/default/core/friends/collectiontabs.php
+++ b/views/default/core/friends/collectiontabs.php
@@ -30,33 +30,32 @@ $ownerid = $vars['owner']->getGUID();
 </ul>
 
 <?php //@todo JS 1.8: no ?>
-<script type="text/javascript">
-$(function () {
+<script>
+require(['jquery'], function($) {
+	$(function () {
+		$('a.collectionmembers<?php echo $friendspicker; ?>').click(function () {
+			// load collection members pane
+			$('#friends-picker_placeholder<?php echo $friendspicker; ?>').load('<?php echo elgg_get_site_url(); ?>pages/friends/collections/pickercallback.php?username=<?php echo elgg_get_logged_in_user_entity()->username; ?>&type=list&collection=<?php echo $collectionid; ?>&friendspicker=<?php echo $friendspicker; ?>');
 
-	$('a.collectionmembers<?php echo $friendspicker; ?>').click(function () {
-		// load collection members pane
-		$('#friends-picker_placeholder<?php echo $friendspicker; ?>').load('<?php echo elgg_get_site_url(); ?>pages/friends/collections/pickercallback.php?username=<?php echo elgg_get_logged_in_user_entity()->username; ?>&type=list&collection=<?php echo $collectionid; ?>&friendspicker=<?php echo $friendspicker; ?>');
+			// remove selected state from previous tab
+			$(this).parent().parent().find("li.elgg-state-selected").removeClass("elgg-state-selected");
+			// add selected class to current tab
+			$(this).parent().addClass("elgg-state-selected");
 
-		// remove selected state from previous tab
-		$(this).parent().parent().find("li.elgg-state-selected").removeClass("elgg-state-selected");
-		// add selected class to current tab
-		$(this).parent().addClass("elgg-state-selected");
+			return false;
+		});
 
-		return false;
+		$('a.editmembers<?php echo $friendspicker; ?>').click(function () {
+			// load friends picker pane
+			$('#friends-picker_placeholder<?php echo $friendspicker; ?>').load('<?php echo elgg_get_site_url(); ?>pages/friends/collections/pickercallback.php?username=<?php echo elgg_get_logged_in_user_entity()->username; ?>&type=picker&collection=<?php echo $collectionid; ?>&friendspicker=<?php echo $friendspicker; ?>');
+
+			// remove selected state from previous tab
+			$(this).parent().parent().find("li.elgg-state-selected").removeClass("elgg-state-selected");
+			// add selected class to current tab
+			$(this).parent().addClass("elgg-state-selected");
+
+			return false;
+		});
 	});
-
-	$('a.editmembers<?php echo $friendspicker; ?>').click(function () {
-		// load friends picker pane
-		$('#friends-picker_placeholder<?php echo $friendspicker; ?>').load('<?php echo elgg_get_site_url(); ?>pages/friends/collections/pickercallback.php?username=<?php echo elgg_get_logged_in_user_entity()->username; ?>&type=picker&collection=<?php echo $collectionid; ?>&friendspicker=<?php echo $friendspicker; ?>');
-
-		// remove selected state from previous tab
-		$(this).parent().parent().find("li.elgg-state-selected").removeClass("elgg-state-selected");
-		// add selected class to current tab
-		$(this).parent().addClass("elgg-state-selected");
-
-		return false;
-	});
-
-
 });
 </script>

--- a/views/default/core/friends/tablelistcountupdate.php
+++ b/views/default/core/friends/tablelistcountupdate.php
@@ -12,6 +12,10 @@
 
 ?>
 <?php //@todo JS 1.8: no ?>
-<script language="text/javascript">
-	$("#friends_membership_count<?php echo $vars['friendspicker']; ?>").html("<?php echo $vars['count']; ?>");
+<script>
+require(['jquery'], function($) {
+	$(function () {
+		$("#friends_membership_count<?php echo $vars['friendspicker']; ?>").html("<?php echo $vars['count']; ?>");
+	});
+});
 </script>

--- a/views/default/input/autocomplete.php
+++ b/views/default/input/autocomplete.php
@@ -42,8 +42,10 @@ elgg_load_js('jquery.ui.autocomplete.html');
 
 ?>
 
-<script type="text/javascript">
-elgg.provide('elgg.autocomplete');
-elgg.autocomplete.url = "<?php echo elgg_get_site_url() . 'livesearch?' . $ac_url_params; ?>";
-</script> 
+<script>
+require(['elgg'], function (elgg) {
+	elgg.provide('elgg.autocomplete');
+	elgg.autocomplete.url = "<?php echo elgg_get_site_url() . 'livesearch?' . $ac_url_params; ?>";
+});
+</script>
 <input type="text" <?php echo elgg_format_attributes($vars); ?> />

--- a/views/default/input/friendspicker.php
+++ b/views/default/input/friendspicker.php
@@ -119,8 +119,9 @@ if (!isset($vars['replacement'])) {
 	if ($formtarget) {
 ?>
 <?php //@todo JS 1.8: no ?>
-<script language="text/javascript">
-	$(function() { // onload...do
+<script>
+require(['elgg', 'jquery'], function(elgg, $) {
+	$(function () {
 		$('#collectionMembersForm<?php echo $friendspicker; ?>').submit(function() {
 			var inputs = [];
 			$(':input', this).each(function() {
@@ -128,7 +129,7 @@ if (!isset($vars['replacement'])) {
 					inputs.push(this.name + '=' + escape(this.value));
 				}
 			});
-			jQuery.ajax({
+			$.ajax({
 				type: "POST",
 				data: inputs.join('&'),
 				url: this.action,
@@ -138,10 +139,10 @@ if (!isset($vars['replacement'])) {
 
 			});
 			return false;
-		})
-	})
-
-	</script>
+		});
+	});
+});
+</script>
 
 <!-- Collection members form -->
 <form id="collectionMembersForm<?php echo $friendspicker; ?>" action="<?php echo $formtarget; ?>" method="post"> <!-- action="" method=""> -->
@@ -290,30 +291,29 @@ if (!$callback) {
 
 }
 
-if (!isset($vars['replacement'])) {
-?>
-<?php //@todo JS 1.8: no ?>
-<script type="text/javascript">
-	// initialise picker
-	$("div#friends-picker<?php echo $friendspicker; ?>").friendsPicker(<?php echo $friendspicker; ?>);
-</script>
-<script type="text/javascript">
-$(document).ready(function () {
-// manually add class to corresponding tab for panels that have content
-<?php
-if (sizeof($activeletters) > 0)
-	//$chararray = elgg_echo('friendspicker:chararray');
-	foreach($activeletters as $letter) {
-		$tab = elgg_strpos($chararray, $letter) + 1;
-?>
-$("div#friends-picker-navigation<?php echo $friendspicker; ?> li.tab<?php echo $tab; ?> a").addClass("tabHasContent");
-<?php
-	}
+if (isset($vars['replacement'])) {
+	return;
+}
 
 ?>
+<script>
+require(['jquery'], function($) {
+	$(function () {
+		// initialise picker
+		$("div#friends-picker<?php echo $friendspicker; ?>").friendsPicker(<?php echo $friendspicker; ?>);
+
+		<?php
+		// manually add class to corresponding tab for panels that have content
+		if (sizeof($activeletters) > 0) {
+			//$chararray = elgg_echo('friendspicker:chararray');
+			foreach($activeletters as $letter) {
+				$tab = elgg_strpos($chararray, $letter) + 1;
+			?>
+		$("div#friends-picker-navigation<?php echo $friendspicker; ?> li.tab<?php echo $tab; ?> a").addClass("tabHasContent");
+		<?php
+			}
+		}
+		?>
+	});
 });
 </script>
-
-<?php
-
-}

--- a/views/default/js/elgg.php
+++ b/views/default/js/elgg.php
@@ -63,18 +63,16 @@ elgg.config.wwwroot = '<?php echo elgg_get_site_url(); ?>';
 elgg.security.interval = <?php echo (int)_elgg_services()->actions->getActionTokenTimeout() * 333; ?>;
 elgg.config.language = '<?php echo (empty($CONFIG->language) ? 'en' : $CONFIG->language); ?>';
 
-!function () {
-	define('elgg', ['jquery', 'languages/' + elgg.get_language()], function($, translations) {
-		elgg.add_translation(elgg.get_language(), translations);
+define('elgg', ['jquery', 'languages/' + elgg.get_language()], function($, translations) {
+	elgg.add_translation(elgg.get_language(), translations);
 
-		$(function() {
-			elgg.trigger_hook('init', 'system');
-			elgg.trigger_hook('ready', 'system');
-		});
-
-		return elgg;
+	$(function() {
+		elgg.trigger_hook('init', 'system');
+		elgg.trigger_hook('ready', 'system');
 	});
-}();
+
+	return elgg;
+});
 
 require(['elgg']); // Forces the define() function to always run
 

--- a/views/default/js/elgg/require_config.php
+++ b/views/default/js/elgg/require_config.php
@@ -4,8 +4,21 @@ $amdConfig = _elgg_services()->amdConfig->getConfig();
 
 // Deps are loaded in page/elements/foot with require([...])
 unset($amdConfig['deps']);
+
+// require is currently an Elgg shim. Convert it to a RequireJS config
 ?>
 // <script>
-if (typeof require == "undefined") {
-	var require = <?php echo json_encode($amdConfig); ?>;
-}
+require = <?php echo json_encode($amdConfig); ?>;
+require.callback = function() {
+	// process queue
+	if (!window._require_queue) {
+		if (window.console) {
+			console.log('Elgg\'s require() shim is not defined. Do not override the view "page/elements/head".');
+		}
+	} else {
+		while (_require_queue.length) {
+			require.apply(null, _require_queue.shift());
+		}
+		delete window._require_queue;
+	}
+};

--- a/views/default/page/elements/head.php
+++ b/views/default/page/elements/head.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * The HTML head
+ *
+ * @internal It's dangerous to alter this view.
  * 
  * JavaScript load sequence (set in views library and this view)
  * ------------------------
@@ -34,7 +36,14 @@ $html5shiv_url = elgg_normalize_url('vendors/html5shiv.js');
 $ie_url = elgg_get_simplecache_url('css', 'ie');
 
 ?>
-
+	<script>
+<?php // Do not convert this to a regular function declaration. It gets redefined later. ?>
+require = function () {
+	// handled in the view "js/elgg"
+	_require_queue.push(arguments);
+};
+_require_queue = [];
+	</script>
 	<!--[if lt IE 9]>
 		<script src="<?php echo $html5shiv_url; ?>"></script>
 	<![endif]-->

--- a/views/default/page/walled_garden.php
+++ b/views/default/page/walled_garden.php
@@ -14,29 +14,33 @@ $wg_body_class = 'elgg-body-walledgarden';
 $inline_js = '';
 if ($is_sticky_register) {
 	$wg_body_class .= ' hidden';
-	$inline_js = <<<__JS
-<script type="text/javascript">
-elgg.register_hook_handler('init', 'system', function() {
-	$('.registration_link').trigger('click');
+	ob_start(); ?>
+<script>
+require(['elgg'], function (elgg) {
+	elgg.register_hook_handler('init', 'system', function() {
+		$('.registration_link').trigger('click');
+	});
 });
 </script>
-__JS;
+	<?php
+	$inline_js = ob_get_clean();
 }
 
 // render content before head so that JavaScript and CSS can be loaded. See #4032
 $messages = elgg_view('page/elements/messages', array('object' => $vars['sysmessages']));
 $content = $vars["body"];
 
-$body = <<<__BODY
+ob_start(); ?>
 <div class="elgg-page elgg-page-walledgarden">
 	<div class="elgg-page-messages">
-		$messages
+		<?php echo $messages ?>
 	</div>
 	<div class="$wg_body_class">
-		$content
+		<?php echo $content ?>
 	</div>
 </div>
-__BODY;
+<?php
+$body = ob_get_clean();
 
 $body .= elgg_view('page/elements/foot');
 

--- a/views/installation/install/js_rewrite_check.php
+++ b/views/installation/install/js_rewrite_check.php
@@ -11,6 +11,6 @@ $args = array(
 	json_encode(elgg_get_site_url() . 'install.php?step=database')
 );
 ?>
-<script type="text/javascript">
+<script>
 	elgg.installer.rewriteTest(<?php echo implode(', ', $args) ?>);
 </script>

--- a/views/installation/page/default.php
+++ b/views/installation/page/default.php
@@ -30,8 +30,8 @@ header('Expires: Fri, 05 Feb 1982 00:00:00 -0500', TRUE);
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 		<link rel="SHORTCUT ICON" href="<?php echo elgg_get_site_url(); ?>_graphics/favicon.ico" />
 		<link rel="stylesheet" href="<?php echo elgg_get_site_url(); ?>install/css/install.css" type="text/css" />
-		<script type="text/javascript" src="<?php echo elgg_get_site_url(); ?>vendors/jquery/jquery-1.11.0.min.js"></script>
-		<script type="text/javascript" src="<?php echo elgg_get_site_url(); ?>install/js/install.js"></script>
+		<script src="<?php echo elgg_get_site_url(); ?>vendors/jquery/jquery-1.11.0.min.js"></script>
+		<script src="<?php echo elgg_get_site_url(); ?>install/js/install.js"></script>
 	</head>
 	<body>
 		<div class="elgg-page">


### PR DESCRIPTION
This allows plugin devs to convert inline scripts to use require() until they can properly convert them to AMD/external files. This also patches many (but surely not all) Elgg core inline scripts to defer using the shim.

Replaces #8244
