### PR TITLE
perf(engine): only update attributes/metadata if value is changed

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -75,14 +75,14 @@ abstract class ElggEntity extends \ElggData implements
 	
 	/**
 	 * Tells how many tables are going to need to be searched in order to fully populate this object
-	 * 
+	 *
 	 * @var int
 	 */
 	protected $tables_split;
 	
 	/**
 	 * Tells how many tables describing object have been loaded thus far
-	 * 
+	 *
 	 * @var int
 	 */
 	protected $tables_loaded;
@@ -178,18 +178,23 @@ abstract class ElggEntity extends \ElggData implements
 
 	/**
 	 * Set an attribute or metadata value for this entity
-	 * 
+	 *
 	 * Anything that is not an attribute is saved as metadata.
-	 * 
-	 * @warning Metadata set this way will inherit the entity's owner and 
+	 *
+	 * @warning Metadata set this way will inherit the entity's owner and
 	 * access ID. If you want more control over metadata, use \ElggEntity::setMetadata()
-	 * 
+	 *
 	 * @param string $name  Name of the attribute or metadata
 	 * @param mixed  $value The value to be set
 	 * @return void
 	 * @see \ElggEntity::setMetadata()
 	 */
 	public function __set($name, $value) {
+		if ($this->$name === $value) {
+			// quick return if value is not changing
+			return;
+		}
+		
 		if (array_key_exists($name, $this->attributes)) {
 			// Certain properties should not be manually changed!
 			switch ($name) {
@@ -234,13 +239,13 @@ abstract class ElggEntity extends \ElggData implements
 
 	/**
 	 * Get an attribute or metadata value
-	 * 
+	 *
 	 * If the name matches an attribute, the attribute is returned. If metadata
 	 * does not exist with that name, a null is returned.
 	 *
 	 * This only returns an array if there are multiple values for a particular
 	 * $name key.
-	 * 
+	 *
 	 * @param string $name Name of the attribute or metadata
 	 * @return mixed
 	 */
@@ -270,14 +275,14 @@ abstract class ElggEntity extends \ElggData implements
 
 	/**
 	 * Get the entity's display name
-	 * 
+	 *
 	 * @return string The title or name of this entity.
 	 */
 	abstract public function getDisplayName();
 
 	/**
 	 * Sets the title or name of this entity.
-	 * 
+	 *
 	 * @param string $displayName The title or name of this entity.
 	 * @return void
 	 */
@@ -1053,7 +1058,7 @@ abstract class ElggEntity extends \ElggData implements
 			_elgg_services()->logger->warning($message);
 			
 			return false;
-		}		
+		}
 		
 		$return = $this->canEdit($user_guid);
 
@@ -1353,7 +1358,7 @@ abstract class ElggEntity extends \ElggData implements
 	public function getIconURL($params = array()) {
 		if (is_array($params)) {
 			$size = elgg_extract('size', $params, 'medium');
-		} else {	
+		} else {
 			$size = is_string($params) ? $params : 'medium';
 			$params = array();
 		}
@@ -1705,7 +1710,7 @@ abstract class ElggEntity extends \ElggData implements
 
 	/**
 	 * Stores non-attributes from the loading of the entity as volatile data
-	 * 
+	 *
 	 * @param array $data Key value array
 	 * @return void
 	 */
@@ -1722,7 +1727,7 @@ abstract class ElggEntity extends \ElggData implements
 	 * @internal This is used when the same entity is selected twice during a
 	 * request in case different select clauses were used to load different data
 	 * into volatile data.
-	 * 
+	 *
 	 * @param \stdClass $row DB row with new entity data
 	 * @return bool
 	 * @access private
@@ -1910,7 +1915,7 @@ abstract class ElggEntity extends \ElggData implements
 		}
 		
 		// first check if we can delete this entity
-		// NOTE: in Elgg <= 1.10.3 this was after the delete event, 
+		// NOTE: in Elgg <= 1.10.3 this was after the delete event,
 		// which could potentially remove some content if the user didn't have access
 		if (!$this->canDelete()) {
 			return false;
@@ -2025,7 +2030,7 @@ abstract class ElggEntity extends \ElggData implements
 
 	/**
 	 * Prepare an object copy for toObject()
-	 * 
+	 *
 	 * @param \stdClass $object Object representation of the entity
 	 * @return \stdClass
 	 */
@@ -2148,7 +2153,7 @@ abstract class ElggEntity extends \ElggData implements
 
 	/**
 	 * Returns the end timestamp.
-	 * 
+	 *
 	 * @return int
 	 * @deprecated 1.9
 	 */
@@ -2395,7 +2400,7 @@ abstract class ElggEntity extends \ElggData implements
 	
 	/**
 	 * Remove all access collections owned by this entity
-	 * 
+	 *
 	 * @return bool
 	 * @since 1.11
 	 */


### PR DESCRIPTION
fixes #8043 

Very easy fix to save a lot of dbcalls when editing (went from 118 to 38 on blog edit if nothing was changed). Could not think of anything wrong with this approach.

Sry about the trailing spaces changes, but i believe that was allowed in master now...
