### PR TITLE
Fixing regex so that invite codes validate

### DIFF
--- a/engine/classes/Elgg/Database/UsersTable.php
+++ b/engine/classes/Elgg/Database/UsersTable.php
@@ -460,7 +460,7 @@ class UsersTable {
 	 */
 	function validateInviteCode($username, $code) {
 		// validate the format of the token created by ->generateInviteCode()
-		if (!preg_match('~^(\d+)\.(\w+)$~', $code, $m)) {
+		if (!preg_match('~^(\d+)\.([\w-]+)$~', $code, $m)) {
 			return false;
 		}
 		$time = $m[1];

--- a/engine/classes/Elgg/Database/UsersTable.php
+++ b/engine/classes/Elgg/Database/UsersTable.php
@@ -460,7 +460,7 @@ class UsersTable {
 	 */
 	function validateInviteCode($username, $code) {
 		// validate the format of the token created by ->generateInviteCode()
-		if (!preg_match('~^(\d+)\.([\w-]+)$~', $code, $m)) {
+		if (!preg_match('~^(\d+)\.([a-zA-Z0-9\-_]+)$~', $code, $m)) {
 			return false;
 		}
 		$time = $m[1];


### PR DESCRIPTION
Invite codes (sometimes) contain hyphens, which are not matched during validation, meaning result is always false.
