### PR TITLE
fix(relationships): Restores functionality of `$inverse_relationship` argument for `get_entity_relationships`

### DIFF
--- a/engine/lib/relationships.php
+++ b/engine/lib/relationships.php
@@ -129,7 +129,7 @@ function remove_entity_relationships($guid, $relationship = "", $inverse_relatio
  * @return \ElggRelationship[]
  */
 function get_entity_relationships($guid, $inverse_relationship = false) {
-	return _elgg_services()->relationshipsTable->getAll($guid, $inverse_relationships);
+	return _elgg_services()->relationshipsTable->getAll($guid, $inverse_relationship);
 }
 
 /**


### PR DESCRIPTION
Hello,

When we have tried to upgrade from elgg 1.9 to elgg 1.10, we found a bug on get_entity_relationships() function.

There is a small typo error on $inverse_relationship variable.

Regards,

ref: #8389
