### PR TITLE
perf(views): Allow serving assets directly from filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,13 @@
 /engine/settings.php
 /.htaccess
 /mod/*
-composer.lock
-composer.phar
+/composer.lock
+/composer.phar
+/cache
 
 # Don't check in third party code
-node_modules
-vendor
+/node_modules
+/vendor
 
 # don't ignore bundled plugins
 !/mod/aalborg_theme/

--- a/docs/admin/performance.rst
+++ b/docs/admin/performance.rst
@@ -83,6 +83,18 @@ It is recommended that you do this on your development platform if you are writi
 This cache is automatically flushed when a plugin is enabled, disabled or reordered,
 or when upgrade.php is executed.
 
+For best performance, you can also create a symlink from ``/cache/`` in your www
+root dir to the ``/views_simplecache/`` directory in the data directory you
+configured when you installed Elgg:
+
+.. code:: shell
+
+    cd /path/to/wwwroot/
+    ln -s /path/to/dataroot/views_simplecache/ cache
+
+If your webserver supports following symlinks, this will serve files straight off
+disk without booting up PHP each time.
+
 System cache
 ------------
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -12,6 +12,23 @@ See the administrator guides for :doc:`how to upgrade a live site </admin/upgrad
 From 1.x to 2.0
 ===============
 
+Cacheable views must have a file extension in their names
+---------------------------------------------------------
+
+This requirement makes it possibile for us to serve assets directly
+from disk for performance, instead of serving them through PHP.
+
+It also makes it much easier to explore the available cached resources
+by navigating to dataroot/views_simplecache and browsing around.
+
+ * Bad: ``my/cool/template``
+ * Good: ``my/cool/template.html``
+
+We now cache assets by ``"$viewtype/$view"``, not ``md5("$viewtype|$view")``,
+which can result in conflicts between cacheable views that don't have file extensions
+to disambiguate files from directories.
+
+
 
 Dropped ``jquery-migrate`` and upgraded ``jquery`` to ^2.1.4
 ------------------------------------------------------------

--- a/docs/guides/views.rst
+++ b/docs/guides/views.rst
@@ -73,10 +73,19 @@ Views as cacheable assets
 =========================
 
 As mentioned before, views can contain JS, CSS, or even images.
-Cacheable views *cannot* take any ``$vars`` parameters. They also must not change
-their output based on who is logged in, the time of day, etc. The simplest way
-to make sure your view meets the requirements for cacheable views is to just avoid
-using any PHP in them.
+
+Asset views must meet certain requirements:
+
+ * They *must not* take any ``$vars`` parameters
+ * They *must not* change their output based on global state like
+
+   * who is logged in
+   * the time of day
+
+ * They *must* contain a valid file extension
+ 
+   * Bad: ``my/cool/template``
+   * Good: ``my/cool/template.html``
 
 For example, suppose you wanted to load some CSS on a page.
 You could define a view ``mystyles.css``, which would look like so:

--- a/engine/classes/Elgg/Cache/SimpleCache.php
+++ b/engine/classes/Elgg/Cache/SimpleCache.php
@@ -146,8 +146,7 @@ class SimpleCache {
 			_elgg_services()->datalist->set('simplecache_enabled', 0);
 			_elgg_services()->config->set('simplecache_enabled', 0);
 	
-			// purge simple cache
-			_elgg_rmdir(_elgg_services()->config->getDataPath() . "views_simplecache");
+			$this->invalidate();
 		}
 	}
 	
@@ -158,7 +157,6 @@ class SimpleCache {
 	 * @return bool
 	 */
 	function invalidate() {
-		_elgg_rmdir("{$this->CONFIG->dataroot}views_simplecache");
 		mkdir("{$this->CONFIG->dataroot}views_simplecache");
 	
 		$time = time();

--- a/engine/classes/Elgg/Cache/SimpleCache.php
+++ b/engine/classes/Elgg/Cache/SimpleCache.php
@@ -157,8 +157,10 @@ class SimpleCache {
 	 * @return bool
 	 */
 	function invalidate() {
-		mkdir("{$this->CONFIG->dataroot}views_simplecache");
-	
+		$cache_dir = "{$this->CONFIG->dataroot}views_simplecache";
+		mkdir($cache_dir);
+		_elgg_rmdir($cache_dir, true);
+
 		$time = time();
 		_elgg_services()->datalist->set("simplecache_lastupdate", $time);
 		$this->CONFIG->lastcache = $time;

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -166,11 +166,13 @@ function elgg_disable_simplecache() {
  * 
  * TODO(ewinslow): Move to filesystem package
  *
- * @param string $dir
+ * @param string $dir   The directory
+ * @param bool   $empty If true, we just empty the directory
+ *
  * @return boolean Whether the dir was successfully deleted.
  * @access private
  */
-function _elgg_rmdir($dir) {
+function _elgg_rmdir($dir, $empty = false) {
 	$files = array_diff(scandir($dir), array('.', '..'));
 	
 	foreach ($files as $file) {
@@ -179,6 +181,10 @@ function _elgg_rmdir($dir) {
 		} else {
 			unlink("$dir/$file");
 		}
+	}
+
+	if ($empty) {
+		return true;
 	}
 	
 	return rmdir($dir);

--- a/views/default/elgg/require_config.js.php
+++ b/views/default/elgg/require_config.js.php
@@ -8,7 +8,7 @@ unset($amdConfig['deps']);
 // Require is currently an Elgg shim. Convert it to a RequireJS config
 ?>
 // <script>
-require = <?php echo json_encode($amdConfig); ?>;
+require = <?php echo json_encode($amdConfig, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES); ?>;
 
 <?php
 // Note we don't process the require() queue yet because it may require('elgg')

--- a/views/default/languages.js.php
+++ b/views/default/languages.js.php
@@ -33,4 +33,4 @@ if ($language != 'en' && isset($all_translations[$language])) {
 }
 
 ?>
-define(<?php echo json_encode($translations); ?>);
+define(<?php echo json_encode($translations, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES); ?>);


### PR DESCRIPTION
So `foo/bar` is verboten because it would conflict with `foo/bar/baz`, but `foo/bar.html` is A-OK, because it won't conflict with `foo/bar/baz.html`.

This opens up is the possibility that we'd be able to serve cached
files directly off disk instead of via PHP for performance.

This also makes it much easier to explore the available cached resources
by navigating to dataroot/views_simplecache and browsing around.

Fixes #8381

To-do:
- [x] submit #8526
- [x] Mark as breaking change
- [x] Send 403 error if view does not have a proper file extension
- [x] Prefix root gitignore files with `/`
- [x] Fix the given symlink command
- [x] Empty the views_simplecache dir on invalidate()
