### PR TITLE
fix(widgets): validate get_list,default_widgets hook output

### DIFF
--- a/engine/lib/widgets.php
+++ b/engine/lib/widgets.php
@@ -197,10 +197,18 @@ function _elgg_default_widgets_init() {
 		// only register the callback once per event
 		$events = array();
 		foreach ($default_widgets as $info) {
-			$events[$info['event'] . ',' . $info['entity_type']] = $info;
-		}
-		foreach ($events as $info) {
-			elgg_register_event_handler($info['event'], $info['entity_type'], '_elgg_create_default_widgets');
+			if (!is_array($info)) {
+				continue;
+			}
+			$event = elgg_extract('event', $info);
+			$entity_type = elgg_extract('entity_type', $info);
+			if (!$event || !$entity_type) {
+				continue;
+			}
+			if (!isset($events[$event][$entity_type])) {
+				elgg_register_event_handler($event, $entity_type, '_elgg_create_default_widgets');
+				$events[$event][$entity_type] = true;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Validates the data returned by get_list,default_widgets hook before trying
to register event handlers.
Fixes invalid offset warnings.
