### PR TITLE
feature(developers): Adds a quick access icon for some admin settings

### DIFF
--- a/mod/developers/actions/developers/settings.php
+++ b/mod/developers/actions/developers/settings.php
@@ -24,11 +24,19 @@ if ($debug) {
 	unset_config('debug', $site->getGUID());
 }
 
-$simple_settings = array('display_errors', 'screen_log', 'show_strings',
-	'wrap_views', 'log_events',);
+$simple_settings = [
+	'display_errors',
+	'screen_log',
+	'show_strings',
+	'wrap_views',
+	'log_events',
+	'show_gear',
+];
 foreach ($simple_settings as $setting) {
 	elgg_set_plugin_setting($setting, get_input($setting), 'developers');
 }
+
+elgg_flush_caches();
 
 system_message(elgg_echo('developers:settings:success'));
 

--- a/mod/developers/classes/Elgg/DevelopersPlugin/Hooks.php
+++ b/mod/developers/classes/Elgg/DevelopersPlugin/Hooks.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Elgg\DevelopersPlugin;
+
+/**
+ * Plugin hook handlers for Developers plugin
+ */
+class Hooks {
+
+	/**
+	 * Alter input of menu sections in "gear" popup
+	 *
+	 * @param string $hook   'view_vars'
+	 * @param string $type   'navigation/menu/elements/section'
+	 * @param array  $value  Menu section $vars
+	 * @param array  $params Hook params
+	 *
+	 * @return mixed
+	 */
+	public static function alterMenuSectionVars($hook, $type, $value, $params) {
+		// I would avoid using context, but we have to use it already for alterMenuSections()
+		if (!elgg_in_context('developers_gear')) {
+			return;
+		}
+
+		$value['class'] = preg_replace('~(^|\\s)elgg-menu-page($|\\s)~', '$1elgg-menu-gear$2', $value['class']);
+		return $value;
+	}
+
+	/**
+	 * Alter output of menu sections in "gear" popup
+	 *
+	 * @param string $hook   'view'
+	 * @param string $type   'navigation/menu/elements/section'
+	 * @param array  $output Menu section HTML
+	 * @param array  $params Hook params
+	 *
+	 * @return mixed
+	 */
+	public static function alterMenuSections($hook, $type, $output, $params) {
+		// I tried avoiding using context, but not enough data is passed down into
+		// this hook to reason if we're in the gear popup view
+		if (!elgg_in_context('developers_gear')) {
+			return;
+		}
+
+		if (false === strpos($params['vars']['class'], 'elgg-child-menu')) {
+			return "<section>$output</section>";
+		}
+	}
+}

--- a/mod/developers/languages/en.php
+++ b/mod/developers/languages/en.php
@@ -28,6 +28,9 @@ return array(
 									This can break non-HTML views in the default viewtype. See developers_wrap_views() for details.",
 	'developers:label:log_events' => "Log events and plugin hooks",
 	'developers:help:log_events' => "Write events and plugin hooks to the log. Warning: there are many of these per page.",
+	'developers:label:show_gear' => "Use %s outside admin area",
+	'developers:help:show_gear' => "An icon on the bottom right of the viewport that gives admins access to developer settings and links.",
+	'developers:label:submit' => "Save and flush caches",
 
 	'developers:debug:off' => 'Off',
 	'developers:debug:error' => 'Error',
@@ -78,5 +81,5 @@ return array(
 	'developers:unit_tests:run' => 'Run',
 
 	// status messages
-	'developers:settings:success' => 'Settings saved',
+	'developers:settings:success' => 'Settings saved and caches flushed',
 );

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -61,6 +61,20 @@ function developers_process_settings() {
 		elgg_register_event_handler('all', 'all', 'developers_log_events', 1);
 		elgg_register_plugin_hook_handler('all', 'all', 'developers_log_events', 1);
 	}
+
+	if (!empty($settings['show_gear']) && elgg_is_admin_logged_in() && !elgg_in_context('admin')) {
+		elgg_require_js('elgg/dev/gear');
+		elgg_load_js('lightbox');
+		elgg_load_css('lightbox');
+		elgg_register_ajax_view('developers/gear_popup');
+
+		// TODO use ::class in 2.0
+		$handler = ['Elgg\DevelopersPlugin\Hooks', 'alterMenuSectionVars'];
+		elgg_register_plugin_hook_handler('view_vars', 'navigation/menu/elements/section', $handler);
+
+		$handler = ['Elgg\DevelopersPlugin\Hooks', 'alterMenuSections'];
+		elgg_register_plugin_hook_handler('view', 'navigation/menu/elements/section', $handler);
+	}
 }
 
 function developers_setup_menu() {

--- a/mod/developers/views/default/admin/developers/settings.php
+++ b/mod/developers/views/default/admin/developers/settings.php
@@ -65,6 +65,13 @@ $data = array(
 		'checked' => elgg_get_plugin_setting('log_events', 'developers') == 1,
 		'readonly' => false,
 	),
+
+	'show_gear' => array(
+		'type' => 'checkbox',
+		'value' => 1,
+		'checked' => elgg_get_plugin_setting('show_gear', 'developers') == 1,
+		'readonly' => false,
+	),
 );
 
 $form_vars = array('id' => 'developer-settings-form', 'class' => 'elgg-form-settings');

--- a/mod/developers/views/default/developers/css.php
+++ b/mod/developers/views/default/developers/css.php
@@ -3,6 +3,7 @@
  * Admin CSS for Elgg Developers plugin
  */
 ?>
+/*<style>*/
 /*** Elgg Developer Tools ***/
 #developers-iframe {
 	width: 100%;
@@ -20,4 +21,58 @@
 	border: 1px solid #999;
 	color: #666;
 	padding: 20px;
+}
+.developers-gear {
+	position: fixed;
+	z-index: 1000;
+	bottom: 0;
+	right: 0;
+	cursor: pointer;
+	padding: 5px 8px;
+}
+.developers-gear-popup {
+	text-align: right;
+}
+.developers-gear-popup > section {
+	display: inline-block;
+	width: 16em;
+	padding: 0 20px 20px 0;
+	text-align: left;
+	vertical-align: top;
+}
+.developers-gear-popup > section.developers-form {
+	width: 20em;
+}
+.developers-gear-popup h2 {
+	margin-bottom: 10px;
+}
+.developers-gear-popup .elgg-child-menu {
+	margin-left: 20px;
+	margin-bottom: 10px;
+}
+.developers-gear-popup .elgg-menu-parent,
+.developers-gear-popup .elgg-menu-parent:hover {
+	color: #000;
+	text-decoration: none;
+	cursor: default;
+}
+.developers-gear-popup .elgg-text-help {
+	display: none;
+}
+.developers-gear-popup label {
+	font-weight: inherit;
+	font-size: inherit;
+}
+.developers-gear-popup fieldset > div {
+	margin-bottom: 10px;
+}
+.developers-gear-popup #developer-settings-form  label .elgg-icon-info,
+.developers-gear-popup #developer-settings-form  label .elgg-text-help {
+	margin-left: 10px;
+	vertical-align: text-top;
+	cursor: pointer;
+}
+.developers-gear-popup #developer-settings-form .elgg-foot {
+	margin-top: 15px;
+	margin-bottom: 0;
 }

--- a/mod/developers/views/default/developers/gear_popup.php
+++ b/mod/developers/views/default/developers/gear_popup.php
@@ -1,0 +1,34 @@
+<?php
+
+elgg_admin_gatekeeper();
+_elgg_admin_add_plugin_settings_menu();
+
+elgg_push_context('admin');
+elgg_push_context('developers_gear');
+
+// requires "admin" in context
+developers_setup_menu();
+
+// requires "admin" and "developers_gear" in context
+$menu = elgg_view_menu('page', [
+	'sort_by' => 'priority',
+	'show_section_headers' => true,
+	'class' => 'elgg-developers-gear',
+]);
+
+$settings_form = elgg_view('admin/developers/settings');
+
+elgg_pop_context();
+elgg_pop_context();
+
+$form_heading = elgg_echo('menu:page:header:develop') . ": " . elgg_echo('admin:developers:settings');
+
+?>
+<div class='developers-gear-popup'>
+	<?php echo $menu; ?>
+
+	<section class="developers-form">
+		<h2><?php echo $form_heading; ?></h2>
+		<?php echo $settings_form; ?>
+	</section>
+</div>

--- a/mod/developers/views/default/forms/developers/settings.php
+++ b/mod/developers/views/default/forms/developers/settings.php
@@ -5,11 +5,15 @@
  * @uses $vars['values']
  */
 
-echo '<p>' . elgg_echo('elgg_dev_tools:settings:explanation') . '</p>';
+if (!elgg_is_xhr()) {
+	echo '<p>' . elgg_echo('elgg_dev_tools:settings:explanation') . '</p>';
+}
 
 foreach ($vars['data'] as $name => $info) {
 	$label = $info['readonly'] ? '<label class="elgg-state-disabled">' : '<label>';
 	$class = $info['readonly'] ? 'elgg-state-disabled' : '';
+	$echo_vars = ($name === 'show_gear') ? ['<span class="elgg-icon-settings-alt elgg-icon"></span>'] : [];
+
 	echo '<div>';
 	if ($info['type'] == 'checkbox') {
 		echo $label;
@@ -19,7 +23,7 @@ foreach ($vars['data'] as $name => $info) {
 			'checked' => $info['checked'],
 			'class' => $class,
 		));
-		echo elgg_echo("developers:label:$name") . '</label>';
+		echo ' ' . elgg_echo("developers:label:$name", $echo_vars) . '</label>';
 	} else {
 		echo $label . elgg_echo("developers:label:$name") . ' ';
 		echo elgg_view("input/{$info['type']}", array(
@@ -38,5 +42,5 @@ foreach ($vars['data'] as $name => $info) {
 }
 
 echo '<div class="elgg-foot">';
-echo elgg_view('input/submit', array('value' => elgg_echo('save')));
+echo elgg_view('input/submit', array('value' => elgg_echo('developers:label:submit')));
 echo '</div>';

--- a/mod/developers/views/default/js/elgg/dev/gear.js
+++ b/mod/developers/views/default/js/elgg/dev/gear.js
@@ -1,0 +1,51 @@
+/**
+ * Note, depends on $.colorbox!
+ */
+define(function (require) {
+	var $ = require('jquery');
+	var elgg = require('elgg');
+	var spinner = require('elgg/spinner');
+
+	$('<div class="developers-gear"><span class="elgg-icon-settings-alt elgg-icon"></span></div>')
+		.appendTo('body')
+		.find('.elgg-icon')
+		.prop('title', elgg.echo('admin:developers:settings'))
+		.on('click', function () {
+			$.colorbox({
+				href: elgg.get_site_url() + 'ajax/view/developers/gear_popup',
+				initialWidth: '90%',
+				width: '90%',
+
+				speed: 0,
+				onComplete: function () {
+					$('#developer-settings-form')
+						.on('submit', spinner.start)
+						.find('fieldset > div')
+						.each(function () {
+							var $help = $('span.elgg-text-help', this),
+								$label = $('label', this);
+
+							if ($help.length != 1 || $label.length != 1) {
+								return;
+							}
+
+							var $icon = $('<span class="elgg-icon-info elgg-icon" />'),
+								$both = $([$icon[0], $help[0]])
+								.appendTo($label)
+								.on('click', function () {
+									$both.toggle();
+									$.colorbox.resize();
+									return false;
+								});
+						});
+				}
+			});
+		});
+
+	$(document).on('click', '.developers-gear-popup a', function() {
+		if ($(this).is('.elgg-menu-parent')) {
+			return false;
+		}
+		spinner.start();
+	});
+});


### PR DESCRIPTION
When enabled, a gear icon appears in the lower right of the viewport. Clicking it opens a popup with the entire admin page menu and the developer settings form.

This also makes it clear that caches are flushed.

Aside: I feel like this could be a bigger feature not limited to the devs plugin. E.g. the gear popup could show page-specific content for admins.
