### PR TITLE
chore(css): provides missing UI class to hide Aria message

### DIFF
--- a/mod/aalborg_theme/views/default/elements/forms.css.php
+++ b/mod/aalborg_theme/views/default/elements/forms.css.php
@@ -250,6 +250,16 @@ select {
 	background-color: #EEE;
 	display: block;
 }
+.ui-helper-hidden-accessible {
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+}
 
 /* ***************************************
 	USER PICKER

--- a/views/default/admin.css.php
+++ b/views/default/admin.css.php
@@ -681,6 +681,16 @@ select {
 	background-color: #eee;
 	display: block;
 }
+.ui-helper-hidden-accessible {
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+}
 
 /* ***************************************
 	USER PICKER

--- a/views/default/elements/forms.css.php
+++ b/views/default/elements/forms.css.php
@@ -258,6 +258,16 @@ input[type="radio"] {
 	background-color: #eee;
 	display: block;
 }
+.ui-helper-hidden-accessible {
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+}
 
 /* ***************************************
 	USER PICKER


### PR DESCRIPTION
We have a newer jQuery UI version that uses this class, but it wasn't in our CSS.

Fixes #8782
