### PR TITLE
feature(i18n): Adds asynchronous client-side translation

### DIFF
--- a/docs/guides/i18n.rst
+++ b/docs/guides/i18n.rst
@@ -3,7 +3,7 @@ Internationalization
 
 Make your UI translatable into many different languages.
 
-If you’d like to contribute translations to Elgg, see :doc:`the contributors' guide </about/contributing>`.
+If you'd like to contribute translations to Elgg, see :doc:`the contributors' guide </about/contributing>`.
 
 Overview
 ========
@@ -12,29 +12,46 @@ Translations are stored in PHP files in the ``/languages`` directory of your plu
 
 .. code-block:: php
 
-   <?php
+    <?php
 
-   // mod/example/languages/en.php
-   return array(
-     ‘example:text’ => ‘Some example text’,
-   );
+    // mod/example/languages/en.php
+    return [
+        'example:text' => 'Some example text',
+    ];
 
-The default language is “en” for English.
+The default language is "en" for English.
 
 To change the wording of any phrase, provide a new mapping in your plugin’s ``{language}.php`` file for the associated key:
 
-.. code:: php
+.. code-block:: php
 
-   <?php
+    <?php
 
-   return array(
-     ‘example:text’ => ‘This is an example’,
-   );
+    return [
+        'example:text' => 'This is an example',
+    ];
 
 .. note::
 
-   Unless you are overriding core’s or another plugin’s language strings, it is good practice for the language keys to start with your plugin name. For example: “yourplugin:success,” “yourplugin:title,” etc. This helps avoid conflicts with other language keys.
+   Unless you are overriding core's or another plugin's language strings, it is good practice for the language keys to start with your plugin name. For example: ``yourplugin:success``, ``yourplugin:title``, etc. This helps avoid conflicts with other language keys.
 
+.. warning:: Do not use spaces in your language keys. The JS API does not support them fully.
+
+Optimized client-side loading
+-----------------------------
+
+Elgg plans to optimize client-side language loading in the future. Plugins may prepare for this by providing a list of language keys that are likely to be needed (via ``elgg/echo``) on the home page or other common URLs.
+
+.. code-block:: php
+
+    <?php // in mod/example/elgg-plugin.php
+
+    return [
+        'home_language_keys' => [
+            'example:home:welcome',
+            'example:home:intro',
+        ],
+    ];
 
 Server-side API
 ===============
@@ -47,32 +64,80 @@ Example:
 
 .. code:: php
 
-   echo elgg_echo(‘example:text’);
+   echo elgg_echo('example:text');
 
 It also supports variable replacement using sprintf syntax:
 
 .. code:: php
 
-   // ‘welcome’ => ‘Welcome to %s, %s!’
-   echo elgg_echo(‘welcome’, array(
-     elgg_get_config(‘sitename’),
-     elgg_get_logged_in_user_entity()->name,
-   ));
+    // 'welcome' => 'Welcome to %s, %s!'
+    echo elgg_echo('welcome', [
+        elgg_get_config('sitename'),
+        elgg_get_logged_in_user_entity()->name,
+    ]);
 
 To force which language should be used for translation, set the third parameter:
 
 .. code:: php
 
-   echo elgg_echo(‘welcome’, array(), ‘es’);
-
+   echo elgg_echo('welcome', [], 'es');
 
 
 Javascript API
 ==============
 
-``elgg.echo(key, args, language)``
+The ``elgg/echo`` RequireJS plugin allows loading translations like AMD modules.
 
-This function is the exact counterpart to ``elgg_echo`` in PHP.
+To translate, register a dependency with the name ``elgg/echo!{key_name}``. The returned module will be a translator function similar to ``elgg_echo``, but with only the ``args`` argument.:
+
+.. code-block:: javascript
+
+    define(function(require) {
+        var intro = require("elgg/echo!example:intro");
+        var hello = require("elgg/echo!example:hello");
+
+		alert(intro());
+		alert(hello(["World"]));
+	});
+
+
+If you want a specific language, use the module name ``elgg/echo!{key_name}@{lang}``:
+
+.. code-block:: javascript
+
+    define(function(require) {
+        var hello = require("elgg/echo!example:hello@es");
+
+        alert(hello(["World"])); // ¡Hola, World!
+	});
+
+
+Like other modules, translators can be loaded at a later time:
+
+.. code-block:: javascript
+
+    // in an Ajax success function...
+
+    require(["elgg/echo!example:great"], function(great) {
+        alert(great());
+    });
+
+Like ``elgg_echo``, translators for non-existent keys will return the key, but you can also directly test whether the key was found:
+
+.. code-block:: javascript
+
+    define(function(require) {
+        var lol = require("elgg/echo!nonexistentkey");
+
+        console.log(lol.found); // false
+	});
+
+.. warning:: Spaces should not be used in language keys and are not supported fully in this API.
+
+Legacy API
+----------
+
+``elgg.echo(key, args, language)`` is identical to ``elgg_echo`` in PHP, but is deprecated in favor of the ``elgg/echo`` module.
 
 Client-side translations are loaded asynchronously. Ensure translations are available by requiring the "elgg" AMD module:
 
@@ -81,7 +146,7 @@ Client-side translations are loaded asynchronously. Ensure translations are avai
 	define(function(require) {
 		var elgg = require("elgg");
 
-		alert(elgg.echo('my_key'));
+		alert(elgg.echo('intro'));
 	});
 
 Translations are also available after the ``init, system`` JavaScript event.

--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -58,10 +58,10 @@ Here we define a basic module that alters the page, by passing a "definition fun
     // in views/default/myplugin/say_hello.js
 
     define(function(require) {
-        var elgg = require("elgg");
+        var hello_world = require("elgg/echo!hello_world");
         var $ = require("jquery");
 
-        $('body').append(elgg.echo('hello_world'));
+        $('body').append(hello_world());
     });
 
 The module's name is determined by the view name, which here is ``myplugin/say_hello.js``.
@@ -82,9 +82,9 @@ the greeting:
     // in views/default/myplugin/hello.js
 
     define(function(require) {
-        var elgg = require("elgg");
+        var hello_world = require("elgg/echo!hello_world");
 
-        return elgg.echo('hello_world');
+        return hello_world();
     });
 
 .. code-block:: javascript
@@ -236,13 +236,25 @@ This will include and execute the linked code.
 Core functions available in JS
 ==============================
 
-``elgg.echo()``
+The ``elgg/echo`` module
 
 Translate interface text
 
 .. code:: js
 
-   elgg.echo('example:text', ['arg1']);
+    require(['elgg/echo!example:text'], function(example_text) {
+        alert(example_text());
+    });
+
+The functions below all require the ``elgg`` AMD module:
+
+.. code:: js
+
+    define(function(require) {
+        var elgg = require('elgg');
+
+        // stuff with elgg
+    });
 
 
 ``elgg.system_message()``
@@ -251,8 +263,7 @@ Display a status message to the user.
 
 .. code:: js
 
-   elgg.system_message(elgg.echo('success'));
-
+    elgg.system_message(echo_success());
 
 ``elgg.register_error()``
 
@@ -260,7 +271,7 @@ Display an error message to the user.
 
 .. code:: js
 
-   elgg.register_error(elgg.echo('error'));
+    elgg.register_error(echo_error());
 
 
 ``elgg.forward()``

--- a/engine/classes/Elgg/Application/CacheHandler.php
+++ b/engine/classes/Elgg/Application/CacheHandler.php
@@ -185,8 +185,8 @@ class CacheHandler {
 	 * @return bool
 	 */
 	protected function isCacheableView($view) {
-		if (preg_match('~^languages/(.*)\.js$~', $view, $m)) {
-			return in_array($m[1],  _elgg_services()->translator->getAllLanguageCodes());
+		if (preg_match('~^languages/(early/|late/)?(.*)\.js$~', $view, $m)) {
+			return in_array($m[2],  _elgg_services()->translator->getAllLanguageCodes());
 		}
 		return _elgg_services()->views->isCacheableView($view);
 	}
@@ -349,9 +349,12 @@ class CacheHandler {
 	protected function renderView($view, $viewtype) {
 		elgg_set_viewtype($viewtype);
 
-		if ($viewtype === 'default' && preg_match("#^languages/(.*?)\\.js$#", $view, $matches)) {
+		if ($viewtype === 'default' && preg_match("#^languages/(early/|late/)?(.*?)\\.js$#", $view, $matches)) {
 			$view = "languages.js";
-			$vars = ['language' => $matches[1]];
+			$vars = ['language' => $matches[2]];
+			if (!empty($matches[1])) {
+				$vars['timing'] = substr($matches[1], 0, -1);
+			}
 		} else {
 			$vars = [];
 		}

--- a/engine/classes/Elgg/I18n/Translator.php
+++ b/engine/classes/Elgg/I18n/Translator.php
@@ -9,7 +9,9 @@ namespace Elgg\I18n;
  * @since 1.10.0
  */
 class Translator {
-	
+
+	const HOME_LANGUAGE_KEYS = 'home_language_keys';
+
 	/**
 	 * Global Elgg configuration
 	 * 
@@ -430,6 +432,47 @@ class Translator {
 		}
 	
 		return array_key_exists($key, $GLOBALS['_ELGG']->translations[$language]);
+	}
+
+	/**
+	 * Get a list of language keys made available early on the client
+	 *
+	 * In 2.x this is only used if $CONFIG->EXPERIMENTAL_echo_async_only is set to true. This flag
+	 * splits the language keys between "early" and "late" modules, with the early module made a
+	 * dependency of the "elgg" module. The late module will only load if the "elgg/echo" plugin
+	 * can't find a translation. For maximum BC, "elgg/echo" shares its translations with the
+	 * elgg.echo() function.
+	 *
+	 * @return string[]
+	 * @access private
+	 */
+	public function getEarlyKeys() {
+		$keys = [
+			'js:lightbox:current',
+			'previous',
+			'next',
+			'close',
+			'hide',
+			'error',
+			'ajax:error',
+			'confirm',
+			'question:areyousure',
+			'access:comments:change',
+			'deleteconfirm',
+		];
+
+		foreach (elgg_get_plugins() as $plugin) {
+			$config = $plugin->getConfigData();
+			if (!empty($config[self::HOME_LANGUAGE_KEYS]) && is_array($config[self::HOME_LANGUAGE_KEYS])) {
+				foreach ($config[self::HOME_LANGUAGE_KEYS] as $key) {
+					if (is_string($key)) {
+						$keys[] = $key;
+					}
+				}
+			}
+		}
+
+		return array_unique($keys);
 	}
 	
 	/**

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -1,4 +1,7 @@
 <?php
+
+use Elgg\Filesystem\Directory\Local;
+
 /**
  * Stores site-side plugin settings as private data.
  *
@@ -753,6 +756,23 @@ class ElggPlugin extends \ElggObject {
 		return true;
 	}
 
+	/**
+	 * Get array data from the plugin's "elgg-plugin.php" file. Returns empty array
+	 * if there's no file.
+	 *
+	 * @return array
+	 * @access private
+	 * @internal
+	 */
+	public function getConfigData() {
+		$file = Local::fromPath($this->getPath())->getFile('elgg-plugin.php');
+		if (!$file->exists()) {
+			return [];
+		}
+
+		$config = $file->includeFile();
+		return is_array($config) ? $config : [];
+	}
 
 	// start helpers
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1555,6 +1555,7 @@ function elgg_views_boot() {
 	elgg_register_css('jquery.imgareaselect', elgg_get_simplecache_url('jquery.imgareaselect.css'));
 
 	elgg_register_ajax_view('languages.js');
+	elgg_require_js('elgg/echo');
 
 	elgg_register_plugin_hook_handler('simplecache:generate', 'js', '_elgg_views_amd');
 	elgg_register_plugin_hook_handler('simplecache:generate', 'css', '_elgg_views_minify');

--- a/js/lib/ajax.js
+++ b/js/lib/ajax.js
@@ -102,7 +102,9 @@ elgg.ajax.handleOptions = function(url, options) {
  * @private
  */
 elgg.ajax.handleAjaxError = function(xhr, status, error) {
-	elgg.register_error(elgg.echo('ajax:error'));
+	require(['elgg/echo!ajax:error'], function (error) {
+		elgg.register_error(error());
+	});
 };
 
 /**

--- a/js/lib/elgglib.js
+++ b/js/lib/elgglib.js
@@ -384,27 +384,17 @@ elgg.register_error = function(errors, delay) {
 };
 
 /**
- * Logs a notice about use of a deprecated function or capability
+ * Informs admin users via a console message about use of a deprecated function or capability
+ *
  * @param {String} msg         The deprecation message to display
  * @param {Number} dep_version The version the function was deprecated for
  * @since 1.9
  */
 elgg.deprecated_notice = function(msg, dep_version) {
 	if (elgg.is_admin_logged_in()) {
-		var parts = elgg.release.split('.');
-		var elgg_major_version = parseInt(parts[0], 10);
-		var elgg_minor_version = parseInt(parts[1], 10);
-		var dep_major_version = Math.floor(dep_version);
-		var dep_minor_version = 10 * (dep_version - dep_major_version);
-
 		msg = "Deprecated in Elgg " + dep_version + ": " + msg;
-
-		if ((dep_major_version < elgg_major_version) || (dep_minor_version < elgg_minor_version)) {
-			elgg.register_error(msg);
-		} else {
-			if (typeof console !== "undefined") {
-				console.warn(msg);
-			}
+		if (typeof console !== "undefined") {
+			console.info(msg);
 		}
 	}
 };

--- a/js/lib/languages.js
+++ b/js/lib/languages.js
@@ -7,6 +7,10 @@ elgg.provide('elgg.config.translations');
 // default language - required by unit tests
 elgg.config.language = 'en';
 
+// this is set just before the elgg module is defined and lets the elgg/echo module
+// know which language module was depended on.
+elgg.config.initial_language_module = null;
+
 /**
  * Analagous to the php version.  Merges translations for a
  * given language into the current translations map.
@@ -35,12 +39,20 @@ elgg.get_language = function() {
  * Translates a string
  *
  * @param {String} key      The string to translate
- * @param {Array}  argv     vsprintf support
+ * @param {Array}  argv     Arguments for vsprintf(). If this argument is given as a string, it's assumed to
+ *                          specify the language and the 3rd argument is ignored.
  * @param {String} language The language to display it in
  *
  * @return {String} The translation
+ * @deprecated Use the elgg/echo module
  */
 elgg.echo = function(key, argv, language) {
+	// debug: uncomment the next two lines to capture which keys were requested
+	//elgg._echoKeys = elgg._echoKeys || {sync:{},async:{}};
+	//elgg._echoKeys.sync[key] = true;
+
+	elgg.deprecated_notice("elgg.echo() is deprecated. Use the elgg/echo module", "2.1");
+
 	//elgg.echo('str', 'en')
 	if (elgg.isString(argv)) {
 		language = argv;

--- a/js/lib/security.js
+++ b/js/lib/security.js
@@ -40,7 +40,9 @@ elgg.security.refreshToken = function() {
 			elgg.security.setToken(data);
 			if (elgg.is_logged_in() && data.logged_in === false) {
 				elgg.session.user = null;
-				elgg.register_error(elgg.echo('session_expired'));
+				require(['elgg/echo!session_expired'], function (session_expired) {
+					elgg.register_error(session_expired());
+				});
 			}
 		}
 	});

--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -1,472 +1,484 @@
 elgg.provide('elgg.ui');
 
-elgg.ui.init = function () {
-	// @todo we need better documentation for this hack
-	// iOS Hover Event Class Fix
-	$('.elgg-page').attr("onclick", "return true");
+!function(){
+	// we'll load translations async before init, but define the functions sync for BC.
+	var echoes = {};
 
-	// add user hover menus
-	elgg.ui.initHoverMenu();
+	elgg.ui.init = function () {
+		// @todo we need better documentation for this hack
+		// iOS Hover Event Class Fix
+		$('.elgg-page').attr("onclick", "return true");
 
-	//if the user clicks a system message, make it disappear
-	$(document).on('click', '.elgg-system-messages li', function() {
-		$(this).stop().fadeOut('fast');
-	});
+		// add user hover menus
+		elgg.ui.initHoverMenu();
 
-	$('.elgg-system-messages li').animate({opacity: 0.9}, 6000);
-	$('.elgg-system-messages li.elgg-state-success').fadeOut('slow');
-
-	$(document).on('click', '[rel=toggle]', elgg.ui.toggles);
-
-	$(document).on('click', '[rel=popup]', elgg.ui.popupOpen);
-
-	$(document).on('click', '.elgg-menu-page .elgg-menu-parent', elgg.ui.toggleMenu);
-
-    $(document).on('click', '*[data-confirm], .elgg-requires-confirmation', elgg.ui.requiresConfirmation);
-    if ($('.elgg-requires-confirmation').length > 0) {
-        elgg.deprecated_notice('Use of .elgg-requires-confirmation is deprecated by data-confirm', '1.10');
-    }
-
-	$('.elgg-autofocus').focus();
-	if ($('.elgg-autofocus').length > 0) {
-		elgg.deprecated_notice('Use of .elgg-autofocus is deprecated by html5 autofocus', 1.9);
-	}
-
-	elgg.ui.initAccessInputs();
-
-	// Allow element to be highlighted using CSS if its id is found from the URL
-	var elementId = elgg.getSelectorFromUrlFragment(document.URL);
-	$(elementId).addClass('elgg-state-highlight');
-};
-
-/**
- * Toggles an element based on clicking a separate element
- *
- * Use rel="toggle" on the toggler element
- * Set the href to target the item you want to toggle (<a rel="toggle" href="#id-of-target">)
- * or use data-toggle-selector="your_jquery_selector" to have an advanced selection method
- * 
- * By default elements perform a slideToggle. 
- * If you want a normal toggle (hide/show) you can add data-toggle-slide="0" on the elements to prevent a slide.
- *
- * @param {Object} event
- * @return void
- */
-elgg.ui.toggles = function(event) {
-	event.preventDefault();
-	var $this = $(this),
-		target = $this.data().toggleSelector;
-	
-	if (!target) {
-		// @todo we can switch to elgg.getSelectorFromUrlFragment() in 1.x if
-		// we also extend it to support href=".some-class"
-		target = $this.attr('href');
-	}
-
-	$this.toggleClass('elgg-state-active');
-
-	$(target).each(function(index, elem) {
-		var $elem = $(elem);
-		if ($elem.data().toggleSlide != false) {
-			$elem.slideToggle('medium');
-		} else {
-			$elem.toggle();
-		}
-	});
-};
-
-/**
- * Pops up an element based on clicking a separate element
- *
- * Set the rel="popup" on the popper and set the href to target the
- * item you want to toggle (<a rel="popup" href="#id-of-target">)
- *
- * This function emits the getOptions, ui.popup hook that plugins can register for to provide custom
- * positioning for elements.  The handler is passed the following params:
- *	targetSelector: The selector used to find the popup
- *	target:         The popup jQuery element as found by the selector
- *	source:         The jquery element whose click event initiated a popup.
- *
- * The return value of the function is used as the options object to .position().
- * Handles can also return false to abort the default behvior and override it with their own.
- *
- * @param {Object} event
- * @return void
- */
-elgg.ui.popupOpen = function(event) {
-	event.preventDefault();
-	event.stopPropagation();
-
-	var target = elgg.getSelectorFromUrlFragment($(this).toggleClass('elgg-state-active').attr('href'));
-	var $target = $(target);
-
-	// emit a hook to allow plugins to position and control popups
-	var params = {
-		targetSelector: target,
-		target: $target,
-		source: $(this)
-	};
-
-	var options = {
-		my: 'center top',
-		at: 'center bottom',
-		of: $(this),
-		collision: 'fit fit'
-	};
-
-	options = elgg.trigger_hook('getOptions', 'ui.popup', params, options);
-
-	// allow plugins to cancel event
-	if (!options) {
-		return;
-	}
-
-	// hide if already open
-	if ($target.is(':visible')) {
-		$target.fadeOut();
-		$('body').die('click', elgg.ui.popupClose);
-		return;
-	}
-
-	$target.appendTo('body')
-		.fadeIn()
-		.position(options);
-
-	$(document)
-		.off('click', 'body', elgg.ui.popupClose)
-		.on('click', 'body', elgg.ui.popupClose);
-};
-
-/**
- * Catches clicks that aren't in a popup and closes all popups.
- */
-elgg.ui.popupClose = function(event) {
-	$eventTarget = $(event.target);
-	var inTarget = false;
-	var $popups = $('[rel=popup]');
-
-	// if the click event target isn't in a popup target, fade all of them out.
-	$popups.each(function(i, e) {
-		var target = elgg.getSelectorFromUrlFragment($(e).attr('href')) + ':visible';
-		var $target = $(target);
-
-		if (!$target.is(':visible')) {
-			return;
-		}
-
-		// didn't click inside the target
-		if ($eventTarget.closest(target).length > 0) {
-			inTarget = true;
-			return false;
-		}
-	});
-
-	if (!inTarget) {
-		$popups.each(function(i, e) {
-			var $e = $(e);
-			var $target = $(elgg.getSelectorFromUrlFragment($e.attr('href')) + ':visible');
-			if ($target.length > 0) {
-				$target.fadeOut();
-				$e.removeClass('elgg-state-active');
-			}
+		//if the user clicks a system message, make it disappear
+		$(document).on('click', '.elgg-system-messages li', function() {
+			$(this).stop().fadeOut('fast');
 		});
 
-		$('body').die('click', elgg.ui.popClose);
-	}
-};
+		$('.elgg-system-messages li').animate({opacity: 0.9}, 6000);
+		$('.elgg-system-messages li.elgg-state-success').fadeOut('slow');
 
-/**
- * Toggles a child menu when the parent is clicked
- *
- * @param {Object} event
- * @return void
- */
-elgg.ui.toggleMenu = function(event) {
-	$(this).siblings().slideToggle('medium');
-	$(this).toggleClass('elgg-menu-closed elgg-menu-opened');
-	event.preventDefault();
-};
+		$(document).on('click', '[rel=toggle]', elgg.ui.toggles);
 
-/**
- * Initialize the hover menu
- *
- * @param {Object} parent
- * @return void
- */
-elgg.ui.initHoverMenu = function(parent) {
+		$(document).on('click', '[rel=popup]', elgg.ui.popupOpen);
+
+		$(document).on('click', '.elgg-menu-page .elgg-menu-parent', elgg.ui.toggleMenu);
+
+		$(document).on('click', '*[data-confirm], .elgg-requires-confirmation', elgg.ui.requiresConfirmation);
+		if ($('.elgg-requires-confirmation').length > 0) {
+			elgg.deprecated_notice('Use of .elgg-requires-confirmation is deprecated by data-confirm', '1.10');
+		}
+
+		$('.elgg-autofocus').focus();
+		if ($('.elgg-autofocus').length > 0) {
+			elgg.deprecated_notice('Use of .elgg-autofocus is deprecated by html5 autofocus', 1.9);
+		}
+
+		elgg.ui.initAccessInputs();
+
+		// Allow element to be highlighted using CSS if its id is found from the URL
+		var elementId = elgg.getSelectorFromUrlFragment(document.URL);
+		$(elementId).addClass('elgg-state-highlight');
+	};
 
 	/**
-	 * For a menu clicked, load the menu into all matching placeholders
+	 * Toggles an element based on clicking a separate element
 	 *
-	 * @param {String} mac Machine authorization code for the menu clicked
+	 * Use rel="toggle" on the toggler element
+	 * Set the href to target the item you want to toggle (<a rel="toggle" href="#id-of-target">)
+	 * or use data-toggle-selector="your_jquery_selector" to have an advanced selection method
+	 *
+	 * By default elements perform a slideToggle.
+	 * If you want a normal toggle (hide/show) you can add data-toggle-slide="0" on the elements to prevent a slide.
+	 *
+	 * @param {Object} event
+	 * @return void
 	 */
-	function loadMenu(mac) {
-		var $all_placeholders = $(".elgg-menu-hover[rel='" + mac + "']");
+	elgg.ui.toggles = function(event) {
+		event.preventDefault();
+		var $this = $(this),
+			target = $this.data().toggleSelector;
 
-		// find the <ul> that contains data for this menu
-		var $ul = $all_placeholders.filter('[data-elgg-menu-data]');
+		if (!target) {
+			// @todo we can switch to elgg.getSelectorFromUrlFragment() in 1.x if
+			// we also extend it to support href=".some-class"
+			target = $this.attr('href');
+		}
 
-		if (!$ul.length) {
+		$this.toggleClass('elgg-state-active');
+
+		$(target).each(function(index, elem) {
+			var $elem = $(elem);
+			if ($elem.data().toggleSlide != false) {
+				$elem.slideToggle('medium');
+			} else {
+				$elem.toggle();
+			}
+		});
+	};
+
+	/**
+	 * Pops up an element based on clicking a separate element
+	 *
+	 * Set the rel="popup" on the popper and set the href to target the
+	 * item you want to toggle (<a rel="popup" href="#id-of-target">)
+	 *
+	 * This function emits the getOptions, ui.popup hook that plugins can register for to provide custom
+	 * positioning for elements.  The handler is passed the following params:
+	 *	targetSelector: The selector used to find the popup
+	 *	target:         The popup jQuery element as found by the selector
+	 *	source:         The jquery element whose click event initiated a popup.
+	 *
+	 * The return value of the function is used as the options object to .position().
+	 * Handles can also return false to abort the default behvior and override it with their own.
+	 *
+	 * @param {Object} event
+	 * @return void
+	 */
+	elgg.ui.popupOpen = function(event) {
+		event.preventDefault();
+		event.stopPropagation();
+
+		var target = elgg.getSelectorFromUrlFragment($(this).toggleClass('elgg-state-active').attr('href'));
+		var $target = $(target);
+
+		// emit a hook to allow plugins to position and control popups
+		var params = {
+			targetSelector: target,
+			target: $target,
+			source: $(this)
+		};
+
+		var options = {
+			my: 'center top',
+			at: 'center bottom',
+			of: $(this),
+			collision: 'fit fit'
+		};
+
+		options = elgg.trigger_hook('getOptions', 'ui.popup', params, options);
+
+		// allow plugins to cancel event
+		if (!options) {
 			return;
 		}
 
-		elgg.get('ajax/view/navigation/menu/user_hover/contents', {
-			data: $ul.data('elggMenuData'),
-			success: function(data) {
-				if (data) {
-					// replace all existing placeholders with new menu
-					$all_placeholders.removeClass('elgg-ajax-loader')
-						.html($(data).children());
-				}
+		// hide if already open
+		if ($target.is(':visible')) {
+			$target.fadeOut();
+			$('body').die('click', elgg.ui.popupClose);
+			return;
+		}
+
+		$target.appendTo('body')
+			.fadeIn()
+			.position(options);
+
+		$(document)
+			.off('click', 'body', elgg.ui.popupClose)
+			.on('click', 'body', elgg.ui.popupClose);
+	};
+
+	/**
+	 * Catches clicks that aren't in a popup and closes all popups.
+	 */
+	elgg.ui.popupClose = function(event) {
+		$eventTarget = $(event.target);
+		var inTarget = false;
+		var $popups = $('[rel=popup]');
+
+		// if the click event target isn't in a popup target, fade all of them out.
+		$popups.each(function(i, e) {
+			var target = elgg.getSelectorFromUrlFragment($(e).attr('href')) + ':visible';
+			var $target = $(target);
+
+			if (!$target.is(':visible')) {
+				return;
 			}
-		});
-	}
 
-	if (!parent) {
-		parent = document;
-	}
-
-	// avatar image menu link
-	$(parent).on('mouseover', ".elgg-avatar", function() {
-		$(this).children(".elgg-icon-hover-menu").show();
-	})
-	.on('mouseout', '.elgg-avatar', function() {
-		$(this).children(".elgg-icon-hover-menu").hide();
-	});
-
-
-	// avatar contextual menu
-	$(document).on('click', ".elgg-avatar > .elgg-icon-hover-menu", function(e) {
-		var $placeholder = $(this).parent().find(".elgg-menu-hover.elgg-ajax-loader");
-
-		if ($placeholder.length) {
-			loadMenu($placeholder.attr("rel"));
-		}
-
-		// check if we've attached the menu to this element already
-		var $hovermenu = $(this).data('hovermenu') || null;
-
-		if (!$hovermenu) {
-			$hovermenu = $(this).parent().find(".elgg-menu-hover");
-			$(this).data('hovermenu', $hovermenu);
-		}
-
-		// close hovermenu if arrow is clicked & menu already open
-		if ($hovermenu.css('display') == "block") {
-			$hovermenu.fadeOut();
-		} else {
-			$avatar = $(this).closest(".elgg-avatar");
-
-			// @todo Use jQuery-ui position library instead -- much simpler
-			var offset = $avatar.offset();
-			var top = $avatar.height() + offset.top + 'px';
-			var left = $avatar.width() - 15 + offset.left + 'px';
-
-			$hovermenu.appendTo('body')
-					.css('position', 'absolute')
-					.css("top", top)
-					.css("left", left)
-					.fadeIn('normal');
-		}
-
-		// hide any other open hover menus
-		$(".elgg-menu-hover:visible").not($hovermenu).fadeOut();
-	});
-
-	// hide avatar menu when user clicks elsewhere
-	$(document).click(function(event) {
-		if ($(event.target).parents(".elgg-avatar").length === 0) {
-			$(".elgg-menu-hover").fadeOut();
-		}
-	});
-};
-
-/**
- * Calls a confirm() and prevents default if denied.
- *
- * @param {Object} e
- * @return void
- */
-elgg.ui.requiresConfirmation = function(e) {
-	var confirmText = $(this).data('confirm') || elgg.echo('question:areyousure');
-	if (!confirm(confirmText)) {
-		e.preventDefault();
-	}
-};
-
-/**
- * Repositions the login popup
- *
- * @param {String} hook    'getOptions'
- * @param {String} type    'ui.popup'
- * @param {Object} params  An array of info about the target and source.
- * @param {Object} options Options to pass to
- *
- * @return {Object}
- */
-elgg.ui.loginHandler = function(hook, type, params, options) {
-	if (params.target.attr('id') == 'login-dropdown-box') {
-		options.my = 'right top';
-		options.at = 'right bottom';
-		return options;
-	}
-	return null;
-};
-
-/**
- * Initialize the date picker
- *
- * Uses the class .elgg-input-date as the selector.
- *
- * If the class .elgg-input-timestamp is set on the input element, the onSelect
- * method converts the date text to a unix timestamp in seconds. That value is
- * stored in a hidden element indicated by the id on the input field.
- *
- * @return void
- * @requires jqueryui.datepicker
- */
-elgg.ui.initDatePicker = function() {
-	function loadDatePicker() {
-		$('.elgg-input-date').datepicker({
-			// ISO-8601
-			dateFormat: 'yy-mm-dd',
-			onSelect: function(dateText) {
-				if ($(this).is('.elgg-input-timestamp')) {
-					// convert to unix timestamp
-					var dateParts = dateText.split("-");
-					var timestamp = Date.UTC(dateParts[0], dateParts[1] - 1, dateParts[2]);
-					timestamp = timestamp / 1000;
-
-					var id = $(this).attr('id');
-					$('input[name="' + id + '"]').val(timestamp);
-				}
-			},
-			nextText: '&#xBB;',
-			prevText: '&#xAB;',
-			changeMonth: true,
-			changeYear: true
-		});
-	}
-
-	if (!$('.elgg-input-date').length) {
-		return;
-	}
-
-	// require language module if necessary
-	var deps = [];
-	if (elgg.get_language() != 'en') {
-		deps.push('jquery-ui/i18n/datepicker-'+ elgg.get_language() + '.min');
-	}
-	require(deps, loadDatePicker);
-};
-
-/**
- * This function registers two menu items that are actions that are the opposite
- * of each other and ajaxifies them. E.g. like/unlike, friend/unfriend, ban/unban, etc.
- *
- * Note the menu item names must be given in their normalized form. So if the
- * name is remove_friend, you should call this function with "remove-friend" instead.
- */
-elgg.ui.registerTogglableMenuItems = function(menuItemNameA, menuItemNameB) {
-	// Handles clicking the first button.
-	$(document).on('click', '.elgg-menu-item-' + menuItemNameA + ' a', function() {
-		var $menu = $(this).closest('.elgg-menu');
-
-		// Be optimistic about success
-		elgg.ui.toggleMenuItems($menu, menuItemNameB, menuItemNameA);
-
-		// Send the ajax request
-		elgg.action($(this).attr('href'), {
-			success: function(json) {
-				if (json.system_messages.error.length) {
-					// Something went wrong, so undo the optimistic changes
-					elgg.ui.toggleMenuItems($menu, menuItemNameA, menuItemNameB);
-				}
-			},
-			error: function() {
-				// Something went wrong, so undo the optimistic changes
-				elgg.ui.toggleMenuItems($menu, menuItemNameA, menuItemNameB);
+			// didn't click inside the target
+			if ($eventTarget.closest(target).length > 0) {
+				inTarget = true;
+				return false;
 			}
 		});
 
-		// Don't want to actually click the link
-		return false;
-	});
-
-	// Handles clicking the second button
-	$(document).on('click', '.elgg-menu-item-' + menuItemNameB + ' a', function() {
-		var $menu = $(this).closest('.elgg-menu');
-
-		// Be optimistic about success
-		elgg.ui.toggleMenuItems($menu, menuItemNameA, menuItemNameB);
-
-		// Send the ajax request
-		elgg.action($(this).attr('href'), {
-			success: function(json) {
-				if (json.system_messages.error.length) {
-					// Something went wrong, so undo the optimistic changes
-					elgg.ui.toggleMenuItems($menu, menuItemNameB, menuItemNameA);
+		if (!inTarget) {
+			$popups.each(function(i, e) {
+				var $e = $(e);
+				var $target = $(elgg.getSelectorFromUrlFragment($e.attr('href')) + ':visible');
+				if ($target.length > 0) {
+					$target.fadeOut();
+					$e.removeClass('elgg-state-active');
 				}
-			},
-			error: function() {
-				// Something went wrong, so undo the optimistic changes
-				elgg.ui.toggleMenuItems($menu, menuItemNameB, menuItemNameA);
-			}
-		});
+			});
 
-		// Don't want to actually click the link
-		return false;
-	});
-};
-
-elgg.ui.toggleMenuItems = function($menu, nameOfItemToShow, nameOfItemToHide) {
-    $menu.find('.elgg-menu-item-' + nameOfItemToShow).removeClass('hidden').find('a').focus();
-    $menu.find('.elgg-menu-item-' + nameOfItemToHide).addClass('hidden');
-};
-
-/**
- * Initialize input/access for dynamic display of members only warning
- *
- * If a select.elgg-input-access is accompanied by a note (.elgg-input-access-membersonly),
- * then hide the note when the select value is PRIVATE or group members.
- *
- * @return void
- * @since 1.9.0
- */
-elgg.ui.initAccessInputs = function () {
-	$('.elgg-input-access').each(function () {
-		function updateMembersonlyNote() {
-			var val = $select.val();
-			if (val != acl && val !== 0) {
-				// .show() failed in Chrome. Maybe a float/jQuery bug
-				$note.css('visibility', 'visible');
-			} else {
-				$note.css('visibility', 'hidden');
-			}
+			$('body').die('click', elgg.ui.popClose);
 		}
-		var $select = $(this),
-			acl = $select.data('group-acl'),
-			$note = $('.elgg-input-access-membersonly', this.parentNode),
-			commentCount = $select.data('comment-count'),
-			originalValue = $select.data('original-value');
-		if ($note) {
-			updateMembersonlyNote();
-			$select.change(updateMembersonlyNote);
-		}
-                
-		if (commentCount) {
-			$select.change(function(e) {
-				if ($(this).val() != originalValue) {
-					if (!confirm(elgg.echo('access:comments:change', [commentCount]))) {
-						$(this).val(originalValue);
+	};
+
+	/**
+	 * Toggles a child menu when the parent is clicked
+	 *
+	 * @param {Object} event
+	 * @return void
+	 */
+	elgg.ui.toggleMenu = function(event) {
+		$(this).siblings().slideToggle('medium');
+		$(this).toggleClass('elgg-menu-closed elgg-menu-opened');
+		event.preventDefault();
+	};
+
+	/**
+	 * Initialize the hover menu
+	 *
+	 * @param {Object} parent
+	 * @return void
+	 */
+	elgg.ui.initHoverMenu = function(parent) {
+
+		/**
+		 * For a menu clicked, load the menu into all matching placeholders
+		 *
+		 * @param {String} mac Machine authorization code for the menu clicked
+		 */
+		function loadMenu(mac) {
+			var $all_placeholders = $(".elgg-menu-hover[rel='" + mac + "']");
+
+			// find the <ul> that contains data for this menu
+			var $ul = $all_placeholders.filter('[data-elgg-menu-data]');
+
+			if (!$ul.length) {
+				return;
+			}
+
+			elgg.get('ajax/view/navigation/menu/user_hover/contents', {
+				data: $ul.data('elggMenuData'),
+				success: function(data) {
+					if (data) {
+						// replace all existing placeholders with new menu
+						$all_placeholders.removeClass('elgg-ajax-loader')
+							.html($(data).children());
 					}
 				}
 			});
 		}
-	});
-};
 
-elgg.register_hook_handler('init', 'system', elgg.ui.init);
-elgg.register_hook_handler('init', 'system', elgg.ui.initDatePicker);
-elgg.register_hook_handler('getOptions', 'ui.popup', elgg.ui.loginHandler);
-elgg.ui.registerTogglableMenuItems('add-friend', 'remove-friend');
+		if (!parent) {
+			parent = document;
+		}
+
+		// avatar image menu link
+		$(parent).on('mouseover', ".elgg-avatar", function() {
+			$(this).children(".elgg-icon-hover-menu").show();
+		})
+			.on('mouseout', '.elgg-avatar', function() {
+				$(this).children(".elgg-icon-hover-menu").hide();
+			});
+
+
+		// avatar contextual menu
+		$(document).on('click', ".elgg-avatar > .elgg-icon-hover-menu", function(e) {
+			var $placeholder = $(this).parent().find(".elgg-menu-hover.elgg-ajax-loader");
+
+			if ($placeholder.length) {
+				loadMenu($placeholder.attr("rel"));
+			}
+
+			// check if we've attached the menu to this element already
+			var $hovermenu = $(this).data('hovermenu') || null;
+
+			if (!$hovermenu) {
+				$hovermenu = $(this).parent().find(".elgg-menu-hover");
+				$(this).data('hovermenu', $hovermenu);
+			}
+
+			// close hovermenu if arrow is clicked & menu already open
+			if ($hovermenu.css('display') == "block") {
+				$hovermenu.fadeOut();
+			} else {
+				$avatar = $(this).closest(".elgg-avatar");
+
+				// @todo Use jQuery-ui position library instead -- much simpler
+				var offset = $avatar.offset();
+				var top = $avatar.height() + offset.top + 'px';
+				var left = $avatar.width() - 15 + offset.left + 'px';
+
+				$hovermenu.appendTo('body')
+					.css('position', 'absolute')
+					.css("top", top)
+					.css("left", left)
+					.fadeIn('normal');
+			}
+
+			// hide any other open hover menus
+			$(".elgg-menu-hover:visible").not($hovermenu).fadeOut();
+		});
+
+		// hide avatar menu when user clicks elsewhere
+		$(document).click(function(event) {
+			if ($(event.target).parents(".elgg-avatar").length === 0) {
+				$(".elgg-menu-hover").fadeOut();
+			}
+		});
+	};
+
+	/**
+	 * Calls a confirm() and prevents default if denied.
+	 *
+	 * @param {Object} e
+	 * @return void
+	 */
+	elgg.ui.requiresConfirmation = function(e) {
+		var confirmText = $(this).data('confirm') || echoes.areyousure();
+		if (!confirm(confirmText)) {
+			e.preventDefault();
+		}
+	};
+
+	/**
+	 * Repositions the login popup
+	 *
+	 * @param {String} hook    'getOptions'
+	 * @param {String} type    'ui.popup'
+	 * @param {Object} params  An array of info about the target and source.
+	 * @param {Object} options Options to pass to
+	 *
+	 * @return {Object}
+	 */
+	elgg.ui.loginHandler = function(hook, type, params, options) {
+		if (params.target.attr('id') == 'login-dropdown-box') {
+			options.my = 'right top';
+			options.at = 'right bottom';
+			return options;
+		}
+		return null;
+	};
+
+	/**
+	 * Initialize the date picker
+	 *
+	 * Uses the class .elgg-input-date as the selector.
+	 *
+	 * If the class .elgg-input-timestamp is set on the input element, the onSelect
+	 * method converts the date text to a unix timestamp in seconds. That value is
+	 * stored in a hidden element indicated by the id on the input field.
+	 *
+	 * @return void
+	 * @requires jqueryui.datepicker
+	 */
+	elgg.ui.initDatePicker = function() {
+		function loadDatePicker() {
+			$('.elgg-input-date').datepicker({
+				// ISO-8601
+				dateFormat: 'yy-mm-dd',
+				onSelect: function(dateText) {
+					if ($(this).is('.elgg-input-timestamp')) {
+						// convert to unix timestamp
+						var dateParts = dateText.split("-");
+						var timestamp = Date.UTC(dateParts[0], dateParts[1] - 1, dateParts[2]);
+						timestamp = timestamp / 1000;
+
+						var id = $(this).attr('id');
+						$('input[name="' + id + '"]').val(timestamp);
+					}
+				},
+				nextText: '&#xBB;',
+				prevText: '&#xAB;',
+				changeMonth: true,
+				changeYear: true
+			});
+		}
+
+		if (!$('.elgg-input-date').length) {
+			return;
+		}
+
+		// require language module if necessary
+		var deps = [];
+		if (elgg.get_language() != 'en') {
+			deps.push('jquery-ui/i18n/datepicker-'+ elgg.get_language() + '.min');
+		}
+		require(deps, loadDatePicker);
+	};
+
+	/**
+	 * This function registers two menu items that are actions that are the opposite
+	 * of each other and ajaxifies them. E.g. like/unlike, friend/unfriend, ban/unban, etc.
+	 *
+	 * Note the menu item names must be given in their normalized form. So if the
+	 * name is remove_friend, you should call this function with "remove-friend" instead.
+	 */
+	elgg.ui.registerTogglableMenuItems = function(menuItemNameA, menuItemNameB) {
+		// Handles clicking the first button.
+		$(document).on('click', '.elgg-menu-item-' + menuItemNameA + ' a', function() {
+			var $menu = $(this).closest('.elgg-menu');
+
+			// Be optimistic about success
+			elgg.ui.toggleMenuItems($menu, menuItemNameB, menuItemNameA);
+
+			// Send the ajax request
+			elgg.action($(this).attr('href'), {
+				success: function(json) {
+					if (json.system_messages.error.length) {
+						// Something went wrong, so undo the optimistic changes
+						elgg.ui.toggleMenuItems($menu, menuItemNameA, menuItemNameB);
+					}
+				},
+				error: function() {
+					// Something went wrong, so undo the optimistic changes
+					elgg.ui.toggleMenuItems($menu, menuItemNameA, menuItemNameB);
+				}
+			});
+
+			// Don't want to actually click the link
+			return false;
+		});
+
+		// Handles clicking the second button
+		$(document).on('click', '.elgg-menu-item-' + menuItemNameB + ' a', function() {
+			var $menu = $(this).closest('.elgg-menu');
+
+			// Be optimistic about success
+			elgg.ui.toggleMenuItems($menu, menuItemNameA, menuItemNameB);
+
+			// Send the ajax request
+			elgg.action($(this).attr('href'), {
+				success: function(json) {
+					if (json.system_messages.error.length) {
+						// Something went wrong, so undo the optimistic changes
+						elgg.ui.toggleMenuItems($menu, menuItemNameB, menuItemNameA);
+					}
+				},
+				error: function() {
+					// Something went wrong, so undo the optimistic changes
+					elgg.ui.toggleMenuItems($menu, menuItemNameB, menuItemNameA);
+				}
+			});
+
+			// Don't want to actually click the link
+			return false;
+		});
+	};
+
+	elgg.ui.toggleMenuItems = function($menu, nameOfItemToShow, nameOfItemToHide) {
+		$menu.find('.elgg-menu-item-' + nameOfItemToShow).removeClass('hidden').find('a').focus();
+		$menu.find('.elgg-menu-item-' + nameOfItemToHide).addClass('hidden');
+	};
+
+	/**
+	 * Initialize input/access for dynamic display of members only warning
+	 *
+	 * If a select.elgg-input-access is accompanied by a note (.elgg-input-access-membersonly),
+	 * then hide the note when the select value is PRIVATE or group members.
+	 *
+	 * @return void
+	 * @since 1.9.0
+	 */
+	elgg.ui.initAccessInputs = function () {
+		$('.elgg-input-access').each(function () {
+			function updateMembersonlyNote() {
+				var val = $select.val();
+				if (val != acl && val !== 0) {
+					// .show() failed in Chrome. Maybe a float/jQuery bug
+					$note.css('visibility', 'visible');
+				} else {
+					$note.css('visibility', 'hidden');
+				}
+			}
+			var $select = $(this),
+				acl = $select.data('group-acl'),
+				$note = $('.elgg-input-access-membersonly', this.parentNode),
+				commentCount = $select.data('comment-count'),
+				originalValue = $select.data('original-value');
+			if ($note) {
+				updateMembersonlyNote();
+				$select.change(updateMembersonlyNote);
+			}
+
+			if (commentCount) {
+				$select.change(function(e) {
+					if ($(this).val() != originalValue) {
+						if (!confirm(echoes.access_comments_change([commentCount]))) {
+							$(this).val(originalValue);
+						}
+					}
+				});
+			}
+		});
+	};
+
+	require(['elgg/echo!question:areyousure', 'elgg/echo!access:comments:change'], function (areyousure, access_comments_change) {
+		echoes = {
+			areyousure: areyousure,
+			access_comments_change: access_comments_change
+		};
+
+		elgg.register_hook_handler('init', 'system', elgg.ui.init);
+		elgg.register_hook_handler('init', 'system', elgg.ui.initDatePicker);
+		elgg.register_hook_handler('getOptions', 'ui.popup', elgg.ui.loginHandler);
+		elgg.ui.registerTogglableMenuItems('add-friend', 'remove-friend');
+	});
+}();

--- a/js/lib/ui.widgets.js
+++ b/js/lib/ui.widgets.js
@@ -107,31 +107,32 @@ elgg.ui.widgets.move = function(event, ui) {
  * @return void
  */
 elgg.ui.widgets.remove = function(event) {
-	if (confirm(elgg.echo('deleteconfirm')) === false) {
-		event.preventDefault();
-		return;
-	}
-	
-	var $widget = $(this).closest('.elgg-module-widget');
-
-	// if widget type is single instance type, enable the add buton
-	var type = $(this).data('elgg-widget-type');
-	$container = $(this).parents('.elgg-layout-widgets').first();
-	$button = $('[data-elgg-widget-type="' + type + '"]', $container);
-	var multiple = $button.attr('class').indexOf('elgg-widget-multiple') != -1;
-	if (multiple === false) {
-		$button.addClass('elgg-state-available');
-		$button.removeClass('elgg-state-unavailable');
-		$button.unbind('click', elgg.ui.widgets.add); // make sure we don't bind twice
-		$button.click(elgg.ui.widgets.add);
-	}
-
-	$widget.remove();
-
-	// delete the widget through ajax
-	elgg.action($(this).attr('href'));
-
 	event.preventDefault();
+	var that = this;
+
+	require(['elgg/echo!deleteconfirm'], function (deleteconfirm) {
+		if (confirm(deleteconfirm()) === false) {
+			return;
+		}
+
+		var $widget = $(that).closest('.elgg-module-widget');
+
+		// if widget type is single instance type, enable the add buton
+		var type = $(that).data('elgg-widget-type');
+		$container = $(that).parents('.elgg-layout-widgets').first();
+		$button = $('[data-elgg-widget-type="' + type + '"]', $container);
+		if (!$button.hasClass('elgg-widget-multiple')) {
+			$button.addClass('elgg-state-available');
+			$button.removeClass('elgg-state-unavailable');
+			$button.unbind('click', elgg.ui.widgets.add); // make sure we don't bind twice
+			$button.click(elgg.ui.widgets.add);
+		}
+
+		$widget.remove();
+
+		// delete the widget through ajax
+		elgg.action($(that).attr('href'));
+	});
 };
 
 /**

--- a/js/lib/upgrades.js
+++ b/js/lib/upgrades.js
@@ -32,16 +32,23 @@ elgg.upgrades.run = function(e) {
 	$('#upgrade-run').addClass('hidden');
 	$('#upgrade-spinner').removeClass('hidden');
 
-	// Start upgrade from offset 0
-	elgg.upgrades.upgradeBatch(0);
+	require([
+		'elgg/echo!upgrade:finished',
+		'elgg/echo!upgrade:finished_with_errors'
+	], function (finished, finished_errors) {
+		// Start upgrade from offset 0
+		elgg.upgrades.upgradeBatch(0, finished, finished_errors);
+	});
 };
 
 /**
  * Fires the ajax action to upgrade a batch of items.
  *
- * @param {Number} offset  The next upgrade offset
+ * @param {Number}   offset          The next upgrade offset
+ * @param {Function} finished        Translator
+ * @param {Function} finished_errors Translator
  */
-elgg.upgrades.upgradeBatch = function(offset) {
+elgg.upgrades.upgradeBatch = function(offset, finished, finished_errors) {
 	var options = {
 		data: {
 			offset: offset
@@ -101,11 +108,11 @@ elgg.upgrades.upgradeBatch = function(offset) {
 
 			if (errorCount > 0) {
 				// Upgrade finished with errors. Give instructions on how to proceed.
-				elgg.register_error(elgg.echo('upgrade:finished_with_errors'));
+				elgg.register_error(finished_errors());
 			} else {
 				// Upgrade is finished. Make one more call to mark it complete.
 				elgg.action(action, {'upgrade_completed': 1});
-				elgg.system_message(elgg.echo('upgrade:finished'));
+				elgg.system_message(finished());
 			}
 		}
 

--- a/js/tests/ElggLanguagesTest.js
+++ b/js/tests/ElggLanguagesTest.js
@@ -7,6 +7,63 @@ define(function(require) {
 		afterEach(function() {
 			elgg.config.translations = {};
 		});
+
+		describe("elgg/echo", function() {
+
+			it("can translate without args", function(done) {
+				require([
+					"elgg/echo!next",
+					"elgg/echo!next@en",
+					"elgg/echo!next@es"
+				], function (next, next_en, next_es) {
+					expect(next()).toBe("Next");
+					expect(next.found).toBe(true);
+
+					expect(next_en()).toBe("Next");
+					expect(next_en.found).toBe(true);
+
+					expect(next_es()).toBe("Siguiente");
+					expect(next_es.found).toBe(true);
+					done();
+				});
+			});
+
+			it("can translate with args", function(done) {
+				require([
+					"elgg/echo!js:lightbox:current",
+					"elgg/echo!js:lightbox:current@es" // fallback
+				], function (current, current_es) {
+					expect(current(['one', 'three'])).toBe("image one of three");
+					expect(current.found).toBe(true);
+
+					expect(current_es(['one', 'three'])).toBe("image one of three");
+					expect(current_es.found).toBe(true);
+					done();
+				});
+			});
+
+			it("returns keys that can't be found", function(done) {
+				require(["elgg/echo!nonexistent"], function (nonexistent) {
+					expect(nonexistent()).toBe("nonexistent");
+					expect(nonexistent.found).toBe(false);
+					done();
+				});
+			});
+
+			it("loads late language set", function(done) {
+				require([
+					"elgg/echo!ajax:error",
+					"elgg/echo!ajax:error@es"
+				], function (error, error_es) {
+					expect(error()).toBe("Unexpected error");
+					expect(error.found).toBe(true);
+
+					expect(error_es()).toBe("Error inesperado");
+					expect(error_es.found).toBe(true);
+					done();
+				});
+			});
+		});
 		
 		describe("elgg.echo", function() {
 	

--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -13,6 +13,10 @@ module.exports = function(config) {
 
 		// list of files / patterns to load in the browser
 		files: [
+			'js/tests/prepare.js',
+
+			{pattern:'views/default/**/*.js',included:false},
+
 			'vendor/bower-asset/jquery/dist/jquery.js',
 			'bower_components/sprintf/src/sprintf.js',
 			'js/lib/elgglib.js',
@@ -20,10 +24,11 @@ module.exports = function(config) {
 			'js/classes/*.js',
 			'js/lib/*.js',
 
+			// setup tests
 			{pattern:'js/tests/*Test.js',included: false},
-			{pattern:'views/default/**/*.js',included:false},
 
-			'js/tests/requirejs.config.js',
+			// setup RequireJS to run tests
+			'js/tests/requirejs.config.js'
 		],
 
 
@@ -54,7 +59,7 @@ module.exports = function(config) {
 
 		// level of logging
 		// possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-		logLevel: config.LOG_INFO,
+		logLevel: config.LOG_DEBUG,
 
 
 		// enable / disable watching file and executing tests whenever any file changes

--- a/js/tests/prepare.js
+++ b/js/tests/prepare.js
@@ -1,0 +1,20 @@
+// These modules are typically built by PHP on the server. We can't do that with the test runner.
+var elgg = elgg || {};
+
+define('elgg', function() {
+	return elgg;
+});
+define('languages/early/en', {
+	"js:lightbox:current": "image %s of %s",
+	"next": "Next"
+});
+define('languages/late/en', {
+	"ajax:error": "Unexpected error"
+});
+define('languages/early/es', {
+	//'js:lightbox:current': "imagen %s de %s",
+	'next': "Siguiente"
+});
+define('languages/late/es', {
+	"ajax:error": "Error inesperado"
+});

--- a/js/tests/requirejs.config.js
+++ b/js/tests/requirejs.config.js
@@ -9,7 +9,7 @@ requirejs.config({
     // Karma serves files from '/base'
     baseUrl: '/base/views/default/',
     paths: {
-        'sprintf': '/base/vendor/bower-asset/sprintf/src/sprintf',
+        'sprintf': '/base/vendor/bower-asset/sprintf/src/sprintf'
     },
 
     // ask Require.js to load these files (all our tests)
@@ -18,7 +18,3 @@ requirejs.config({
     // start test run, once Require.js is done
     callback: window.__karma__.start
 });
-
-// This module is typically built in PHP. We can't do that with the test runner.
-define('elgg', function() { return elgg; });
-

--- a/mod/blog/views/default/elgg/blog/save_draft.js
+++ b/mod/blog/views/default/elgg/blog/save_draft.js
@@ -6,6 +6,7 @@
 define(function(require) {
 	var $ = require('jquery');
 	var elgg = require('elgg');
+	var error = require('elgg/echo!error');
 
 	var saveDraftCallback = function(data, textStatus, XHR) {
 		if (textStatus == 'success' && data.success == true) {
@@ -23,7 +24,7 @@ define(function(require) {
 			}
 			$(".blog-save-status-time").html(d.toLocaleDateString() + " @ " + d.getHours() + ":" + mins);
 		} else {
-			$(".blog-save-status-time").html(elgg.echo('error'));
+			$(".blog-save-status-time").html(error());
 		}
 	};
 

--- a/mod/ckeditor/elgg-plugin.php
+++ b/mod/ckeditor/elgg-plugin.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+	'home_language_keys' => [
+		'ckeditor:html',
+		'ckeditor:visual',
+	],
+];

--- a/mod/ckeditor/views/default/elgg/ckeditor.js
+++ b/mod/ckeditor/views/default/elgg/ckeditor.js
@@ -2,6 +2,8 @@ define(function(require) {
 	var elgg = require('elgg');
 	var $ = require('jquery'); require('jquery.ckeditor');
 	var CKEDITOR = require('ckeditor');
+	var ckeditor_html = require('elgg/echo!ckeditor:html');
+	var ckeditor_visual = require('elgg/echo!ckeditor:visual');
 
 	CKEDITOR.plugins.addExternal('blockimagepaste', elgg.get_simplecache_url('elgg/ckeditor/blockimagepaste.js'), '');
 	
@@ -20,10 +22,10 @@ define(function(require) {
 	
 			if (!$(target).data('ckeditorInstance')) {
 				$(target).ckeditor(elggCKEditor.init, elggCKEditor.config);
-				$(this).html(elgg.echo('ckeditor:html'));
+				$(this).html(ckeditor_html());
 			} else {
 				$(target).ckeditorGet().destroy();
-				$(this).html(elgg.echo('ckeditor:visual'));
+				$(this).html(ckeditor_visual());
 			}
 		},
 

--- a/mod/ckeditor/views/default/elgg/ckeditor/blockimagepaste.js
+++ b/mod/ckeditor/views/default/elgg/ckeditor/blockimagepaste.js
@@ -3,9 +3,9 @@
 CKEDITOR.plugins.add( 'blockimagepaste', {
         init : function(editor) {
  
-	        function replaceImgText(html) {
+	        function replaceImgText(html, blockimagepaste) {
 	            var ret = html.replace( /<img[^>]*src="data:image\/(bmp|dds|gif|jpg|jpeg|png|psd|pspimage|tga|thm|tif|tiff|yuv|ai|eps|ps|svg);base64,.*?"[^>]*>/gi, function( img ){
-                    alert(elgg.echo('ckeditor:blockimagepaste'));
+                    alert(blockimagepaste());
                     return '';
                  });
 	            return ret;
@@ -16,10 +16,12 @@ CKEDITOR.plugins.add( 'blockimagepaste', {
 	            if (editor.readOnly) {
 	                return;
 	            }
-	            
-	            setTimeout(function() {
-	                editor.document.$.body.innerHTML = replaceImgText(editor.document.$.body.innerHTML);
-	            }, 100);
+
+				require(['elgg/echo!ckeditor:blockimagepaste'], function (blockimagepaste) {
+					setTimeout(function() {
+						editor.document.$.body.innerHTML = replaceImgText(editor.document.$.body.innerHTML, blockimagepaste);
+					}, 100);
+				});
 	        }
 	         
 	        editor.on('contentDom', function() {

--- a/mod/developers/elgg-plugin.php
+++ b/mod/developers/elgg-plugin.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+	'home_language_keys' => [
+		'admin:developers:settings',
+	],
+];

--- a/mod/developers/views/default/elgg/dev/amd_monitor.js
+++ b/mod/developers/views/default/elgg/dev/amd_monitor.js
@@ -4,7 +4,7 @@
 
 	define(function (require) {
 		var $ = require('jquery');
-		var elgg = require('elgg');
+		var developers_amd = require('elgg/echo!developers:amd');
 
 		var known = {};
 		var count = 0;
@@ -14,7 +14,7 @@
 				if (!known[name]) {
 					known[name] = 1;
 					count++;
-					console.log(count + ' ' + elgg.echo('developers:amd') + '(' + name + ')', val);
+					console.log(count + ' ' + developers_amd() + '(' + name + ')', val);
 				}
 			});
 		}

--- a/mod/developers/views/default/elgg/dev/gear.js
+++ b/mod/developers/views/default/elgg/dev/gear.js
@@ -6,11 +6,12 @@ define(function (require) {
 	var elgg = require('elgg');
 	var spinner = require('elgg/spinner');
 	var gear_html = require('text!elgg/dev/gear.html');
+	var developers_settings = require('elgg/echo!admin:developers:settings');
 
 	$(gear_html)
 		.appendTo('body')
 		.find('.elgg-icon')
-		.prop('title', elgg.echo('admin:developers:settings'))
+		.prop('title', developers_settings())
 		.on('click', function () {
 			$.colorbox({
 				href: elgg.get_site_url() + 'ajax/view/developers/gear_popup',

--- a/mod/embed/views/default/embed/embed.js.php
+++ b/mod/embed/views/default/embed/embed.js.php
@@ -146,9 +146,11 @@ elgg.embed.submit = function(event) {
 			}
 		},
 		error    : function(xhr, status) {
-			elgg.register_error(elgg.echo('actiongatekeeper:uploadexceeded'));
-			$('.embed-throbber').hide();
-			$('.embed-wrapper .elgg-form-file-upload').show();
+			require(['elgg/echo!actiongatekeeper:uploadexceeded'], function (uploadexceeded) {
+				elgg.register_error(uploadexceeded());
+				$('.embed-throbber').hide();
+				$('.embed-wrapper .elgg-form-file-upload').show();
+			});
 		}
 	});
 

--- a/mod/messageboard/views/default/messageboard/js.php
+++ b/mod/messageboard/views/default/messageboard/js.php
@@ -40,16 +40,18 @@ elgg.messageboard.submit = function(e) {
 
 elgg.messageboard.deletePost = function(elem) {
 	var $link = $(elem);
-	var confirmText = $link.attr('title') || elgg.echo('question:areyousure');
+	require(['elgg/echo!question:areyousure'], function (areyousure) {
+		var confirmText = $link.attr('title') || areyousure();
 
-	if (confirm(confirmText)) {
-		elgg.action($link.attr('href'), {
-			success: function() {
-				var item = $link.closest('.elgg-item');
-				item.remove();
-			}
-		});
-	}
+		if (confirm(confirmText)) {
+			elgg.action($link.attr('href'), {
+				success: function() {
+					var item = $link.closest('.elgg-item');
+					item.remove();
+				}
+			});
+		}
+	});
 };
 
 elgg.register_hook_handler('init', 'system', elgg.messageboard.init);

--- a/mod/reportedcontent/elgg-plugin.php
+++ b/mod/reportedcontent/elgg-plugin.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+	'home_language_keys' => [
+		'reportedcontent:refresh',
+	],
+];

--- a/mod/reportedcontent/views/default/elgg/reportedcontent.js
+++ b/mod/reportedcontent/views/default/elgg/reportedcontent.js
@@ -1,6 +1,7 @@
 define(function (require) {
-	var elgg = require('elgg'),
-		$ = require('jquery');
+	var elgg = require('elgg');
+	var	$ = require('jquery');
+	var reportedcontent_refresh = require('elgg/echo!reportedcontent:refresh');
 
 	$('.elgg-menu-item-report-this a, .elgg-menu-item-reportuser a').each(function () {
 		if (!/address=/.test(this.href)) {
@@ -62,7 +63,7 @@ define(function (require) {
 
 				if (!$('.reported-content-refresh').length) {
 					$li.parent().after('<p class="reported-content-refresh mtm ptm elgg-divide-top center">' +
-						'<a href="">' + elgg.echo('reportedcontent:refresh') + '</a></p>');
+						'<a href="">' + reportedcontent_refresh() + '</a></p>');
 				}
 			}
 		});

--- a/mod/thewire/views/default/thewire.js
+++ b/mod/thewire/views/default/thewire.js
@@ -48,34 +48,41 @@ elgg.thewire.textCounter = function(textarea, status, limit) {
  * @return void
  */
 elgg.thewire.viewPrevious = function(event) {
+	event.preventDefault();
+
 	var $link = $(this);
 	var postGuid = $link.attr("href").split("/").pop();
 	var $previousDiv = $("#thewire-previous-" + postGuid);
 
-	if ($link.html() == elgg.echo('hide')) {
-		$link.html(elgg.echo('previous'));
-		$link.attr("title", elgg.echo('thewire:previous:help'));
-		$previousDiv.slideUp(400);
-	} else {
-		$link.html(elgg.echo('hide'));
-		$link.attr("title", elgg.echo('thewire:hide:help'));
+	require([
+		'elgg/echo!hide',
+		'elgg/echo!previous',
+		'elgg/echo!thewire:previous:help',
+		'elgg/echo!thewire:hide:help'
+	], function (hide, previous, previous_help, hide_help) {
+		if ($link.html() == hide()) {
+			$link.html(previous());
+			$link.attr("title", previous_help());
+			$previousDiv.slideUp(400);
+		} else {
+			$link.html(hide());
+			$link.attr("title", hide_help());
 
-		elgg.get({
-			url: elgg.config.wwwroot + "ajax/view/thewire/previous",
-			dataType: "html",
-			cache: false,
-			data: {guid: postGuid},
-			success: function(htmlData) {
-				if (htmlData.length > 0) {
-					$previousDiv.html(htmlData);
-					$previousDiv.slideDown(600);
+			elgg.get({
+				url: elgg.config.wwwroot + "ajax/view/thewire/previous",
+				dataType: "html",
+				cache: false,
+				data: {guid: postGuid},
+				success: function(htmlData) {
+					if (htmlData.length > 0) {
+						$previousDiv.html(htmlData);
+						$previousDiv.slideDown(600);
+					}
 				}
-			}
-		});
+			});
 
-	}
-
-	event.preventDefault();
+		}
+	});
 };
 
 elgg.register_hook_handler('init', 'system', elgg.thewire.init);

--- a/views/default/elgg.js.php
+++ b/views/default/elgg.js.php
@@ -51,6 +51,12 @@ foreach ($files as $file) {
 	echo "\n";
 }
 
+// If this config flag is true, the "elgg" module will depend on a tiny set of translations
+// and load the rest on demand in the "elgg/echo" module. As the elgg.echo() function is synchronous,
+// it will fail in some cases in this scenario, so this is setting is not officially supported, but
+// will be the standard behavior in 3.0. After changing this setting, the simplecache must be flushed.
+$early = elgg_get_config('EXPERIMENTAL_echo_async_only') ? "early/" : "";
+
 /**
  * Set some values that are cacheable
  */
@@ -64,10 +70,10 @@ elgg.config.wwwroot = '<?php echo elgg_get_site_url(); ?>';
 // refresh token 3 times during its lifetime (in microseconds 1000 * 1/3)
 elgg.security.interval = <?php echo (int)_elgg_services()->actions->getActionTokenTimeout() * 333; ?>;
 elgg.config.language = '<?php echo (empty($CONFIG->language) ? 'en' : $CONFIG->language); ?>';
+elgg.config.initial_language_module = 'languages/<?= $early ?>' + elgg.get_language();
 
-// We require jquery-ui because loading the file in an AMD environment doesn't automatically
-// apply its functionality to jQuery.
-define('elgg', ['jquery', 'languages/' + elgg.get_language()], function($, translations) {
+define('elgg', ['jquery', elgg.config.initial_language_module], function($, translations) {
+
 	elgg.add_translation(elgg.get_language(), translations);
 
 	$(function() {

--- a/views/default/elgg/admin.js
+++ b/views/default/elgg/admin.js
@@ -7,6 +7,7 @@ define(function(require) {
 	var $ = require('jquery');
 	var ui = require('jquery-ui');
 	var elgg = require('elgg');
+	var Priority = require('elgg/echo!ElggPlugin:Dependencies:Priority');
 
 	function init () {
 		// system messages do not fade in admin area, instead slide up when clicked
@@ -85,7 +86,7 @@ define(function(require) {
 			},
 			success: function() {
 				// update plugins with priority dependences
-				var priorityDep = new RegExp(elgg.echo('ElggPlugin:Dependencies:Priority'));
+				var priorityDep = new RegExp(Priority());
 				ui.item.siblings().andSelf().each(function() {
 					if (priorityDep.test($(this).find('.elgg-dependency-requires').text())) {
 						updatePluginView($(this));

--- a/views/default/elgg/echo.js
+++ b/views/default/elgg/echo.js
@@ -1,0 +1,108 @@
+/**
+ * Returns a "translator" function for an individual message key.
+ *
+ * - require('elgg/echo!{key}') returns a function that outputs the translation for {key} in
+ * the default language.
+ *
+ * - require('elgg/echo!{key}@{lang}') returns a translator for language {lang}.
+ *
+ * The "elgg" module already loads the "languages/{lang}" module, so this module mostly provides a
+ * future-ready asynchronous API to the already-loaded translations.
+ */
+define(function(require) {
+
+	// TODO formalize dependency on vsprintf
+	var elgg = require('elgg');
+
+	var default_lang = elgg.get_language();
+
+	function getTranslation(lang, key, callback) {
+		// debug: uncomment the next two lines to capture which keys were requested
+		//elgg._echoKeys = elgg._echoKeys || {sync:{},async:{}};
+		//elgg._echoKeys.async[key] = true;
+
+		var translations = null;
+		if (elgg.config.translations && elgg.config.translations[lang]) {
+			translations = elgg.config.translations[lang];
+		}
+
+		if (translations && translations.hasOwnProperty(key)) {
+			callback(translations[key]);
+			return;
+		}
+
+		if (elgg.config.initial_language_module == ('languages/' + lang)) {
+			// we've loaded the full translation set and we just don't have this key
+			callback(null);
+			return;
+		}
+
+		/**
+		 * In 3.0 "elgg" will depend on the much smaller "languages/early/{lang}" module initially, and this
+		 * module will request the remaining "languages/late/{lang}" module only when needed.
+		 *
+		 * A site owner may enable the 3.0 behavior via an experimental flag in settings.php. (This mode
+		 * cannot be officially supported, as some uses of elgg.echo() will certainly fail.)
+		 */
+		require(['languages/early/' + lang], function (map) {
+			if (map.hasOwnProperty(key)) {
+				callback(map[key]);
+				// to benefit plugins still using elgg.echo, go ahead and merge these when we get them
+				elgg.add_translation(lang, map);
+			} else {
+				require(['languages/late/' + lang], function (map) {
+					// debug: uncomment the next line to see which key loaded the "late" translations
+					//console.log('key "' + key + '" caused the late translations to load');
+
+					callback(map.hasOwnProperty(key) ? map[key] : null);
+					elgg.add_translation(lang, map);
+				});
+			}
+		});
+	}
+
+	return { // loader plugin http://requirejs.org/docs/plugins.html#apiload
+
+		// this function takes name and calls online when it has the return value
+		load: function(name, req, onload, config) {
+
+			// turn a translation string into a translator function and pass it
+			// to online
+			function makeTranslator(translation) {
+				var f;
+
+				if (null === translation) {
+					f = function() {
+						return name;
+					};
+					f.found = false;
+
+				} else {
+					f = function(args) {
+						return vsprintf(translation, args || []);
+					};
+					f.found = true;
+				}
+
+				onload(f);
+			}
+
+			var lang = default_lang;
+			var m = name.match(/^(.*)@([a-z_]+)$/i);
+			if (m) {
+				name = m[1];
+				lang = m[2];
+			}
+
+			getTranslation(lang, name, function(translation) {
+				if (translation !== null) {
+					return makeTranslator(translation);
+				}
+				if (lang !== default_lang) {
+					return getTranslation(default_lang, name, makeTranslator);
+				}
+				makeTranslator(null);
+			});
+		}
+	};
+});

--- a/views/default/languages.js.php
+++ b/views/default/languages.js.php
@@ -1,9 +1,13 @@
 <?php
 /**
  * @uses $vars['language']
+ * @uses $vars['timing'] If "early", return only keys marked as critical
+ *                       If "late", return the rest of the language keys
+ *                       If missing, return all keys (2.0 BC)
  */
 
 $language = elgg_extract('language', $vars, 'en');
+$timing = elgg_extract('timing', $vars);
 
 $all_translations = $GLOBALS['_ELGG']->translations;
 $translations = $all_translations['en'];
@@ -16,6 +20,23 @@ if ($language != 'en' && !isset($all_translations[$language])) {
 
 if ($language != 'en' && isset($all_translations[$language])) {
 	$translations = array_merge($translations, $all_translations[$language]);
+}
+
+if ($timing) {
+	$early = [];
+	$late = $translations;
+
+	// avoid copy-on-write when moving elements
+	unset($translations);
+
+	foreach (_elgg_services()->translator->getEarlyKeys() as $key) {
+		if (isset($late[$key])) {
+			$early[$key] = $late[$key];
+			unset($late[$key]);
+		}
+	}
+
+	$translations = ($timing === 'early') ? $early : $late;
 }
 
 ?>

--- a/views/default/lightbox.js.php
+++ b/views/default/lightbox.js.php
@@ -81,26 +81,39 @@ elgg.ui.lightbox.bind = function (selector, opts) {
 		opts = {};
 	}
 
-	// merge opts into defaults
-	opts = $.extend({}, elgg.ui.lightbox.getSettings(), opts);
+	require([
+		'elgg/echo!js:lightbox:current',
+		'elgg/echo!previous',
+		'elgg/echo!next',
+		'elgg/echo!close',
+		'elgg/echo!error'
+	], function(current, previous, next, close, error) {
 
-	$(document).on('click', selector, function (e) {
-		var $this = $(this),
-			href = $this.prop('href') || $this.prop('src'),
-			dataOpts = $this.data('colorboxOpts');
-		// Note: data-colorbox was reserved https://github.com/jackmoore/colorbox/issues/435
+		// we pass these translators in for the default view, but for BC the lightbox/settings.js
+		// view can be overridden safely.
+		var settings = elgg.ui.lightbox.getSettings(current, previous, next, close, error);
 
-		if (!$.isPlainObject(dataOpts)) {
-			dataOpts = {};
-		}
+		// merge opts into defaults
+		opts = $.extend({}, settings, opts);
 
-		if (!dataOpts.href && href) {
-			dataOpts.href = href;
-		}
+		$(document).on('click', selector, function (e) {
+			var $this = $(this),
+				href = $this.prop('href') || $this.prop('src'),
+				dataOpts = $this.data('colorboxOpts');
+			// Note: data-colorbox was reserved https://github.com/jackmoore/colorbox/issues/435
 
-		// merge data- options into opts
-		$.colorbox($.extend({}, opts, dataOpts));
-		e.preventDefault();
+			if (!$.isPlainObject(dataOpts)) {
+				dataOpts = {};
+			}
+
+			if (!dataOpts.href && href) {
+				dataOpts.href = href;
+			}
+
+			// merge data- options into opts
+			$.colorbox($.extend({}, opts, dataOpts));
+			e.preventDefault();
+		});
 	});
 };
 

--- a/views/default/lightbox/settings.js.php
+++ b/views/default/lightbox/settings.js.php
@@ -8,14 +8,22 @@
 ?>
 //<script>
 
-elgg.ui.lightbox.getSettings = function () {
+/**
+ * @param {Function} current  Translator
+ * @param {Function} previous Translator
+ * @param {Function} next     Translator
+ * @param {Function} close    Translator
+ * @param {Function} error    Translator
+ * @returns {Object}
+ */
+elgg.ui.lightbox.getSettings = function (current, previous, next, close, error) {
 	return {
-		current: elgg.echo('js:lightbox:current', ['{current}', '{total}']),
-		previous: elgg.echo('previous'),
-		next: elgg.echo('next'),
-		close: elgg.echo('close'),
-		xhrError: elgg.echo('error:default'),
-		imgError: elgg.echo('error:default'),
+		current: current(['{current}', '{total}']),
+		previous: previous(),
+		next: next(),
+		close: close(),
+		xhrError: error(),
+		imgError: error(),
 		opacity: 0.5,
 		maxWidth: '100%',
 


### PR DESCRIPTION
Elgg currently loads over 27K (gzipped) of translations by default, and these block all modules dependent on the "elgg" module. 3.0 will load a tiny subset initially and load the rest as needed, but plugins must begin converting to an asynchronous API, which this provides as `elgg/echo`.

`elgg/echo` is a RequireJS plugin that returns translator functions with the key and language preconfigured.

Deprecates `elgg.echo()` and migrates all usages to the `elgg/echo` plugin.

Makes the JS deprecation strategy like PHP (console.info, not register_error)

Adds a convention for providing plugin configuration data via `elgg-plugin.php`.

Adds an experimental config flag (`$CONFIG->EXPERIMENTAL_echo_async_only = true`) to enable the 3.0 behavior. This reduces the 27K languages file to less than 1K. In 2.x we can't support this, however, because the legacy `elgg.echo()` may fail for some keys.

Fixes #8999
- [ ] JS test failing (but works locally, I need help here!)
- [ ] use `!` as separator (and update docs)
