### PR TITLE
feature(php): Require PHP 5.5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
- - 5.4
  - 5.5
  - 5.6
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "type": "project",
     "require": {
-        "php": "~5.4",
+        "php": "~5.5",
         "ext-mysql": "*",
         "ext-gd": "*",
         "ext-json": "*",
@@ -16,7 +16,6 @@
         "mrclay/minify": "~2.0",
         "knplabs/gaufrette": "~0.1.0",
         "tedivm/stash": "~0.12",
-        "ircmaxell/password-compat": "~1.0",
         "roave/security-advisories": "dev-master",
         "elgg/login_as": "~1.9"
     },

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -11,7 +11,7 @@ Requirements
 ============
 
 -  MySQL 5+
--  PHP 5.4+ with the following extensions:
+-  PHP 5.5+ with the following extensions:
 
    -  GD (for graphics processing)
    -  `Multibyte String support`_ (for i18n)

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -1011,7 +1011,7 @@ class ElggInstaller {
 	protected function checkPHP(&$report) {
 		$phpReport = array();
 
-		$min_php_version = '5.4.0';
+		$min_php_version = '5.5.0';
 		if (version_compare(PHP_VERSION, $min_php_version, '<')) {
 			$phpReport[] = array(
 				'severity' => 'failure',

--- a/install.php
+++ b/install.php
@@ -6,8 +6,7 @@
  * @subpackage Core
  */
 
-// check for PHP < 5.4 before we do anything else
-if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+if (version_compare(PHP_VERSION, '5.5.0', '<')) {
 	echo "Your server's version of PHP (" . PHP_VERSION . ") is too old to run Elgg.\n";
 	exit;
 }


### PR DESCRIPTION
PHP 5.4 will stop getting security support in September 2015.
It's likely that 2.0.0 final won't ship until around that time,
so there's not much point in supporting 5.4 in 2.0 at all.
