### PR TITLE
chore(views): Removes several BC workarounds in view rendering

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -56,6 +56,27 @@ Removed Functions
  - get_db_link()
  - load_plugins()
 
+Removed Plugin Hooks
+--------------------
+
+ - ``[display, view]``: See the :ref:`new plugin hook<guides/views#altering-view-output>`.
+
+Removed View Variables
+----------------------
+
+During rendering, the view system no longer injects these into the scope:
+
+ - ``$vars['url']``: replace with ``elgg_get_site_url()``
+ - ``$vars['user']``: replace with ``elgg_get_logged_in_user_entity()``
+ - ``$vars['config']``: use ``elgg_get_config()`` and ``elgg_set_config()``
+ - ``$CONFIG``: use ``elgg_get_config()`` and ``elgg_set_config()``
+
+Also several workarounds for very old views are no longer performed. Make these changes:
+
+ - Set ``$vars['full_view']`` instead of ``$vars['full']``.
+ - Set ``$vars['name']`` instead of ``$vars['internalname']``.
+ - Set ``$vars['id']`` instead of ``$vars['internalid']``.
+
 Callbacks in Queries
 --------------------
 

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -141,7 +141,6 @@ function elgg_format_attributes(array $attrs = array()) {
 		return '';
 	}
 
-	$attrs = _elgg_clean_vars($attrs);
 	$attributes = array();
 
 	if (isset($attrs['js'])) {
@@ -246,51 +245,6 @@ function elgg_format_element($tag_name, array $attributes = array(), $text = '',
 	} else {
 		return "<{$tag_name}{$attrs}>$text</$tag_name>";
 	}
-}
-
-/**
- * Preps an associative array for use in {@link elgg_format_attributes()}.
- *
- * Removes all the junk that {@link elgg_view()} puts into $vars.
- * Maintains backward compatibility with attributes like 'internalname' and 'internalid'
- *
- * @note This function is called automatically by elgg_format_attributes(). No need to
- *       call it yourself before using elgg_format_attributes().
- *
- * @param array $vars The raw $vars array with all it's dirtiness (config, url, etc.)
- *
- * @return array The array, ready to be used in elgg_format_attributes().
- * @access private
- */
-function _elgg_clean_vars(array $vars = array()) {
-	unset($vars['config']);
-	unset($vars['url']);
-	unset($vars['user']);
-
-	// backwards compatibility code
-	if (isset($vars['internalname'])) {
-		if (!isset($vars['__ignoreInternalname'])) {
-			$vars['name'] = $vars['internalname'];
-		}
-		unset($vars['internalname']);
-	}
-
-	if (isset($vars['internalid'])) {
-		if (!isset($vars['__ignoreInternalid'])) {
-			$vars['id'] = $vars['internalid'];
-		}
-		unset($vars['internalid']);
-	}
-
-	if (isset($vars['__ignoreInternalid'])) {
-		unset($vars['__ignoreInternalid']);
-	}
-
-	if (isset($vars['__ignoreInternalname'])) {
-		unset($vars['__ignoreInternalname']);
-	}
-
-	return $vars;
 }
 
 /**

--- a/views/default/navigation/tabs.php
+++ b/views/default/navigation/tabs.php
@@ -14,7 +14,7 @@
  * 	'link_id' => string, // ID to pass to the link
  * )
  */
-$options = _elgg_clean_vars($vars);
+$options = $vars;
 
 $type = elgg_extract('type', $vars, 'horizontal');
 

--- a/views/default/page/elements/comments.php
+++ b/views/default/page/elements/comments.php
@@ -31,9 +31,6 @@ if (isset($vars['class'])) {
 	$class = "$class {$vars['class']}";
 }
 
-// work around for deprecation code in elgg_view()
-unset($vars['internalid']);
-
 echo "<div $id class=\"$class\">";
 
 $html = elgg_list_entities(array(


### PR DESCRIPTION
BREAKING CHANGE
Removes injected $CONFIG and $vars variables
Removes the [display, view] hook
Removes auto-correcting things like `$vars['internalname']`
