### PR TITLE
feature(application): Allows fetching dataroot statically from Application

### DIFF
--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -84,6 +84,10 @@ class Config implements Services\Config {
 	 * {@inheritdoc}
 	 */
 	public function getDataPath() {
+		if (!isset($this->config->dataroot)) {
+			\Elgg\Application::getDataPath();
+		}
+
 		return $this->config->dataroot;
 	}
 
@@ -211,7 +215,12 @@ class Config implements Services\Config {
 		// normalize commonly needed values
 		if (isset($CONFIG->dataroot)) {
 			$CONFIG->dataroot = rtrim($CONFIG->dataroot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+			$GLOBALS['_ELGG']->dataroot_in_settings = true;
+		} else {
+			$GLOBALS['_ELGG']->dataroot_in_settings = false;
 		}
+
+		$GLOBALS['_ELGG']->simplecache_enabled_in_settings = isset($CONFIG->simplecache_enabled);
 
 		if (!$global_is_bound) {
 			// must manually copy settings into our storage

--- a/engine/classes/Elgg/Database/Datalist.php
+++ b/engine/classes/Elgg/Database/Datalist.php
@@ -60,10 +60,7 @@ class Datalist {
 	 */
 	function get($name) {
 		$name = trim($name);
-	
-		// cannot store anything longer than 255 characters in db, so catch here
-		if (elgg_strlen($name) > 255) {
-			$this->logger->error("The name length for configuration variables cannot be greater than 255");
+		if (!$this->validateName($name)) {
 			return false;
 		}
 
@@ -92,13 +89,9 @@ class Datalist {
 	 */
 	function set($name, $value) {
 		$name = trim($name);
-	
-		// cannot store anything longer than 255 characters in db, so catch before we set
-		if (elgg_strlen($name) > 255) {
-			$this->logger->error("The name length for configuration variables cannot be greater than 255");
+		if (!$this->validateName($name)) {
 			return false;
 		}
-	
 	
 		$escaped_name = $this->db->sanitizeString($name);
 		$escaped_value = $this->db->sanitizeString($value);
@@ -178,5 +171,27 @@ class Datalist {
 		} else {
 			return false;
 		}
+	}
+
+	/**
+	 * Verify a datalist name is valid
+	 *
+	 * @param string $name Datalist name to be checked
+	 *
+	 * @return bool
+	 */
+	protected function validateName($name) {
+		// Can't use elgg_strlen() because not available until core loaded.
+		if (is_callable('mb_strlen')) {
+			$is_valid = (mb_strlen($name) <= 255);
+		} else {
+			$is_valid = (strlen($name) <= 255);
+		}
+
+		if (!$is_valid) {
+			$this->logger->error("The name length for configuration variables cannot be greater than 255");
+		}
+
+		return $is_valid;
 	}
 }

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -353,35 +353,16 @@ function _elgg_load_application_config() {
 		_elgg_services()->datalist->loadAll();
 	}
 
-	// allow sites to set dataroot and simplecache_enabled in settings.php
-	if (isset($CONFIG->dataroot)) {
-		$CONFIG->dataroot = sanitise_filepath($CONFIG->dataroot);
-		$GLOBALS['_ELGG']->dataroot_in_settings = true;
-	} else {
-		$dataroot = datalist_get('dataroot');
-		if (!empty($dataroot)) {
-			$CONFIG->dataroot = $dataroot;
-		}
-		$GLOBALS['_ELGG']->dataroot_in_settings = false;
-	}
-	if (isset($CONFIG->simplecache_enabled)) {
-		$GLOBALS['_ELGG']->simplecache_enabled_in_settings = true;
-	} else {
+	// make sure dataroot gets set
+	\Elgg\Application::getDataPath();
+
+	if (!$GLOBALS['_ELGG']->simplecache_enabled_in_settings) {
 		$simplecache_enabled = datalist_get('simplecache_enabled');
-		if ($simplecache_enabled !== false) {
-			$CONFIG->simplecache_enabled = $simplecache_enabled;
-		} else {
-			$CONFIG->simplecache_enabled = 1;
-		}
-		$GLOBALS['_ELGG']->simplecache_enabled_in_settings = false;
+		$CONFIG->simplecache_enabled = ($simplecache_enabled === false) ? 1 : $simplecache_enabled;
 	}
 
 	$system_cache_enabled = datalist_get('system_cache_enabled');
-	if ($system_cache_enabled !== false) {
-		$CONFIG->system_cache_enabled = $system_cache_enabled;
-	} else {
-		$CONFIG->system_cache_enabled = 1;
-	}
+	$CONFIG->system_cache_enabled = ($system_cache_enabled === false) ? 1 : $system_cache_enabled;
 
 	// needs to be set before system, init for links in html head
 	$CONFIG->lastcache = (int)datalist_get("simplecache_lastupdate");


### PR DESCRIPTION
This moves the dataroot resolution from lib/configuration.php to the Application and makes sure that create() sets/gets a singleton instance. Also updates icondirect.php to use the new method.

Fixes #8653
