### PR TITLE
perf(views): No longer regenerates the $vars[‘user’] wrapper for each view

### DIFF
--- a/engine/classes/Elgg/ViewsService.php
+++ b/engine/classes/Elgg/ViewsService.php
@@ -75,6 +75,7 @@ class ViewsService {
 				$warning = 'Use elgg_get_logged_in_user_entity() rather than assuming elgg_view() '
 							. 'populates $vars["user"]';
 				$this->user_wrapper = new \Elgg\DeprecationWrapper($user, $warning, 1.8);
+				$this->user_wrapped = $user;
 			}
 			$user = $this->user_wrapper;
 		}


### PR DESCRIPTION
This forgotten line caused the user deprecation wrapper to be recreated on every view rendering.

I think this is safe for 1.11, but I'm open to moving it to a later branch.
