### PR TITLE
deprecate(views): elgg_get_view_location is going away in 2.0

### DIFF
--- a/engine/lib/deprecated-1.12.php
+++ b/engine/lib/deprecated-1.12.php
@@ -32,3 +32,20 @@ function set_template_handler($function_name) {
 	}
 	return false;
 }
+
+/**
+ * Returns the file location for a view.
+ *
+ * @warning This doesn't check if the file exists, but only
+ * constructs (or extracts) the path and returns it.
+ *
+ * @param string $view     The view.
+ * @param string $viewtype The viewtype
+ *
+ * @return string
+ * @deprecated 1.12 This function is going away in 2.0.
+ */
+function elgg_get_view_location($view, $viewtype = '') {
+	elgg_deprecated_notice("elgg_get_view_location() is going away in 2.0.", "1.12");
+	return _elgg_services()->views->getViewLocation($view, $viewtype);
+}

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -269,20 +269,6 @@ function elgg_unregister_external_view($view) {
 	}
 }
 
-/**
- * Returns the file location for a view.
- *
- * @warning This doesn't check if the file exists, but only
- * constructs (or extracts) the path and returns it.
- *
- * @param string $view     The view.
- * @param string $viewtype The viewtype
- *
- * @return string
- */
-function elgg_get_view_location($view, $viewtype = '') {
-	return _elgg_services()->views->getViewLocation($view, $viewtype);
-}
 
 /**
  * Set an alternative base location for a view.


### PR DESCRIPTION
It is making some 2.0 views refactor work more difficult than it needs to be.
