### PR TITLE
Lightbox improvement and embed fix (if JS error)

### DIFF
--- a/mod/embed/start.php
+++ b/mod/embed/start.php
@@ -80,7 +80,10 @@ ___JS;
 
 	$items[] = ElggMenuItem::factory(array(
 		'name' => 'embed',
-		'href' => $url,
+		'href' => 'javascript:void()',
+		'data-colorbox-opts' => json_encode([
+			'href' => elgg_normalize_url($url),
+		]),
 		'text' => $text,
 		'rel' => "embed-lightbox-{$vars['id']}",
 		'link_class' => "elgg-longtext-control elgg-lightbox embed-control embed-control-{$vars['id']}",

--- a/views/default/js/lightbox.php
+++ b/views/default/js/lightbox.php
@@ -88,14 +88,18 @@ elgg.ui.lightbox.bind = function (selector, opts) {
 		var $this = $(this),
 			href = $this.prop('href') || $this.prop('src'),
 			dataOpts = $this.data('colorboxOpts');
-		// Q: why not use "colorbox"? A: https://github.com/jackmoore/colorbox/issues/435
+		// Note: data-colorbox was reserved https://github.com/jackmoore/colorbox/issues/435
 
 		if (!$.isPlainObject(dataOpts)) {
 			dataOpts = {};
 		}
 
+		if (!dataOpts.href && href) {
+			dataOpts.href = href;
+		}
+
 		// merge data- options into opts
-		$.colorbox($.extend({href: href}, opts, dataOpts));
+		$.colorbox($.extend({}, opts, dataOpts));
 		e.preventDefault();
 	});
 };


### PR DESCRIPTION
feature(lightbox): More sensible handling of href options

If an elgg-lightbox element has no href/src properties, {href:null} is no longer passed to colorbox. Also, if `data-colorbox-opts` has an href, it overrides the element’s href/src.

fix(embed): embed link no longer leaves the page before events are setup

Fixes #8284
