### PR TITLE
chore(amd): Make the requires in foot more readable

### DIFF
--- a/views/default/page/elements/foot.php
+++ b/views/default/page/elements/foot.php
@@ -11,5 +11,5 @@ foreach ($js as $script) { ?>
 $deps = _elgg_services()->amdConfig->getDependencies();
 ?>
 <script>
-require(<?php echo json_encode($deps); ?>);
+require(<?= json_encode($deps, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT); ?>);
 </script>


### PR DESCRIPTION
Before:

``` html
<script>
require(["elgg\/dev","elgg\/reportedcontent"]);
</script>
```

After:

``` html
<script>
require([
    "elgg/dev",
    "elgg/reportedcontent"
]);
</script>
```
