### PR TITLE
fix(file): Default file type icons again available in the theme sandbox

### DIFF
--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -83,7 +83,7 @@ function file_init() {
 
 	elgg_register_menu_item('embed', $item);
 
-	elgg_extend_view('theme_sandbox/icons', 'file/theme_sandbox/icons');
+	elgg_extend_view('theme_sandbox/icons', 'file/theme_sandbox/icons/files');
 }
 
 /**


### PR DESCRIPTION
(at the bottom of the "icons" page)
