### PR TITLE
fix(db): Will now validate invite codes that contain "-" characters.

### DIFF
--- a/engine/classes/Elgg/Database/UsersTable.php
+++ b/engine/classes/Elgg/Database/UsersTable.php
@@ -460,7 +460,7 @@ class UsersTable {
 	 */
 	function validateInviteCode($username, $code) {
 		// validate the format of the token created by ->generateInviteCode()
-		if (!preg_match('~^(\d+)\.(\w+)$~', $code, $m)) {
+		if (!preg_match('~^(\d+)\.([a-zA-Z0-9\-_]+)$~', $code, $m)) {
 			return false;
 		}
 		$time = $m[1];


### PR DESCRIPTION
Invite codes are sometimes generated that contain "-" characters, these could not be validated by the original regex despite being correct.
