### PR TITLE
feature(javascript): Allows AMD modules to be bundled in the js/elgg script

### DIFF
--- a/docs/admin/performance.rst
+++ b/docs/admin/performance.rst
@@ -174,6 +174,12 @@ These speed up your site by caching the compiled byte code from your
 script meaning that your server doesn't have to compile the PHP code
 each time it is executed.
 
+Reduce HTTP Requests
+====================
+
+You may find it useful to :ref:`inline AMD modules <reduce-amd-requests>` to reduce HTTP requests
+on your landing pages.
+
 Hosting
 =======
 

--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -456,8 +456,14 @@ Other
 **robots.txt, site**
 	Filter the robots.txt values for ``$params['site']``.
 
+AMD
+===
+
 **config, amd**
 	Filter the AMD config for the requirejs library.
+
+**bundle_amd, js/elgg**
+	Filter the list of modules that will :ref:`be inlined <reduce-amd-requests>` in the ``js/elgg`` view.
 
 Plugins
 =======

--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -164,6 +164,38 @@ Some things to note
 #. JS and CSS views (names starting with ``js/`` or ``css/``) as well as static (.js/.css) files
    are automatically minified and cached by Elgg's simplecache system.
 
+.. _reduce-amd-requests:
+
+Reducing HTTP requests for AMD modules
+======================================
+
+For sites not served via HTTP/2 or SPDY, the overhead of many AMD requests can delay dynamic functionality
+like WYSIWYG initialization and the application of event listeners. This is particularly an issue for
+clients arriving to a site with no resources cached.
+
+You can optimize the loading of common landing pages by bundling AMD module definitions into the main
+``js/elgg`` view using the plugin hook ``bundle_amd, js/elgg``:
+
+.. code-block:: php
+
+    <?php
+    function myplugin_bundle_modules($hook, $type, $values, $params) {
+        $values[] = 'myplugin/module';
+        return $values;
+    }
+
+    elgg_register_plugin_hook_handler('bundle_amd', 'js/elgg', 'myplugin_bundle_modules');
+
+This only works with modules in standard view locations and which call ``define()``.
+
+.. warning::
+
+    Bundled modules, though not automatically executed, still must be compiled by browsers on each page load.
+
+.. note::
+
+    If the ``js/elgg`` script is slow to load, or a module could not be inlined for some reason, it will
+    be loaded the standard way.
 
 Migrating JS from Elgg 1.8 to AMD / 1.9
 =======================================

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1912,6 +1912,8 @@ function _elgg_init() {
 		'src' => '/vendors/jquery/jquery.ui.autocomplete.html.js',
 		'deps' => array('jquery.ui')
 	));
+
+	elgg_extend_view('js/elgg', 'js/elgg/inlined_modules');
 	
 	elgg_register_external_view('js/elgg/UserPicker.js', true);
 

--- a/views/default/js/elgg/inlined_modules.php
+++ b/views/default/js/elgg/inlined_modules.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Outputs a concatenated list of AMD modules with explicit names
+ *
+ * @internal Do not use or alter this view
+ */
+
+$modules = [
+	// core defaults
+	'elgg/spinner',
+];
+$modules = _elgg_services()->hooks->trigger("bundle_amd", "js/elgg", null, $modules);
+$modules = array_unique($modules);
+
+$filter = new \Elgg\Amd\ViewFilter();
+$views = _elgg_services()->views;
+
+foreach ($modules as $module) {
+	if ($module === 'js/elgg' || 0 === strpos($module, 'languages/')) {
+		continue;
+	}
+
+	$view = "js/$module.js";
+	if (!$views->viewExists($view, 'default')) {
+		continue;
+	}
+
+	$view_output = $views->renderView($view, [], false, 'default');
+	if (!$view_output) {
+		continue;
+	}
+
+	$filtered = $filter->filter($view, $view_output);
+	if ($filtered === $view_output) {
+		// may not be a module
+		if (!preg_match('/^define\([\'"]/m', $view_output)) {
+			// no define was found... this may not be a module
+			continue;
+		}
+	}
+
+	echo "$filtered;\n";
+}


### PR DESCRIPTION
Via plugin hook, plugins can register modules to be given explicit names and inlined in the js/elgg view. By default this inlines the elgg/spinner module.

Fixes #8320
