### PR TITLE
feature(memcache): support Memcache namespace prefix

### DIFF
--- a/docs/admin/performance.rst
+++ b/docs/admin/performance.rst
@@ -142,12 +142,12 @@ Memcache is a generic caching technology developed by Brad Fitzpatrick for LiveJ
 
 Installation requirements:
 
-| ``   * php5-memcache``
-| ``   * memcached``
+- php5-memcache
+- memcached
 
 Configuration:
 
-Uncomment and populate the following sections in settings.php
+Uncomment and populate the following sections in `settings.php`
 
 .. code:: php
 
@@ -157,6 +157,13 @@ Uncomment and populate the following sections in settings.php
         array('server1', 11211),
         array('server2', 11211)
     );
+
+Optionaly if you run multiple Elgg installations but use ony one Memcache server, you may want 
+to add a namespace prefix. In order to do this, uncomment the following line
+
+.. code:: php
+
+	$CONFIG->memcache_namespace_prefix = '';
 
 Squid
 -----

--- a/engine/classes/ElggMemcache.php
+++ b/engine/classes/ElggMemcache.php
@@ -8,7 +8,7 @@
 class ElggMemcache extends \ElggSharedMemoryCache {
 	/**
 	 * Global Elgg configuration
-	 * 
+	 *
 	 * @var \stdClass
 	 */
 	private $CONFIG;
@@ -220,5 +220,23 @@ class ElggMemcache extends \ElggSharedMemoryCache {
 		return $result;
 
 		// @todo Namespaces as in #532
+	}
+	
+	/**
+	 * Set the namespace of this cache.
+	 *
+	 * This will also add the Memcache namespace prefix as defined in settings.php
+	 *
+	 * @param string $namespace Namespace for cache
+	 *
+	 * @return void
+	 */
+	public function setNamespace($namespace = "default") {
+		
+		if (isset($this->CONFIG->memcache_namespace_prefix)) {
+			$namespace = $this->CONFIG->memcache_namespace_prefix . $namespace;
+		}
+		
+		parent::setNamespace($namespace);
 	}
 }

--- a/engine/settings.example.php
+++ b/engine/settings.example.php
@@ -102,6 +102,9 @@ $CONFIG->dbprefix = '{{dbprefix}}';
  * 	1) One or more memcache servers (http://www.danga.com/memcached/)
  *  2) PHP memcache wrapper (http://php.net/manual/en/memcache.setup.php)
  *
+ * You can set a namespace prefix if you run multiple Elgg instances
+ * on the same Memcache server.
+ *
  * Note: Multiple server support is only available on server 1.2.1
  * or higher with PECL library > 2.0.0
  */
@@ -112,6 +115,8 @@ $CONFIG->dbprefix = '{{dbprefix}}';
 //	array('server2', 11211)
 //);
 
+// namespace prefix
+// $CONFIG->memcache_namespace_prefix = '';
 
 /**
  * Better caching performance
@@ -129,17 +134,17 @@ $CONFIG->dbprefix = '{{dbprefix}}';
 /**
  * Cookie configuration
  *
- * Elgg uses 2 cookies: a PHP session cookie and an extended login cookie 
+ * Elgg uses 2 cookies: a PHP session cookie and an extended login cookie
  * (also called the remember me cookie). See the PHP manual for documentation on
  * each of these parameters. Possible options:
- * 
+ *
  *  - Set the session name to share the session across applications.
  *  - Set the path because Elgg is not installed in the root of the web directory.
  *  - Set the secure option to true if you only serve the site over HTTPS.
  *  - Set the expire option on the remember me cookie to change its lifetime
  *
  * To use, uncomment the appropriate sections below and update for your site.
- * 
+ *
  * @global array $CONFIG->cookies
  */
 // get the default parameters from php.ini
@@ -196,16 +201,16 @@ $CONFIG->min_password_length = 6;
 /**
  * This is an optional script used to override Elgg's default handling of
  * uncaught exceptions.
- * 
+ *
  * This should be an absolute file path to a php script that will be called
  * any time an uncaught exception is thrown.
- * 
+ *
  * The script will have access to the following variables as part of the scope
  * global $CONFIG
  * $exception - the unhandled exception
- * 
+ *
  * @warning - the database may not be available
- * 
+ *
  * @global string $CONFIG->exception_include
  */
 $CONFIG->exception_include = '';


### PR DESCRIPTION
If you have multiple Elgg installations but only use one Memcache server
you'll have to separate the Memcache namespaces in order to prevent data
overlapping/corruption.

fixes #2834
