### PR TITLE
fix(notification): Removes warning handling the email, system hook

### DIFF
--- a/engine/lib/comments.php
+++ b/engine/lib/comments.php
@@ -275,6 +275,10 @@ function _elgg_comments_permissions_override($hook, $type, $return, $params) {
  * @return array $returnvalue Modified mail parameters
  */
 function _elgg_comments_notification_email_subject($hook, $type, $returnvalue, $params) {
+	if (!is_array($returnvalue)) {
+		// another hook handler returned a non-array, let's not override it
+		return;
+	}
 
 	/** @var Elgg\Notifications\Notification */
 	$notification = elgg_extract('notification', $returnvalue['params']);


### PR DESCRIPTION
If a [email, system] hook handler returns a non-array before this handler, we now return early.

Fixes #8333
