### PR TITLE
chore(upgrade): Pages remind people doing upgrades to update web server config

### DIFF
--- a/engine/handlers/cache_handler.php
+++ b/engine/handlers/cache_handler.php
@@ -1,0 +1,15 @@
+<?php
+// if 500 is returned, output will not be shown to the user.
+header('Content-Type: application/javascript');
+header('Cache-Control: no-cache, must-revalidate');
+?>
+//<script>
+!function(){
+	if (!window.__cache_handler) {
+		window.__cache_handler = 1;
+		var msg = 'Update your web server configuration (e.g. .htaccess). See docs/admin/upgrading';
+		console.log(msg);
+		var html = '<h3 style="color:red">' + msg + '</h3>';
+		document.querySelector('body').insertAdjacentHTML('afterbegin', html);
+	}
+}();


### PR DESCRIPTION
When upgrading (or switching between branches) you may forget to remove the URL rewrites from your server config. This displays a bright red reminder at the top of the page.
