### PR TITLE
fix(IDE): Public APIs no longer marked with @internal

### DIFF
--- a/engine/classes/Elgg/Database/ConfigTable.php
+++ b/engine/classes/Elgg/Database/ConfigTable.php
@@ -68,10 +68,10 @@ class ConfigTable {
 	 * @warning Names should be selected so as not to collide with the names for the
 	 * datalist (application configuration)
 	 * 
-	 * @internal These settings are stored in the dbprefix_config table and read 
+	 * @note Internal: These settings are stored in the dbprefix_config table and read
 	 * during system boot into $CONFIG.
 	 * 
-	 * @internal The value is serialized so we maintain type information.
+	 * @note Internal: The value is serialized so we maintain type information.
 	 *
 	 * @param string $name      The name of the configuration value
 	 * @param mixed  $value     Its value
@@ -113,7 +113,7 @@ class ConfigTable {
 	 * 
 	 * Plugin authors should use elgg_get_config().
 	 *
-	 * @internal These settings are stored in the dbprefix_config table and read 
+	 * @note Internal: These settings are stored in the dbprefix_config table and read
 	 * during system boot into $CONFIG.
 	 *
 	 * @param string $name      The name of the config value

--- a/engine/classes/ElggAnnotation.php
+++ b/engine/classes/ElggAnnotation.php
@@ -6,7 +6,7 @@
  * essentially the same as metadata, but with additional helper functions for
  * performing calculations.
  *
- * @internal Annotations are stored in the annotations table.
+ * @note Internal: Annotations are stored in the annotations table.
  *
  * @package    Elgg.Core
  * @subpackage DataModel.Annotations

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1870,7 +1870,7 @@ abstract class ElggEntity extends \ElggData implements
 	 *
 	 * You can ignore the disabled field by using {@link access_show_hidden_entities()}.
 	 *
-	 * @internal Disabling an entity sets the 'enabled' column to 'no'.
+	 * @note Internal: Disabling an entity sets the 'enabled' column to 'no'.
 	 *
 	 * @param string $reason    Optional reason
 	 * @param bool   $recursive Recursively disable all contained entities?

--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -10,7 +10,7 @@
  * as the related row in the entities table as represented by the parent
  * \ElggEntity object.
  *
- * @internal Title and description are stored in the objects_entity table.
+ * @note Internal: Title and description are stored in the objects_entity table.
  *
  * @package    Elgg.Core
  * @subpackage DataModel.Object

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -32,7 +32,7 @@ class ElggPlugin extends \ElggObject {
 	/**
 	 * Creates a new plugin from path
 	 *
-	 * @internal also supports database objects
+	 * @note Internal: also supports database objects
 	 *
 	 * @warning Unlike other \ElggEntity objects, you cannot null instantiate
 	 *          \ElggPlugin. You must provide the path to the plugin directory.

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -12,7 +12,7 @@
  *
  * Every \ElggEntity belongs to a site.
  *
- * @internal \ElggSite represents a single row from the sites_entity
+ * @note Internal: \ElggSite represents a single row from the sites_entity
  * table, as well as the corresponding \ElggEntity row from the entities table.
  *
  * @warning Multiple site support isn't fully developed.

--- a/engine/lib/access.php
+++ b/engine/lib/access.php
@@ -26,13 +26,13 @@
  * @warning This will not show disabled entities.
  * Use {@link access_show_hidden_entities()} to access disabled entities.
  * 
- * @internal The access override is checked in elgg_override_permissions(). It is
+ * @note Internal: The access override is checked in elgg_override_permissions(). It is
  * registered for the 'permissions_check' hooks to override the access system for
  * the canEdit() and canWriteToContainer() methods.
  * 
- * @internal This clears the access cache.
+ * @note Internal: This clears the access cache.
  *
- * @internal For performance reasons this is done at the database access clause level.
+ * @note Internal: For performance reasons this is done at the database access clause level.
  *
  * @param bool $ignore If true, disables all access checks.
  *
@@ -86,7 +86,7 @@ function get_access_list($user_guid = 0, $site_guid = 0, $flush = false) {
  * to plus public and logged in access levels. If the user is an admin, it includes
  * the private access level.
  *
- * @internal this is only used in core for creating the SQL where clause when
+ * @note Internal: this is only used in core for creating the SQL where clause when
  * retrieving content from the database. The friends access level is handled by
  * _elgg_get_access_where_sql().
  *
@@ -296,7 +296,7 @@ function can_edit_access_collection($collection_id, $user_guid = null) {
  *
  * Triggers plugin hook 'access:collections:addcollection', 'collection'
  *
- * @internal Access collections are stored in the access_collections table.
+ * @note Internal: Access collections are stored in the access_collections table.
  * Memberships to collections are in access_collections_membership.
  *
  * @param string $name       The name of the collection.

--- a/engine/lib/actions.php
+++ b/engine/lib/actions.php
@@ -66,7 +66,7 @@ function action($action, $forwarder = "") {
  *
  * @tip You don't need to include engine/start.php in your action files.
  *
- * @internal Actions are saved in $CONFIG->actions as an array in the form:
+ * @note Internal: Actions are saved in $CONFIG->actions as an array in the form:
  * <code>
  * array(
  * 	'file' => '/location/to/file.php',

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -173,7 +173,7 @@ function run_function_once($functionname, $timelastupdatedcheck = 0) {
 /**
  * Removes a config setting.
  *
- * @internal These settings are stored in the dbprefix_config table and read 
+ * @note Internal: These settings are stored in the dbprefix_config table and read
  * during system boot into $CONFIG.
  *
  * @param string $name      The name of the field.

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -395,7 +395,7 @@ function sanitise_filepath($path, $append_slash = true) {
  * {@link views/default/page/shells/default.php} and displays messages as
  * javascript popups.
  *
- * @internal Messages are stored as strings in the Elgg session as ['msg'][$register] array.
+ * @note Internal: Messages are stored as strings in the Elgg session as ['msg'][$register] array.
  *
  * @warning This function is used to both add to and clear the message
  * stack.  If $messages is null, $register will be returned and cleared.
@@ -501,7 +501,7 @@ function register_error($error) {
  *
  * @tip When referring to events, the preferred syntax is "event, type".
  *
- * @internal Events are stored in $CONFIG->events as:
+ * Internal note: Events are stored in $CONFIG->events as:
  * <code>
  * $CONFIG->events[$event][$type][$priority] = $callback;
  * </code>
@@ -554,10 +554,10 @@ function elgg_unregister_event_handler($event, $object_type, $callback) {
  *
  * @tip When referring to events, the preferred syntax is "event, type".
  *
- * @internal Only rarely should events be changed, added, or removed in core.
+ * @note Internal: Only rarely should events be changed, added, or removed in core.
  * When making changes to events, be sure to first create a ticket on Github.
  *
- * @internal @tip Think of $object_type as the primary namespace element, and
+ * @note Internal: @tip Think of $object_type as the primary namespace element, and
  * $event as the secondary namespace.
  *
  * @param string $event       The event type
@@ -661,7 +661,7 @@ function elgg_trigger_deprecated_event($event, $object_type, $object = null, $me
  *  - mixed $params An optional array of parameters.  Used to provide additional
  *  information to plugins.
  *
- * @internal Plugin hooks are stored in $CONFIG->hooks as:
+ * @note Internal: Plugin hooks are stored in $CONFIG->hooks as:
  * <code>
  * $CONFIG->hooks[$hook][$type][$priority] = $callback;
  * </code>
@@ -747,7 +747,7 @@ function elgg_unregister_plugin_hook_handler($hook, $entity_type, $callback) {
  * @tip It's not possible for a plugin hook to change a non-null $returnvalue
  * to null.
  *
- * @internal The checks for $hook and/or $type not being equal to 'all' is to
+ * @note Internal: The checks for $hook and/or $type not being equal to 'all' is to
  * prevent a plugin hook being registered with an 'all' being called more than
  * once if the trigger occurs with an 'all'. An example in core of this is in
  * actions.php:

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -563,9 +563,9 @@ function _elgg_get_entity_time_where_sql($table, $time_created_upper = null,
  *
  * @tip Pagination is handled automatically.
  *
- * @internal This also provides the views for elgg_view_annotation().
+ * @note Internal: This also provides the views for elgg_view_annotation().
  *
- * @internal If the initial COUNT query returns 0, the $getter will not be called again.
+ * @note Internal: If the initial COUNT query returns 0, the $getter will not be called again.
  *
  * @param array    $options Any options from $getter options plus:
  *                   item_view => STR Optional. Alternative view used to render list items

--- a/engine/lib/private_settings.php
+++ b/engine/lib/private_settings.php
@@ -260,7 +260,7 @@ $pairs = null, $pair_operator = 'AND', $name_prefix = '') {
  * Plugin authors can set private data on entities.  By default
  * private data will not be searched or exported.
  *
- * @internal Private data is used to store settings for plugins
+ * @note Internal: Private data is used to store settings for plugins
  * and user settings.
  *
  * @param int    $entity_guid The entity GUID

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -36,10 +36,10 @@
  * 'default' is a standard HTML view.  Types can be defined on the fly
  * and you can get the current viewtype with {@link elgg_get_viewtype()}.
  *
- * @internal Plugin views are autoregistered before their init functions
+ * @note Internal: Plugin views are autoregistered before their init functions
  * are called, so the init order doesn't affect views.
  *
- * @internal The file that determines the output of the view is the last
+ * @note Internal: The file that determines the output of the view is the last
  * registered by {@link elgg_set_view_location()}.
  *
  * @package Elgg.Core
@@ -81,7 +81,7 @@ function elgg_set_viewtype($viewtype = "") {
  * Viewtypes are automatically detected and can be set with $_REQUEST['view']
  * or {@link elgg_set_viewtype()}.
  *
- * @internal Viewtype is determined in this order:
+ * @note Internal: Viewtype is determined in this order:
  *  - $CURRENT_SYSTEM_VIEWTYPE Any overrides by {@link elgg_set_viewtype()}
  *  - $CONFIG->view  The default view as saved in the DB.
  *
@@ -290,7 +290,7 @@ function elgg_get_view_location($view, $viewtype = '') {
  * Views are expected to be in plugin_name/views/.  This function can
  * be used to change that location.
  *
- * @internal Core view locations are stored in $CONFIG->viewpath.
+ * @note Internal: Core view locations are stored in $CONFIG->viewpath.
  *
  * @tip This is useful to optionally register views in a plugin.
  *
@@ -386,7 +386,7 @@ function elgg_view_deprecated($view, array $vars, $suggestion, $version) {
  * Priority can be specified and affects the order in which extensions
  * are appended or prepended.
  *
- * @internal View extensions are stored in
+ * @note Internal: View extensions are stored in
  * $CONFIG->views->extensions[$view][$priority] = $view_extension
  *
  * @param string $view           The view to extend.


### PR DESCRIPTION
Even the inline `@internal` meant to add developer notes has the effect of marking the function not a part of the public API, so, e.g. PHPStorm was showing usages with a strikethrough.

Fixes #7714
