### PR TITLE
fix(site_notifications): no ajax error without reason on auto-deletion of site notifications

### DIFF
--- a/mod/site_notifications/views/default/js/site_notifications.php
+++ b/mod/site_notifications/views/default/js/site_notifications.php
@@ -48,10 +48,20 @@ elgg.site_notifications.delete = function(event) {
  * @return void
  */
 elgg.site_notifications.auto_delete = function(event) {
-	var id = $(this).attr('id');
-	id = id.replace("link", "delete");
-	elgg.action($('#' + id).attr('href'), {});
-}
+	var href = this.href;
+	var id = this.id.replace("link", "delete");
+
+	require(['elgg/spinner'], function (spinner) {
+		elgg.action($('#' + id).prop('href'), {
+			beforeSend: spinner.start,
+			complete: function() {
+				location.href = href;
+			}
+		});
+	});
+
+	return false;
+};
 
 /**
  * Toggle the checkboxes in the site notification listing


### PR DESCRIPTION
This problem occurs both on 1.X and 2.X. Further discussion see https://github.com/Elgg/Elgg/issues/8413.

I think this fix is more a workaround to stop the error from showing up specifically on auto-deletion of site notifications. But the problem might be caused rather by a default error option being added in elgg.ajax.handleOptions in ajax.js. If you don't provide your own error option or if you don't return success = true specifially the error would does occur in other cases, too.
