### PR TITLE
chore(events): Stop firing the deprecated delete relationship event

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -309,10 +309,12 @@ The behavior of the ``container_permissions_check`` hook has changed when an ent
 
 In 2.0, when an entity is created in a container like a group, if the owner is the same as the logged in user (almost always the case), this first check is bypassed. So the ``container_permissions_check`` hook will almost always be called once with ``$params['container']`` being the correct container of the entity.
 
-Creating a relationship triggers only one event
------------------------------------------------
+Creating or deleting a relationship triggers only one event
+-----------------------------------------------------------
 
-Entity relationship creation no longer fires the legacy "create" event using the relationship name as the type. E.g. Listening for the ``"create", "member"`` event will no longer capture group membership additions. Use the ``"create", "relationship"`` event.
+The "create" and "delete" relationship events are now only fired once, with ``"relationship"`` as the object type.
+
+E.g. Listening for the ``"create", "member"`` or ``"delete", "member"`` event(s) will no longer capture group membership additions/removals. Use the ``"create", "relationship"`` or ``"delete", "relationship"`` events.
 
 Discussion feature has been pulled from groups into its own plugin
 ------------------------------------------------------------------

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -215,7 +215,9 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			return new \Elgg\Database\QueryCounter($c->db);
 		}, false);
 
-		$this->setClassName('relationshipsTable', \Elgg\Database\RelationshipsTable::class);
+		$this->setFactory('relationshipsTable', function(ServiceProvider $c) {
+			return new \Elgg\Database\RelationshipsTable($c->db);
+		});
 
 		$this->setFactory('request', [\Elgg\Http\Request::class, 'createFromGlobals']);
 

--- a/engine/classes/ElggRelationship.php
+++ b/engine/classes/ElggRelationship.php
@@ -38,7 +38,7 @@ class ElggRelationship extends \ElggData implements
 
 			$id = (int)$row;
 			elgg_deprecated_notice('Passing an ID to constructor is deprecated. Use get_relationship()', 1.9);
-			$row = _elgg_get_relationship_row($id);
+			$row = _elgg_services()->relationshipsTable->getRow($id);
 			if (!$row) {
 				throw new \InvalidArgumentException("Relationship not found with ID $id");
 			}

--- a/engine/lib/relationships.php
+++ b/engine/lib/relationships.php
@@ -34,18 +34,6 @@ function get_relationship($id) {
 }
 
 /**
- * Get a database row from the relationship table
- *
- * @param int $id The relationship ID
- *
- * @return \stdClass|false False if no row found
- * @access private
- */
-function _elgg_get_relationship_row($id) {
-	return _elgg_services()->relationshipsTable->getRow($id);
-}
-
-/**
  * Delete a relationship by its ID
  *
  * @param int $id The relationship ID


### PR DESCRIPTION
We no longer fire the "delete" event with the relationship name as the object type.

This also cleans up the RelationshipsTable class and adds the DB as an explicit dependency.

BREAKING CHANGE:
Relationship deletions only fire the "delete", "relationship" event.

(I realize this is late for 2.0, but we missed this when removing the duplicate create event. Anyway, I thought I'd give it a shot. Remove it from the milestone if you're adamantly against it.)
