### PR TITLE
WIP - Introduces a new upgrading feature

### DIFF
--- a/actions/admin/upgrade.php
+++ b/actions/admin/upgrade.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ *
+ */
+
+$guid = get_input('guid');
+
+$upgrade = get_entity($guid);
+
+if (!$upgrade instanceof \ElggUpgrade) {
+	register_error(elgg_echo('admin:upgrades:error:invalid_upgrade', array($entity->title, $guid)));
+	exit;
+}
+
+$upgrader = new \Elgg\BatchUpgrader;
+$upgrader->setUpgrade($upgrade);
+$upgrader->run();
+
+echo json_encode($upgrader->getResult());

--- a/engine/classes/Elgg/BatchUpgrade.php
+++ b/engine/classes/Elgg/BatchUpgrade.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Elgg;
+
+interface BatchUpgrade {
+	public function isRequired();
+
+	public function run();
+
+	public function getNumRemaining();
+
+	public function getErrorMessages();
+
+	public function getNextOffset();
+}

--- a/engine/classes/Elgg/BatchUpgrader.php
+++ b/engine/classes/Elgg/BatchUpgrader.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Elgg;
+
+use ElggUpgrade;
+
+class BatchUpgrader {
+
+	/**
+	 * @var $upgrade \Elgg\BatchUpgrade
+	 */
+	private $upgrade;
+
+	/**
+	 *
+	 */
+	public function setUpgrade(ElggUpgrade $upgrade) {
+		$this->upgrade = $upgrade;
+	}
+
+	public function run() {
+		// Upgrade also disabled data, so the compatibility is
+		// preserved in case the data ever gets enabled again
+		global $ENTITY_SHOW_HIDDEN_OVERRIDE;
+		$ENTITY_SHOW_HIDDEN_OVERRIDE = true;
+
+		// from engine/start.php
+		global $START_MICROTIME;
+
+		do {
+			$this->upgrade->getUpgrade()->run();
+
+			// TODO(juho) Remove after debugging
+			sleep(1);
+
+		} while ((microtime(true) - $START_MICROTIME) < $this->config->batch_run_time_in_secs);
+
+		if ($this->upgrade->getUpgrade()->getNumRemaining() === 0) {
+			// Upgrade is finished
+			if ($this->upgrade->has_errors) {
+				// The upgrade was finished with errors. Reset offset
+				// and errors so the upgrade can start from a scratch
+				// if attempted to run again.
+				$this->upgrade->offset = 0;
+				$this->upgrade->has_errors = false;
+			} else {
+				// Everything has been processed witout errors
+				// so the upgrade can be marked as completed.
+				$this->upgrade->setCompleted();
+			}
+		} else {
+			// TODO(juho) make this less silly
+			$this->upgrade->offset = $this->upgrade->getUpgrade()->getNextOffset();
+			$errors = $this->upgrade->getUpgrade()->getErrorMessages();
+
+			if ($errors) {
+				$this->upgrade->has_errors = true;
+			}
+		}
+	}
+
+	/**
+	 *
+	 */
+	public function getResult() {
+		return array(
+			'errors' => $this->upgrade->getUpgrade()->getErrorMessages(),
+			'numSuccess' => $this->upgrade->getUpgrade()->getSuccessCount(),
+		);
+	}
+}

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -56,6 +56,8 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\Cache\SystemCache                  $systemCache
  * @property-read \Elgg\SystemMessagesService              $systemMessages
  * @property-read \Elgg\I18n\Translator                    $translator
+ * @property-read \Elgg\Upgrade\Locator                    $upgradeLocator
+ * @property-read \Elgg\Upgrader                           $batchUpgrader
  * @property-read \Elgg\Database\UsersTable                $usersTable
  * @property-read \Elgg\ViewsService                       $views
  * @property-read \Elgg\WidgetsService                     $widgets
@@ -109,6 +111,10 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 
 		$this->setClassName('autoP', \ElggAutoP::class);
 
+		$this->setFactory('batchUpgrader', function(ServiceProvider $c) {
+			return new \Elgg\BatchUpgrader($config);
+		});
+
 		$this->setValue('config', $config);
 
 		$this->setClassName('configTable', \Elgg\Database\ConfigTable::class);
@@ -157,7 +163,7 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setFactory('logger', function(ServiceProvider $c) {
 			return $this->resolveLoggerDependencies('logger');
 		});
-		
+
 		// TODO(evan): Support configurable transports...
 		$this->setClassName('mailer', 'Zend\Mail\Transport\Sendmail');
 
@@ -261,6 +267,11 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setClassName('translator', \Elgg\I18n\Translator::class);
 
 		$this->setClassName('usersTable', \Elgg\Database\UsersTable::class);
+
+		$this->setFactory('upgradeLocator', function(ServiceProvider $c) {
+			return new \Elgg\Upgrade\Locator($c->configTable, $c->plugins,
+				$c->logger, $c->privateSettings, $this->hooks);
+		});
 
 		$this->setFactory('views', function(ServiceProvider $c) {
 			return new \Elgg\ViewsService($c->hooks, $c->logger);

--- a/engine/classes/Elgg/Upgrade/Locator.php
+++ b/engine/classes/Elgg/Upgrade/Locator.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Elgg\Upgrade;
+
+use Elgg\Database\PrivateSettingsTable;
+use Elgg\Database\ConfigTable;
+use Elgg\Database\Plugins;
+use Elgg\PluginHooksService;
+use Elgg\BatchUpgrade;
+use Elgg\Logger;
+use ElggUpgrade;
+
+/**
+ * Locates and registers both core and plugin upgrades
+ *
+ * @private
+ */
+class Locator {
+
+	private $config;
+
+	private $plugins;
+
+	private $logger;
+
+	private $privateSettings;
+
+	private $hooks;
+
+	/**
+	 *
+	 */
+	public function __construct(ConfigTable $config, Plugins $plugins, Logger $logger, PrivateSettingsTable $privateSettings, PluginHooksService $hooks) {
+		$this->config = $config;
+		$this->plugins = $plugins;
+		$this->logger = $logger;
+		$this->privateSettings = $privateSettings;
+		$this->hooks = $hooks;
+	}
+
+	/**
+	 * Looks for upgrades and saves them as ElggUpgrade entities
+	 *
+	 * @return boolean $pending_upgrades Are there pending upgrades
+	 */
+	public function run() {
+		//$upgrade_paths[] = $this->config->get('path') . 'engine/classes/Elgg/Upgrades';
+
+		$data = $this->hooks->trigger('register', 'upgrades', array(), array());
+
+		foreach ($data as $upgrade_data) {
+			$plugin_id = $upgrade_data['plugin_id'];
+			$version = $upgrade_data['version'];
+			$class = $upgrade_data['class'];
+
+			$upgrade_id = "{$plugin_id}:{$version}";
+
+			if ($this->upgradeExists($upgrade_id)) {
+				continue;
+			}
+
+			if (!class_exists($class)) {
+				$this->logger->error("Upgrade class $class was not found");
+				continue;
+			}
+
+			$test = new $class;
+			if (!$test instanceof BatchUpgrade) {
+				$this->logger->error("Upgrade class $class should implement BatchUpgrade");
+				continue;
+			}
+
+			// Create a new ElggUpgrade to represent the upgrade in the database
+			$upgrade = new ElggUpgrade();
+			$upgrade->setId($upgrade_id);
+			$upgrade->setClass($class);
+			$upgrade->title = "{$plugin_id}:upgrade:{$version}:title";
+			$upgrade->description = "{$plugin_id}:upgrade:{$version}:description";
+			$upgrade->save();
+
+			$pending_upgrades = true;
+		}
+
+		return $pending_upgrades;
+
+		/*
+		$plugins = $this->plugins->find('all');
+
+		$pending_upgrades = false;
+
+		foreach ($plugins as $plugin) {
+			$filename = "{$plugin->getPath()}lib/upgrades.json";
+
+			if (!file_exists($filename)) {
+				continue;
+			}
+
+			$upgrades = json_decode(file_get_contents($filename));
+
+			if (json_last_error() !== JSON_ERROR_NONE) {
+				$msg = json_last_error_msg();
+				$this->logger->error("Upgrade file $filename contains invalid JSON: $msg");
+				continue;
+			}
+
+			foreach ($upgrades as $upgrade_data) {
+
+				// TODO How to define an unique id?
+				$upgrade_id = $plugin->getID() . $upgrade_data->title . $upgrade_data->time;
+
+				if ($this->upgradeExists($upgrade_id)) {
+					continue;
+				}
+
+				if (!class_exists($upgrade_data->class)) {
+					$this->logger->error("Upgrade class {$upgrade_data->class} was not found");
+					continue;
+				}
+
+				// Create a new ElggUpgrade to represent the upgrade in the database
+				$upgrade = new ElggUpgrade();
+				$upgrade->setId($upgrade_id);
+				$upgrade->title = $upgrade_data->title;
+				$upgrade->description = $upgrade_data->description;
+				$upgrade->setClass($upgrade_data->class);
+				$upgrade->save();
+
+				$pending_upgrades = true;
+			}
+
+		}
+
+		return true; //$pending_upgrades;
+		*/
+	}
+
+	/**
+	 * Check if there already is an ElggUpgrade for this upgrade
+	 *
+	 * @param string $upgrade
+	 * @return boolean
+	 */
+	private function upgradeExists($upgrade_id) {
+		$upgrade = $this->privateSettings->getEntities(array(
+			'type' => 'object',
+			'subtype' => 'elgg_upgrade',
+			'private_setting_name' => 'id',
+			'private_setting_value' => $upgrade_id,
+		));
+
+		return !empty($upgrade);
+	}
+}

--- a/engine/classes/Elgg/UpgradeService.php
+++ b/engine/classes/Elgg/UpgradeService.php
@@ -58,7 +58,6 @@ class UpgradeService {
 			$this->processUpgrades();
 		}
 
-		_elgg_services()->events->trigger('upgrade', 'system', null);
 		elgg_flush_caches();
 
 		$this->releaseUpgradeMutex();

--- a/engine/classes/ElggUpgrade.php
+++ b/engine/classes/ElggUpgrade.php
@@ -18,9 +18,10 @@
  */
 class ElggUpgrade extends \ElggObject {
 	private $requiredProperties = array(
+		'id',
 		'title',
 		'description',
-		'upgrade_url',
+		'class',
 	);
 
 	/**
@@ -69,33 +70,37 @@ class ElggUpgrade extends \ElggObject {
 	}
 
 	/**
-	 * Sets an upgrade URL path
+	 * Sets an unique id for the upgrade
 	 *
-	 * @param string $path Set the URL path (without site URL) for the upgrade page
-	 * @return void
-	 * @throws InvalidArgumentException
+	 * @param string $id
 	 */
-	public function setPath($path) {
-		if (!$path) {
-			throw new InvalidArgumentException('Invalid value for URL path.');
-		}
-
-		$path = ltrim($path, '/');
-
-		if ($this->getUpgradeFromPath($path)) {
-			throw new InvalidArgumentException('Upgrade URL paths must be unique.');
-		}
-
-		$this->upgrade_url = $path;
+	public function setID($id) {
+		$this->id = $id;
 	}
 
 	/**
-	 * Returns a normalized URL for the upgrade page.
+	 * Sets a class for the upgrade
 	 *
-	 * @return string
+	 * @param string $class
 	 */
-	public function getURL() {
-		return elgg_normalize_url($this->upgrade_url);
+	public function setClass($class) {
+		$this->class = $class;
+	}
+
+	/**
+	 * Return instance of the class that processes the data
+	 *
+	 * @return \Elgg\BatchUpgrade
+	 */
+	public function getUpgrade() {
+		static $upgrade;
+
+		if (!$upgrade) {
+			$upgrade = new $this->class;
+			$upgrade->setOffset($this->offset);
+		}
+
+		return $upgrade;
 	}
 
 	/**
@@ -167,44 +172,5 @@ class ElggUpgrade extends \ElggObject {
 		}
 
 		return $this->getPrivateSetting($name);
-	}
-
-	/**
-	 * Find an ElggUpgrade object by the unique URL path
-	 *
-	 * @param string $path The Upgrade URL path (after site URL)
-	 * @return ElggUpgrade|false
-	 */
-	public function getUpgradeFromPath($path) {
-		$path = ltrim($path, '/');
-
-		if (!$path) {
-			return false;
-		}
-
-		// test for full URL values (used at 1.9.0)
-		$options = array(
-			'type' => 'object',
-			'subtype' => 'elgg_upgrade',
-			'private_setting_name' => 'upgrade_url',
-			'private_setting_value' => elgg_normalize_url($path),
-		);
-		$upgrades = call_user_func($this->_callable_egefps, $options);
-		/* @var ElggUpgrade[] $upgrades */
-
-		if ($upgrades) {
-			// replace URL with path (we can't use setPath due to recursion)
-			$upgrades[0]->upgrade_url = $path;
-			return $upgrades[0];
-		}
-
-		$options['private_setting_value'] = $path;
-		$upgrades = call_user_func($this->_callable_egefps, $options);
-
-		if ($upgrades) {
-			return $upgrades[0];
-		}
-
-		return false;
 	}
 }

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -228,11 +228,8 @@ function _elgg_admin_init() {
 	elgg_register_action('admin/site/set_robots', '', 'admin');
 	elgg_register_action('admin/site/set_maintenance_mode', '', 'admin');
 
-	elgg_register_action('admin/upgrades/upgrade_comments', '', 'admin');
-	elgg_register_action('admin/upgrades/upgrade_datadirs', '', 'admin');
-	elgg_register_action('admin/upgrades/upgrade_discussion_replies', '', 'admin');
-	elgg_register_action('admin/upgrades/upgrade_comments_access', '', 'admin');
 	elgg_register_action('admin/site/regenerate_secret', '', 'admin');
+	elgg_register_action('admin/upgrade', '', 'admin');
 
 	elgg_register_action('admin/menu/save', '', 'admin');
 

--- a/languages/en.php
+++ b/languages/en.php
@@ -496,6 +496,8 @@ return array(
 
 	'admin:administer_utilities:maintenance' => 'Maintenance mode',
 	'admin:upgrades' => 'Upgrades',
+	'admin:upgrades:run' => 'Run upgrades now',
+	'admin:upgrades:error:invalid_upgrade' => 'The upgrade %s (%s)is not an instance of ElggUpgrade',
 
 	'admin:settings' => 'Settings',
 	'admin:settings:basic' => 'Basic Settings',
@@ -1126,7 +1128,7 @@ Once you have logged in, we highly recommend that you change your password.
 	'upgrade:item_count' => 'There are <b>%s</b> items that need to be upgraded.',
 	'upgrade:warning' => '<b>Warning:</b> On a large site this upgrade may take a significantly long time!',
 	'upgrade:success_count' => 'Upgraded:',
-	'upgrade:error_count' => 'Errors:',
+	'upgrade:error_count' => 'Errors: %s',
 	'upgrade:river_update_failed' => 'Failed to update the river entry for item id %s',
 	'upgrade:timestamp_update_failed' => 'Failed to update the timestamps for item id %s',
 	'upgrade:finished' => 'Upgrade finished',

--- a/mod/blog/classes/Blog/Upgrades/FancyBlogUpgrade2015061700.php
+++ b/mod/blog/classes/Blog/Upgrades/FancyBlogUpgrade2015061700.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Blog\Upgrades;
+
+use Elgg\BatchUpgrade;
+
+class FancyBlogUpgrade2015061700 implements BatchUpgrade {
+
+	private $offset;
+
+	public function getNumRemaining() {
+		$count = elgg_get_entities(array(
+			'type' => 'object',
+			'subtype' => 'blog',
+			'count' => true,
+		));
+
+		return $count - $this->offset;
+	}
+
+	public function isRequired() {
+		return true;
+	}
+
+	public function setOffset($offset) {
+		$this->offset = $offset;
+	}
+
+	public function getErrorMessages() {
+		return array();
+	}
+
+	public function getSuccessCount() {
+		return $this->offset;
+	}
+
+	public function run() {
+		$blogs = elgg_get_entities(array(
+			'type' => 'object',
+			'subtype' => 'blog',
+		));
+
+		foreach ($blogs as $blog) {
+
+			$this->offset++;
+		}
+	}
+
+	public function getNextOffset() {
+		return 0;
+	}
+}

--- a/mod/blog/languages/en.php
+++ b/mod/blog/languages/en.php
@@ -21,7 +21,7 @@ return array(
 	'blog:excerpt' => 'Excerpt',
 	'blog:body' => 'Body',
 	'blog:save_status' => 'Last saved: ',
-	
+
 	'blog:revision' => 'Revision',
 	'blog:auto_saved_revision' => 'Auto Saved Revision',
 
@@ -62,5 +62,8 @@ View and comment on the blog post:
 	'blog:widget:description' => 'Display your latest blog posts',
 	'blog:moreblogs' => 'More blog posts',
 	'blog:numbertodisplay' => 'Number of blog posts to display',
-	'blog:noblogs' => 'No blog posts'
+	'blog:noblogs' => 'No blog posts',
+
+	'blog:upgrade:201506150:title' => 'Test title',
+	'blog:upgrade:201506150:description' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur tincidunt sollicitudin lectus, vel consequat arcu fringilla sit amet. Vivamus fringilla malesuada tellus. Curabitur faucibus mi ante, a varius mauris finibus tempor. Proin convallis rhoncus pharetra. In id leo a tellus ultrices posuere nec eu urna. Nam eget nisl ac justo pharetra pretium. Aliquam erat volutpat. Fusce rhoncus mauris at consectetur tincidunt. Morbi mauris orci, auctor at vehicula non, euismod ut massa.',
 );

--- a/mod/blog/lib/upgrades.json
+++ b/mod/blog/lib/upgrades.json
@@ -1,0 +1,14 @@
+[
+	{
+		"title": "Blog upgrade",
+		"description": "Lorem ipsum dolor sit amet",
+		"date": 2015052200,
+		"class": "Blog\\Upgrades\\FancyBlogUpgrade2015061700"
+	},
+	{
+		"title": "Another blog upgrade",
+		"description": "Lorem ipsum dolor sit amet",
+		"date": 2015052201,
+		"class": "Blog\\Upgrades\\Bar"
+	}
+]

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -68,6 +68,16 @@ function blog_init() {
 
 	// ecml
 	elgg_register_plugin_hook_handler('get_views', 'ecml', 'blog_ecml_views_hook');
+
+	elgg_register_plugin_hook_handler('register', 'upgrades', function($hook, $type, $return, $params) {
+		$return[] = array(
+			'plugin_id' => 'blog',
+			'version' => 201506150,
+			'class' => 'Blog\Upgrades\FancyBlogUpgrade2015061700',
+		);
+
+		return $return;
+	});
 }
 
 /**
@@ -105,35 +115,35 @@ function blog_page_handler($page) {
 	switch ($page_type) {
 		case 'owner':
 			set_input('username', $page[1]);
-			
+
 			echo elgg_view('resources/blog/owner');
 			break;
 		case 'friends':
 			set_input('username', $page[1]);
-			
+
 			echo elgg_view('resources/blog/friends');
 			break;
 		case 'archive':
 			set_input('username', $page[1]);
 			set_input('lower', $page[2]);
 			set_input('upper', $page[3]);
-			
+
 			echo elgg_view('resources/blog/archive');
 			break;
 		case 'view':
 			set_input('guid', $page[1]);
-			
+
 			echo elgg_view('resources/blog/view');
 			break;
 		case 'add':
 			set_input('guid', $page[1]);
-			
+
 			echo elgg_view('resources/blog/add');
 			break;
 		case 'edit':
 			set_input('guid', $page[1]);
 			set_input('revision', $page[2]);
-			
+
 			echo elgg_view('resources/blog/edit');
 			break;
 		case 'group':
@@ -141,7 +151,7 @@ function blog_page_handler($page) {
 			set_input('page_type', $page[2]);
 			set_input('lower', $page[3]);
 			set_input('upper', $page[4]);
-			
+
 			echo elgg_view('resources/blog/group');
 			break;
 		case 'all':

--- a/upgrade.php
+++ b/upgrade.php
@@ -39,6 +39,13 @@ if (strpos($forward_url, '/') !== 0) {
 }
 
 if (get_input('upgrade') == 'upgrade') {
+	// Find unprocessed batch uprade classes and save them as ElggUpgrade objects
+	$has_pending_upgrades = _elgg_services()->upgradeLocator->run();
+
+	if ($has_pending_upgrades) {
+		// Forward to the list of pending upgrades
+		$forward_url = '/admin/upgrades';
+	}
 
 	$upgrader = new \Elgg\UpgradeService();
 	$result = $upgrader->run();
@@ -68,7 +75,7 @@ if (get_input('upgrade') == 'upgrade') {
 			echo $msg;
 			exit;
 		}
-		
+
 		// note: translation may not be available until after upgrade
 		$msg = elgg_echo("installation:htaccess:needs_upgrade");
 		if ($msg === "installation:htaccess:needs_upgrade") {
@@ -85,7 +92,7 @@ if (get_input('upgrade') == 'upgrade') {
 
 	// reset cache to have latest translations available during upgrade
 	elgg_reset_system_cache();
-	
+
 	echo elgg_view_page(elgg_echo('upgrading'), '', 'upgrade', $vars);
 	exit;
 }

--- a/views/default/admin/upgrades.php
+++ b/views/default/admin/upgrades.php
@@ -3,12 +3,26 @@
  * Lists pending upgrades
  */
 
+elgg_require_js('elgg/upgrader');
+
+elgg_register_menu_item('title', array(
+	'name' => 'run_upgrades',
+	'text' => elgg_echo('admin:upgrades:run'),
+	'id' => 'elgg-upgrades-run',
+	'link_class' => 'elgg-button elgg-button-action hidden',
+));
+
 $upgrades = elgg_get_entities_from_private_settings(array(
 	'type' => 'object',
 	'subtype' => 'elgg_upgrade',
 	'private_setting_name' => 'is_completed',
 	'private_setting_value' => false
 ));
+
+// TODO(juho) Remove after debugging
+//foreach ($upgrades as $upgrade) {
+//	$upgrade->delete();
+//}
 
 if (!$upgrades) {
 	echo elgg_echo('admin:upgrades:none');

--- a/views/default/js/elgg/upgrader.js
+++ b/views/default/js/elgg/upgrader.js
@@ -1,0 +1,239 @@
+
+define(function(require) {
+	var $ = require('jquery');
+	var elgg = require('elgg');
+	var spinner = require('elgg/spinner');
+
+	var upgrades = $('.elgg-item-object-elgg_upgrade');
+	var upgrade;
+	var guid;
+	var progressbar;
+	var upgradeStartTime;
+	var timer;
+	var counter;
+	var percent;
+	var errorCounter;
+	var errorMessages = [];
+	var numSuccess;
+	var numError;
+	var numProcessed = 0;
+	var total;
+	var messages = [];
+	var messageList;
+
+	/**
+	 * Initializes the upgrade page
+	 *
+	 * Makes the upgrade button visible and adds a progress bar
+	 * to each upgrade.
+	 */
+	function init () {
+		$('#elgg-upgrades-run').removeClass('hidden').click(run);
+
+		upgrades.each(function(key, value) {
+			// Initialize progressbar
+			$(value).find('.elgg-progressbar').progressbar();
+		});
+	};
+
+	/**
+	 * Runs all individual upgrades one at a time
+	 *
+	 * @param {Object} e Event object
+	 */
+	function run (e) {
+		e.preventDefault();
+
+		// Replace button with spinner when upgrade starts
+		$('#upgrade-run').addClass('hidden');
+		spinner.start();
+
+		upgrade = upgrades.first();
+		runUpgrade();
+
+		return false;
+	};
+
+	/**
+	 * Takes care of processing a single upgrade in multiple batches
+	 */
+	function runUpgrade () {
+		upgrade = $(upgrade);
+		progressbar = upgrade.find('.elgg-progressbar');
+		counter = upgrade.find('.upgrade-counter');
+		percent = upgrade.find('.upgrade-percent');
+		timer = upgrade.find('.upgrade-timer');
+		messageList = upgrade.find('.upgrade-messages');
+		errorCounter = upgrade.find('.upgrade-error-counter');
+		data = upgrade.find('.upgrade-data');
+
+		// The total amount of items to be upgraded
+		total = data.attr('data-total');
+
+		// Get the GUID from the element id: elgg-object-123
+		guid = upgrade.attr('id').replace('elgg-object-', '');
+
+		// Initialize progressbar
+		$(upgrade).find('.elgg-progressbar').progressbar({
+			value: 0,
+			max: total
+		});
+
+		upgradeStartTime = new Date().getTime();
+
+		processBatch();
+	};
+
+	/**
+	 * Takes care of upgrading a single batch of items
+	 */
+	function processBatch () {
+		var options = {
+			data: {guid: guid},
+			dataType: 'json'
+		};
+
+		options.data = elgg.security.addToken(options.data);
+
+		var upgradeCount = $('#upgrade-count');
+
+		options.success = function(json) {
+			// Append possible errors after the progressbar
+			if (json.system_messages.error.length) {
+				// Display only the errors that haven't already been shown
+				$(json.system_messages.error).each(function(key, message) {
+					if ($.inArray(message, errorMessages) === -1) {
+						var msg = '<li>' + message + '</li>';
+						messageList.append(msg);
+						messages.push(message);
+					}
+				});
+			}
+
+			$(json.output.errors).each(function(key, message) {
+				var msg = '<li>' + message + '</li>';
+				messageList.append(msg);
+				messages.push(message);
+			});
+
+			numSuccess = parseInt(json.output.numSuccess);
+			numError = parseInt(json.output.errors.length);
+
+			numProcessed += (numSuccess + numError);
+
+			// Increase success statistics
+			counter.text(numProcessed + '/' + total);
+
+			// Increase the progress bar
+			progressbar.progressbar({ value: numProcessed });
+
+			if (numError > 0) {
+				errorCounter
+					.text(elgg.echo('upgrade:error_count', [messages.length]))
+					.css('color', 'red');
+			}
+
+			updateCounter();
+
+			var percentage = 0;
+			if (numProcessed < total) {
+				percentage = parseInt(numProcessed * 100 / total);
+
+				// Increase percentage
+				percent.html(percentage + '%');
+
+				// Start next upgrade call
+				processBatch();
+			} else {
+				if (numError > 0) {
+					// Upgrade finished with errors. Give instructions on how to proceed.
+					elgg.register_error(elgg.echo('upgrade:finished_with_errors'));
+				}
+
+				// Increase percentage
+				percent.html('100%');
+
+				// Reset all counters
+				numSuccess = numError = numProcessed = percentage = 0;
+				messages = [];
+
+				// Get next upgrade
+				upgrade = upgrade.next();
+
+				if (upgrade.length) {
+					// Continue to next upgrade
+					runUpgrade();
+				} else {
+					spinner.stop();
+					$('#upgrade-finished').removeClass('hidden');
+				}
+			}
+		};
+
+		// We use post() instead of action() so we can catch error messages
+		// and display them manually underneath the upgrade view.
+		return elgg.post('action/admin/upgrade', options);
+	};
+
+	/**
+	 * Displays estimated amount of time needed for a single upgrade to finish
+	 */
+	function updateCounter () {
+		var now = new Date().getTime();
+
+		// How many milliseconds ago the last batch was started
+		var difference = (now - upgradeStartTime) / 1000;
+
+		// How many items are waiting to be processed
+		var unProcessed = total - numProcessed;
+
+		var timeLeft = Math.round((difference / numProcessed) * unProcessed);
+
+		if (timeLeft < 60) {
+			var hours = '00';
+			var minutes = '00';
+			var seconds = timeLeft;
+		} else {
+			if (timeLeft < 3600) {
+				var minutes = Math.floor(timeLeft / 60);
+				var seconds = timeLeft % 60;
+				var hours = '00';
+			} else {
+				var hours = Math.floor(timeLeft / 3600);
+				var timeLeft = timeLeft % 3600;
+				var minutes = Math.floor(timeLeft / 60);
+				var seconds = timeLeft % 60;
+			}
+		}
+
+		hours = formatDigits(hours);
+		minutes = formatDigits(minutes);
+		seconds = formatDigits(seconds);
+
+		var value = hours + ':' + minutes + ':' + seconds;
+
+		timer.html(value);
+	};
+
+	/**
+	 * Rounds hours, minutes or seconds and adds a leading zero if necessary
+	 *
+	 * @param {String} time
+	 * @return {String} time
+	 */
+	function formatDigits (time) {
+		time = Math.floor(time);
+
+		if (time < 1) {
+			return '00';
+		}
+
+		if (time < 10) {
+			return '0' + time;
+		}
+
+		return time;
+	};
+
+	init();
+});

--- a/views/default/object/elgg_upgrade.php
+++ b/views/default/object/elgg_upgrade.php
@@ -1,17 +1,53 @@
 <?php
 /**
  * ElggUpgrade view
- *
- * @package Elgg
- * @subpackage Core
  */
 
 $entity = elgg_extract('entity', $vars);
 
-// don't pass title so it will be automatically linkified
+$total = $entity->getUpgrade()->getNumRemaining();
+
+$data = elgg_format_element(
+	'span',
+	array(
+		'class' => 'upgrade-data hidden',
+		'data-total' => $total,
+	)
+);
+
+$timer = elgg_format_element(
+	'span',
+	array('class' => 'upgrade-timer'),
+	'00:00:00'
+);
+
+$counter = elgg_format_element(
+	'span',
+	array('class' => 'upgrade-counter float-alt'),
+	"0/$total"
+);
+
+$progressbar = elgg_format_element('div', array(
+	'class' => 'elgg-progressbar',
+));
+
+$errors_link = elgg_view('output/url', array(
+	'href' => "#upgrade-errors-{$entity->guid}",
+	'text' => elgg_echo('upgrade:error_count', array(0)),
+	'rel' => 'toggle',
+	'class' => 'upgrade-error-counter',
+));
+
+$errors = elgg_format_element('ul', array(
+	'id' => "upgrade-errors-{$entity->guid}",
+	'class' => 'upgrade-messages elgg-message elgg-state-error hidden',
+));
+
 $params = array(
 	'entity' => $entity,
-	'subtitle' => $entity->description,
+	'title' => elgg_echo($entity->title),
+	'subtitle' => elgg_echo($entity->description),
+	'content' => $data . $counter . $timer . $progressbar . $errors_link . $errors,
 );
 
 $body = elgg_view('object/elements/summary', $params + $vars);


### PR DESCRIPTION
This approach saves each data upgrade in to the database as an ElggUpgrade entity.
- [ ] Add more info to docblocks
- [ ] Add rst docs
- [ ] Define the BatchUpgrade interface in more detail
- [ ] Decide what info is sent to browser after each batch run
- [x] Finish the features that mark upgrades completed
- [x] Clean up the features that define an unique id for an upgrade
- [ ] How/when to update version number in version.php?
- [x] Decide if we want to i18n upgrade titles and descriptions. If yes, where should they be translated?
- [ ] More testing

The current workflow:
1. Dev adds a new implementation of `BatchUpgrade` interface that contains the upgrade logic
2. The upgrade class is registered using [register, upgrades] hook
3.  When `upgrade.php` is ran, Elgg creates a new `ElggUpgrade` object of each new upgrade and saves the related information to it
4. When running the upgrade, the GUID of the `ElggUpgrade` is passed to the action and the object is passed into `ElggUpgrader` which calls the implementation of BatchUpgrade until batch run time is finished.
5. Results (number of errors etc) is returned to browser which then calls the action again if there are more items left to upgrade
