### PR TITLE
chore(services): Remove the public config service from Application

### DIFF
--- a/docs/guides/services.rst
+++ b/docs/guides/services.rst
@@ -1,30 +1,8 @@
 Services
 ########
 
-Elgg uses the ``Elgg\Application`` class to load and bootstrap Elgg, but this class also offers
-a set of service objects for plugins to use.
-
-Plugins can access the application instance via the global function ``elgg()``, from which
-services are available via property access. E.g. these are equivalent:
-
-.. code:: php
-
-    $foo = elgg_get_config('foo');
-
-    $foo = elgg()->config->get('foo');
-
-Should I modify existing plugin code to use services?
------------------------------------------------------
-
-This is not necessary. Pre-existing global functions like ``elgg_get_config()`` are *not*
-deprecated and will be supported at least through Elgg 2.x. If they will reduce your maintenance
-burden of supporting older Elgg versions, we encourage you to continue using them in your plugins.
-
-Service: config
----------------
-
-An instance of ``Elgg\Services\Config``, this is for getting and setting various system
-configuration values.
+Elgg uses the ``Elgg\Application`` class to load and bootstrap Elgg. In future releases this
+class will offer a set of service objects for plugins to use.
 
 .. note::
 

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -12,8 +12,6 @@ use Elgg\Di\ServiceProvider;
  *
  * The full path is necessary to work around this: https://bugs.php.net/bug.php?id=55726
  *
- * @property-read \Elgg\Services\Config $config
- *
  * @since 2.0.0
  */
 class Application {
@@ -46,7 +44,7 @@ class Application {
 	 * @var string[]
 	 */
 	private static $public_services = [
-		'config' => true,
+		//'config' => true,
 	];
 
 	/**
@@ -295,7 +293,7 @@ class Application {
 
 		if (php_sapi_name() === 'cli-server') {
 			$www_root = "http://{$_SERVER['SERVER_NAME']}:{$_SERVER['SERVER_PORT']}/";
-			$this->config->set('wwwroot', $www_root);
+			$this->services->config->set('wwwroot', $www_root);
 		}
 
 		if (0 === strpos($path, '/cache/')) {

--- a/engine/classes/Elgg/Application/CacheHandler.php
+++ b/engine/classes/Elgg/Application/CacheHandler.php
@@ -40,7 +40,7 @@ class CacheHandler {
 	 * @return void
 	 */
 	public function handleRequest($path) {
-		$config = $this->application->config;
+		$config = _elgg_services()->config;
 
 		$request = $this->parsePath($path);
 		if (!$request) {
@@ -153,7 +153,7 @@ class CacheHandler {
 	 */
 	protected function setupSimplecache() {
 		// we can't use Elgg\Config::get yet. It fails before the core is booted
-		$config = $this->application->config;
+		$config = _elgg_services()->config;
 		$config->loadSettingsFile();
 
 		if ($config->getVolatile('dataroot') && $config->getVolatile('simplecache_enabled') !== null) {
@@ -304,7 +304,7 @@ class CacheHandler {
 		}
 
 		// disable error reporting so we don't cache problems
-		$this->application->config->set('debug', null);
+		_elgg_services()->config->set('debug', null);
 
 		// @todo elgg_view() checks if the page set is done (isset($CONFIG->pagesetupdone)) and
 		// triggers an event if it's not. Calling elgg_view() here breaks submenus
@@ -312,7 +312,7 @@ class CacheHandler {
 		// contexts can be correctly set (since this is called before page_handler()).
 		// To avoid this, lie about $CONFIG->pagehandlerdone to force
 		// the trigger correctly when the first view is actually being output.
-		$this->application->config->set('pagesetupdone', true);
+		_elgg_services()->config->set('pagesetupdone', true);
 
 		return elgg_view($view);
 	}

--- a/engine/tests/phpunit/Elgg/ApplicationTest.php
+++ b/engine/tests/phpunit/Elgg/ApplicationTest.php
@@ -21,7 +21,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 		$app = new Application($services);
 
 		$names = [
-			'config',
+			//'config',
 		];
 
 		foreach	($names as $name) {

--- a/mod/profile/icondirect.php
+++ b/mod/profile/icondirect.php
@@ -35,7 +35,7 @@ $app = new \Elgg\Application();
 $app->loadSettings();
 
 $data_root = call_user_func(function () use ($app) {
-	$dataroot = $app->config->getVolatile('dataroot');
+	$dataroot = _elgg_services()->config->getVolatile('dataroot');
 	if ($dataroot) {
 		return $dataroot;
 	}


### PR DESCRIPTION
The plan is to provide services mostly for new functionality. We don’t want to duplicate existing APIs.

Fixes #8472
