### PR TITLE
chore(messages): unread count again updates when you view new messages

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -408,6 +408,9 @@ Just as before, the ``permissions_check:annotate`` hook is still called and may 
 Plugin Messages
 ---------------
 
+If you've removed or replaced the handler function ``messages_notifier`` to hide/alter the inbox icon, you'll instead need to do the
+same for the topbar menu handler ``messages_register_topbar``. ``messages_notifier`` is no longer used to add the menu link.
+
 Messages will no longer get the metadata 'msg' for newly created messages. This means you can not rely on that metadata to exist.
 
 Plugin Blog


### PR DESCRIPTION
To display an accurate count, the count must be calculated after the new message is displayed. Previously we were tied to the pagesetup event, but that now fires early due to the use of resource views. Instead we add the topbar menu item in the register hook.

BREAKING CHANGE:
If a plugin has removed or replaced messages_notifier to hide/alter the inbox icon, the plugin must instead do the same for the topbar menu handler (messages_register_topbar).

Fixes #8862
