### PR TITLE
fix(profile): Support composer for icondirect requests

### DIFF
--- a/mod/profile/icondirect.php
+++ b/mod/profile/icondirect.php
@@ -30,7 +30,13 @@ if (!empty($_GET['size'])) {
 	}
 }
 
-require_once __DIR__ . '/../../vendor/autoload.php';
+
+$initialRoot = dirname(dirname(__DIR__));
+$backupRoot = dirname(dirname(dirname($initialRoot)));
+
+if (!include_once "$initialRoot/vendor/autoload.php") {
+	require_once "$backupRoot/vendor/autoload.php";
+}
 
 $data_root = \Elgg\Application::getDataPath();
 $locator = new \Elgg\EntityDirLocator($guid);


### PR DESCRIPTION
We were getting broken image requests because the symlinking strategy means we have to treat core plugins like they could be installed at `/mod/plugin/` or `/vendor/elgg/elgg/mod/plugin/`
