### PR TITLE
chore(composer): Stop forcing autoloader optimization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,8 +69,5 @@
         "squizlabs/php_codesniffer": "~1.5",
         "simpletest/simpletest": "~1.1",
         "phpdocumentor/reflection-docblock": "~2.0"
-    },
-    "config": {
-        "optimize-autoloader": true
     }
 }


### PR DESCRIPTION
The optimization process takes a little extra time during updates and installs.
It's easy enough to pass `-o` when you actually need that for production.
