### PR TITLE
perf(views): only draw menus when they are used

### DIFF
--- a/mod/blog/views/default/object/blog.php
+++ b/mod/blog/views/default/object/blog.php
@@ -46,18 +46,17 @@ if ($blog->comments_on != 'Off') {
 	$comments_link = '';
 }
 
-$metadata = elgg_view_menu('entity', array(
-	'entity' => $vars['entity'],
-	'handler' => 'blog',
-	'sort_by' => 'priority',
-	'class' => 'elgg-menu-hz',
-));
-
 $subtitle = "$author_text $date $comments_link $categories";
 
-// do not show the metadata and controls in widget view
-if (elgg_in_context('widgets')) {
-	$metadata = '';
+$metadata = '';
+if (!elgg_in_context('widgets')) {
+	// only show entity menu outside of widgets
+	$metadata = elgg_view_menu('entity', array(
+		'entity' => $vars['entity'],
+		'handler' => 'blog',
+		'sort_by' => 'priority',
+		'class' => 'elgg-menu-hz',
+	));
 }
 
 if ($full) {

--- a/mod/bookmarks/views/default/object/bookmarks.php
+++ b/mod/bookmarks/views/default/object/bookmarks.php
@@ -41,18 +41,17 @@ if ($comments_count != 0) {
 	$comments_link = '';
 }
 
-$metadata = elgg_view_menu('entity', array(
-	'entity' => $vars['entity'],
-	'handler' => 'bookmarks',
-	'sort_by' => 'priority',
-	'class' => 'elgg-menu-hz',
-));
-
 $subtitle = "$author_text $date $comments_link $categories";
 
-// do not show the metadata and controls in widget view
-if (elgg_in_context('widgets')) {
-	$metadata = '';
+$metadata = '';
+if (!elgg_in_context('widgets') && !elgg_in_context('gallery')) {
+	// only show entity menu outside of widgets and gallery view
+	$metadata = elgg_view_menu('entity', array(
+		'entity' => $vars['entity'],
+		'handler' => 'bookmarks',
+		'sort_by' => 'priority',
+		'class' => 'elgg-menu-hz',
+	));
 }
 
 if ($full && !elgg_in_context('gallery')) {

--- a/mod/discussions/views/default/object/discussion.php
+++ b/mod/discussions/views/default/object/discussion.php
@@ -67,9 +67,9 @@ if ($num_replies != 0) {
 }
 
 // do not show the metadata and controls in widget view
-if (elgg_in_context('widgets')) {
-	$metadata = '';
-} else {
+$metadata = '';
+if (!elgg_in_context('widgets')) {
+	// only show entity menu outside of widgets
 	$metadata = elgg_view_menu('entity', array(
 		'entity' => $vars['entity'],
 		'handler' => 'discussion',

--- a/mod/discussions/views/default/object/discussion_reply.php
+++ b/mod/discussions/views/default/object/discussion_reply.php
@@ -22,10 +22,9 @@ $poster_text = elgg_echo('byline', array($poster->name));
 
 $date = elgg_view_friendly_time($reply->time_created);
 
-// Do not show the metadata and controls in widget view
-if (elgg_in_context('widgets')) {
-	$metadata = '';
-} else {
+$metadata = '';
+if (!elgg_in_context('widgets')) {
+	// only show entity menu outside of widgets
 	$metadata = elgg_view_menu('entity', array(
 		'entity' => $vars['entity'],
 		'handler' => 'discussion_reply',

--- a/mod/file/views/default/object/file.php
+++ b/mod/file/views/default/object/file.php
@@ -40,18 +40,17 @@ if ($comments_count != 0) {
 	$comments_link = '';
 }
 
-$metadata = elgg_view_menu('entity', array(
-	'entity' => $vars['entity'],
-	'handler' => 'file',
-	'sort_by' => 'priority',
-	'class' => 'elgg-menu-hz',
-));
-
 $subtitle = "$author_text $date $comments_link $categories";
 
-// do not show the metadata and controls in widget view
-if (elgg_in_context('widgets')) {
-	$metadata = '';
+$metadata = '';
+if (!elgg_in_context('widgets') && !elgg_in_context('gallery')) {
+	// only show entity menu outside of widgets and gallery view
+	$metadata = elgg_view_menu('entity', array(
+		'entity' => $vars['entity'],
+		'handler' => 'file',
+		'sort_by' => 'priority',
+		'class' => 'elgg-menu-hz',
+	));
 }
 
 if ($full && !elgg_in_context('gallery')) {

--- a/mod/groups/views/default/group/default.php
+++ b/mod/groups/views/default/group/default.php
@@ -1,7 +1,7 @@
-<?php 
+<?php
 /**
  * Group entity view
- * 
+ *
  * @package ElggGroups
  */
 
@@ -9,15 +9,15 @@ $group = $vars['entity'];
 
 $icon = elgg_view_entity_icon($group, 'tiny', $vars);
 
-$metadata = elgg_view_menu('entity', array(
-	'entity' => $group,
-	'handler' => 'groups',
-	'sort_by' => 'priority',
-	'class' => 'elgg-menu-hz',
-));
-
-if (elgg_in_context('owner_block') || elgg_in_context('widgets')) {
-	$metadata = '';
+$metadata = '';
+if (!elgg_in_context('owner_block') && !elgg_in_context('widgets')) {
+	// only show entity menu outside of widgets and owner block
+	$metadata = elgg_view_menu('entity', array(
+		'entity' => $group,
+		'handler' => 'groups',
+		'sort_by' => 'priority',
+		'class' => 'elgg-menu-hz',
+	));
 }
 
 

--- a/mod/pages/views/default/annotation/page.php
+++ b/mod/pages/views/default/annotation/page.php
@@ -42,7 +42,9 @@ $body = <<< HTML
 <p class="elgg-subtext">$subtitle</p>
 HTML;
 
+$menu = '';
 if (!elgg_in_context('widgets')) {
+	// only show annotation menu outside of widgets
 	$menu = elgg_view_menu('annotation', array(
 		'annotation' => $annotation,
 		'sort_by' => 'priority',

--- a/mod/pages/views/default/object/page_top.php
+++ b/mod/pages/views/default/object/page_top.php
@@ -69,6 +69,7 @@ if ($comments_count != 0 && !$revision) {
 
 $subtitle = "$editor_text $comments_link $categories";
 
+$metadata = '';
 // do not show the metadata and controls in widget view
 if (!elgg_in_context('widgets')) {
 	// If we're looking at a revision, display annotation menu

--- a/mod/thewire/views/default/object/thewire.php
+++ b/mod/thewire/views/default/object/thewire.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * View a wire post
- * 
+ *
  * @uses $vars['entity']
  */
 
@@ -31,18 +31,17 @@ $owner_link = elgg_view('output/url', array(
 $author_text = elgg_echo('byline', array($owner_link));
 $date = elgg_view_friendly_time($post->time_created);
 
-$metadata = elgg_view_menu('entity', array(
-	'entity' => $post,
-	'handler' => 'thewire',
-	'sort_by' => 'priority',
-	'class' => 'elgg-menu-hz',
-));
-
 $subtitle = "$author_text $date";
 
-// do not show the metadata and controls in widget view
+$metadata = '';
 if (elgg_in_context('widgets')) {
-	$metadata = '';
+	// only show entity menu outside of widgets
+	$metadata = elgg_view_menu('entity', array(
+		'entity' => $post,
+		'handler' => 'thewire',
+		'sort_by' => 'priority',
+		'class' => 'elgg-menu-hz',
+	));
 }
 
 $params = array(

--- a/views/default/user/default.php
+++ b/views/default/user/default.php
@@ -29,19 +29,18 @@ if (!$title) {
 	$title = elgg_view('output/url', $link_params);
 }
 
-$metadata = elgg_view_menu('entity', array(
-	'entity' => $entity,
-	'sort_by' => 'priority',
-	'class' => 'elgg-menu-hz',
-));
-
-if (elgg_in_context('owner_block') || elgg_in_context('widgets')) {
-	$metadata = '';
-}
-
 if (elgg_get_context() == 'gallery') {
 	echo $icon;
 } else {
+	$metadata = '';
+	if (!elgg_in_context('owner_block') && !elgg_in_context('widgets')) {
+		$metadata = elgg_view_menu('entity', array(
+			'entity' => $entity,
+			'sort_by' => 'priority',
+			'class' => 'elgg-menu-hz',
+		));
+	}
+	
 	if ($entity->isBanned()) {
 		$banned = elgg_echo('banned');
 		$params = array(


### PR DESCRIPTION
In a lot of cases a menu was drawn only to disregard it a few lines
later. This caused a load on the system that wasn't needed.
