### PR TITLE
chore(i18n): Client-side language files work again

### DIFF
--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -248,22 +248,4 @@ function elgg_language_key_exists($key, $language = 'en') {
 	return _elgg_services()->translator->languageKeyExists($key, $language);
 }
 
-/**
- * Initializes simplecache views for translations
- * 
- * @return void
- */
-function _elgg_translations_init() {
-	$translations = _elgg_services()->translator->getAllLanguageCodes();
-	foreach ($translations as $language_code) {
-		// make the js view available for each language
-		elgg_extend_view("languages/$language_code.js", "languages.js");
-	
-		// register the js view for use in simplecache
-		elgg_register_simplecache_view("languages/$language_code.js");
-	}
-}
-
-return function(\Elgg\EventsService $events) {
-	$events->registerHandler('init', 'system', '_elgg_translations_init');
-};
+return function(\Elgg\EventsService $events) {};

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -250,18 +250,6 @@ function elgg_register_external_view($view, $cacheable = false) {
 }
 
 /**
- * Check whether a view is registered as cacheable.
- *
- * @param string $view The name of the view.
- * @return boolean
- * @access private
- * @since 1.9.0
- */
-function _elgg_is_view_cacheable($view) {
-	return _elgg_services()->views->isCacheableView($view);
-}
-
-/**
  * Unregister a view for ajax calls
  *
  * @param string $view The view name

--- a/views/default/languages.js.php
+++ b/views/default/languages.js.php
@@ -3,21 +3,7 @@
  * @uses $vars['language']
  */
 
-$language = elgg_extract('language', $vars);
-
-if (empty($language)) {
-	// try to detect it
-	preg_match("/\/js\/languages\/(.*?).js+/", current_page_url(), $matches);
-	
-	if (!empty($matches) && isset($matches[1])) {
-		$language = $matches[1];
-	}	
-}
-
-if (empty($language)) {
-	// fallback to 'en'
-	$language = 'en';
-}
+$language = elgg_extract('language', $vars, 'en');
 
 $all_translations = $GLOBALS['_ELGG']->translations;
 $translations = $all_translations['en'];


### PR DESCRIPTION
This teaches the cache handler how to prepare `languages/*.js` requests to use the "languages.js" view. We no longer need to artificially extend "languages.js" or sniff URLs inside it.

Fixes #8958
