### PR TITLE
chore(i18n): forces transifex client to always download latest translations

### DIFF
--- a/.scripts/release.php
+++ b/.scripts/release.php
@@ -49,7 +49,7 @@ run_commands([
 
 // Update translations
 run_commands([
-	"tx pull -a --minimum-perc=95",
+	"tx pull -af --minimum-perc=95",
 ]);
 
 // Clean translations


### PR DESCRIPTION
For some reason the latest translations were not getting downloaded even when a translation at Transifex was never than the one in git.
