### PR TITLE
fix(entities): Entity creation no longer needlessly checks owner container

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -195,6 +195,10 @@ Permission hooks
 	Return boolean for if the user ``$params['user']`` can use the entity ``$params['container']``
 	as a container for an entity of ``<entity_type>`` and subtype ``$params['subtype']``.
 
+	In the rare case where an entity is created with neither the ``container_guid`` nor the ``owner_guid``
+	matching the logged in user, this hook is called *twice*, and in the first call ``$params['container']``
+	will be the *owner*, not the entity's real container.
+
 **permissions_check, <entity_type>**
 	Return boolean for if the user ``$params['user']`` can edit the entity ``$params['entity']``.
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -302,6 +302,13 @@ Comments plugin hook
 
 Plugins can now return an empty string from ``'comments',$entity_type`` hook in order to override the default comments component view. To force the default comments component, your plugin must return ``false``. If you were using empty strings to force the default comments view, you need to update your hook handlers to return ``false``.
 
+Container permissions hook
+--------------------------
+
+The behavior of the ``container_permissions_check`` hook has changed when an entity is being created: Before 2.0, the hook would be called twice if the entity's container was not the owner. On the first call, the entity's owner would be passed in as ``$params['container']``, which could confuse handlers.
+
+In 2.0, when an entity is created in a container like a group, if the owner is the same as the logged in user (almost always the case), this first check is bypassed. So the ``container_permissions_check`` hook will almost always be called once with ``$params['container']`` being the correct container of the entity.
+
 Creating a relationship triggers only one event
 -----------------------------------------------
 


### PR DESCRIPTION
BREAKING CHANGE:
When creating within a group, ElggEntity::create used to always separately check if the current user can use the owner's account as a container. This made sure that one group member could not post to the group using another member as owner. This separate check led to confusion, as handlers of the container_permissions_check hook were told that the owner was to be the container, when it was actually the group.

Here we bypass the separate owner container check if the desired owner_guid is the logged in user GUID. This eliminates the check under all normal circumstances but leaves it in place in case a poorly coded plugin allows the impersonation described above.

This also denies creation if the owner/container GUIDs are set but can't be loaded. Before, create() would simply bypass the permissions check if it couldn't load the owner/container.

Fixes #4231

(This is a modest change that eliminates the most common cases of #4231, but ultimately I think #8790 is the future)
- [x] log cases where return false
- [x] fix typo in docs
