### PR TITLE
chore(email): Switch to \Zend\Mail library instead of raw mail() function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "knplabs/gaufrette": "~0.1.0",
         "tedivm/stash": "~0.12",
         "roave/security-advisories": "dev-master",
-        "elgg/login_as": "~1.9"
+        "elgg/login_as": "~1.9",
+        "zendframework/zend-mail": "~2.4"
     },
     "scripts": {
         "test": "phpunit",

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -18,6 +18,13 @@ Dropped login-over-https feature
 For the best security and performance, serve all pages over HTTPS by switching
 the scheme in your site's wwwroot to `https` at http://yoursite.tld/admin/settings/advanced
 
+Introduced third-party library for sending email
+------------------------------------------------
+
+We are using the excellent ``Zend\Mail`` library to send emails in Elgg 2.0.
+There are likely edge cases that the library handles differently than Elgg 1.x.
+Take care to test your email notifications carefully when upgrading to 2.0.
+
 All scripts moved to bottom of page
 -----------------------------------
 

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -3,6 +3,7 @@ namespace Elgg\Di;
 
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
+use Zend\Mail\Transport\TransportInterface as Mailer;
 
 /**
  * Provides common Elgg services.
@@ -34,6 +35,7 @@ use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
  * @property-read \Elgg\PluginHooksService                 $hooks
  * @property-read \Elgg\Http\Input                         $input
  * @property-read \Elgg\Logger                             $logger
+ * @property-read Mailer                                   $mailer
  * @property-read \Elgg\Cache\MetadataCache                $metadataCache
  * @property-read \Elgg\Database\MetadataTable             $metadataTable
  * @property-read \Elgg\Database\MetastringsTable          $metastringsTable
@@ -154,6 +156,9 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setFactory('logger', function(ServiceProvider $c) {
 			return $this->resolveLoggerDependencies('logger');
 		});
+		
+		// TODO(evan): Support configurable transports...
+		$this->setClassName('mailer', 'Zend\Mail\Transport\Sendmail');
 
 		$this->setFactory('metadataCache', function (ServiceProvider $c) {
 			return new \Elgg\Cache\MetadataCache($c->session);

--- a/engine/classes/Elgg/Mail/Address.php
+++ b/engine/classes/Elgg/Mail/Address.php
@@ -19,10 +19,10 @@ class Address {
 	public static function fromString($contact) {
 		$containsName = preg_match('/<(.*)>/', $contact, $matches) == 1;
 		if ($containsName) {
-			$name = trim(elgg_substr($contact, 0, elgg_strpos($contact, '<')));
+			$name = trim(substr($contact, 0, strpos($contact, '<')));
 			return new \Zend\Mail\Address($matches[1], $name); 
 		} else {
-			return new \Zend\Mail\Address($contact);
+			return new \Zend\Mail\Address(trim($contact));
 		}
 	}
 }

--- a/engine/classes/Elgg/Mail/Address.php
+++ b/engine/classes/Elgg/Mail/Address.php
@@ -1,0 +1,28 @@
+<?php
+namespace Elgg\Mail;
+
+/**
+ * TODO(ewinslow): Contribute something like this back to Zend project.
+ * 
+ * @access private
+ */
+class Address {
+	/**
+	 * Parses strings like "Evan <evan@elgg.org>" into name/email objects.
+	 * 
+	 * This is not very sophisticated and only used to provide a light BC effort.
+	 * 
+	 * @param string $contact e.g. "Evan <evan@elgg.org>"
+	 * 
+	 * @return \Zend\Mail\Address
+	 */
+	public static function fromString($contact) {
+		$containsName = preg_match('/<(.*)>/', $contact, $matches) == 1;
+		if ($containsName) {
+			$name = trim(elgg_substr($contact, 0, elgg_strpos($contact, '<')));
+			return new \Zend\Mail\Address($matches[1], $name); 
+		} else {
+			return new \Zend\Mail\Address($contact);
+		}
+	}
+}

--- a/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
+++ b/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
@@ -2,6 +2,7 @@
 namespace Elgg\Di;
 
 use phpDocumentor\Reflection\DocBlock;
+use Zend\Mail\Transport\InMemory;
 
 class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
 
@@ -66,6 +67,12 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
 		foreach ($readonly_props as $prop) {
 			$name = substr($prop->getVariableName(), 1);
 			$type = $prop->getType();
+
+			// stuff set in PHPUnit bootstrap
+			if ($name === 'mailer') {
+				$type = InMemory::class;
+			}
+
 			$sets[] = [$name, $type];
 		}
 

--- a/engine/tests/phpunit/Elgg/Mail/MailerTest.php
+++ b/engine/tests/phpunit/Elgg/Mail/MailerTest.php
@@ -1,24 +1,89 @@
 <?php
 namespace Elgg\Mail;
 
-use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Mail\Transport\InMemory as InMemoryTransport;
 
-class MailerTest extends TestCase {
-	
-	function testElggSendEmailPassesAllFieldsAsMessageToMailer() {
-		$mailer = new InMemoryTransport();
-		_elgg_services()->setValue('mailer', $mailer);
-		
-		elgg_send_email("From <from@elgg.org>", "To <to@elgg.org>", "Dummy subject", "Dummy body");
-		
-		$message = $mailer->getLastMessage();
-		
-		$this->assertEquals('To', $message->getTo()->get('to@elgg.org')->getName());
-		$this->assertEquals('From', $message->getFrom()->get('from@elgg.org')->getName());
-		$this->assertEquals("Dummy subject", $message->getSubject());
-		$this->assertEquals("Dummy body", $message->getBodyText());
-	}
-	
-}
+class MailerTest extends \PHPUnit_Framework_TestCase {
 
+	public $hookArgs = [];
+
+	/**
+	 * @var InMemoryTransport
+	 */
+	public $mailer;
+
+	public function setUp() {
+		$this->mailer = new InMemoryTransport();
+		_elgg_services()->setValue('mailer', $this->mailer);
+	}
+
+	public function tearDown() {
+		// don't keep messages in memory for other test cases
+		$this->setUp();
+	}
+
+	function testElggSendEmailPassesAllFieldsAsMessageToMailer() {
+		$body = str_repeat("<p>You &amp; me &lt; she.</p>\n", 10);
+		$body_expected = wordwrap(str_repeat("You & me < she.\n", 10));
+
+		$subject = "<p>You &amp;\r\nme &lt;\rshe.</p>\n\n";
+		$subject_expected = "You & me < she.";
+
+		elgg_send_email("Frōm <from@elgg.org>", "Tō <to@elgg.org>", $subject, $body);
+		
+		$message = $this->mailer->getLastMessage();
+		
+		$this->assertEquals('Tō', $message->getTo()->get('to@elgg.org')->getName());
+		$this->assertEquals('Frōm', $message->getFrom()->get('from@elgg.org')->getName());
+		$this->assertEquals($subject_expected, $message->getSubject());
+		$this->assertEquals($body_expected, $message->getBodyText());
+		$this->assertEquals('UTF-8', $message->getEncoding());
+	}
+
+	function testElggSendEmailUsesHook() {
+		_elgg_services()->hooks->registerHandler('email', 'system', [$this, 'handleEmailHook1']);
+
+		elgg_send_email("from@elgg.org", "to@elgg.org", "Hello", "World", ['foo' => 1]);
+
+		_elgg_services()->hooks->unregisterHandler('email', 'system', [$this, 'handleEmailHook1']);
+
+		$expected_data = [
+			'to' => "to@elgg.org",
+			'from' => "from@elgg.org",
+			'subject' => "Hello",
+			'body' => "World",
+			'headers' => [
+				"Content-Type" => "text/plain; charset=UTF-8; format=flowed",
+				"MIME-Version" => "1.0",
+				"Content-Transfer-Encoding" => "8bit",
+			],
+			'params' => ['foo' => 1],
+		];
+		$this->assertEquals($expected_data, $this->hookArgs[0][2]);
+		$this->assertEquals($expected_data, $this->hookArgs[0][3]);
+
+		$message = $this->mailer->getLastMessage();
+
+		$this->assertEquals("<Hello>", $message->getBodyText());
+	}
+
+	function testElggSendEmailBypass() {
+		_elgg_services()->hooks->registerHandler('email', 'system', [$this, 'handleEmailHookTrue']);
+
+		$this->assertTrue(elgg_send_email("from@elgg.org", "to@elgg.org", "Hello", "World", ['foo' => 1]));
+
+		_elgg_services()->hooks->unregisterHandler('email', 'system', [$this, 'handleEmailHookTrue']);
+
+		$this->assertNull($this->mailer->getLastMessage());
+	}
+
+	function handleEmailHook1($hook, $type, $value, $params) {
+		$this->hookArgs[] = func_get_args();
+		$value['body'] = "<p>&lt;Hello&gt;</p>";
+		return $value;
+	}
+
+	function handleEmailHookTrue() {
+		return true;
+	}
+}

--- a/engine/tests/phpunit/Elgg/Mail/MailerTest.php
+++ b/engine/tests/phpunit/Elgg/Mail/MailerTest.php
@@ -1,0 +1,24 @@
+<?php
+namespace Elgg\Mail;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mail\Transport\InMemory as InMemoryTransport;
+
+class MailerTest extends TestCase {
+	
+	function testElggSendEmailPassesAllFieldsAsMessageToMailer() {
+		$mailer = new InMemoryTransport();
+		_elgg_services()->setValue('mailer', $mailer);
+		
+		elgg_send_email("From <from@elgg.org>", "To <to@elgg.org>", "Dummy subject", "Dummy body");
+		
+		$message = $mailer->getLastMessage();
+		
+		$this->assertEquals('To', $message->getTo()->get('to@elgg.org')->getName());
+		$this->assertEquals('From', $message->getFrom()->get('from@elgg.org')->getName());
+		$this->assertEquals("Dummy subject", $message->getSubject());
+		$this->assertEquals("Dummy body", $message->getBodyText());
+	}
+	
+}
+

--- a/engine/tests/suite.php
+++ b/engine/tests/suite.php
@@ -6,6 +6,8 @@
  * @subpackage Test
  */
 
+use Zend\Mail\Transport\InMemory as InMemoryTransport;
+
 require_once __DIR__ . '/../../autoloader.php';
 
 (new \Elgg\Application())->bootCore();
@@ -38,6 +40,9 @@ foreach ($events as $type => $subtypes) {
 		$notifications->unregisterEvent($type, $subtype);
 	}
 }
+
+// disable emails
+_elgg_services()->setValue('mailer', new InMemoryTransport());
 
 // Disable maximum execution time.
 // Tests take a while...


### PR DESCRIPTION
(replaces #8315)

This lays a good foundation for improving Elgg's flexibility and security in sending emails. Some of the features we open up because of this change:
- HTML emails
- Attachments
- Improved security (automatic header escaping, etc.)
- Third-party SMTP services (e.g. Mandrill)
- Receiving emails
- In-memory transport for easier testing/development

We aren't introducing our own interfaces because `Zend\Mail` is plenty well supported and the API is agreeable to us. Writing a wrapper would just be unnecessary overhead.

BREAKING CHANGE:
We are switching to `Zend\Mail` for sending emails in Elgg 2.0. It's likely that there are some edge cases that the library handles differently than Elgg 1.x used to. Take care to test your email notifications carefully when upgrading to 2.0.

Fixes #5918
