### PR TITLE
chore(travis): Fail CI if PHP 7 fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ branches:
 matrix:
   fast_finish: true
   allow_failures:
-    - php: 7.0
     - php: hhvm
   include:
     # Lint checks for PHP code and composer.json


### PR DESCRIPTION
Now that PHP 7 has started shipping releases, we want to make sure
we keep up with any breaking changes so that we're compatible when
the final release of PHP 7.0.0 is made.
