### PR TITLE
fix(spinner): elgg/spinner delays a bit before displaying

### DIFF
--- a/js/tests/ElggSpinnerTest.js
+++ b/js/tests/ElggSpinnerTest.js
@@ -13,17 +13,53 @@ define(function(require) {
 			expect($('.elgg-spinner').length).toBe(1);
 		});
 
-		it("start() adds the body class", function() {
+		it("start() doesn't add the body class immediately", function() {
 			expect($(visible_selector).length).toBe(0);
 			spinner.start();
-			expect($(visible_selector).length).toBe(1);
+			expect($(visible_selector).length).toBe(0);
+		});
+
+		it("start() adds the body class after 20ms", function() {
+			expect($(visible_selector).length).toBe(0);
+			var flag = false;
+
+			runs(function() {
+				spinner.start();
+
+				setTimeout(function() {
+					flag = true;
+				}, 25);
+			});
+
+			waitsFor(function() {
+				return flag;
+			});
+
+			runs(function() {
+				expect($(visible_selector).length).toBe(1);
+			});
 		});
 
 		it("stop() removes the body class", function() {
-			spinner.start();
-			expect($(visible_selector).length).toBe(1);
-			spinner.stop();
-			expect($(visible_selector).length).toBe(0);
+			var flag = false;
+
+			runs(function() {
+				spinner.start();
+
+				setTimeout(function() {
+					flag = true;
+				}, 25);
+			});
+
+			waitsFor(function() {
+				return flag;
+			});
+
+			runs(function() {
+				expect($(visible_selector).length).toBe(1);
+				spinner.stop();
+				expect($(visible_selector).length).toBe(0);
+			});
 		});
 	});
 });

--- a/views/default/js/elgg/spinner.js
+++ b/views/default/js/elgg/spinner.js
@@ -1,14 +1,23 @@
 define(function (require) {
 	var $ = require('jquery');
 
+	var active = false;
+	var SHOW_DELAY = 20;
+
 	$('body').append('<div class="elgg-spinner"><div class="elgg-ajax-loader"></div></div>');
 
 	return {
 		start: function () {
-			$('body').addClass('elgg-spinner-active');
+			active = true;
+			setTimeout(function () {
+				if (active) {
+					$('body').addClass('elgg-spinner-active');
+				}
+			}, SHOW_DELAY);
 		},
 
 		stop: function () {
+			active = false;
 			$('body').removeClass('elgg-spinner-active');
 		}
 	};


### PR DESCRIPTION
Requests served from browser cache are near instantaneously, and in these cases the spinner is a distraction. So we wait 20ms before showing it.

Fixes #8361
