### PR TITLE
chore(discussions): Make context of discussions hook-configurable 

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -469,6 +469,15 @@ Other
 Plugins
 =======
 
+Discussions
+-----------
+
+**discussions:allow_context, <type>:<subtype>**
+    This is called to set the default permissions for whether to allow discussions on an entity of type
+    ``<type>`` and subtype ``<subtype>``.
+
+    .. note:: The callback ``'Elgg\Values::getTrue'`` is a useful handler for this hook.
+
 Embed
 -----
 

--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -1,6 +1,12 @@
 <?php
 /**
  * Discussion plugin
+ *
+ * To host discussions outside groups, use the discussions:allow_context hook to register your type:subtype. E.g.
+ *
+ * <code>
+ * elgg_register_plugin_hook_handler('discussions:allow_context', 'object:mysubtype', 'Elgg\Values::getTrue');
+ * </code>
  */
 
 elgg_register_event_handler('init', 'system', 'discussion_init');
@@ -15,6 +21,12 @@ function discussion_init() {
 	elgg_register_page_handler('discussion', 'discussion_page_handler');
 
 	elgg_register_plugin_hook_handler('entity:url', 'object', 'discussion_set_topic_url');
+
+	// control context of discussions
+	elgg_register_plugin_hook_handler('container_permissions_check', 'object', 'discussion_topic_container_permissions', 700);
+
+	// allow group context
+	elgg_register_plugin_hook_handler('discussions:allow_context', 'group:', 'Elgg\Values::getTrue');
 
 	// commenting not allowed on discussion topics (use a different annotation)
 	elgg_register_plugin_hook_handler('permissions_check:comment', 'object', 'discussion_comment_override');
@@ -622,4 +634,32 @@ function discussion_prepare_form_vars($topic = NULL) {
 	elgg_clear_sticky_form('topic');
 
 	return $values;
+}
+
+/**
+ * @param string $hook   "container_permissions_check"
+ * @param string $type   "object"
+ * @param bool   $value  Hook value
+ * @param array  $params Hook params
+ * @return bool
+ */
+function discussion_topic_container_permissions($hook, $type, $value, $params) {
+	$subtype = elgg_extract('subtype', $params);
+	$container = elgg_extract('container', $params);
+
+	if (!$value || !$container || $subtype !== 'discussion') {
+		return;
+	}
+
+	return discussion_is_context_allowed($container->type, $container->getSubtype());
+}
+
+/**
+ * @param string $type    Entity type
+ * @param string $subtype Entity subtype
+ *
+ * @return bool
+ */
+function discussion_is_context_allowed($type, $subtype = '') {
+	return (bool)elgg_trigger_plugin_hook('discussions:allow_context', "$type:$subtype", [], false);
 }

--- a/mod/discussions/views/default/resources/discussion/add.php
+++ b/mod/discussions/views/default/resources/discussion/add.php
@@ -6,7 +6,7 @@ $guid = elgg_extract('guid', $vars);
 $container = get_entity($guid);
 
 // Make sure user has permissions to add a topic to container
-if (!$container->canWriteToContainer(0, 'object', 'discussion')) {
+if (!$container || !$container->canWriteToContainer(0, 'object', 'discussion')) {
 	register_error(elgg_echo('actionunauthorized'));
 	forward(REFERER);
 }

--- a/mod/discussions/views/default/resources/discussion/all.php
+++ b/mod/discussions/views/default/resources/discussion/all.php
@@ -3,7 +3,10 @@
 elgg_pop_breadcrumb();
 elgg_push_breadcrumb(elgg_echo('discussion'));
 
-elgg_register_title_button();
+$user = elgg_get_logged_in_user_entity();
+if ($user && $user->canWriteToContainer(0, 'object', 'discussion')) {
+	elgg_register_title_button();
+}
 
 $content = elgg_list_entities(array(
 	'type' => 'object',

--- a/mod/discussions/views/default/resources/discussion/owner.php
+++ b/mod/discussions/views/default/resources/discussion/owner.php
@@ -3,16 +3,22 @@
 $guid = elgg_extract('owner_guid', $vars);
 elgg_set_page_owner_guid($guid);
 
+elgg_entity_gatekeeper($guid);
 elgg_group_gatekeeper();
 
-$group = get_entity($guid);
-if (!elgg_instanceof($group, 'group')) {
+$container = get_entity($guid);
+$type = $container->type;
+$subtype = $container->getSubtype();
+if (!discussion_is_context_allowed($container->type, $container->getSubtype())) {
 	forward('', '404');
 }
-elgg_push_breadcrumb($group->name, $group->getURL());
+
+elgg_push_breadcrumb($container->getDisplayName(), $container->getURL());
 elgg_push_breadcrumb(elgg_echo('item:object:discussion'));
 
-elgg_register_title_button();
+if ($container->canWriteToContainer(0, 'object', 'discussion')) {
+	elgg_register_title_button();
+}
 
 $title = elgg_echo('item:object:discussion');
 

--- a/mod/discussions/views/default/resources/discussion/view.php
+++ b/mod/discussions/views/default/resources/discussion/view.php
@@ -10,15 +10,18 @@ elgg_entity_gatekeeper($guid, 'object', 'discussion');
 
 $topic = get_entity($guid);
 
+elgg_set_page_owner_guid($topic->container_guid);
+
+elgg_group_gatekeeper();
+
+// container may be hidden group. If so, we still allow visible topic to be shown
 $container = $topic->getContainerEntity();
 
 elgg_load_js('elgg.discussion');
 
-elgg_set_page_owner_guid($container->getGUID());
-
-elgg_group_gatekeeper();
-
-elgg_push_breadcrumb($container->getDisplayName(), "discussion/owner/$container->guid");
+if ($container) {
+	elgg_push_breadcrumb($container->getDisplayName(), "discussion/owner/$container->guid");
+}
 elgg_push_breadcrumb($topic->title);
 
 $params = array(
@@ -37,7 +40,8 @@ if ($topic->status == 'closed') {
 	}
 	$content .= elgg_view('discussion/replies', $params);
 } else {
-	$params['show_add_form'] = true;
+	// if container could be loaded, allow replies
+	$params['show_add_form'] = (bool)$container;
 	$content .= elgg_view('discussion/replies', $params);
 }
 


### PR DESCRIPTION
Adds a hook `discussions:allow_context` that allows registering a type:subtype to be available for hosting discussions.

Also allows discussion/owner and view pages to work for hidden groups and non-groups. If the topic container can’t be loaded (group is hidden from the user) we don’t show the reply form.

Fixes #8757
