### PR TITLE
chore(docs): wrong parameter order in code example (notfy_user function)

### DIFF
--- a/docs/guides/notifications.rst
+++ b/docs/guides/notifications.rst
@@ -50,7 +50,7 @@ rating to the owner.
 	);
 
 	// Send the notification
-	notify_user($user->guid, $owner->guid, $subject, $body, $params);
+	notify_user($owner->guid, $user->guid, $subject, $body, $params);
 
 .. note::
 


### PR DESCRIPTION
Reference states the parameter order as $to, $from...

The $owner then must be the first parameter, since he is being notified that the $user rated his post.
