### PR TITLE
DO NOT MERGE: Community monitoring for 8736

### DIFF
--- a/engine/classes/Elgg/PersistentLoginService.php
+++ b/engine/classes/Elgg/PersistentLoginService.php
@@ -182,10 +182,6 @@ class PersistentLoginService {
 	 * @return void
 	 */
 	protected function storeHash(\ElggUser $user, $hash) {
-		// This prevents inserting the same hash twice, which seems to be happening in some rare cases
-		// and for unknown reasons. See https://github.com/Elgg/Elgg/issues/8104
-		$this->removeHash($hash);
-
 		$time = time();
 		$hash = $this->db->sanitizeString($hash);
 

--- a/engine/tests/phpunit/Elgg/PersistentLoginTest.php
+++ b/engine/tests/phpunit/Elgg/PersistentLoginTest.php
@@ -152,13 +152,9 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 		$subject = $this->user123;
 		$modifier = $this->user123;
 
-		$this->dbMock->expects($this->exactly(2))
-			->method('deleteData');
-		// Here we can't make an expectation on mock_deleteAll because one
-		// of the calls deletes all, and another deletes only a single hash.
-		// We'd have to fix mock_deleteAll to handle it.
-		// @todo replace this with a real DB test
-
+		$this->dbMock->expects($this->once())
+			->method('deleteData')
+			->will($this->returnCallback(array($this, 'mock_deleteAll')));
 		$this->dbMock->expects($this->once())
 			->method('insertData')
 			->will($this->returnCallback(array($this, 'mock_insertData')));
@@ -190,7 +186,7 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 		$subject = $this->user123;
 		$modifier = $this->getMockElggUser(234);
 
-		$this->dbMock->expects($this->atLeastOnce())
+		$this->dbMock->expects($this->once())
 			->method('deleteData')
 			->will($this->returnCallback(array($this, 'mock_deleteAll')));
 		$this->dbMock->expects($this->never())
@@ -269,7 +265,7 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 	function testLegacyCookiesAreReplacedInDbCookieAndSession() {
 		$this->svc = $this->getSvcWithCookie(str_repeat('a', 32));
 
-		$this->dbMock->expects($this->atLeastOnce())
+		$this->dbMock->expects($this->once())
 			->method('deleteData');
 		$this->dbMock->expects($this->once())
 			->method('insertData');


### PR DESCRIPTION
This is purely for deploying on Community temporarily. It includes the changes proposed in #8737 as well as adding logging of any occurrences of the bug #8736.

Basically it maintains an ElggGuid cookie alongside all elggperm cookies, and if the system tries to log a user in with an elggperm token that doesn't match ElggGuid, we log some info, send it to a few admins (currently me), and deny the user change.
