### PR TITLE
fix(users): admins are again able to reset user's password

### DIFF
--- a/engine/classes/Elgg/PasswordService.php
+++ b/engine/classes/Elgg/PasswordService.php
@@ -112,7 +112,7 @@ final class PasswordService {
 	 */
 	function forcePasswordReset($user, $password) {
 		if (!$user instanceof \ElggUser) {
-			$user = _elgg_services()->usersTable->get($user);
+			$user = _elgg_services()->entityTable->get($user, 'user');
 			if (!$user) {
 				return false;
 			}


### PR DESCRIPTION
The PasswordService was trying to get the user using UsersTable::get($guid) which has been removed in favor of EntityTable::get($guid, 'user').

Refs #7665
