### PR TITLE
fix(discussions): List of discussions by owner now works with any entity type

### DIFF
--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -94,7 +94,12 @@ function discussion_page_handler($page) {
 			break;
 		case 'owner':
 			echo elgg_view_resource('discussion/owner', [
-				'owner_guid' => elgg_extract(1, $page),
+				'guid' => elgg_extract(1, $page),
+			]);
+			break;
+		case 'group':
+			echo elgg_view_resource('discussion/group', [
+				'guid' => elgg_extract(1, $page),
 			]);
 			break;
 		case 'add':
@@ -250,7 +255,7 @@ function discussion_comment_override($hook, $type, $return, $params) {
 function discussion_owner_block_menu($hook, $type, $return, $params) {
 	if (elgg_instanceof($params['entity'], 'group')) {
 		if ($params['entity']->forum_enable != "no") {
-			$url = "discussion/owner/{$params['entity']->guid}";
+			$url = "discussion/group/{$params['entity']->guid}";
 			$item = new ElggMenuItem('discussion', elgg_echo('discussion:group'), $url);
 			$return[] = $item;
 		}

--- a/mod/discussions/views/default/resources/discussion/all.php
+++ b/mod/discussions/views/default/resources/discussion/all.php
@@ -3,8 +3,6 @@
 elgg_pop_breadcrumb();
 elgg_push_breadcrumb(elgg_echo('discussion'));
 
-elgg_register_title_button();
-
 $content = elgg_list_entities(array(
 	'type' => 'object',
 	'subtype' => 'discussion',

--- a/mod/discussions/views/default/resources/discussion/group.php
+++ b/mod/discussions/views/default/resources/discussion/group.php
@@ -1,20 +1,18 @@
 <?php
+/**
+ * Lists discussions created inside a specific group
+ */
 
 $guid = elgg_extract('guid', $vars);
-
-$target = get_entity($guid);
-
-if ($target instanceof ElggGroup) {
-	// Before Elgg 2.0 only groups could work as containers for discussions.
-	// Back then the URL that listed all discussions within a group was
-	// "discussion/owner/<guid>". Now that any entity can be used as a
-	// container, we use the standard "<content type>/group/<guid>" URL
-	// also with discussions.
-	forward("discussion/group/$guid", '301');
-}
-
 elgg_set_page_owner_guid($guid);
 
+elgg_group_gatekeeper();
+
+$group = get_entity($guid);
+if (!elgg_instanceof($group, 'group')) {
+	forward('', '404');
+}
+elgg_push_breadcrumb($group->name, $group->getURL());
 elgg_push_breadcrumb(elgg_echo('item:object:discussion'));
 
 elgg_register_title_button();
@@ -26,19 +24,11 @@ $options = array(
 	'subtype' => 'discussion',
 	'limit' => max(20, elgg_get_config('default_limit')),
 	'order_by' => 'e.last_action desc',
+	'container_guid' => $guid,
 	'full_view' => false,
 	'no_results' => elgg_echo('discussion:none'),
 	'preload_owners' => true,
 );
-
-if ($target instanceof ElggUser) {
-	// Display all discussions started by the user regardless of
-	// the entity that is working as a container. See #4878.
-	$options['owner_guid'] = $guid;
-} else {
-	$options['container_guid'] = $guid;
-}
-
 $content = elgg_list_entities($options);
 
 $params = array(

--- a/mod/discussions/views/default/resources/discussion/view.php
+++ b/mod/discussions/views/default/resources/discussion/view.php
@@ -18,7 +18,13 @@ elgg_set_page_owner_guid($container->getGUID());
 
 elgg_group_gatekeeper();
 
-elgg_push_breadcrumb($container->getDisplayName(), "discussion/owner/$container->guid");
+if ($container instanceof ElggGroup) {
+	$owner_url = "discussion/group/$container->guid";
+} else {
+	$owner_url = "discussion/owner/$container->guid";
+}
+
+elgg_push_breadcrumb($container->getDisplayName(), $owner_url);
 elgg_push_breadcrumb($topic->title);
 
 $params = array(


### PR DESCRIPTION
Earlier the `discussion/owner/<guid>` page accepted only a group as the container of the discussions. Now groups have a separate page `discussion/group/<guid>` (like all other content plugins), and the owner page accepts any entity as a container.

Refs: #8757

IMO this would be enough for 2.0. It doesn't encourage user-centered discussions because it doesn't add new menu item to:
- owner block
- site menu
- title menu on discussion/all page

It does however make it really easy to add discussions support to non-groups if necessary.
