### PR TITLE
chore(assets): Check in assets that don't have bower repos

### DIFF
--- a/bower_components/jquery-imgareaselect/distfiles/GPL-LICENSE.txt
+++ b/bower_components/jquery-imgareaselect/distfiles/GPL-LICENSE.txt
@@ -1,0 +1,278 @@
+        GNU GENERAL PUBLIC LICENSE
+           Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+          Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+        GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+          NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.

--- a/bower_components/jquery-imgareaselect/distfiles/MIT-LICENSE.txt
+++ b/bower_components/jquery-imgareaselect/distfiles/MIT-LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2008-2013 Michal Wojciechowski, http://odyniec.net/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/bower_components/jquery-imgareaselect/distfiles/css/imgareaselect-deprecated.css
+++ b/bower_components/jquery-imgareaselect/distfiles/css/imgareaselect-deprecated.css
@@ -1,0 +1,36 @@
+/*
+ * imgAreaSelect style to be used with deprecated options
+ */
+
+.imgareaselect-border1, .imgareaselect-border2,
+.imgareaselect-border3, .imgareaselect-border4 {
+    filter: alpha(opacity=50);
+	opacity: 0.5;
+}
+
+.imgareaselect-border1 {
+	border: solid 1px #000;
+}
+
+.imgareaselect-border2 {
+	border: dashed 1px #fff;
+}
+
+.imgareaselect-handle {
+    background-color: #fff;
+    border: solid 1px #000;
+    filter: alpha(opacity=50);
+    opacity: 0.5;
+}
+
+.imgareaselect-outer {
+    background-color: #000;
+    filter: alpha(opacity=40);
+    opacity: 0.4;
+}
+
+.imgareaselect-selection {
+	background-color: #fff;
+    filter: alpha(opacity=0);
+	opacity: 0;
+}

--- a/bower_components/jquery-imgareaselect/jquery.imgareaselect.dev.js
+++ b/bower_components/jquery-imgareaselect/jquery.imgareaselect.dev.js
@@ -1,0 +1,1205 @@
+/*
+ * imgAreaSelect jQuery plugin
+ * version 0.9.10
+ *
+ * Copyright (c) 2008-2013 Michal Wojciechowski (odyniec.net)
+ *
+ * Dual licensed under the MIT (MIT-LICENSE.txt)
+ * and GPL (GPL-LICENSE.txt) licenses.
+ *
+ * http://odyniec.net/projects/imgareaselect/
+ *
+ */
+
+(function($) {
+
+/*
+ * Math functions will be used extensively, so it's convenient to make a few
+ * shortcuts
+ */    
+var abs = Math.abs,
+    max = Math.max,
+    min = Math.min,
+    round = Math.round;
+
+/**
+ * Create a new HTML div element
+ * 
+ * @return A jQuery object representing the new element
+ */
+function div() {
+    return $('<div/>');
+}
+
+/**
+ * imgAreaSelect initialization
+ * 
+ * @param img
+ *            A HTML image element to attach the plugin to
+ * @param options
+ *            An options object
+ */
+$.imgAreaSelect = function (img, options) {
+    var 
+        /* jQuery object representing the image */ 
+        $img = $(img),
+        
+        /* Has the image finished loading? */
+        imgLoaded,
+        
+        /* Plugin elements */
+        
+        /* Container box */
+        $box = div(),
+        /* Selection area */
+        $area = div(),
+        /* Border (four divs) */
+        $border = div().add(div()).add(div()).add(div()),
+        /* Outer area (four divs) */
+        $outer = div().add(div()).add(div()).add(div()),
+        /* Handles (empty by default, initialized in setOptions()) */
+        $handles = $([]),
+        
+        /*
+         * Additional element to work around a cursor problem in Opera
+         * (explained later)
+         */
+        $areaOpera,
+        
+        /* Image position (relative to viewport) */
+        left, top,
+        
+        /* Image offset (as returned by .offset()) */
+        imgOfs = { left: 0, top: 0 },
+        
+        /* Image dimensions (as returned by .width() and .height()) */
+        imgWidth, imgHeight,
+        
+        /*
+         * jQuery object representing the parent element that the plugin
+         * elements are appended to
+         */
+        $parent,
+        
+        /* Parent element offset (as returned by .offset()) */
+        parOfs = { left: 0, top: 0 },
+        
+        /* Base z-index for plugin elements */
+        zIndex = 0,
+                
+        /* Plugin elements position */
+        position = 'absolute',
+        
+        /* X/Y coordinates of the starting point for move/resize operations */ 
+        startX, startY,
+        
+        /* Horizontal and vertical scaling factors */
+        scaleX, scaleY,
+        
+        /* Current resize mode ("nw", "se", etc.) */
+        resize,
+        
+        /* Selection area constraints */
+        minWidth, minHeight, maxWidth, maxHeight,
+        
+        /* Aspect ratio to maintain (floating point number) */
+        aspectRatio,
+        
+        /* Are the plugin elements currently displayed? */
+        shown,
+        
+        /* Current selection (relative to parent element) */
+        x1, y1, x2, y2,
+        
+        /* Current selection (relative to scaled image) */
+        selection = { x1: 0, y1: 0, x2: 0, y2: 0, width: 0, height: 0 },
+        
+        /* Document element */
+        docElem = document.documentElement,
+
+        /* User agent */
+        ua = navigator.userAgent,
+        
+        /* Various helper variables used throughout the code */ 
+        $p, d, i, o, w, h, adjusted;
+
+    /*
+     * Translate selection coordinates (relative to scaled image) to viewport
+     * coordinates (relative to parent element)
+     */
+    
+    /**
+     * Translate selection X to viewport X
+     * 
+     * @param x
+     *            Selection X
+     * @return Viewport X
+     */
+    function viewX(x) {
+        return x + imgOfs.left - parOfs.left;
+    }
+
+    /**
+     * Translate selection Y to viewport Y
+     * 
+     * @param y
+     *            Selection Y
+     * @return Viewport Y
+     */
+    function viewY(y) {
+        return y + imgOfs.top - parOfs.top;
+    }
+
+    /*
+     * Translate viewport coordinates to selection coordinates
+     */
+    
+    /**
+     * Translate viewport X to selection X
+     * 
+     * @param x
+     *            Viewport X
+     * @return Selection X
+     */
+    function selX(x) {
+        return x - imgOfs.left + parOfs.left;
+    }
+
+    /**
+     * Translate viewport Y to selection Y
+     * 
+     * @param y
+     *            Viewport Y
+     * @return Selection Y
+     */
+    function selY(y) {
+        return y - imgOfs.top + parOfs.top;
+    }
+    
+    /*
+     * Translate event coordinates (relative to document) to viewport
+     * coordinates
+     */
+    
+    /**
+     * Get event X and translate it to viewport X
+     * 
+     * @param event
+     *            The event object
+     * @return Viewport X
+     */
+    function evX(event) {
+        return event.pageX - parOfs.left;
+    }
+
+    /**
+     * Get event Y and translate it to viewport Y
+     * 
+     * @param event
+     *            The event object
+     * @return Viewport Y
+     */
+    function evY(event) {
+        return event.pageY - parOfs.top;
+    }
+
+    /**
+     * Get the current selection
+     * 
+     * @param noScale
+     *            If set to <code>true</code>, scaling is not applied to the
+     *            returned selection
+     * @return Selection object
+     */
+    function getSelection(noScale) {
+        var sx = noScale || scaleX, sy = noScale || scaleY;
+        
+        return { x1: round(selection.x1 * sx),
+            y1: round(selection.y1 * sy),
+            x2: round(selection.x2 * sx),
+            y2: round(selection.y2 * sy),
+            width: round(selection.x2 * sx) - round(selection.x1 * sx),
+            height: round(selection.y2 * sy) - round(selection.y1 * sy) };
+    }
+    
+    /**
+     * Set the current selection
+     * 
+     * @param x1
+     *            X coordinate of the upper left corner of the selection area
+     * @param y1
+     *            Y coordinate of the upper left corner of the selection area
+     * @param x2
+     *            X coordinate of the lower right corner of the selection area
+     * @param y2
+     *            Y coordinate of the lower right corner of the selection area
+     * @param noScale
+     *            If set to <code>true</code>, scaling is not applied to the
+     *            new selection
+     */
+    function setSelection(x1, y1, x2, y2, noScale) {
+        var sx = noScale || scaleX, sy = noScale || scaleY;
+        
+        selection = {
+            x1: round(x1 / sx || 0),
+            y1: round(y1 / sy || 0),
+            x2: round(x2 / sx || 0),
+            y2: round(y2 / sy || 0)
+        };
+        
+        selection.width = selection.x2 - selection.x1;
+        selection.height = selection.y2 - selection.y1;
+    }
+
+    /**
+     * Recalculate image and parent offsets
+     */
+    function adjust() {
+        /*
+         * Do not adjust if image has not yet loaded or if width is not a
+         * positive number. The latter might happen when imgAreaSelect is put
+         * on a parent element which is then hidden.
+         */
+        if (!imgLoaded || !$img.width())
+            return;
+        
+        /*
+         * Get image offset. The .offset() method returns float values, so they
+         * need to be rounded.
+         */
+        imgOfs = { left: round($img.offset().left), top: round($img.offset().top) };
+        
+        /* Get image dimensions */
+        imgWidth = $img.innerWidth();
+        imgHeight = $img.innerHeight();
+        
+        imgOfs.top += ($img.outerHeight() - imgHeight) >> 1;
+        imgOfs.left += ($img.outerWidth() - imgWidth) >> 1;
+
+        /* Set minimum and maximum selection area dimensions */
+        minWidth = round(options.minWidth / scaleX) || 0;
+        minHeight = round(options.minHeight / scaleY) || 0;
+        maxWidth = round(min(options.maxWidth / scaleX || 1<<24, imgWidth));
+        maxHeight = round(min(options.maxHeight / scaleY || 1<<24, imgHeight));
+        
+        /*
+         * Workaround for jQuery 1.3.2 incorrect offset calculation, originally
+         * observed in Safari 3. Firefox 2 is also affected.
+         */
+        if ($().jquery == '1.3.2' && position == 'fixed' &&
+            !docElem['getBoundingClientRect'])
+        {
+            imgOfs.top += max(document.body.scrollTop, docElem.scrollTop);
+            imgOfs.left += max(document.body.scrollLeft, docElem.scrollLeft);
+        }
+
+        /* Determine parent element offset */ 
+        parOfs = /absolute|relative/.test($parent.css('position')) ?
+            { left: round($parent.offset().left) - $parent.scrollLeft(),
+                top: round($parent.offset().top) - $parent.scrollTop() } :
+            position == 'fixed' ?
+                { left: $(document).scrollLeft(), top: $(document).scrollTop() } :
+                { left: 0, top: 0 };
+                
+        left = viewX(0);
+        top = viewY(0);
+        
+        /*
+         * Check if selection area is within image boundaries, adjust if
+         * necessary
+         */
+        if (selection.x2 > imgWidth || selection.y2 > imgHeight)
+            doResize();
+    }
+
+    /**
+     * Update plugin elements
+     * 
+     * @param resetKeyPress
+     *            If set to <code>false</code>, this instance's keypress
+     *            event handler is not activated
+     */
+    function update(resetKeyPress) {
+        /* If plugin elements are hidden, do nothing */
+        if (!shown) return;
+
+        /*
+         * Set the position and size of the container box and the selection area
+         * inside it
+         */
+        $box.css({ left: viewX(selection.x1), top: viewY(selection.y1) })
+            .add($area).width(w = selection.width).height(h = selection.height);
+
+        /*
+         * Reset the position of selection area, borders, and handles (IE6/IE7
+         * position them incorrectly if we don't do this)
+         */ 
+        $area.add($border).add($handles).css({ left: 0, top: 0 });
+
+        /* Set border dimensions */
+        $border
+            .width(max(w - $border.outerWidth() + $border.innerWidth(), 0))
+            .height(max(h - $border.outerHeight() + $border.innerHeight(), 0));
+
+        /* Arrange the outer area elements */
+        $($outer[0]).css({ left: left, top: top,
+            width: selection.x1, height: imgHeight });
+        $($outer[1]).css({ left: left + selection.x1, top: top,
+            width: w, height: selection.y1 });
+        $($outer[2]).css({ left: left + selection.x2, top: top,
+            width: imgWidth - selection.x2, height: imgHeight });
+        $($outer[3]).css({ left: left + selection.x1, top: top + selection.y2,
+            width: w, height: imgHeight - selection.y2 });
+        
+        w -= $handles.outerWidth();
+        h -= $handles.outerHeight();
+        
+        /* Arrange handles */
+        switch ($handles.length) {
+        case 8:
+            $($handles[4]).css({ left: w >> 1 });
+            $($handles[5]).css({ left: w, top: h >> 1 });
+            $($handles[6]).css({ left: w >> 1, top: h });
+            $($handles[7]).css({ top: h >> 1 });
+        case 4:
+            $handles.slice(1,3).css({ left: w });
+            $handles.slice(2,4).css({ top: h });
+        }
+
+        if (resetKeyPress !== false) {
+            /*
+             * Need to reset the document keypress event handler -- unbind the
+             * current handler
+             */
+            if ($.imgAreaSelect.onKeyPress != docKeyPress)
+                $(document).unbind($.imgAreaSelect.keyPress,
+                    $.imgAreaSelect.onKeyPress);
+
+            if (options.keys)
+                /*
+                 * Set the document keypress event handler to this instance's
+                 * docKeyPress() function
+                 */
+                $(document)[$.imgAreaSelect.keyPress](
+                    $.imgAreaSelect.onKeyPress = docKeyPress);
+        }
+
+        /*
+         * Internet Explorer displays 1px-wide dashed borders incorrectly by
+         * filling the spaces between dashes with white. Toggling the margin
+         * property between 0 and "auto" fixes this in IE6 and IE7 (IE8 is still
+         * broken). This workaround is not perfect, as it requires setTimeout()
+         * and thus causes the border to flicker a bit, but I haven't found a
+         * better solution.
+         * 
+         * Note: This only happens with CSS borders, set with the borderWidth,
+         * borderOpacity, borderColor1, and borderColor2 options (which are now
+         * deprecated). Borders created with GIF background images are fine.
+         */ 
+        if (msie && $border.outerWidth() - $border.innerWidth() == 2) {
+            $border.css('margin', 0);
+            setTimeout(function () { $border.css('margin', 'auto'); }, 0);
+        }
+    }
+    
+    /**
+     * Do the complete update sequence: recalculate offsets, update the
+     * elements, and set the correct values of x1, y1, x2, and y2.
+     * 
+     * @param resetKeyPress
+     *            If set to <code>false</code>, this instance's keypress
+     *            event handler is not activated
+     */
+    function doUpdate(resetKeyPress) {
+        adjust();
+        update(resetKeyPress);
+        x1 = viewX(selection.x1); y1 = viewY(selection.y1);
+        x2 = viewX(selection.x2); y2 = viewY(selection.y2);
+    }
+    
+    /**
+     * Hide or fade out an element (or multiple elements)
+     * 
+     * @param $elem
+     *            A jQuery object containing the element(s) to hide/fade out
+     * @param fn
+     *            Callback function to be called when fadeOut() completes
+     */
+    function hide($elem, fn) {
+        options.fadeSpeed ? $elem.fadeOut(options.fadeSpeed, fn) : $elem.hide(); 
+    }
+
+    /**
+     * Selection area mousemove event handler
+     * 
+     * @param event
+     *            The event object
+     */
+    function areaMouseMove(event) {
+        var x = selX(evX(event)) - selection.x1,
+            y = selY(evY(event)) - selection.y1;
+        
+        if (!adjusted) {
+            adjust();
+            adjusted = true;
+
+            $box.one('mouseout', function () { adjusted = false; });
+        }
+
+        /* Clear the resize mode */
+        resize = '';
+
+        if (options.resizable) {
+            /*
+             * Check if the mouse pointer is over the resize margin area and set
+             * the resize mode accordingly
+             */
+            if (y <= options.resizeMargin)
+                resize = 'n';
+            else if (y >= selection.height - options.resizeMargin)
+                resize = 's';
+            if (x <= options.resizeMargin)
+                resize += 'w';
+            else if (x >= selection.width - options.resizeMargin)
+                resize += 'e';
+        }
+
+        $box.css('cursor', resize ? resize + '-resize' :
+            options.movable ? 'move' : '');
+        if ($areaOpera)
+            $areaOpera.toggle();
+    }
+
+    /**
+     * Document mouseup event handler
+     * 
+     * @param event
+     *            The event object
+     */
+    function docMouseUp(event) {
+        /* Set back the default cursor */
+        $('body').css('cursor', '');
+        /*
+         * If autoHide is enabled, or if the selection has zero width/height,
+         * hide the selection and the outer area
+         */
+        if (options.autoHide || selection.width * selection.height == 0)
+            hide($box.add($outer), function () { $(this).hide(); });
+
+        $(document).unbind('mousemove', selectingMouseMove);
+        $box.mousemove(areaMouseMove);
+        
+        options.onSelectEnd(img, getSelection());
+    }
+
+    /**
+     * Selection area mousedown event handler
+     * 
+     * @param event
+     *            The event object
+     * @return false
+     */
+    function areaMouseDown(event) {
+        if (event.which != 1) return false;
+
+        adjust();
+
+        if (resize) {
+            /* Resize mode is in effect */
+            $('body').css('cursor', resize + '-resize');
+
+            x1 = viewX(selection[/w/.test(resize) ? 'x2' : 'x1']);
+            y1 = viewY(selection[/n/.test(resize) ? 'y2' : 'y1']);
+            
+            $(document).mousemove(selectingMouseMove)
+                .one('mouseup', docMouseUp);
+            $box.unbind('mousemove', areaMouseMove);
+        }
+        else if (options.movable) {
+            startX = left + selection.x1 - evX(event);
+            startY = top + selection.y1 - evY(event);
+
+            $box.unbind('mousemove', areaMouseMove);
+
+            $(document).mousemove(movingMouseMove)
+                .one('mouseup', function () {
+                    options.onSelectEnd(img, getSelection());
+
+                    $(document).unbind('mousemove', movingMouseMove);
+                    $box.mousemove(areaMouseMove);
+                });
+        }
+        else
+            $img.mousedown(event);
+
+        return false;
+    }
+
+    /**
+     * Adjust the x2/y2 coordinates to maintain aspect ratio (if defined)
+     * 
+     * @param xFirst
+     *            If set to <code>true</code>, calculate x2 first. Otherwise,
+     *            calculate y2 first.
+     */
+    function fixAspectRatio(xFirst) {
+        if (aspectRatio)
+            if (xFirst) {
+                x2 = max(left, min(left + imgWidth,
+                    x1 + abs(y2 - y1) * aspectRatio * (x2 > x1 || -1)));    
+                y2 = round(max(top, min(top + imgHeight,
+                    y1 + abs(x2 - x1) / aspectRatio * (y2 > y1 || -1))));
+                x2 = round(x2);
+            }
+            else {
+                y2 = max(top, min(top + imgHeight,
+                    y1 + abs(x2 - x1) / aspectRatio * (y2 > y1 || -1)));
+                x2 = round(max(left, min(left + imgWidth,
+                    x1 + abs(y2 - y1) * aspectRatio * (x2 > x1 || -1))));
+                y2 = round(y2);
+            }
+    }
+
+    /**
+     * Resize the selection area respecting the minimum/maximum dimensions and
+     * aspect ratio
+     */
+    function doResize() {
+        /*
+         * Make sure the top left corner of the selection area stays within
+         * image boundaries (it might not if the image source was dynamically
+         * changed).
+         */
+        x1 = min(x1, left + imgWidth);
+        y1 = min(y1, top + imgHeight);
+        
+        if (abs(x2 - x1) < minWidth) {
+            /* Selection width is smaller than minWidth */
+            x2 = x1 - minWidth * (x2 < x1 || -1);
+
+            if (x2 < left)
+                x1 = left + minWidth;
+            else if (x2 > left + imgWidth)
+                x1 = left + imgWidth - minWidth;
+        }
+
+        if (abs(y2 - y1) < minHeight) {
+            /* Selection height is smaller than minHeight */
+            y2 = y1 - minHeight * (y2 < y1 || -1);
+
+            if (y2 < top)
+                y1 = top + minHeight;
+            else if (y2 > top + imgHeight)
+                y1 = top + imgHeight - minHeight;
+        }
+
+        x2 = max(left, min(x2, left + imgWidth));
+        y2 = max(top, min(y2, top + imgHeight));
+        
+        fixAspectRatio(abs(x2 - x1) < abs(y2 - y1) * aspectRatio);
+
+        if (abs(x2 - x1) > maxWidth) {
+            /* Selection width is greater than maxWidth */
+            x2 = x1 - maxWidth * (x2 < x1 || -1);
+            fixAspectRatio();
+        }
+
+        if (abs(y2 - y1) > maxHeight) {
+            /* Selection height is greater than maxHeight */
+            y2 = y1 - maxHeight * (y2 < y1 || -1);
+            fixAspectRatio(true);
+        }
+
+        selection = { x1: selX(min(x1, x2)), x2: selX(max(x1, x2)),
+            y1: selY(min(y1, y2)), y2: selY(max(y1, y2)),
+            width: abs(x2 - x1), height: abs(y2 - y1) };
+
+        update();
+
+        options.onSelectChange(img, getSelection());
+    }
+
+    /**
+     * Mousemove event handler triggered when the user is selecting an area
+     * 
+     * @param event
+     *            The event object
+     * @return false
+     */
+    function selectingMouseMove(event) {
+        x2 = /w|e|^$/.test(resize) || aspectRatio ? evX(event) : viewX(selection.x2);
+        y2 = /n|s|^$/.test(resize) || aspectRatio ? evY(event) : viewY(selection.y2);
+
+        doResize();
+
+        return false;        
+    }
+
+    /**
+     * Move the selection area
+     * 
+     * @param newX1
+     *            New viewport X1
+     * @param newY1
+     *            New viewport Y1
+     */
+    function doMove(newX1, newY1) {
+        x2 = (x1 = newX1) + selection.width;
+        y2 = (y1 = newY1) + selection.height;
+
+        $.extend(selection, { x1: selX(x1), y1: selY(y1), x2: selX(x2),
+            y2: selY(y2) });
+
+        update();
+
+        options.onSelectChange(img, getSelection());
+    }
+
+    /**
+     * Mousemove event handler triggered when the selection area is being moved
+     * 
+     * @param event
+     *            The event object
+     * @return false
+     */
+    function movingMouseMove(event) {
+        x1 = max(left, min(startX + evX(event), left + imgWidth - selection.width));
+        y1 = max(top, min(startY + evY(event), top + imgHeight - selection.height));
+
+        doMove(x1, y1);
+
+        event.preventDefault();     
+        return false;
+    }
+
+    /**
+     * Start selection
+     */
+    function startSelection() {
+        $(document).unbind('mousemove', startSelection);
+        adjust();
+
+        x2 = x1;
+        y2 = y1;       
+        doResize();
+
+        resize = '';
+
+        if (!$outer.is(':visible'))
+            /* Show the plugin elements */
+            $box.add($outer).hide().fadeIn(options.fadeSpeed||0);
+
+        shown = true;
+
+        $(document).unbind('mouseup', cancelSelection)
+            .mousemove(selectingMouseMove).one('mouseup', docMouseUp);
+        $box.unbind('mousemove', areaMouseMove);
+
+        options.onSelectStart(img, getSelection());
+    }
+
+    /**
+     * Cancel selection
+     */
+    function cancelSelection() {
+        $(document).unbind('mousemove', startSelection)
+            .unbind('mouseup', cancelSelection);
+        hide($box.add($outer));
+        
+        setSelection(selX(x1), selY(y1), selX(x1), selY(y1));
+        
+        /* If this is an API call, callback functions should not be triggered */
+        if (!(this instanceof $.imgAreaSelect)) {
+            options.onSelectChange(img, getSelection());
+            options.onSelectEnd(img, getSelection());
+        }
+    }
+
+    /**
+     * Image mousedown event handler
+     * 
+     * @param event
+     *            The event object
+     * @return false
+     */
+    function imgMouseDown(event) {
+        /* Ignore the event if animation is in progress */
+        if (event.which != 1 || $outer.is(':animated')) return false;
+
+        adjust();
+        startX = x1 = evX(event);
+        startY = y1 = evY(event);
+
+        /* Selection will start when the mouse is moved */
+        $(document).mousemove(startSelection).mouseup(cancelSelection);
+
+        return false;
+    }
+    
+    /**
+     * Window resize event handler
+     */
+    function windowResize() {
+        doUpdate(false);
+    }
+
+    /**
+     * Image load event handler. This is the final part of the initialization
+     * process.
+     */
+    function imgLoad() {
+        imgLoaded = true;
+
+        /* Set options */
+        setOptions(options = $.extend({
+            classPrefix: 'imgareaselect',
+            movable: true,
+            parent: 'body',
+            resizable: true,
+            resizeMargin: 10,
+            onInit: function () {},
+            onSelectStart: function () {},
+            onSelectChange: function () {},
+            onSelectEnd: function () {}
+        }, options));
+
+        $box.add($outer).css({ visibility: '' });
+        
+        if (options.show) {
+            shown = true;
+            adjust();
+            update();
+            $box.add($outer).hide().fadeIn(options.fadeSpeed||0);
+        }
+
+        /*
+         * Call the onInit callback. The setTimeout() call is used to ensure
+         * that the plugin has been fully initialized and the object instance is
+         * available (so that it can be obtained in the callback).
+         */
+        setTimeout(function () { options.onInit(img, getSelection()); }, 0);
+    }
+
+    /**
+     * Document keypress event handler
+     * 
+     * @param event
+     *            The event object
+     * @return false
+     */
+    var docKeyPress = function(event) {
+        var k = options.keys, d, t, key = event.keyCode;
+        
+        d = !isNaN(k.alt) && (event.altKey || event.originalEvent.altKey) ? k.alt :
+            !isNaN(k.ctrl) && event.ctrlKey ? k.ctrl :
+            !isNaN(k.shift) && event.shiftKey ? k.shift :
+            !isNaN(k.arrows) ? k.arrows : 10;
+
+        if (k.arrows == 'resize' || (k.shift == 'resize' && event.shiftKey) ||
+            (k.ctrl == 'resize' && event.ctrlKey) ||
+            (k.alt == 'resize' && (event.altKey || event.originalEvent.altKey)))
+        {
+            /* Resize selection */
+            
+            switch (key) {
+            case 37:
+                /* Left */
+                d = -d;
+            case 39:
+                /* Right */
+                t = max(x1, x2);
+                x1 = min(x1, x2);
+                x2 = max(t + d, x1);
+                fixAspectRatio();
+                break;
+            case 38:
+                /* Up */
+                d = -d;
+            case 40:
+                /* Down */
+                t = max(y1, y2);
+                y1 = min(y1, y2);
+                y2 = max(t + d, y1);
+                fixAspectRatio(true);
+                break;
+            default:
+                return;
+            }
+
+            doResize();
+        }
+        else {
+            /* Move selection */
+            
+            x1 = min(x1, x2);
+            y1 = min(y1, y2);
+
+            switch (key) {
+            case 37:
+                /* Left */
+                doMove(max(x1 - d, left), y1);
+                break;
+            case 38:
+                /* Up */
+                doMove(x1, max(y1 - d, top));
+                break;
+            case 39:
+                /* Right */
+                doMove(x1 + min(d, imgWidth - selX(x2)), y1);
+                break;
+            case 40:
+                /* Down */
+                doMove(x1, y1 + min(d, imgHeight - selY(y2)));
+                break;
+            default:
+                return;
+            }
+        }
+
+        return false;
+    };
+
+    /**
+     * Apply style options to plugin element (or multiple elements)
+     * 
+     * @param $elem
+     *            A jQuery object representing the element(s) to style
+     * @param props
+     *            An object that maps option names to corresponding CSS
+     *            properties
+     */
+    function styleOptions($elem, props) {
+        for (var option in props)
+            if (options[option] !== undefined)
+                $elem.css(props[option], options[option]);
+    }
+
+    /**
+     * Set plugin options
+     * 
+     * @param newOptions
+     *            The new options object
+     */
+    function setOptions(newOptions) {
+        if (newOptions.parent)
+            ($parent = $(newOptions.parent)).append($box.add($outer));
+        
+        /* Merge the new options with the existing ones */
+        $.extend(options, newOptions);
+
+        adjust();
+
+        if (newOptions.handles != null) {
+            /* Recreate selection area handles */
+            $handles.remove();
+            $handles = $([]);
+
+            i = newOptions.handles ? newOptions.handles == 'corners' ? 4 : 8 : 0;
+
+            while (i--)
+                $handles = $handles.add(div());
+            
+            /* Add a class to handles and set the CSS properties */
+            $handles.addClass(options.classPrefix + '-handle').css({
+                position: 'absolute',
+                /*
+                 * The font-size property needs to be set to zero, otherwise
+                 * Internet Explorer makes the handles too large
+                 */
+                fontSize: 0,
+                zIndex: zIndex + 1 || 1
+            });
+            
+            /*
+             * If handle width/height has not been set with CSS rules, set the
+             * default 5px
+             */
+            if (!parseInt($handles.css('width')) >= 0)
+                $handles.width(5).height(5);
+            
+            /*
+             * If the borderWidth option is in use, add a solid border to
+             * handles
+             */
+            if (o = options.borderWidth)
+                $handles.css({ borderWidth: o, borderStyle: 'solid' });
+
+            /* Apply other style options */
+            styleOptions($handles, { borderColor1: 'border-color',
+                borderColor2: 'background-color',
+                borderOpacity: 'opacity' });
+        }
+
+        /* Calculate scale factors */
+        scaleX = options.imageWidth / imgWidth || 1;
+        scaleY = options.imageHeight / imgHeight || 1;
+
+        /* Set selection */
+        if (newOptions.x1 != null) {
+            setSelection(newOptions.x1, newOptions.y1, newOptions.x2,
+                newOptions.y2);
+            newOptions.show = !newOptions.hide;
+        }
+
+        if (newOptions.keys)
+            /* Enable keyboard support */
+            options.keys = $.extend({ shift: 1, ctrl: 'resize' },
+                newOptions.keys);
+
+        /* Add classes to plugin elements */
+        $outer.addClass(options.classPrefix + '-outer');
+        $area.addClass(options.classPrefix + '-selection');
+        for (i = 0; i++ < 4;)
+            $($border[i-1]).addClass(options.classPrefix + '-border' + i);
+
+        /* Apply style options */
+        styleOptions($area, { selectionColor: 'background-color',
+            selectionOpacity: 'opacity' });
+        styleOptions($border, { borderOpacity: 'opacity',
+            borderWidth: 'border-width' });
+        styleOptions($outer, { outerColor: 'background-color',
+            outerOpacity: 'opacity' });
+        if (o = options.borderColor1)
+            $($border[0]).css({ borderStyle: 'solid', borderColor: o });
+        if (o = options.borderColor2)
+            $($border[1]).css({ borderStyle: 'dashed', borderColor: o });
+
+        /* Append all the selection area elements to the container box */
+        $box.append($area.add($border).add($areaOpera)).append($handles);
+
+        if (msie) {
+            if (o = ($outer.css('filter')||'').match(/opacity=(\d+)/))
+                $outer.css('opacity', o[1]/100);
+            if (o = ($border.css('filter')||'').match(/opacity=(\d+)/))
+                $border.css('opacity', o[1]/100);
+        }
+        
+        if (newOptions.hide)
+            hide($box.add($outer));
+        else if (newOptions.show && imgLoaded) {
+            shown = true;
+            $box.add($outer).fadeIn(options.fadeSpeed||0);
+            doUpdate();
+        }
+
+        /* Calculate the aspect ratio factor */
+        aspectRatio = (d = (options.aspectRatio || '').split(/:/))[0] / d[1];
+
+        $img.add($outer).unbind('mousedown', imgMouseDown);
+        
+        if (options.disable || options.enable === false) {
+            /* Disable the plugin */
+            $box.unbind('mousemove', areaMouseMove).unbind('mousedown', areaMouseDown);
+            $(window).unbind('resize', windowResize);
+        }
+        else {
+            if (options.enable || options.disable === false) {
+                /* Enable the plugin */
+                if (options.resizable || options.movable)
+                    $box.mousemove(areaMouseMove).mousedown(areaMouseDown);
+    
+                $(window).resize(windowResize);
+            }
+
+            if (!options.persistent)
+                $img.add($outer).mousedown(imgMouseDown);
+        }
+        
+        options.enable = options.disable = undefined;
+    }
+    
+    /**
+     * Remove plugin completely
+     */
+    this.remove = function () {
+        /*
+         * Call setOptions with { disable: true } to unbind the event handlers
+         */
+        setOptions({ disable: true });
+        $box.add($outer).remove();
+    };
+    
+    /*
+     * Public API
+     */
+    
+    /**
+     * Get current options
+     * 
+     * @return An object containing the set of options currently in use
+     */
+    this.getOptions = function () { return options; };
+    
+    /**
+     * Set plugin options
+     * 
+     * @param newOptions
+     *            The new options object
+     */
+    this.setOptions = setOptions;
+    
+    /**
+     * Get the current selection
+     * 
+     * @param noScale
+     *            If set to <code>true</code>, scaling is not applied to the
+     *            returned selection
+     * @return Selection object
+     */
+    this.getSelection = getSelection;
+    
+    /**
+     * Set the current selection
+     * 
+     * @param x1
+     *            X coordinate of the upper left corner of the selection area
+     * @param y1
+     *            Y coordinate of the upper left corner of the selection area
+     * @param x2
+     *            X coordinate of the lower right corner of the selection area
+     * @param y2
+     *            Y coordinate of the lower right corner of the selection area
+     * @param noScale
+     *            If set to <code>true</code>, scaling is not applied to the
+     *            new selection
+     */
+    this.setSelection = setSelection;
+    
+    /**
+     * Cancel selection
+     */
+    this.cancelSelection = cancelSelection;
+    
+    /**
+     * Update plugin elements
+     * 
+     * @param resetKeyPress
+     *            If set to <code>false</code>, this instance's keypress
+     *            event handler is not activated
+     */
+    this.update = doUpdate;
+
+    /* Do the dreaded browser detection */
+    var msie = (/msie ([\w.]+)/i.exec(ua)||[])[1],
+        opera = /opera/i.test(ua),
+        safari = /webkit/i.test(ua) && !/chrome/i.test(ua);
+
+    /* 
+     * Traverse the image's parent elements (up to <body>) and find the
+     * highest z-index
+     */
+    $p = $img;
+
+    while ($p.length) {
+        zIndex = max(zIndex,
+            !isNaN($p.css('z-index')) ? $p.css('z-index') : zIndex);
+        /* Also check if any of the ancestor elements has fixed position */ 
+        if ($p.css('position') == 'fixed')
+            position = 'fixed';
+
+        $p = $p.parent(':not(body)');
+    }
+    
+    /*
+     * If z-index is given as an option, it overrides the one found by the
+     * above loop
+     */
+    zIndex = options.zIndex || zIndex;
+
+    if (msie)
+        $img.attr('unselectable', 'on');
+
+    /*
+     * In MSIE and WebKit, we need to use the keydown event instead of keypress
+     */
+    $.imgAreaSelect.keyPress = msie || safari ? 'keydown' : 'keypress';
+
+    /*
+     * There is a bug affecting the CSS cursor property in Opera (observed in
+     * versions up to 10.00) that prevents the cursor from being updated unless
+     * the mouse leaves and enters the element again. To trigger the mouseover
+     * event, we're adding an additional div to $box and we're going to toggle
+     * it when mouse moves inside the selection area.
+     */
+    if (opera)    
+        $areaOpera = div().css({ width: '100%', height: '100%',
+            position: 'absolute', zIndex: zIndex + 2 || 2 });
+
+    /*
+     * We initially set visibility to "hidden" as a workaround for a weird
+     * behaviour observed in Google Chrome 1.0.154.53 (on Windows XP). Normally
+     * we would just set display to "none", but, for some reason, if we do so
+     * then Chrome refuses to later display the element with .show() or
+     * .fadeIn().
+     */
+    $box.add($outer).css({ visibility: 'hidden', position: position,
+        overflow: 'hidden', zIndex: zIndex || '0' });
+    $box.css({ zIndex: zIndex + 2 || 2 });
+    $area.add($border).css({ position: 'absolute', fontSize: 0 });
+    
+    /*
+     * If the image has been fully loaded, or if it is not really an image (eg.
+     * a div), call imgLoad() immediately; otherwise, bind it to be called once
+     * on image load event.
+     */
+    img.complete || img.readyState == 'complete' || !$img.is('img') ?
+        imgLoad() : $img.one('load', imgLoad);
+
+    /* 
+     * MSIE 9.0 doesn't always fire the image load event -- resetting the src
+     * attribute seems to trigger it. The check is for version 7 and above to
+     * accommodate for MSIE 9 running in compatibility mode.
+     */
+    if (!imgLoaded && msie && msie >= 7)
+        img.src = img.src;
+};
+
+/**
+ * Invoke imgAreaSelect on a jQuery object containing the image(s)
+ * 
+ * @param options
+ *            Options object
+ * @return The jQuery object or a reference to imgAreaSelect instance (if the
+ *         <code>instance</code> option was specified)
+ */
+$.fn.imgAreaSelect = function (options) {
+    options = options || {};
+
+    this.each(function () {
+        /* Is there already an imgAreaSelect instance bound to this element? */
+        if ($(this).data('imgAreaSelect')) {
+            /* Yes there is -- is it supposed to be removed? */
+            if (options.remove) {
+                /* Remove the plugin */
+                $(this).data('imgAreaSelect').remove();
+                $(this).removeData('imgAreaSelect');
+            }
+            else
+                /* Reset options */
+                $(this).data('imgAreaSelect').setOptions(options);
+        }
+        else if (!options.remove) {
+            /* No exising instance -- create a new one */
+            
+            /*
+             * If neither the "enable" nor the "disable" option is present, add
+             * "enable" as the default
+             */ 
+            if (options.enable === undefined && options.disable === undefined)
+                options.enable = true;
+
+            $(this).data('imgAreaSelect', new $.imgAreaSelect(this, options));
+        }
+    });
+    
+    if (options.instance)
+        /*
+         * Return the imgAreaSelect instance bound to the first element in the
+         * set
+         */
+        return $(this).data('imgAreaSelect');
+
+    return this;
+};
+
+})(jQuery);

--- a/bower_components/jquery-jeditable/README.textile
+++ b/bower_components/jquery-jeditable/README.textile
@@ -1,0 +1,43 @@
+h3. Changelog
+
+h4. 1.7.3
+
+* Add support for "jQuery plugin repository":http://plugins.jquery.com/
+
+h4. 1.7.2
+
+* Submit on change if input type select and no submit button defined ("gregpyp":http://github.com/gregpyp)
+
+h4. 1.7.1
+
+* Namespace default event as click.editable ("Zangetsu":http://github.com/Zangetsu)
+* Trim whitespace when determining the selected value of pulldown ("binarylogic":http://github.com/binarylogic)
+* Make default settings publicly available ("lawrencepit":http://github.com/lawrencepit)
+* Allow ajax calls other than 'html', e.g. json and script calls. ("lawrencepit":http://github.com/lawrencepit)
+* Do not follow links if they are editable ("Darwin":http://github.com/darwin)
+* make JSLInt happy ("olleolleolle":http://github.com/olleolleolle)
+
+h4. 1.7.0
+
+* Full control over jQuery AJAX options for those who want to tinker.
+* Fix problem with IE and placeholder with HTML tags.
+* Add $.editable('disable'), $.editable('enable') and $.editable('destroy')
+* Add onedit, onsubmit, onreset and onerror hooks. 
+* Allow passing select options as JavaScript object.
+* Fix IE throwing error with textareas when width or height was set to 'none'.
+
+h4. 1.6.2
+
+* Fix problems when xhtml is served application/xhtml+xml.
+
+h4. 1.6.1
+
+* Submit method can now be POST (default) or PUT.
+* Fix form being submitted twice in some cases.
+
+h4. 1.6.0
+
+* Onblur parameter can now be a function.
+* Support for any arbitary event for triggering Jeditable
+* Submitting of form will be canceled if submit() method of custom input returns false. 
+* Custom inputs now have access to reset() method. 

--- a/bower_components/jquery-jeditable/jquery.jeditable.js
+++ b/bower_components/jquery-jeditable/jquery.jeditable.js
@@ -1,0 +1,546 @@
+/*
+ * Jeditable - jQuery in place edit plugin
+ *
+ * Copyright (c) 2006-2013 Mika Tuupola, Dylan Verheul
+ *
+ * Licensed under the MIT license:
+ *   http://www.opensource.org/licenses/mit-license.php
+ *
+ * Project home:
+ *   http://www.appelsiini.net/projects/jeditable
+ *
+ * Based on editable by Dylan Verheul <dylan_at_dyve.net>:
+ *    http://www.dyve.net/jquery/?editable
+ *
+ */
+
+/**
+  * Version 1.7.3
+  *
+  * ** means there is basic unit tests for this parameter. 
+  *
+  * @name  Jeditable
+  * @type  jQuery
+  * @param String  target             (POST) URL or function to send edited content to **
+  * @param Hash    options            additional options 
+  * @param String  options[method]    method to use to send edited content (POST or PUT) **
+  * @param Function options[callback] Function to run after submitting edited content **
+  * @param String  options[name]      POST parameter name of edited content
+  * @param String  options[id]        POST parameter name of edited div id
+  * @param Hash    options[submitdata] Extra parameters to send when submitting edited content.
+  * @param String  options[type]      text, textarea or select (or any 3rd party input type) **
+  * @param Integer options[rows]      number of rows if using textarea ** 
+  * @param Integer options[cols]      number of columns if using textarea **
+  * @param Mixed   options[height]    'auto', 'none' or height in pixels **
+  * @param Mixed   options[width]     'auto', 'none' or width in pixels **
+  * @param String  options[loadurl]   URL to fetch input content before editing **
+  * @param String  options[loadtype]  Request type for load url. Should be GET or POST.
+  * @param String  options[loadtext]  Text to display while loading external content.
+  * @param Mixed   options[loaddata]  Extra parameters to pass when fetching content before editing.
+  * @param Mixed   options[data]      Or content given as paramameter. String or function.**
+  * @param String  options[indicator] indicator html to show when saving
+  * @param String  options[tooltip]   optional tooltip text via title attribute **
+  * @param String  options[event]     jQuery event such as 'click' of 'dblclick' **
+  * @param String  options[submit]    submit button value, empty means no button **
+  * @param String  options[cancel]    cancel button value, empty means no button **
+  * @param String  options[cssclass]  CSS class to apply to input form. 'inherit' to copy from parent. **
+  * @param String  options[style]     Style to apply to input form 'inherit' to copy from parent. **
+  * @param String  options[select]    true or false, when true text is highlighted ??
+  * @param String  options[placeholder] Placeholder text or html to insert when element is empty. **
+  * @param String  options[onblur]    'cancel', 'submit', 'ignore' or function ??
+  *             
+  * @param Function options[onsubmit] function(settings, original) { ... } called before submit
+  * @param Function options[onreset]  function(settings, original) { ... } called before reset
+  * @param Function options[onerror]  function(settings, original, xhr) { ... } called on error
+  *             
+  * @param Hash    options[ajaxoptions]  jQuery Ajax options. See docs.jquery.com.
+  *             
+  */
+
+(function($) {
+
+    $.fn.editable = function(target, options) {
+            
+        if ('disable' == target) {
+            $(this).data('disabled.editable', true);
+            return;
+        }
+        if ('enable' == target) {
+            $(this).data('disabled.editable', false);
+            return;
+        }
+        if ('destroy' == target) {
+            $(this)
+                .unbind($(this).data('event.editable'))
+                .removeData('disabled.editable')
+                .removeData('event.editable');
+            return;
+        }
+        
+        var settings = $.extend({}, $.fn.editable.defaults, {target:target}, options);
+        
+        /* setup some functions */
+        var plugin   = $.editable.types[settings.type].plugin || function() { };
+        var submit   = $.editable.types[settings.type].submit || function() { };
+        var buttons  = $.editable.types[settings.type].buttons 
+                    || $.editable.types['defaults'].buttons;
+        var content  = $.editable.types[settings.type].content 
+                    || $.editable.types['defaults'].content;
+        var element  = $.editable.types[settings.type].element 
+                    || $.editable.types['defaults'].element;
+        var reset    = $.editable.types[settings.type].reset 
+                    || $.editable.types['defaults'].reset;
+        var callback = settings.callback || function() { };
+        var onedit   = settings.onedit   || function() { }; 
+        var onsubmit = settings.onsubmit || function() { };
+        var onreset  = settings.onreset  || function() { };
+        var onerror  = settings.onerror  || reset;
+          
+        /* Show tooltip. */
+        if (settings.tooltip) {
+            $(this).attr('title', settings.tooltip);
+        }
+        
+        settings.autowidth  = 'auto' == settings.width;
+        settings.autoheight = 'auto' == settings.height;
+        
+        return this.each(function() {
+                        
+            /* Save this to self because this changes when scope changes. */
+            var self = this;  
+                   
+            /* Inlined block elements lose their width and height after first edit. */
+            /* Save them for later use as workaround. */
+            var savedwidth  = $(self).width();
+            var savedheight = $(self).height();
+
+            /* Save so it can be later used by $.editable('destroy') */
+            $(this).data('event.editable', settings.event);
+            
+            /* If element is empty add something clickable (if requested) */
+            if (!$.trim($(this).html())) {
+                $(this).html(settings.placeholder);
+            }
+            
+            $(this).bind(settings.event, function(e) {
+                
+                /* Abort if element is disabled. */
+                if (true === $(this).data('disabled.editable')) {
+                    return;
+                }
+                
+                /* Prevent throwing an exeption if edit field is clicked again. */
+                if (self.editing) {
+                    return;
+                }
+                
+                /* Abort if onedit hook returns false. */
+                if (false === onedit.apply(this, [settings, self])) {
+                   return;
+                }
+                
+                /* Prevent default action and bubbling. */
+                e.preventDefault();
+                e.stopPropagation();
+                
+                /* Remove tooltip. */
+                if (settings.tooltip) {
+                    $(self).removeAttr('title');
+                }
+                
+                /* Figure out how wide and tall we are, saved width and height. */
+                /* Workaround for http://dev.jquery.com/ticket/2190 */
+                if (0 == $(self).width()) {
+                    settings.width  = savedwidth;
+                    settings.height = savedheight;
+                } else {
+                    if (settings.width != 'none') {
+                        settings.width = 
+                            settings.autowidth ? $(self).width()  : settings.width;
+                    }
+                    if (settings.height != 'none') {
+                        settings.height = 
+                            settings.autoheight ? $(self).height() : settings.height;
+                    }
+                }
+                
+                /* Remove placeholder text, replace is here because of IE. */
+                if ($(this).html().toLowerCase().replace(/(;|"|\/)/g, '') == 
+                    settings.placeholder.toLowerCase().replace(/(;|"|\/)/g, '')) {
+                        $(this).html('');
+                }
+                                
+                self.editing    = true;
+                self.revert     = $(self).html();
+                $(self).html('');
+
+                /* Create the form object. */
+                var form = $('<form />');
+                
+                /* Apply css or style or both. */
+                if (settings.cssclass) {
+                    if ('inherit' == settings.cssclass) {
+                        form.attr('class', $(self).attr('class'));
+                    } else {
+                        form.attr('class', settings.cssclass);
+                    }
+                }
+
+                if (settings.style) {
+                    if ('inherit' == settings.style) {
+                        form.attr('style', $(self).attr('style'));
+                        /* IE needs the second line or display wont be inherited. */
+                        form.css('display', $(self).css('display'));                
+                    } else {
+                        form.attr('style', settings.style);
+                    }
+                }
+
+                /* Add main input element to form and store it in input. */
+                var input = element.apply(form, [settings, self]);
+
+                /* Set input content via POST, GET, given data or existing value. */
+                var input_content;
+                
+                if (settings.loadurl) {
+                    var t = setTimeout(function() {
+                        input.disabled = true;
+                        content.apply(form, [settings.loadtext, settings, self]);
+                    }, 100);
+
+                    var loaddata = {};
+                    loaddata[settings.id] = self.id;
+                    if ($.isFunction(settings.loaddata)) {
+                        $.extend(loaddata, settings.loaddata.apply(self, [self.revert, settings]));
+                    } else {
+                        $.extend(loaddata, settings.loaddata);
+                    }
+                    $.ajax({
+                       type : settings.loadtype,
+                       url  : settings.loadurl,
+                       data : loaddata,
+                       async : false,
+                       success: function(result) {
+                          window.clearTimeout(t);
+                          input_content = result;
+                          input.disabled = false;
+                       }
+                    });
+                } else if (settings.data) {
+                    input_content = settings.data;
+                    if ($.isFunction(settings.data)) {
+                        input_content = settings.data.apply(self, [self.revert, settings]);
+                    }
+                } else {
+                    input_content = self.revert; 
+                }
+                content.apply(form, [input_content, settings, self]);
+
+                input.attr('name', settings.name);
+        
+                /* Add buttons to the form. */
+                buttons.apply(form, [settings, self]);
+         
+                /* Add created form to self. */
+                $(self).append(form);
+         
+                /* Attach 3rd party plugin if requested. */
+                plugin.apply(form, [settings, self]);
+
+                /* Focus to first visible form element. */
+                $(':input:visible:enabled:first', form).focus();
+
+                /* Highlight input contents when requested. */
+                if (settings.select) {
+                    input.select();
+                }
+        
+                /* discard changes if pressing esc */
+                input.keydown(function(e) {
+                    if (e.keyCode == 27) {
+                        e.preventDefault();
+                        reset.apply(form, [settings, self]);
+                    }
+                });
+
+                /* Discard, submit or nothing with changes when clicking outside. */
+                /* Do nothing is usable when navigating with tab. */
+                var t;
+                if ('cancel' == settings.onblur) {
+                    input.blur(function(e) {
+                        /* Prevent canceling if submit was clicked. */
+                        t = setTimeout(function() {
+                            reset.apply(form, [settings, self]);
+                        }, 500);
+                    });
+                } else if ('submit' == settings.onblur) {
+                    input.blur(function(e) {
+                        /* Prevent double submit if submit was clicked. */
+                        t = setTimeout(function() {
+                            form.submit();
+                        }, 200);
+                    });
+                } else if ($.isFunction(settings.onblur)) {
+                    input.blur(function(e) {
+                        settings.onblur.apply(self, [input.val(), settings]);
+                    });
+                } else {
+                    input.blur(function(e) {
+                      /* TODO: maybe something here */
+                    });
+                }
+
+                form.submit(function(e) {
+
+                    if (t) { 
+                        clearTimeout(t);
+                    }
+
+                    /* Do no submit. */
+                    e.preventDefault(); 
+            
+                    /* Call before submit hook. */
+                    /* If it returns false abort submitting. */                    
+                    if (false !== onsubmit.apply(form, [settings, self])) { 
+                        /* Custom inputs call before submit hook. */
+                        /* If it returns false abort submitting. */
+                        if (false !== submit.apply(form, [settings, self])) { 
+
+                          /* Check if given target is function */
+                          if ($.isFunction(settings.target)) {
+                              var str = settings.target.apply(self, [input.val(), settings]);
+                              $(self).html(str);
+                              self.editing = false;
+                              callback.apply(self, [self.innerHTML, settings]);
+                              /* TODO: this is not dry */                              
+                              if (!$.trim($(self).html())) {
+                                  $(self).html(settings.placeholder);
+                              }
+                          } else {
+                              /* Add edited content and id of edited element to POST. */
+                              var submitdata = {};
+                              submitdata[settings.name] = input.val();
+                              submitdata[settings.id] = self.id;
+                              /* Add extra data to be POST:ed. */
+                              if ($.isFunction(settings.submitdata)) {
+                                  $.extend(submitdata, settings.submitdata.apply(self, [self.revert, settings]));
+                              } else {
+                                  $.extend(submitdata, settings.submitdata);
+                              }
+
+                              /* Quick and dirty PUT support. */
+                              if ('PUT' == settings.method) {
+                                  submitdata['_method'] = 'put';
+                              }
+
+                              /* Show the saving indicator. */
+                              $(self).html(settings.indicator);
+                              
+                              /* Defaults for ajaxoptions. */
+                              var ajaxoptions = {
+                                  type    : 'POST',
+                                  data    : submitdata,
+                                  dataType: 'html',
+                                  url     : settings.target,
+                                  success : function(result, status) {
+                                      if (ajaxoptions.dataType == 'html') {
+                                        $(self).html(result);
+                                      }
+                                      self.editing = false;
+                                      callback.apply(self, [result, settings]);
+                                      if (!$.trim($(self).html())) {
+                                          $(self).html(settings.placeholder);
+                                      }
+                                  },
+                                  error   : function(xhr, status, error) {
+                                      onerror.apply(form, [settings, self, xhr]);
+                                  }
+                              };
+                              
+                              /* Override with what is given in settings.ajaxoptions. */
+                              $.extend(ajaxoptions, settings.ajaxoptions);   
+                              $.ajax(ajaxoptions);          
+                              
+                            }
+                        }
+                    }
+                    
+                    /* Show tooltip again. */
+                    $(self).attr('title', settings.tooltip);
+                    
+                    return false;
+                });
+            });
+            
+            /* Privileged methods */
+            this.reset = function(form) {
+                /* Prevent calling reset twice when blurring. */
+                if (this.editing) {
+                    /* Before reset hook, if it returns false abort reseting. */
+                    if (false !== onreset.apply(form, [settings, self])) { 
+                        $(self).html(self.revert);
+                        self.editing   = false;
+                        if (!$.trim($(self).html())) {
+                            $(self).html(settings.placeholder);
+                        }
+                        /* Show tooltip again. */
+                        if (settings.tooltip) {
+                            $(self).attr('title', settings.tooltip);                
+                        }
+                    }                    
+                }
+            };            
+        });
+
+    };
+
+
+    $.editable = {
+        types: {
+            defaults: {
+                element : function(settings, original) {
+                    var input = $('<input type="hidden"></input>');                
+                    $(this).append(input);
+                    return(input);
+                },
+                content : function(string, settings, original) {
+                    $(':input:first', this).val(string);
+                },
+                reset : function(settings, original) {
+                  original.reset(this);
+                },
+                buttons : function(settings, original) {
+                    var form = this;
+                    if (settings.submit) {
+                        /* If given html string use that. */
+                        if (settings.submit.match(/>$/)) {
+                            var submit = $(settings.submit).click(function() {
+                                if (submit.attr("type") != "submit") {
+                                    form.submit();
+                                }
+                            });
+                        /* Otherwise use button with given string as text. */
+                        } else {
+                            var submit = $('<button type="submit" />');
+                            submit.html(settings.submit);                            
+                        }
+                        $(this).append(submit);
+                    }
+                    if (settings.cancel) {
+                        /* If given html string use that. */
+                        if (settings.cancel.match(/>$/)) {
+                            var cancel = $(settings.cancel);
+                        /* otherwise use button with given string as text */
+                        } else {
+                            var cancel = $('<button type="cancel" />');
+                            cancel.html(settings.cancel);
+                        }
+                        $(this).append(cancel);
+
+                        $(cancel).click(function(event) {
+                            if ($.isFunction($.editable.types[settings.type].reset)) {
+                                var reset = $.editable.types[settings.type].reset;                                                                
+                            } else {
+                                var reset = $.editable.types['defaults'].reset;                                
+                            }
+                            reset.apply(form, [settings, original]);
+                            return false;
+                        });
+                    }
+                }
+            },
+            text: {
+                element : function(settings, original) {
+                    var input = $('<input />');
+                    if (settings.width  != 'none') { input.width(settings.width);  }
+                    if (settings.height != 'none') { input.height(settings.height); }
+                    /* https://bugzilla.mozilla.org/show_bug.cgi?id=236791 */
+                    //input[0].setAttribute('autocomplete','off');
+                    input.attr('autocomplete','off');
+                    $(this).append(input);
+                    return(input);
+                }
+            },
+            textarea: {
+                element : function(settings, original) {
+                    var textarea = $('<textarea />');
+                    if (settings.rows) {
+                        textarea.attr('rows', settings.rows);
+                    } else if (settings.height != "none") {
+                        textarea.height(settings.height);
+                    }
+                    if (settings.cols) {
+                        textarea.attr('cols', settings.cols);
+                    } else if (settings.width != "none") {
+                        textarea.width(settings.width);
+                    }
+                    $(this).append(textarea);
+                    return(textarea);
+                }
+            },
+            select: {
+               element : function(settings, original) {
+                    var select = $('<select />');
+                    $(this).append(select);
+                    return(select);
+                },
+                content : function(data, settings, original) {
+                    /* If it is string assume it is json. */
+                    if (String == data.constructor) {      
+                        eval ('var json = ' + data);
+                    } else {
+                    /* Otherwise assume it is a hash already. */
+                        var json = data;
+                    }
+                    for (var key in json) {
+                        if (!json.hasOwnProperty(key)) {
+                            continue;
+                        }
+                        if ('selected' == key) {
+                            continue;
+                        } 
+                        var option = $('<option />').val(key).append(json[key]);
+                        $('select', this).append(option);    
+                    }                    
+                    /* Loop option again to set selected. IE needed this... */ 
+                    $('select', this).children().each(function() {
+                        if ($(this).val() == json['selected'] || 
+                            $(this).text() == $.trim(original.revert)) {
+                                $(this).attr('selected', 'selected');
+                        }
+                    });
+                    /* Submit on change if no submit button defined. */
+                    if (!settings.submit) {
+                        var form = this;
+                        $('select', this).change(function() {
+                            form.submit();
+                        });
+                    }
+                }
+            }
+        },
+
+        /* Add new input type */
+        addInputType: function(name, input) {
+            $.editable.types[name] = input;
+        }
+    };
+
+    /* Publicly accessible defaults. */
+    $.fn.editable.defaults = {
+        name       : 'value',
+        id         : 'id',
+        type       : 'text',
+        width      : 'auto',
+        height     : 'auto',
+        event      : 'click.editable',
+        onblur     : 'cancel',
+        loadtype   : 'GET',
+        loadtext   : 'Loading...',
+        placeholder: 'Click to edit',
+        loaddata   : {},
+        submitdata : {},
+        ajaxoptions: {}
+    };
+
+})(jQuery);

--- a/bower_components/jquery-ui-extensions/readme.md
+++ b/bower_components/jquery-ui-extensions/readme.md
@@ -1,0 +1,16 @@
+This repository is not actively maintained. It works with whatever version of
+jQuery UI is used in the demos. There are no tests and I don't use any of these
+in any of my code anywhere. Individual extensions may or may not work with newer
+version of jQuery UI.
+
+At some point in 2013, I will update all of this code, add tests, support
+multiple versions of jQuery UI, create several more extensions and post these
+on the new plugins site.
+
+If you're looking for the `selectFirst` extension for autocomplete, check the
+[1-8 branch](https://github.com/scottgonzalez/jquery-ui-extensions/tree/1-8).
+`selectFirst` has been removed from master because the option was rolled into
+newer versions of jQuery UI as the
+[`autoFocus`](http://api.jqueryui.com/autocomplete/#option-autoFocus) option.
+
+Support this project by [donating on Gittip](https://www.gittip.com/scottgonzalez/).

--- a/bower_components/jquery-ui-extensions/src/autocomplete/jquery.ui.autocomplete.html.js
+++ b/bower_components/jquery-ui-extensions/src/autocomplete/jquery.ui.autocomplete.html.js
@@ -1,0 +1,40 @@
+/*
+ * jQuery UI Autocomplete HTML Extension
+ *
+ * Copyright 2010, Scott González (http://scottgonzalez.com)
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ *
+ * http://github.com/scottgonzalez/jquery-ui-extensions
+ */
+(function( $ ) {
+
+var proto = $.ui.autocomplete.prototype,
+	initSource = proto._initSource;
+
+function filter( array, term ) {
+	var matcher = new RegExp( $.ui.autocomplete.escapeRegex(term), "i" );
+	return $.grep( array, function(value) {
+		return matcher.test( $( "<div>" ).html( value.label || value.value || value ).text() );
+	});
+}
+
+$.extend( proto, {
+	_initSource: function() {
+		if ( this.options.html && $.isArray(this.options.source) ) {
+			this.source = function( request, response ) {
+				response( filter( this.options.source, request.term ) );
+			};
+		} else {
+			initSource.call( this );
+		}
+	},
+
+	_renderItem: function( ul, item) {
+		return $( "<li></li>" )
+			.data( "item.autocomplete", item )
+			.append( $( "<a></a>" )[ this.options.html ? "html" : "text" ]( item.label ) )
+			.appendTo( ul );
+	}
+});
+
+})( jQuery );

--- a/bower_components/sprintf/LICENSE.md
+++ b/bower_components/sprintf/LICENSE.md
@@ -1,0 +1,24 @@
+Copyright (c) Alexandru Marasteanu <hello [at) alexei (dot] ro>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of sprintf() for JavaScript nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL Alexandru Marasteanu BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/bower_components/sprintf/README.md
+++ b/bower_components/sprintf/README.md
@@ -1,0 +1,48 @@
+# sprintf.js
+sprintf.js is a complete open source JavaScript sprintf implementation.
+
+It's prototype is simple:
+	string sprintf(string format , [mixed arg1 [, mixed arg2 [ ,...]]]);
+
+The placeholders in the format string are marked by "%" and are followed by one or more of these elements, in this order:
+* An optional "+" sign that forces to preceed the result with a plus or minus sign on numeric values. By default, only the "-" sign is used on negative numbers.
+* An optional padding specifier that says what character to use for padding (if specified). Possible values are 0 or any other character precedeed by a '. The default is to pad with spaces.
+* An optional "-" sign, that causes sprintf to left-align the result of this placeholder. The default is to right-align the result.
+* An optional number, that says how many characters the result should have. If the value to be returned is shorter than this number, the result will be padded.
+* An optional precision modifier, consisting of a "." (dot) followed by a number, that says how many digits should be displayed for floating point numbers. When used on a string, it causes the result to be truncated.
+* A type specifier that can be any of:
+    * % — print a literal "%" character
+    * b — print an integer as a binary number
+    * c — print an integer as the character with that ASCII value
+    * d — print an integer as a signed decimal number
+    * e — print a float as scientific notation
+    * u — print an integer as an unsigned decimal number
+    * f — print a float as is
+    * o — print an integer as an octal number
+    * s — print a string as is
+    * x — print an integer as a hexadecimal number (lower-case)
+    * X — print an integer as a hexadecimal number (upper-case)
+
+## JavaScript vsprintf()
+vsprintf() is the same as sprintf() except that it accepts an array of arguments, rather than a variable number of arguments:
+	vsprintf('The first 4 letters of the english alphabet are: %s, %s, %s and %s', ['a', 'b', 'c', 'd']);
+
+## Argument swapping
+You can also swap the arguments. That is, the order of the placeholders doesn't have to match the order of the arguments. You can do that by simply indicating in the format string which arguments the placeholders refer to:
+	sprintf('%2$s %3$s a %1$s', 'cracker', 'Polly', 'wants');
+And, of course, you can repeat the placeholders without having to increase the number of arguments.
+
+## Named arguments
+Format strings may contain replacement fields rather than positional placeholders. Instead of referring to a certain argument, you can now refer to a certain key within an object. Replacement fields are surrounded by rounded parentheses () and begin with a keyword that refers to a key:
+	var user = {
+		name: 'Dolly'
+	};
+	sprintf('Hello %(name)s', user); // Hello Dolly
+Keywords in replacement fields can be optionally followed by any number of keywords or indexes:
+	var users = [
+		{name: 'Dolly'},
+		{name: 'Molly'},
+		{name: 'Polly'}
+	];
+	sprintf('Hello %(users[0].name)s, %(users[1].name)s and %(users[2].name)s', {users: users}); // Hello Dolly, Molly and Polly
+Note: mixing positional and named placeholders is not (yet) supported

--- a/bower_components/sprintf/src/sprintf.js
+++ b/bower_components/sprintf/src/sprintf.js
@@ -1,0 +1,183 @@
+/**
+sprintf() for JavaScript 0.7-beta1
+http://www.diveintojavascript.com/projects/javascript-sprintf
+
+Copyright (c) Alexandru Marasteanu <alexaholic [at) gmail (dot] com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of sprintf() for JavaScript nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL Alexandru Marasteanu BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Changelog:
+2010.09.06 - 0.7-beta1
+  - features: vsprintf, support for named placeholders
+  - enhancements: format cache, reduced global namespace pollution
+
+2010.05.22 - 0.6:
+ - reverted to 0.4 and fixed the bug regarding the sign of the number 0
+ Note:
+ Thanks to Raphael Pigulla <raph (at] n3rd [dot) org> (http://www.n3rd.org/)
+ who warned me about a bug in 0.5, I discovered that the last update was
+ a regress. I appologize for that.
+
+2010.05.09 - 0.5:
+ - bug fix: 0 is now preceeded with a + sign
+ - bug fix: the sign was not at the right position on padded results (Kamal Abdali)
+ - switched from GPL to BSD license
+
+2007.10.21 - 0.4:
+ - unit test and patch (David Baird)
+
+2007.09.17 - 0.3:
+ - bug fix: no longer throws exception on empty paramenters (Hans Pufal)
+
+2007.09.11 - 0.2:
+ - feature: added argument swapping
+
+2007.04.03 - 0.1:
+ - initial release
+**/
+
+var sprintf = (function() {
+	function get_type(variable) {
+		return Object.prototype.toString.call(variable).slice(8, -1).toLowerCase();
+	}
+	function str_repeat(input, multiplier) {
+		for (var output = []; multiplier > 0; output[--multiplier] = input) {/* do nothing */}
+		return output.join('');
+	}
+
+	var str_format = function() {
+		if (!str_format.cache.hasOwnProperty(arguments[0])) {
+			str_format.cache[arguments[0]] = str_format.parse(arguments[0]);
+		}
+		return str_format.format.call(null, str_format.cache[arguments[0]], arguments);
+	};
+
+	str_format.format = function(parse_tree, argv) {
+		var cursor = 1, tree_length = parse_tree.length, node_type = '', arg, output = [], i, k, match, pad, pad_character, pad_length;
+		for (i = 0; i < tree_length; i++) {
+			node_type = get_type(parse_tree[i]);
+			if (node_type === 'string') {
+				output.push(parse_tree[i]);
+			}
+			else if (node_type === 'array') {
+				match = parse_tree[i]; // convenience purposes only
+				if (match[2]) { // keyword argument
+					arg = argv[cursor];
+					for (k = 0; k < match[2].length; k++) {
+						if (!arg.hasOwnProperty(match[2][k])) {
+							throw(sprintf('[sprintf] property "%s" does not exist', match[2][k]));
+						}
+						arg = arg[match[2][k]];
+					}
+				}
+				else if (match[1]) { // positional argument (explicit)
+					arg = argv[match[1]];
+				}
+				else { // positional argument (implicit)
+					arg = argv[cursor++];
+				}
+
+				if (/[^s]/.test(match[8]) && (get_type(arg) != 'number')) {
+					throw(sprintf('[sprintf] expecting number but found %s', get_type(arg)));
+				}
+				switch (match[8]) {
+					case 'b': arg = arg.toString(2); break;
+					case 'c': arg = String.fromCharCode(arg); break;
+					case 'd': arg = parseInt(arg, 10); break;
+					case 'e': arg = match[7] ? arg.toExponential(match[7]) : arg.toExponential(); break;
+					case 'f': arg = match[7] ? parseFloat(arg).toFixed(match[7]) : parseFloat(arg); break;
+					case 'o': arg = arg.toString(8); break;
+					case 's': arg = ((arg = String(arg)) && match[7] ? arg.substring(0, match[7]) : arg); break;
+					case 'u': arg = Math.abs(arg); break;
+					case 'x': arg = arg.toString(16); break;
+					case 'X': arg = arg.toString(16).toUpperCase(); break;
+				}
+				arg = (/[def]/.test(match[8]) && match[3] && arg >= 0 ? '+'+ arg : arg);
+				pad_character = match[4] ? match[4] == '0' ? '0' : match[4].charAt(1) : ' ';
+				pad_length = match[6] - String(arg).length;
+				pad = match[6] ? str_repeat(pad_character, pad_length) : '';
+				output.push(match[5] ? arg + pad : pad + arg);
+			}
+		}
+		return output.join('');
+	};
+
+	str_format.cache = {};
+
+	str_format.parse = function(fmt) {
+		var _fmt = fmt, match = [], parse_tree = [], arg_names = 0;
+		while (_fmt) {
+			if ((match = /^[^\x25]+/.exec(_fmt)) !== null) {
+				parse_tree.push(match[0]);
+			}
+			else if ((match = /^\x25{2}/.exec(_fmt)) !== null) {
+				parse_tree.push('%');
+			}
+			else if ((match = /^\x25(?:([1-9]\d*)\$|\(([^\)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-fosuxX])/.exec(_fmt)) !== null) {
+				if (match[2]) {
+					arg_names |= 1;
+					var field_list = [], replacement_field = match[2], field_match = [];
+					if ((field_match = /^([a-z_][a-z_\d]*)/i.exec(replacement_field)) !== null) {
+						field_list.push(field_match[1]);
+						while ((replacement_field = replacement_field.substring(field_match[0].length)) !== '') {
+							if ((field_match = /^\.([a-z_][a-z_\d]*)/i.exec(replacement_field)) !== null) {
+								field_list.push(field_match[1]);
+							}
+							else if ((field_match = /^\[(\d+)\]/.exec(replacement_field)) !== null) {
+								field_list.push(field_match[1]);
+							}
+							else {
+								throw('[sprintf] huh?');
+							}
+						}
+					}
+					else {
+						throw('[sprintf] huh?');
+					}
+					match[2] = field_list;
+				}
+				else {
+					arg_names |= 2;
+				}
+				if (arg_names === 3) {
+					throw('[sprintf] mixing positional and named placeholders is not (yet) supported');
+				}
+				parse_tree.push(match);
+			}
+			else {
+				throw('[sprintf] huh?');
+			}
+			_fmt = _fmt.substring(match[0].length);
+		}
+		return parse_tree;
+	};
+
+	return str_format;
+})();
+
+var vsprintf = function(fmt, argv) {
+	argv.unshift(fmt);
+	return sprintf.apply(null, argv);
+};

--- a/composer.json
+++ b/composer.json
@@ -25,61 +25,11 @@
         "bower-asset/jquery-ui": "^1.11.4",
         "bower-asset/text": "^2.0.4",
         "bower-asset/requirejs": "^2.1.18",
-        "bower-asset/sprintf": "^0.7.0",
         "bower-asset/jquery-form": "^3.51",
         "bower-asset/jquery-colorbox": "^1.5.14",
-        "bower-asset/jquery-imgareaselect": "^0.9.0",
-        "bower-asset/jquery-ui-extensions": "dev-master",
-        "bower-asset/jquery-jeditable": "^1.7.3",
         "FortAwesome/Font-Awesome": "^4.3",
         "michelf/php-markdown": "^1.5.0"
     },
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "bower-asset/sprintf",
-                "version": "0.7.0",
-                "dist": {
-                    "type": "zip",
-                    "url": "https://github.com/alexei/sprintf.js/archive/v0.7.zip"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "bower-asset/jquery-imgareaselect",
-                "version": "0.9.10",
-                "dist": {
-                    "type": "zip",
-                    "url": "https://github.com/odyniec/imgareaselect/archive/v0.9.10.zip"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "bower-asset/jquery-ui-extensions",
-                "version": "dev-master",
-                "dist": {
-                    "type": "zip",
-                    "url": "https://github.com/scottgonzalez/jquery-ui-extensions/archive/fb7fd7df3d70e0288394f07bfe78262b548c30d6.zip"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "bower-asset/jquery-jeditable",
-                "version": "1.7.3",
-                "dist": {
-                    "type": "zip",
-                    "url": "https://github.com/tuupola/jquery_jeditable/archive/1.7.3.zip"
-                }
-            }
-        }
-    ],
     "scripts": {
         "pre-install-cmd": "php .scripts/check_global_requirements.php",
         "lint": [

--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -14,8 +14,7 @@ module.exports = function(config) {
 		// list of files / patterns to load in the browser
 		files: [
 			'vendor/bower-asset/jquery/dist/jquery.js',
-			'vendor/bower-asset/jquery-migrate/jquery-migrate.js',
-			'vendor/bower-asset/sprintf/src/sprintf.js',
+			'bower_components/sprintf/src/sprintf.js',
 			'js/lib/elgglib.js',
 			'js/lib/hooks.js',
 			'js/classes/*.js',

--- a/views.php
+++ b/views.php
@@ -13,13 +13,8 @@ return [
 		"jquery.min.map" => "vendor/bower-asset/jquery/dist/jquery.min.map",
 		"jquery-migrate.js" => "vendor/bower-asset/jquery-migrate/jquery-migrate.min.js",
 		"jquery.form.js" => "vendor/bower-asset/jquery-form/jquery.form.js",
-		"jquery.imgareaselect.css" => "vendor/bower-asset/jquery-imgareaselect/distfiles/css/imgareaselect-deprecated.css",
-		"jquery.imgareaselect.js" => "vendor/bower-asset/jquery-imgareaselect/jquery.imgareaselect.dev.js",
-		"jquery.jeditable.js" => "vendor/bower-asset/jquery-jeditable/jquery.jeditable.js",
 		"jquery.colorbox.js" => "vendor/bower-asset/jquery-colorbox/jquery.colorbox-min.js",
-		"jquery.ui.autocomplete.html.js" => "vendor/bower-asset/jquery-ui-extensions/src/autocomplete/jquery.ui.autocomplete.html.js",
 		"require.js" => "vendor/bower-asset/requirejs/require.js",
-		"sprintf.js" => "vendor/bower-asset/sprintf/dist/sprintf.min.js",
 		"text.js" => "vendor/bower-asset/text/text.js",
 		
 		// need to use some folder structure, because FontAwesome includes fonts relative to css
@@ -35,5 +30,10 @@ return [
 		"elgg/ui.avatar_cropper.js" => __DIR__ . "/js/lib/ui.avatar_cropper.js",
 		"elgg/ui.friends_picker.js" => __DIR__ . "/js/lib/ui.friends_picker.js",
 		"elgg/ui.river.js" => __DIR__ . "/js/lib/ui.river.js",
+		"jquery.imgareaselect.css" => __DIR__ . "/bower_components/jquery-imgareaselect/distfiles/css/imgareaselect-deprecated.css",
+		"jquery.imgareaselect.js" => __DIR__ . "/bower_components/jquery-imgareaselect/jquery.imgareaselect.dev.js",
+		"jquery.jeditable.js" => __DIR__ . "/bower_components/jquery-jeditable/jquery.jeditable.js",
+		"jquery.ui.autocomplete.html.js" => __DIR__ . "/bower_components/jquery-ui-extensions/src/autocomplete/jquery.ui.autocomplete.html.js",
+		"sprintf.js" => __DIR__ . "/bower_components/sprintf/src/sprintf.js",
 	],
 ];

--- a/views/default/elgg.js.php
+++ b/views/default/elgg.js.php
@@ -15,10 +15,12 @@ if (typeof elgg != 'object') {
 
 JS;
 
+// For backwards compatibility...
+echo elgg_view('sprintf.js');
+
 $elggDir = \Elgg\Application::elggDir();
 $files = array(
 	// these must come first
-	Directory\Local::root()->getPath('vendor/bower-asset/sprintf/src/sprintf.js'),
 	$elggDir->getPath("js/lib/elgglib.js"),
 
 	// class definitions


### PR DESCRIPTION
The whole point of going through composer-asset-plugin is to get automatic updates,
but that's not possible with these 4 libraries because they aren't available on
bower at all, so we get no benefit and only complications from depending on them
via bower-asset/\* repos.

This is also much easier than finding a replacement library and updating the code
to use the new library.

Fixes #8420
