### PR TITLE
fix(https): Drop login-over-https

### DIFF
--- a/actions/admin/site/update_advanced.php
+++ b/actions/admin/site/update_advanced.php
@@ -74,12 +74,6 @@ set_config('allow_registration', $allow_registration, $site->getGUID());
 $walled_garden = ('on' === get_input('walled_garden', false));
 set_config('walled_garden', $walled_garden, $site->getGUID());
 
-if ('on' === get_input('https_login')) {
-	set_config('https_login', 1, $site->getGUID());
-} else {
-	unset_config('https_login', $site->getGUID());
-}
-
 $regenerate_site_secret = get_input('regenerate_site_secret', false);
 if ($regenerate_site_secret) {
 	// if you cancel this even you should present a message to the user

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -12,6 +12,12 @@ See the administrator guides for :doc:`how to upgrade a live site </admin/upgrad
 From 1.11 to 2.0
 ================
 
+Dropped login-over-https feature
+--------------------------------
+
+For the best security and performance, serve all pages over HTTPS by switching
+the scheme in your site's wwwroot to `https` at http://yoursite.tld/admin/settings/advanced
+
 All scripts moved to bottom of page
 -----------------------------------
 

--- a/languages/en.php
+++ b/languages/en.php
@@ -1064,8 +1064,6 @@ Once you have logged in, we highly recommend that you change your password.
 	'installation:walled_garden:description' => 'Enable this to prevent non-members from viewing the site except for web pages marked as public (such as login and registration).',
 	'installation:walled_garden:label' => 'Restrict pages to logged-in users',
 
-	'installation:httpslogin' => "Enable this to have user logins performed over HTTPS. This requires an HTTPS enabled web server!",
-	'installation:httpslogin:label' => "Enable HTTPS logins",
 	'installation:view' => "Enter the view which will be used as the default for your site or leave this blank for the default view (if in doubt, leave as default):",
 
 	'installation:siteemail' => "Site email address (used when sending system emails):",

--- a/pages/account/register.php
+++ b/pages/account/register.php
@@ -28,13 +28,7 @@ if (elgg_is_logged_in()) {
 
 $title = elgg_echo("register");
 
-// create the registration url - including switching to https if configured
-$register_url = elgg_get_site_url() . 'action/register';
-if (elgg_get_config('https_login')) {
-	$register_url = str_replace("http:", "https:", $register_url);
-}
 $form_params = array(
-	'action' => $register_url,
 	'class' => 'elgg-form-account',
 );
 

--- a/views/default/core/account/login_box.php
+++ b/views/default/core/account/login_box.php
@@ -10,13 +10,8 @@
 
 $module = elgg_extract('module', $vars, 'aside');
 
-$login_url = elgg_get_site_url();
-if (elgg_get_config('https_login')) {
-	$login_url = str_replace("http:", "https:", $login_url);
-}
-
 $title = elgg_extract('title', $vars, elgg_echo('login'));
 
-$body = elgg_view_form('login', array('action' => "{$login_url}action/login"));
+$body = elgg_view_form('login');
 
 echo elgg_view_module($module, $title, $body);

--- a/views/default/core/account/login_dropdown.php
+++ b/views/default/core/account/login_dropdown.php
@@ -7,12 +7,7 @@ if (elgg_is_logged_in()) {
 	return true;
 }
 
-$login_url = elgg_get_site_url();
-if (elgg_get_config('https_login')) {
-	$login_url = str_replace("http:", "https:", elgg_get_site_url());
-}
-
-$body = elgg_view_form('login', array('action' => "{$login_url}action/login"), array('returntoreferer' => TRUE));
+$body = elgg_view_form('login', array(), array('returntoreferer' => TRUE));
 ?>
 <div id="login-dropdown">
 	<?php 

--- a/views/default/core/settings/account.php
+++ b/views/default/core/settings/account.php
@@ -6,13 +6,6 @@
  * @subpackage Core
  */
 
-$action_url = elgg_get_site_url();
-if (elgg_get_config('https_login')) {
-	$action_url = str_replace("http:", "https:", $action_url);
-}
-$action_url .= 'action/usersettings/save';
-
 echo elgg_view_form('usersettings/save', array(
 	'class' => 'elgg-form-alt',
-	'action' => $action_url,
 ));

--- a/views/default/forms/admin/site/advanced/site_access.php
+++ b/views/default/forms/admin/site/advanced/site_access.php
@@ -17,13 +17,6 @@ $walled_garen_input = elgg_view('input/checkbox', array(
 	'checked' => (bool)elgg_get_config('walled_garden'),
 ));
 
-// https login
-$https_input = elgg_view("input/checkbox", array(
-	'label' => elgg_echo('installation:httpslogin:label'),
-	'name' => 'https_login',
-	'checked' => (bool)elgg_get_config('https_login'),
-));
-
 ?>
 
 <fieldset class="elgg-fieldset" id="elgg-settings-advanced-site-access">
@@ -37,11 +30,5 @@ $https_input = elgg_view("input/checkbox", array(
 	<div>
 		<?php echo $walled_garen_input; ?>
 		<p class="elgg-text-help"><?php echo elgg_echo('installation:walled_garden:description'); ?></p>
-	</div>
-		
-		
-	<div>
-		<?php echo $https_input; ?>
-		<p class="elgg-text-help"><?php echo elgg_echo('installation:httpslogin'); ?></p>
 	</div>
 </fieldset>


### PR DESCRIPTION
BREAKING CHANGE:
For the best security and performance, serve all pages over HTTPS
by switching the scheme in your site's wwwroot to `https` at
http://yoursite.tld/admin/settings/advanced

Fixes #5729
