### PR TITLE
fix(composer): Symlink plugins from root mod dir

### DIFF
--- a/engine/classes/Elgg/Composer/PostUpdate.php
+++ b/engine/classes/Elgg/Composer/PostUpdate.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elgg\Composer;
 
 use Composer\Script\Event;
@@ -22,6 +21,49 @@ class PostUpdate {
 		self::copyFromElggToRoot("index.php", "index.php");
 		self::copyFromElggToRoot("install.php", "install.php");
 		self::copyFromElggToRoot("upgrade.php", "upgrade.php");
+		
+		$managed_plugins = [
+			'aalborg_theme',
+			'blog',
+			'bookmarks',
+			'categories',
+			'ckeditor',
+			'custom_index',
+			'dashboard',
+			'developers',
+			'diagnostics',
+			'discussions',
+			'embed',
+			'externalpages',
+			'file',
+			'garbagecollector',
+			'groups',
+			'htmlawed',
+			'invitefriends',
+			'legacy_urls',
+			'likes',
+			'logbrowser',
+			'logrotate',
+			'members',
+			'messageboard',
+			'messages',
+			'notifications',
+			'pages',
+			'profile',
+			'reportedcontent',
+			'search',
+			'site_notifications',
+			'tagcloud',
+			'thewire',
+			'twitter_api',
+			'uservalidationbyemail',
+			'web_services',
+			'zaudio',
+		];
+		
+		foreach ($managed_plugins as $plugin) {
+			self::symlinkPluginFromRootToElgg($plugin);
+		}
 	}
 	
 	/**
@@ -30,13 +72,27 @@ class PostUpdate {
 	 * @param string $elggPath Path relative to elgg dir.
 	 * @param string $rootPath Path relative to app root dir.
 	 * 
-	 * @return void
+	 * @return boolean Whether the copy succeeded.
 	 */
 	private static function copyFromElggToRoot($elggPath, $rootPath) {
 		$from = Elgg\Application::elggDir()->getPath($elggPath);
 		$to = Directory\Local::root()->getPath($rootPath);
 		
-		echo "Copying '$from' to '$to'...\n";
-		copy($from, $to);
+		return copy($from, $to);
+	}
+	
+	/**
+	 * Make it possible for composer-managed Elgg site to recognize plugins
+	 * version-controlled in Elgg core.
+	 * 
+	 * @param string $plugin The name of the plugin to symlink
+	 * 
+	 * @return bool Whether the symlink succeeded.
+	 */
+	private static function symlinkPluginFromRootToElgg($plugin) {
+		$from = Directory\Local::root()->getPath("mod/$plugin");
+		$to = Elgg\Application::elggDir()->getPath("mod/$plugin");
+		
+		return !file_exists($from) && symlink($to, $from);
 	}
 }


### PR DESCRIPTION
This allows us to actually use bundled plugins in a composer-managed install.
