### PR TITLE
chore(javascript): unmarks elgg.normalize_url as private

### DIFF
--- a/js/lib/elgglib.js
+++ b/js/lib/elgglib.js
@@ -251,7 +251,6 @@ elgg.inherit = function(Child, Parent) {
  *
  * @param {String} url The url to normalize
  * @return {String} The extended url
- * @private
  */
 elgg.normalize_url = function(url) {
 	url = url || '';


### PR DESCRIPTION
This is used in lots of 3rd party plugins and there’s no great reason for it to be private.
