### PR TITLE
fix(menus): only display location menu item if value is string

### DIFF
--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -564,8 +564,9 @@ function elgg_users_setup_entity_menu($hook, $type, $return, $params) {
 		$return = array(\ElggMenuItem::factory($options));
 	} else {
 		$return = array();
-		if (isset($entity->location)) {
-			$location = htmlspecialchars($entity->location, ENT_QUOTES, 'UTF-8', false);
+		$location = $entity->location;
+		if (is_string($location) && $location !== '') {
+			$location = htmlspecialchars($location, ENT_QUOTES, 'UTF-8', false);
 			$options = array(
 				'name' => 'location',
 				'text' => "<span>$location</span>",


### PR DESCRIPTION
Validates that the location metadata on the user entity is a non-empty string before displaying a menu item
Fixes a situation where third-party plugins may have stored multiple location metadata values, and the menu hook was trying to output it as a string
Replaces #8009 
