### PR TITLE
fix(events): All hook/event handlers are now weighted properly

### DIFF
--- a/docs/design/events.rst
+++ b/docs/design/events.rst
@@ -57,7 +57,7 @@ logged in during the [login, user] event?
 
 Before Events have names ending in ":before" and are triggered before
 something happens. Like traditional events, handlers can cancel the
-event by returning `false`.
+event by returning ``false``.
 
 After Events, with names ending in ":after", are triggered after
 something happens. Unlike traditional events, handlers *cannot* cancel
@@ -262,3 +262,13 @@ by giving the static version of the callback:
 
 Even though the event handler references a dynamic method call, the code above will successfully
 remove the handler.
+
+Handler Calling Order
+---------------------
+
+Handlers are called first in order of priority, then registration order.
+
+.. note::
+
+    Before Elgg 2.0, registering with the ``all`` keywords caused handlers to be called later, even
+    if they were registered with lower priorities.

--- a/docs/examples/hooks/all.php
+++ b/docs/examples/hooks/all.php
@@ -4,7 +4,7 @@
  * type.
  */
 
-elgg_register_plugin_hook_handler('all', 'system', 'example_plugin_hook_handler');
+elgg_register_plugin_hook_handler('all', 'system', 'example_plugin_hook_handler', 600);
 
 // This function will be called for any hook of type 'system'
 function example_plugin_hook_handler($hook, $type, $value, $params) {

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -156,6 +156,19 @@ Plugins should use the class ``Elgg\Application`` to boot Elgg. Typical usage:
     require_once dirname(dirname(__DIR__)) . '/autoloader.php';
     (new \Elgg\Application)->bootCore();
 
+Event/Hook calling order may change
+-----------------------------------
+
+When registering for events/hooks, the ``all`` keyword for wildcard matching no longer has any effect
+on the order that handlers are called. To ensure your handler is called last, you must give it the
+highest priority of all matching handlers, or to ensure your handler is called first, you must give
+it the lowest priority of all matching handlers.
+
+If handlers were registered with the same priority, these are called in the order they were registered.
+
+To emulate prior behavior, Elgg core handlers registered with the ``all`` keyword have been raised in
+priority. Some of these handlers will most likely be called in a different order.
+
 ``export/`` URLs are no longer available
 ----------------------------------------
 

--- a/engine/classes/Elgg/Debug/Inspector.php
+++ b/engine/classes/Elgg/Debug/Inspector.php
@@ -115,7 +115,6 @@ class Inspector {
 		// view handlers
 		$handlers = _elgg_services()->hooks->getAllHandlers();
 
-
 		$filtered_views = array();
 		if (!empty($handlers['view'])) {
 			$filtered_views = array_keys($handlers['view']);
@@ -359,12 +358,15 @@ class Inspector {
 		$root = elgg_get_root_path();
 
 		foreach ($all_handlers as $hook => $types) {
-			foreach ($types as $type => $handlers) {
-				array_walk($handlers, function (&$callable, $priority) use ($root) {
-					$description = $this->describeCallable($callable, $root);
-					$callable = "$priority: $description";
-				});
-				$tree[$hook . ',' . $type] = $handlers;
+			foreach ($types as $type => $priorities) {
+				foreach ($priorities as $priority => $handlers) {
+
+					array_walk($handlers, function (&$callable) use ($root, $priority) {
+						$description = $this->describeCallable($callable, $root);
+						$callable = "$priority: $description";
+					});
+					$tree[$hook . ',' . $type] = $handlers;
+				}
 			}
 		}
 

--- a/engine/lib/access.php
+++ b/engine/lib/access.php
@@ -606,8 +606,8 @@ return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hoo
 	$events->registerHandler('ready', 'system', 'access_init');
 
 	// For overrided permissions
-	$hooks->registerHandler('permissions_check', 'all', 'elgg_override_permissions');
-	$hooks->registerHandler('container_permissions_check', 'all', 'elgg_override_permissions');
+	$hooks->registerHandler('permissions_check', 'all', 'elgg_override_permissions', 600);
+	$hooks->registerHandler('container_permissions_check', 'all', 'elgg_override_permissions', 600);
 
 	$hooks->registerHandler('unit_test', 'system', 'access_test');
 };

--- a/engine/lib/actions.php
+++ b/engine/lib/actions.php
@@ -302,8 +302,8 @@ function actions_init() {
 
 	elgg_register_simplecache_view('js/languages/en');
 
-	elgg_register_plugin_hook_handler('action', 'all', 'ajax_action_hook');
-	elgg_register_plugin_hook_handler('forward', 'all', 'ajax_forward_hook');
+	elgg_register_plugin_hook_handler('action', 'all', 'ajax_action_hook', 600);
+	elgg_register_plugin_hook_handler('forward', 'all', 'ajax_forward_hook', 600);
 }
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -202,8 +202,8 @@ function _elgg_admin_init() {
 
 	// maintenance mode
 	if (elgg_get_config('elgg_maintenance_mode', null)) {
-		elgg_register_plugin_hook_handler('route', 'all', '_elgg_admin_maintenance_handler');
-		elgg_register_plugin_hook_handler('action', 'all', '_elgg_admin_maintenance_action_check');
+		elgg_register_plugin_hook_handler('route', 'all', '_elgg_admin_maintenance_handler', 600);
+		elgg_register_plugin_hook_handler('action', 'all', '_elgg_admin_maintenance_action_check', 600);
 		elgg_register_css('maintenance', elgg_get_simplecache_url('css', 'maintenance'));
 
 		elgg_register_menu_item('topbar', array(

--- a/engine/lib/autoloader.php
+++ b/engine/lib/autoloader.php
@@ -71,5 +71,5 @@ function elgg_register_class($class, $location) {
 }
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
-	$events->registerHandler('upgrade', 'all', '_elgg_delete_autoload_cache');
+	$events->registerHandler('upgrade', 'all', '_elgg_delete_autoload_cache', 600);
 };

--- a/engine/lib/comments.php
+++ b/engine/lib/comments.php
@@ -21,7 +21,7 @@ function _elgg_comments_init() {
 	elgg_register_plugin_hook_handler('permissions_check', 'object', '_elgg_comments_permissions_override');
 	elgg_register_plugin_hook_handler('email', 'system', '_elgg_comments_notification_email_subject');
 	
-	elgg_register_event_handler('update:after', 'all', '_elgg_comments_access_sync');
+	elgg_register_event_handler('update:after', 'all', '_elgg_comments_access_sync', 600);
 
 	elgg_register_page_handler('comment', '_elgg_comments_page_handler');
 

--- a/engine/lib/metadata.php
+++ b/engine/lib/metadata.php
@@ -406,7 +406,7 @@ function _elgg_metadata_test($hook, $type, $value, $params) {
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
 	/** Call a function whenever an entity is updated **/
-	$events->registerHandler('update', 'all', 'metadata_update');
+	$events->registerHandler('update', 'all', 'metadata_update', 600);
 
 	$hooks->registerHandler('unit_test', 'system', '_elgg_metadata_test');
 };

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -286,7 +286,7 @@ function _elgg_notifications_smtp_thread_headers($hook, $type, $returnvalue, $pa
  */
 function _elgg_notifications_init() {
 	elgg_register_plugin_hook_handler('cron', 'minute', '_elgg_notifications_cron', 100);
-	elgg_register_event_handler('all', 'all', '_elgg_enqueue_notification_event');
+	elgg_register_event_handler('all', 'all', '_elgg_enqueue_notification_event', 700);
 
 	// add email notifications
 	elgg_register_notification_method('email');

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -837,6 +837,6 @@ function _elgg_river_init() {
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
 	$events->registerHandler('init', 'system', '_elgg_river_init');
-	$events->registerHandler('disable:after', 'all', '_elgg_river_disable');
-	$events->registerHandler('enable:after', 'all', '_elgg_river_enable');
+	$events->registerHandler('disable:after', 'all', '_elgg_river_disable', 600);
+	$events->registerHandler('enable:after', 'all', '_elgg_river_enable', 600);
 };

--- a/engine/tests/ElggCoreAccessCollectionsTest.php
+++ b/engine/tests/ElggCoreAccessCollectionsTest.php
@@ -176,7 +176,7 @@ class ElggCoreAccessCollectionsTest extends \ElggCoreUnitTest {
 			return $value;
 		}
 
-		elgg_register_plugin_hook_handler('access:collections:write', 'all', 'test_acl_access_hook');
+		elgg_register_plugin_hook_handler('access:collections:write', 'all', 'test_acl_access_hook', 600);
 
 		// enable security since we usually run as admin
 		$ia = elgg_set_ignore_access(false);

--- a/engine/tests/ElggCoreRegressionBugsTest.php
+++ b/engine/tests/ElggCoreRegressionBugsTest.php
@@ -131,7 +131,7 @@ class ElggCoreRegressionBugsTest extends \ElggCoreUnitTest {
 			}
 		}
 
-		elgg_register_plugin_hook_handler('container_permissions_check', 'all', 'can_write_to_container_test_hook');
+		elgg_register_plugin_hook_handler('container_permissions_check', 'all', 'can_write_to_container_test_hook', 600);
 		$this->assertTrue(can_write_to_container($user->guid, $object->guid));
 		elgg_unregister_plugin_hook_handler('container_permissions_check', 'all', 'can_write_to_container_test_hook');
 

--- a/engine/tests/phpunit/Elgg/HooksRegistrationServiceTest.php
+++ b/engine/tests/phpunit/Elgg/HooksRegistrationServiceTest.php
@@ -21,17 +21,16 @@ class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($this->mock->registerHandler('foo', 'bar', $f));
 		$this->assertTrue($this->mock->registerHandler('foo', 'baz', 'callback3', 100));
 
-		$expected = array(
-			'foo' => array(
-				'bar' => array(
-					500 => 'callback1',
-					501 => $f,
-				),
-				'baz' => array(
-					100 => 'callback3'
-				)
-			)
-		);
+		$expected = [
+			'foo' => [
+				'bar' => [
+					500 => ['callback1', $f],
+				],
+				'baz' => [
+					100 => ['callback3'],
+				],
+			],
+		];
 
 		$this->assertSame($expected, $this->mock->getAllHandlers());
 
@@ -58,16 +57,16 @@ class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($this->mock->unregisterHandler(
 			'foo', 'bar', [$o, '__invoke']));
 
-		$expected = array(
-			'foo' => array(
-				'bar' => array(
-					// only one removed
-					150 => 'callback2',
+		$expected = [
+			'foo' => [
+				'bar' => [
+					500 => ['callback1'],
 
-					500 => 'callback1',
-				)
-			)
-		);
+					// only one removed
+					150 => ['callback2'],
+				]
+			]
+		];
 		$this->assertSame($expected, $this->mock->getAllHandlers());
 
 		// check unregistering things that aren't registered
@@ -80,22 +79,25 @@ class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue($this->mock->unregisterHandler('foo', 'bar', 'callback'));
 
-		$this->assertSame([501 => 'callback'], $this->mock->getAllHandlers()['foo']['bar']);
+		$this->assertSame([500 => ['callback']], $this->mock->getAllHandlers()['foo']['bar']);
 	}
 
 	public function testGetOrderedHandlers() {
 		$this->mock->registerHandler('foo', 'bar', 'callback1');
 		$this->mock->registerHandler('foo', 'bar', 'callback2');
+		$this->mock->registerHandler('all', 'all', 'callback4', 100);
 		$this->mock->registerHandler('foo', 'baz', 'callback3', 100);
 
-		$expected_foo_bar = array(
+		$expected_foo_bar = [
+			'callback4', // first even though it's [all, all]
 			'callback1',
-			'callback2'
-		);
+			'callback2',
+		];
 
-		$expected_foo_baz = array(
-			'callback3'
-		);
+		$expected_foo_baz = [
+			'callback4', // first even though it's [all, all]
+			'callback3',
+		];
 
 		$this->assertSame($expected_foo_bar, $this->mock->getOrderedHandlers('foo', 'bar'));
 		$this->assertSame($expected_foo_baz, $this->mock->getOrderedHandlers('foo', 'baz'));

--- a/mod/developers/classes/ElggInspector.php
+++ b/mod/developers/classes/ElggInspector.php
@@ -27,8 +27,10 @@ class ElggInspector {
 		$tree = array();
 		$events = _elgg_services()->events->getAllHandlers();
 		foreach ($events as $event => $types) {
-			foreach ($types as $type => $handlers) {
-				$tree[$event . ',' . $type] = array_values($handlers);
+			foreach ($types as $type => $priorities) {
+				foreach ($priorities as $priority => $handlers) {
+					$tree[$event . ',' . $type] = array_values($handlers);
+				}
 			}
 		}
 
@@ -46,8 +48,10 @@ class ElggInspector {
 		$tree = array();
 		$hooks = _elgg_services()->hooks->getAllHandlers();
 		foreach ($hooks as $hook => $types) {
-			foreach ($types as $type => $handlers) {
-				$tree[$hook . ',' . $type] = array_values($handlers);
+			foreach ($types as $type => $priorities) {
+				foreach ($priorities as $priority => $handlers) {
+					$tree[$hook . ',' . $type] = array_values($handlers);
+				}
 			}
 		}
 

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -58,7 +58,7 @@ function developers_process_settings() {
 	}
 
 	if (!empty($settings['wrap_views'])) {
-		elgg_register_plugin_hook_handler('view', 'all', 'developers_wrap_views');
+		elgg_register_plugin_hook_handler('view', 'all', 'developers_wrap_views', 600);
 	}
 
 	if (!empty($settings['log_events'])) {

--- a/mod/developers/views/default/theme_sandbox/modules/widgets.php
+++ b/mod/developers/views/default/theme_sandbox/modules/widgets.php
@@ -7,7 +7,7 @@ $url = current_page_url();
 
 elgg_register_plugin_hook_handler('view', 'widgets/friends/content', 'css_widget_content');
 elgg_register_plugin_hook_handler('view', 'widgets/friends/edit', 'css_widget_content');
-elgg_register_plugin_hook_handler('permissions_check', 'all', 'css_permissions_override');
+elgg_register_plugin_hook_handler('permissions_check', 'all', 'css_permissions_override', 600);
 
 function css_widget_content() {
 	return $ipsum = elgg_view('developers/ipsum');

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -81,7 +81,7 @@ function groups_init() {
 	elgg_extend_view('js/elgg', 'groups/js');
 
 	// Access permissions
-	elgg_register_plugin_hook_handler('access:collections:write', 'all', 'groups_write_acl_plugin_hook');
+	elgg_register_plugin_hook_handler('access:collections:write', 'all', 'groups_write_acl_plugin_hook', 600);
 	elgg_register_plugin_hook_handler('default', 'access', 'groups_access_default_override');
 
 	// Register profile menu hook


### PR DESCRIPTION
`getOrderedHandlers()` now orders handlers first by the priority and then by the registration order. This also bumps the priority of “all” handlers in attempt to emulate the calling order before this change.

Fixes #1378

BREAKING CHANGE:
To ensure your handler is called last, you must give it the highest priority of all matching handlers. To ensure your handler is called first, you must give it the lowest priority of all matching handlers. Registering with the keyword “all” no longer has any effect on calling order.
- [x] consider raising priority of core stuff registered with `all` to compensate
