### PR TITLE
Mitigates cross-user authentication problems on community.elgg.org

### DIFF
--- a/engine/classes/Elgg/PersistentLoginService.php
+++ b/engine/classes/Elgg/PersistentLoginService.php
@@ -182,10 +182,6 @@ class PersistentLoginService {
 	 * @return void
 	 */
 	protected function storeHash(\ElggUser $user, $hash) {
-		// This prevents inserting the same hash twice, which seems to be happening in some rare cases
-		// and for unknown reasons. See https://github.com/Elgg/Elgg/issues/8104
-		$this->removeHash($hash);
-
 		$time = time();
 		$hash = $this->db->sanitizeString($hash);
 

--- a/engine/tests/phpunit/Elgg/PersistentLoginTest.php
+++ b/engine/tests/phpunit/Elgg/PersistentLoginTest.php
@@ -152,13 +152,9 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 		$subject = $this->user123;
 		$modifier = $this->user123;
 
-		$this->dbMock->expects($this->exactly(2))
-			->method('deleteData');
-		// Here we can't make an expectation on mock_deleteAll because one
-		// of the calls deletes all, and another deletes only a single hash.
-		// We'd have to fix mock_deleteAll to handle it.
-		// @todo replace this with a real DB test
-
+		$this->dbMock->expects($this->once())
+			->method('deleteData')
+			->will($this->returnCallback(array($this, 'mock_deleteAll')));
 		$this->dbMock->expects($this->once())
 			->method('insertData')
 			->will($this->returnCallback(array($this, 'mock_insertData')));
@@ -190,7 +186,7 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 		$subject = $this->user123;
 		$modifier = $this->getMockElggUser(234);
 
-		$this->dbMock->expects($this->atLeastOnce())
+		$this->dbMock->expects($this->once())
 			->method('deleteData')
 			->will($this->returnCallback(array($this, 'mock_deleteAll')));
 		$this->dbMock->expects($this->never())
@@ -269,7 +265,7 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 	function testLegacyCookiesAreReplacedInDbCookieAndSession() {
 		$this->svc = $this->getSvcWithCookie(str_repeat('a', 32));
 
-		$this->dbMock->expects($this->atLeastOnce())
+		$this->dbMock->expects($this->once())
 			->method('deleteData');
 		$this->dbMock->expects($this->once())
 			->method('insertData');


### PR DESCRIPTION
fix(session): Removes potential cause of cross-account authentications

This reverts #8303 in the hope that this will stop users from being automatically logged into other users’ accounts. This will reintroduce bug #8104, which must be fixed another way.

Currently it's undetermined if any sites other than community.elgg.org are affected by either bug.

Fixes #8736

---

fix(crypto): Prevents ElggCrypt from creating lower-entropy random bytes

If a server lacks the openssl and mcrypt PHP extensions and cannot read from /dev/urandom, ElggCrypt uses a slow process measuring microtime() result values to add entropy.

In this rare case, microtime(true) has been shown to return identical values for $c1 and $c2. This caused a division by zero warning in the calculation of $rounds, and $rounds would be set to 0. This likely mildly reduced the entropy gathered through later iterations of microtime() calls.

This change uses a more precise method to measure the time period between $c1and $c2 and makes sure it’s never 0.

Fixes #8603

---

fix(session): Silently abort persistent login if hash already exists

It’s unconfirmed that #8104 affects any server other than community.elgg.org.

Fixes #8104
