### PR TITLE
feature(ui): Allows modifying system messages/errors

### DIFF
--- a/engine/classes/Elgg/SystemMessages/RegisterSet.php
+++ b/engine/classes/Elgg/SystemMessages/RegisterSet.php
@@ -1,0 +1,28 @@
+<?php
+namespace Elgg\SystemMessages;
+
+/**
+ * Represents the state of system messages and errors.
+ *
+ * This is returned by elgg_get_system_messages() and must be given to elgg_set_system_messages().
+ *
+ * @see   elgg_get_system_messages
+ * @see   elgg_set_system_messages
+ * @since 2.1
+ */
+class RegisterSet {
+
+	/**
+	 * @var string[] Strings added via system_message()
+	 *
+	 * @note do not change this property name. It must match SystemMessagesService::SUCCESS
+	 */
+	public $success = [];
+
+	/**
+	 * @var string[] Strings added via register_error()
+	 *
+	 * @note do not change this property name. It must match SystemMessagesService::ERROR
+	 */
+	public $error = [];
+}

--- a/engine/lib/deprecated-2.1.php
+++ b/engine/lib/deprecated-2.1.php
@@ -12,3 +12,54 @@ function row_to_elggrelationship($row) {
 	elgg_deprecated_notice(__FUNCTION__ . " is deprecated.", 2.1);
 	return _elgg_services()->relationshipsTable->rowToElggRelationship($row);
 }
+
+/**
+ * Queues a message to be displayed.
+ *
+ * Messages will not be displayed immediately, but are stored in
+ * for later display, usually upon next page load.
+ *
+ * The method of displaying these messages differs depending upon plugins and
+ * viewtypes.  The core default viewtype retrieves messages in
+ * {@link views/default/page/shells/default.php} and displays messages as
+ * javascript popups.
+ *
+ * @note Internal: Messages are stored as strings in the Elgg session as ['msg'][$register] array.
+ *
+ * @warning This function is used to both add to and clear the message
+ * stack.  If $messages is null, $register will be returned and cleared.
+ * If $messages is null and $register is empty, all messages will be
+ * returned and removed.
+ *
+ * @param mixed  $message  Optionally, a single message or array of messages to add, (default: null)
+ * @param string $register Types of message: "error", "success" (default: success)
+ * @param bool   $count    Count the number of messages (default: false)
+ *
+ * @return bool|array Either the array of messages, or a response regarding
+ *                          whether the message addition was successful.
+ *
+ * @deprecated
+ */
+function system_messages($message = null, $register = "success", $count = false) {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated', '2.1');
+
+	$svc = _elgg_services()->systemMessages;
+	if ($count) {
+		return $svc->count($register);
+	}
+	if ($message === null) {
+		return $svc->dumpRegister($register);
+	}
+	if (!$register) {
+		return false;
+	}
+	$set = $svc->loadRegisters();
+	if (!isset($set->{$register})) {
+		$set->{$register} = [];
+	}
+	foreach ((array)$message as $str) {
+		$set->{$register}[] = $str;
+	}
+	$svc->saveRegisters($set);
+	return true;
+}

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -2,7 +2,6 @@
 
 use Elgg\Filesystem\Directory;
 
-
 /**
  * Bootstrapping and helper procedural code available for use in Elgg core and plugins.
  *
@@ -414,41 +413,6 @@ function sanitise_filepath($path, $append_slash = true) {
 }
 
 /**
- * Queues a message to be displayed.
- *
- * Messages will not be displayed immediately, but are stored in
- * for later display, usually upon next page load.
- *
- * The method of displaying these messages differs depending upon plugins and
- * viewtypes.  The core default viewtype retrieves messages in
- * {@link views/default/page/shells/default.php} and displays messages as
- * javascript popups.
- *
- * @note Internal: Messages are stored as strings in the Elgg session as ['msg'][$register] array.
- *
- * @warning This function is used to both add to and clear the message
- * stack.  If $messages is null, $register will be returned and cleared.
- * If $messages is null and $register is empty, all messages will be
- * returned and removed.
- *
- * @param mixed  $message  Optionally, a single message or array of messages to add, (default: null)
- * @param string $register Types of message: "error", "success" (default: success)
- * @param bool   $count    Count the number of messages (default: false)
- *
- * @return bool|array Either the array of messages, or a response regarding
- *                          whether the message addition was successful.
- */
-function system_messages($message = null, $register = "success", $count = false) {
-	if ($count) {
-		return _elgg_services()->systemMessages->count($register);
-	}
-	if ($message === null) {
-		return _elgg_services()->systemMessages->dumpRegister($register);
-	}
-	return _elgg_services()->systemMessages->addMessageToRegister($message, $register);
-}
-
-/**
  * Counts the number of messages, either globally or in a particular register
  *
  * @param string $register Optionally, the register
@@ -469,7 +433,8 @@ function count_messages($register = "") {
  * @return bool
  */
 function system_message($message) {
-	return _elgg_services()->systemMessages->addSuccessMessage($message);
+	_elgg_services()->systemMessages->addSuccessMessage($message);
+	return true;
 }
 
 /**
@@ -482,7 +447,29 @@ function system_message($message) {
  * @return bool
  */
 function register_error($error) {
-	return _elgg_services()->systemMessages->addErrorMessage($error);
+	_elgg_services()->systemMessages->addErrorMessage($error);
+	return true;
+}
+
+/**
+ * Get a copy of the current system messages.
+ *
+ * @return \Elgg\SystemMessages\RegisterSet
+ * @since 2.1
+ */
+function elgg_get_system_messages() {
+	return _elgg_services()->systemMessages->loadRegisters();
+}
+
+/**
+ * Set the system messages. This will overwrite the state of all messages and errors!
+ *
+ * @param \Elgg\SystemMessages\RegisterSet $set Set of messages
+ * @return void
+ * @since 2.1
+ */
+function elgg_set_system_messages(\Elgg\SystemMessages\RegisterSet $set) {
+	_elgg_services()->systemMessages->saveRegisters($set);
 }
 
 /**

--- a/engine/tests/phpunit/Elgg/SystemMessagesServiceTest.php
+++ b/engine/tests/phpunit/Elgg/SystemMessagesServiceTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elgg;
 
+use Elgg\SystemMessages\RegisterSet;
+
 class SystemMessagesServiceTest extends \PHPUnit_Framework_TestCase {
 
 	/**
@@ -25,13 +27,9 @@ class SystemMessagesServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->svc->addErrorMessage('e1');
 		$this->svc->addErrorMessage(['e2', 'e3']);
 
-		$this->svc->addMessageToRegister('n1', 'notice');
-		$this->svc->addMessageToRegister(['n2', 'n3'], 'notice');
-
 		$this->assertEquals([
 			'success' => ['s1', 's2', 's3'],
 			'error' => ['e1', 'e2', 'e3'],
-			'notice' => ['n1', 'n2', 'n3'],
 		], $this->svc->dumpRegister());
 
 		$this->assertEmpty($this->svc->dumpRegister());
@@ -69,5 +67,57 @@ class SystemMessagesServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(2, $this->svc->count("success"));
 		$this->assertEquals(3, $this->svc->count("error"));
 		$this->assertEquals(5, $this->svc->count());
+	}
+
+	function testCanModifyRegisterSet() {
+		$this->svc->addSuccessMessage(['s2', 's3']);
+		$this->svc->addErrorMessage(['e1', 'e2', 'e3']);
+
+		$set = $this->svc->loadRegisters();
+		$this->assertEquals(['s2', 's3'], $set->success);
+		$this->assertEquals(['e1', 'e2', 'e3'], $set->error);
+
+		// will be filtered
+		$set->success = ['', 's2'];
+		$set->error = ['e1', false];
+		$set->notice = ['n1', 'n2'];
+		$set->invalid = true;
+		$this->svc->saveRegisters($set);
+
+		$this->assertEquals([
+			'success' => ['s2'],
+		], $this->svc->dumpRegister('success'));
+
+		$this->assertEquals([
+			'error' => ['e1'],
+		], $this->svc->dumpRegister('error'));
+
+		$this->assertEquals([
+			'notice' => ['n1', 'n2'],
+		], $this->svc->dumpRegister());
+	}
+
+	function testSystemMessagesFunction() {
+		$old_svc = _elgg_services()->systemMessages;
+		_elgg_services()->setValue('systemMessages', $this->svc);
+
+		// register new messages
+		$this->assertTrue(system_messages('n1', 'notice'));
+		$this->assertTrue(system_messages(['s1', 's2'], 'success'));
+
+		// missing register
+		$this->assertFalse(system_messages('--', ''));
+
+		// count
+		$this->assertEquals(3, system_messages(null, '', true));
+
+		// dump
+		$this->assertEquals([
+			'notice' => ['n1'],
+			'success' => ['s1', 's2']
+		], system_messages(null, ''));
+
+		// clean up
+		_elgg_services()->setValue('systemMessages', $old_svc);
 	}
 }


### PR DESCRIPTION
This adds functions to get and set all the system messages (and errors), allowing plugins to remove/replace messages or errors already registered.

This also deprecates the Swiss army function system_messages().
