### PR TITLE
feature(views): Nearly all plugin static resources are in views

### DIFF
--- a/engine/classes/Elgg/Application/CacheHandler.php
+++ b/engine/classes/Elgg/Application/CacheHandler.php
@@ -242,7 +242,9 @@ class CacheHandler {
 			case 'html':
 			case 'xml':
 				return "text/$extension";
-			
+
+			case 'swf':
+				return 'application/x-shockwave-flash';
 			default:
 				break;
 		}

--- a/js/lib/configuration.js
+++ b/js/lib/configuration.js
@@ -12,20 +12,27 @@ elgg.get_site_url = function() {
 /**
  * Get the URL for the cached file
  * 
- * @param {String} type
- * @param {String} view
+ * @param {String} view    The full view name
+ * @param {String} subview If the first arg is "css" or "js", the rest of the view name
  * @return {String} The site URL.
  */
-elgg.get_simplecache_url = function(type, view) {
-	var lastcache;
+elgg.get_simplecache_url = function(view, subview) {
+	var lastcache, path;
+
 	if (elgg.config.simplecache_enabled) {
 		lastcache = elgg.config.lastcache;
 	} else {
 		lastcache = 0;
 	}
-	if ((type === 'js' || type === 'css') && 0 === view.indexOf(type + '/')) {
-		view = view.substr(type.length + 1);
+
+	if (!subview) {
+		path = '/cache/' + lastcache + '/' + elgg.config.viewtype + '/' + view;
+	} else {
+		if ((view === 'js' || view === 'css') && 0 === subview.indexOf(view + '/')) {
+			subview = subview.substr(view.length + 1);
+		}
+		path = '/cache/' + lastcache + '/' + elgg.config.viewtype + '/' + view + '/' + subview;
 	}
-	var path = '/cache/' + lastcache + '/' + elgg.config.viewtype + '/' + type + '/' + view;
+
 	return elgg.normalize_url(path);
 };

--- a/mod/aalborg_theme/start.php
+++ b/mod/aalborg_theme/start.php
@@ -109,7 +109,7 @@ function aalborg_theme_setup_head($hook, $type, $data) {
 
 	$data['links']['apple-touch-icon'] = array(
 		'rel' => 'apple-touch-icon',
-		'href' => elgg_normalize_url('mod/aalborg_theme/graphics/homescreen.png'),
+		'href' => elgg_get_simplecache_url('aalborg_theme/homescreen.png'),
 	);
 
 	return $data;

--- a/mod/aalborg_theme/views.php
+++ b/mod/aalborg_theme/views.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+	'default' => [
+		'aalborg_theme/avatar_menu_arrows.png' => __DIR__ . '/graphics/avatar_menu_arrows.png',
+		'allborg_theme/homescreen.png' => __DIR__ . '/graphics/homescreen.png',
+	],
+];

--- a/mod/aalborg_theme/views/default/css/elements/icons.php
+++ b/mod/aalborg_theme/views/default/css/elements/icons.php
@@ -110,13 +110,13 @@
 .elgg-icon-hover-menu-hover,
 .elgg-icon-hover-menu:hover,
 :focus > .elgg-icon-hover-menu {
-	background: transparent url(<?php echo elgg_get_site_url();?>mod/aalborg_theme/graphics/avatar_menu_arrows.png) no-repeat;
+	background: transparent url(<?= elgg_get_simplecache_url('aalborg_theme/avatar_menu_arrows.png') ?>) no-repeat;
 	background-position: right bottom;
 	width: 100%;
 	height: 100%;
 }
 .elgg-icon-hover-menu {
-	background: transparent url(<?php echo elgg_get_site_url();?>mod/aalborg_theme/graphics/avatar_menu_arrows.png) no-repeat;
+	background: transparent url(<?= elgg_get_simplecache_url('aalborg_theme/avatar_menu_arrows.png') ?>) no-repeat;
 	background-position: right bottom;
 	width: 100%;
 	height: 100%;

--- a/mod/aalborg_theme/views/default/notifications/css.php
+++ b/mod/aalborg_theme/views/default/notifications/css.php
@@ -65,16 +65,16 @@
 	display: block;
 }
 #notificationstable td.emailtogglefield a.emailtoggleOff {
-	background: url(<?php echo elgg_get_site_url(); ?>mod/notifications/graphics/icon_notifications_email.gif) no-repeat right 2px;
+	background: url(<?= elgg_get_simplecache_url('notifications/icon_notifications_email.gif'); ?>) no-repeat right 2px;
 }
 #notificationstable td.emailtogglefield a.emailtoggleOn {
-	background: url(<?php echo elgg_get_site_url(); ?>mod/notifications/graphics/icon_notifications_email.gif) no-repeat right -36px;
+	background: url(<?= elgg_get_simplecache_url('notifications/icon_notifications_email.gif'); ?>) no-repeat right -36px;
 }
 #notificationstable td.sitetogglefield a.sitetoggleOff {
-	background: url(<?php echo elgg_get_site_url(); ?>mod/notifications/graphics/icon_notifications_site.gif) no-repeat right 2px;
+	background: url(<?= elgg_get_simplecache_url('notifications/icon_notifications_site.gif'); ?>) no-repeat right 2px;
 }
 #notificationstable td.sitetogglefield a.sitetoggleOn {
-	background: url(<?php echo elgg_get_site_url(); ?>mod/notifications/graphics/icon_notifications_site.gif) no-repeat right -37px;
+	background: url(<?= elgg_get_simplecache_url('notifications/icon_notifications_site.gif'); ?>) no-repeat right -37px;
 }
 .notification_friends,
 .notification_personal,

--- a/mod/bookmarks/views.php
+++ b/mod/bookmarks/views.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+	'default' => [
+		'bookmarks/bookmark.gif' => __DIR__ . '/graphics/bookmark.gif',
+		'bookmarks/bookmarklet.gif' => __DIR__ . '/graphics/bookmarklet.gif',
+	],
+];

--- a/mod/bookmarks/views/default/bookmarks/bookmarklet.php
+++ b/mod/bookmarks/views/default/bookmarks/bookmarklet.php
@@ -21,7 +21,7 @@ if (!$name && ($user = elgg_get_logged_in_user_entity())) {
 
 $url = elgg_get_site_url();
 $img = elgg_view('output/img', array(
-	'src' => 'mod/bookmarks/graphics/bookmarklet.gif',
+	'src' => elgg_get_simplecache_url('bookmarks/bookmarklet.gif'),
 	'alt' => $title,
 ));
 $bookmarklet = "<a href=\"javascript:location.href='{$url}bookmarks/add/$guid?address='"

--- a/mod/bookmarks/views/default/bookmarks/css.php
+++ b/mod/bookmarks/views/default/bookmarks/css.php
@@ -1,3 +1,3 @@
 .elgg-icon-bookmark {
-	background: transparent url(<?php echo elgg_get_site_url();?>mod/bookmarks/graphics/bookmark.gif);
+	background: transparent url(<?= elgg_get_simplecache_url('bookmarks/bookmark.gif'); ?>);
 }

--- a/mod/ckeditor/start.php
+++ b/mod/ckeditor/start.php
@@ -15,11 +15,9 @@ function ckeditor_init() {
 	elgg_extend_view('css/elgg/wysiwyg.css', 'css/elements/typography', 100);
 
 	elgg_define_js('ckeditor', array(
-		'src' => '/mod/ckeditor/vendors/ckeditor/ckeditor.js',
 		'exports' => 'CKEDITOR',
 	));
 	elgg_define_js('jquery.ckeditor', array(
-		'src' => '/mod/ckeditor/vendors/ckeditor/adapters/jquery.js',
 		'deps' => array('jquery', 'ckeditor'),
 		'exports' => 'jQuery.fn.ckeditor',
 	));

--- a/mod/ckeditor/views.php
+++ b/mod/ckeditor/views.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+	'default' => [
+		'js/ckeditor.js' => __DIR__ . '/vendors/ckeditor/ckeditor.js',
+		'js/jquery.ckeditor.js' => __DIR__ . '/vendors/ckeditor/adapters/jquery.js',
+	],
+];

--- a/mod/ckeditor/views/default/js/elgg/ckeditor.js
+++ b/mod/ckeditor/views/default/js/elgg/ckeditor.js
@@ -3,7 +3,7 @@ define(function(require) {
 	var $ = require('jquery'); require('jquery.ckeditor');
 	var CKEDITOR = require('ckeditor');
 
-	CKEDITOR.plugins.addExternal('blockimagepaste', elgg.get_site_url() + 'mod/ckeditor/views/default/js/elgg/ckeditor/blockimagepaste.js', '');
+	CKEDITOR.plugins.addExternal('blockimagepaste', elgg.get_simplecache_url('js/elgg/ckeditor/blockimagepaste.js'), '');
 	
 	var elggCKEditor = {
 

--- a/mod/ckeditor/views/default/js/elgg/ckeditor/config.js
+++ b/mod/ckeditor/views/default/js/elgg/ckeditor/config.js
@@ -13,7 +13,7 @@ define(function(require) {
 		language: elgg.get_language(),
 		skin: 'moono',
 		uiColor: '#EEEEEE',
-		contentsCss: elgg.get_simplecache_url('css', 'elgg/wysiwyg.css'),
+		contentsCss: elgg.get_simplecache_url('css/elgg/wysiwyg.css'),
 		disableNativeSpellChecker: false,
 		disableNativeTableHandles: false,
 		removeDialogTabs: 'image:advanced;image:Link;link:advanced;link:target',

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -23,11 +23,10 @@ function developers_init() {
 	elgg_register_action('developers/settings', "$action_base/settings.php", 'admin');
 
 	elgg_define_js('jquery.jstree', array(
-		'src' => '/mod/developers/vendors/jsTree/jquery.jstree.js',
 		'exports' => 'jQuery.fn.jstree',
 		'deps' => array('jquery'),
 	));
-	elgg_register_css('jquery.jstree', '/mod/developers/vendors/jsTree/themes/default/style.css');
+	elgg_register_css('jquery.jstree', elgg_get_simplecache_url('jquery.jstree.css'));
 
 	elgg_require_js('elgg/dev');
 }

--- a/mod/developers/views.php
+++ b/mod/developers/views.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+	'default' => [
+		'js/jquery.jstree.js' => __DIR__ . '/vendors/jsTree/jquery.jstree.js',
+		'jquery.jstree.css' => __DIR__ . '/vendors/jsTree/themes/default/style.css',
+	],
+];

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -239,8 +239,8 @@ function file_owner_block_menu($hook, $type, $return, $params) {
 /**
  * Registers page menu items for file type filtering and returns a view
  *
- * @param int       $container_guid The GUID of the container of the files
- * @param bool      $friends        Whether we're looking at the container or the container's friends
+ * @param int  $container_guid The GUID of the container of the files
+ * @param bool $friends        Whether we're looking at the container or the container's friends
  * 
  * @return string The typecloud
  */
@@ -414,7 +414,7 @@ function file_set_icon_url($hook, $type, $url, $params) {
 			$ext = '';
 		}
 
-		$url = "mod/file/graphics/icons/{$type}{$ext}.gif";
+		$url = elgg_get_simplecache_url("file/icons/{$type}{$ext}.gif");
 		$url = elgg_trigger_plugin_hook('file:icon:url', 'override', $params, $url);
 		return $url;
 	}

--- a/mod/file/views.php
+++ b/mod/file/views.php
@@ -1,0 +1,16 @@
+<?php
+
+return call_user_func(function() {
+	$dir = dir(__DIR__ . '/graphics/icons');
+	$ret = [];
+
+	while (false !== ($entry = $dir->read())) {
+		if ($entry[0] === '.') {
+			continue;
+		}
+
+		$ret['default']["file/icons/$entry"] = "{$dir->path}/$entry";
+	}
+
+	return $ret;
+});

--- a/mod/groups/icon.php
+++ b/mod/groups/icon.php
@@ -43,11 +43,12 @@ if ($filehandler->open("read")) {
 }
 
 if (!$success) {
-	$location = elgg_get_plugins_path() . "groups/graphics/default{$size}.gif";
-	$contents = @file_get_contents($location);
+	$contents = elgg_view("groups/default{$size}.gif");
+	header("Content-type: image/gif");
+} else {
+	header("Content-type: image/jpeg");
 }
 
-header("Content-type: image/jpeg");
 header('Expires: ' . gmdate('D, d M Y H:i:s \G\M\T', strtotime("+10 days")), true);
 header("Pragma: public");
 header("Cache-Control: public");

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -329,7 +329,7 @@ function groups_set_icon_url($hook, $type, $url, $params) {
 		return "groupicon/$group->guid/$size/$icontime.jpg";
 	}
 
-	return "mod/groups/graphics/default{$size}.gif";
+	return elgg_get_simplecache_url("groups/default{$size}.gif");
 }
 
 /**

--- a/mod/groups/views.php
+++ b/mod/groups/views.php
@@ -1,0 +1,9 @@
+<?php
+
+return call_user_func(function() {
+	foreach (['large', 'medium', 'small', 'tiny'] as $size) {
+		$ret['default']["groups/default$size.gif"] = __DIR__ . "/graphics/default$size.gif";
+	}
+
+	return $ret;
+});

--- a/mod/notifications/views.php
+++ b/mod/notifications/views.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+	'default' => [
+		'notifications/icon_notifications_email.gif' => __DIR__ . '/graphics/icon_notifications_email.gif',
+		'notifications/icon_notifications_site.gif' => __DIR__ . '/graphics/icon_notifications_site.gif',
+	],
+];

--- a/mod/notifications/views/default/notifications/css.php
+++ b/mod/notifications/views/default/notifications/css.php
@@ -64,16 +64,16 @@
 	display: block;
 }
 #notificationstable td.emailtogglefield a.emailtoggleOff {
-	background: url(<?php echo elgg_get_site_url(); ?>mod/notifications/graphics/icon_notifications_email.gif) no-repeat right 2px;
+	background: url(<?= elgg_get_simplecache_url('notifications/icon_notifications_email.gif'); ?>) no-repeat right 2px;
 }
 #notificationstable td.emailtogglefield a.emailtoggleOn {
-	background: url(<?php echo elgg_get_site_url(); ?>mod/notifications/graphics/icon_notifications_email.gif) no-repeat right -36px;
+	background: url(<?= elgg_get_simplecache_url('notifications/icon_notifications_email.gif'); ?>) no-repeat right -36px;
 }
 #notificationstable td.sitetogglefield a.sitetoggleOff {
-	background: url(<?php echo elgg_get_site_url(); ?>mod/notifications/graphics/icon_notifications_site.gif) no-repeat right 2px;
+	background: url(<?= elgg_get_simplecache_url('notifications/icon_notifications_site.gif'); ?>) no-repeat right 2px;
 }
 #notificationstable td.sitetogglefield a.sitetoggleOn {
-	background: url(<?php echo elgg_get_site_url(); ?>mod/notifications/graphics/icon_notifications_site.gif) no-repeat right -37px;
+	background: url(<?= elgg_get_simplecache_url('notifications/icon_notifications_site.gif'); ?>) no-repeat right -37px;
 }
 .notification_friends,
 .notification_personal,

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -205,10 +205,10 @@ function pages_icon_url_override($hook, $type, $returnvalue, $params) {
 			case 'topbar':
 			case 'tiny':
 			case 'small':
-				return 'mod/pages/images/pages.gif';
+				return elgg_get_simplecache_url('pages/pages.gif');
 				break;
 			default:
-				return 'mod/pages/images/pages_lrg.gif';
+				return elgg_get_simplecache_url('pages/pages_lrg.gif');
 				break;
 		}
 	}

--- a/mod/pages/views.php
+++ b/mod/pages/views.php
@@ -1,0 +1,7 @@
+<?php
+return [
+	'default' => [
+		'pages/pages.gif' => __DIR__ . '/images/pages.gif',
+		'pages/pages_lrg.gif' => __DIR__ . '/images/pages_lrg.gif',
+	],
+];

--- a/mod/reportedcontent/views.php
+++ b/mod/reportedcontent/views.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+	'default' => [
+		'reportedcontent/icon_reportthis.gif' => __DIR__ . '/graphics/icon_reportthis.gif',
+	],
+];

--- a/mod/reportedcontent/views/default/reportedcontent/css.php
+++ b/mod/reportedcontent/views/default/reportedcontent/css.php
@@ -10,5 +10,5 @@
 ?>
 /* Reported Content */
 .elgg-icon-report-this {
-	background: url(<?php echo elgg_get_site_url(); ?>mod/reportedcontent/graphics/icon_reportthis.gif) no-repeat left top;
+	background: url(<?php echo elgg_get_simplecache_url('reportedcontent/icon_reportthis.gif'); ?>) no-repeat left top;
 }

--- a/mod/twitter_api/views.php
+++ b/mod/twitter_api/views.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+	'default' => [
+		'twitter_api/sign-in-with-twitter-d.png' => __DIR__ . '/graphics/sign-in-with-twitter-d.png',
+		'twitter_api/sign-in-with-twitter-l.png' => __DIR__ . '/graphics/sign-in-with-twitter-l.png',
+		'twitter_api/sign-in-with-twitter.gif' => __DIR__ . '/graphics/sign-in-with-twitter.gif',
+	],
+];

--- a/mod/twitter_api/views/default/twitter_api/login.php
+++ b/mod/twitter_api/views/default/twitter_api/login.php
@@ -4,7 +4,7 @@
  */
 
 $url = elgg_get_site_url() . 'twitter_api/forward';
-$img_url = elgg_get_site_url() . 'mod/twitter_api/graphics/sign-in-with-twitter-d.png';
+$img_url = elgg_get_simplecache_url('twitter_api/sign-in-with-twitter-d.png');
 
 $login = <<<__HTML
 <div class="login_with_twitter">

--- a/mod/zaudio/start.php
+++ b/mod/zaudio/start.php
@@ -14,11 +14,9 @@ function zaudio_init() {
 	elgg_extend_view('css/elgg', 'zaudio/css');
 
 	elgg_define_js('AudioPlayer', [
-		'src' => 'mod/zaudio/audioplayer/audio-player.20150521.min.js',
 		'exports' => 'AudioPlayer',
 	]);
 
 	// leave library registered for BC
-	$js_url = elgg_get_site_url() . 'mod/zaudio/audioplayer/audio-player.20150521.min.js';
-	elgg_register_js('elgg.zaudio', $js_url);
+	elgg_register_js('elgg.zaudio', elgg_get_simplecache_url('js/AudioPlayer.js'));
 }

--- a/mod/zaudio/views.php
+++ b/mod/zaudio/views.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+	'default' => [
+		'js/AudioPlayer.js' => __DIR__ . '/audioplayer/audio-player.20150521.min.js',
+		'AudioPlayer.swf' => __DIR__ . '/audioplayer/player.20150521.swf',
+	],
+];

--- a/mod/zaudio/views/default/js/elgg/zaudio.js
+++ b/mod/zaudio/views/default/js/elgg/zaudio.js
@@ -7,7 +7,7 @@ define(function (require) {
 	// for unique IDs
 	var i = 0;
 
-	AudioPlayer.setup(elgg.get_site_url() + "mod/zaudio/audioplayer/player.20150521.swf", {width: 290});
+	AudioPlayer.setup(elgg.get_simplecache_url('AudioPlayer.swf'), {width: 290});
 
 	function embed(element) {
 		var config = $(element).data().zaudioPlayer;


### PR DESCRIPTION
Makes elgg.get_simplecache_url() match the PHP version.
Associates .swf files with the right Content-Type.
groups/icon.php sends the right Content-Type for gifs.

(this is a follow up to #8513)
