### PR TITLE
Adds permission hook param and makes context of discussions hook-configurable

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -195,6 +195,10 @@ Permission hooks
 	Return boolean for if the user ``$params['user']`` can use the entity ``$params['container']``
 	as a container for an entity of ``<entity_type>`` and subtype ``$params['subtype']``.
 
+	During entity creation, this may also be triggered for entity owner-to-be (where the owner will *not* be the
+	container). In this single case, ``$params['checking_owner']`` will be set to true. For all other cases, it
+	will be false, indicating that ``$params['container']`` will indeed be the entity's container.
+
 **permissions_check, <entity_type>**
 	Return boolean for if the user ``$params['user']`` can edit the entity ``$params['entity']``.
 

--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -473,6 +473,15 @@ Other
 Plugins
 =======
 
+Discussions
+-----------
+
+**discussions:allow_context, <type>:<subtype>**
+    This is called to set the default permissions for whether to allow discussions on an entity of type
+    ``<type>`` and subtype ``<subtype>``.
+
+    .. note:: The callback ``'Elgg\Values::getTrue'`` is a useful handler for this hook.
+
 Embed
 -----
 

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1117,12 +1117,13 @@ abstract class ElggEntity extends \ElggData implements
 	 * @param int    $user_guid The GUID of the user creating the entity (0 for logged in user).
 	 * @param string $type      The type of entity we're looking to write
 	 * @param string $subtype   The subtype of the entity we're looking to write
+	 * @param string $checking  Do not provide this argument. This is only to be used by ElggEntity::create.
 	 *
 	 * @return bool
 	 * @see elgg_set_ignore_access()
 	 */
-	public function canWriteToContainer($user_guid = 0, $type = 'all', $subtype = 'all') {
-		return can_write_to_container($user_guid, $this->guid, $type, $subtype);
+	public function canWriteToContainer($user_guid = 0, $type = 'all', $subtype = 'all', $checking = '') {
+		return can_write_to_container($user_guid, $this->guid, $type, $subtype, $checking);
 	}
 
 	/**
@@ -1525,13 +1526,14 @@ abstract class ElggEntity extends \ElggData implements
 		}
 
 		$owner = $this->getOwnerEntity();
-		if ($owner && !$owner->canWriteToContainer(0, $type, $subtype)) {
+		$checking = ($owner_guid === $container_guid) ? 'container' : 'owner';
+		if ($owner && !$owner->canWriteToContainer(0, $type, $subtype, $checking)) {
 			return false;
 		}
 		
 		if ($owner_guid != $container_guid) {
 			$container = $this->getContainerEntity();
-			if ($container && !$container->canWriteToContainer(0, $type, $subtype)) {
+			if ($container && !$container->canWriteToContainer(0, $type, $subtype, 'container')) {
 				return false;
 			}
 		}

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -291,10 +291,11 @@ function update_subtype($type, $subtype, $class = '') {
  * @param int    $container_guid The container, or 0 for the current page owner.
  * @param string $type           The type of entity we want to create (default: 'all')
  * @param string $subtype        The subtype of the entity we want to create (default: 'all')
+ * @param string $checking       Do not provide this argument. This is only to be used by ElggEntity::create.
  *
  * @return bool
  */
-function can_write_to_container($user_guid = 0, $container_guid = 0, $type = 'all', $subtype = 'all') {
+function can_write_to_container($user_guid = 0, $container_guid = 0, $type = 'all', $subtype = 'all', $checking = '') {
 	$container_guid = (int)$container_guid;
 	if (!$container_guid) {
 		$container_guid = elgg_get_page_owner_guid();
@@ -328,7 +329,8 @@ function can_write_to_container($user_guid = 0, $container_guid = 0, $type = 'al
 			array(
 				'container' => $container,
 				'user' => $user,
-				'subtype' => $subtype
+				'subtype' => $subtype,
+				'checking_owner' => ($checking === 'owner'),
 			),
 			$return);
 }

--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -1,6 +1,12 @@
 <?php
 /**
  * Discussion plugin
+ *
+ * To host discussions outside groups, use the discussions:allow_context hook to register your type:subtype. E.g.
+ *
+ * <code>
+ * elgg_register_plugin_hook_handler('discussions:allow_context', 'object:mysubtype', 'Elgg\Values::getTrue');
+ * </code>
  */
 
 elgg_register_event_handler('init', 'system', 'discussion_init');
@@ -15,6 +21,12 @@ function discussion_init() {
 	elgg_register_page_handler('discussion', 'discussion_page_handler');
 
 	elgg_register_plugin_hook_handler('entity:url', 'object', 'discussion_set_topic_url');
+
+	// control context of discussions
+	elgg_register_plugin_hook_handler('container_permissions_check', 'object', 'discussion_topic_container_permissions', 700);
+
+	// allow group context
+	elgg_register_plugin_hook_handler('discussions:allow_context', 'group:', 'Elgg\Values::getTrue');
 
 	// commenting not allowed on discussion topics (use a different annotation)
 	elgg_register_plugin_hook_handler('permissions_check:comment', 'object', 'discussion_comment_override');
@@ -622,4 +634,33 @@ function discussion_prepare_form_vars($topic = NULL) {
 	elgg_clear_sticky_form('topic');
 
 	return $values;
+}
+
+/**
+ * @param string $hook   "container_permissions_check"
+ * @param string $type   "object"
+ * @param bool   $value  Hook value
+ * @param array  $params Hook params
+ * @return bool
+ */
+function discussion_topic_container_permissions($hook, $type, $value, $params) {
+	$checking_owner = elgg_extract('checking_owner', $params);
+	$subtype = elgg_extract('subtype', $params);
+	$container = elgg_extract('container', $params);
+
+	if (!$value || !$container || $subtype !== 'discussion' || $checking_owner) {
+		return;
+	}
+
+	return discussion_is_context_allowed($container->type, $container->getSubtype());
+}
+
+/**
+ * @param string $type    Entity type
+ * @param string $subtype Entity subtype
+ *
+ * @return bool
+ */
+function discussion_is_context_allowed($type, $subtype = '') {
+	return (bool)elgg_trigger_plugin_hook('discussions:allow_context', "$type:$subtype", [], false);
 }

--- a/mod/discussions/views/default/resources/discussion/add.php
+++ b/mod/discussions/views/default/resources/discussion/add.php
@@ -6,7 +6,7 @@ $guid = elgg_extract('guid', $vars);
 $container = get_entity($guid);
 
 // Make sure user has permissions to add a topic to container
-if (!$container->canWriteToContainer(0, 'object', 'discussion')) {
+if (!$container || !$container->canWriteToContainer(0, 'object', 'discussion')) {
 	register_error(elgg_echo('actionunauthorized'));
 	forward(REFERER);
 }

--- a/mod/discussions/views/default/resources/discussion/all.php
+++ b/mod/discussions/views/default/resources/discussion/all.php
@@ -3,7 +3,10 @@
 elgg_pop_breadcrumb();
 elgg_push_breadcrumb(elgg_echo('discussion'));
 
-elgg_register_title_button();
+$user = elgg_get_logged_in_user_entity();
+if ($user && $user->canWriteToContainer(0, 'object', 'discussion')) {
+	elgg_register_title_button();
+}
 
 $content = elgg_list_entities(array(
 	'type' => 'object',

--- a/mod/discussions/views/default/resources/discussion/owner.php
+++ b/mod/discussions/views/default/resources/discussion/owner.php
@@ -3,16 +3,22 @@
 $guid = elgg_extract('owner_guid', $vars);
 elgg_set_page_owner_guid($guid);
 
+elgg_entity_gatekeeper($guid);
 elgg_group_gatekeeper();
 
-$group = get_entity($guid);
-if (!elgg_instanceof($group, 'group')) {
+$container = get_entity($guid);
+$type = $container->type;
+$subtype = $container->getSubtype();
+if (!discussion_is_context_allowed($container->type, $container->getSubtype())) {
 	forward('', '404');
 }
-elgg_push_breadcrumb($group->name, $group->getURL());
+
+elgg_push_breadcrumb($container->getDisplayName(), $container->getURL());
 elgg_push_breadcrumb(elgg_echo('item:object:discussion'));
 
-elgg_register_title_button();
+if ($container->canWriteToContainer(0, 'object', 'discussion')) {
+	elgg_register_title_button();
+}
 
 $title = elgg_echo('item:object:discussion');
 

--- a/mod/discussions/views/default/resources/discussion/view.php
+++ b/mod/discussions/views/default/resources/discussion/view.php
@@ -10,15 +10,18 @@ elgg_entity_gatekeeper($guid, 'object', 'discussion');
 
 $topic = get_entity($guid);
 
+elgg_set_page_owner_guid($topic->container_guid);
+
+elgg_group_gatekeeper();
+
+// container may be hidden group. If so, we still allow visible topic to be shown
 $container = $topic->getContainerEntity();
 
 elgg_load_js('elgg.discussion');
 
-elgg_set_page_owner_guid($container->getGUID());
-
-elgg_group_gatekeeper();
-
-elgg_push_breadcrumb($container->getDisplayName(), "discussion/owner/$container->guid");
+if ($container) {
+	elgg_push_breadcrumb($container->getDisplayName(), "discussion/owner/$container->guid");
+}
 elgg_push_breadcrumb($topic->title);
 
 $params = array(
@@ -37,7 +40,8 @@ if ($topic->status == 'closed') {
 	}
 	$content .= elgg_view('discussion/replies', $params);
 } else {
-	$params['show_add_form'] = true;
+	// if container could be loaded, allow replies
+	$params['show_add_form'] = (bool)$container;
 	$content .= elgg_view('discussion/replies', $params);
 }
 


### PR DESCRIPTION
(This is a reworking of #8761 but with a core modification to allow container_permissions_check handlers to recognize the "owner" check that occur in ElggEntity::create.)

feature(hooks): Adds indication in container permissions hook of checking owner

For some reason ElggEntity::create checks the ability to write to the entity owner, even if the owner will not be the entity’s container. In this case, the container_permissions_check hook is called twice, and handlers cannot tell which `$params[‘container’]` will actually be the entity container, and which is really the owner being checked.

This introduces a flag `$params[‘checking_owner’]` to let handlers know that `$params[‘container’]` is actually not the container of the entity being created.

Fixes #8774

chore(discussions): Make context of discussions hook-configurable

Adds a hook `discussions:allow_context` that allows registering a type:subtype to be available for hosting discussions.

Also allows discussion/owner and view pages to work for hidden groups and non-groups. If the topic container can’t be loaded (group is hidden from the user) we don’t show the reply form.

Fixes #8757
