### PR TITLE
Sizes of Font awesome icons are now more consistent with old icons

### DIFF
--- a/views/default/elements/fa.css
+++ b/views/default/elements/fa.css
@@ -1,0 +1,13 @@
+/**
+ * Hack that reduces size inconsistencies within Font awesome icons
+ */
+
+.fa-mobile-phone:before,
+.fa-mobile:before,
+.fa-remove:before,
+.fa-close:before,
+.fa-times:before,
+.fa-caret-down:before,
+.fa-caret-down:before {
+	font-size: larger !important;
+}

--- a/views/default/elements/icons.css.php
+++ b/views/default/elements/icons.css.php
@@ -14,9 +14,7 @@
 *************************************** */
 .elgg-icon {
 	color: #CCC;
-	font-size: 16px;
-	width: 16px;
-	height: 16px;
+	font-size: 18px;
 	margin: 0 2px;
 }
 
@@ -67,20 +65,20 @@ h6 > .elgg-icon {
 .elgg-avatar-tiny > a > img {
 	width: 25px;
 	height: 25px;
-	
+
 	/* remove the border-radius if you don't want rounded avatars in supported browsers */
 	border-radius: 3px;
-	
+
 	background-clip:  border;
 	background-size: 25px;
 }
 .elgg-avatar-small > a > img {
 	width: 40px;
 	height: 40px;
-	
+
 	/* remove the border-radius if you don't want rounded avatars in supported browsers */
 	border-radius: 5px;
-	
+
 	background-clip:  border;
 	background-size: 40px;
 }

--- a/views/default/elgg.css.php
+++ b/views/default/elgg.css.php
@@ -39,6 +39,7 @@ Skin CSS
  * layout_objects - lists, content blocks, notifications, avatars
  * layout         - page layout
  * misc           - to be removed/redone
+ * fa             - hacks to reduce size inconsistencies in Font awesome icons
 
 *******************************************************************************/
 echo elgg_view('elements/typography.css', $vars);
@@ -51,6 +52,7 @@ echo elgg_view('elements/components.css', $vars);
 echo elgg_view('elements/layout.css', $vars);
 echo elgg_view('elements/misc.css', $vars);
 echo elgg_view('elements/misc/spinner.css', $vars);
+echo elgg_view('elements/fa.css', $vars);
 
 
 // included last to have higher priority


### PR DESCRIPTION
Reduces inconsistencies between different fa-icons and increases the overall font size.

Fixes #8733 and #8861
- [x] drop ".php" from CSS file.
- [x] use "fa" in the comments instead of "fa-hacks"
- [x] A few others should test it
