### PR TITLE
feature(environment): Allows plugins to detect the site environment

### DIFF
--- a/docs/guides/services.rst
+++ b/docs/guides/services.rst
@@ -1,6 +1,13 @@
 Services
 ########
 
+.. contents:: Contents
+   :local:
+   :depth: 2
+
+Accessing Services
+==================
+
 Elgg uses the ``Elgg\Application`` class to load and bootstrap Elgg, but this class also offers
 a set of service objects for plugins to use.
 
@@ -21,11 +28,36 @@ deprecated and will be supported at least through Elgg 2.x. If they will reduce 
 burden of supporting older Elgg versions, we encourage you to continue using them in your plugins.
 
 Service: config
----------------
+===============
 
-An instance of ``Elgg\Services\ConfigInterface``, this is for getting and setting various system
+An instance of ``Elgg\Services\Config``, this is for getting and setting various system
 configuration values.
+
+Service: env
+============
+
+An instance of ``Elgg\Services\Environment``, this is for determining the environment in which
+the site is running, via methods ``getName()`` and ``isProd()``.
+
+The environment can be configured in your settings.php file by setting ``$CONFIG->elgg_env`` to
+an array with keys:
+
+- **name**: (string) the Name of the site instance
+- **is_prod**: (bool) ``true`` if the instance is in production, else ``false``
+
+Alternately you may provide an anonymous function that returns an implementation of
+``Elgg\Services\Environment``.
+
+.. warning::
+
+    You cannot read ``$CONFIG->elgg_env`` or ``elgg_get_config('elgg_env')`` in your plugins. Use
+    the ``elgg()->env`` service.
 
 .. note::
 
-    If you have a useful idea, you can :doc:`add a new service </contribute/services>`!
+    The environment values can be seen by admins on the page ``/admin/statistics/server/``.
+
+Contribute a new service
+========================
+
+If you have a useful idea, you can :doc:`add a new service </contribute/services>`!

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -3,11 +3,13 @@
 namespace Elgg;
 
 use Elgg\Di\ServiceProvider;
+use Elgg\Environments\BasicEnvironment;
 
 /**
  * Load, boot, and implement a front controller for an Elgg application
  *
- * @property-read \Elgg\Services\Config $config
+ * @property-read \Elgg\Services\Config      $config
+ * @property-read \Elgg\Services\Environment $env
  *
  * @since 2.0.0
  */
@@ -38,6 +40,7 @@ class Application {
 	 */
 	private static $public_services = [
 		'config' => true,
+		'env' => true,
 	];
 
 	/**
@@ -224,6 +227,10 @@ class Application {
 
 		// in case not loaded already
 		$this->loadCore();
+
+		// Make sure devs can't read $CONFIG->elgg_env
+		$this->services->env;
+		$config->set(BasicEnvironment::CONFIG_KEY_FACTORY, null);
 
 		$events = $this->services->events;
 

--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -7,6 +7,9 @@ namespace Elgg;
  * @since 1.10.0
  */
 class Config implements Services\Config {
+
+	const CONFIG_KEY_SETTINGS_FILE = 'Config_file';
+
 	/**
 	 * Configuration storage. Is usually reference to global $CONFIG
 	 * 
@@ -184,12 +187,12 @@ class Config implements Services\Config {
 			return;
 		}
 
-		if (isset($this->config->Config_file)) {
-			if ($this->config->Config_file === false) {
+		if (isset($this->config->{self::CONFIG_KEY_SETTINGS_FILE})) {
+			if ($this->config->{self::CONFIG_KEY_SETTINGS_FILE} === false) {
 				$this->settings_loaded = true;
 				return;
 			}
-			$path = $this->config->Config_file;
+			$path = $this->config->{self::CONFIG_KEY_SETTINGS_FILE};
 		} else {
 			$path = dirname(dirname(__DIR__)) . '/settings.php';
 		}

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -30,6 +30,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\DeprecationService                 $deprecation
  * @property-read \Elgg\EntityPreloader                    $entityPreloader
  * @property-read \Elgg\Database\EntityTable               $entityTable
+ * @property-read \Elgg\Services\Environment               $env
  * @property-read \Elgg\EventsService                      $events
  * @property-read \Elgg\Assets\ExternalFiles               $externalFiles
  * @property-read \Elgg\PluginHooksService                 $hooks
@@ -64,6 +65,8 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  */
 class ServiceProvider extends \Elgg\Di\DiContainer {
 
+	const CONFIG_KEY_SKIP_AUTOLOAD_STORAGE = 'AutoloaderManager_skip_storage';
+
 	/**
 	 * Constructor
 	 *
@@ -79,7 +82,7 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 
 		$this->setFactory('autoloadManager', function(ServiceProvider $c) {
 			$manager = new \Elgg\AutoloadManager($c->classLoader);
-			if (!$c->config->get('AutoloaderManager_skip_storage')) {
+			if (!$c->config->get(self::CONFIG_KEY_SKIP_AUTOLOAD_STORAGE)) {
 				$manager->setStorage($c->systemCache->getFileCache());
 				$manager->loadCache();
 			}
@@ -138,6 +141,10 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setClassName('entityPreloader', \Elgg\EntityPreloader::class);
 
 		$this->setClassName('entityTable', \Elgg\Database\EntityTable::class);
+
+		$this->setFactory('env', function(ServiceProvider $c) {
+			return \Elgg\Environments\BasicEnvironment::factory($c->config);
+		});
 
 		$this->setFactory('events', function(ServiceProvider $c) {
 			return $this->resolveLoggerDependencies('events');

--- a/engine/classes/Elgg/Environments/BasicEnvironment.php
+++ b/engine/classes/Elgg/Environments/BasicEnvironment.php
@@ -1,0 +1,84 @@
+<?php
+namespace Elgg\Environments;
+
+use Elgg\Services\Config;
+use Elgg\Services\Environment;
+
+/**
+ * Typical environment
+ */
+class BasicEnvironment implements Environment {
+
+	const DEFAULT_NAME = 'default';
+	const DEFAULT_IS_PROD = true;
+	const CONFIG_KEY_FACTORY = 'elgg_env';
+
+	/**
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * @var bool
+	 */
+	private $is_prod;
+
+	/**
+	 * Constructor
+	 *
+	 * @param string $name    Name of this instance
+	 * @param bool   $is_prod Is this a production site?
+	 */
+	public function __construct($name, $is_prod) {
+		$this->name = (string)$name;
+		$this->is_prod = (bool)$is_prod;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function isProd() {
+		return $this->is_prod;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getName() {
+		return $this->name;
+	}
+
+	/**
+	 * Build an environment from the application config
+	 *
+	 * @param Config $config The Config service
+	 * @return BasicEnvironment
+	 * @throws \ConfigurationException
+	 */
+	public static function factory(Config $config) {
+		$factory = $config->getVolatile(self::CONFIG_KEY_FACTORY);
+		if (!$factory) {
+			// try after making sure settings are loaded
+			$config->loadSettingsFile();
+			$factory = $config->getVolatile(self::CONFIG_KEY_FACTORY);
+		}
+		if (!$factory) {
+			$factory = [];
+		}
+		if (is_array($factory)) {
+			$factory = array_merge([
+				'name' => self::DEFAULT_NAME,
+				'is_prod' => self::DEFAULT_IS_PROD,
+			], $factory);
+			return new self($factory['name'], $factory['is_prod']);
+		}
+		if ($factory instanceof \Closure) {
+			$env = $factory();
+		}
+		if (empty($env) || !($env instanceof Environment)) {
+			throw new \ConfigurationException('$CONFIG->' . self::CONFIG_KEY_FACTORY . ' must be an array or a Closure'
+				. ' that returns an implementation of Elgg\Services\Environment');
+		}
+		return $env;
+	}
+}

--- a/engine/classes/Elgg/Services/Environment.php
+++ b/engine/classes/Elgg/Services/Environment.php
@@ -1,0 +1,22 @@
+<?php
+namespace Elgg\Services;
+
+/**
+ * Describes an object that differentiates between different instances of the same site/codebase
+ */
+interface Environment {
+
+	/**
+	 * Is this site instance in production?
+	 *
+	 * @return bool
+	 */
+	public function isProd();
+
+	/**
+	 * Get the site instance name. E.g. "dev", "test", "prod"
+	 *
+	 * @return string
+	 */
+	public function getName();
+}

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -382,12 +382,32 @@ function _elgg_admin_pagesetup() {
 			'priority' => 900,
 		));
 
+		$user_link = elgg_view('output/url', [
+			'is_trusted' => true,
+			'href' => $admin->getURL(),
+			'text' => $admin->name,
+		]);
 		elgg_register_menu_item('admin_header', array(
 			'name' => 'admin_profile',
 			'href' => false,
-			'text' => elgg_echo('admin:loggedin', array($admin->name)),
+			'text' => elgg_echo('admin:loggedin', [$user_link]),
 			'priority' => 800,
 		));
+
+		$env = elgg()->env;
+		if ($env->getName() !== 'default') {
+			$env_link = elgg_view('output/url', [
+				'is_trusted' => true,
+				'href' => 'admin/statistics/server',
+				'text' => elgg()->env->getName(),
+			]);
+			elgg_register_menu_item('admin_header', array(
+				'name' => 'admin_environment',
+				'href' => false,
+				'text' => elgg_echo('admin:environment', [$env_link]),
+				'priority' => 850,
+			));
+		}
 
 		if (elgg_get_config('elgg_maintenance_mode', null)) {
 			elgg_register_menu_item('admin_header', array(

--- a/engine/settings.example.php
+++ b/engine/settings.example.php
@@ -19,8 +19,20 @@ if (!isset($CONFIG)) {
 	$CONFIG = new \stdClass;
 }
 
+/**
+ * The application environment
+ *
+ * @warning Do not read this value from config! Use the "env" service.
+ *
+ * @link http://learn.elgg.org/en/latest/guides/services.html#service-env
+ */
+$CONFIG->elgg_env = [
+	'name' => 'default',
+	'is_prod' => true,
+];
+
 /*
- * Standard configuration
+ * Database configuration
  *
  * You will use the same database connection for reads and writes.
  * This is the easiest configuration, and will suit 99.99% of setups. However, if you're

--- a/engine/tests/phpunit/Elgg/ApplicationTest.php
+++ b/engine/tests/phpunit/Elgg/ApplicationTest.php
@@ -22,6 +22,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 
 		$names = [
 			'config',
+			'env',
 		];
 
 		foreach	($names as $name) {

--- a/engine/tests/phpunit/Elgg/Environments/BasicEnvironmentTest.php
+++ b/engine/tests/phpunit/Elgg/Environments/BasicEnvironmentTest.php
@@ -1,0 +1,71 @@
+<?php
+namespace Elgg\Environments;
+
+use Elgg\Config;
+
+class BasicEnvironmentTest extends \PHPUnit_Framework_TestCase {
+
+	function testBuildsProdIfNotConfigured() {
+		$config = $this->getEmptyConfig();
+		$env = BasicEnvironment::factory($config);
+
+		$this->assertTrue($env->isProd());
+		$this->assertEquals(BasicEnvironment::DEFAULT_NAME, $env->getName());
+	}
+
+	function testBuildsIfConfiguredByArray() {
+		$config = $this->getEmptyConfig();
+		$config->set(BasicEnvironment::CONFIG_KEY_FACTORY, [
+			'name' => 'foo',
+		]);
+		$env = BasicEnvironment::factory($config);
+
+		$this->assertTrue($env->isProd());
+		$this->assertEquals('foo', $env->getName());
+
+		$config = $this->getEmptyConfig();
+		$config->set(BasicEnvironment::CONFIG_KEY_FACTORY, [
+			'is_prod' => false,
+		]);
+		$env = BasicEnvironment::factory($config);
+
+		$this->assertFalse($env->isProd());
+		$this->assertEquals(BasicEnvironment::DEFAULT_NAME, $env->getName());
+	}
+
+	function testBuildsIfConfiguredByClosure() {
+		$config = $this->getEmptyConfig();
+		$config->set(BasicEnvironment::CONFIG_KEY_FACTORY, function () {
+			return new BasicEnvironment('test', false);
+		});
+		$env = BasicEnvironment::factory($config);
+
+		$this->assertFalse($env->isProd());
+		$this->assertEquals('test', $env->getName());
+	}
+
+	/**
+	 * @expectedException \ConfigurationException
+	 */
+	function testBuildThrowsIfBadConfig() {
+		$config = $this->getEmptyConfig();
+		$config->set(BasicEnvironment::CONFIG_KEY_FACTORY, 'hello');
+		BasicEnvironment::factory($config);
+	}
+
+	/**
+	 * @expectedException \ConfigurationException
+	 */
+	function testBuildThrowsIfBadFactory() {
+		$config = $this->getEmptyConfig();
+		$config->set(BasicEnvironment::CONFIG_KEY_FACTORY, function () {
+			return 'dev';
+		});
+		BasicEnvironment::factory($config);
+	}
+
+	protected function getEmptyConfig() {
+		$settings = (object)['Config_file' => false];
+		return new Config($settings, false);
+	}
+}

--- a/engine/tests/phpunit/bootstrap.php
+++ b/engine/tests/phpunit/bootstrap.php
@@ -1,6 +1,10 @@
 <?php
 
 use Zend\Mail\Transport\InMemory as InMemoryTransport;
+use Elgg\Environments\BasicEnvironment;
+use Elgg\Application;
+use Elgg\Di\ServiceProvider;
+use Elgg\Config;
 
 require_once __DIR__ . '/../../../autoloader.php';
 
@@ -11,10 +15,10 @@ error_reporting(E_ALL | E_STRICT);
 /**
  * Get/set an Application for testing purposes
  *
- * @param \Elgg\Application $app Elgg Application
- * @return \Elgg\Application
+ * @param Application $app Elgg Application
+ * @return Application
  */
-function _elgg_testing_application(\Elgg\Application $app = null) {
+function _elgg_testing_application(Application $app = null) {
 	static $inst;
 	if ($app) {
 		$inst = $app;
@@ -34,8 +38,13 @@ $CONFIG = (object)[
 	'wwwroot' => 'http://localhost/',
 	'dataroot' => __DIR__ . '/test_files/dataroot/',
 	'site_guid' => 1,
-	'AutoloaderManager_skip_storage' => true,
 	'simplecache_enabled' => false,
+	ServiceProvider::CONFIG_KEY_SKIP_AUTOLOAD_STORAGE => true,
+	Config::CONFIG_KEY_SETTINGS_FILE => false,
+	BasicEnvironment::CONFIG_KEY_FACTORY => [
+		'name' => 'phpunit',
+		'is_prod' => false,
+	],
 ];
 
 // PHPUnit will serialize globals between tests, so let's not introduce any globals here.

--- a/languages/en.php
+++ b/languages/en.php
@@ -456,6 +456,7 @@ return array(
 
 	'admin:view_site' => 'View site',
 	'admin:loggedin' => 'Logged in as %s',
+	'admin:environment' => 'on %s',
 	'admin:menu' => 'Menu',
 
 	'admin:configuration:success' => "Your settings have been saved.",
@@ -666,6 +667,7 @@ three sections:
 
 	'admin:server:label:php' => 'PHP',
 	'admin:server:label:web_server' => 'Web Server',
+	'admin:server:label:env' => 'Application Environment',
 	'admin:server:label:server' => 'Server',
 	'admin:server:label:log_location' => 'Log Location',
 	'admin:server:label:php_version' => 'PHP version',
@@ -677,6 +679,8 @@ three sections:
 	'admin:server:label:post_max_size' => 'POST maximum size',
 	'admin:server:label:upload_max_filesize' => 'Upload maximum size',
 	'admin:server:warning:post_max_too_small' => '(Note: post_max_size must be larger than this value to support uploads of this size)',
+	'admin:env:label:name' => 'Instance name',
+	'admin:env:label:is_prod' => 'In production',
 
 	'admin:user:label:search' => "Find users:",
 	'admin:user:label:searchbutton' => "Search",

--- a/views/default/admin/statistics/server.php
+++ b/views/default/admin/statistics/server.php
@@ -3,6 +3,16 @@
  * Server information
  */
 
+$link = elgg_view('output/url', [
+	'is_trusted' => true,
+	'href' => 'http://learn.elgg.org/en/latest/guides/services.html#service-env',
+	'text' => elgg_echo('more_info'),
+]);
+$title = elgg_echo('admin:server:label:env')
+	. " (" . $link . ")";
+
+echo elgg_view_module('inline', $title, elgg_view('admin/statistics/server/env'));
+
 echo elgg_view_module('inline', elgg_echo('admin:server:label:web_server'), elgg_view('admin/statistics/server/web_server'));
 
 echo elgg_view_module('inline', elgg_echo('admin:server:label:php'), elgg_view('admin/statistics/server/php'));

--- a/views/default/admin/statistics/server/env.php
+++ b/views/default/admin/statistics/server/env.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Environment info
+ */
+
+$env = elgg()->env;
+$name = '"' . $env->getName() . '"';
+$prod_key = $env->isProd() ? 'option:yes' : 'option:no';
+
+?>
+<table class="elgg-table-alt">
+	<tr class="odd">
+		<td><b><?php echo elgg_echo('admin:env:label:name'); ?> :</b></td>
+		<td><?php echo elgg_view('output/text', ['value' => $name]) ?></td>
+	</tr>
+	<tr class="even">
+		<td><b><?php echo elgg_echo('admin:env:label:is_prod'); ?> :</b></td>
+		<td><?php echo elgg_echo($prod_key) ?></td>
+	</tr>
+</table>


### PR DESCRIPTION
Adds an “env” service to detect name/production status
Allows this to be set via settings.php from an array (or factory function)
Shows the environment values on the server info page
Env name shown in admin header (if name !== default)
Adds TOC to services docs
Replaces some $CONFIG keys with class constants
Links the user name in admin header

Fixes #8016
