### PR TITLE
chore(i18n): required translation completeness is now 95%

### DIFF
--- a/.scripts/release.php
+++ b/.scripts/release.php
@@ -49,7 +49,7 @@ run_commands([
 
 // Update translations
 run_commands([
-	"tx pull -a --minimum-perc=100",
+	"tx pull -a --minimum-perc=95",
 ]);
 
 // Clean translations


### PR DESCRIPTION
Reduces the minimum acceptable percentage of a translation.
This allows translation to be included in a release even if
a couple of strings are still missing from it.

Fixes #8959
