### PR TITLE
docs(code): Clarify interface naming convention

### DIFF
--- a/docs/contribute/code.rst
+++ b/docs/contribute/code.rst
@@ -282,6 +282,18 @@ Use self-documenting variable names.  ``$group_guids`` is better than ``$array``
 
 Avoid double-negatives. Prefer ``$enable = true`` to ``$disable = false``.
 
+Interface names
+^^^^^^^^^^^^^^^
+
+Use the pattern `Elgg\{Namespace}\{Name}`.
+
+Do not include an `I` prefix or an `Interface` suffix.
+
+We do not include any prefix or suffix so that we're encouraged to:
+
+ * name implementation classes more descriptively (the "default" name is taken).
+ * type-hint on interfaces, because that is the shortest, easiest thing to do.
+
 Functions
 ^^^^^^^^^
 


### PR DESCRIPTION
Fixes #8293
