### PR TITLE
chore(file): Removes the class FilePluginFile

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -133,6 +133,11 @@ Plugin Messages
 
 Messages will no longer get the metadata 'msg' for newly created messages. This means you can not rely on that metadata to exist.
 
+Removed Classes
+---------------
+
+ - ``FilePluginFile``: replace with ``ElggFile`` (or load with ``get_entity()``)
+
 Removed Functions
 -----------------
 

--- a/mod/file/actions/file/delete.php
+++ b/mod/file/actions/file/delete.php
@@ -7,11 +7,12 @@
 
 $guid = (int) get_input('guid');
 
-$file = new FilePluginFile($guid);
-if (!$file->guid) {
+$file = get_entity($guid);
+if (!$file instanceof ElggFile) {
 	register_error(elgg_echo("file:deletefailed"));
 	forward('file/all');
 }
+/* @var ElggFile $file */
 
 if (!$file->canEdit()) {
 	register_error(elgg_echo("file:deletefailed"));

--- a/mod/file/actions/file/upload.php
+++ b/mod/file/actions/file/upload.php
@@ -41,7 +41,7 @@ if ($new_file) {
 		forward(REFERER);
 	}
 
-	$file = new FilePluginFile();
+	$file = new ElggFile();
 	$file->subtype = "file";
 
 	// if no title on new upload, grab filename
@@ -51,11 +51,12 @@ if ($new_file) {
 
 } else {
 	// load original file object
-	$file = new FilePluginFile($guid);
-	if (!$file) {
+	$file = get_entity($guid);
+	if (!$file instanceof ElggFile) {
 		register_error(elgg_echo('file:cannotload'));
 		forward(REFERER);
 	}
+	/* @var ElggFile $file */
 
 	// user must be able to edit file
 	if (!$file->canEdit()) {

--- a/mod/file/classes/FilePluginFile.php
+++ b/mod/file/classes/FilePluginFile.php
@@ -1,42 +1,15 @@
 <?php
 
 /**
- * Override the ElggFile
- *
- * @note When extending an ElggEntity, one should always register a unique type/subtype
- *       combination. We failed to do so here, so get_entity() and friends will always return
- *       these objects as ElggFile. We leave it this way just for BC.
+ * Removed subclass of ElggFile. See https://github.com/Elgg/Elgg/issues/7763
  */
-class FilePluginFile extends ElggFile {
-	protected function  initializeAttributes() {
-		parent::initializeAttributes();
-
-		// This should have been a unique subtype (see above)
-		$this->attributes['subtype'] = "file";
-	}
-
-	public function __construct($guid = null) {
-		if ($guid && !is_object($guid)) {
-			// Loading entities via __construct(GUID) is deprecated, so we give it the entity row and the
-			// attribute loader will finish the job. This is necessary due to not using a custom
-			// subtype (see above).
-			$guid = get_entity_as_row($guid);
-		}
-		parent::__construct($guid);
-	}
-
-	public function delete() {
-
-		$thumbnails = array($this->thumbnail, $this->smallthumb, $this->largethumb);
-		foreach ($thumbnails as $thumbnail) {
-			if ($thumbnail) {
-				$delfile = new ElggFile();
-				$delfile->owner_guid = $this->owner_guid;
-				$delfile->setFilename($thumbnail);
-				$delfile->delete();
-			}
-		}
-
-		return parent::delete();
+class FilePluginFile {
+	/**
+	 * Constructor
+	 *
+	 * @throws APIException
+	 */
+	public function __construct() {
+		throw new APIException(__CLASS__ . ' is no longer available. Use ElggFile or get_entity()');
 	}
 }

--- a/mod/file/lib/file.php
+++ b/mod/file/lib/file.php
@@ -8,7 +8,7 @@
 /**
  * Prepare the upload/edit form variables
  *
- * @param FilePluginFile $file
+ * @param ElggFile $file
  * @return array
  */
 function file_prepare_form_vars($file = null) {

--- a/mod/file/pages/file/edit.php
+++ b/mod/file/pages/file/edit.php
@@ -10,10 +10,13 @@ elgg_load_library('elgg:file');
 elgg_gatekeeper();
 
 $file_guid = (int) get_input('guid');
-$file = new FilePluginFile($file_guid);
-if (!$file) {
+
+$file = get_entity($file_guid);
+if (!$file instanceof ElggFile) {
 	forward();
 }
+/* @var ElggFile $file */
+
 if (!$file->canEdit()) {
 	forward();
 }

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -58,6 +58,10 @@ function file_init() {
 	// temporary - see #2010
 	elgg_register_action("file/download", "$action_path/download.php");
 
+	// cleanup thumbnails on delete. high priority because we want to try to make sure the
+	// deletion will actually occur before we go through with this.
+	elgg_register_event_handler('delete', 'object', 'file_handle_object_delete', 999);
+
 	// embed support
 	$item = ElggMenuItem::factory(array(
 		'name' => 'file',
@@ -415,5 +419,33 @@ function file_set_icon_url($hook, $type, $url, $params) {
 		$url = "mod/file/graphics/icons/{$type}{$ext}.gif";
 		$url = elgg_trigger_plugin_hook('file:icon:url', 'override', $params, $url);
 		return $url;
+	}
+}
+
+/**
+ * Handle an object being deleted
+ *
+ * @param string     $event Event name
+ * @param string     $type  Event type
+ * @param ElggObject $file  The object deleted
+ * @return void
+ */
+function file_handle_object_delete($event, $type, ElggObject $file) {
+	if (!$file instanceof ElggFile) {
+		return;
+	}
+	if (!$file->guid) {
+		// this is an ElggFile used as temporary API
+		return;
+	}
+
+	$thumbnails = array($file->thumbnail, $file->smallthumb, $file->largethumb);
+	foreach ($thumbnails as $thumbnail) {
+		if ($thumbnail) {
+			$delfile = new ElggFile();
+			$delfile->owner_guid = $file->owner_guid;
+			$delfile->setFilename($thumbnail);
+			$delfile->delete();
+		}
 	}
 }

--- a/mod/file/views/default/file/theme_sandbox/icons/files.php
+++ b/mod/file/views/default/file/theme_sandbox/icons/files.php
@@ -1,6 +1,6 @@
 <?php
 
-$file = new FilePluginFile();
+$file = new ElggFile();
 
 $mapping = array(
 	'general' => 'general',


### PR DESCRIPTION
BREAKING CHANGE:
If you use the class FilePluginFile in your plugin, replace this usage with ElggFile (for construction). Load files objects with get_entity().

Fixes #7763
