### PR TITLE
feature(events): Adds new handler API available for events and hooks

### DIFF
--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -343,8 +343,8 @@ class Database {
 		$query_id = (int)$single . $query . '|';
 		if ($callback) {
 			if (!is_callable($callback)) {
-				$inspector = new \Elgg\Debug\Inspector();
-				throw new \RuntimeException('$callback must be a callable function. Given ' . $inspector->describeCallable($callback));
+				throw new \RuntimeException('$callback must be a callable function. Given '
+											. _elgg_services()->handlers->describeCallable($callback));
 			}
 			$query_id .= $this->fingerprintCallback($callback);
 		}

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -33,6 +33,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\Database\EntityTable               $entityTable
  * @property-read \Elgg\EventsService                      $events
  * @property-read \Elgg\Assets\ExternalFiles               $externalFiles
+ * @property-read \Elgg\HandlersService                    $handlers
  * @property-read \Elgg\PluginHooksService                 $hooks
  * @property-read \Elgg\Http\Input                         $input
  * @property-read \Elgg\Logger                             $logger
@@ -148,6 +149,8 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setFactory('externalFiles', function(ServiceProvider $c) {
 			return new \Elgg\Assets\ExternalFiles($c->config->getStorageObject());
 		});
+
+		$this->setClassName('handlers', \Elgg\HandlersService::class);
 
 		$this->setFactory('hooks', function(ServiceProvider $c) {
 			return $this->resolveLoggerDependencies('hooks');

--- a/engine/classes/Elgg/Event.php
+++ b/engine/classes/Elgg/Event.php
@@ -1,0 +1,38 @@
+<?php
+namespace Elgg;
+
+/**
+ * Models an event passed to event handlers
+ *
+ * @since 2.0.0
+ */
+interface Event {
+
+	/**
+	 * Get the name of the event
+	 *
+	 * @return string
+	 */
+	public function getName();
+
+	/**
+	 * Get the type of the event object
+	 *
+	 * @return string
+	 */
+	public function getType();
+
+	/**
+	 * Get the object of the event
+	 *
+	 * @return mixed
+	 */
+	public function getObject();
+
+	/**
+	 * Get the Elgg application
+	 *
+	 * @return \Elgg\Application
+	 */
+	public function elgg();
+}

--- a/engine/classes/Elgg/EventHandler.php
+++ b/engine/classes/Elgg/EventHandler.php
@@ -1,0 +1,19 @@
+<?php
+namespace Elgg;
+
+/**
+ * Defines an event handler
+ *
+ * @since 2.0.0
+ */
+interface EventHandler {
+
+	/**
+	 * Handle the event
+	 *
+	 * @param Event $event The event object
+	 *
+	 * @return bool if false, the handler is requesting to cancel the event
+	 */
+	public function __invoke(Event $event);
+}

--- a/engine/classes/Elgg/HandlersService.php
+++ b/engine/classes/Elgg/HandlersService.php
@@ -1,0 +1,69 @@
+<?php
+namespace Elgg;
+
+use Elgg\Di\DiContainer;
+
+/**
+ * Helpers for providing callable-based APIs
+ *
+ * @access private
+ */
+class HandlersService {
+
+	/**
+	 * Resolve a callable, possibly instantiating a class name
+	 *
+	 * @param callable|string $callable Callable or class name
+	 *
+	 * @return callable|null
+	 */
+	public function resolveCallable($callable) {
+		if (is_callable($callable)) {
+			return $callable;
+		}
+		if (is_string($callable)
+				&& preg_match(DiContainer::CLASS_NAME_PATTERN_53, $callable)
+				&& class_exists($callable)) {
+
+			// @todo Eventually a more advanced DIC could auto-inject dependencies
+			$callable = new $callable;
+		}
+		return is_callable($callable) ? $callable : null;
+	}
+
+	/**
+	 * Get a string description of a callback
+	 *
+	 * E.g. "function_name", "Static::method", "(ClassName)->method", "(Closure path/to/file.php:23)"
+	 *
+	 * @param mixed  $callable  The callable value to describe
+	 * @param string $file_root if provided, it will be removed from the beginning of file names
+	 * @return string
+	 */
+	public function describeCallable($callable, $file_root = '') {
+		if (is_string($callable)) {
+			return $callable;
+		}
+		if (is_array($callable) && array_keys($callable) === array(0, 1) && is_string($callable[1])) {
+			if (is_string($callable[0])) {
+				return "{$callable[0]}::{$callable[1]}";
+			}
+			return "(" . get_class($callable[0]) . ")->{$callable[1]}";
+		}
+		if ($callable instanceof \Closure) {
+			$ref = new \ReflectionFunction($callable);
+			$file = $ref->getFileName();
+			$line = $ref->getStartLine();
+
+			if ($file_root && 0 === strpos($file, $file_root)) {
+				$file = substr($file, strlen($file_root));
+			}
+
+			return "(Closure {$file}:{$line})";
+		}
+		if (is_object($callable)) {
+			return "(" . get_class($callable) . ")->__invoke()";
+		}
+		return print_r($callable, true);
+	}
+}

--- a/engine/classes/Elgg/Hook.php
+++ b/engine/classes/Elgg/Hook.php
@@ -1,0 +1,70 @@
+<?php
+namespace Elgg;
+
+/**
+ * Models an event passed to hook handlers
+ *
+ * @since 2.0.0
+ */
+interface Hook {
+
+	/**
+	 * Get the name of the hook
+	 *
+	 * @return string
+	 */
+	public function getName();
+
+	/**
+	 * Get the type of the hook
+	 *
+	 * @return string
+	 */
+	public function getType();
+
+	/**
+	 * Get the current value of the hook
+	 *
+	 * @return mixed
+	 */
+	public function getValue();
+
+	/**
+	 * Get the parameters passed to the trigger call
+	 *
+	 * @return mixed
+	 */
+	public function getParams();
+
+	/**
+	 * Get an element of the params array. If the params array is not an array,
+	 * the default will always be returned.
+	 *
+	 * @param string $key     The key of the value in the params array
+	 * @param mixed  $default The value to return if missing
+	 *
+	 * @return mixed
+	 */
+	public function getParam($key, $default = null);
+
+	/**
+	 * Gets the "entity" key from the params if it holds an Elgg entity
+	 *
+	 * @return \ElggEntity|null
+	 */
+	public function getEntity();
+
+	/**
+	 * Gets the "user" key from the params if it holds an Elgg user
+	 *
+	 * @return \ElggUser|null
+	 */
+	public function getUser();
+
+	/**
+	 * Get the Elgg application
+	 *
+	 * @return \Elgg\Application
+	 */
+	public function elgg();
+}

--- a/engine/classes/Elgg/HookHandler.php
+++ b/engine/classes/Elgg/HookHandler.php
@@ -1,0 +1,19 @@
+<?php
+namespace Elgg;
+
+/**
+ * Defines a plugin hook handler
+ *
+ * @since 2.0.0
+ */
+interface HookHandler {
+
+	/**
+	 * Handle the plugin hook
+	 *
+	 * @param Hook $hook The plugin hook object
+	 *
+	 * @return mixed if not null, this will become the new value of the hook
+	 */
+	public function __invoke(Hook $hook);
+}

--- a/engine/classes/Elgg/HooksRegistrationService/Event.php
+++ b/engine/classes/Elgg/HooksRegistrationService/Event.php
@@ -1,0 +1,63 @@
+<?php
+namespace Elgg\HooksRegistrationService;
+
+use Elgg\Application;
+
+/**
+ * The object passed to invokable class name handlers
+ *
+ * @access private
+ */
+class Event implements
+	\Elgg\Event,
+	\Elgg\ObjectEvent,
+	\Elgg\UserEvent {
+
+	private $elgg;
+	private $name;
+	private $type;
+	private $object;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Application $elgg   Elgg application
+	 * @param string      $name   Event name
+	 * @param string      $type   Event type
+	 * @param mixed       $object Object of the event
+	 */
+	public function __construct(Application $elgg, $name, $type, $object) {
+		$this->elgg = $elgg;
+		$this->name = $name;
+		$this->type = $type;
+		$this->object = $object;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getName() {
+		return $this->name;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getType() {
+		return $this->type;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getObject() {
+		return $this->object;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function elgg() {
+		return $this->elgg;
+	}
+}

--- a/engine/classes/Elgg/HooksRegistrationService/Hook.php
+++ b/engine/classes/Elgg/HooksRegistrationService/Hook.php
@@ -1,0 +1,111 @@
+<?php
+namespace Elgg\HooksRegistrationService;
+
+use Elgg\Application;
+
+/**
+ * The object passed to invokable class name handlers
+ *
+ * @access private
+ */
+class Hook implements \Elgg\Hook {
+
+	private $elgg;
+	private $name;
+	private $type;
+	private $value;
+	private $params;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Application $elgg   Elgg application
+	 * @param string      $name   Hook name
+	 * @param string      $type   Hook type
+	 * @param mixed       $value  Hook value
+	 * @param mixed       $params Hook params
+	 */
+	public function __construct(Application $elgg, $name, $type, $value, $params) {
+		$this->elgg = $elgg;
+		$this->name = $name;
+		$this->type = $type;
+		$this->value = $value;
+		$this->params = $params;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getName() {
+		return $this->name;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getType() {
+		return $this->type;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getValue() {
+		return $this->value;
+	}
+
+	/**
+	 * Update the value
+	 *
+	 * @param mixed $value The new value
+	 * @return void
+	 * @internal
+	 */
+	public function setValue($value) {
+		$this->value = $value;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getParams() {
+		return $this->params;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getParam($key, $default = null) {
+		if (!is_array($this->params)) {
+			return $default;
+		}
+		return array_key_exists($key, $this->params) ? $this->params[$key] : $default;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getEntity() {
+		if (isset($this->params['entity']) && $this->params['entity'] instanceof \ElggEntity) {
+			return $this->params['entity'];
+		}
+		return null;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getUser() {
+		if (isset($this->params['user']) && $this->params['user'] instanceof \ElggUser) {
+			return $this->params['user'];
+		}
+		return null;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function elgg() {
+		return $this->elgg;
+	}
+}

--- a/engine/classes/Elgg/ObjectEvent.php
+++ b/engine/classes/Elgg/ObjectEvent.php
@@ -1,0 +1,17 @@
+<?php
+namespace Elgg;
+
+/**
+ * Models an object event passed to event handlers
+ *
+ * @since 2.0.0
+ */
+interface ObjectEvent extends Event {
+
+	/**
+	 * Get the object of the event
+	 *
+	 * @return \ElggObject
+	 */
+	public function getObject();
+}

--- a/engine/classes/Elgg/UserEvent.php
+++ b/engine/classes/Elgg/UserEvent.php
@@ -1,0 +1,17 @@
+<?php
+namespace Elgg;
+
+/**
+ * Models a user event passed to event handlers
+ *
+ * @since 2.0.0
+ */
+interface UserEvent extends Event {
+
+	/**
+	 * Get the user subject of the event
+	 *
+	 * @return \ElggUser
+	 */
+	public function getObject();
+}

--- a/engine/tests/phpunit/Elgg/PluginHooksServiceTest.php
+++ b/engine/tests/phpunit/Elgg/PluginHooksServiceTest.php
@@ -1,11 +1,12 @@
 <?php
 namespace Elgg;
 
+use Elgg\HooksRegistrationService\Hook;
 
 class PluginHooksServiceTest extends \PHPUnit_Framework_TestCase {
-	
+
 	public function testTriggerCallsRegisteredHandlers() {
-		$hooks = new \Elgg\PluginHooksService();
+		$hooks = new PluginHooksService();
 		
 		$this->setExpectedException('InvalidArgumentException');
 		
@@ -15,7 +16,7 @@ class PluginHooksServiceTest extends \PHPUnit_Framework_TestCase {
 	}
 	
 	public function testCanPassParamsAndChangeReturnValue() {
-		$hooks = new \Elgg\PluginHooksService();
+		$hooks = new PluginHooksService();
 		$hooks->registerHandler('foo', 'bar', array('\Elgg\PluginHooksServiceTest', 'changeReturn'));
 		
 		$returnval = $hooks->trigger('foo', 'bar', array(
@@ -35,16 +36,41 @@ class PluginHooksServiceTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testUncallableHandlersAreLogged() {
-		$hooks = new \Elgg\PluginHooksService();
+		$hooks = new PluginHooksService();
 
 		$loggerMock = $this->getMock('\Elgg\Logger', array(), array(), '', false);
 		$hooks->setLogger($loggerMock);
 		$hooks->registerHandler('foo', 'bar', array(new \stdClass(), 'uncallableMethod'));
 
-		$expectedMsg = 'handler for plugin hook [foo, bar] is not callable: (stdClass)->uncallableMethod';
+		$expectedMsg = 'Handler for plugin hook [foo, bar] is not callable nor the name of a class that implements '
+			. HookHandler::class . ': (stdClass)->uncallableMethod';
 		$loggerMock->expects($this->once())->method('warn')->with($expectedMsg);
 
 		$hooks->trigger('foo', 'bar');
+	}
+
+	public function testInvokableClassNamesGetHookObject() {
+		$hooks = new PluginHooksService();
+
+		// assume separate instances will be created
+		// @todo should we keep instances around?
+		$hooks->registerHandler('foo', 'bar', TestHookHandler::class);
+		$hooks->registerHandler('foo', 'bar', TestHookHandler::class);
+
+		$this->assertEquals(2, $hooks->trigger('foo', 'bar', null, 0));
+		$this->assertCount(2, TestHookHandler::$invocations);
+		$this->assertCount(1, TestHookHandler::$invocations[0]["args"]);
+		$this->assertInstanceOf(Hook::class, TestHookHandler::$invocations[0]["args"][0]);
+		$this->assertNotSame(
+			TestHookHandler::$invocations[0]["this"],
+			TestHookHandler::$invocations[1]["this"]
+		);
+
+		TestHookHandler::$invocations = [];
+	}
+	
+	public static function returnTwo() {
+		return 2;
 	}
 
 	public static function changeReturn($foo, $bar, $returnval, $params) {
@@ -60,3 +86,15 @@ class PluginHooksServiceTest extends \PHPUnit_Framework_TestCase {
 	}
 }
 
+class TestHookHandler implements HookHandler {
+
+	public static $invocations = [];
+
+	function __invoke(\Elgg\Hook $hook) {
+		self::$invocations[] = [
+			'this' => $this,
+			'args' => func_get_args(),
+		];
+		return $hook->getValue() + 1;
+	}
+}


### PR DESCRIPTION
Classes that implement the new interfaces HookHandler and EventHandler can be used as handlers by registering the class name instead of a callable. These handlers are passed single Hook/Event objects instead of several arguments.

Usage looks like:

``` php
namespace MyBlog\Hooks;

class Url implements \Elgg\HookHandler {
    public function __invoke(\Elgg\Hook $hook) {
        $entity = $hook->getEntity(); // like $params['entity'] but type hinted
        // ...
    }
}

// in init
elgg_register_plugin_hook_handler('entity:url', 'object', MyPlugin\Hooks\Url::class);
```

...and as classes, each is lazy-loaded when needed.
