### PR TITLE
chore(core): Use PHP5.5 ::class syntax to remove string classnames

### DIFF
--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -92,9 +92,9 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			return new \Elgg\Database\AccessCollections($c->config->get('site_guid'));
 		});
 
-		$this->setClassName('actions', '\Elgg\ActionsService');
+		$this->setClassName('actions', \Elgg\ActionsService::class);
 
-		$this->setClassName('adminNotices', '\Elgg\Database\AdminNotices');
+		$this->setClassName('adminNotices', \Elgg\Database\AdminNotices::class);
 
 		$this->setFactory('amdConfig', function(ServiceProvider $c) {
 			$obj = new \Elgg\Amd\Config($c->hooks);
@@ -102,17 +102,17 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			return $obj;
 		});
 
-		$this->setClassName('annotations', '\Elgg\Database\Annotations');
+		$this->setClassName('annotations', \Elgg\Database\Annotations::class);
 
-		$this->setClassName('autoP', '\ElggAutoP');
+		$this->setClassName('autoP', \ElggAutoP::class);
 
 		$this->setValue('config', $config);
 
-		$this->setClassName('configTable', '\Elgg\Database\ConfigTable');
+		$this->setClassName('configTable', \Elgg\Database\ConfigTable::class);
 
-		$this->setClassName('context', '\Elgg\Context');
+		$this->setClassName('context', \Elgg\Context::class);
 
-		$this->setClassName('crypto', '\ElggCrypto');
+		$this->setClassName('crypto', \ElggCrypto::class);
 
 		$this->setFactory('datalist', function(ServiceProvider $c) {
 			// TODO(ewinslow): Add back memcached support
@@ -133,9 +133,9 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			return new \Elgg\DeprecationService($c->session, $c->logger);
 		});
 
-		$this->setClassName('entityPreloader', '\Elgg\EntityPreloader');
+		$this->setClassName('entityPreloader', \Elgg\EntityPreloader::class);
 
-		$this->setClassName('entityTable', '\Elgg\Database\EntityTable');
+		$this->setClassName('entityTable', \Elgg\Database\EntityTable::class);
 
 		$this->setFactory('events', function(ServiceProvider $c) {
 			return $this->resolveLoggerDependencies('events');
@@ -149,7 +149,7 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			return $this->resolveLoggerDependencies('hooks');
 		});
 
-		$this->setClassName('input', 'Elgg\Http\Input');
+		$this->setClassName('input', \Elgg\Http\Input::class);
 
 		$this->setFactory('logger', function(ServiceProvider $c) {
 			return $this->resolveLoggerDependencies('logger');
@@ -204,9 +204,9 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			return new \Elgg\Database\QueryCounter($c->db);
 		}, false);
 
-		$this->setClassName('relationshipsTable', '\Elgg\Database\RelationshipsTable');
+		$this->setClassName('relationshipsTable', \Elgg\Database\RelationshipsTable::class);
 
-		$this->setFactory('request', '\Elgg\Http\Request::createFromGlobals');
+		$this->setFactory('request', [\Elgg\Http\Request::class, 'createFromGlobals']);
 
 		$this->setFactory('router', function(ServiceProvider $c) {
 			// TODO(evan): Init routes from plugins or cache
@@ -234,29 +234,29 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			return new \ElggSession($session);
 		});
 
-		$this->setClassName('simpleCache', '\Elgg\Cache\SimpleCache');
+		$this->setClassName('simpleCache', \Elgg\Cache\SimpleCache::class);
 
-		$this->setClassName('siteSecret', '\Elgg\Database\SiteSecret');
+		$this->setClassName('siteSecret', \Elgg\Database\SiteSecret::class);
 
-		$this->setClassName('stickyForms', 'Elgg\Forms\StickyForms');
+		$this->setClassName('stickyForms', \Elgg\Forms\StickyForms::class);
 
-		$this->setClassName('subtypeTable', '\Elgg\Database\SubtypeTable');
+		$this->setClassName('subtypeTable', \Elgg\Database\SubtypeTable::class);
 
-		$this->setClassName('systemCache', '\Elgg\Cache\SystemCache');
+		$this->setClassName('systemCache', \Elgg\Cache\SystemCache::class);
 
 		$this->setFactory('systemMessages', function(ServiceProvider $c) {
 			return new \Elgg\SystemMessagesService($c->session);
 		});
 
-		$this->setClassName('translator', '\Elgg\I18n\Translator');
+		$this->setClassName('translator', \Elgg\I18n\Translator::class);
 
-		$this->setClassName('usersTable', '\Elgg\Database\UsersTable');
+		$this->setClassName('usersTable', \Elgg\Database\UsersTable::class);
 
 		$this->setFactory('views', function(ServiceProvider $c) {
 			return new \Elgg\ViewsService($c->hooks, $c->logger);
 		});
 
-		$this->setClassName('widgets', '\Elgg\WidgetsService');
+		$this->setClassName('widgets', \Elgg\WidgetsService::class);
 
 	}
 

--- a/engine/classes/ElggMenuBuilder.php
+++ b/engine/classes/ElggMenuBuilder.php
@@ -212,13 +212,13 @@ class ElggMenuBuilder {
 
 		switch ($sort_by) {
 			case 'text':
-				$sort_callback = array('\ElggMenuBuilder', 'compareByText');
+				$sort_callback = [\ElggMenuBuilder::class, 'compareByText'];
 				break;
 			case 'name':
-				$sort_callback = array('\ElggMenuBuilder', 'compareByName');
+				$sort_callback = [\ElggMenuBuilder::class, 'compareByName'];
 				break;
 			case 'priority':
-				$sort_callback = array('\ElggMenuBuilder', 'compareByPriority');
+				$sort_callback = [\ElggMenuBuilder::class, 'compareByPriority'];
 				break;
 			case 'register':
 				// use registration order - usort breaks this

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -488,7 +488,7 @@ function _elgg_admin_sort_page_menu($hook, $type, $return, $params) {
 			/* @var \ElggMenuItem $settings */
 			$children = $settings->getChildren();
 			$site_settings = array_splice($children, 0, 2);
-			usort($children, array('\ElggMenuBuilder', 'compareByText'));
+			usort($children, [\ElggMenuBuilder::class, 'compareByText']);
 			array_splice($children, 0, 0, $site_settings);
 			$settings->setChildren($children);
 		}

--- a/engine/tests/ElggBatchTest.php
+++ b/engine/tests/ElggBatchTest.php
@@ -13,7 +13,7 @@ class ElggBatchTest extends \ElggCoreUnitTest {
 			'offset' => 0,
 			'limit' => 11
 		);
-		$batch = new \ElggBatch(array('\ElggBatchTest', 'elgg_batch_callback_test'), $options,
+		$batch = new \ElggBatch([\ElggBatchTest::class, 'elgg_batch_callback_test'], $options,
 				null, 5);
 		$j = 0;
 		foreach ($batch as $e) {
@@ -31,7 +31,7 @@ class ElggBatchTest extends \ElggCoreUnitTest {
 			'offset' => 0,
 			'limit' => 11
 		);
-		$batch = new \ElggBatch(array('\ElggBatchTest', 'elgg_batch_callback_test'), $options,
+		$batch = new \ElggBatch([\ElggBatchTest::class, 'elgg_batch_callback_test'], $options,
 				null, 5);
 		$batch->setIncrementOffset(false);
 
@@ -50,7 +50,7 @@ class ElggBatchTest extends \ElggCoreUnitTest {
 			'offset' => 3,
 			'limit' => 11
 		);
-		$batch = new \ElggBatch(array('\ElggBatchTest', 'elgg_batch_callback_test'), $options,
+		$batch = new \ElggBatch([\ElggBatchTest::class, 'elgg_batch_callback_test'], $options,
 				null, 5);
 		$batch->setIncrementOffset(false);
 

--- a/engine/tests/ElggCorePluginsAPITest.php
+++ b/engine/tests/ElggCorePluginsAPITest.php
@@ -25,14 +25,14 @@ class ElggCorePluginsAPITest extends \ElggCoreUnitTest {
 		$manifest_file = file_get_contents(get_config('path') . 'engine/tests/test_files/plugin_18/manifest.xml');
 		$manifest = new \ElggPluginManifest($manifest_file);
 
-		$this->assertIsA($manifest, '\ElggPluginManifest');
+		$this->assertIsA($manifest, \ElggPluginManifest::class);
 	}
 
 	public function testElggPluginManifestFromFile() {
 		$file = get_config('path') . 'engine/tests/test_files/plugin_18/manifest.xml';
 		$manifest = new \ElggPluginManifest($file);
 
-		$this->assertIsA($manifest, '\ElggPluginManifest');
+		$this->assertIsA($manifest, \ElggPluginManifest::class);
 	}
 
 	public function testElggPluginManifestFromXMLEntity() {
@@ -40,7 +40,7 @@ class ElggCorePluginsAPITest extends \ElggCoreUnitTest {
 		$xml = new \ElggXMLElement($manifest_file);
 		$manifest = new \ElggPluginManifest($xml);
 
-		$this->assertIsA($manifest, '\ElggPluginManifest');
+		$this->assertIsA($manifest, \ElggPluginManifest::class);
 	}
 
 	// exact manifest values


### PR DESCRIPTION
Strings are bad for static analysis and make refactoring more dangerous.
