### PR TITLE
perf(simplecache): Faster serving in case symlink not used

### DIFF
--- a/engine/classes/Elgg/Application/CacheHandler.php
+++ b/engine/classes/Elgg/Application/CacheHandler.php
@@ -107,6 +107,15 @@ class CacheHandler {
 		$etag = "\"$ts\"";
 		$this->handle304($etag);
 
+		// trust the client but check for an existing cache file
+		$filename = $config->getVolatile('dataroot') . "views_simplecache/$ts/$viewtype/$view";
+		if (file_exists($filename)) {
+			$this->sendCacheHeaders($etag);
+			readfile($filename);
+			exit;
+		}
+
+		// the hard way
 		$this->application->bootCore();
 
 		elgg_set_viewtype($viewtype);
@@ -117,11 +126,6 @@ class CacheHandler {
 		$lastcache = (int)$config->get('lastcache');
 
 		$filename = $config->getVolatile('dataroot') . "views_simplecache/$lastcache/$viewtype/$view";
-		if (file_exists($filename)) {
-			$this->sendCacheHeaders($etag);
-			readfile($filename);
-			exit;
-		}
 
 		if ($lastcache == $ts) {
 			$this->sendCacheHeaders($etag);


### PR DESCRIPTION
We only need to boot and check `lastcache` time if the client’s given view file doesn’t already exist. This is safe because the path is already verified not to contain `..`.

(we could do this in 1.x if we really want it, but merging might be a pain)
