### PR TITLE
feature(likes): Entities are not likable by default

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -105,6 +105,20 @@ If you'd prefer to just add it back, you can use this code in your plugin's init
 
 Also, define a ``jquery-migrate.js`` view containing the contents of the script.
 
+Entities are no longer likable by default
+-----------------------------------------
+
+3rd party entity subtypes must be registered with the ``likes`` plugin to accept and display likes.
+
+.. code:: php
+
+    if (function_exists('likes_register_type')) {
+        likes_register_type('object', 'my_subtype');
+    }
+
+Just as before, you may return ``false`` in the ``permissions_check:annotate`` hook to effectively
+disable likes for entities that were registered by another plugin.
+
 JS and CSS views have been moved out of the js/ and css/ directories
 --------------------------------------------------------------------
 

--- a/engine/lib/comments.php
+++ b/engine/lib/comments.php
@@ -26,6 +26,10 @@ function _elgg_comments_init() {
 	elgg_register_page_handler('comment', '_elgg_comments_page_handler');
 
 	elgg_register_ajax_view('core/ajax/edit_comment');
+
+	if (function_exists('likes_register_type')) {
+		likes_register_type('object', 'comment');
+	}
 }
 
 /**

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -68,6 +68,11 @@ function blog_init() {
 
 	// ecml
 	elgg_register_plugin_hook_handler('get_views', 'ecml', 'blog_ecml_views_hook');
+
+	// allow to be liked
+	if (function_exists('likes_register_type')) {
+		likes_register_type('object', 'blog');
+	}
 }
 
 /**

--- a/mod/bookmarks/start.php
+++ b/mod/bookmarks/start.php
@@ -67,6 +67,11 @@ function bookmarks_init() {
 	// Groups
 	add_group_tool_option('bookmarks', elgg_echo('bookmarks:enablebookmarks'), true);
 	elgg_extend_view('groups/tool_latest', 'bookmarks/group_module');
+
+	// allow to be liked
+	if (function_exists('likes_register_type')) {
+		likes_register_type('object', 'bookmarks');
+	}
 }
 
 /**

--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -61,6 +61,12 @@ function discussion_init() {
 
 	// allow ecml in discussion
 	elgg_register_plugin_hook_handler('get_views', 'ecml', 'discussion_ecml_views_hook');
+
+	// allow to be liked
+	if (function_exists('likes_register_type')) {
+		likes_register_type('object', 'discussion');
+		likes_register_type('object', 'discussion_reply');
+	}
 }
 
 /**

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -88,6 +88,11 @@ function file_init() {
 	elgg_register_menu_item('embed', $item);
 
 	elgg_extend_view('theme_sandbox/icons', 'file/theme_sandbox/icons/files');
+
+	// allow to be liked
+	if (function_exists('likes_register_type')) {
+		likes_register_type('object', 'file');
+	}
 }
 
 /**

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -362,7 +362,7 @@ function groups_entity_menu_setup($hook, $type, $return, $params) {
 
 	/* @var ElggMenuItem $item */
 	foreach ($return as $index => $item) {
-		if (in_array($item->getName(), array('access', 'likes', 'unlike', 'edit', 'delete'))) {
+		if (in_array($item->getName(), array('access', 'edit', 'delete'))) {
 			unset($return[$index]);
 		}
 	}

--- a/mod/likes/actions/likes/add.php
+++ b/mod/likes/actions/likes/add.php
@@ -19,7 +19,7 @@ if (!$entity) {
 }
 
 // limit likes through a plugin hook (to prevent liking your own content for example)
-if (!$entity->canAnnotate(0, 'likes')) {
+if (!_likes_can_like($entity)) {
 	// plugins should register the error message to explain why liking isn't allowed
 	forward(REFERER);
 }

--- a/mod/likes/views/default/likes/button.php
+++ b/mod/likes/views/default/likes/button.php
@@ -15,7 +15,7 @@ $entity = $vars['entity'];
 $guid = $entity->getGUID();
 
 // check to see if the user has already liked this
-if (elgg_is_logged_in() && $entity->canAnnotate(0, 'likes')) {
+if (_likes_can_like($entity)) {
 	if (!elgg_annotation_exists($guid, 'likes')) {
 		$url = elgg_get_site_url() . "action/likes/add?guid={$guid}";
 		$params = array(

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -90,6 +90,12 @@ function pages_init() {
 
 	// register ecml views to parse
 	elgg_register_plugin_hook_handler('get_views', 'ecml', 'pages_ecml_views_hook');
+
+	// allow to be liked
+	if (function_exists('likes_register_type')) {
+		likes_register_type('object', 'page');
+		likes_register_type('object', 'page_top');
+	}
 }
 
 /**

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -62,6 +62,11 @@ function thewire_init() {
 	elgg_register_action("thewire/add", "$action_base/add.php");
 	elgg_register_action("thewire/delete", "$action_base/delete.php");
 
+	// allow to be liked
+	if (function_exists('likes_register_type')) {
+		likes_register_type('object', 'thewire');
+	}
+
 	elgg_register_plugin_hook_handler('unit_test', 'system', 'thewire_test');
 
 	elgg_register_event_handler('upgrade', 'system', 'thewire_run_upgrades');


### PR DESCRIPTION
BREAKING CHANGE:
If you want to allow likes on your content you will have to register your type/subtype using likes_register_type() in your plugin init function.

Fixes #5996

(alternate approach of #8654)
