### PR TITLE
WIP for a new Ajax API

### DIFF
--- a/docs/guides/services.rst
+++ b/docs/guides/services.rst
@@ -26,6 +26,12 @@ Service: config
 An instance of ``Elgg\Services\ConfigInterface``, this is for getting and setting various system
 configuration values.
 
+Service: ajaxApi
+----------------
+
+An instance of ``Elgg\Services\AjaxApi``, this is for registering Ajax endpoints for use with the
+AMD module ``elgg/ajax``.
+
 .. note::
 
     If you have a useful idea, you can :doc:`add a new service </contribute/services>`!

--- a/engine/classes/Elgg/AjaxApi/ApiResponse.php
+++ b/engine/classes/Elgg/AjaxApi/ApiResponse.php
@@ -1,0 +1,61 @@
+<?php
+namespace Elgg\AjaxApi;
+
+/**
+ * JSON endpoint response
+ *
+ * @since 2.0.0
+ * @access private
+ * @internal Devs should type hint the interface
+ */
+class ApiResponse implements \Elgg\Services\AjaxApi\ApiResponse {
+
+	private $ttl = 0;
+	private $data = null;
+	private $cancelled = false;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setTtl($ttl = 0) {
+		$this->ttl = (int)max($ttl, 0);
+		return $this;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getTtl() {
+		return $this->ttl;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setData($data) {
+		$this->data = $data;
+		return $this;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getData() {
+		return $this->data;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function cancel() {
+		$this->cancelled = true;
+		return $this;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function isCancelled() {
+		return $this->cancelled;
+	}
+}

--- a/engine/classes/Elgg/AjaxApi/HelloWorld.php
+++ b/engine/classes/Elgg/AjaxApi/HelloWorld.php
@@ -1,0 +1,31 @@
+<?php
+namespace Elgg\AjaxApi;
+
+use Elgg\Application;
+use Elgg\Services\AjaxApi\ApiResponse;
+
+/**
+ * Just an example for reviewers
+ *
+ * @todo Remove this before merge
+ */
+class HelloWorld {
+
+	/**
+	 * Handle the API request
+	 *
+	 * @param ApiResponse $response API response
+	 * @param Application $elgg     Elgg app
+	 *
+	 * @return ApiResponse
+	 */
+	function __invoke(ApiResponse $response, Application $elgg) {
+		$name = get_input('name', 'Dave');
+
+		system_message("How are you doing, $name?");
+
+		return $response->setData([
+			'name' => $name,
+		]);
+	}
+}

--- a/engine/classes/Elgg/AjaxApi/Service.php
+++ b/engine/classes/Elgg/AjaxApi/Service.php
@@ -1,0 +1,133 @@
+<?php
+namespace Elgg\AjaxApi;
+
+use Elgg\Di\DiContainer;
+use Elgg\Http\Input;
+use Elgg\PluginHooksService;
+use Elgg\SystemMessagesService;
+use Elgg\Services\AjaxApi;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Models the Ajax API service
+ *
+ * @since 2.0.0
+ * @access private
+ * @internal
+ */
+class Service implements AjaxApi {
+
+	/**
+	 * @var callable[]
+	 */
+	private $handlers;
+
+	/**
+	 * @var PluginHooksService
+	 */
+	private $hooks;
+
+	/**
+	 * @var SystemMessagesService
+	 */
+	private $msgs;
+
+	/**
+	 * @var Input
+	 */
+	private $input;
+
+	/**
+	 * Constructor
+	 *
+	 * @param PluginHooksService    $hooks Hooks service
+	 * @param SystemMessagesService $msgs  System messages service
+	 * @param Input                 $input Input service
+	 */
+	public function __construct(PluginHooksService $hooks, SystemMessagesService $msgs, Input $input) {
+		$this->hooks = $hooks;
+		$this->msgs = $msgs;
+		$this->input = $input;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function register($endpoint, $class_name) {
+		if (!preg_match(DiContainer::CLASS_NAME_PATTERN_53, $class_name)) {
+			throw new \InvalidArgumentException("'$class_name' is not a valid class name");
+		}
+		$this->handlers[$endpoint] = $class_name;
+	}
+
+	/**
+	 * Handle a request
+	 *
+	 * @param string $endpoint Endpoint name
+	 *
+	 * @return Response
+	 * @access private
+	 * @throws \RuntimeException
+	 */
+	public function handle($endpoint) {
+		$get_error = function ($code, $msg = '') {
+			return new JsonResponse(['error' => $msg], $code);
+		};
+
+		if (empty($this->handlers[$endpoint])) {
+			return $get_error(404, "Unregistered endpoint '$endpoint'");
+		}
+
+		$class_name = $this->handlers[$endpoint];
+		if (!class_exists($class_name)) {
+			throw new \RuntimeException("Class $class_name cannot be found");
+		}
+
+		// TODO move into DI system
+		$handler = new $class_name;
+		if (!is_callable($handler)) {
+			throw new \RuntimeException("Class $class_name is not invokable");
+		}
+
+		$api_response = new ApiResponse();
+		$api_response->setTtl($this->input->get('response_ttl', 0, false));
+
+		$api_response = call_user_func($handler, $api_response, elgg());
+		if (!$api_response instanceof \Elgg\Services\AjaxApi\ApiResponse) {
+			throw new \RuntimeException("$class_name::__invoke did not return an ApiResponse");
+		}
+
+		$hook = AjaxApi::RESPONSE_HOOK;
+		$api_response = $this->hooks->trigger($hook, $endpoint, null, $api_response);
+		if (!$api_response instanceof \Elgg\Services\AjaxApi\ApiResponse) {
+			throw new \RuntimeException("The value returned by hook [$hook, $endpoint] was not an ApiResponse");
+		}
+
+		if ($api_response->isCancelled()) {
+			return $get_error(400, "The response was cancelled");
+		}
+
+		$response = new JsonResponse([
+			'msgs' => $this->msgs->dumpRegister(),
+			'data' => $api_response->getData(),
+		]);
+
+		$ttl = $api_response->getTtl();
+		if ($ttl > 0) {
+			// Required to remove headers set by PHP session
+			header_remove('Expires');
+			header_remove('Pragma');
+			header_remove('Cache-Control');
+
+			// JsonRequest sets a default Cache-Control header we don't want
+			$response->headers->remove('Cache-Control');
+
+			$response->setClientTtl($ttl);
+
+			// if we don't set Expires, Apache will add a far-off max-age and Expires for us.
+			$response->headers->set('Expires', gmdate('D, d M Y H:i:s \G\M\T', time() + $ttl));
+		}
+		return $response;
+	}
+}

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -7,7 +7,8 @@ use Elgg\Di\ServiceProvider;
 /**
  * Load, boot, and implement a front controller for an Elgg application
  *
- * @property-read \Elgg\Services\Config $config
+ * @property-read \Elgg\Services\Config  $config
+ * @property-read \Elgg\Services\AjaxApi $ajaxApi
  *
  * @since 2.0.0
  */
@@ -38,6 +39,7 @@ class Application {
 	 */
 	private static $public_services = [
 		'config' => true,
+		'ajaxApi' => true,
 	];
 
 	/**

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -16,6 +16,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \ElggStaticVariableCache                 $accessCache
  * @property-read \Elgg\ActionsService                     $actions
  * @property-read \Elgg\Database\AdminNotices              $adminNotices
+ * @property-read \Elgg\AjaxApi\Service                    $ajaxApi
  * @property-read \Elgg\Amd\Config                         $amdConfig
  * @property-read \Elgg\Database\Annotations               $annotations
  * @property-read \ElggAutoP                               $autoP
@@ -95,6 +96,10 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		});
 
 		$this->setClassName('actions', \Elgg\ActionsService::class);
+
+		$this->setFactory('ajaxApi', function(ServiceProvider $c) {
+			return new \Elgg\AjaxApi\Service($c->hooks, $c->systemMessages, $c->input);
+		});
 
 		$this->setClassName('adminNotices', \Elgg\Database\AdminNotices::class);
 

--- a/engine/classes/Elgg/Services/AjaxApi.php
+++ b/engine/classes/Elgg/Services/AjaxApi.php
@@ -1,0 +1,30 @@
+<?php
+namespace Elgg\Services;
+
+/**
+ * Describes an object that establishes JSON API endpoints
+ *
+ * @since 2.0.0
+ */
+interface AjaxApi {
+
+	const RESPONSE_HOOK = 'ajax_api:response';
+
+	/**
+	 * Register an invokable class as a handler for JSON requests
+	 *
+	 * The class will be instantiated with no arguments. Then __invoke will be called, receiving two
+	 * arguments: an \Elgg\AjaxApi\ApiResponse object, and the \Elgg\Application instance. The
+	 * handler must return the ApiResponse.
+	 *
+	 * The response is finally passed through the hook [ajax_api:response, <endpoint>] before
+	 * being used to construct the HTTP response.
+	 *
+	 * @param string $endpoint   The endpoint name
+	 * @param string $class_name The handler class name
+	 *
+	 * @return void
+	 * @throws \InvalidArgumentException
+	 */
+	public function register($endpoint, $class_name);
+}

--- a/engine/classes/Elgg/Services/AjaxApi/ApiResponse.php
+++ b/engine/classes/Elgg/Services/AjaxApi/ApiResponse.php
@@ -1,0 +1,54 @@
+<?php
+namespace Elgg\Services\AjaxApi;
+
+/**
+ * JSON endpoint response
+ *
+ * @since 2.0.0
+ */
+interface ApiResponse {
+
+	/**
+	 * Set the max-age for client caching
+	 *
+	 * @param int $ttl Time to cache in seconds
+	 * @return self
+	 */
+	public function setTtl($ttl = 0);
+
+	/**
+	 * Get the max-age for client caching
+	 *
+	 * @return int
+	 */
+	public function getTtl();
+
+	/**
+	 * Set the response data
+	 *
+	 * @param mixed $data Response data. Must be able to be encoded in JSON.
+	 * @return self
+	 */
+	public function setData($data);
+
+	/**
+	 * Get the response data
+	 *
+	 * @return mixed
+	 */
+	public function getData();
+
+	/**
+	 * Cancel the response and send a 403 header
+	 *
+	 * @return self
+	 */
+	public function cancel();
+
+	/**
+	 * Has the response been cancelled?
+	 *
+	 * @return bool
+	 */
+	public function isCancelled();
+}

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1522,6 +1522,12 @@ function _elgg_ajax_page_handler($segments) {
 		return true;
 	}
 
+	if ($segments[0] === 'endpoint') {
+		$response = _elgg_services()->ajaxApi->handle($segments[1]);
+		$response->send();
+		return true;
+	}
+
 	return false;
 }
 
@@ -1873,6 +1879,9 @@ function _elgg_engine_boot() {
  */
 function _elgg_init() {
 	global $CONFIG;
+
+	// TODO remove me before merging feature
+	elgg()->ajaxApi->register('elgg.hello', \Elgg\AjaxApi\HelloWorld::class);
 
 	elgg_register_action('comment/save');
 	elgg_register_action('comment/delete');

--- a/views/default/js/elgg/ajax.js
+++ b/views/default/js/elgg/ajax.js
@@ -1,0 +1,136 @@
+define(function (require) {
+	var $ = require('jquery');
+	var elgg = require('elgg');
+	var spinner = require('elgg/spinner');
+
+	var spinner_enabled = true;
+	var ajax = {
+		/**
+		 * The options.data will be passed through this hook, with the endpoint name as hook type and
+		 * params.option will have a copy of the original options object
+		 */
+		REQUEST_DATA_HOOK: 'ajax_api:request_data',
+
+		/**
+		 * The returned data will be passed through this hook, with the endpoint name as hook type and
+		 * params.option will have a copy of the original options object.
+		 *
+		 * Note this hook will be triggered twice if you provide an options.success function.
+		 */
+		RESPONSE_DATA_HOOK: 'ajax_api:response_data',
+
+		/**
+		 * Fetch a value from an Ajax endpoint registered via the "ajaxApi" service
+		 *
+		 * Note that this function does not support the array form of "success".
+		 *
+		 * To request the response be cached, set options.data.response_ttl to a number of seconds.
+		 *
+		 * @param {Object} options including jQuery.ajax options. The default method is "GET".
+		 *
+		 *     endpoint : {String} required name of the Ajax API endpoint
+		 *
+		 * @returns {jqXHR}
+		 */
+		fetch: function (options) {
+			var orig_options,
+				msgs_were_set = 0,
+				params;
+
+			function unwrap_data(data) {
+				var params;
+
+				if (!msgs_were_set) {
+					data.msgs.error && elgg.register_error(data.msgs.error);
+					data.msgs.success && elgg.system_message(data.msgs.success);
+					msgs_were_set = 1;
+				}
+
+				params = {
+					options: orig_options
+				};
+				return elgg.trigger_hook(ajax.RESPONSE_DATA_HOOK, options.endpoint, params, data.data);
+			}
+
+			if (!$.isPlainObject(options) || !options.endpoint) {
+				throw new Error('options must be a plain with key "endpoint"');
+			}
+
+			// ease hook filtering by making these keys always available
+			options.data = options.data || {};
+			options.dataType = 'json';
+			if (!options.method) {
+				options.method = 'GET';
+			}
+
+			// copy of original options
+			orig_options = $.extend({}, options);
+
+			params = {
+				options: options
+			};
+			options.data = elgg.trigger_hook(ajax.REQUEST_DATA_HOOK, options.endpoint, params, options.data);
+
+			if ($.isArray(options.success)) {
+				throw new Error('The array form of options.success is not supported');
+			}
+
+			if (!elgg.isFunction(options.error)) {
+				// add a generic error handler
+				options.error = function(xhr, status, error) {
+					elgg.ajax.handleAjaxError(xhr, status, error);
+				};
+			}
+
+			if (elgg.isFunction(options.success)) {
+				options.success = function (data) {
+					data = unwrap_data(data);
+					orig_options.success(data);
+				};
+			}
+
+			if (spinner_enabled) {
+				options.beforeSend = function () {
+					orig_options.beforeSend && orig_options.beforeSend();
+					spinner.start();
+				};
+				options.complete = function () {
+					spinner.stop();
+					orig_options.complete && orig_options.complete();
+				};
+			}
+
+			if (!options.error) {
+				options.error = elgg.ajax.handleAjaxError;
+			}
+
+			options.url = elgg.get_site_url() + 'ajax/endpoint/' + options.endpoint;
+
+			return $.ajax(options).then(unwrap_data);
+		},
+
+		/**
+		 * Fetch content and set it as HTML content of $target
+		 *
+		 * @param {jQuery} $target jQuery-wrapped element(s)
+		 * @param {Object} options Fetch options (e.g. data)
+		 * @returns {jqXHR}
+		 */
+		load: function ($target, options) {
+			return ajax.fetch(options).done(function (content) {
+				$target.html(content);
+			});
+		},
+
+		/**
+		 * Set whether Ajax functions should activate the page-level loading spinner
+		 *
+		 * @param {Bool} enabled
+		 */
+		setEnableSpinner: function (enabled) {
+			spinner_enabled = !!enabled;
+		}
+	};
+
+	return ajax;
+});

--- a/views/default/js/elgg/ajax_example.js
+++ b/views/default/js/elgg/ajax_example.js
@@ -1,0 +1,21 @@
+define(function(require) {
+	var ajax = require('elgg/ajax');
+	var elgg = require('elgg');
+
+	var log = console.log.bind(console);
+
+	elgg.register_hook_handler(ajax.REQUEST_DATA_HOOK, 'all', function (name, type, params, returnValue) {
+		log(arguments);
+	});
+
+	elgg.register_hook_handler(ajax.RESPONSE_DATA_HOOK, 'all', function (name, type, params, returnValue) {
+		log(arguments);
+	});
+
+	ajax.fetch({
+		endpoint: 'elgg.hello',
+		data: {
+			name: 'William'
+		}
+	});
+});


### PR DESCRIPTION
For #8323. Obviously missing RST docs, but if you check this out and enter `require(['elgg/ajax_example'])` at the console you'll see a request go through. You can see the `HelloWorld` class as an example endpoint.

Client-side, hooks can alter data sent to and/or returned from the server. Though I think this will mostly be helpful for being notified when some operations take place. e.g. something is liked.

Server-side, handlers (only classes) and plugin hook handlers receive an ApiResponse, a simplified HTTP response object that gets turned into a Symfony JSONResponse.

I'd like to add actions here, too, such that the caller only gets the data back, not the full response wrapper.
