### PR TITLE
chore(views): Remove `set_template_handler`

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -229,6 +229,7 @@ Removed Functions
  - ``get_db_link()``
  - ``load_plugins()``
  - ``mysql_*()``: Elgg :ref:`no longer uses ext/mysql<migrated-to-pdo>`
+ - ``set_template_handler()``
 
 Removed Plugin Hooks
 --------------------

--- a/docs/guides/views.rst
+++ b/docs/guides/views.rst
@@ -323,23 +323,6 @@ Consider these two examples:
 
 In the first example, we are displaying a list of groups a user is a member of using the default group view. In the second example, we want to display a list of groups the user was invited to. Since invitations are not entities, they do not have their own views and can not be listed using ``elgg_list_*``. We are providing an alternative item view, that will use the group entity to display an invitation that contains a group name and buttons to access or reject the invitation.
 
-Using a different templating system
-===================================
-
-.. warning::
-
-    This functionality is deprecated as of Elgg 1.12. It will be removed in 2.0.
-    It affects the behavior of templates globally, which is almost sure to cause
-    breakages and therefore we suspect no one uses it in practice.
-
-You can write your own templating system if you want to.
-
-Before going through the motions of drawing views, Elgg checks the ``$CONFIG->template_handler`` variable to see if it contains the name of a callable function. If it does, the function will be passed the view name and template vars, and the return value of this function will be returned instead of the standard output:
-
-.. code-block:: php
-
-	return $template_handler($view, $vars);
-
 Related
 =======
 

--- a/engine/classes/Elgg/ViewsService.php
+++ b/engine/classes/Elgg/ViewsService.php
@@ -225,14 +225,6 @@ class ViewsService {
 			_elgg_services()->events->trigger('pagesetup', 'system');
 		}
 
-		// If it's been requested, pass off to a template handler instead
-		if ($bypass == false && isset($this->CONFIG->template_handler) && !empty($this->CONFIG->template_handler)) {
-			$template_handler = $this->CONFIG->template_handler;
-			if (is_callable($template_handler)) {
-				return call_user_func($template_handler, $view, $vars);
-			}
-		}
-
 		// Set up any extensions to the requested view
 		if (isset($this->CONFIG->views->extensions[$view])) {
 			$viewlist = $this->CONFIG->views->extensions[$view];

--- a/engine/lib/deprecated-1.12.php
+++ b/engine/lib/deprecated-1.12.php
@@ -2,38 +2,6 @@
 
 
 /**
- * Registers a function to handle templates.
- *
- * Alternative template handlers can be registered to handle
- * all output functions.  By default, {@link elgg_view()} will
- * simply include the view file.  If an alternate template handler
- * is registered, the view name and passed $vars will be passed to the
- * registered function, which is then responsible for generating and returning
- * output.
- *
- * Template handlers need to accept two arguments: string $view_name and array
- * $vars.
- *
- * @warning This is experimental.
- *
- * @param string $function_name The name of the function to pass to.
- *
- * @return bool
- * @see elgg_view()
- * @deprecated 1.12
- */
-function set_template_handler($function_name) {
-	elgg_deprecated_notice("Support for custom template handlers will end soon.", "1.12");
-	global $CONFIG;
-
-	if (is_callable($function_name)) {
-		$CONFIG->template_handler = $function_name;
-		return true;
-	}
-	return false;
-}
-
-/**
  * Returns the file location for a view.
  *
  * @warning This doesn't check if the file exists, but only

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -312,25 +312,16 @@ function elgg_view_exists($view, $viewtype = '', $recurse = true) {
  *
  * Views are called with a special $vars variable set,
  * which includes any variables passed as the second parameter.
- * For backward compatbility, the following variables are also set but we
- * recommend that you do not use them:
- *  - $vars['config'] The $CONFIG global. (Use {@link elgg_get_config()} instead).
- *  - $vars['url'] The site URL. (use {@link elgg_get_site_url()} instead).
- *  - $vars['user'] The logged in user. (use {@link elgg_get_logged_in_user_entity()} instead).
  *
- * Custom template handlers can be set with {@link set_template_handler()}.
+ * The input of views can be intercepted by registering for the
+ * view_vars, $view_name plugin hook.
  *
  * The output of views can be intercepted by registering for the
  * view, $view_name plugin hook.
- *
- * @warning Any variables in $_SESSION will override passed vars
- * upon name collision.  See https://github.com/Elgg/Elgg/issues/2124
- *
+ * 
  * @param string  $view     The name and location of the view to use
  * @param array   $vars     Variables to pass to the view.
- * @param boolean $bypass   If set to true, elgg_view will bypass any specified
- *                          alternative template handler; by default, it will
- *                          hand off to this if requested (see set_template_handler)
+ * @param boolean $bypass   This argument is ignored and will be removed eventually
  * @param boolean $ignored  This argument is ignored and will be removed eventually
  * @param string  $viewtype If set, forces the viewtype for the elgg_view call to be
  *                          this value (default: standard detection)
@@ -800,8 +791,7 @@ function elgg_view_menu_item(\ElggMenuItem $item, array $vars = array()) {
  *                            In Elgg 1.7 and earlier it was the boolean $full_view
  *      'full_view'        Whether to show a full or condensed view. (Default: true)
  *      'item_view'        Alternative view used to render this entity
- * @param boolean     $bypass If true, will not pass to a custom template handler.
- *                            {@link set_template_handler()}
+ * @param boolean     $bypass Ignored and will be removed eventually
  * @param boolean     $debug  Complain if views are missing
  *
  * @return string HTML to display or false
@@ -924,8 +914,7 @@ function elgg_view_entity_icon(\ElggEntity $entity, $size = 'medium', $vars = ar
  * @param \ElggAnnotation $annotation The annotation to display
  * @param array           $vars       Variable array for view.
  *      'item_view'  Alternative view used to render an annotation
- * @param bool            $bypass     If true, will not pass to a custom
- *                                    template handler. {@link set_template_handler()}
+ * @param bool            $bypass     Ignored and will be removed eventually
  * @param bool            $debug      Complain if views are missing
  *
  * @return string/false Rendered annotation


### PR DESCRIPTION
BREAKING CHANGE:
Elgg no longer allows customizing the views template handler.
We don't think this ever really worked in the first place, so
probably no one was using it, but since it's conceivable someone
could be, we're leaving this warning.

Fixes #8440
