### PR TITLE
chore(views): Show view overrides only if different path

### DIFF
--- a/engine/classes/Elgg/ViewsService.php
+++ b/engine/classes/Elgg/ViewsService.php
@@ -625,10 +625,11 @@ class ViewsService {
 	 */
 	private function setViewLocation($view, $viewtype, $path) {
 		$view = $this->canonicalizeViewName($view);
-		
-		if (isset($this->locations[$viewtype][$view])) {
+		$path = strtr($path, '\\', '/');
+
+		if (isset($this->locations[$viewtype][$view]) && $path !== $this->locations[$viewtype][$view]) {
 			$this->overrides[$viewtype][$view][] = $this->locations[$viewtype][$view];
 		}
-		$this->locations[$viewtype][$view] = strtr($path, '\\', '/');
+		$this->locations[$viewtype][$view] = $path;
 	}
 }


### PR DESCRIPTION
In some situations the same path gets set more than once. We don't want to show these as view overrides in the inspector.
