### PR TITLE
chore(css): Remove support for long-deprecated 'css' view

### DIFF
--- a/views/default/css/elgg.php
+++ b/views/default/css/elgg.php
@@ -13,14 +13,6 @@
  *  #e4ecf5 - elgg very light blue
  */
 
-// check if there is a theme overriding the old css view and use it, if it exists
-$old_css_view = elgg_get_view_location('css');
-if ($old_css_view != elgg_get_config('viewpath')) {
-	echo elgg_view('css', $vars);
-	return true;
-}
-
-
 /*******************************************************************************
 
 Base CSS
@@ -63,7 +55,3 @@ echo elgg_view('css/elements/misc/spinner.css', $vars);
 
 // included last to have higher priority
 echo elgg_view('css/elements/helpers', $vars);
-
-
-// in case plugins are still extending the old 'css' view, display it
-echo elgg_view('css', $vars);


### PR DESCRIPTION
BREAKING CHANGE:
If your theme or plugin was overriding or extending the 'css' view,
you should override/extend the 'css/elgg' view instead.
