### PR TITLE
chore(tests): Improves service provider test and coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "phpunit/phpunit": "~4.1",
         "elgg/sniffs": "dev-master",
         "squizlabs/php_codesniffer": "~1.5",
-        "simpletest/simpletest": "~1.1"
+        "simpletest/simpletest": "~1.1",
+        "phpdocumentor/reflection-docblock": "~2.0"
     },
     "config": {
         "optimize-autoloader": true

--- a/docs/contribute/services.rst
+++ b/docs/contribute/services.rst
@@ -6,9 +6,6 @@ The :doc:`services guide </guides/services>` has general information about using
 To add a new service object to Elgg:
 
 #. Annotate your class as ``@access private``.
-#. Open the PHPUnit test ``Elgg\Di\ServiceProviderTest``.
-#. In ``testPropertiesReturnCorrectClassNames()``, add your service key and class name to the array of
-   existing services.
 #. Open the class ``Elgg\Di\ServiceProvider``.
 #. Add a ``@property-read`` annotation for your service at the top. This allows IDEs and static code
    analyzers to understand the type of the property.
@@ -69,7 +66,7 @@ Now your service will be available via property access on the ``Elgg\Application
 
 .. note::
 
-    For examples, see the ``config`` service, including the interface ``Elgg\Services\ConfigInterface``
+    For examples, see the ``config`` service, including the interface ``Elgg\Services\Config``
     and the concrete implementation ``Elgg\Config``.
 
 Service Life Cycle and Factories

--- a/engine/classes/Elgg/Di/DiContainer.php
+++ b/engine/classes/Elgg/Di/DiContainer.php
@@ -174,5 +174,27 @@ class DiContainer {
 		}
 		return (bool)property_exists($this, $name);
 	}
+
+	/**
+	 * Get names for all values/factories
+	 *
+	 * @access private
+	 * @internal For unit testing only, do not use
+	 * @return string[]
+	 */
+	public function getNames() {
+		$names = [];
+
+		$refl = new \ReflectionObject($this);
+		foreach ($refl->getProperties(\ReflectionProperty::IS_PUBLIC) as $prop) {
+			$names[] = $prop->name;
+		}
+		foreach (array_keys($this->factories_) as $name) {
+			$names[] = $name;
+		}
+
+		sort($names);
+		return $names;
+	}
 }
 

--- a/engine/classes/Elgg/Queue/DatabaseQueue.php
+++ b/engine/classes/Elgg/Queue/DatabaseQueue.php
@@ -31,8 +31,8 @@ class DatabaseQueue implements \Elgg\Queue\Queue {
 	 */
 	public function __construct($name, \Elgg\Database $db) {
 		$this->db = $db;
-		$this->name = $this->db->sanitizeString($name);
-		$this->workerId = $this->db->sanitizeString(md5(microtime() . getmypid()));
+		$this->name = $name;
+		$this->workerId = md5(microtime() . getmypid());
 	}
 
 	/**
@@ -40,10 +40,12 @@ class DatabaseQueue implements \Elgg\Queue\Queue {
 	 */
 	public function enqueue($item) {
 		$prefix = $this->db->getTablePrefix();
+		$name = $this->db->sanitizeString($this->name);
 		$blob = $this->db->sanitizeString(serialize($item));
 		$time = time();
+
 		$query = "INSERT INTO {$prefix}queue
-			SET name = '$this->name', data = '$blob', timestamp = $time";
+			SET name = '$name', data = '$blob', timestamp = $time";
 		return $this->db->insertData($query) !== false;
 	}
 
@@ -52,19 +54,22 @@ class DatabaseQueue implements \Elgg\Queue\Queue {
 	 */
 	public function dequeue() {
 		$prefix = $this->db->getTablePrefix();
+		$name = $this->db->sanitizeString($this->name);
+		$worker_id = $this->db->sanitizeString($this->workerId);
+
 		$update = "UPDATE {$prefix}queue 
-			SET worker = '$this->workerId'
-			WHERE name = '$this->name' AND worker IS NULL
+			SET worker = '$worker_id'
+			WHERE name = '$name' AND worker IS NULL
 			ORDER BY id ASC LIMIT 1";
 		$num = $this->db->updateData($update, true);
 		if ($num === 1) {
 			$select = "SELECT data FROM {$prefix}queue
-				WHERE worker = '$this->workerId'";
+				WHERE worker = '$worker_id'";
 			$obj = $this->db->getDataRow($select);
 			if ($obj) {
 				$data = unserialize($obj->data);
 				$delete = "DELETE FROM {$prefix}queue
-					WHERE name = '$this->name' AND worker = '$this->workerId'";
+					WHERE name = '$name' AND worker = '$worker_id'";
 				$this->db->deleteData($delete);
 				return $data;
 			}
@@ -78,7 +83,9 @@ class DatabaseQueue implements \Elgg\Queue\Queue {
 	 */
 	public function clear() {
 		$prefix = $this->db->getTablePrefix();
-		$this->db->deleteData("DELETE FROM {$prefix}queue WHERE name = '$this->name'");
+		$name = $this->db->sanitizeString($this->name);
+
+		$this->db->deleteData("DELETE FROM {$prefix}queue WHERE name = '$name'");
 	}
 
 	/**
@@ -86,7 +93,9 @@ class DatabaseQueue implements \Elgg\Queue\Queue {
 	 */
 	public function size() {
 		$prefix = $this->db->getTablePrefix();
-		$result = $this->db->getDataRow("SELECT COUNT(id) AS total FROM {$prefix}queue WHERE name = '$this->name'");
+		$name = $this->db->sanitizeString($this->name);
+
+		$result = $this->db->getDataRow("SELECT COUNT(id) AS total FROM {$prefix}queue WHERE name = '$name'");
 		return (int)$result->total;
 	}
 }

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -275,6 +275,33 @@ function _elgg_load_site_config() {
 }
 
 /**
+ * Set up CONFIG->cookies. (this is for unit testing)
+ *
+ * @see phpunit/bootstrap.php
+ *
+ * @param stdClass $CONFIG Elgg's config object
+ * @access private
+ */
+function _elgg_configure_cookies($CONFIG) {
+	// set cookie values for session and remember me
+	if (!isset($CONFIG->cookies)) {
+		$CONFIG->cookies = array();
+	}
+	if (!isset($CONFIG->cookies['session'])) {
+		$CONFIG->cookies['session'] = array();
+	}
+	$session_defaults = session_get_cookie_params();
+	$session_defaults['name'] = 'Elgg';
+	$CONFIG->cookies['session'] = array_merge($session_defaults, $CONFIG->cookies['session']);
+	if (!isset($CONFIG->cookies['remember_me'])) {
+		$CONFIG->cookies['remember_me'] = array();
+	}
+	$session_defaults['name'] = 'elggperm';
+	$session_defaults['expire'] = strtotime("+30 days");
+	$CONFIG->cookies['remember_me'] = array_merge($session_defaults, $CONFIG->cookies['remember_me']);
+}
+
+/**
  * Loads configuration related to Elgg as an application
  *
  * This runs on the engine boot and loads from the datalists database table.
@@ -305,21 +332,7 @@ function _elgg_load_application_config() {
 	}
 
 	// set cookie values for session and remember me
-	if (!isset($CONFIG->cookies)) {
-		$CONFIG->cookies = array();
-	}
-	if (!isset($CONFIG->cookies['session'])) {
-		$CONFIG->cookies['session'] = array();
-	}
-	$session_defaults = session_get_cookie_params();
-	$session_defaults['name'] = 'Elgg';
-	$CONFIG->cookies['session'] = array_merge($session_defaults, $CONFIG->cookies['session']);
-	if (!isset($CONFIG->cookies['remember_me'])) {
-		$CONFIG->cookies['remember_me'] = array();
-	}
-	$session_defaults['name'] = 'elggperm';
-	$session_defaults['expire'] = strtotime("+30 days");
-	$CONFIG->cookies['remember_me'] = array_merge($session_defaults, $CONFIG->cookies['remember_me']);
+	_elgg_configure_cookies($CONFIG);
 
 	if (!is_memcache_available()) {
 		_elgg_services()->datalist->loadAll();

--- a/engine/tests/phpunit/bootstrap.php
+++ b/engine/tests/phpunit/bootstrap.php
@@ -33,11 +33,15 @@ $CONFIG = (object)[
 	'dataroot' => __DIR__ . '/test_files/dataroot/',
 	'site_guid' => 1,
 	'AutoloaderManager_skip_storage' => true,
+	'simplecache_enabled' => false,
 ];
 
 $app = new \Elgg\Application(new \Elgg\Di\ServiceProvider(new \Elgg\Config($CONFIG)));
 $app->loadCore();
 _elgg_testing_application($app);
+
+// persistentLogin service needs this set to instantiate without calling DB
+_elgg_configure_cookies($CONFIG);
 
 // PHPUnit will serialize globals between tests, $app contains Closures!
 unset($app);


### PR DESCRIPTION
The test now collects all registered names out of the DiContainer, makes sure each is present in the `@property-read` declarations, and now tests the return types of _all_ services (9 more).

Refactors DatabaseQueue and lib/configuration, and updates the PHPunit bootstrap to avoid using ext/mysql during instantiation.
- [ ] One more LGTM
