### PR TITLE
feature(likes): Entities are no longer likable by default

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -481,6 +481,15 @@ HTMLawed
 **config, htmlawed**
 	Filter the HTMLawed config array.
 
+Likes
+-----
+
+**likes:is_likable, <type>:<subtype>**
+    This is called to set the default permissions for whether to display/allow likes on an entity of type
+    ``<type>`` and subtype ``<subtype>``.
+
+    .. note:: The callback ``'Elgg\Values::getTrue'`` is a useful handler for this hook.
+
 Members
 -------
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -386,6 +386,18 @@ The following views received ``label`` elements around some of the input fields.
 - views/default/forms/admin/plugins/sort.php
 - views/default/forms/login.php
 
+Plugin Likes
+------------
+
+Objects are no longer likable by default. To support liking, you can register a handler to permit the annotation,
+or more simply register for the hook ``["likes:is_likable", "<type>:<subtype>"]`` and return true. E.g.
+
+.. code:: php
+
+    elgg_register_plugin_hook_handler('likes:is_likable', 'object:mysubtype', 'Elgg\Values::getTrue');
+
+Just as before, the ``permissions_check:annotate`` hook is still called and may be used to override default behavior.
+
 Plugin Messages
 ---------------
 

--- a/engine/lib/comments.php
+++ b/engine/lib/comments.php
@@ -26,6 +26,8 @@ function _elgg_comments_init() {
 	elgg_register_page_handler('comment', '_elgg_comments_page_handler');
 
 	elgg_register_ajax_view('core/ajax/edit_comment');
+
+	elgg_register_plugin_hook_handler('likes:is_likable', 'object:comment', 'Elgg\Values::getTrue');
 }
 
 /**

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -68,6 +68,9 @@ function blog_init() {
 
 	// ecml
 	elgg_register_plugin_hook_handler('get_views', 'ecml', 'blog_ecml_views_hook');
+
+	// allow to be liked
+	elgg_register_plugin_hook_handler('likes:is_likable', 'object:blog', 'Elgg\Values::getTrue');
 }
 
 /**

--- a/mod/bookmarks/start.php
+++ b/mod/bookmarks/start.php
@@ -67,6 +67,9 @@ function bookmarks_init() {
 	// Groups
 	add_group_tool_option('bookmarks', elgg_echo('bookmarks:enablebookmarks'), true);
 	elgg_extend_view('groups/tool_latest', 'bookmarks/group_module');
+
+	// allow to be liked
+	elgg_register_plugin_hook_handler('likes:is_likable', 'object:bookmarks', 'Elgg\Values::getTrue');
 }
 
 /**

--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -61,6 +61,10 @@ function discussion_init() {
 
 	// allow ecml in discussion
 	elgg_register_plugin_hook_handler('get_views', 'ecml', 'discussion_ecml_views_hook');
+
+	// allow to be liked
+	elgg_register_plugin_hook_handler('likes:is_likable', 'object:discussion', 'Elgg\Values::getTrue');
+	elgg_register_plugin_hook_handler('likes:is_likable', 'object:discussion_reply', 'Elgg\Values::getTrue');
 }
 
 /**

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -88,6 +88,9 @@ function file_init() {
 	elgg_register_menu_item('embed', $item);
 
 	elgg_extend_view('theme_sandbox/icons', 'file/theme_sandbox/icons/files');
+
+	// allow to be liked
+	elgg_register_plugin_hook_handler('likes:is_likable', 'object:file', 'Elgg\Values::getTrue');
 }
 
 /**

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -90,6 +90,10 @@ function pages_init() {
 
 	// register ecml views to parse
 	elgg_register_plugin_hook_handler('get_views', 'ecml', 'pages_ecml_views_hook');
+
+	// allow to be liked
+	elgg_register_plugin_hook_handler('likes:is_likable', 'object:page', 'Elgg\Values::getTrue');
+	elgg_register_plugin_hook_handler('likes:is_likable', 'object:page_top', 'Elgg\Values::getTrue');
 }
 
 /**

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -62,6 +62,9 @@ function thewire_init() {
 	elgg_register_action("thewire/add", "$action_base/add.php");
 	elgg_register_action("thewire/delete", "$action_base/delete.php");
 
+	// allow to be liked
+	elgg_register_plugin_hook_handler('likes:is_likable', 'object:thewire', 'Elgg\Values::getTrue');
+
 	elgg_register_plugin_hook_handler('unit_test', 'system', 'thewire_test');
 
 	elgg_register_event_handler('upgrade', 'system', 'thewire_run_upgrades');


### PR DESCRIPTION
BREAKING CHANGE:
To allow likes on your content you must permit the annotation to be created. Likes provides a new hook “likes:is_likable” to allow easily registering entities by type:subtype.

Fixes #5996

(This combines ideas from previous attempts to allow one-line registering of subtypes by plugin hook)
