### PR TITLE
fix(entities): also check canEdit permissions when creating entities

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1640,13 +1640,13 @@ abstract class ElggEntity extends \ElggData implements
 		}
 
 		$owner = $this->getOwnerEntity();
-		if ($owner && !$owner->canWriteToContainer(0, $type, $subtype)) {
+		if ($owner && !$owner->canEdit() && !$owner->canWriteToContainer(0, $type, $subtype)) {
 			return false;
 		}
 		
 		if ($owner_guid != $container_guid) {
 			$container = $this->getContainerEntity();
-			if ($container && !$container->canWriteToContainer(0, $type, $subtype)) {
+			if ($container && !$container->canEdit() && !$container->canWriteToContainer(0, $type, $subtype)) {
 				return false;
 			}
 		}


### PR DESCRIPTION
canWriteToContainer() permissions are sometimes filtered by the hooks, and overwrite canEdit() permissions. This causes probems when creating new entities.
This PR adds an additional check for canEdit() permissions on owner and container entities

Fixes #7998
