### PR TITLE
chore(install): add client_max_body_size nginx directive

### DIFF
--- a/install/config/nginx.dist
+++ b/install/config/nginx.dist
@@ -28,6 +28,9 @@ server {
 	error_log /var/log/nginx/$server_name.error.log error;
 	access_log /var/log/nginx/$server_name.access.log;
 
+	# Max post size
+	client_max_body_size 8M;
+
 	location ~ (^\.|/\.) {
 		return 403;
 	}


### PR DESCRIPTION
Set to 8M to match the default value we have for apache .htaccess
