### PR TITLE
feature(javascript): moves hooks to dedicated AMD modules, adds plugin boot modules

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1539,6 +1539,11 @@ function elgg_views_boot() {
 	elgg_register_css('elgg', elgg_get_simplecache_url('elgg.css'));
 	elgg_load_css('elgg');
 
+	elgg_register_simplecache_view('elgg/booted.js');
+	elgg_require_js('elgg/booted');
+	elgg_require_js('elgg/hooks/register');
+	elgg_require_js('elgg/hooks/trigger');
+
 	// optional stuff
 	elgg_register_js('lightbox', elgg_get_simplecache_url('lightbox.js'));
 	elgg_register_css('lightbox', elgg_get_simplecache_url('lightbox/elgg-colorbox-theme/colorbox.css'));

--- a/js/lib/comments.js
+++ b/js/lib/comments.js
@@ -129,4 +129,6 @@ elgg.comments.init = function() {
 	});
 };
 
-elgg.register_hook_handler('init', 'system', elgg.comments.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.comments.init);
+});

--- a/js/lib/elgglib.js
+++ b/js/lib/elgglib.js
@@ -422,9 +422,9 @@ elgg.forward = function(url) {
 /**
  * Parse a URL into its parts. Mimicks http://php.net/parse_url
  *
- * @param {String} url       The URL to parse
- * @param {Int}    component A component to return
- * @param {Bool}   expand    Expand the query into an object? Else it's a string.
+ * @param {String}  url       The URL to parse
+ * @param {Number}  component A component to return
+ * @param {Boolean} expand    Expand the query into an object? Else it's a string.
  *
  * @return {Object} The parsed URL
  */
@@ -562,7 +562,7 @@ elgg.getSelectorFromUrlFragment = function(url) {
  *
  * @param {Object} object The object to add to
  * @param {String} parent The parent array to add to.
- * @param {Mixed}  value  The value
+ * @param {*}  value  The value
  */
 elgg.push_to_object_array = function(object, parent, value) {
 	elgg.assertTypeOf('object', object);
@@ -584,7 +584,7 @@ elgg.push_to_object_array = function(object, parent, value) {
  *
  * @param {Object} object The object to add to
  * @param {String} parent The parent array to add to.
- * @param {Mixed}  value  The value
+ * @param {*}  value  The value
  */
 elgg.is_in_object_array = function(object, parent, value) {
 	elgg.assertTypeOf('object', object);

--- a/js/lib/hooks.js
+++ b/js/lib/hooks.js
@@ -7,21 +7,9 @@ elgg.provide('elgg.config.instant_hooks');
 elgg.provide('elgg.config.triggered_hooks');
 
 /**
- * Registers a hook handler with the event system.
- *
- * The special keyword "all" can be used for either the name or the type or both
- * and means to call that handler for all of those hooks.
- *
- * Note that handlers registering for instant hooks will be executed immediately if the instant
- * hook has been previously triggered.
- *
- * @param {String}   name     Name of the plugin hook to register for
- * @param {String}   type     Type of the event to register for
- * @param {Function} handler  Handle to call
- * @param {Number}   priority Priority to call the event handler
- * @return {Bool}
+ * @private
  */
-elgg.register_hook_handler = function(name, type, handler, priority) {
+elgg._register_hook_handler = function(name, type, handler, priority) {
 	elgg.assertTypeOf('string', name);
 	elgg.assertTypeOf('string', type);
 	elgg.assertTypeOf('function', handler);
@@ -47,30 +35,26 @@ elgg.register_hook_handler = function(name, type, handler, priority) {
 };
 
 /**
- * Emits a hook.
+ * Registers a hook handler with the event system.
  *
- * Loops through all registered hooks and calls the handler functions in order.
- * Every handler function will always be called, regardless of the return value.
- *
- * @warning Handlers take the same 4 arguments in the same order as when calling this function.
- * This is different from the PHP version!
- *
- * @note Instant hooks do not support params or values.
- *
- * Hooks are called in this order:
- *	specifically registered (event_name and event_type match)
- *	all names, specific type
- *	specific name, all types
- *	all names, all types
- *
- * @param {String} name   Name of the hook to emit
- * @param {String} type   Type of the hook to emit
- * @param {Object} params Optional parameters to pass to the handlers
- * @param {Object} value  Initial value of the return. Can be mangled by handlers
- *
- * @return {Bool}
+ * @deprecated Use the elgg/hooks/register module in a boot module
  */
-elgg.trigger_hook = function(name, type, params, value) {
+elgg.register_hook_handler = function(name, type, handler, priority) {
+	if (name === 'boot' && type === 'system') {
+		elgg.deprecated_notice("The hook [boot, system] is deprecated. Use [init, system] in a plugin boot" +
+			" module", "2.1");
+	} else {
+		elgg.deprecated_notice("elgg.register_hook_handler is deprecated. Use the elgg/hooks/register module" +
+			" in your plugin boot module", "2.1");
+	}
+
+	return elgg._register_hook_handler(name, type, handler, priority);
+};
+
+/**
+ * @private
+ */
+elgg._trigger_hook = function(name, type, params, value) {
 	elgg.assertTypeOf('string', name);
 	elgg.assertTypeOf('string', type);
 
@@ -122,6 +106,16 @@ elgg.trigger_hook = function(name, type, params, value) {
 };
 
 /**
+ * Emits a hook.
+ *
+ * @deprecated Use the elgg/hooks/trigger module
+ */
+elgg.trigger_hook = function(name, type, params, value) {
+	elgg.deprecated_notice("elgg.trigger_hook is deprecated. Use the elgg/hooks/trigger module", "2.1");
+	return elgg._trigger_hook(name, type, params, value);
+};
+
+/**
  * Registers a hook as an instant hook.
  *
  * After being trigger once, registration of a handler to an instant hook will cause the
@@ -132,7 +126,7 @@ elgg.trigger_hook = function(name, type, params, value) {
  *
  * @param {String} name The hook name.
  * @param {String} type The hook type.
- * @return {Int}
+ * @return {Number} integer
  */
 elgg.register_instant_hook = function(name, type) {
 	elgg.assertTypeOf('string', name);

--- a/js/lib/security.js
+++ b/js/lib/security.js
@@ -104,4 +104,6 @@ elgg.security.init = function() {
 	elgg.security.tokenRefreshTimer = setInterval(elgg.security.refreshToken, elgg.security.interval);
 };
 
-elgg.register_hook_handler('boot', 'system', elgg.security.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.security.init);
+});

--- a/js/lib/ui.autocomplete.js
+++ b/js/lib/ui.autocomplete.js
@@ -20,4 +20,6 @@ elgg.autocomplete.init = function() {
 	});
 };
 
-elgg.register_hook_handler('init', 'system', elgg.autocomplete.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.autocomplete.init);
+});

--- a/js/lib/ui.avatar_cropper.js
+++ b/js/lib/ui.avatar_cropper.js
@@ -77,4 +77,6 @@ elgg.avatarCropper.selectChange = function(img, selection) {
 	$('input[name=y2]').val(selection.y2);
 };
 
-elgg.register_hook_handler('init', 'system', elgg.avatarCropper.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.avatarCropper.init);
+});

--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -114,7 +114,7 @@ elgg.ui.popupOpen = function(event) {
 		collision: 'fit fit'
 	};
 
-	options = elgg.trigger_hook('getOptions', 'ui.popup', params, options);
+	options = elgg._trigger_hook('getOptions', 'ui.popup', params, options);
 
 	// allow plugins to cancel event
 	if (!options) {
@@ -472,7 +472,9 @@ elgg.ui.initAccessInputs = function () {
 	});
 };
 
-elgg.register_hook_handler('init', 'system', elgg.ui.init);
-elgg.register_hook_handler('init', 'system', elgg.ui.initDatePicker);
-elgg.register_hook_handler('getOptions', 'ui.popup', elgg.ui.loginHandler);
-elgg.ui.registerTogglableMenuItems('add-friend', 'remove-friend');
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.ui.init);
+	register('init', 'system', elgg.ui.initDatePicker);
+	register('getOptions', 'ui.popup', elgg.ui.loginHandler);
+	elgg.ui.registerTogglableMenuItems('add-friend', 'remove-friend');
+});

--- a/js/lib/ui.river.js
+++ b/js/lib/ui.river.js
@@ -11,4 +11,6 @@ elgg.ui.river.init = function() {
 	});
 };
 
-elgg.register_hook_handler('init', 'system', elgg.ui.river.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.ui.river.init);
+});

--- a/js/lib/ui.widgets.js
+++ b/js/lib/ui.widgets.js
@@ -208,4 +208,6 @@ elgg.ui.widgets.setMinHeight = function(selector) {
 	});
 };
 
-elgg.register_hook_handler('init', 'system', elgg.ui.widgets.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.ui.widgets.init);
+});

--- a/js/lib/upgrades.js
+++ b/js/lib/upgrades.js
@@ -118,4 +118,6 @@ elgg.upgrades.upgradeBatch = function(offset) {
 	return elgg.post(action, options);
 };
 
-elgg.register_hook_handler('init', 'system', elgg.upgrades.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.upgrades.init);
+});

--- a/js/tests/ElggHooksTest.js
+++ b/js/tests/ElggHooksTest.js
@@ -11,40 +11,40 @@ define(function(require) {
 	
 		describe("elgg.trigger_hook()", function() {
 			it("return value defaults to null", function() {
-				expect(elgg.trigger_hook("fee", "fum")).toBe(null);
+				expect(elgg._trigger_hook("fee", "fum")).toBe(null);
 				
-				elgg.register_hook_handler('fee', 'fum', elgg.nullFunction);
-				expect(elgg.trigger_hook("fee", "fum")).toBe(null);
+				elgg._register_hook_handler('fee', 'fum', elgg.nullFunction);
+				expect(elgg._trigger_hook("fee", "fum")).toBe(null);
 
-				expect(elgg.trigger_hook('x', 'y', {}, null)).toBe(null);
-				expect(elgg.trigger_hook('x', 'z', {}, false)).toBe(false);
+				expect(elgg._trigger_hook('x', 'y', {}, null)).toBe(null);
+				expect(elgg._trigger_hook('x', 'z', {}, false)).toBe(false);
 			});
 
 			it("handlers returning null/undefined don't change returnvalue", function() {
-				elgg.register_hook_handler('test', 'test', elgg.nullFunction);
-				expect(elgg.trigger_hook('test', 'test', {}, 1984)).toBe(1984);
+				elgg._register_hook_handler('test', 'test', elgg.nullFunction);
+				expect(elgg._trigger_hook('test', 'test', {}, 1984)).toBe(1984);
 
-				elgg.register_hook_handler('test', 'test', function(hook, type, params, value) {
+				elgg._register_hook_handler('test', 'test', function(hook, type, params, value) {
 					return undefined;
 				});
-				expect(elgg.trigger_hook('test', 'test', {}, 42)).toBe(42);
+				expect(elgg._trigger_hook('test', 'test', {}, 42)).toBe(42);
 			});
 
 			it("triggers handlers registered with 'all'", function() {
-				elgg.register_hook_handler('all', 'bar', elgg.abstractMethod);
-				expect(function() { elgg.trigger_hook('foo', 'bar'); }).toThrow();
+				elgg._register_hook_handler('all', 'bar', elgg.abstractMethod);
+				expect(function() { elgg._trigger_hook('foo', 'bar'); }).toThrow();
 			
-				elgg.register_hook_handler('foo', 'all', elgg.abstractMethod);
-				expect(function() { elgg.trigger_hook('foo', 'baz'); }).toThrow();
+				elgg._register_hook_handler('foo', 'all', elgg.abstractMethod);
+				expect(function() { elgg._trigger_hook('foo', 'baz'); }).toThrow();
 			
-				elgg.register_hook_handler('all', 'all', elgg.abstractMethod);
-				expect(function() { elgg.trigger_hook('pinky', 'winky'); }).toThrow();
+				elgg._register_hook_handler('all', 'all', elgg.abstractMethod);
+				expect(function() { elgg._trigger_hook('pinky', 'winky'); }).toThrow();
 			});
 		});
 		
 		describe("elgg.register_hook_handler()", function() {
 			it("only accepts functions as handlers", function() {
-				expect(function() { elgg.register_hook_handler('str', 'str', 'oops'); }).toThrow();
+				expect(function() { elgg._register_hook_handler('str', 'str', 'oops'); }).toThrow();
 			});
 		});
 	});

--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -13,6 +13,11 @@ module.exports = function(config) {
 
 		// list of files / patterns to load in the browser
 		files: [
+			'js/tests/prepare.js',
+
+			// early because some libs use require(['elgg/hooks/register'])
+			{pattern:'views/default/**/*.js',included:false},
+
 			'vendor/bower-asset/jquery/dist/jquery.js',
 			'bower_components/sprintf/src/sprintf.js',
 			'js/lib/elgglib.js',
@@ -20,10 +25,11 @@ module.exports = function(config) {
 			'js/classes/*.js',
 			'js/lib/*.js',
 
+			// setup tests
 			{pattern:'js/tests/*Test.js',included: false},
-			{pattern:'views/default/**/*.js',included:false},
 
-			'js/tests/requirejs.config.js',
+			// setup RequireJS to run tests
+			'js/tests/requirejs.config.js'
 		],
 
 
@@ -54,7 +60,7 @@ module.exports = function(config) {
 
 		// level of logging
 		// possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-		logLevel: config.LOG_INFO,
+		logLevel: config.LOG_DEBUG,
 
 
 		// enable / disable watching file and executing tests whenever any file changes

--- a/js/tests/prepare.js
+++ b/js/tests/prepare.js
@@ -1,0 +1,9 @@
+// These modules are typically built by PHP on the server. We can't do that with the test runner.
+var elgg = elgg || {};
+
+define('elgg', function() {
+	return elgg;
+});
+define('elgg/hooks/register', function () {
+	return elgg._register_hook_handler;
+});

--- a/js/tests/requirejs.config.js
+++ b/js/tests/requirejs.config.js
@@ -18,7 +18,3 @@ requirejs.config({
     // start test run, once Require.js is done
     callback: window.__karma__.start
 });
-
-// This module is typically built in PHP. We can't do that with the test runner.
-define('elgg', function() { return elgg; });
-

--- a/mod/blog/views/default/elgg/blog/save_draft.js
+++ b/mod/blog/views/default/elgg/blog/save_draft.js
@@ -6,6 +6,7 @@
 define(function(require) {
 	var $ = require('jquery');
 	var elgg = require('elgg');
+	var register = require('elgg/hooks/register');
 
 	var saveDraftCallback = function(data, textStatus, XHR) {
 		if (textStatus == 'success' && data.success == true) {
@@ -54,14 +55,12 @@ define(function(require) {
 		$.post(draftURL, postData, saveDraftCallback, 'json');
 	};
 
-	var init = function() {
+	register('init', 'system', function () {
 		// get a copy of the body to compare for auto save
 		oldDescription = $('form[id=blog-post-edit]').find('textarea[name=description]').val();
 
 		setInterval(saveDraft, 60000);
-	};
-
-	elgg.register_hook_handler('init', 'system', init);
+	});
 
 	return {
 		saveDraft: saveDraft

--- a/mod/bookmarks/views/default/bookmarks/js.php
+++ b/mod/bookmarks/views/default/bookmarks/js.php
@@ -1,3 +1,4 @@
+//<script>
 
 elgg.provide('elgg.bookmarks');
 
@@ -9,4 +10,6 @@ elgg.bookmarks.init = function() {
 	e.attr('href', link);
 };
 
-elgg.register_hook_handler('init', 'system', elgg.bookmarks.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.bookmarks.init);
+});

--- a/mod/ckeditor/views/default/elgg/ckeditor/insert.js
+++ b/mod/ckeditor/views/default/elgg/ckeditor/insert.js
@@ -4,16 +4,18 @@
  * This JavaScript view is extending the view embed/embed.js
  */
 
-elgg.register_hook_handler('embed', 'editor', function(hook, type, params, value) {
-	var textArea = $('#' + params.textAreaId);
-	var content = params.content;
-	if ($.fn.ckeditorGet) {
-		try {
-			var editor = textArea.ckeditorGet();
-			editor.insertHtml(content);
-			return false;
-		} catch (e) {
-			// do nothing.
+require(['elgg/hooks/register'], function(register) {
+	register('embed', 'editor', function(hook, type, params, value) {
+		var textArea = $('#' + params.textAreaId);
+		var content = params.content;
+		if ($.fn.ckeditorGet) {
+			try {
+				var editor = textArea.ckeditorGet();
+				editor.insertHtml(content);
+				return false;
+			} catch (e) {
+				// do nothing.
+			}
 		}
-	}
+	});
 });

--- a/mod/dashboard/views/default/dashboard/js.php
+++ b/mod/dashboard/views/default/dashboard/js.php
@@ -3,11 +3,17 @@
 elgg.provide('elgg.dashboard');
 
 elgg.dashboard.init = function() {
-	// for group activity widget, set the widget title to the group name
-	$(".elgg-widget-edit").on("submit", ".elgg-form-widgets-save-group-activity", function(event) {
-		var title = $(this).find('select[name*="params[group_guid]"] option:selected').html();
-		$(this).find('input[name*="title"]').val(title);
+	require(['jquery'], function($) {
+		$(function() {
+			// for group activity widget, set the widget title to the group name
+			$(".elgg-widget-edit").on("submit", ".elgg-form-widgets-save-group-activity", function(event) {
+				var title = $(this).find('select[name*="params[group_guid]"] option:selected').html();
+				$(this).find('input[name*="title"]').val(title);
+			});
+		});
 	});
-}
+};
 
-elgg.register_hook_handler('init', 'system', elgg.dashboard.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.dashboard.init);
+});

--- a/mod/discussions/views/default/discussion/discussion.js
+++ b/mod/discussions/views/default/discussion/discussion.js
@@ -115,4 +115,6 @@ elgg.discussion.init = function() {
 	});
 };
 
-elgg.register_hook_handler('init', 'system', elgg.discussion.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.discussion.init);
+});

--- a/mod/embed/views/default/embed/embed.js.php
+++ b/mod/embed/views/default/embed/embed.js.php
@@ -6,7 +6,11 @@ elgg.embed.init = function() {
 	// inserts the embed content into the textarea
 	$(document).on('click', ".embed-item", elgg.embed.insert);
 
-	elgg.register_hook_handler('embed', 'editor', elgg.embed._deprecated_custom_insert_js);
+	// this will cause a warning because this runs after elgg/booted, but we
+	// can't refactor this until 3.0
+	require(['elgg/hooks/register'], function(register) {
+		register('embed', 'editor', elgg.embed._deprecated_custom_insert_js);
+	});
 
 	// caches the current textarea id
 	$(document).on('click', ".embed-control", function() {
@@ -187,4 +191,6 @@ elgg.embed.addContainerGUID = function(url) {
 	}
 };
 
-elgg.register_hook_handler('init', 'system', elgg.embed.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.embed.init);
+});

--- a/mod/likes/views/default/likes/js.php
+++ b/mod/likes/views/default/likes/js.php
@@ -3,7 +3,7 @@
  * Likes JavaScript extension for elgg.js
  */
 ?>
-
+//<script>
 /**
  * Repositions the likes popup
  *
@@ -23,5 +23,8 @@ elgg.ui.likesPopupHandler = function(hook, type, params, options) {
 	return null;
 };
 
-elgg.register_hook_handler('getOptions', 'ui.popup', elgg.ui.likesPopupHandler);
+require(['elgg/hooks/register'], function(register) {
+	register('getOptions', 'ui.popup', elgg.ui.likesPopupHandler);
+});
+
 elgg.ui.registerTogglableMenuItems('likes', 'unlike');

--- a/mod/messageboard/views/default/messageboard/js.php
+++ b/mod/messageboard/views/default/messageboard/js.php
@@ -52,4 +52,6 @@ elgg.messageboard.deletePost = function(elem) {
 	}
 };
 
-elgg.register_hook_handler('init', 'system', elgg.messageboard.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.messageboard.init);
+});

--- a/mod/messages/views/default/messages/js.php
+++ b/mod/messages/views/default/messages/js.php
@@ -1,7 +1,10 @@
-
+//<script>
 // messages plugin toggle
-elgg.register_hook_handler('init', 'system', function() {
-	$("#messages-toggle").click(function() {
-		$('input[type=checkbox]').click();
+require(['jquery', 'elgg/hooks/register'], function($, register) {
+	register('init', 'system', function () {
+		$("#messages-toggle").click(function () {
+			$('input[type=checkbox]').click();
+
+		});
 	});
 });

--- a/mod/profile/views/default/profile/js.php
+++ b/mod/profile/views/default/profile/js.php
@@ -1,9 +1,12 @@
-
+//<script>
 // force the first column to at least be as large as the profile box in cols 2 and 3
 // we also want to run before the widget init happens so priority is < 500
-elgg.register_hook_handler('init', 'system', function() {
-	// only do this on the profile page's widget canvas.
-	if ($('.profile').length) {
-		$('#elgg-widget-col-1').css('min-height', $('.profile').outerHeight(true) + 1);
-	}
-}, 400);
+
+require(['jquery', 'elgg/hooks/register'], function($, register) {
+	register('init', 'system', function() {
+		// only do this on the profile page's widget canvas.
+		if ($('.profile').length) {
+			$('#elgg-widget-col-1').css('min-height', $('.profile').outerHeight(true) + 1);
+		}
+	}, 400);
+});

--- a/mod/site_notifications/views/default/site_notifications.js
+++ b/mod/site_notifications/views/default/site_notifications.js
@@ -35,7 +35,7 @@ elgg.site_notifications.delete = function(event) {
 	});
 
 	event.preventDefault();
-}
+};
 
 /**
  * Delete notification for this link
@@ -48,7 +48,7 @@ elgg.site_notifications.auto_delete = function(event) {
 	var id = $(this).attr('id');
 	id = id.replace("link", "delete");
 	elgg.action($('#' + id).attr('href'), {});
-}
+};
 
 /**
  * Toggle the checkboxes in the site notification listing
@@ -59,4 +59,6 @@ elgg.site_notifications.toggle_all = function() {
 	$('.site-notifications-container input[type=checkbox]').click();
 };
 
-elgg.register_hook_handler('init', 'system', elgg.site_notifications.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.site_notifications.init);
+});

--- a/mod/thewire/views/default/thewire.js
+++ b/mod/thewire/views/default/thewire.js
@@ -78,4 +78,6 @@ elgg.thewire.viewPrevious = function(event) {
 	event.preventDefault();
 };
 
-elgg.register_hook_handler('init', 'system', elgg.thewire.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.thewire.init);
+});

--- a/mod/twitter_api/views/default/twitter_api/js.php
+++ b/mod/twitter_api/views/default/twitter_api/js.php
@@ -1,16 +1,18 @@
 <?php if (0): ?><script><?php endif; ?>
 
 // add ?persistent to login link
-elgg.register_hook_handler('init', 'system', function() {
-	$('form.elgg-form-login').each(function () {
-		var link = $('.login_with_twitter a', this).get(0),
-			$input = $('input[name="persistent"]', this);
-		function sync() {
-			link.href = link.href.replace(/\?.*/, '') + ($input[0].checked ? '?persistent' : '');
-		}
-		if (link && $input.length) {
-			sync();
-			$input.change(sync);
-		}
+require(['elgg/hooks/register', 'jquery'], function(register, $) {
+	register('init', 'system', function() {
+		$('form.elgg-form-login').each(function () {
+			var link = $('.login_with_twitter a', this).get(0),
+				$input = $('input[name="persistent"]', this);
+			function sync() {
+				link.href = link.href.replace(/\?.*/, '') + ($input[0].checked ? '?persistent' : '');
+			}
+			if (link && $input.length) {
+				sync();
+				$input.change(sync);
+			}
+		});
 	});
 });

--- a/mod/uservalidationbyemail/views/default/uservalidationbyemail/js.php
+++ b/mod/uservalidationbyemail/views/default/uservalidationbyemail/js.php
@@ -1,3 +1,4 @@
+//<script>
 
 elgg.provide('elgg.uservalidationbyemail');
 
@@ -25,4 +26,6 @@ elgg.uservalidationbyemail.init = function() {
 	});
 };
 
-elgg.register_hook_handler('init', 'system', elgg.uservalidationbyemail.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.uservalidationbyemail.init);
+});

--- a/views/default/elgg.js.php
+++ b/views/default/elgg.js.php
@@ -70,11 +70,6 @@ elgg.config.language = '<?php echo (empty($CONFIG->language) ? 'en' : $CONFIG->l
 define('elgg', ['jquery', 'languages/' + elgg.get_language()], function($, translations) {
 	elgg.add_translation(elgg.get_language(), translations);
 
-	$(function() {
-		elgg.trigger_hook('init', 'system');
-		elgg.trigger_hook('ready', 'system');
-	});
-
 	return elgg;
 });
 
@@ -93,4 +88,4 @@ if (!window._require_queue) {
 	delete window._require_queue;
 }
 
-elgg.trigger_hook('boot', 'system');
+elgg._trigger_hook('boot', 'system');

--- a/views/default/elgg/Plugin.js
+++ b/views/default/elgg/Plugin.js
@@ -1,0 +1,54 @@
+/**
+ * If your plugin has a boot module, it must return an instance of the class defined by
+ * this module.
+ */
+define(function (require) {
+	var $ = require('jquery');
+
+	/**
+	 * Constructor
+	 *
+	 * @param {Object} spec Specification object with keys:
+	 *
+	 *     exports: {Object} optional set of values to you want to make available
+	 *     init: {Function} optional function called in plugin order during the elgg/booted module,
+	 *
+	 * @constructor
+	 */
+	function Plugin(spec) {
+		var expected_keys = {
+			exports: 1,
+			init: 1
+		};
+
+		spec = spec || {};
+		$.each(spec, function (key, val) {
+			if (!expected_keys[key]) {
+				console.error("The key '" + key + "' is unrecognized. Is this a typo?");
+			}
+		});
+
+		/**
+		 * Get the exports of the boot module, if any
+		 *
+		 * @returns {*}
+		 */
+		this.get_exports = function () {
+			return spec.exports || {};
+		};
+
+		/**
+		 * This is called by Elgg to initialize the plugin. Do not use.
+		 *
+		 * @access private
+		 * @internal
+		 */
+		this._init = function () {
+			if ($.isFunction(spec.init)) {
+				spec.init();
+			}
+		};
+	}
+
+	return Plugin;
+});

--- a/views/default/elgg/UserPicker.js
+++ b/views/default/elgg/UserPicker.js
@@ -1,6 +1,11 @@
 /** @module elgg/UserPicker */
 
-define(['jquery', 'elgg', 'jquery.ui.autocomplete.html'], function ($, elgg) {
+define(function(require) {
+	var $ = require('jquery');
+	var elgg = require('elgg');
+	var register = require('elgg/hooks/register');
+	require('jquery.ui.autocomplete.html');
+
 	/**
 	 * @param {HTMLElement} wrapper outer div
 	 * @constructor
@@ -135,7 +140,7 @@ define(['jquery', 'elgg', 'jquery.ui.autocomplete.html'], function ($, elgg) {
 	 * @param {String} selector
 	 */
 	UserPicker.setup = function(selector) {
-		elgg.register_hook_handler('init', 'system', function () {
+		register('init', 'system', function () {
 			$(selector).each(function () {
 				// we only want to wrap each picker once
 				if (!$(this).data('initialized')) {

--- a/views/default/elgg/booted.js.php
+++ b/views/default/elgg/booted.js.php
@@ -1,0 +1,63 @@
+<?php
+
+$modules = [];
+foreach (elgg_get_plugins() as $plugin) {
+	$id = $plugin->getID();
+	if (elgg_view_exists("boot/$id.js")) {
+		$modules[] = [
+			'name' => "boot/$id",
+			'id' => $id,
+		];
+	}
+}
+
+?>
+//<script>
+/**
+ * Finalize the boot sequence by making sure all available $plugin_id/boot modules are
+ * loaded before firing the init/ready plugin hooks.
+ */
+define(function (require) {
+	var Plugin = require('elgg/Plugin');
+	var elgg = require('elgg');
+	var modules = [];
+	var id_map = {};
+	var i, module;
+
+	<?php foreach ($modules as $module) { ?>
+	module = {
+		plugin: require(<?= json_encode($module['name']) ?>),
+		name: <?= json_encode($module['name']) ?>,
+		exports: null
+	};
+	modules.push(module);
+	id_map[<?= json_encode($module['id']) ?>] = module;
+	<?php } ?>
+
+	for (i = 0; i < modules.length; i++) {
+		if (modules[i].plugin instanceof Plugin) {
+			modules[i].plugin._init();
+
+		} else {
+			console.error("Boot module " + modules[i].name + " did not return an instance of Plugin (from elgg/Plugin)");
+		}
+	}
+
+	// will check in elgg/hooks/register
+	elgg._plugins_booted = true;
+
+	elgg._trigger_hook('init', 'system');
+	elgg._trigger_hook('ready', 'system');
+
+	return {
+		/**
+		 * Get a booted Plugin object (null if plugin not present or doesn't have a boot module)
+		 *
+		 * @param {String} id Plugin ID
+		 * @returns {elgg/Plugin|null}
+		 */
+		get_plugin: function(id) {
+			return id_map.hasOwnProperty(id) ? id_map[id] : null;
+		}
+	};
+});

--- a/views/default/elgg/hooks/register.js
+++ b/views/default/elgg/hooks/register.js
@@ -1,0 +1,27 @@
+/**
+ * Registers a hook handler with the event system.
+ *
+ * The special keyword "all" can be used for either the name or the type or both
+ * and means to call that handler for all of those hooks.
+ *
+ * Note that handlers registering for instant hooks will be executed immediately if the instant
+ * hook has been previously triggered.
+ *
+ * @param {String}   name     Name of the plugin hook to register for
+ * @param {String}   type     Type of the event to register for
+ * @param {Function} handler  Handle to call
+ * @param {Number}   priority Priority to call the event handler
+ * @return {Boolean}
+ */
+define(function(require) {
+	var elgg = require("elgg");
+
+	return function (name, type, handler, priority) {
+		if (elgg._plugins_booted && window.console) {
+			console.warn("This hook registration may be too late. Register handlers in a plugin boot" +
+				" module for best results.");
+		}
+
+		return elgg._register_hook_handler(name, type, handler, priority);
+	};
+});

--- a/views/default/elgg/hooks/trigger.js
+++ b/views/default/elgg/hooks/trigger.js
@@ -1,0 +1,29 @@
+/**
+ * Emits a hook.
+ *
+ * Loops through all registered hooks and calls the handler functions in order.
+ * Every handler function will always be called, regardless of the return value.
+ *
+ * @warning Handlers take the same 4 arguments in the same order as when calling this function.
+ * This is different from the PHP version!
+ *
+ * @note Instant hooks do not support params or values.
+ *
+ * Hooks are called in this order:
+ *	specifically registered (event_name and event_type match)
+ *	all names, specific type
+ *	specific name, all types
+ *	all names, all types
+ *
+ * @param {String} name   Name of the hook to emit
+ * @param {String} type   Type of the hook to emit
+ * @param {Object} params Optional parameters to pass to the handlers
+ * @param {Object} value  Initial value of the return. Can be mangled by handlers
+ *
+ * @return {Boolean}
+ */
+define(function(require) {
+	require("elgg/booted");
+
+	return require("elgg")._trigger_hook;
+});

--- a/views/default/lightbox.js.php
+++ b/views/default/lightbox.js.php
@@ -112,6 +112,8 @@ elgg.ui.lightbox.close = function() {
 	$.colorbox.close();
 };
 
-elgg.register_hook_handler('init', 'system', elgg.ui.lightbox.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.ui.lightbox.init);
+});
 
 <?= elgg_view('jquery.colorbox.js'); ?>

--- a/views/default/page/walled_garden.php
+++ b/views/default/page/walled_garden.php
@@ -16,10 +16,8 @@ if ($is_sticky_register) {
 	$wg_body_class .= ' hidden';
 	ob_start(); ?>
 <script>
-require(['elgg'], function (elgg) {
-	elgg.register_hook_handler('init', 'system', function() {
-		$('.registration_link').trigger('click');
-	});
+require(['elgg', 'jquery'], function (elgg, $) {
+	$('.registration_link').trigger('click');
 });
 </script>
 	<?php

--- a/views/default/walled_garden.js.php
+++ b/views/default/walled_garden.js.php
@@ -71,4 +71,6 @@ elgg.walled_garden.load = function(view) {
 	};
 };
 
-elgg.register_hook_handler('init', 'system', elgg.walled_garden.init);
+require(['elgg/hooks/register'], function(register) {
+	register('init', 'system', elgg.walled_garden.init);
+});


### PR DESCRIPTION
Deprecates `elgg.register_hook_handler()` and `elgg.trigger_hook()` in favor of dedicated `elgg/hooks/register` and `elgg/hooks/trigger` modules. These and other new modules ensure all hooks are registered before being triggered:

Plugins should register inside boot modules, named `boot/<plugin_id>`. The trigger module depends on a new `elgg/booted` module, which loads and initializes all plugin boot modules in priority order, then triggers the system hooks.

Plugin boot modules return an instance of `elgg/Plugin`.

Formally deprecates the `boot, system` hook.

Fixes #7926
