### PR TITLE
feature(js): adds plugin boot modules and modules based on system events

### DIFF
--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -191,6 +191,54 @@ Some things to note
 #. Return the value of the module instead of adding to a global variable.
 #. Static (.js,.css,etc.) files are automatically minified and cached by Elgg's simplecache system.
 
+Booting your plugin
+===================
+
+To add functionality to each page, or make sure your hook handlers are registered early enough, you may create a boot module for your plugin, with the name ``boot/<plugin_id>``.
+
+.. code-block:: javascript
+
+    // in views/default/boot/example.js
+
+    define(function(require) {
+        var elgg = require("elgg");
+        var Plugin = require("elgg/Plugin");
+
+        // plugin logic
+        function my_init() { ... }
+
+        return new Plugin({
+            // executed in order of plugin priority
+            init: function () {
+                elgg.register_hook_handler("init", "system", my_init, 400);
+            }
+        });
+    });
+
+When your plugin is active, this module will automatically be loaded on each page. Other modules can depend on ``elgg/init`` to make sure all boot modules are loaded.
+
+Each boot module **must** return an instance of ``elgg/Plugin``. The constructor must receive an object with a function in the ``init`` key. The ``init`` function will be called in the order of the plugin in Elgg's admin area.
+
+.. note:: Though not strictly necessary, you may want to use the ``init, system`` event to control when your initialization code runs with respect to other modules.
+
+.. warning:: A boot module **cannot** depend on the modules ``elgg/init`` or ``elgg/ready``.
+
+
+The elgg/init module
+--------------------
+
+``elgg/init`` loads and initializes all boot modules in priority order and triggers the [init, system] hook.
+
+Require this module to make sure all plugins are ready.
+
+
+The elgg/ready module
+---------------------
+
+``elgg/ready`` loads and initializes all plugin boot modules in priority order.
+
+Require this module to make sure all plugins are ready.
+
 
 Migrating JS from Elgg 1.8 to AMD / 1.9
 =======================================
@@ -297,8 +345,7 @@ Parse a URL into its component parts:
    //   path: "/file.php",
    //   query: "arg=val"
    // }
-   elgg.parse_url(
-     'http://community.elgg.org/file.php?arg=val#fragment');
+   elgg.parse_url('http://community.elgg.org/file.php?arg=val#fragment');
 
 
 ``elgg.get_page_owner_guid()``
@@ -308,29 +355,36 @@ Get the GUID of the current page's owner.
 
 ``elgg.register_hook_handler()``
 
-Register a hook handler with the event system.
+Register a hook handler with the event system. For best results, do this in a plugin boot module.
 
-.. code:: js
+.. code-block:: js
 
-    // old initialization style
-    elgg.register_hook_handler('init', 'system', my_plugin.init);
-
-    // new: AMD module
+    // boot module: /views/default/boot/example.js
     define(function (require) {
         var elgg = require('elgg');
+        var Plugin = require('elgg/Plugin');
 
-        // [init, system] has fired
+        elgg.register_hook_handler('foo', 'bar', function () { ... });
+
+        return new Plugin();
     });
 
 
 ``elgg.trigger_hook()``
 
-Emit a hook event in the event system.
+Emit a hook event in the event system. For best results depend on the elgg/init module.
 
-.. code:: js
+.. code-block:: js
 
-    // allow other plugins to alter value
+    // old
     value = elgg.trigger_hook('my_plugin:filter', 'value', {}, value);
+
+    define(function (require) {
+        require('elgg/init');
+        var elgg = require('elgg');
+
+        value = elgg.trigger_hook('my_plugin:filter', 'value', {}, value);
+    });
 
 
 ``elgg.security.refreshToken()``
@@ -426,26 +480,34 @@ The ``elgg/spinner`` module can be used to create an Ajax loading indicator fixe
 Hooks
 -----
 
-The JS engine has a hooks system similar to the PHP engine's plugin hooks: hooks are triggered and plugins can register callbacks to react or alter information. There is no concept of Elgg events in the JS engine; everything in the JS engine is implemented as a hook.
+The JS engine has a hooks system similar to the PHP engine's plugin hooks: hooks are triggered and plugins can register functions to react or alter information. There is no concept of Elgg events in the JS engine; everything in the JS engine is implemented as a hook.
 
-Registering a callback to a hook
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Registering hook handlers
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Callbacks are registered using ``elgg.register_hook_handler()``. Multiple callbacks can be registered for the same hook.
+Handler functions are registered using ``elgg.register_hook_handler()``. Multiple handlers can be registered for the same hook.
 
-The following example registers the ``elgg.ui.initDatePicker`` callback for the *init*, *system* event. Note that a difference in the JS engine is that instead of passing a string you pass the function itself to ``elgg.register_hook_handler()`` as the callback.
+The following example registers the ``handleFoo`` function for the ``foo, bar`` hook.
 
-.. code:: javascript
+.. code-block:: javascript
 
-   elgg.provide('elgg.ui.initDatePicker');
-   elgg.ui.initDatePicker = function() { ... }
-   
-   elgg.register_hook_handler('init', 'system', elgg.ui.initDatePicker);
+    define(function (require) {
+        var elgg = require('elgg');
+        var Plugin = require('elgg/Plugin');
 
-The callback
-^^^^^^^^^^^^
+        function handleFoo(hook, type, params, value) {
+            // do something
+        }
 
-The callback accepts 4 arguments:
+        elgg.register_hook_handler('foo', 'bar', handleFoo);
+
+        return new Plugin();
+   });
+
+The handler function
+^^^^^^^^^^^^^^^^^^^^
+
+The handler will receive 4 arguments:
 
 - **hook** - The hook name
 - **type** - The hook type
@@ -461,16 +523,26 @@ Plugins can trigger their own hooks:
 
 .. code:: javascript
 
-   elgg.hook.trigger_hook('name', 'type', {params}, "value");
+    define(function(require) {
+        require('elgg/init');
+        var elgg = require('elgg');
+
+        elgg.trigger_hook('name', 'type', {params}, "value");
+    });
+
+.. note:: Be aware of timing. If you don't depend on elgg/init, other plugins may not have had a chance to register their handlers.
 
 Available hooks
 ^^^^^^^^^^^^^^^
 
-init, system
-   This hook is fired when the JS system is ready. Plugins should register their init functions for this hook.
+**init, system**
+    Plugins should register their init functions for this hook. It is fired after Elgg's JS is loaded and all plugin boot modules have been initialized. Depend on the ``elgg/init`` module to be sure this has completed.
 
-ready, system
-   This hook is fired when the system has fully booted.
+**ready, system**
+    This hook is fired when the system has fully booted (after init). Depend on the ``elgg/ready`` module to be sure this has completed.
 
-getOptions, ui.popup
-   This hook is fired for pop up displays ("rel"="popup") and allows for customized placement options.
+**getOptions, ui.popup**
+    This hook is fired for pop up displays (``"rel"="popup"``) and allows for customized placement options.
+
+**config, ckeditor**
+    This filters the CKEditor config object. Register for this hook in a plugin boot module. The defaults can be seen in the module ``elgg/ckeditor/config``.

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1599,6 +1599,10 @@ function elgg_views_boot() {
 	elgg_register_css('elgg', elgg_get_simplecache_url('elgg.css'));
 	elgg_load_css('elgg');
 
+	elgg_register_simplecache_view('elgg/init.js');
+	elgg_require_js('elgg/init');
+	elgg_require_js('elgg/ready');
+
 	// optional stuff
 	elgg_register_js('lightbox', elgg_get_simplecache_url('lightbox.js'));
 	elgg_register_css('lightbox', elgg_get_simplecache_url('lightbox/elgg-colorbox-theme/colorbox.css'));

--- a/js/lib/elgglib.js
+++ b/js/lib/elgglib.js
@@ -422,9 +422,9 @@ elgg.forward = function(url) {
 /**
  * Parse a URL into its parts. Mimicks http://php.net/parse_url
  *
- * @param {String} url       The URL to parse
- * @param {Int}    component A component to return
- * @param {Bool}   expand    Expand the query into an object? Else it's a string.
+ * @param {String}  url       The URL to parse
+ * @param {Number}  component A component to return
+ * @param {Boolean} expand    Expand the query into an object? Else it's a string.
  *
  * @return {Object} The parsed URL
  */
@@ -562,7 +562,7 @@ elgg.getSelectorFromUrlFragment = function(url) {
  *
  * @param {Object} object The object to add to
  * @param {String} parent The parent array to add to.
- * @param {Mixed}  value  The value
+ * @param {*}      value  The value
  */
 elgg.push_to_object_array = function(object, parent, value) {
 	elgg.assertTypeOf('object', object);
@@ -584,7 +584,7 @@ elgg.push_to_object_array = function(object, parent, value) {
  *
  * @param {Object} object The object to add to
  * @param {String} parent The parent array to add to.
- * @param {Mixed}  value  The value
+ * @param {*}      value  The value
  */
 elgg.is_in_object_array = function(object, parent, value) {
 	elgg.assertTypeOf('object', object);

--- a/js/lib/hooks.js
+++ b/js/lib/hooks.js
@@ -9,6 +9,8 @@ elgg.provide('elgg.config.triggered_hooks');
 /**
  * Registers a hook handler with the event system.
  *
+ * For best results, depend on the elgg/ready module, so plugins will have been booted.
+ *
  * The special keyword "all" can be used for either the name or the type or both
  * and means to call that handler for all of those hooks.
  *
@@ -19,7 +21,7 @@ elgg.provide('elgg.config.triggered_hooks');
  * @param {String}   type     Type of the event to register for
  * @param {Function} handler  Handle to call
  * @param {Number}   priority Priority to call the event handler
- * @return {Bool}
+ * @return {Boolean}
  */
 elgg.register_hook_handler = function(name, type, handler, priority) {
 	elgg.assertTypeOf('string', name);
@@ -68,7 +70,7 @@ elgg.register_hook_handler = function(name, type, handler, priority) {
  * @param {Object} params Optional parameters to pass to the handlers
  * @param {Object} value  Initial value of the return. Can be mangled by handlers
  *
- * @return {Bool}
+ * @return {Boolean}
  */
 elgg.trigger_hook = function(name, type, params, value) {
 	elgg.assertTypeOf('string', name);
@@ -132,7 +134,7 @@ elgg.trigger_hook = function(name, type, params, value) {
  *
  * @param {String} name The hook name.
  * @param {String} type The hook type.
- * @return {Int}
+ * @return {Number} integer
  */
 elgg.register_instant_hook = function(name, type) {
 	elgg.assertTypeOf('string', name);

--- a/js/tests/ElggHooksTest.js
+++ b/js/tests/ElggHooksTest.js
@@ -48,4 +48,30 @@ define(function(require) {
 			});
 		});
 	});
+
+	// note elgg/init and a fake boot module are defined in prepare.js
+	describe("elgg/ready", function() {
+		it("requires init (boots plugins and fires init) and fires ready", function(done) {
+			elgg._test_signals = [];
+
+			require(['elgg/ready'], function () {
+				expect(elgg._test_signals).toEqual([
+					'boot/example define',
+
+					// boot Plugin inits are called
+					'boot/example init',
+
+					// init, system fired
+					'boot/example init,system',
+
+					// ready, system fired
+					'boot/example ready,system'
+				]);
+
+				delete(elgg._test_signals);
+
+				done();
+			});
+		});
+	});
 });

--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -13,6 +13,8 @@ module.exports = function(config) {
 
 		// list of files / patterns to load in the browser
 		files: [
+			'js/tests/prepare.js',
+
 			'vendor/bower-asset/jquery/dist/jquery.js',
 			'bower_components/sprintf/src/sprintf.js',
 			'js/lib/elgglib.js',
@@ -23,7 +25,7 @@ module.exports = function(config) {
 			{pattern:'js/tests/*Test.js',included: false},
 			{pattern:'views/default/**/*.js',included:false},
 
-			'js/tests/requirejs.config.js',
+			'js/tests/requirejs.config.js'
 		],
 
 

--- a/js/tests/prepare.js
+++ b/js/tests/prepare.js
@@ -1,0 +1,39 @@
+// These modules are typically built in PHP. We can't do that with the test runner.
+
+var elgg = elgg || {};
+
+define('elgg', function() {
+	return elgg;
+});
+
+// for ElggHooksTest.js
+define('boot/example', function(require) {
+	var elgg = require('elgg');
+	var Plugin = require('elgg/Plugin');
+
+	elgg._test_signals.push('boot/example define');
+
+	elgg.register_hook_handler('init', 'system', function() {
+		elgg._test_signals.push('boot/example init,system');
+	});
+	elgg.register_hook_handler('ready', 'system', function() {
+		elgg._test_signals.push('boot/example ready,system');
+	});
+
+	return new Plugin({
+		init: function () {
+			elgg._test_signals.push('boot/example init');
+		}
+	});
+});
+
+// for ElggHooksTest.js
+define('elgg/init', function (require) {
+	var elgg = require('elgg');
+	var plugin = require('boot/example');
+
+	console.log(plugin);
+	plugin._init();
+
+	elgg.trigger_hook('init', 'system');
+});

--- a/js/tests/requirejs.config.js
+++ b/js/tests/requirejs.config.js
@@ -18,7 +18,3 @@ requirejs.config({
     // start test run, once Require.js is done
     callback: window.__karma__.start
 });
-
-// This module is typically built in PHP. We can't do that with the test runner.
-define('elgg', function() { return elgg; });
-

--- a/mod/ckeditor/views/default/elgg/ckeditor.js
+++ b/mod/ckeditor/views/default/elgg/ckeditor.js
@@ -1,7 +1,9 @@
 define(function(require) {
 	var elgg = require('elgg');
-	var $ = require('jquery'); require('jquery.ckeditor');
+	var $ = require('jquery');
+	require('jquery.ckeditor');
 	var CKEDITOR = require('ckeditor');
+	var config = require('elgg/ckeditor/config');
 
 	CKEDITOR.plugins.addExternal('blockimagepaste', elgg.get_simplecache_url('elgg/ckeditor/blockimagepaste.js'), '');
 	
@@ -73,8 +75,7 @@ define(function(require) {
 		 * You can find configuration information here:
 		 * http://docs.ckeditor.com/#!/api/CKEDITOR.config
 		 */
-		config: require('elgg/ckeditor/config')
-
+		config: config
 	};
 
 	CKEDITOR.on('instanceReady', elggCKEditor.fixImageAttributes);

--- a/mod/ckeditor/views/default/elgg/ckeditor/config.js
+++ b/mod/ckeditor/views/default/elgg/ckeditor/config.js
@@ -1,12 +1,13 @@
 define(function(require) {
+	require('elgg/init');
 	var elgg = require('elgg');
 	var $ = require('jquery');
 
-	return {
+	return elgg.trigger_hook('config', 'ckeditor', null, {
 		toolbar: [['Bold', 'Italic', 'Underline', 'RemoveFormat'], ['Strike', 'NumberedList', 'BulletedList', 'Undo', 'Redo', 'Link', 'Unlink', 'Image', 'Blockquote', 'Paste', 'PasteFromWord', 'Maximize']],
 		removeButtons: 'Subscript,Superscript', // To have Underline back
 		allowedContent: true,
-		baseHref: elgg.config.wwwroot,
+		baseHref: elgg.get_site_url(),
 		removePlugins: 'liststyle,contextmenu,tabletools,resize',
 		extraPlugins: 'blockimagepaste',
 		defaultLanguage: 'en',
@@ -18,5 +19,5 @@ define(function(require) {
 		disableNativeTableHandles: false,
 		removeDialogTabs: 'image:advanced;image:Link;link:advanced;link:target',
 		autoGrow_maxHeight: $(window).height() - 100
-	};
+	});
 });

--- a/mod/messages/views/default/messages/js.php
+++ b/mod/messages/views/default/messages/js.php
@@ -1,4 +1,4 @@
-
+//<script>
 // messages plugin toggle
 elgg.register_hook_handler('init', 'system', function() {
 	$("#messages-toggle").click(function() {

--- a/mod/profile/views/default/profile/js.php
+++ b/mod/profile/views/default/profile/js.php
@@ -1,4 +1,4 @@
-
+//<script>
 // force the first column to at least be as large as the profile box in cols 2 and 3
 // we also want to run before the widget init happens so priority is < 500
 elgg.register_hook_handler('init', 'system', function() {

--- a/mod/site_notifications/views/default/site_notifications.js
+++ b/mod/site_notifications/views/default/site_notifications.js
@@ -35,7 +35,7 @@ elgg.site_notifications.delete = function(event) {
 	});
 
 	event.preventDefault();
-}
+};
 
 /**
  * Delete notification for this link

--- a/views/default/elgg.js.php
+++ b/views/default/elgg.js.php
@@ -79,11 +79,6 @@ define('jquery-ui/datepicker', jQuery.datepicker);
 define('elgg', ['jquery', 'languages/' + elgg.get_language()], function($, translations) {
 	elgg.add_translation(elgg.get_language(), translations);
 
-	$(function() {
-		elgg.trigger_hook('init', 'system');
-		elgg.trigger_hook('ready', 'system');
-	});
-
 	return elgg;
 });
 

--- a/views/default/elgg/Plugin.js
+++ b/views/default/elgg/Plugin.js
@@ -1,0 +1,33 @@
+/**
+ * If your plugin has a boot module, it must return an instance of the class defined by
+ * this module.
+ */
+define(function (require) {
+
+	/**
+	 * Constructor
+	 *
+	 * @param {Object} spec Specification object with keys:
+	 *
+	 *     init: {Function} optional function called in plugin order in the elgg/init module,
+	 *
+	 * @constructor
+	 */
+	function Plugin(spec) {
+		spec = spec || {};
+
+		/**
+		 * This is called by elgg/init to initialize the plugin. Do not use.
+		 *
+		 * @access private
+		 * @internal
+		 */
+		this._init = function () {
+			if (spec.init) {
+				spec.init();
+			}
+		};
+	}
+
+	return Plugin;
+});

--- a/views/default/elgg/UserPicker.js
+++ b/views/default/elgg/UserPicker.js
@@ -1,6 +1,10 @@
 /** @module elgg/UserPicker */
 
-define(['jquery', 'elgg', 'jquery.ui.autocomplete.html'], function ($, elgg) {
+define(function(require) {
+	var $ = require('jquery');
+	var elgg = require('elgg');
+	require('jquery.ui.autocomplete.html');
+
 	/**
 	 * @param {HTMLElement} wrapper outer div
 	 * @constructor

--- a/views/default/elgg/init.js.php
+++ b/views/default/elgg/init.js.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Boot all the plugins and trigger the [init, system] hook
+ *
+ * Depend on this module to guarantee all [init, system] handlers have been called
+ */
+
+$modules = [];
+foreach (elgg_get_plugins() as $plugin) {
+	$id = $plugin->getID();
+	if (elgg_view_exists("boot/$id.js")) {
+		$modules[] = "boot/$id";
+	}
+}
+
+?>
+//<script>
+define(function (require) {
+	var Plugin = require('elgg/Plugin');
+	var elgg = require('elgg');
+
+	var modules = [];
+	var i;
+
+	// We need literal require('boot/example'); statements. We can't use async require in here because we promise to
+	// not return this module until all boot plugins are loaded.
+<?php foreach ($modules as $name) { ?>
+	modules.push({
+		plugin: require(<?= json_encode($name, JSON_UNESCAPED_SLASHES) ?>),
+		name: <?= json_encode($name, JSON_UNESCAPED_SLASHES) ?>
+	});
+<?php } ?>
+
+	for (i = 0; i < modules.length; i++) {
+		if (modules[i].plugin instanceof Plugin) {
+			modules[i].plugin._init();
+		} else {
+			console.error("Boot module boot/" + modules[i].name + " did not return an instance of Plugin (from elgg/Plugin)");
+		}
+	}
+
+	elgg.trigger_hook('init', 'system');
+});

--- a/views/default/elgg/ready.js
+++ b/views/default/elgg/ready.js
@@ -1,0 +1,12 @@
+/**
+ * Trigger the [ready, system] hook
+ *
+ * Depend on this module to guarantee all [ready, system] handlers have been called
+ *
+ */
+define(function(require) {
+	var elgg = require('elgg');
+	require('elgg/init');
+
+	elgg.trigger_hook('ready', 'system');
+});


### PR DESCRIPTION
To reduce race conditions, plugins can create boot modules, named like `boot/<plugin_id>`. All these modules are loaded before the `init, system` hook. Registering for plugin hooks should be done inside these.

Depending on the new `elgg/init` module ensures your code runs after this process.

Similarly, you can depend on the new `elgg/ready` module to ensure all ready hooks have been called.

Plugin boot modules return an instance of `elgg/Plugin`.

A new hook `config, ckeditor` now filters the CKEditor config object, and plugins can reliably register for it in a boot module.

Fixes #7131
Fixes #7926
