### PR TITLE
fix(web_services): no longer uses deprecated export global

### DIFF
--- a/mod/web_services/views/json/api/output.php
+++ b/mod/web_services/views/json/api/output.php
@@ -9,9 +9,4 @@
 
 $result = $vars['result'];
 $export = $result->export();
-
-global $jsonexport;
-
-// with api calls, we don't want extra baggage found in other json views
-// so we skip the associative array
-$jsonexport = $export;
+echo json_encode($export);


### PR DESCRIPTION
Web services API now outputs json encoded string rather than relying on a deprecated $jsonexport global
