### PR TITLE
feature(annotations): Adds a more granular permission hook for canAnnotate

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -193,7 +193,7 @@ Permission hooks
 
 **container_permissions_check, <entity_type>**
 	Return boolean for if the user ``$params['user']`` can use the entity ``$params['container']``
-	as a container for an entity of <entity_type> and subtype ``$params['subtype']``.
+	as a container for an entity of ``<entity_type>`` and subtype ``$params['subtype']``.
 
 **permissions_check, <entity_type>**
 	Return boolean for if the user ``$params['user']`` can edit the entity ``$params['entity']``.
@@ -212,9 +212,15 @@ Permission hooks
 **permissions_check:comment, <entity_type>**
 	Return boolean for if the user ``$params['user']`` can comment on the entity ``$params['entity']``.
 
-**permissions_check:annotate**
-	Return boolean for if the user ``$params['user']`` can create an annotation with the name
-	``$params['annotation_name']`` on the entity ``$params['entity']``.
+**permissions_check:annotate:<annotation_name>, <entity_type>**
+	Return boolean for if the user ``$params['user']`` can create an annotation ``<annotation_name>`` on the
+	entity ``$params['entity']``. If logged in, the default is true.
+
+	.. note:: This is called before the more general ``permissions_check:annotate`` hook, and its return value is that hook's initial value.
+
+**permissions_check:annotate, <entity_type>**
+	Return boolean for if the user ``$params['user']`` can create an annotation ``$params['annotation_name']``
+	on the entity ``$params['entity']``. if logged in, the default is true.
 
 	.. warning:: This is functions differently than the ``permissions_check:metadata`` hook by passing the annotation name instead of the metadata object.
 

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1198,8 +1198,8 @@ abstract class ElggEntity extends \ElggData implements
 	/**
 	 * Can a user annotate an entity?
 	 *
-	 * @tip Can be overridden by registering for the permissions_check:annotate,
-	 * <entity type> plugin hook.
+	 * @tip Can be overridden by registering for the plugin hook [permissions_check:annotate:<name>,
+	 * <entity type>] or [permissions_check:annotate, <entity type>]. The hooks are called in that order.
 	 *
 	 * @tip If you want logged out users to annotate an object, do not call
 	 * canAnnotate(). It's easier than using the plugin hook.
@@ -1220,12 +1220,19 @@ abstract class ElggEntity extends \ElggData implements
 			$return = false;
 		}
 
+		$hooks = _elgg_services()->hooks;
+
 		$params = array(
 			'entity' => $this,
 			'user' => $user,
 			'annotation_name' => $annotation_name,
 		);
-		return _elgg_services()->hooks->trigger('permissions_check:annotate', $this->type, $params, $return);
+		if ($annotation_name !== '') {
+			$return = $hooks->trigger("permissions_check:annotate:$annotation_name", $this->type, $params, $return);
+		}
+		$return = $hooks->trigger('permissions_check:annotate', $this->type, $params, $return);
+
+		return $return;
 	}
 
 	/**


### PR DESCRIPTION
`ElggEntity::canAnnotate` now first triggers the hook `permissions_check:annotate:<name>`
before the generic `permissions_check:annotate` hook.

(Also adds tests for both hooks)
