### PR TITLE
fix(permissions): All permissions functions handle user fetches consistently

### DIFF
--- a/engine/classes/Elgg/Database/AccessCollections.php
+++ b/engine/classes/Elgg/Database/AccessCollections.php
@@ -2,6 +2,8 @@
 
 namespace Elgg\Database;
 
+use Elgg\Database\EntityTable\UserFetchFailureException;
+
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
  *
@@ -436,19 +438,19 @@ class AccessCollections {
 	 * @return bool
 	 */
 	function canEdit($collection_id, $user_guid = null) {
-		if ($user_guid) {
-			$user = _elgg_services()->entityTable->get((int) $user_guid);
-		} else {
-			$user = _elgg_services()->session->getLoggedInUser();
+		try {
+			$user = _elgg_services()->entityTable->getUserForPermissionsCheck($user_guid);
+		} catch (UserFetchFailureException $e) {
+			return false;
 		}
 	
 		$collection = get_access_collection($collection_id);
 	
-		if (!($user instanceof \ElggUser) || !$collection) {
+		if (!$user || !$collection) {
 			return false;
 		}
 	
-		$write_access = get_write_access_array($user->getGUID(), 0, true);
+		$write_access = get_write_access_array($user->guid, 0, true);
 	
 		// don't ignore access when checking users.
 		if ($user_guid) {

--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elgg\Database;
 
+use Elgg\Database\EntityTable\UserFetchFailureException;
 use IncompleteEntityException;
 
 /**
@@ -1234,5 +1235,40 @@ class EntityTable {
 		} else {
 			return false;
 		}
+	}
+
+	/**
+	 * Get a user by GUID even if the entity is hidden or disabled
+	 *
+	 * @param int $guid User GUID. Default is logged in user
+	 *
+	 * @return \ElggUser|false
+	 * @throws UserFetchFailureException
+	 * @access private
+	 */
+	public function getUserForPermissionsCheck($guid = 0) {
+		if (!$guid) {
+			return _elgg_services()->session->getLoggedInUser();
+		}
+
+		// need to ignore access and show hidden entities for potential hidden/disabled users
+		$ia = _elgg_services()->session->setIgnoreAccess(true);
+		$show_hidden = access_show_hidden_entities(true);
+
+		$user = $this->get($guid, 'user');
+
+		_elgg_services()->session->setIgnoreAccess($ia);
+		access_show_hidden_entities($show_hidden);
+
+		if (!$user) {
+			// requested to check access for a specific user_guid, but there is no user entity, so the caller
+			// should cancel the check and return false
+			$message = _elgg_services()->translator->translate('UserFetchFailureException', array($guid));
+			_elgg_services()->logger->warn($message);
+
+			throw new UserFetchFailureException();
+		}
+
+		return $user;
 	}
 }

--- a/engine/classes/Elgg/Database/EntityTable/UserFetchResultException.php
+++ b/engine/classes/Elgg/Database/EntityTable/UserFetchResultException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Elgg\Database\EntityTable;
+
+/**
+ * Exception indicating a user could not be looked up for a permissions check
+ */
+class UserFetchFailureException extends \RuntimeException {}

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -6,6 +6,8 @@
  * @subpackage DataModel.Entities
  */
 
+use Elgg\Database\EntityTable\UserFetchFailureException;
+
 /**
  * Cache entities in memory once loaded.
  *
@@ -302,15 +304,14 @@ function can_write_to_container($user_guid = 0, $container_guid = 0, $type = 'al
 
 	$container = get_entity($container_guid);
 
-	$user_guid = (int)$user_guid;
-	if ($user_guid == 0) {
-		$user = elgg_get_logged_in_user_entity();
-		$user_guid = elgg_get_logged_in_user_guid();
-	} else {
-		$user = get_user($user_guid);
-		if (!$user) {
-			return false;
-		}
+	try {
+		$user = _elgg_services()->entityTable->getUserForPermissionsCheck($user_guid);
+	} catch (UserFetchFailureException $e) {
+		return false;
+	}
+
+	if ($user) {
+		$user_guid = $user->guid;
 	}
 
 	$return = false;

--- a/languages/en.php
+++ b/languages/en.php
@@ -100,6 +100,8 @@ return array(
 	'LoginException:ChangePasswordFailure' => 'Failed current password check.',
 	'LoginException:Unknown' => 'We could not log you in due to an unknown error.',
 
+	'UserFetchFailureException' => 'Cannot check permission for user_guid [%s] as the user does not exist.',
+
 	'deprecatedfunction' => 'Warning: This code uses the deprecated function \'%s\' and is not compatible with this version of Elgg',
 
 	'pageownerunavailable' => 'Warning: The page owner %d is not accessible!',
@@ -1287,7 +1289,7 @@ Please do not reply to this email.",
 	'entity:delete:success' => 'Entity %s has been deleted',
 	'entity:delete:fail' => 'Entity %s could not be deleted',
 	
-	'entity:can_delete:invaliduser' => 'Can not check canDelete for user_guid [%s] as the user does not exist.',
+	'entity:can_delete:invaliduser' => 'Cannot check canDelete() for user_guid [%s] as the user does not exist.',
 
 /**
  * Action gatekeeper


### PR DESCRIPTION
All permissions functions now find hidden/disabled users and, when a given GUID isn't found, they return false and issue a warning. Previously, only some functions issued warnings, and some functions would silently substitute the logged in user if a given GUID couldn't load.

Fixes #8941
Fixes #8038
Fixes #8945
