### PR TITLE
chore(docs): reduce ambiguity in use of variable names in reference t…

### DIFF
--- a/engine/classes/Elgg/Database/AccessCollections.php
+++ b/engine/classes/Elgg/Database/AccessCollections.php
@@ -722,28 +722,28 @@ class AccessCollections {
 	}
 	
 	/**
-	 * Get all of members of an access collection
-	 *
-	 * @param int  $collection The collection's ID
-	 * @param bool $idonly     If set to true, will only return the members' GUIDs (default: false)
-	 *
-	 * @return \ElggUser[]|int[]|false guids or entities if successful, false if not
-	 */
-	function getMembers($collection, $idonly = false) {
-		$collection = (int)$collection;
+	* Get all of members of an access collection
+	*
+	* @param int  $collection_id The collection's ID
+	* @param bool $guids_only    If set to true, will only return the members' GUIDs (default: false)
+	*
+	* @return ElggUser[]|int[]|false guids or entities if successful, false if not
+	*/
+	function getMembers($collection_id, $guids_only = false) {
+		$collection_id = (int) $collection_id;
 
 		$db = _elgg_services()->db;
 		$prefix = $db->getTablePrefix();
 
-		if (!$idonly) {
+		if (!$guids_only) {
 			$query = "SELECT e.* FROM {$prefix}access_collection_membership m"
 				. " JOIN {$prefix}entities e ON e.guid = m.user_guid"
-				. " WHERE m.access_collection_id = {$collection}";
+				. " WHERE m.access_collection_id = {$collection_id}";
 			$collection_members = $db->getData($query, "entity_row_to_elggstar");
 		} else {
 			$query = "SELECT e.guid FROM {$prefix}access_collection_membership m"
 				. " JOIN {$prefix}entities e ON e.guid = m.user_guid"
-				. " WHERE m.access_collection_id = {$collection}";
+				. " WHERE m.access_collection_id = {$collection_id}";
 			$collection_members = $db->getData($query);
 			if (!$collection_members) {
 				return false;

--- a/engine/lib/access.php
+++ b/engine/lib/access.php
@@ -409,14 +409,14 @@ function get_user_access_collections($owner_guid, $site_guid = 0) {
 /**
  * Get all of members of an access collection
  *
- * @param int  $collection The collection's ID
- * @param bool $idonly     If set to true, will only return the members' GUIDs (default: false)
+ * @param int  $collection_id The collection's ID
+ * @param bool $guids_only    If set to true, will only return the members' GUIDs (default: false)
  *
  * @return ElggUser[]|int[]|false guids or entities if successful, false if not
  * @see add_user_to_access_collection()
  */
-function get_members_of_access_collection($collection, $idonly = false) {
-	return _elgg_services()->accessCollections->getMembers($collection, $idonly);
+function get_members_of_access_collection($collection_id, $guids_only = false) {
+	return _elgg_services()->accessCollections->getMembers($collection_id, $guids_only);
 }
 
 /**


### PR DESCRIPTION
…o access collections

Replaces variable names to reduce ambiguity. Uses collection_id to refer to the collection ID (in stead of collection),
and guids_only to refer to member guids (in stead of idonly)
