### PR TITLE
chore(relationships): Removes the deprecated relationship create event

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -143,6 +143,11 @@ Comments plugin hook
 
 Plugins can now return an empty string from ``'comments',$entity_type`` hook in order to override the default comments component view. To force the default comments component, your plugin must return ``false``. If you were using empty strings to force the default comments view, you need to update your hook handlers to return ``false``.
 
+Creating a relationship triggers only one event
+-----------------------------------------------
+
+Entity relationship creation no longer fires the legacy "create" event using the relationship name as the type. E.g. Listening for the ``"create", "member"`` event will no longer capture group membership additions. Use the ``"create", "relationship"`` event.
+
 Dropped login-over-https feature
 --------------------------------
 

--- a/engine/classes/Elgg/Database/RelationshipsTable.php
+++ b/engine/classes/Elgg/Database/RelationshipsTable.php
@@ -117,11 +117,8 @@ class RelationshipsTable {
 		if ($id !== false) {
 			$obj = get_relationship($id);
 	
-			// this event has been deprecated in 1.9. Use 'create', 'relationship'
-			$result_old = _elgg_services()->events->trigger('create', $relationship, $obj);
-	
 			$result = _elgg_services()->events->trigger('create', 'relationship', $obj);
-			if ($result && $result_old) {
+			if ($result) {
 				return true;
 			} else {
 				delete_relationship($result);


### PR DESCRIPTION
Fixes #5998

BREAKING CHANGE:
Relationship additions only fire the “create”, “relationship” event.

(Motivation for this: https://github.com/Elgg/Elgg/issues/5993#issue-18745896)
