### PR TITLE
fix(file): thumbnails are visible again

### DIFF
--- a/mod/file/thumbnail.php
+++ b/mod/file/thumbnail.php
@@ -6,7 +6,13 @@
  */
 
 // Get engine
-require_once __DIR__ . '/../../vendor/autoload.php';
+$initial_root = dirname(dirname(__DIR__));
+if (file_exists("$initial_root/vendor/autoload.php")) {
+	require_once "$initial_root/vendor/autoload.php";
+} else {
+	$backup_root = dirname(dirname(dirname($initial_root)));
+	require_once "$backup_root/vendor/autoload.php";
+}
 
 \Elgg\Application::start();
 


### PR DESCRIPTION
The path to autoload.php was wrong in the file serving the thumbnails, if
Elgg was installed as a composer dependency. Now autoload.php is incluced
correctly regardless if Elgg is a composer dependency or not.
