### PR TITLE
chore(topbar): Simplify CSS for topbar menu

### DIFF
--- a/mod/aalborg_theme/views/default/aalborg_theme/css.php
+++ b/mod/aalborg_theme/views/default/aalborg_theme/css.php
@@ -26,46 +26,7 @@
 .elgg-module .elgg-widget-content > .elgg-list { /* margin for profile and dashboard widgets */
     margin-top: 0;
 }
-/* ***************************************
-	TOPBAR MENU DROPDOWN
-*****************************************/
-.elgg-topbar-dropdown {
-	padding-bottom: 8px; /* forces button to reach bottom of topbar */
-}
-.elgg-menu-topbar > li > .elgg-topbar-dropdown:hover {
-	color: #EEE;
-	cursor: default;
-}
-.elgg-menu-topbar-alt ul {
-	position: absolute;
-	display: none;
-	background-color: #FFF;
-	border: 1px solid #DEDEDE;
-	text-align: left;
-	top: 33px;
-	margin-left: -100px;
-	width: 180px;
 
-	border-radius: 0 0 3px 3px;
-	box-shadow: 1px 3px 5px rgba(0, 0, 0, 0.25);
-}
-.elgg-menu-topbar-alt li ul > li > a {
-	text-decoration: none;
-	padding: 10px 20px;
-	background-color: #FFF;
-	color: #444;
-}
-.elgg-menu-topbar-alt li ul > li > a:hover {
-	background-color: #F0F0F0;
-	color: #444;
-}
-.elgg-menu-topbar-alt > li:hover > ul {
-	display: block;
-}
-.elgg-menu-item-account > a:after {
-	content: "\bb";
-	margin-left: 6px;
-}
 /* ***************************************
 	ICONS
 *****************************************/

--- a/mod/aalborg_theme/views/default/elements/layout.css
+++ b/mod/aalborg_theme/views/default/elements/layout.css
@@ -40,9 +40,7 @@
 	background: #424242;
 	border-top: 1px solid #424242;
 	border-bottom: 1px solid #000000;
-	padding: 0 20px;
 	position: relative;
-	height: 32px;
 	z-index: 9000;
 }
 

--- a/mod/aalborg_theme/views/default/elements/navigation.css
+++ b/mod/aalborg_theme/views/default/elements/navigation.css
@@ -126,46 +126,73 @@
 	TOPBAR MENU
 *************************************** */
 .elgg-menu-topbar {
-	font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
-	float: left;
+	display: table;
+	padding: 0 .5em;
 }
 
 .elgg-menu-topbar > li {
-	float: left;
-	height: 33px;
+	display: table-cell;
+	vertical-align: middle;
 }
 
 .elgg-menu-topbar > li > a {
-	padding-top: 5px;
 	color: #EEE;
-	margin: 0 15px;
+	padding: .5em 1em;
+	vertical-align: middle;
 }
 
-.elgg-menu-topbar > li > a:hover {
+.elgg-menu-topbar > li > a:hover,
+.elgg-menu-topbar > li > a:hover *,
+.elgg-menu-topbar > li > a:focus,
+.elgg-menu-topbar > li > a:focus * {
 	color: #60B8F7;
 	text-decoration: none;
+}
+
+.elgg-menu-topbar-default {
+	float: left;
 }
 
 .elgg-menu-topbar-alt {
 	float: right;
 }
 
-.elgg-menu-topbar .elgg-icon {
-	vertical-align: middle;
-	margin-top: -1px;
+/* ***************************************
+	TOPBAR MENU DROPDOWN
+*****************************************/
+.elgg-menu-topbar > li.elgg-menu-item-account > a:after {
+	content: " \bb";
 }
 
-.elgg-menu-topbar > li > a.elgg-topbar-logo {
-	margin-top: 0;
-	padding-left: 5px;
-	width: 38px;
-	height: 20px;
+.elgg-menu-topbar > li > .elgg-child-menu {
+	background-color: #FFF;
+	box-shadow: 1px 3px 5px rgba(0, 0, 0, 0.25);
+	display: none;
+	max-width: 10em;
+	position: absolute;
+	text-align: left;
+	top: 100%;
 }
 
-.elgg-menu-topbar > li > a.elgg-topbar-avatar {
-	width: 18px;
-	height: 18px;
-	padding-top: 7px;
+.elgg-menu-topbar-alt > li > .elgg-child-menu {
+	right: 0;
+}
+
+.elgg-menu-topbar > li:hover > .elgg-child-menu {
+	display: block;
+}
+
+.elgg-menu-topbar > li > .elgg-child-menu > li > a {
+	background-color: #FFF;
+	color: #444;
+	padding: .5em 1em;
+	text-decoration: none;
+}
+
+.elgg-menu-topbar > li > .elgg-child-menu > li > a:focus,
+.elgg-menu-topbar > li > .elgg-child-menu > li:hover > a {
+	background-color: #F0F0F0;
+	color: #444;
 }
 
 /* ***************************************


### PR DESCRIPTION
I started out looking into #8733 but got sidetracked with cleaning up what felt like technical debt. It's no good if several different variables in distant files have to stay in sync just-so in order to work correctly. I think this is a more robust approach...

Before:
![topbar-before](https://cloud.githubusercontent.com/assets/356564/9149223/18cc62f8-3d55-11e5-9d7e-dd597f8c3f79.png)

After:
![topbar-after](https://cloud.githubusercontent.com/assets/356564/9149224/18cf53f0-3d55-11e5-9a92-d334d8c66466.png)
