### PR TITLE
fix(files): ensure file is readable before calling finfo_* and mime_*

### DIFF
--- a/engine/classes/ElggFile.php
+++ b/engine/classes/ElggFile.php
@@ -141,17 +141,19 @@ class ElggFile extends \ElggObject {
 
 		$mime = $default;
 
-		// for PHP5 folks.
-		if (function_exists('finfo_file') && defined('FILEINFO_MIME_TYPE')) {
-			$resource = finfo_open(FILEINFO_MIME_TYPE);
-			if ($resource) {
-				$mime = finfo_file($resource, $file);
+		if (is_readable($file)) {
+			// for PHP5 folks.
+			if (function_exists('finfo_file') && defined('FILEINFO_MIME_TYPE')) {
+				$resource = finfo_open(FILEINFO_MIME_TYPE);
+				if ($resource) {
+					$mime = finfo_file($resource, $file);
+				}
 			}
-		}
 
-		// for everyone else.
-		if (!$mime && function_exists('mime_content_type')) {
-			$mime = mime_content_type($file);
+			// for everyone else.
+			if (!$mime && function_exists('mime_content_type')) {
+				$mime = mime_content_type($file);
+			}
 		}
 
 		$params = array(


### PR DESCRIPTION
Logs are populated with errors if one tries to detect mime on a non-existing resource

Fixes #8846
