### PR TITLE
chore(tests): Eases testing of hooks, events, and logging

### DIFF
--- a/engine/classes/Elgg/HooksRegistrationService.php
+++ b/engine/classes/Elgg/HooksRegistrationService.php
@@ -29,6 +29,11 @@ abstract class HooksRegistrationService {
 	private $registrations = [];
 
 	/**
+	 * @var array
+	 */
+	private $backups = [];
+
+	/**
 	 * @var \Elgg\Logger
 	 */
 	protected $logger;
@@ -242,5 +247,37 @@ abstract class HooksRegistrationService {
 		}
 
 		return new MethodMatcher($spec[0], $spec[1]);
+	}
+
+	/**
+	 * Temporarily remove all event/hook registrations (before tests)
+	 *
+	 * Call backup() before your tests and restore() after.
+	 *
+	 * @note This behaves like a stack. You must call restore() for each backup() call.
+	 *
+	 * @return void
+	 * @see restore
+	 * @access private
+	 * @internal
+	 */
+	public function backup() {
+		$this->backups[] = $this->registrations;
+		$this->registrations = [];
+	}
+
+	/**
+	 * Restore backed up event/hook registrations (after tests)
+	 *
+	 * @return void
+	 * @see backup
+	 * @access private
+	 * @internal
+	 */
+	public function restore() {
+		$backup = array_pop($this->backups);
+		if (is_array($backup)) {
+			$this->registrations = $backup;
+		}
 	}
 }

--- a/engine/tests/phpunit/Elgg/HooksRegistrationServiceTest.php
+++ b/engine/tests/phpunit/Elgg/HooksRegistrationServiceTest.php
@@ -123,6 +123,34 @@ class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->assertSame($expected_foo_bar, $this->mock->getOrderedHandlers('foo', 'bar'));
 		$this->assertSame($expected_foo_baz, $this->mock->getOrderedHandlers('foo', 'baz'));
 	}
+
+	public function testCanBackupAndRestoreRegistrations() {
+		$this->mock->registerHandler('foo', 'bar', 'callback2');
+		$this->mock->registerHandler('all', 'all', 'callback4', 100);
+		$handlers = $this->mock->getAllHandlers();
+
+		$this->mock->backup();
+		$this->assertEmpty($this->mock->getAllHandlers());
+
+		$this->mock->restore();
+		$this->assertEquals($handlers, $this->mock->getAllHandlers());
+	}
+
+	public function testBackupIsAStack() {
+		$this->mock->registerHandler('foo', 'bar', 'callback2');
+		$handlers1 = $this->mock->getAllHandlers();
+		$this->mock->backup();
+
+		$this->mock->registerHandler('all', 'all', 'callback4', 100);
+		$handlers2 = $this->mock->getAllHandlers();
+		$this->mock->backup();
+
+		$this->mock->restore();
+		$this->assertEquals($handlers2, $this->mock->getAllHandlers());
+
+		$this->mock->restore();
+		$this->assertEquals($handlers1, $this->mock->getAllHandlers());
+	}
 }
 
 class HooksRegistrationServiceTest_invokable {

--- a/engine/tests/phpunit/Elgg/LoggerTest.php
+++ b/engine/tests/phpunit/Elgg/LoggerTest.php
@@ -21,6 +21,63 @@ class LoggerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($logger->log("hello", 123));
 	}
 
+	public function testDisablePreventsProcessingAndCapturesLogCalls() {
+		$logger = _elgg_services()->logger;
+		$logger->disable();
+		$hooks = _elgg_services()->hooks;
+		$hooks->backup();
+
+		$num_processed = 0;
+		$hooks->registerHandler('debug', 'log', function () use (&$num_processed) {
+			$num_processed++;
+			return false;
+		});
+		$logger->error("Testing");
+
+		$this->assertEquals(0, $num_processed, "disable() still allowed log to be processed");
+
+		$captured = $logger->enable();
+
+		$this->assertEquals([
+			['message' => 'Testing', 'level' => Logger::ERROR],
+		], $captured);
+
+		$hooks->restore();
+	}
+
+	public function testDisableEnableActsAsAStack() {
+		$logger = _elgg_services()->logger;
+		$hooks = _elgg_services()->hooks;
+		$hooks->backup();
+
+		$num_processed = 0;
+		$hooks->registerHandler('debug', 'log', function () use (&$num_processed) {
+			$num_processed++;
+			return false;
+		});
+
+		$logger->disable();
+		$logger->error("Test1");
+
+		$logger->disable();
+		$logger->warn("Test2");
+
+		$this->assertEquals([
+			['message' => 'Test2', 'level' => Logger::WARNING],
+		], $logger->enable());
+
+		$this->assertEquals([
+			['message' => 'Test1', 'level' => Logger::ERROR],
+		], $logger->enable());
+
+		$this->assertEquals(0, $num_processed);
+
+		$logger->error("Test3");
+		$this->assertEquals(1, $num_processed, "Last enable() did not enable processing");
+
+		$hooks->restore();
+	}
+
 	protected function getLoggerInstance() {
 		$mock = $this->getMock('\Elgg\PluginHooksService', array('trigger'));
 		$mock->expects($this->never())->method('trigger');


### PR DESCRIPTION
This allows temporarily disabling logging while capturing log calls, and temporarily clearing and restoring event/hook handlers. This is particularly for situations where components involved in your test must rely on the Service Provider and you cannot radically alter the dependency graph to inject your test objects.
