### PR TITLE
security(web_services): api auth is now required by default for exposed methods

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -439,6 +439,18 @@ The metadata ``$entity->view`` no longer specifies the view used to render in ``
 
 Similarly the property ``$annotation->view`` no longer has an effect within ``elgg_view_annotation()``.
 
+
+API authentication for web services is required by default
+----------------------------------------------------------
+
+All exposed methods that do not explicitly set API auth requirement to false, will require API authentication.
+
+You can verify what values are used on your site in one of the following ways:
+
+ - by checking every instance of ``elgg_ws_expose_function()`` (``$require_api_auth`` is the 6th argument accepted by the function)
+ - by accessing web services ``system.api.list`` method, which lists all methods with the type of authentication they require
+ - by dumping the output of ``list_all_apis()`` in PHP
+
 From 1.10 to 1.11
 =================
 

--- a/mod/web_services/start.php
+++ b/mod/web_services/start.php
@@ -126,7 +126,7 @@ $ERRORS = array();
  * @param string $description       (optional) human readable description of the function.
  * @param string $call_method       (optional) Define what http method must be used for
  *                                  this function. Default: GET
- * @param bool   $require_api_auth  (optional) (default is false) Does this method
+ * @param bool   $require_api_auth  (optional) (default is true) Does this method
  *                                  require API authorization? (example: API key)
  * @param bool   $require_user_auth (optional) (default is false) Does this method
  *                                  require user authorization?
@@ -135,7 +135,7 @@ $ERRORS = array();
  * @throws InvalidParameterException
  */
 function elgg_ws_expose_function($method, $function, array $parameters = NULL, $description = "",
-		$call_method = "GET", $require_api_auth = false, $require_user_auth = false) {
+		$call_method = "GET", $require_api_auth = true, $require_user_auth = false) {
 
 	global $API_METHODS;
 


### PR DESCRIPTION
BREAKING CHANGE

All exposed methods that do not set API auth requirement to false will now
require API authentication
