### PR TITLE
chore(developers): Remove scrollbar in gear lightbox

### DIFF
--- a/mod/developers/views/default/js/elgg/dev/gear.js
+++ b/mod/developers/views/default/js/elgg/dev/gear.js
@@ -38,6 +38,7 @@ define(function (require) {
 									return false;
 								});
 						});
+					$.colorbox.resize();
 				}
 			});
 		});


### PR DESCRIPTION
Inserting the help bubbles added some height, so we resize immediately after.

(This feature isn't released yet, is it confusing to call this a "fix" in the release notes?)
