### PR TITLE
chore(views): Adds elgg_view_resource() for rendering full-page views

### DIFF
--- a/docs/guides/guidelines.rst
+++ b/docs/guides/guidelines.rst
@@ -37,10 +37,10 @@ Use standardized routing with page handlers
    +---------------+-----------------------------------+
    | Group list    | page_handler/group/<guid>/owner   |
    +---------------+-----------------------------------+
-- Include page handler scripts from the page handler. Almost every page handler should have a page handler script. (Example: ``bookmarks/all`` => ``mod/bookmarks/pages/bookmarks/all.php``)
+- Include page handler scripts from the page handler. Almost every page handler should have a page handler script. (Example: ``bookmarks/all`` => ``mod/bookmarks/views/default/resources/bookmarks/all.php``)
 - Call ``set_input()`` for entity guids in the page handler and use ``get_input()`` in the page handler scripts.
 - Call ``elgg_gatekeeper()`` and ``elgg_admin_gatekeeper()`` in the page handler function if required.
-- The group URL should use the ``pages/<handler>/owner.php`` script.
+- The group URL should use views like ``resources/groups/*.php`` to render pages.
 - Page handlers should not contain HTML.
 - If upgrading a 1.7 plugin, update the URLs throughout the plugin. (Don’t forget to remove ``/pg/``!)
 
@@ -48,7 +48,8 @@ Use standardized page handlers and scripts
 ------------------------------------------
 
 - Example: Bookmarks plugin
-- Store page handler scripts in ``mod/<plugin>/pages/<page_handler>/<page_name>``
+- Store page functionality in ``mod/<plugin>/views/default/resources/<page_handler>/<page_name>.php``
+- Use ``elgg_view_resource('<page_handler>/<page_name>')`` to render that.
 - Use the content page layout in page handler scripts: ``$content = elgg_view_layout('content', $options);``
 - Page handler scripts should not contain HTML
 - Call ``elgg_push_breadcrumb()`` in the page handler scripts.

--- a/docs/guides/pagehandler.rst
+++ b/docs/guides/pagehandler.rst
@@ -15,12 +15,13 @@ The plugin's page handler is passed two parameters:
 Code flow
 ---------
 
-Pages in plugins should be served only through page handlers, stored in ``pages/`` of your plugin's directory and do not need to use ``Elgg\Application``. The purpose of these files are to knit together output from different views to form the page that the user sees. The program flow is something like this:
+Pages in plugins should be rendered via page handlers (not by using ``Elgg\Application``). Generally the rendering is done by views with names starting with ``resources/``. The program flow is something like this:
 
 1. A user requests ``/plugin_name/section/entity``
 2. Elgg checks if ``plugin_name`` is registered to a page handler and calls that function, passing ``array('section', 'entity')`` as the first argument
-3. The page handler function determines which page to display, optionally sets some values, and then includes the correct page under ``plugin_name/pages/plugin_name/``
-4. The included file combines many separate views, calls formatting functions like ``elgg_view_layout()`` and ``elgg_view_page()``, and then echos the final output
-5. The user sees a fully rendered page
+3. The page handler function determines which page to display, optionally setting some values using ``set_input()``
+4. The handler uses ``elgg_view_resource()`` to render the page.
+5. The resource view combines many separate views, calls formatting functions like ``elgg_view_layout()`` and ``elgg_view_page()``, and then echos the final output
+6. The user sees a fully rendered page
 
 There is no syntax enforced on the URLs, but Elgg's coding standards suggests a certain format.

--- a/docs/guides/plugins/plugin-skeleton.rst
+++ b/docs/guides/plugins/plugin-skeleton.rst
@@ -1,7 +1,7 @@
 Plugin skeleton
 ===============
 
-The following is the standard for plugin structure in Elgg as of Elgg 1.8. Plugins written for Elgg 1.7 and down are strongly encouraged to use this structure as well, though some of the benefits are not as apparent as when used in 1.8.
+The following is the standard for plugin structure in Elgg as of Elgg 2.0.
 
 Example Structure
 -----------------
@@ -15,35 +15,27 @@ The following files for plugin ``example`` would go in ``/mod/example/``
     actions/
         example/
             action.php
-        other_action.php
+            other_action.php
     classes/
-        ExampleClass.php
-    graphics/
-        example.png
-    js/
-        example.js
+        VendorNamespace/
+            ExampleClass.php
     languages/
         en.php
-    lib/
-        example.php
-    pages/
-        example/
-            all.php
-            owner.php
     vendors/
         example_3rd_party_lib/
     views/
         default/
-            example/
-                css.php
+            example.png
+            css/
+                example.css
             forms/
                 example/
                     action.php
                     other_action.php
             js/
-                example.php
+                example.js
             object/
-                 example.php
+                example.php
                 example/
                     context1.php
                     context2.php
@@ -51,6 +43,10 @@ The following files for plugin ``example`` would go in ``/mod/example/``
                 example/
                     settings.php
                     usersettings.php
+            resources/
+                example/
+                    all.php
+                    owner.php
             widgets/
                 example_widget/
                     content.php
@@ -88,7 +84,7 @@ For example, the action ``my/example/action`` would go in ``my_plugin/actions/my
 Similarly, the body of the form that submits to this action should be located in ``forms/my/example/action.php``. Not only does this make the connection b/w action handler, form code, and action name obvious, but it allows you to use the new (as of Elgg 1.8) ``elgg_view_form()`` function easily.
 
 Text Files
------------
+----------
 
 Plugins *may* provide various \*.txt as additional documentation for the plugin. These files **must** be in Markdown syntax and will generate links on the plugin management sections.
 
@@ -112,27 +108,22 @@ Plugins *may* include additional \*.txt files besides these, but no interface is
 Pages
 -----
 
-Plugins *should* put page-generating scripts in a ``pages/`` directory inside their plugin root. Furthermore, plugins *should* put page-generating scripts under a directory named for their handler. For example, the script for page ``yoursite.com/my_handler/view/1234`` *should* be located at ``mod/my_plugin/pages/my_handler/view.php``.
+To render full pages, plugins should use **resource views** (which have names beginning with ``resources/``). This allows other plugins
+to easily replace functionality via the view system.
 
-In the past, these scripts were included directly in the plugin root. Plugins *should not* do this anymore, and if any core plugins are found to do this, that is a bug if not present solely for the sake of backwards compatibility.
-
-.. note:: 
+.. note::
 
     The reason we encourage this structure is
     
     - To form a logical relationship between urls and scripts, so that people examining the code can have an idea of what it does just by examining the structure.
     - To clean up the root plugin directory, which historically has quickly gotten cluttered with the page handling scripts.
-    
 
 Classes
 -------
 
-All classes that your plugin defines *should* be included in a ``classes/`` directory. This directory has special meaning to Elgg. Classes placed in this directory are autoloaded on demand, and do not need to be included explicitly.
+Elgg provides `PSR-0 <http://www.php-fig.org/psr/psr-0/>`_ autoloading out of every active plugin's ``classes/`` directory.
 
-.. warning::
-
-    Each file **must** have exactly one class defined inside it.
-    The file name **must** match the name of the one class that the file defines (except for the ".php" suffix). 
+You're encouraged to follow the `PHP-FIG <http://www.php-fig.org/>`_ standards when writing your classes.
 
 .. note::
  
@@ -143,20 +134,12 @@ Vendors
 
 Included third-party libraries of any kind *should* be included in the ``vendors/`` folder in the plugin root. Though this folder has no special significance to the Elgg engine, this has historically been the location where Elgg core stores its third-party libraries, so we encourage the same format for the sake of consistency and familiarity.
 
-Lib
----
-
-Procedural code defined by your plugin *should* be placed in the `lib/` directory. Though this folder has no special significance to the Elgg engine, this has historically been the location where Elgg core stores its procedural code, so we encourage the same format for the sake of consistency and familiarity.
-
 Views
 -----
 
 In order to override core views, a plugin's views **must** be placed in a ``views/``. This directory has special meaning to Elgg as views defined here automatically override Elgg core's version of those views. For more info, see :doc:`/guides/views`.
 
-Javascript
-----------
-
-Javascript that will be included on every page *should* be put in the ``plugin/js`` view and your plugin *should* extend ``js/elgg`` with this view. Javascript that does not need to be included on every page *should* be put in a static javascript file under the ``js/`` directory. For more information on Javascript in Elgg, see :doc:`/guides/javascript`.
+Javascript and CSS will live in the views system. See :doc:`/guides/javascript`.
 
 activate.php and deactivate.php
 -------------------------------

--- a/docs/guides/routing.rst
+++ b/docs/guides/routing.rst
@@ -42,7 +42,7 @@ the request to a resource view.
 
             // use a view for the page logic to allow other plugins to easily change it
             set_input('guid', (int)elgg_extract(1, $segments));
-            echo elgg_view('resources/blog/view');
+            echo elgg_view_resource('blog/view');
 
             // in page handlers, return true says, "we've handled this request"
             return true;

--- a/docs/tutorials/hello_world.rst
+++ b/docs/tutorials/hello_world.rst
@@ -87,26 +87,35 @@ Update the ``start.php`` to look like this:
     }
     
     function hello_world_page_handler() {
-    	$params = array(
-            'title' => 'Hello world!',
-            'content' => 'This is my first plugin.',
-    	    'filter' => '',
-        );
-
-        $body = elgg_view_layout('content', $params);
-
-        echo elgg_view_page('Hello', $body);
+    	echo elgg_view_resource('hello');
     }
 
 The call to ``elgg_register_page_handler()`` tells Elgg that it should
 call the function ``hello_world_page_handler()`` when user goes to your site
 and has "hello" at the end of the URL.
 
-The ``hello_world_page_handler()`` makes it possible for the users to access
-the actual page. Inside the function we first give an array of parameters to the
-``elgg_view_layout()`` function.
+The ``hello_world_page_handler()`` passes off rendering the actual page to the
+``resources/hello`` view. Let's create it:
 
-The parameters include:
+Create ``views/default/resources/hello.php`` with this:
+
+.. code-block:: php
+
+    <?php
+
+    $params = array(
+        'title' => 'Hello world!',
+        'content' => 'This is my first plugin.',
+        'filter' => '',
+    );
+
+    $body = elgg_view_layout('content', $params);
+
+    echo elgg_view_page('Hello', $body);
+
+
+We give an array of parameters to the ``elgg_view_layout()`` function, including:
+
  - The title of the page
  - The contents of the page
  - Filter which is left empty because there's currently nothing to filter

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -575,7 +575,7 @@ function _elgg_admin_plugin_screenshot_page_handler($pages) {
 	$filename = sanitise_filepath($filename, false);
 	set_input('filename', $filename);
 
-	echo elgg_view('resources/admin/plugin_screenshot.img');
+	echo elgg_view_resource('admin/plugin_screenshot.img');
 	return true;
 }
 
@@ -599,7 +599,7 @@ function _elgg_admin_markdown_page_handler($pages) {
 	set_input('plugin_id', elgg_extract(0, $pages));
 	set_input('filename', elgg_extract(1, $pages));
 
-	echo elgg_view('resources/admin/plugin_text_file');
+	echo elgg_view_resource('admin/plugin_text_file');
 	return true;
 }
 
@@ -609,7 +609,7 @@ function _elgg_admin_markdown_page_handler($pages) {
  * @access private
  */
 function _elgg_robots_page_handler() {
-	echo elgg_view('resources/robots.txt');
+	echo elgg_view_resource('robots.txt');
 	return true;
 }
 
@@ -658,7 +658,7 @@ function _elgg_admin_maintenance_handler($hook, $type, $info) {
 
 	elgg_unregister_plugin_hook_handler('register', 'menu:login', '_elgg_login_menu_setup');
 
-	echo elgg_view('resources/maintenance');
+	echo elgg_view_resource('maintenance');
 
 	return false;
 }

--- a/engine/lib/comments.php
+++ b/engine/lib/comments.php
@@ -42,7 +42,7 @@ function _elgg_comments_page_handler($segments) {
 
 		case 'edit':
 			set_input('guid', elgg_extract(1, $segments));
-			echo elgg_view('resources/comments/edit');
+			echo elgg_view_resource('comments/edit');
 			return true;
 			break;
 

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1755,7 +1755,7 @@ function _elgg_is_valid_options_for_batch_operation($options, $type) {
  * @access private
  */
 function _elgg_walled_garden_index() {
-	echo elgg_view('resources/walled_garden');
+	echo elgg_view_resource('walled_garden');
 	return true;
 }
 

--- a/engine/lib/friends.php
+++ b/engine/lib/friends.php
@@ -128,10 +128,10 @@ function _elgg_friends_page_handler($segments, $handler) {
 
 	switch ($handler) {
 		case 'friends':
-			echo elgg_view("resources/friends/index");
+			echo elgg_view_resource("friends/index");
 			break;
 		case 'friendsof':
-			echo elgg_view("resources/friends/of");
+			echo elgg_view_resource("friends/of");
 			break;
 		default:
 			return false;
@@ -155,19 +155,19 @@ function _elgg_collections_page_handler($page_elements) {
 			case 'add':
 				elgg_set_page_owner_guid(elgg_get_logged_in_user_guid());
 				
-				echo elgg_view("resources/friends/collections/add");
+				echo elgg_view_resource("friends/collections/add");
 				return true;
 			case 'owner':
 				$user = get_user_by_username($page_elements[1]);
 				if ($user) {
 					elgg_set_page_owner_guid($user->getGUID());
 					
-					echo elgg_view("resources/friends/collections/view");
+					echo elgg_view_resource("friends/collections/view");
 					return true;
 				}
 				break;
 			case 'pickercallback':
-				echo elgg_view('resources/friends/collections/pickercallback');
+				echo elgg_view_resource('friends/collections/pickercallback');
 				return true;
 		}
 	}

--- a/engine/lib/pagehandler.php
+++ b/engine/lib/pagehandler.php
@@ -226,7 +226,7 @@ function elgg_ajax_gatekeeper() {
  * @return bool
  */
 function elgg_front_page_handler() {
-	echo elgg_view('resources/index');
+	echo elgg_view_resource('index');
 	return true;
 }
 
@@ -247,7 +247,7 @@ function elgg_error_page_handler($hook, $type, $result, $params) {
 	set_input('type', $type);
 	set_input('params', $params);
 
-	echo elgg_view('resources/error');
+	echo elgg_view_resource('error');
 	exit;
 }
 

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -744,7 +744,7 @@ function _elgg_river_page_handler($page) {
 	}
 	set_input('page_type', $page_type);
 
-	echo elgg_view("resources/river");
+	echo elgg_view_resource("river");
 	return true;
 }
 

--- a/engine/lib/user_settings.php
+++ b/engine/lib/user_settings.php
@@ -366,17 +366,17 @@ function _elgg_user_settings_page_handler($page) {
 
 	switch ($page[0]) {
 		case 'statistics':
-			echo elgg_view('resources/settings/statistics');
+			echo elgg_view_resource('settings/statistics');
 			return true;
 		case 'plugins':
 			if (isset($page[2])) {
 				set_input("plugin_id", $page[2]);
-				echo elgg_view('resources/settings/tools');
+				echo elgg_view_resource('settings/tools');
 				return true;
 			}
 			break;
 		case 'user':
-			echo elgg_view("resources/settings/account");
+			echo elgg_view_resource("settings/account");
 			return true;
 	}
 

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -380,16 +380,16 @@ function elgg_user_account_page_handler($page_elements, $handler) {
 
 	switch ($handler) {
 		case 'login':
-			echo elgg_view("resources/account/login");
+			echo elgg_view_resource("account/login");
 			break;
 		case 'forgotpassword':
-			echo elgg_view("resources/account/forgotten_password");
+			echo elgg_view_resource("account/forgotten_password");
 			break;
 		case 'changepassword':
-			echo elgg_view("resources/account/change_password");
+			echo elgg_view_resource("account/change_password");
 			break;
 		case 'register':
-			echo elgg_view("resources/account/register");
+			echo elgg_view_resource("account/register");
 			break;
 		default:
 			return false;
@@ -653,11 +653,11 @@ function elgg_avatar_page_handler($page) {
 	}
 
 	if ($page[0] == 'edit') {
-		echo elgg_view("resources/avatar/edit");
+		echo elgg_view_resource("avatar/edit");
 		return true;
 	} else {
 		set_input('size', $page[2]);
-		echo elgg_view("resources/avatar/view");
+		echo elgg_view_resource("avatar/view");
 		return true;
 	}
 	return false;
@@ -677,7 +677,7 @@ function elgg_profile_page_handler($page) {
 	elgg_set_page_owner_guid($user->guid);
 
 	if ($page[1] == 'edit') {
-		echo elgg_view("resources/profile/edit");
+		echo elgg_view_resource("profile/edit");
 		return true;
 	}
 	return false;

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -485,6 +485,37 @@ function elgg_view_page($title, $body, $page_shell = 'default', $vars = array())
 }
 
 /**
+ * Render a resource view. Use this in your page handler to hand off page rendering to
+ * a view in "resources/". If not found in the current viewtype, we try the "default" viewtype.
+ *
+ * @param string $name The view name without the leading "resources/"
+ *
+ * @return string
+ * @throws SecurityException
+ */
+function elgg_view_resource($name) {
+	$view = "resources/$name";
+
+	if (elgg_view_exists($view)) {
+		return _elgg_services()->views->renderView($view);
+	}
+
+	if (elgg_get_viewtype() !== 'default' && elgg_view_exists($view, 'default')) {
+		return _elgg_services()->views->renderView($view, [], false, 'default');
+	}
+
+	_elgg_services()->logger->error("The view $view is missing.");
+
+	if (elgg_get_viewtype() === 'default') {
+		// only works for default viewtype
+		forward('', '404');
+	} else {
+		register_error(elgg_echo('error:404:content'));
+		forward('');
+	}
+}
+
+/**
  * Prepare the variables for the html head
  *
  * @param string $title Page title for <head>

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -106,35 +106,35 @@ function blog_page_handler($page) {
 		case 'owner':
 			set_input('username', $page[1]);
 			
-			echo elgg_view('resources/blog/owner');
+			echo elgg_view_resource('blog/owner');
 			break;
 		case 'friends':
 			set_input('username', $page[1]);
 			
-			echo elgg_view('resources/blog/friends');
+			echo elgg_view_resource('blog/friends');
 			break;
 		case 'archive':
 			set_input('username', $page[1]);
 			set_input('lower', $page[2]);
 			set_input('upper', $page[3]);
 			
-			echo elgg_view('resources/blog/archive');
+			echo elgg_view_resource('blog/archive');
 			break;
 		case 'view':
 			set_input('guid', $page[1]);
 			
-			echo elgg_view('resources/blog/view');
+			echo elgg_view_resource('blog/view');
 			break;
 		case 'add':
 			set_input('guid', $page[1]);
 			
-			echo elgg_view('resources/blog/add');
+			echo elgg_view_resource('blog/add');
 			break;
 		case 'edit':
 			set_input('guid', $page[1]);
 			set_input('revision', $page[2]);
 			
-			echo elgg_view('resources/blog/edit');
+			echo elgg_view_resource('blog/edit');
 			break;
 		case 'group':
 			set_input('group_guid', $page[1]);
@@ -142,10 +142,10 @@ function blog_page_handler($page) {
 			set_input('lower', $page[3]);
 			set_input('upper', $page[4]);
 			
-			echo elgg_view('resources/blog/group');
+			echo elgg_view_resource('blog/group');
 			break;
 		case 'all':
-			echo elgg_view('resources/blog/all');
+			echo elgg_view_resource('blog/all');
 			break;
 		default:
 			return false;

--- a/mod/bookmarks/start.php
+++ b/mod/bookmarks/start.php
@@ -99,38 +99,38 @@ function bookmarks_page_handler($page) {
 
 	switch ($page[0]) {
 		case "all":
-			echo elgg_view('resources/bookmarks/all');
+			echo elgg_view_resource('bookmarks/all');
 			break;
 
 		case "owner":
-			echo elgg_view('resources/bookmarks/owner');
+			echo elgg_view_resource('bookmarks/owner');
 			break;
 
 		case "friends":
-			echo elgg_view('resources/bookmarks/friends');
+			echo elgg_view_resource('bookmarks/friends');
 			break;
 
 		case "view":
 			set_input('guid', $page[1]);
-			echo elgg_view('resources/bookmarks/view');
+			echo elgg_view_resource('bookmarks/view');
 			break;
 
 		case "add":
-			echo elgg_view('resources/bookmarks/add');
+			echo elgg_view_resource('bookmarks/add');
 			break;
 
 		case "edit":
 			set_input('guid', $page[1]);
-			echo elgg_view('resources/bookmarks/edit');
+			echo elgg_view_resource('bookmarks/edit');
 			break;
 
 		case 'group':
-			echo elgg_view('resources/bookmarks/owner');
+			echo elgg_view_resource('bookmarks/owner');
 			break;
 
 		case "bookmarklet":
 			set_input('container_guid', $page[1]);
-			echo elgg_view('resources/bookmarks/bookmarklet');
+			echo elgg_view_resource('bookmarks/bookmarklet');
 			break;
 
 		default:

--- a/mod/categories/start.php
+++ b/mod/categories/start.php
@@ -31,7 +31,7 @@ function categories_init() {
  * @return bool
  */
 function categories_page_handler() {
-	echo elgg_view('resources/categories/listing');
+	echo elgg_view_resource('categories/listing');
 	return true;
 }
 

--- a/mod/custom_index/views/default/resources/index.php
+++ b/mod/custom_index/views/default/resources/index.php
@@ -63,7 +63,7 @@ $params = array(
 	'members' => $newest_members,
 );
 
-$body = elgg_view('resources/index-content', $params);
+$body = elgg_view_resource('index-content', $params);
 
 // no RSS feed with a "widget" front page
 global $autofeed;

--- a/mod/dashboard/start.php
+++ b/mod/dashboard/start.php
@@ -27,7 +27,7 @@ function dashboard_init() {
  * @return bool
  */
 function dashboard_page_handler() {
-	echo elgg_view('resources/dashboard');
+	echo elgg_view_resource('dashboard');
 	return true;
 }
 

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -224,7 +224,7 @@ function developers_theme_sandbox_controller($page) {
 	}
 	set_input('page', $page[0]);
 
-	echo elgg_view('resources/theme_sandbox');
+	echo elgg_view_resource('theme_sandbox');
 	return true;
 }
 

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -117,38 +117,38 @@ function file_page_handler($page) {
 	switch ($page_type) {
 		case 'owner':
 			file_register_toggle();
-			echo elgg_view('resources/file/owner');
+			echo elgg_view_resource('file/owner');
 			break;
 		case 'friends':
 			file_register_toggle();
-			echo elgg_view('resources/file/friends');
+			echo elgg_view_resource('file/friends');
 			break;
 		case 'view':
 			set_input('guid', $page[1]);
-			echo elgg_view('resources/file/view');
+			echo elgg_view_resource('file/view');
 			break;
 		case 'add':
-			echo elgg_view('resources/file/upload');
+			echo elgg_view_resource('file/upload');
 			break;
 		case 'edit':
 			set_input('guid', $page[1]);
-			echo elgg_view('resources/file/edit');
+			echo elgg_view_resource('file/edit');
 			break;
 		case 'search':
 			file_register_toggle();
-			echo elgg_view('resources/file/search');
+			echo elgg_view_resource('file/search');
 			break;
 		case 'group':
 			file_register_toggle();
-			echo elgg_view('resources/file/owner');
+			echo elgg_view_resource('file/owner');
 			break;
 		case 'all':
 			file_register_toggle();
-			echo elgg_view('resources/file/world');
+			echo elgg_view_resource('file/world');
 			break;
 		case 'download':
 			set_input('guid', $page[1]);
-			echo elgg_view('resources/file/download');
+			echo elgg_view_resource('file/download');
 			break;
 		default:
 			return false;

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -243,12 +243,12 @@ function groups_page_handler($page) {
 		case 'all':
 		case 'owner':
 		case 'search':
-			echo elgg_view("resources/groups/{$page[0]}");
+			echo elgg_view_resource("groups/{$page[0]}");
 			break;
 		case 'invitations':
 		case 'member':
 			set_input('username', $page[1]);
-			echo elgg_view("resources/groups/{$page[0]}");
+			echo elgg_view_resource("groups/{$page[0]}");
 			break;
 		case 'activity':
 		case 'edit':
@@ -257,7 +257,7 @@ function groups_page_handler($page) {
 		case 'profile':
 		case 'requests':
 			set_input('guid', $page[1]);
-			echo elgg_view("resources/groups/{$page[0]}");
+			echo elgg_view_resource("groups/{$page[0]}");
 			break;
 		default:
 			return false;
@@ -788,21 +788,21 @@ function discussion_page_handler($page) {
 
 	switch ($page[0]) {
 		case 'all':
-			echo elgg_view('resources/discussion/all');
+			echo elgg_view_resource('discussion/all');
 			break;
 		case 'owner':
 			set_input('owner_guid', elgg_extract(1, $page));
-			echo elgg_view('resources/discussion/owner');
+			echo elgg_view_resource('discussion/owner');
 			break;
 		case 'add':
 			set_input('guid', elgg_extract(1, $page));
-			echo elgg_view('resources/discussions/add');
+			echo elgg_view_resource('discussions/add');
 			break;
 		case 'reply':
 			switch (elgg_extract(1, $page)) {
 				case 'edit':
 					set_input('guid', elgg_extract(2, $page));
-					echo elgg_view('resources/discussion/reply/edit');
+					echo elgg_view_resource('discussion/reply/edit');
 					break;
 				case 'view':
 					discussion_redirect_to_reply(elgg_extract(2, $page), elgg_extract(3, $page));
@@ -813,11 +813,11 @@ function discussion_page_handler($page) {
 			break;
 		case 'edit':
 			set_input('guid', elgg_extract(1, $page));
-			echo elgg_view('resources/discussion/edit');
+			echo elgg_view_resource('discussion/edit');
 			break;
 		case 'view':
 			set_input('guid', elgg_extract(1, $page));
-			echo elgg_view('resources/discussion/view');
+			echo elgg_view_resource('discussion/view');
 			break;
 		default:
 			return false;

--- a/mod/members/start.php
+++ b/mod/members/start.php
@@ -145,9 +145,9 @@ function members_page_handler($page) {
 	$vars['page'] = $page[0];
 
 	if ($page[0] == 'search') {
-		echo elgg_view('resources/members/search', $vars);
+		echo elgg_view_resource('members/search', $vars);
 	} else {
-		echo elgg_view('resources/members/index', $vars);
+		echo elgg_view_resource('members/index', $vars);
 	}
 	return true;
 }

--- a/mod/messageboard/start.php
+++ b/mod/messageboard/start.php
@@ -59,20 +59,20 @@ function messageboard_page_handler($page) {
 				set_input('history_username', $username);
 			}
 
-			echo elgg_view('resources/messageboard/owner');
+			echo elgg_view_resource('messageboard/owner');
 			break;
 
 		case 'add':
 			$container_guid = elgg_extract(1, $page);
 			set_input('container_guid', $container_guid);
-			echo elgg_view('resources/messageboard/add');
+			echo elgg_view_resource('messageboard/add');
 			break;
 
 		case 'group':
 			elgg_group_gatekeeper();
 			$owner_guid = elgg_extract(1, $page);
 			set_input('page_owner_guid', $owner_guid);
-			echo elgg_view('resources/messageboard/owner');
+			echo elgg_view_resource('messageboard/owner');
 			break;
 
 		default:

--- a/mod/messages/start.php
+++ b/mod/messages/start.php
@@ -101,19 +101,19 @@ function messages_page_handler($page) {
 	switch ($page[0]) {
 		case 'inbox':
 			set_input('username', $page[1]);
-			echo elgg_view('resources/messages/inbox');
+			echo elgg_view_resource('messages/inbox');
 			break;
 		case 'sent':
 			set_input('username', $page[1]);
-			echo elgg_view('resources/messages/sent');
+			echo elgg_view_resource('messages/sent');
 			break;
 		case 'read':
 			set_input('guid', $page[1]);
-			echo elgg_view('resources/messages/read');
+			echo elgg_view_resource('messages/read');
 			break;
 		case 'compose':
 		case 'add':
-			echo elgg_view('resources/messages/send');
+			echo elgg_view_resource('messages/send');
 			break;
 		default:
 			return false;

--- a/mod/notifications/start.php
+++ b/mod/notifications/start.php
@@ -56,10 +56,10 @@ function notifications_page_handler($page) {
 	// note: $user passed in
 	switch ($page[0]) {
 		case 'group':
-			echo elgg_view('resources/notifications/groups');
+			echo elgg_view_resource('notifications/groups');
 			break;
 		case 'personal':
-			echo elgg_view('resources/notifications/index');
+			echo elgg_view_resource('notifications/index');
 			break;
 		default:
 			return false;

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -123,36 +123,36 @@ function pages_page_handler($page) {
 	$page_type = $page[0];
 	switch ($page_type) {
 		case 'owner':
-			echo elgg_view('resources/pages/owner');
+			echo elgg_view_resource('pages/owner');
 			break;
 		case 'friends':
-			echo elgg_view('resources/pages/friends');
+			echo elgg_view_resource('pages/friends');
 			break;
 		case 'view':
 			set_input('guid', $page[1]);
-			echo elgg_view('resources/pages/view');
+			echo elgg_view_resource('pages/view');
 			break;
 		case 'add':
 			set_input('guid', $page[1]);
-			echo elgg_view('resources/pages/new');
+			echo elgg_view_resource('pages/new');
 			break;
 		case 'edit':
 			set_input('guid', $page[1]);
-			echo elgg_view('resources/pages/edit');
+			echo elgg_view_resource('pages/edit');
 			break;
 		case 'group':
-			echo elgg_view('resources/pages/owner');
+			echo elgg_view_resource('pages/owner');
 			break;
 		case 'history':
 			set_input('guid', $page[1]);
-			echo elgg_view('resources/pages/history');
+			echo elgg_view_resource('pages/history');
 			break;
 		case 'revision':
 			set_input('id', $page[1]);
-			echo elgg_view('resources/pages/revision');
+			echo elgg_view_resource('pages/revision');
 			break;
 		case 'all':
-			echo elgg_view('resources/pages/world');
+			echo elgg_view_resource('pages/world');
 			break;
 		default:
 			return false;

--- a/mod/profile/start.php
+++ b/mod/profile/start.php
@@ -73,12 +73,12 @@ function profile_page_handler($page) {
 
 	if ($action == 'edit') {
 		// use the core profile edit page
-		echo elgg_view('resources/profile/edit');
+		echo elgg_view_resource('profile/edit');
 		return true;
 	}
 
 	set_input('username', $page[0]);
-	echo elgg_view('resources/profile/view');
+	echo elgg_view_resource('profile/view');
 	return true;
 }
 

--- a/mod/reportedcontent/start.php
+++ b/mod/reportedcontent/start.php
@@ -67,11 +67,11 @@ function reportedcontent_page_handler($page) {
 	elgg_gatekeeper();
 
 	if (elgg_extract(0, $page) === 'add' && elgg_is_xhr()) {
-		echo elgg_view('resources/reportedcontent/add_form');
+		echo elgg_view_resource('reportedcontent/add_form');
 		return true;
 	}
 
-	echo elgg_view('resources/reportedcontent/add');
+	echo elgg_view_resource('reportedcontent/add');
 	return true;
 }
 

--- a/mod/search/start.php
+++ b/mod/search/start.php
@@ -59,7 +59,7 @@ function search_page_handler($page) {
 		//set_input('search_type', 'tags');
 	}
 
-	echo elgg_view('resources/search/index');
+	echo elgg_view_resource('search/index');
 	return true;
 }
 

--- a/mod/site_notifications/start.php
+++ b/mod/site_notifications/start.php
@@ -49,7 +49,7 @@ function site_notifications_page_handler($segments) {
 
 	elgg_set_page_owner_guid($user->guid);
 
-	echo elgg_view('resources/site_notifications/view');
+	echo elgg_view_resource('site_notifications/view');
 
 	return true;
 }

--- a/mod/tagcloud/start.php
+++ b/mod/tagcloud/start.php
@@ -23,6 +23,6 @@ function tagcloud_init() {
  * @return bool
  */
 function tagcloud_tags_page_handler($page) {
-	echo elgg_view('resources/tagcloud');
+	echo elgg_view_resource('tagcloud');
 	return true;
 }

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -90,50 +90,50 @@ function thewire_page_handler($page) {
 
 	switch ($page[0]) {
 		case "all":
-			echo elgg_view('resources/thewire/everyone');
+			echo elgg_view_resource('thewire/everyone');
 			break;
 
 		case "friends":
-			echo elgg_view('resources/thewire/friends');
+			echo elgg_view_resource('thewire/friends');
 			break;
 
 		case "owner":
-			echo elgg_view('resources/thewire/owner');
+			echo elgg_view_resource('thewire/owner');
 			break;
 
 		case "view":
 			if (isset($page[1])) {
 				set_input('guid', $page[1]);
 			}
-			echo elgg_view('resources/thewire/view');
+			echo elgg_view_resource('thewire/view');
 			break;
 
 		case "thread":
 			if (isset($page[1])) {
 				set_input('thread_id', $page[1]);
 			}
-			echo elgg_view('resources/thewire/thread');
+			echo elgg_view_resource('thewire/thread');
 			break;
 
 		case "reply":
 			if (isset($page[1])) {
 				set_input('guid', $page[1]);
 			}
-			echo elgg_view('resources/thewire/reply');
+			echo elgg_view_resource('thewire/reply');
 			break;
 
 		case "tag":
 			if (isset($page[1])) {
 				set_input('tag', $page[1]);
 			}
-			echo elgg_view('resources/thewire/tag');
+			echo elgg_view_resource('thewire/tag');
 			break;
 
 		case "previous":
 			if (isset($page[1])) {
 				set_input('guid', $page[1]);
 			}
-			echo elgg_view('resources/thewire/previous');
+			echo elgg_view_resource('thewire/previous');
 			break;
 
 		default:

--- a/mod/twitter_api/start.php
+++ b/mod/twitter_api/start.php
@@ -92,7 +92,7 @@ function twitter_api_pagehandler($page) {
 				register_error(elgg_echo('twitter_api:invalid_page'));
 				forward();
 			}
-			echo elgg_view('resources/twitter_api/interstitial');
+			echo elgg_view_resource('twitter_api/interstitial');
 			break;
 		default:
 			return false;

--- a/mod/uservalidationbyemail/start.php
+++ b/mod/uservalidationbyemail/start.php
@@ -200,7 +200,7 @@ function uservalidationbyemail_page_handler($page) {
 			require __DIR__ . "/pages/confirm.php";
 			break;
 		case 'emailsent':
-			echo elgg_view("resources/uservalidationbyemail/emailsent");
+			echo elgg_view_resource("uservalidationbyemail/emailsent");
 			break;
 		default:
 			forward('', '404');


### PR DESCRIPTION
This makes sure that resource views are requested with the “default” viewtype and issues an error and 404 if the view is missing.

Fixes #8436
