### PR TITLE
WIP: feature(river): Adds hook-based permissions for river item delete action

### DIFF
--- a/actions/river/delete.php
+++ b/actions/river/delete.php
@@ -6,14 +6,23 @@
  * @subpackage Core
  */
 
-$id = get_input('id', false);
+$id = (int)get_input('id');
 
-if ($id !== false && elgg_is_admin_logged_in()) {
-	if (elgg_delete_river(array('id' => $id))) {
-		system_message(elgg_echo('river:delete:success'));
-	} else {
-		register_error(elgg_echo('river:delete:fail'));
-	}
+$items = elgg_get_river(['id' => $id]);
+if (!$items) {
+	register_error(elgg_echo('river:delete:fail'));
+	forward(REFERER);
+}
+
+$item = $items[0];
+
+if (!$item->canDelete()) {
+	register_error(elgg_echo('river:delete:lack_permission'));
+	forward(REFERER);
+}
+
+if ($item->delete()) {
+	system_message(elgg_echo('river:delete:success'));
 } else {
 	register_error(elgg_echo('river:delete:fail'));
 }

--- a/docs/guides/events-list.rst
+++ b/docs/guides/events-list.rst
@@ -194,6 +194,14 @@ River events
 **created, river**
 	Called after a river item is created.
 
+	.. note:: Use the plugin hook ``creating, river`` to cancel creation (or alter options).
+
+**delete:before, river**
+	Triggered before a river item is deleted. Returning false cancels the deletion.
+
+**delete:after, river**
+	Triggered after a river item was deleted.
+
 Notes
 =====
 

--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -97,7 +97,8 @@ System hooks
 	Trigger by ``elgg_view_menu()``. Used to sort, add, remove, and modify menu items.
 
 **creating, river**
-	Triggered before a river item is created. Return false to prevent river item from being created.
+	The options for ``elgg_create_river_item`` are filtered through this hook. You may alter values
+	or return ``false`` to cancel the item creation.
 
 **simplecache:generate, <view>**
 	Triggered when generating the cached content of a view.
@@ -204,6 +205,12 @@ Permission hooks
 
 **permissions_check:delete, <entity_type>**
 	Return boolean for if the user ``$params['user']`` can delete the entity ``$params['entity']``. Defaults to ``$entity->canEdit()``.
+
+**permissions_check:delete, river**
+	Return boolean for if the user ``$params['user']`` can delete the river item ``$params['item']``. Defaults to
+	``true`` for admins and ``false`` for other users.
+
+	.. note:: This check is not performed when using the deprecated ``elgg_delete_river()``.
 
 **permissions_check, widget_layout**
 	Return boolean for if ``$params['user']`` can edit the widgets in the context passed as

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -171,6 +171,7 @@ class Application {
 			'deprecated-1.10.php',
 			'deprecated-1.11.php',
 			'deprecated-1.12.php',
+			'deprecated-2.1.php',
 		);
 
 		// isolate global scope

--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -144,7 +144,7 @@ class EntityTable {
 	 * @param string $type The type of the entity. If given, even an existing entity with the given GUID
 	 *                     will not be returned unless its type matches.
 	 *
-	 * @return \ElggEntity The correct Elgg or custom object based upon entity type and subtype
+	 * @return \ElggEntity|false The correct Elgg or custom object based upon entity type and subtype
 	 */
 	function get($guid, $type = '') {
 		// We could also use: if (!(int) $guid) { return false },
@@ -1234,5 +1234,31 @@ class EntityTable {
 		} else {
 			return false;
 		}
+	}
+
+	/**
+	 * Get a user by GUID even if the entity is hidden or disabled
+	 *
+	 * @param int $guid User GUID. Default is logged in user
+	 *
+	 * @return \ElggUser|false
+	 * @access private
+	 */
+	public function resolveUser($guid = 0) {
+		if (!$guid) {
+			return _elgg_services()->session->getLoggedInUser();
+		}
+
+		// need to ignore access and show hidden entities for potential hidden/disabled users
+		$ia = _elgg_services()->session->setIgnoreAccess(true);
+		$show_hidden = access_show_hidden_entities(true);
+
+		$user = $this->get($guid, 'user');
+		/* @var \ElggUser|false $user */
+
+		_elgg_services()->session->setIgnoreAccess($ia);
+		access_show_hidden_entities($show_hidden);
+
+		return $user;
 	}
 }

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1035,21 +1035,8 @@ abstract class ElggEntity extends \ElggData implements
 	 * @see elgg_set_ignore_access()
 	 */
 	public function canDelete($user_guid = 0) {
-		$user_guid = (int) $user_guid;
+		$user = _elgg_services()->entityTable->resolveUser($user_guid);
 
-		if (!$user_guid) {
-			$user_guid = _elgg_services()->session->getLoggedInUserGuid();
-		}
-
-		// need to ignore access and show hidden entities for potential hidden/disabled users
-		$ia = elgg_set_ignore_access(true);
-		$show_hidden = access_show_hidden_entities(true);
-		
-		$user = _elgg_services()->entityTable->get($user_guid, 'user');
-		
-		elgg_set_ignore_access($ia);
-		access_show_hidden_entities($show_hidden);
-		
 		if ($user_guid & !$user) {
 			// requested to check access for a specific user_guid, but there is no user entity, so return false
 			$message = _elgg_services()->translator->translate('entity:can_delete:invaliduser', array($user_guid));

--- a/engine/classes/ElggSession.php
+++ b/engine/classes/ElggSession.php
@@ -209,7 +209,7 @@ class ElggSession implements \ArrayAccess {
 	/**
 	 * Gets the logged in user
 	 * 
-	 * @return \ElggUser
+	 * @return \ElggUser|null
 	 * @since 1.9
 	 */
 	public function getLoggedInUser() {

--- a/engine/lib/deprecated-2.1.php
+++ b/engine/lib/deprecated-2.1.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Delete river items
+ *
+ * @warning not checking access (should we?) nor does this check canDelete() on the items.
+ *
+ * @param array $options Parameters:
+ *   ids                  => INT|ARR River item id(s)
+ *   subject_guids        => INT|ARR Subject guid(s)
+ *   object_guids         => INT|ARR Object guid(s)
+ *   target_guids         => INT|ARR Target guid(s)
+ *   annotation_ids       => INT|ARR The identifier of the annotation(s)
+ *   action_types         => STR|ARR The river action type(s) identifier
+ *   views                => STR|ARR River view(s)
+ *
+ *   types                => STR|ARR Entity type string(s)
+ *   subtypes             => STR|ARR Entity subtype string(s)
+ *   type_subtype_pairs   => ARR     Array of type => subtype pairs where subtype
+ *                                   can be an array of subtype strings
+ *
+ *   posted_time_lower    => INT     The lower bound on the time posted
+ *   posted_time_upper    => INT     The upper bound on the time posted
+ *
+ * @return bool
+ * @since 1.8.0
+ * @deprecated Call delete() on items returned by elgg_get_river()
+ */
+function elgg_delete_river(array $options = array()) {
+	global $CONFIG;
+
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Call delete() on items returned by elgg_get_river()', '2.1');
+
+	$defaults = array(
+		'ids'                  => ELGG_ENTITIES_ANY_VALUE,
+
+		'subject_guids'	       => ELGG_ENTITIES_ANY_VALUE,
+		'object_guids'         => ELGG_ENTITIES_ANY_VALUE,
+		'target_guids'         => ELGG_ENTITIES_ANY_VALUE,
+		'annotation_ids'       => ELGG_ENTITIES_ANY_VALUE,
+
+		'views'                => ELGG_ENTITIES_ANY_VALUE,
+		'action_types'         => ELGG_ENTITIES_ANY_VALUE,
+
+		'types'	               => ELGG_ENTITIES_ANY_VALUE,
+		'subtypes'             => ELGG_ENTITIES_ANY_VALUE,
+		'type_subtype_pairs'   => ELGG_ENTITIES_ANY_VALUE,
+
+		'posted_time_lower'	   => ELGG_ENTITIES_ANY_VALUE,
+		'posted_time_upper'	   => ELGG_ENTITIES_ANY_VALUE,
+
+		'wheres'               => array(),
+		'joins'                => array(),
+
+	);
+
+	$options = array_merge($defaults, $options);
+
+	$singulars = array('id', 'subject_guid', 'object_guid', 'target_guid', 'annotation_id', 'action_type', 'view', 'type', 'subtype');
+	$options = _elgg_normalize_plural_options_array($options, $singulars);
+
+	$wheres = $options['wheres'];
+
+	$wheres[] = _elgg_get_guid_based_where_sql('rv.id', $options['ids']);
+	$wheres[] = _elgg_get_guid_based_where_sql('rv.subject_guid', $options['subject_guids']);
+	$wheres[] = _elgg_get_guid_based_where_sql('rv.object_guid', $options['object_guids']);
+	$wheres[] = _elgg_get_guid_based_where_sql('rv.target_guid', $options['target_guids']);
+	$wheres[] = _elgg_get_guid_based_where_sql('rv.annotation_id', $options['annotation_ids']);
+	$wheres[] = _elgg_river_get_action_where_sql($options['action_types']);
+	$wheres[] = _elgg_river_get_view_where_sql($options['views']);
+	$wheres[] = _elgg_get_river_type_subtype_where_sql('rv', $options['types'],
+		$options['subtypes'], $options['type_subtype_pairs']);
+
+	if ($options['posted_time_lower'] && is_int($options['posted_time_lower'])) {
+		$wheres[] = "rv.posted >= {$options['posted_time_lower']}";
+	}
+
+	if ($options['posted_time_upper'] && is_int($options['posted_time_upper'])) {
+		$wheres[] = "rv.posted <= {$options['posted_time_upper']}";
+	}
+
+	// see if any functions failed
+	// remove empty strings on successful functions
+	foreach ($wheres as $i => $where) {
+		if ($where === false) {
+			return false;
+		} elseif (empty($where)) {
+			unset($wheres[$i]);
+		}
+	}
+
+	// remove identical where clauses
+	$wheres = array_unique($wheres);
+
+	$query = "DELETE rv.* FROM {$CONFIG->dbprefix}river rv ";
+
+	// remove identical join clauses
+	$joins = array_unique($options['joins']);
+
+	// add joins
+	foreach ($joins as $j) {
+		$query .= " $j ";
+	}
+
+	// add wheres
+	$query .= ' WHERE ';
+
+	foreach ($wheres as $w) {
+		$query .= " $w AND ";
+	}
+	$query .= "1=1";
+
+	return delete_data($query);
+}

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -434,10 +434,10 @@ function _elgg_river_menu_setup($hook, $type, $return, $params) {
 			}
 		}
 		
-		if (elgg_is_admin_logged_in()) {
+		if ($item->canDelete()) {
 			$options = array(
 				'name' => 'delete',
-				'href' => elgg_add_action_tokens_to_url("action/river/delete?id=$item->id"),
+				'href' => elgg_add_action_tokens_to_url("action/river/delete?id={$item->id}"),
 				'text' => elgg_view_icon('delete'),
 				'title' => elgg_echo('river:delete'),
 				'confirm' => elgg_echo('deleteconfirm'),

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -135,116 +135,6 @@ function elgg_create_river_item(array $options = array()) {
 }
 
 /**
- * Delete river items
- *
- * @warning not checking access (should we?)
- *
- * @param array $options Parameters:
- *   ids                  => INT|ARR River item id(s)
- *   subject_guids        => INT|ARR Subject guid(s)
- *   object_guids         => INT|ARR Object guid(s)
- *   target_guids         => INT|ARR Target guid(s)
- *   annotation_ids       => INT|ARR The identifier of the annotation(s)
- *   action_types         => STR|ARR The river action type(s) identifier
- *   views                => STR|ARR River view(s)
- *
- *   types                => STR|ARR Entity type string(s)
- *   subtypes             => STR|ARR Entity subtype string(s)
- *   type_subtype_pairs   => ARR     Array of type => subtype pairs where subtype
- *                                   can be an array of subtype strings
- *
- *   posted_time_lower    => INT     The lower bound on the time posted
- *   posted_time_upper    => INT     The upper bound on the time posted
- *
- * @return bool
- * @since 1.8.0
- */
-function elgg_delete_river(array $options = array()) {
-	global $CONFIG;
-
-	$defaults = array(
-		'ids'                  => ELGG_ENTITIES_ANY_VALUE,
-
-		'subject_guids'	       => ELGG_ENTITIES_ANY_VALUE,
-		'object_guids'         => ELGG_ENTITIES_ANY_VALUE,
-		'target_guids'         => ELGG_ENTITIES_ANY_VALUE,
-		'annotation_ids'       => ELGG_ENTITIES_ANY_VALUE,
-
-		'views'                => ELGG_ENTITIES_ANY_VALUE,
-		'action_types'         => ELGG_ENTITIES_ANY_VALUE,
-
-		'types'	               => ELGG_ENTITIES_ANY_VALUE,
-		'subtypes'             => ELGG_ENTITIES_ANY_VALUE,
-		'type_subtype_pairs'   => ELGG_ENTITIES_ANY_VALUE,
-
-		'posted_time_lower'	   => ELGG_ENTITIES_ANY_VALUE,
-		'posted_time_upper'	   => ELGG_ENTITIES_ANY_VALUE,
-
-		'wheres'               => array(),
-		'joins'                => array(),
-
-	);
-
-	$options = array_merge($defaults, $options);
-
-	$singulars = array('id', 'subject_guid', 'object_guid', 'target_guid', 'annotation_id', 'action_type', 'view', 'type', 'subtype');
-	$options = _elgg_normalize_plural_options_array($options, $singulars);
-
-	$wheres = $options['wheres'];
-
-	$wheres[] = _elgg_get_guid_based_where_sql('rv.id', $options['ids']);
-	$wheres[] = _elgg_get_guid_based_where_sql('rv.subject_guid', $options['subject_guids']);
-	$wheres[] = _elgg_get_guid_based_where_sql('rv.object_guid', $options['object_guids']);
-	$wheres[] = _elgg_get_guid_based_where_sql('rv.target_guid', $options['target_guids']);
-	$wheres[] = _elgg_get_guid_based_where_sql('rv.annotation_id', $options['annotation_ids']);
-	$wheres[] = _elgg_river_get_action_where_sql($options['action_types']);
-	$wheres[] = _elgg_river_get_view_where_sql($options['views']);
-	$wheres[] = _elgg_get_river_type_subtype_where_sql('rv', $options['types'],
-		$options['subtypes'], $options['type_subtype_pairs']);
-
-	if ($options['posted_time_lower'] && is_int($options['posted_time_lower'])) {
-		$wheres[] = "rv.posted >= {$options['posted_time_lower']}";
-	}
-
-	if ($options['posted_time_upper'] && is_int($options['posted_time_upper'])) {
-		$wheres[] = "rv.posted <= {$options['posted_time_upper']}";
-	}
-
-	// see if any functions failed
-	// remove empty strings on successful functions
-	foreach ($wheres as $i => $where) {
-		if ($where === false) {
-			return false;
-		} elseif (empty($where)) {
-			unset($wheres[$i]);
-		}
-	}
-
-	// remove identical where clauses
-	$wheres = array_unique($wheres);
-
-	$query = "DELETE rv.* FROM {$CONFIG->dbprefix}river rv ";
-
-	// remove identical join clauses
-	$joins = array_unique($options['joins']);
-
-	// add joins
-	foreach ($joins as $j) {
-		$query .= " $j ";
-	}
-
-	// add wheres
-	$query .= ' WHERE ';
-
-	foreach ($wheres as $w) {
-		$query .= " $w AND ";
-	}
-	$query .= "1=1";
-
-	return delete_data($query);
-}
-
-/**
  * Get river items
  *
  * @note If using types and subtypes in a query, they are joined with an AND.
@@ -280,7 +170,7 @@ function elgg_delete_river(array $options = array()) {
  *                                   option without a full understanding of the
  *                                   underlying SQL query Elgg creates. (true)
  *
- * @return array|int
+ * @return ElggRiverItem[]|int
  * @since 1.8.0
  */
 function elgg_get_river(array $options = array()) {

--- a/languages/en.php
+++ b/languages/en.php
@@ -332,8 +332,10 @@ return array(
 	'river:none' => 'No activity',
 	'river:update' => 'Update for %s',
 	'river:delete' => 'Remove this activity item',
-	'river:delete:success' => 'River item has been deleted',
-	'river:delete:fail' => 'River item could not be deleted',
+	'river:delete:success' => 'Activity item has been deleted',
+	'river:delete:fail' => 'Activity item could not be deleted',
+	'river:delete:lack_permission' => 'You lack permission to delete this activity item',
+	'river:can_delete:invaliduser' => 'Cannot check canDelete for user_guid [%s] as the user does not exist.',
 	'river:subject:invalid_subject' => 'Invalid user',
 	'activity:owner' => 'View activity',
 
@@ -1287,7 +1289,7 @@ Please do not reply to this email.",
 	'entity:delete:success' => 'Entity %s has been deleted',
 	'entity:delete:fail' => 'Entity %s could not be deleted',
 	
-	'entity:can_delete:invaliduser' => 'Can not check canDelete for user_guid [%s] as the user does not exist.',
+	'entity:can_delete:invaliduser' => 'Cannot check canDelete for user_guid [%s] as the user does not exist.',
 
 /**
  * Action gatekeeper


### PR DESCRIPTION
Fixes #8936
- [x] Add ElggRiverItem::delete()
- [x] permissions hook and before/after events
- [x] deprecate elgg_delete_river()
- [ ] Use new API from #8944 in canDelete()
- [ ] tests
