### PR TITLE
fix(cli): Rewrite `::installDir()` to `Directory\Local::root()` in CLI server

### DIFF
--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -382,7 +382,7 @@ class Application {
 
 		if (php_sapi_name() === 'cli-server') {
 			// The CLI server routes ALL requests here (even existing files), so we have to check for these.
-			if ($path !== '/' && self::installDir()->isFile($path)) {
+			if ($path !== '/' && Directory\Local::root()->isFile($path)) {
 				// serve the requested resource as-is.
 				return false;
 			}


### PR DESCRIPTION
This was causing a fatal error. It should be runnable again after this change.
