### PR TITLE
WIP: invokable class name handlers

### DIFF
--- a/docs/guides/actions.rst
+++ b/docs/guides/actions.rst
@@ -22,9 +22,35 @@ Actions must be registered before use. Use ``elgg_register_action`` for this:
 
 .. code:: php
 
+   elgg_register_action("example", MyPlugin\Actions\Example::class);
+
+Your class might look like:
+
+.. code:: php
+
+    <?php
+    namespace MyPlugin\Actions;
+
+    use Elgg\Services\ActionRequest;
+
+    class Example {
+        function __invoke(ActionRequest $req) {
+
+            // do stuff
+
+            forward();
+        }
+    }
+
+When Elgg receives a request for ``http://localhost/elgg/action/example``, Elgg will instantiate your class (with no constructor arguments) and call it as a function, passing in the ``ActionRequest``.
+
+Raw PHP scripts can also be used:
+
+.. code:: php
+
    elgg_register_action("example", __DIR__ . "/actions/example.php");
 
-The ``mod/example/actions/example.php`` script will now be run whenever a form is submitted to ``http://localhost/elgg/action/example``.
+Elgg will execute the script to handle the action. Note no variables will be provided in local scope.
 
 .. warning:: A stumbling point for many new developers is the URL for actions. The URL always uses ``/action/`` (singular) and never ``/actions/`` (plural). However, action script files are usually saved under the directory ``/actions/`` (plural) and always have an extension.
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -113,6 +113,11 @@ Plugins should use the class ``Elgg\Application`` to boot Elgg. Typical usage:
     require_once dirname(dirname(__DIR__)) . '/autoloader.php';
     (new \Elgg\Application)->bootCore();
 
+``forward()`` uses an exception
+-------------------------------
+
+When using try/catch, do *not* catch overly general exceptions like ``Exception``.
+
 Introduced third-party library for sending email
 ------------------------------------------------
 

--- a/engine/classes/Elgg/ActionRequest.php
+++ b/engine/classes/Elgg/ActionRequest.php
@@ -1,0 +1,38 @@
+<?php
+namespace Elgg;
+
+/**
+ * Models the API handed to an action handler
+ *
+ * @access private
+ */
+class ActionRequest implements \Elgg\Services\ActionRequest {
+
+	private $name;
+	private $elgg;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Application $elgg Elgg application
+	 * @param string      $name Action name
+	 */
+	public function __construct(Application $elgg, $name) {
+		$this->elgg = $elgg;
+		$this->name = $name;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getName() {
+		return $this->name;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function elgg() {
+		return $this->elgg;
+	}
+}

--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -343,8 +343,8 @@ class Database {
 		$query_id = (int)$single . $query . '|';
 		if ($callback) {
 			if (!is_callable($callback)) {
-				$inspector = new \Elgg\Debug\Inspector();
-				throw new \RuntimeException('$callback must be a callable function. Given ' . $inspector->describeCallable($callback));
+				throw new \RuntimeException('$callback must be a callable function. Given '
+											. _elgg_services()->handlers->describeCallable($callback));
 			}
 			$query_id .= $this->fingerprintCallback($callback);
 		}

--- a/engine/classes/Elgg/Debug/Inspector.php
+++ b/engine/classes/Elgg/Debug/Inspector.php
@@ -312,42 +312,6 @@ class Inspector {
 	}
 
 	/**
-	 * Get a string description of a callback
-	 *
-	 * E.g. "function_name", "Static::method", "(ClassName)->method", "(Closure path/to/file.php:23)"
-	 *
-	 * @param mixed  $callable  The callable value to describe
-	 * @param string $file_root if provided, it will be removed from the beginning of file names
-	 * @return string
-	 */
-	public function describeCallable($callable, $file_root = '') {
-		if (is_string($callable)) {
-			return $callable;
-		}
-		if (is_array($callable) && array_keys($callable) === array(0, 1) && is_string($callable[1])) {
-			if (is_string($callable[0])) {
-				return "{$callable[0]}::{$callable[1]}";
-			}
-			return "(" . get_class($callable[0]) . ")->{$callable[1]}";
-		}
-		if ($callable instanceof \Closure) {
-			$ref = new \ReflectionFunction($callable);
-			$file = $ref->getFileName();
-			$line = $ref->getStartLine();
-
-			if ($file_root && 0 === strpos($file, $file_root)) {
-				$file = substr($file, strlen($file_root));
-			}
-
-			return "(Closure {$file}:{$line})";
-		}
-		if (is_object($callable)) {
-			return "(" . get_class($callable) . ")->__invoke()";
-		}
-		return print_r($callable, true);
-	}
-
-	/**
 	 * Build a tree of event handlers
 	 *
 	 * @param array $all_handlers Set of handlers from a HooksRegistrationService
@@ -361,7 +325,7 @@ class Inspector {
 		foreach ($all_handlers as $hook => $types) {
 			foreach ($types as $type => $handlers) {
 				array_walk($handlers, function (&$callable, $priority) use ($root) {
-					$description = $this->describeCallable($callable, $root);
+					$description = _elgg_services()->handlers->describeCallable($callable, $root);
 					$callable = "$priority: $description";
 				});
 				$tree[$hook . ',' . $type] = $handlers;

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -32,6 +32,8 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\Database\EntityTable               $entityTable
  * @property-read \Elgg\EventsService                      $events
  * @property-read \Elgg\Assets\ExternalFiles               $externalFiles
+ * @property-read \Elgg\Forwarder                          $forwarder
+ * @property-read \Elgg\HandlersService                    $handlers
  * @property-read \Elgg\PluginHooksService                 $hooks
  * @property-read \Elgg\Http\Input                         $input
  * @property-read \Elgg\Logger                             $logger
@@ -146,6 +148,13 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setFactory('externalFiles', function(ServiceProvider $c) {
 			return new \Elgg\Assets\ExternalFiles($c->config->getStorageObject());
 		});
+
+		$this->setFactory('forwarder', function(ServiceProvider $c) {
+			$referrer = $c->request->headers->get('Referer');
+			return new \Elgg\Forwarder($c->hooks, $c->config->getSiteUrl(0), $referrer);
+		});
+
+		$this->setClassName('handlers', \Elgg\HandlersService::class);
 
 		$this->setFactory('hooks', function(ServiceProvider $c) {
 			return $this->resolveLoggerDependencies('hooks');

--- a/engine/classes/Elgg/EventsService.php
+++ b/engine/classes/Elgg/EventsService.php
@@ -1,6 +1,6 @@
 <?php
 namespace Elgg;
-use Elgg\Debug\Inspector;
+use Elgg\HooksRegistrationService\Event;
 
 /**
  * Service for Events
@@ -24,15 +24,15 @@ class EventsService extends \Elgg\HooksRegistrationService {
 	 * @see elgg_trigger_after_event
 	 * @access private
 	 */
-	public function trigger($event, $type, $object = null, array $options = array()) {
+	public function trigger($name, $type, $object = null, array $options = array()) {
 		$options = array_merge(array(
 			self::OPTION_STOPPABLE => true,
 			self::OPTION_DEPRECATION_MESSAGE => '',
 			self::OPTION_DEPRECATION_VERSION => '',
 		), $options);
 
-		$events = $this->hasHandler($event, $type);
-		if ($events && $options[self::OPTION_DEPRECATION_MESSAGE]) {
+		$has_handler = $this->hasHandler($name, $type);
+		if ($has_handler && $options[self::OPTION_DEPRECATION_MESSAGE]) {
 			elgg_deprecated_notice(
 				$options[self::OPTION_DEPRECATION_MESSAGE],
 				$options[self::OPTION_DEPRECATION_VERSION],
@@ -40,20 +40,37 @@ class EventsService extends \Elgg\HooksRegistrationService {
 			);
 		}
 
-		$events = $this->getOrderedHandlers($event, $type);
-		$args = array($event, $type, $object);
+		$events = $this->getOrderedHandlers($name, $type);
+		// create Event on demand
+		$event = null;
+		$args = array($name, $type, $object);
 
 		foreach ($events as $callback) {
-			if (!is_callable($callback)) {
-				if ($this->logger) {
-					$inspector = new Inspector();
-					$this->logger->warn("handler for event [$event, $type] is not callable: "
-										. $inspector->describeCallable($callback));
+			// for perf, shortcut on valid callables
+			if (is_callable($callback)) {
+				// old API
+				$return = call_user_func_array($callback, $args);
+				if (!empty($options[self::OPTION_STOPPABLE]) && ($return === false)) {
+					return false;
 				}
 				continue;
 			}
 
-			$return = call_user_func_array($callback, $args);
+			$orig_callback = $callback;
+
+			$callback = _elgg_services()->handlers->resolveCallable($callback);
+			if (!$callback) {
+				if ($this->logger) {
+					$this->logger->warn("handler for event [$name, $type] is not callable: "
+						. _elgg_services()->handlers->describeCallable($orig_callback));
+				}
+				continue;
+			}
+
+			if ($event === null) {
+				$event = new Event(elgg(), $name, $type, $object);
+			}
+			$return = call_user_func($callback, $event);
 			if (!empty($options[self::OPTION_STOPPABLE]) && ($return === false)) {
 				return false;
 			}

--- a/engine/classes/Elgg/ForwardException.php
+++ b/engine/classes/Elgg/ForwardException.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Elgg;
+
+/**
+ * Exception thrown on forward() call
+ *
+ * @access private
+ * @internal Do not use this
+ */
+class ForwardException extends \Exception {
+
+	private $location;
+	private $reason;
+
+	/**
+	 * Constructor
+	 *
+	 * @param string     $location URL to forward to browser to. This can be a path
+	 *                             relative to the network's URL.
+	 * @param string     $reason   Short explanation for why we're forwarding. Set to '404' to forward
+	 *                             to error page. Default message is 'system'.
+	 * @param \Exception $previous The previous exception
+	 */
+	public function __construct($location = "", $reason = 'system', \Exception $previous = null) {
+		$this->location = $location;
+		$this->reason = $reason;
+
+		parent::__construct("The system has issued a forward() call.", 0, $previous);
+	}
+
+	/**
+	 * Get the URL requested
+	 *
+	 * @return string
+	 */
+	public function getLocation() {
+		return $this->location;
+	}
+
+	/**
+	 * Get the reason stated for the redirect
+	 *
+	 * @return string
+	 */
+	public function getReason() {
+		return $this->reason;
+	}
+}

--- a/engine/classes/Elgg/Forwarder.php
+++ b/engine/classes/Elgg/Forwarder.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Elgg;
+
+/**
+ * Service for handling forward exceptions
+ *
+ * @access private
+ */
+class Forwarder {
+
+	/**
+	 * @var PluginHooksService
+	 */
+	private $hooks;
+
+	private $url;
+	private $referrer;
+
+	/**
+	 * Constructor
+	 *
+	 * @param PluginHooksService $hooks       Hooks service
+	 * @param string             $current_url The current URL
+	 * @param string|null        $referrer    The HTTP Referer header
+	 */
+	public function __construct(PluginHooksService $hooks, $current_url, $referrer = null) {
+		$this->hooks = $hooks;
+		$this->url = $current_url;
+		$this->referrer = $referrer;
+	}
+
+	/**
+	 * Handle the forward exception
+	 *
+	 * @param ForwardException $exception The exception
+	 * @return void
+	 * @throws \SecurityException
+	 */
+	public function handleException(ForwardException $exception) {
+		$location = $exception->getLocation();
+		$reason = $exception->getReason();
+
+		if (headers_sent($file, $line)) {
+			$msg = "Redirect could not be issued due to headers already being sent. Halting execution for security. "
+				. "Output started in file $file at line $line. Search http://learn.elgg.org/ for more information.";
+			throw new \SecurityException($msg, 0, $exception);
+		}
+
+		if ($location === REFERER) {
+			$location = $this->referrer;
+		}
+
+		$location = elgg_normalize_url($location);
+
+		// return new forward location or false to stop the forward or empty string to exit
+		$params = array('current_url' => $this->url, 'forward_url' => $location);
+		$location = $this->hooks->trigger('forward', $reason, $params, $location);
+
+		if ($location) {
+			header("Location: {$location}");
+		}
+		exit;
+	}
+}

--- a/engine/classes/Elgg/HandlersService.php
+++ b/engine/classes/Elgg/HandlersService.php
@@ -1,0 +1,69 @@
+<?php
+namespace Elgg;
+
+use Elgg\Di\DiContainer;
+
+/**
+ * Help for dealing with using callables as event handlers
+ *
+ * @access private
+ */
+class HandlersService {
+
+	/**
+	 * Resolve a callable, possibly instantiating a class name
+	 *
+	 * @param callable|string $callable Callable or class name
+	 *
+	 * @return callable|null
+	 */
+	public function resolveCallable($callable) {
+		if (is_callable($callable)) {
+			return $callable;
+		}
+		if (is_string($callable)
+				&& preg_match(DiContainer::CLASS_NAME_PATTERN_53, $callable)
+				&& class_exists($callable)) {
+
+			// @todo Eventually a more advanced DIC could auto-inject dependencies
+			$callable = new $callable;
+		}
+		return is_callable($callable) ? $callable : null;
+	}
+
+	/**
+	 * Get a string description of a callback
+	 *
+	 * E.g. "function_name", "Static::method", "(ClassName)->method", "(Closure path/to/file.php:23)"
+	 *
+	 * @param mixed  $callable  The callable value to describe
+	 * @param string $file_root if provided, it will be removed from the beginning of file names
+	 * @return string
+	 */
+	public function describeCallable($callable, $file_root = '') {
+		if (is_string($callable)) {
+			return $callable;
+		}
+		if (is_array($callable) && array_keys($callable) === array(0, 1) && is_string($callable[1])) {
+			if (is_string($callable[0])) {
+				return "{$callable[0]}::{$callable[1]}";
+			}
+			return "(" . get_class($callable[0]) . ")->{$callable[1]}";
+		}
+		if ($callable instanceof \Closure) {
+			$ref = new \ReflectionFunction($callable);
+			$file = $ref->getFileName();
+			$line = $ref->getStartLine();
+
+			if ($file_root && 0 === strpos($file, $file_root)) {
+				$file = substr($file, strlen($file_root));
+			}
+
+			return "(Closure {$file}:{$line})";
+		}
+		if (is_object($callable)) {
+			return "(" . get_class($callable) . ")->__invoke()";
+		}
+		return print_r($callable, true);
+	}
+}

--- a/engine/classes/Elgg/HooksRegistrationService/Event.php
+++ b/engine/classes/Elgg/HooksRegistrationService/Event.php
@@ -1,0 +1,63 @@
+<?php
+namespace Elgg\HooksRegistrationService;
+
+use Elgg\Application;
+
+/**
+ * The object passed to invokable class name handlers
+ *
+ * @access private
+ */
+class Event implements
+	\Elgg\Services\Event,
+	\Elgg\Services\ObjectEvent,
+	\Elgg\Services\UserEvent {
+
+	private $elgg;
+	private $name;
+	private $type;
+	private $object;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Application $elgg   Elgg application
+	 * @param string      $name   Event name
+	 * @param string      $type   Event type
+	 * @param mixed       $object Object of the event
+	 */
+	public function __construct(Application $elgg, $name, $type, $object) {
+		$this->elgg = $elgg;
+		$this->name = $name;
+		$this->type = $type;
+		$this->object = $object;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getName() {
+		return $this->name;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getType() {
+		return $this->type;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getObject() {
+		return $this->object;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function elgg() {
+		return $this->elgg;
+	}
+}

--- a/engine/classes/Elgg/HooksRegistrationService/Hook.php
+++ b/engine/classes/Elgg/HooksRegistrationService/Hook.php
@@ -1,0 +1,111 @@
+<?php
+namespace Elgg\HooksRegistrationService;
+
+use Elgg\Application;
+
+/**
+ * The object passed to invokable class name handlers
+ *
+ * @access private
+ */
+class Hook implements \Elgg\Services\Hook {
+
+	private $elgg;
+	private $name;
+	private $type;
+	private $value;
+	private $params;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Application $elgg   Elgg application
+	 * @param string      $name   Hook name
+	 * @param string      $type   Hook type
+	 * @param mixed       $value  Hook value
+	 * @param mixed       $params Hook params
+	 */
+	public function __construct(Application $elgg, $name, $type, $value, $params) {
+		$this->elgg = $elgg;
+		$this->name = $name;
+		$this->type = $type;
+		$this->value = $value;
+		$this->params = $params;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getName() {
+		return $this->name;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getType() {
+		return $this->type;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getValue() {
+		return $this->value;
+	}
+
+	/**
+	 * Update the value
+	 *
+	 * @param mixed $value The new value
+	 * @return void
+	 * @internal
+	 */
+	public function setValue($value) {
+		$this->value = $value;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getParams() {
+		return $this->params;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getParam($key, $default = null) {
+		if (!is_array($this->params)) {
+			return $default;
+		}
+		return array_key_exists($key, $this->params) ? $this->params[$key] : $default;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getEntity() {
+		if (isset($this->params['entity']) && $this->params['entity'] instanceof \ElggEntity) {
+			return $this->params['entity'];
+		}
+		return null;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getUser() {
+		if (isset($this->params['user']) && $this->params['user'] instanceof \ElggUser) {
+			return $this->params['user'];
+		}
+		return null;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function elgg() {
+		return $this->elgg;
+	}
+}

--- a/engine/classes/Elgg/InvokableMock.php
+++ b/engine/classes/Elgg/InvokableMock.php
@@ -1,0 +1,55 @@
+<?php
+namespace Elgg;
+
+/**
+ * Mock object usable as an invokable class name handler
+ */
+class InvokableMock {
+
+	/**
+	 * Recorded array of invocations
+	 *
+	 * Each element has keys "this", "args", and "return"
+	 *
+	 * @var array[]
+	 */
+	public static $invocations = [];
+
+	/**
+	 * If callable, this will handle the __invoke call
+	 *
+	 * @var callable
+	 */
+	public static $invoke_handler;
+
+	/**
+	 * Invoke the function
+	 *
+	 * @return mixed
+	 */
+	public function __invoke() {
+		$invocation = [
+			'this' => $this,
+			'args' => func_get_args(),
+		];
+
+		if (is_callable(self::$invoke_handler)) {
+			$invocation['return'] = call_user_func_array(self::$invoke_handler, $invocation['args']);
+		} else {
+			$invocation['return'] = null;
+		}
+
+		self::$invocations[] = $invocation;
+		return $invocation['return'];
+	}
+
+	/**
+	 * Reset the static state
+	 *
+	 * @return void
+	 */
+	public static function reset() {
+		self::$invocations = [];
+		self::$invoke_handler = null;
+	}
+}

--- a/engine/classes/Elgg/PageRequest.php
+++ b/engine/classes/Elgg/PageRequest.php
@@ -1,0 +1,55 @@
+<?php
+namespace Elgg;
+
+/**
+ * Models the API handed to page handler
+ *
+ * @access private
+ */
+class PageRequest implements \Elgg\Services\PageRequest {
+
+	private $id;
+	private $segments;
+	private $elgg;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Application $elgg     Elgg application
+	 * @param string      $id       ID
+	 * @param string[]    $segments URL segments
+	 */
+	public function __construct(Application $elgg, $id, $segments) {
+		$this->elgg = $elgg;
+		$this->id = $id;
+		$this->segments = $segments;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getId() {
+		return $this->id;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getSegments() {
+		return $this->segments;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getSegment($index, $default = null) {
+		return isset($this->segments[$index]) ? $this->segments[$index] : $default;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function elgg() {
+		return $this->elgg;
+	}
+}

--- a/engine/classes/Elgg/Services/ActionRequest.php
+++ b/engine/classes/Elgg/Services/ActionRequest.php
@@ -1,0 +1,22 @@
+<?php
+namespace Elgg\Services;
+
+/**
+ * Models the API handed to an action handler
+ */
+interface ActionRequest {
+
+	/**
+	 * Get the name of the action
+	 *
+	 * @return string
+	 */
+	public function getName();
+
+	/**
+	 * Get the Elgg application
+	 *
+	 * @return \Elgg\Application
+	 */
+	public function elgg();
+}

--- a/engine/classes/Elgg/Services/Event.php
+++ b/engine/classes/Elgg/Services/Event.php
@@ -1,0 +1,36 @@
+<?php
+namespace Elgg\Services;
+
+/**
+ * Models an event passed to event handlers
+ */
+interface Event {
+
+	/**
+	 * Get the name
+	 *
+	 * @return string
+	 */
+	public function getName();
+
+	/**
+	 * Get the type of the object
+	 *
+	 * @return string
+	 */
+	public function getType();
+
+	/**
+	 * Get the event object
+	 *
+	 * @return mixed
+	 */
+	public function getObject();
+
+	/**
+	 * Get the Elgg application
+	 *
+	 * @return \Elgg\Application
+	 */
+	public function elgg();
+}

--- a/engine/classes/Elgg/Services/Hook.php
+++ b/engine/classes/Elgg/Services/Hook.php
@@ -1,0 +1,68 @@
+<?php
+namespace Elgg\Services;
+
+/**
+ * Models an event passed to hook handlers
+ */
+interface Hook {
+
+	/**
+	 * Get the name
+	 *
+	 * @return string
+	 */
+	public function getName();
+
+	/**
+	 * Get the type
+	 *
+	 * @return string
+	 */
+	public function getType();
+
+	/**
+	 * Get the current value of the hook
+	 *
+	 * @return mixed
+	 */
+	public function getValue();
+
+	/**
+	 * Get the params array
+	 *
+	 * @return mixed
+	 */
+	public function getParams();
+
+	/**
+	 * Get an element of the params array. If the params array is not an array,
+	 * the default will always be returned.
+	 *
+	 * @param string $key     The key of the value in the params array
+	 * @param mixed  $default The value to return if missing
+	 *
+	 * @return mixed
+	 */
+	public function getParam($key, $default = null);
+
+	/**
+	 * Gets the "entity" key from the params if it holds an Elgg entity
+	 *
+	 * @return \ElggEntity|null
+	 */
+	public function getEntity();
+
+	/**
+	 * Gets the "user" key from the params if it holds an Elgg user
+	 *
+	 * @return \ElggUser|null
+	 */
+	public function getUser();
+
+	/**
+	 * Get the Elgg application
+	 *
+	 * @return \Elgg\Application
+	 */
+	public function elgg();
+}

--- a/engine/classes/Elgg/Services/ObjectEvent.php
+++ b/engine/classes/Elgg/Services/ObjectEvent.php
@@ -1,0 +1,36 @@
+<?php
+namespace Elgg\Services;
+
+/**
+ * Models an object event passed to event handlers
+ */
+interface ObjectEvent {
+
+	/**
+	 * Get the name
+	 *
+	 * @return string
+	 */
+	public function getName();
+
+	/**
+	 * Get the type of the object
+	 *
+	 * @return string
+	 */
+	public function getType();
+
+	/**
+	 * Get the object of the event
+	 *
+	 * @return \ElggObject
+	 */
+	public function getObject();
+
+	/**
+	 * Get the Elgg application
+	 *
+	 * @return \Elgg\Application
+	 */
+	public function elgg();
+}

--- a/engine/classes/Elgg/Services/PageRequest.php
+++ b/engine/classes/Elgg/Services/PageRequest.php
@@ -1,0 +1,39 @@
+<?php
+namespace Elgg\Services;
+
+/**
+ * Models the API handed to page handler
+ */
+interface PageRequest {
+
+	/**
+	 * Get the identifier
+	 *
+	 * @return string
+	 */
+	public function getId();
+
+	/**
+	 * Get the URL segments (not including the identifier)
+	 *
+	 * @return string[]
+	 */
+	public function getSegments();
+
+	/**
+	 * Get a particular URL segment (not including the identifier)
+	 *
+	 * @param int   $index   Index of the URL segment
+	 * @param mixed $default Return value if index is out of range
+	 *
+	 * @return mixed
+	 */
+	public function getSegment($index, $default = null);
+
+	/**
+	 * Get the Elgg application
+	 *
+	 * @return \Elgg\Application
+	 */
+	public function elgg();
+}

--- a/engine/classes/Elgg/Services/UserEvent.php
+++ b/engine/classes/Elgg/Services/UserEvent.php
@@ -1,0 +1,36 @@
+<?php
+namespace Elgg\Services;
+
+/**
+ * Models a user event passed to event handlers
+ */
+interface UserEvent {
+
+	/**
+	 * Get the name
+	 *
+	 * @return string
+	 */
+	public function getName();
+
+	/**
+	 * Get the type of the object
+	 *
+	 * @return string
+	 */
+	public function getType();
+
+	/**
+	 * Get the user subject of the event
+	 *
+	 * @return \ElggUser
+	 */
+	public function getObject();
+
+	/**
+	 * Get the Elgg application
+	 *
+	 * @return \Elgg\Application
+	 */
+	public function elgg();
+}

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -85,29 +85,11 @@ function elgg_load_library($name) {
  *                         'system'.
  *
  * @return void
- * @throws SecurityException
+ * @throws \Elgg\ForwardException
+ * @see _elgg_php_exception_handler Internally this (ab)uses an exception to jump out of code execution.
  */
 function forward($location = "", $reason = 'system') {
-	if (!headers_sent($file, $line)) {
-		if ($location === REFERER) {
-			$location = _elgg_services()->request->headers->get('Referer');
-		}
-
-		$location = elgg_normalize_url($location);
-
-		// return new forward location or false to stop the forward or empty string to exit
-		$current_page = current_page_url();
-		$params = array('current_url' => $current_page, 'forward_url' => $location);
-		$location = elgg_trigger_plugin_hook('forward', $reason, $params, $location);
-
-		if ($location) {
-			header("Location: {$location}");
-		}
-		exit;
-	} else {
-		throw new \SecurityException("Redirect could not be issued due to headers already being sent. Halting execution for security. "
-			. "Output started in file $file at line $line. Search http://learn.elgg.org/ for more information.");
-	}
+	throw new \Elgg\ForwardException($location, $reason);
 }
 
 /**
@@ -801,6 +783,12 @@ function elgg_trigger_plugin_hook($hook, $type, $params = null, $returnvalue = n
  * @access private
  */
 function _elgg_php_exception_handler($exception) {
+	// special case for forward()
+	if ($exception instanceof \Elgg\ForwardException) {
+		_elgg_services()->forwarder->handleException($exception);
+		exit;
+	}
+
 	$timestamp = time();
 	error_log("Exception #$timestamp: $exception");
 

--- a/engine/tests/phpunit/Elgg/ActionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ActionsServiceTest.php
@@ -11,7 +11,7 @@ class ActionsServiceTest extends \PHPUnit_Framework_TestCase {
 	 * Tests register, exists and unregisrer
 	 */
 	public function testCanRegisterFilesAsActions() {
-		$actions = new \Elgg\ActionsService();
+		$actions = new ActionsService();
 		
 		$this->assertFalse($actions->exists('test/output'));
 		$this->assertFalse($actions->exists('test/not_registered'));
@@ -25,11 +25,11 @@ class ActionsServiceTest extends \PHPUnit_Framework_TestCase {
 		
 		return $actions;
 	}
-	
+
 	/**
 	 * @depends testCanRegisterFilesAsActions
 	 */
-	public function testCanUnregisterActions($actions) {
+	public function testCanUnregisterActions(ActionsService $actions) {
 
 		$this->assertTrue($actions->unregister('test/output'));
 		$this->assertTrue($actions->unregister('test/non_ex_file'));
@@ -39,12 +39,37 @@ class ActionsServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($actions->exists('test/non_ex_file'));
 		$this->assertFalse($actions->exists('test/not_registered'));
 	}
+
+	public function testCanUseClassNamesAsActions() {
+		$actions = new ActionsService();
+		InvokableMock::reset();
+		InvokableMock::$invoke_handler = function (ActionRequest $request) {
+			echo $request->getName();
+		};
+
+		$this->assertTrue($actions->register('test/good', InvokableMock::class, 'public'));
+		$this->assertTrue($actions->register('test/bad', 'NotReallyAClass', 'public'));
+
+		$this->assertTrue($actions->exists('test/good'));
+		$this->assertFalse($actions->exists('test/bad'));
+
+		$actions->_bypass_gatekeeper = true;
+		ob_start();
+		try {
+			$actions->execute('test/good');
+		} catch (ForwardException $e) {}
+
+		$output = ob_get_clean();
+		$this->assertEquals('test/good', $output);
+
+		InvokableMock::reset();
+	}
 	
 	/**
 	 * Tests overwriting existing action
 	 */
 	public function testCanOverrideRegisteredActions() {
-		$actions = new \Elgg\ActionsService();
+		$actions = new ActionsService();
 		
 		$this->assertFalse($actions->exists('test/output'));
 		
@@ -58,7 +83,7 @@ class ActionsServiceTest extends \PHPUnit_Framework_TestCase {
 	}
 	
 	public function testActionsAccessLevels() {
-		$actions = new \Elgg\ActionsService();
+		$actions = new ActionsService();
 		
 		$this->assertFalse($actions->exists('test/output'));
 		$this->assertFalse($actions->exists('test/not_registered'));
@@ -75,11 +100,19 @@ class ActionsServiceTest extends \PHPUnit_Framework_TestCase {
 	public function testActionReturnValuesAreIgnored() {
 		$this->markTestIncomplete();
 	}
-	
-	//TODO call non existing
 
-	
-	//TODO token generation/validation
+	public function testActionErrorsOnNonExistingAction() {
+		$this->markTestIncomplete();
+	}
+
+	public function testTokenGeneration() {
+		$this->markTestIncomplete();
+	}
+
+	public function testTokenValidation() {
+		$this->markTestIncomplete();
+	}
+
 // 	public function testGenerateValidateTokens() {
 // 		$actions = new \Elgg\ActionsService();
 		
@@ -94,7 +127,8 @@ class ActionsServiceTest extends \PHPUnit_Framework_TestCase {
 // 		}
 		
 // 	}
-	
-	//TODO gatekeeper?
-}
 
+	public function testActionGatekeeper() {
+		$this->markTestIncomplete();
+	}
+}

--- a/engine/tests/phpunit/Elgg/ForwarderTest.php
+++ b/engine/tests/phpunit/Elgg/ForwarderTest.php
@@ -1,0 +1,17 @@
+<?php
+namespace Elgg;
+
+class ForwarderTest extends \PHPUnit_Framework_TestCase {
+
+	public function testForward() {
+		try {
+			forward();
+		} catch (ForwardException $e) {
+			$this->assertEquals('', $e->getLocation());
+			$this->assertEquals('system', $e->getReason());
+			return;
+		}
+
+		$this->fail('Did not throw ' . ForwardException::class);
+	}
+}

--- a/languages/en.php
+++ b/languages/en.php
@@ -37,6 +37,7 @@ return array(
 
 	'actionundefined' => "The requested action (%s) was not defined in the system.",
 	'actionnotfound' => "The action file for %s was not found.",
+	'actionclassinvalid' => "The class %s for action %s was not found or not invokable.",
 	'actionloggedout' => "Sorry, you cannot perform this action while logged out.",
 	'actionunauthorized' => 'You are unauthorized to perform this action',
 	


### PR DESCRIPTION
Now that we can rely on the `MyClass::class` syntax, we have an exciting opportunity to extend our callable-based APIs in a fully BC way.

A dev can now use an invokable class name "MyClass" as a callable, and Elgg can easily distinguish this as a class name and instantiate it as a handler. But this also allows us to overhaul the handler signature for just those handlers.

Just posting this here to share my thinking so far. Highlights:
- hooks, events, page handlers, and actions can all be handled by invokable classes
- all these are passed a single concrete implementation of an interface
- interfaces are in `Elgg\Services\`, maybe don't belong there
- classes include `->elgg()` so users don't need to use global `elgg()`. Though I'm not crazy about these composing the whole application. Might be better to pass Application as a second argument to __invoke.
- page handlers and actions are TESTABLE.
- forward() is catchable (#8338)
- devs can type-hint on object/user-specific event interfaces.
- the hook interface gives devs some convenience methods for reading entity/user from params
- the page request interface offers getSegment() to remove need to use elgg_extract()
- cleans up `ActionService::execute` considerably
