### PR TITLE
WIP feature(likes): entities are not likeable by default

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -213,10 +213,15 @@ Permission hooks
 	Return boolean for if the user ``$params['user']`` can comment on the entity ``$params['entity']``.
 
 **permissions_check:annotate**
-	Return boolean for if the user ``$params['user']`` can create an annotation with the name
-	``$params['annotation']`` on the entity ``$params['entity']``.
+	Return boolean for if the user ``$params['user']`` can create an annotation ``$params['annotation']`` 
+	on the entity ``$params['entity']``.
 
 	.. warning:: This is functions differently than the ``permissions_check:metadata`` hook by passing the annotation name instead of the metadata object.
+
+**permissions_check:annotate:<annotation_name>**
+	Return boolean for if the user ``$params['user']`` can create an annotation ``$params['annotation']`` 
+	with the name <annotation_name> on the entity ``$params['entity']``. This hook gets triggered before the less granular
+	`permissions_check:annotate` hook.
 
 **permissions_check:annotation**
 	Return boolean for if the user in ``$params['user']`` can edit the annotation ``$params['annotation']`` on the

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -377,6 +377,30 @@ The following views received ``label`` elements around some of the input fields.
 - views/default/forms/admin/plugins/sort.php
 - views/default/forms/login.php
 
+Plugin Likes
+------------
+
+Objects are no longer likeable by default. If you need your content to support liking, you will need to register a plugin hook for it. An example on how to do that is shown below.
+
+.. code:: php
+
+    elgg_register_plugin_hook_handler('permissions_check:annotate:likes', 'object', 'myplugin_permissions_check_annotate');
+
+    function myplugin_permissions_check_annotate($hook, $type, $return, $params) {
+        if ($return !== false) {
+            // we only want to change to true if it is false
+            return;
+        }
+
+        $user = elgg_extract('user', $params);
+        $entity = elgg_extract('entity', $params);
+
+        $isUser = elgg_instanceof($user, 'user');
+        $isCorrectEntity = elgg_instanceof($entity, 'object', 'mysubtype');
+
+        return $isUser && $isCorrectEntity ? true : null;
+    }
+
 Plugin Messages
 ---------------
 

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1177,6 +1177,11 @@ abstract class ElggEntity extends \ElggData implements
 			'user' => $user,
 			'annotation_name' => $annotation_name,
 		);
+		
+		if (!empty($annotation_name)) {
+			$return = _elgg_services()->hooks->trigger("permissions_check:annotate:{$annotation_name}", $this->type, $params, $return);
+		}
+		
 		return _elgg_services()->hooks->trigger('permissions_check:annotate', $this->type, $params, $return);
 	}
 

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -68,6 +68,9 @@ function blog_init() {
 
 	// ecml
 	elgg_register_plugin_hook_handler('get_views', 'ecml', 'blog_ecml_views_hook');
+	
+	// Permissions
+	elgg_register_plugin_hook_handler('permissions_check:annotate:likes', 'object', 'blog_permissions_check_annotate');
 }
 
 /**
@@ -277,4 +280,29 @@ function blog_run_upgrades($event, $type, $details) {
 
 		elgg_set_plugin_setting('upgrade_version', 1, 'blogs');
 	}
+}
+
+/**
+ * Allow liking of a blog
+ *
+ * @param string $hook   "permissions_check:annotate:likes"
+ * @param string $type   "object"
+ * @param array  $return Current value
+ * @param array  $params Hook parameters
+ *
+ * @return void|true
+ */
+function blog_permissions_check_annotate($hook, $type, $return, $params) {
+	if ($return !== false) {
+		// we only want to change to true if it is false
+		return;
+	}
+	
+	$user = elgg_extract('user', $params);
+	$entity = elgg_extract('entity', $params);
+	
+	$isUser = elgg_instanceof($user, 'user');
+	$isBlog = elgg_instanceof($entity, 'object', 'blog');
+	
+	return $isUser && $isBlog ? true : null;
 }

--- a/mod/bookmarks/start.php
+++ b/mod/bookmarks/start.php
@@ -67,6 +67,9 @@ function bookmarks_init() {
 	// Groups
 	add_group_tool_option('bookmarks', elgg_echo('bookmarks:enablebookmarks'), true);
 	elgg_extend_view('groups/tool_latest', 'bookmarks/group_module');
+	
+	// Permissions
+	elgg_register_plugin_hook_handler('permissions_check:annotate:likes', 'object', 'bookmarks_permissions_check_annotate');
 }
 
 /**
@@ -160,7 +163,7 @@ function bookmark_set_url($hook, $type, $url, $params) {
 
 /**
  * Add a menu item to an ownerblock
- * 
+ *
  * @param string $hook
  * @param string $type
  * @param array  $return
@@ -184,7 +187,7 @@ function bookmarks_owner_block_menu($hook, $type, $return, $params) {
 
 /**
  * Prepare a notification message about a new bookmark
- * 
+ *
  * @param string                          $hook         Hook name
  * @param string                          $type         Hook type
  * @param Elgg\Notifications\Notification $notification The notification to prepare
@@ -201,7 +204,7 @@ function bookmarks_prepare_notification($hook, $type, $notification, $params) {
 	$descr = $entity->description;
 	$title = $entity->title;
 
-	$notification->subject = elgg_echo('bookmarks:notify:subject', array($title), $language); 
+	$notification->subject = elgg_echo('bookmarks:notify:subject', array($title), $language);
 	$notification->body = elgg_echo('bookmarks:notify:body', array(
 		$owner->name,
 		$title,
@@ -255,4 +258,29 @@ function bookmarks_page_menu($hook, $type, $return, $params) {
 function bookmarks_ecml_views_hook($hook, $type, $return, $params) {
 	$return['object/bookmarks'] = elgg_echo('item:object:bookmarks');
 	return $return;
+}
+
+/**
+ * Allow liking of a bookmark
+ *
+ * @param string $hook   "permissions_check:annotate:likes"
+ * @param string $type   "object"
+ * @param array  $return Current value
+ * @param array  $params Hook parameters
+ *
+ * @return void|false
+ */
+function bookmarks_permissions_check_annotate($hook, $type, $return, $params) {
+	if ($return !== false) {
+		// we only want to change to true if it is false
+		return;
+	}
+
+	$user = elgg_extract('user', $params);
+	$entity = elgg_extract('entity', $params);
+
+	$isUser = elgg_instanceof($user, 'user');
+	$isBookmark = elgg_instanceof($entity, 'object', 'bookmarks');
+
+	return $isUser && $isBookmark ? true : null;
 }

--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -61,6 +61,9 @@ function discussion_init() {
 
 	// allow ecml in discussion
 	elgg_register_plugin_hook_handler('get_views', 'ecml', 'discussion_ecml_views_hook');
+
+	// Permissions
+	elgg_register_plugin_hook_handler('permissions_check:annotate:likes', 'object', 'discussion_permissions_check_annotate');
 }
 
 /**
@@ -576,4 +579,30 @@ function discussion_search_discussion($hook, $type, $value, $params) {
 
 	// trigger the 'normal' object search as it can handle the added options
 	return elgg_trigger_plugin_hook('search', 'object', $params, array());
+}
+
+/**
+ * Allow liking of a discussion
+ *
+ * @param string $hook   "permissions_check:annotate:likes"
+ * @param string $type   "object"
+ * @param array  $return Current value
+ * @param array  $params Hook parameters
+ *
+ * @return void|false
+ */
+function discussion_permissions_check_annotate($hook, $type, $return, $params) {
+	if ($return !== false) {
+		// we only want to change to true if it is false
+		return;
+	}
+
+	$user = elgg_extract('user', $params);
+	$entity = elgg_extract('entity', $params);
+
+	$isUser = elgg_instanceof($user, 'user');
+	$isDiscussion = elgg_instanceof($entity, 'object', 'discussion');
+	$isReply = elgg_instanceof($entity, 'object', 'discussion_reply');
+
+	return $isUser && ($isDiscussion || $isReply) ? true : null;
 }

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -88,6 +88,9 @@ function file_init() {
 	elgg_register_menu_item('embed', $item);
 
 	elgg_extend_view('theme_sandbox/icons', 'file/theme_sandbox/icons/files');
+	
+	// Permissions
+	elgg_register_plugin_hook_handler('permissions_check:annotate:likes', 'object', 'file_permissions_check_annotate');
 }
 
 /**
@@ -241,7 +244,7 @@ function file_owner_block_menu($hook, $type, $return, $params) {
  *
  * @param int  $container_guid The GUID of the container of the files
  * @param bool $friends        Whether we're looking at the container or the container's friends
- * 
+ *
  * @return string The typecloud
  */
 function file_get_type_cloud($container_guid = "", $friends = false) {
@@ -441,4 +444,29 @@ function file_handle_object_delete($event, $type, ElggObject $file) {
 			$delfile->delete();
 		}
 	}
+}
+
+/**
+ * Allow liking of a file
+ *
+ * @param string $hook   "permissions_check:annotate:likes"
+ * @param string $type   "object"
+ * @param array  $return Current value
+ * @param array  $params Hook parameters
+ *
+ * @return void|false
+ */
+function file_permissions_check_annotate($hook, $type, $return, $params) {
+	if ($return !== false) {
+		// we only want to change to true if it is false
+		return;
+	}
+
+	$user = elgg_extract('user', $params);
+	$entity = elgg_extract('entity', $params);
+
+	$isUser = elgg_instanceof($user, 'user');
+	$isFile = elgg_instanceof($entity, 'object', 'file');
+
+	return $isUser && $isFile ? true : null;
 }

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -84,6 +84,9 @@ function groups_init() {
 	elgg_register_plugin_hook_handler('access:collections:write', 'all', 'groups_write_acl_plugin_hook', 600);
 	elgg_register_plugin_hook_handler('default', 'access', 'groups_access_default_override');
 
+	// Permissions
+	elgg_register_plugin_hook_handler('permissions_check:annotate:likes', 'group', 'groups_permissions_check_annotate');
+	
 	// Register profile menu hook
 	elgg_register_plugin_hook_handler('profile_menu', 'profile', 'activity_profile_menu');
 
@@ -760,4 +763,25 @@ function groups_invitationrequest_menu_setup($hook, $type, $menu, $params) {
 	));
 
 	return $menu;
+}
+
+/**
+ * Allow liking of a group
+ *
+ * @param string $hook   "permissions_check:annotate:likes"
+ * @param string $type   "group"
+ * @param array  $return Current value
+ * @param array  $params Hook parameters
+ *
+ * @return void|true
+ */
+function groups_permissions_check_annotate($hook, $type, $return, $params) {
+	if ($return !== false) {
+		// we only want to change to true if it is false
+		return;
+	}
+
+	$user = elgg_extract('user', $params);
+	
+	return elgg_instanceof($user, 'user') ? true : null;
 }

--- a/mod/likes/start.php
+++ b/mod/likes/start.php
@@ -18,7 +18,8 @@ function likes_init() {
 	elgg_register_plugin_hook_handler('register', 'menu:river', 'likes_river_menu_setup', 400);
 	elgg_register_plugin_hook_handler('register', 'menu:entity', 'likes_entity_menu_setup', 400);
 	elgg_register_plugin_hook_handler('permissions_check', 'annotation', 'likes_permissions_check');
-
+	elgg_register_plugin_hook_handler('permissions_check:annotate:likes', 'all', 'likes_permissions_check_annotate', 0);
+	
 	$actions_base = __DIR__ . '/actions/likes';
 	elgg_register_action('likes/add', "$actions_base/add.php");
 	elgg_register_action('likes/delete', "$actions_base/delete.php");
@@ -28,12 +29,12 @@ function likes_init() {
 
 /**
  * Only allow annotation owner (or someone who can edit the owner, like an admin) to delete like
- * 
+ *
  * @param string $hook   "permissions_check"
  * @param string $type   "annotation"
  * @param array  $return Current value
  * @param array  $params Hook parameters
- * 
+ *
  * @return bool
  */
 function likes_permissions_check($hook, $type, $return, $params) {
@@ -49,6 +50,20 @@ function likes_permissions_check($hook, $type, $return, $params) {
 	}
 	
 	return $owner->canEdit();
+}
+
+/**
+ * By default disallow liking of an entity
+ *
+ * @param string $hook   "permissions_check:annotate:likes"
+ * @param string $type   "object|user|group|site"
+ * @param array  $return Current value
+ * @param array  $params Hook parameters
+ *
+ * @return void|false
+ */
+function likes_permissions_check_annotate($hook, $type, $return, $params) {
+	return false;
 }
 
 /**

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -65,6 +65,9 @@ function thewire_init() {
 	elgg_register_plugin_hook_handler('unit_test', 'system', 'thewire_test');
 
 	elgg_register_event_handler('upgrade', 'system', 'thewire_run_upgrades');
+	
+	// Permissions
+	elgg_register_plugin_hook_handler('permissions_check:annotate:likes', 'object', 'thewire_permissions_check_annotate');
 }
 
 /**
@@ -485,4 +488,29 @@ function thewire_run_upgrades() {
 	foreach ($files as $file) {
 		include $path . $file;
 	}
+}
+
+/**
+ * Allow liking of a wire post
+ *
+ * @param string $hook   "permissions_check:annotate:likes"
+ * @param string $type   "object"
+ * @param array  $return Current value
+ * @param array  $params Hook parameters
+ *
+ * @return void|false
+ */
+function thewire_permissions_check_annotate($hook, $type, $return, $params) {
+	if ($return !== false) {
+		// we only want to change to true if it is false
+		return;
+	}
+
+	$user = elgg_extract('user', $params);
+	$entity = elgg_extract('entity', $params);
+
+	$isUser = elgg_instanceof($user, 'user');
+	$isWire = elgg_instanceof($entity, 'object', 'thewire');
+
+	return $isUser && $isWire ? true : null;
 }


### PR DESCRIPTION
BREAKING CHANGE:
If you want to allow likes on your content you will have to register a
'permissions_check:annotate' hook to allow like annotations. Core
content plugins have been adjusted to provide these hooks.

fixes #5996 

Need feedback on the blog hook... if that is ok, then i will copy that approach to the other plugins
- [x] copy "allow likes" hook to groups, blog, bookmarks, file, pages, thewire, discussions and comments
- [x] add upgrading docs
