### PR TITLE
fix(comments): Ajax-saved comments show proper server formatting

### DIFF
--- a/actions/comment/save.php
+++ b/actions/comment/save.php
@@ -32,6 +32,15 @@ if ($comment_guid) {
 	$comment->description = $comment_text;
 	if ($comment->save()) {
 		system_message(elgg_echo('generic_comment:updated'));
+
+		if (elgg_is_xhr()) {
+			// @todo move to its own view object/comment/content in 1.x
+			echo elgg_view('output/longtext', array(
+				'value' => $comment->description,
+				'class' => 'elgg-inner',
+				'data-role' => 'comment-text',
+			));
+		}
 	} else {
 		register_error(elgg_echo('generic_comment:failure'));
 	}

--- a/js/lib/comments.js
+++ b/js/lib/comments.js
@@ -67,9 +67,23 @@ elgg.comments.Comment.prototype = {
 		elgg.action('comment/save', {
 			data: $form.serialize(),
 			success: function(json) {
+				// https://github.com/kvz/phpjs/blob/master/LICENSE.txt
+				function nl2br(content) {
+					if (/<(?:p|br)\b/.test(content)) {
+						// probably formatted already
+						return content;
+					}
+					return content.replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1<br>$2');
+				}
+
 				if (json.status === 0) {
 					// Update list item content
-					that.$item.find('[data-role="comment-text"]').html(value);
+					if (json.output) {
+						that.$item.find('[data-role="comment-text"]').replaceWith(json.output);
+					} else {
+						// action has been overridden and doesn't return comment content
+						that.$item.find('[data-role="comment-text"]').html(nl2br(value));
+					}
 				}
 				that.hideForm(function () {
 					that.getForm().remove();


### PR DESCRIPTION
Fixes #8294
