### PR TITLE
feature(hooks): Adds elgg_filter as shorthand for triggering a hook

### DIFF
--- a/docs/design/events.rst
+++ b/docs/design/events.rst
@@ -236,6 +236,22 @@ Parameters:
 
 .. warning:: The `$params` and `$value` arguments are reversed between the plugin hook handlers and trigger functions!
 
+Filtering values via hook
+-------------------------
+
+Elgg provides ``elgg_filter`` as a shorthand for triggering the hook ``filter``, and this gives plugins a concise
+way to allow other plugins to modify values via a hook handler.
+
+.. code-block:: php
+
+    // allow plugins to filter this value
+    $value = elgg_filter('myPlugin:value', $value);
+
+This is equivalent to:
+
+.. code-block:: php
+
+    $value = elgg_trigger_plugin_hook('filter', 'myPlugin:value', null, $value);
 
 Unregister Event/Hook Handlers
 ------------------------------

--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -459,6 +459,9 @@ Other
 **config, amd**
 	Filter the AMD config for the requirejs library.
 
+**filter, <type>**
+    Filter a value. This is triggered via ``elgg_filter()``.
+
 Plugins
 =======
 

--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -302,7 +302,22 @@ Emit a hook event in the event system.
 .. code:: js
 
     // allow other plugins to alter value
-    value = elgg.trigger_hook('my_plugin:filter', 'value', {}, value);
+    value = elgg.trigger_hook('filter', 'my_plugin:value', {}, value);
+
+
+``elgg.filter()``
+
+Pass a value through the "filter" hook.
+
+.. code:: js
+
+    // allow other plugins to alter value
+    value = elgg.filter('my_plugin:value', value);
+
+    // define a class method that plugins can alter
+    Foo.prototype.init = elgg.filter('Foo::init', function () {
+        // do stuff with this
+    });
 
 
 ``elgg.security.refreshToken()``

--- a/engine/classes/Elgg/PluginHooksService.php
+++ b/engine/classes/Elgg/PluginHooksService.php
@@ -43,4 +43,19 @@ class PluginHooksService extends \Elgg\HooksRegistrationService {
 	
 		return $returnvalue;
 	}
+
+	/**
+	 * Filter a value by passing it through the 'filter' plugin hook
+	 *
+	 * @param string $type   Hook type
+	 * @param mixed  $value  Value filtered
+	 * @param mixed  $params Hook params
+	 *
+	 * @return mixed
+	 * @see elgg_filter
+	 * @since 1.12
+	 */
+	public function filter($type, $value, $params = null) {
+		return $this->trigger('filter', $type, $params, $value);
+	}
 }

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -778,6 +778,20 @@ function elgg_trigger_plugin_hook($hook, $type, $params = null, $returnvalue = n
 }
 
 /**
+ * Filter a value by passing it through the 'filter' plugin hook.
+ *
+ * @param string $type   Hook type
+ * @param mixed  $value  Value filtered
+ * @param mixed  $params Hook params
+ *
+ * @return mixed
+ * @since 1.12
+ */
+function elgg_filter($type, $value, $params = null) {
+	return _elgg_services()->hooks->filter($type, $value, $params);
+}
+
+/**
  * Intercepts, logs, and displays uncaught exceptions.
  *
  * To use a viewtype other than failsafe, create the views:

--- a/js/lib/hooks.js
+++ b/js/lib/hooks.js
@@ -122,6 +122,21 @@ elgg.trigger_hook = function(name, type, params, value) {
 };
 
 /**
+ * Filter a value by passing it through the 'filter' plugin hook.
+ *
+ * @param {String} type   Hook type
+ * @param {*}      value  Value filtered
+ * @param {Object} params Hook params
+ *
+ * @return {*}
+ * @since 1.12
+ */
+elgg.filter = function(type, value, params) {
+	elgg.assertTypeOf('string', type);
+	return elgg.trigger_hook('filter', type, params, value);
+};
+
+/**
  * Registers a hook as an instant hook.
  *
  * After being trigger once, registration of a handler to an instant hook will cause the

--- a/js/tests/ElggHooksTest.js
+++ b/js/tests/ElggHooksTest.js
@@ -47,5 +47,20 @@ define(function(require) {
 				expect(function() { elgg.register_hook_handler('str', 'str', 'oops'); }).toThrow();
 			});
 		});
+
+		describe("elgg.filter()", function() {
+			it("is a simple wrapper for the 'filter' hook", function() {
+				elgg.register_hook_handler("filter", "greet", function (name, type, params, returnValue) {
+					var ret = "Hello " + returnValue + ".";
+					if (params && params.place) {
+						ret += " Welcome to " + params.place + ".";
+					}
+					return ret;
+				});
+
+				expect(elgg.filter("greet", "aliens")).toBe("Hello aliens.");
+				expect(elgg.filter("greet", "aliens", {place:"Earth"})).toBe("Hello aliens. Welcome to Earth.");
+			});
+		});
 	});
 });


### PR DESCRIPTION
elgg_filter() and elgg.filter() are simple shortcuts for passing a value through the ‘filter’ plugin hook.

Fixes #8433
