### PR TITLE
feature(settings): Site URL can be set in settings file

### DIFF
--- a/docs/design/database.rst
+++ b/docs/design/database.rst
@@ -137,6 +137,11 @@ Beyond the standard ElggEntity properties, ElggSites also support:
 -  ``description`` A description of the site
 -  ``url`` The address of the site
 
+.. note::
+
+    The site URL can be overridden via the settings file. To reliably obtain the URL stored in
+    the DB (which may not be the active site URL!), use ``ElggSite::getStoredURL()``.
+
 ElggGroup
 =========
 

--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -216,6 +216,9 @@ class Config implements Services\Config {
 		if (isset($CONFIG->dataroot)) {
 			$CONFIG->dataroot = rtrim($CONFIG->dataroot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 		}
+		if (isset($CONFIG->wwwroot)) {
+			$CONFIG->wwwroot = rtrim($CONFIG->wwwroot, '/') . '/';
+		}
 
 		if (!$global_is_bound) {
 			// must manually copy settings into our storage

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -28,6 +28,11 @@
 class ElggSite extends \ElggEntity {
 
 	/**
+	 * @var string|null URL from settings file
+	 */
+	private $settings_url;
+
+	/**
 	 * Initialize the attributes array.
 	 * This is vital to distinguish between metadata and base attributes.
 	 *
@@ -222,14 +227,52 @@ class ElggSite extends \ElggEntity {
 
 		return parent::disable($reason, $recursive);
 	}
+
+	/**
+	 * Get a property
+	 *
+	 * @param string $name Property name
+	 *
+	 * @return mixed
+	 */
+	public function __get($name) {
+		if ($name === 'url' && $this->settings_url) {
+			return $this->settings_url;
+		}
+		return parent::__get($name);
+	}
 	
 	/**
 	 * Returns the URL for this site
 	 *
+	 * @note This value might come from the settings file. Use getStoredURL() for the URL in the DB.
+	 *
 	 * @return string The URL
+	 * @see getStoredURL
 	 */
 	public function getURL() {
 		return $this->url;
+	}
+
+	/**
+	 * Returns the URL for this entity from the DB, even if another URL has been set via settings
+	 *
+	 * @return string The URL
+	 * @since 2.0.0
+	 */
+	public function getStoredURL() {
+		return $this->attributes['url'];
+	}
+
+	/**
+	 * Force the entity to return the given URL for ->url and ->getURL()
+	 *
+	 * @param string $url Site URL from settings
+	 * @access private
+	 * @internal do no use
+	 */
+	public function overrideUrl($url) {
+		$this->settings_url = $url;
 	}
 
 	/**

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -252,16 +252,26 @@ function _elgg_load_site_config() {
 
 	$CONFIG->site_guid = (int) datalist_get('default_site');
 	$CONFIG->site_id = $CONFIG->site_guid;
-	$CONFIG->site = _elgg_services()->entityTable->get($CONFIG->site_guid, 'site');
-	if (!$CONFIG->site) {
+
+	$site = _elgg_services()->entityTable->get($CONFIG->site_guid, 'site');
+	/* @var ElggSite $site */
+	$CONFIG->site = $site;
+	if (!$site) {
 		throw new \InstallationException("Unable to handle this request. This site is not configured or the database is down.");
 	}
 
-	$CONFIG->wwwroot = $CONFIG->site->url;
-	$CONFIG->sitename = $CONFIG->site->name;
-	$CONFIG->sitedescription = $CONFIG->site->description;
-	$CONFIG->siteemail = $CONFIG->site->email;
+	// allow sites to set from config file
+	if (empty($CONFIG->wwwroot)) {
+		$CONFIG->wwwroot = $CONFIG->site->url;
+	} else {
+		$site->overrideUrl($CONFIG->wwwroot);
+		$CONFIG->wwwroot_in_settings = true;
+	}
 	$CONFIG->url = $CONFIG->wwwroot;
+
+	$CONFIG->sitename = $site->name;
+	$CONFIG->sitedescription = $site->description;
+	$CONFIG->siteemail = $site->email;
 
 	_elgg_services()->configTable->loadAll();
 

--- a/engine/settings.example.php
+++ b/engine/settings.example.php
@@ -161,6 +161,14 @@ $CONFIG->dbprefix = '{{dbprefix}}';
 //$CONFIG->cookies['remember_me']['secure'] = false;
 //$CONFIG->cookies['remember_me']['httponly'] = false;
 
+/**
+ * Site URL (optional)
+ *
+ * If you wish to override the URL stored in the site entity, you may set this. All 1.x APIs
+ * that return site URL will return this value. The value actually in the DB is accessible via
+ * elgg_get_site_entity()->getStoredURL(). Most sites will not need to set this.
+ */
+//$CONFIG->wwwroot = "https://example.org/elgg/";
 
 /**
  * Use non-standard headers for broken MTAs.

--- a/engine/tests/ElggSiteTest.php
+++ b/engine/tests/ElggSiteTest.php
@@ -75,6 +75,14 @@ class ElggCoreSiteTest extends \ElggCoreUnitTest {
 		$this->site->url = 'http://example.com/';
 		$this->assertIdentical($this->site->getURL(), 'http://example.com/');
 	}
+
+	public function testElggSiteOverrideUrl() {
+		$this->site->url = 'http://example.com/';
+		$this->site->overrideUrl('http://override.org/');
+
+		$this->assertIdentical($this->site->getURL(), 'http://override.org/');
+		$this->assertIdentical($this->site->getStoredURL(), 'http://example.com/');
+	}
 }
 
 class ElggSiteTest extends \ElggSite {

--- a/views/default/forms/admin/site/advanced/system.php
+++ b/views/default/forms/admin/site/advanced/system.php
@@ -11,17 +11,23 @@
 
 		$params = [
 			'name' => $field,
-			'value' => elgg_get_config($field)
 		];
-		if ($field == 'dataroot' && elgg_get_config('dataroot_in_settings')) {
+		if ($field === 'wwwroot') {
+			$params['value'] = elgg_get_site_entity()->getStoredURL();
+		} else {
+			$params['value'] = elgg_get_config($field);
+		}
+
+		if (in_array($field, ['dataroot', 'wwwroot']) && elgg_get_config("{$field}_in_settings")) {
 			$params['readonly'] = true;
 			$params['class'] = 'elgg-state-disabled';
 			$warning = elgg_echo('admin:settings:in_settings_file');
 		}
 
-		$input = elgg_view("input/text", $params);
 		if ($warning) {
 			$input = "<span class=\"elgg-text-help\">$warning</span>";
+		} else {
+			$input = elgg_view("input/text", $params);
 		}
 		
 		?>


### PR DESCRIPTION
The bootstrap allows the active ElggSite to return the settings URL, and so this provides a new getStoredURL() method to reliably get the value in the database.

Fixes #8426
- [ ] one more :+1: 
