### PR TITLE
feature(hooks): Adds a function to call 3rd party plugin APIs

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -119,6 +119,13 @@ System hooks
 
 **add, river**
 
+**elgg_call:method, <method>**
+	This filters the ``$method`` argument in ``elgg_call``. A handler may return a callable, a class name,
+	or ``false`` to cancel the call.
+
+**elgg_call:value, <method>**
+	This filters the method return value in ``elgg_call()`` if a call is made.
+
 User hooks
 ==========
 

--- a/engine/classes/Elgg/CallResult.php
+++ b/engine/classes/Elgg/CallResult.php
@@ -1,0 +1,17 @@
+<?php
+namespace Elgg;
+
+/**
+ * The result of an elgg_call() call.
+ */
+class CallResult {
+	/**
+	 * @var bool Was the method (or a substitute) called?
+	 */
+	public $was_called = false;
+
+	/**
+	 * @var mixed The output of the method call it was called
+	 */
+	public $value;
+}

--- a/engine/tests/phpunit/Elgg/lib/elgglib/CallTest.php
+++ b/engine/tests/phpunit/Elgg/lib/elgglib/CallTest.php
@@ -1,0 +1,117 @@
+<?php
+namespace Elgg\lib\elgglib;
+
+use Elgg\CallResult;
+
+class CallTest extends \PHPUnit_Framework_TestCase {
+
+	function tearDown() {
+		elgg_clear_plugin_hook_handlers('elgg_call:method', Greeter1::class);
+		elgg_clear_plugin_hook_handlers('elgg_call:value', Greeter1::class);
+	}
+
+	function testCall() {
+		$res = elgg_call('Elgg\\lib\\elgglib\\testFunction', ['Name']);
+
+		$this->assertInstanceOf(CallResult::class, $res);
+		$this->assertTrue($res->was_called);
+		$this->assertEquals('Hello, Name', $res->value);
+	}
+
+	function testTrimsLeadingSlash() {
+		$res = elgg_call('\\Elgg\\lib\\elgglib\\testFunction', ['Name']);
+
+		$this->assertEquals('Hello, Name', $res->value);
+	}
+
+	function testMissingCall() {
+		$res = elgg_call('not_a_real_function', ['Name']);
+
+		$this->assertInstanceOf(CallResult::class, $res);
+		$this->assertFalse($res->was_called);
+	}
+
+	function testClassNameCall() {
+		$res = elgg_call(Greeter1::class, ['Name']);
+
+		$this->assertEquals('Hello, Name', $res->value);
+	}
+
+	function testOverrideMethodCall() {
+		$handler = function ($h, $t, $v, $p) use (&$args) {
+			$args = func_get_args();
+			return Greeter2::class;
+		};
+		elgg_register_plugin_hook_handler('elgg_call:method', Greeter1::class, $handler);
+
+		$res = elgg_call(Greeter1::class, ['Name']);
+
+		$this->assertEquals('Hola, Name', $res->value);
+
+		$expected_params = [
+			'method' => Greeter1::class,
+			'args' => ['Name'],
+		];
+		$this->assertEquals($expected_params, $args[3]);
+	}
+
+	function testOverrideValue() {
+		$handler = function ($h, $t, $v, $p) {
+			return "$v!!";
+		};
+		elgg_register_plugin_hook_handler('elgg_call:value', Greeter1::class, $handler);
+
+		$res = elgg_call(Greeter1::class, ['Name']);
+
+		$this->assertEquals('Hello, Name!!', $res->value);
+	}
+
+	function testCancel() {
+		elgg_register_plugin_hook_handler('elgg_call:method', Greeter1::class, 'Elgg\Values::getFalse');
+
+		$res = elgg_call(Greeter1::class, ['Name']);
+
+		$this->assertFalse($res->was_called);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	function testNonStringMethod() {
+		elgg_call([]);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	function testEmptyMethod() {
+		elgg_call('');
+	}
+
+	/**
+	 * @expectedException \RuntimeException
+	 */
+	function testCannotInstantiate() {
+		elgg_call(Greeter3::class, ['Name']);
+	}
+}
+
+class Greeter1 {
+	function __invoke($name) {
+		return "Hello, $name";
+	}
+}
+
+class Greeter2 {
+	function __invoke($name) {
+		return "Hola, $name";
+	}
+}
+
+class Greeter3 extends Greeter1 {
+	function __construct($arg1) {}
+}
+
+function testFunction($name) {
+	return "Hello, $name";
+}


### PR DESCRIPTION
`elgg_call()` allows use of many callables whether or not the API is defined. Hooks allow overriding the method to be called and filtering the value returned. The user must check the result object to verify that the method was called.

Fixes #8763

(see discussion also in #8765)
- [ ] docs, w/ examples of good usage pattern
