### PR TITLE
perf(engine): Viewtype is auto-detected only once

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -540,6 +540,13 @@ The metadata ``$entity->view`` no longer specifies the view used to render in ``
 
 Similarly the property ``$annotation->view`` no longer has an effect within ``elgg_view_annotation()``.
 
+Viewtype is static after the initial ``elgg_get_viewtype()`` call
+-----------------------------------------------------------------
+
+``elgg_set_viewtype()`` must be used to set the viewtype at runtime. Although Elgg still checks the
+``view`` input and ``$CONFIG->view`` initially, this is only done once per request.
+
+
 From 1.10 to 1.11
 =================
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -89,11 +89,24 @@ function elgg_set_viewtype($viewtype = "") {
  * @see elgg_set_viewtype()
  */
 function elgg_get_viewtype() {
-	global $CURRENT_SYSTEM_VIEWTYPE, $CONFIG;
+	global $CURRENT_SYSTEM_VIEWTYPE;
 
-	if ($CURRENT_SYSTEM_VIEWTYPE != "") {
-		return $CURRENT_SYSTEM_VIEWTYPE;
+	if (empty($CURRENT_SYSTEM_VIEWTYPE)) {
+		$CURRENT_SYSTEM_VIEWTYPE = _elgg_get_initial_viewtype();
 	}
+
+	return $CURRENT_SYSTEM_VIEWTYPE;
+}
+
+/**
+ * Get the initial viewtype
+ *
+ * @return string
+ * @access private
+ * @since 2.0.0
+ */
+function _elgg_get_initial_viewtype() {
+	global $CONFIG;
 
 	$viewtype = get_input('view', '', false);
 	if (_elgg_is_valid_viewtype($viewtype)) {

--- a/engine/tests/phpunit/ElggCoreViewtypeTest.php
+++ b/engine/tests/phpunit/ElggCoreViewtypeTest.php
@@ -3,8 +3,14 @@
 class ElggCoreViewtypeTest extends \PHPUnit_Framework_TestCase {
 
 	protected function setUp() {
-		global $CURRENT_SYSTEM_VIEWTYPE;
+		global $CURRENT_SYSTEM_VIEWTYPE, $CONFIG;
 		$CURRENT_SYSTEM_VIEWTYPE = '';
+		set_input('view', '');
+		unset($CONFIG->view);
+	}
+
+	protected function tearDown() {
+		$this->setUp();
 	}
 
 	public function testElggSetViewtype() {
@@ -12,14 +18,37 @@ class ElggCoreViewtypeTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals('test', elgg_get_viewtype());
 	}
 
-	public function testElggGetViewtype() {
+	public function testDefaultViewtype() {
+		$this->assertEquals('default', elgg_get_viewtype());
+	}
+
+	public function testInputSetsInitialViewtype() {
+		set_input('view', 'foo');
+		$this->assertEquals('foo', elgg_get_viewtype());
+	}
+
+	public function testConfigSetsInitialViewtype() {
+		global $CONFIG;
+		$CONFIG->view = 'bar';
+
+		$this->assertEquals('bar', elgg_get_viewtype());
+	}
+
+	public function testSettingInputDoesNotChangeViewtype() {
 		$this->assertEquals('default', elgg_get_viewtype());
 
 		set_input('view', 'foo');
-		$this->assertEquals('foo', elgg_get_viewtype());
-
-		set_input('view', 'a;b');
 		$this->assertEquals('default', elgg_get_viewtype());
+	}
+
+	public function testSettingConfigDoesNotChangeViewtype() {
+		global $CONFIG;
+
+		$this->assertEquals('default', elgg_get_viewtype());
+
+		$CONFIG->view = 'foo';
+		$this->assertEquals('default', elgg_get_viewtype());
+		unset($CONFIG->view);
 	}
 
 	public function testElggIsValidViewtype() {


### PR DESCRIPTION
BREAKING CHANGE:
Elgg no longer checks get_input(‘view’) and $CONFIG->view for every call of elgg_get_viewtype(). elgg_set_viewtype() must be used to change the global viewtype.

Fixes #8438
