### PR TITLE
chore(theme): links inside .elgg-subtext are distinguishable again

### DIFF
--- a/mod/aalborg_theme/views/default/elements/typography.css
+++ b/mod/aalborg_theme/views/default/elements/typography.css
@@ -109,7 +109,7 @@ h6 { font-size: 0.8em; }
 	font-style: italic;
 }
 
-.elgg-subtext a {
+.elgg-subtext time {
 	color: #666;
 }
 

--- a/views/default/admin.css.php
+++ b/views/default/admin.css.php
@@ -288,7 +288,7 @@ a.elgg-maintenance-mode-warning {
 	width: 210px;
 	float: right;
 	margin-left: 30px;
-	
+
 	-webkit-box-sizing: border-box;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
@@ -480,7 +480,7 @@ input {
 	color: #666;
 	border-radius: 5px;
 	margin: 0;
-	
+
 	-webkit-box-sizing: border-box;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
@@ -532,7 +532,7 @@ select {
 	padding: 6px 12px;
 	margin-bottom: 5px;
 	cursor: pointer;
-	
+
 	-webkit-box-sizing: border-box;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
@@ -1348,17 +1348,17 @@ h6 > .elgg-icon {
 .elgg-avatar-tiny > a > img {
 	width: 25px;
 	height: 25px;
-	
+
 	/* remove the border-radius if you don't want rounded avatars in supported browsers */
 	border-radius: 3px;
-	
+
 	background-clip:  border;
 	background-size: 25px;
 }
 .elgg-avatar-small > a > img {
 	width: 40px;
 	height: 40px;
-	
+
 	/* remove the border-radius if you don't want rounded avatars in supported browsers */
 	border-radius: 5px;
 	background-clip:  border;
@@ -1601,7 +1601,7 @@ ul.elgg-plugin-resources, ul.elgg-plugin-resources > li {
 	margin-bottom: 5px;
 }
 
-.elgg-subtext a {
+.elgg-subtext time {
 	color: #666;
 }
 

--- a/views/default/elements/typography.css.php
+++ b/views/default/elements/typography.css.php
@@ -39,7 +39,7 @@ p:last-child {
 pre, code {
 	font-family: Monaco, "Courier New", Courier, monospace;
 	font-size: 12px;
-	
+
 	background:#EBF5FF;
 	color:#000000;
 	overflow:auto;
@@ -48,7 +48,7 @@ pre, code {
 
 	white-space: pre-wrap;
 	word-wrap: break-word; /* IE 5.5-7 */
-	
+
 }
 
 pre {
@@ -118,7 +118,7 @@ h6 { font-size: 0.8em; }
 	font-style: italic;
 }
 
-.elgg-subtext a {
+.elgg-subtext time {
 	color: #666;
 }
 


### PR DESCRIPTION
The `<time>` element of comment and discussion_reply objects was earlier
converted to a link and the link color was set to grey. This accidentally
affected all links inside `.elgg-subtext`. This fix makes the CSS selector
of the `<time>` links more specific so that regular links still have their
original color.

Fixes #8839
