### PR TITLE
chore(email): Switch to \Zend\Mail library instead of raw mail() function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "tedivm/stash": "~0.12",
         "ircmaxell/password-compat": "~1.0",
         "roave/security-advisories": "dev-master",
-        "elgg/login_as": "~1.9"
+        "elgg/login_as": "~1.9",
+        "zendframework/zend-mail": "~2.4"
     },
     "scripts": {
         "test": "phpunit",

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -12,6 +12,13 @@ See the administrator guides for :doc:`how to upgrade a live site </admin/upgrad
 From 1.11 to 2.0
 ================
 
+Introduced third-party library for sending email
+------------------------------------------------
+
+We are using the excellent ``Zend\Mail`` library to send emails in Elgg 2.0.
+There are likely edge cases that the library handles differently than Elgg 1.x.
+Take care to test your email notifications carefully when upgrading to 2.0.
+
 All scripts moved to bottom of page
 -----------------------------------
 

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -3,6 +3,7 @@ namespace Elgg\Di;
 
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
+use Zend\Mail\Transport\TransportInterface as Mailer;
 
 /**
  * Provides common Elgg services.
@@ -34,6 +35,7 @@ use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
  * @property-read \Elgg\PluginHooksService                 $hooks
  * @property-read \Elgg\Http\Input                         $input
  * @property-read \Elgg\Logger                             $logger
+ * @property-read Mailer                                   $mailer
  * @property-read \Elgg\Cache\MetadataCache                $metadataCache
  * @property-read \Elgg\Database\MetadataTable             $metadataTable
  * @property-read \Elgg\Database\MetastringsTable          $metastringsTable
@@ -154,6 +156,9 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setFactory('logger', function(ServiceProvider $c) {
 			return $this->resolveLoggerDependencies('logger');
 		});
+		
+		// TODO(evan): Support configurable transports...
+		$this->setClassName('mailer', 'Zend\Mail\Transport\Sendmail');
 
 		$this->setFactory('metadataCache', function (ServiceProvider $c) {
 			return new \Elgg\Cache\MetadataCache($c->session);

--- a/engine/classes/Elgg/Mail/Address.php
+++ b/engine/classes/Elgg/Mail/Address.php
@@ -1,0 +1,28 @@
+<?php
+namespace Elgg\Mail;
+
+/**
+ * TODO(ewinslow): Contribute something like this back to Zend project.
+ * 
+ * @access private
+ */
+class Address {
+	/**
+	 * Parses strings like "Evan <evan@elgg.org>" into name/email objects.
+	 * 
+	 * This is not very sophisticated and only used to provide a light BC effort.
+	 * 
+	 * @param string $contact e.g. "Evan <evan@elgg.org>"
+	 * 
+	 * @return \Zend\Mail\Address
+	 */
+	public static function fromString($contact) {
+		$containsName = preg_match('/<(.*)>/', $contact, $matches) == 1;
+		if ($containsName) {
+			$name = trim(elgg_substr($contact, 0, elgg_strpos($contact, '<')));
+			return new \Zend\Mail\Address($matches[1], $name); 
+		} else {
+			return new \Zend\Mail\Address($contact);
+		}
+	}
+}

--- a/engine/tests/phpunit/Elgg/Mail/MailerTest.php
+++ b/engine/tests/phpunit/Elgg/Mail/MailerTest.php
@@ -1,0 +1,24 @@
+<?php
+namespace Elgg\Mail;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mail\Transport\InMemory as InMemoryTransport;
+
+class MailerTest extends TestCase {
+	
+	function testElggSendEmailPassesAllFieldsAsMessageToMailer() {
+		$mailer = new InMemoryTransport();
+		_elgg_services()->setValue('mailer', $mailer);
+		
+		elgg_send_email("From <from@elgg.org>", "To <to@elgg.org>", "Dummy subject", "Dummy body");
+		
+		$message = $mailer->getLastMessage();
+		
+		$this->assertEquals('To', $message->getTo()->get('to@elgg.org')->getName());
+		$this->assertEquals('From', $message->getFrom()->get('from@elgg.org')->getName());
+		$this->assertEquals("Dummy subject", $message->getSubject());
+		$this->assertEquals("Dummy body", $message->getBodyText());
+	}
+	
+}
+


### PR DESCRIPTION
This lays a good foundation for improving Elgg's flexibility and security
in sending emails. Some of the features we open up because of this change:
- HTML emails
- Attachments
- Improved security (automatic header escaping, etc.)
- Third-party SMTP services (e.g. Mandrill)
- Receiving emails
- In-memory transport for easier testing/development

We aren't introducing our own interfaces because `Zend\Mail`
is plenty well supported and the API is agreeable to us.
Writing a wrapper would just be unnecessary overhead.

BREAKING CHANGE:
We are switching to `Zend\Mail` for sending emails in Elgg 2.0.
It's likely that there are some edge cases that the library
handles differently than Elgg 1.x used to. Take care to test
your email notifications carefully when upgrading to 2.0.

Fixes #5918
