### PR TITLE
chore(forward): Allows forward() calls to be caught for testing

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -12,6 +12,13 @@ See the administrator guides for :doc:`how to upgrade a live site </admin/upgrad
 From 2.x to 3.0
 ===============
 
+``forward()`` uses an exception
+-------------------------------
+
+If you use try/catch, do *not* catch overly general exceptions like ``Exception``.
+
+If your code must catch the new ``Elgg\ForwardException``, re-throw it.
+
 Removed views
 -------------
 

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -35,6 +35,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\EventsService                      $events
  * @property-read \Elgg\Assets\ExternalFiles               $externalFiles
  * @property-read \ElggDiskFilestore                       $filestore
+ * @property-read \Elgg\Forwarder                          $forwarder
  * @property-read \Elgg\PluginHooksService                 $hooks
  * @property-read \Elgg\Http\Input                         $input
  * @property-read \Elgg\Logger                             $logger
@@ -166,6 +167,11 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 
 		$this->setFactory('filestore', function(ServiceProvider $c) {
 			return new \ElggDiskFilestore($c->config->getDataPath());
+		});
+
+		$this->setFactory('forwarder', function(ServiceProvider $c) {
+			$referrer = $c->request->headers->get('Referer');
+			return new \Elgg\Forwarder($c->hooks, $c->config->getSiteUrl(0), $referrer);
 		});
 
 		$this->setFactory('hooks', function(ServiceProvider $c) {

--- a/engine/classes/Elgg/ForwardException.php
+++ b/engine/classes/Elgg/ForwardException.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Elgg;
+
+/**
+ * Exception thrown on forward() call
+ *
+ * If you catch this exception, re-throw it.
+ */
+class ForwardException extends \Exception {
+
+	private $location;
+	private $reason;
+
+	/**
+	 * Constructor
+	 *
+	 * @param string     $location URL to forward to browser to. This can be a path
+	 *                             relative to the network's URL.
+	 * @param string     $reason   Short explanation for why we're forwarding. Set to '404' to forward
+	 *                             to error page. Default message is 'system'.
+	 * @param \Exception $previous The previous exception
+	 */
+	public function __construct($location = "", $reason = 'system', \Exception $previous = null) {
+		$this->location = $location;
+		$this->reason = $reason;
+
+		parent::__construct("The system has issued a forward() call.", 0, $previous);
+	}
+
+	/**
+	 * Get the URL requested
+	 *
+	 * @return string
+	 */
+	public function getLocation() {
+		return $this->location;
+	}
+
+	/**
+	 * Get the reason stated for the redirect
+	 *
+	 * @return string
+	 */
+	public function getReason() {
+		return $this->reason;
+	}
+
+	/**
+	 * Redirect the browser based on the data within this exception
+	 *
+	 * @return void
+	 * @throws \SecurityException
+	 */
+	public function performRedirect() {
+		_elgg_services()->forwarder->handleException($this);
+	}
+}

--- a/engine/classes/Elgg/Forwarder.php
+++ b/engine/classes/Elgg/Forwarder.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Elgg;
+
+/**
+ * Service for handling forward exceptions
+ *
+ * @access private
+ */
+class Forwarder {
+
+	/**
+	 * @var PluginHooksService
+	 */
+	private $hooks;
+
+	/**
+	 * @var string
+	 */
+	private $url;
+
+	/**
+	 * @var string|null
+	 */
+	private $referrer;
+
+	/**
+	 * Constructor
+	 *
+	 * @param PluginHooksService $hooks       Hooks service
+	 * @param string             $current_url The current URL
+	 * @param string|null        $referrer    The HTTP Referer header
+	 */
+	public function __construct(PluginHooksService $hooks, $current_url, $referrer = null) {
+		$this->hooks = $hooks;
+		$this->url = $current_url;
+		$this->referrer = $referrer;
+	}
+
+	/**
+	 * Handle the forward exception
+	 *
+	 * @param ForwardException $exception The exception
+	 * @return void
+	 * @throws \SecurityException
+	 */
+	public function handleException(ForwardException $exception) {
+		$location = $exception->getLocation();
+		$reason = $exception->getReason();
+
+		if (headers_sent($file, $line)) {
+			$msg = "Redirect could not be issued due to headers already being sent. Halting execution for security. "
+				. "Output started in file $file at line $line. Search http://learn.elgg.org/ for more information.";
+			throw new \SecurityException($msg, 0, $exception);
+		}
+
+		if ($location === REFERER) {
+			$location = $this->referrer;
+		}
+
+		$location = elgg_normalize_url($location);
+
+		// return new forward location or false to stop the forward or empty string to exit
+		$params = array('current_url' => $this->url, 'forward_url' => $location);
+		$location = $this->hooks->trigger('forward', $reason, $params, $location);
+
+		if ($location) {
+			header("Location: {$location}");
+		}
+		exit;
+	}
+}

--- a/engine/tests/phpunit/Elgg/ForwarderTest.php
+++ b/engine/tests/phpunit/Elgg/ForwarderTest.php
@@ -1,0 +1,17 @@
+<?php
+namespace Elgg;
+
+class ForwarderTest extends \PHPUnit_Framework_TestCase {
+
+	public function testForward() {
+		try {
+			forward();
+		} catch (ForwardException $e) {
+			$this->assertEquals('', $e->getLocation());
+			$this->assertEquals('system', $e->getReason());
+			return;
+		}
+
+		$this->fail('Did not throw ' . ForwardException::class);
+	}
+}


### PR DESCRIPTION
`forward()` now throws an exception, which Elgg catches and handles just as before. The exception allows tests or other Elgg internal components to intercept `forward()` calls.

Fixes #8338

BREAKING CHANGES:
Code placed in a try/catch block should not call `forward()` unless the catch #is particular about which exceptions to catch. Code that catches the general `\Exception $e`, e.g., will catch `Elgg\ForwardException` and have to re-throw it.
