### PR TITLE
chore(thewire): show wire post entity menus in the correct context

### DIFF
--- a/mod/thewire/views/default/object/thewire.php
+++ b/mod/thewire/views/default/object/thewire.php
@@ -34,7 +34,7 @@ $date = elgg_view_friendly_time($post->time_created);
 $subtitle = "$author_text $date";
 
 $metadata = '';
-if (elgg_in_context('widgets')) {
+if (!elgg_in_context('widgets')) {
 	// only show entity menu outside of widgets
 	$metadata = elgg_view_menu('entity', array(
 		'entity' => $post,


### PR DESCRIPTION
#8665 accidentally reversed the condition that determines whether this menu is drawn.

Fixes #8728
