### PR TITLE
fix(files): make sure method is callable on a concrete object instance

### DIFF
--- a/engine/classes/ElggFile.php
+++ b/engine/classes/ElggFile.php
@@ -133,7 +133,8 @@ class ElggFile extends \ElggObject {
 	 * @todo Move this out into a utility class
 	 */
 	public function detectMimeType($file = null, $default = null) {
-		if (!$file && isset($this)) {
+		$class = __CLASS__;
+		if (!$file && isset($this) && $this instanceof $class) {
 			$file = $this->getFilenameOnFilestore();
 		}
 
@@ -156,7 +157,7 @@ class ElggFile extends \ElggObject {
 			$mime = mime_content_type($file);
 		}
 
-		$original_filename = isset($this) ? $this->originalfilename : basename($file);
+		$original_filename = isset($this) && $this instanceof $class ? $this->originalfilename : basename($file);
 		$params = array(
 			'filename' => $file,
 			'original_filename' => $original_filename, // @see file upload action

--- a/engine/tests/ElggCoreFilestoreTest.php
+++ b/engine/tests/ElggCoreFilestoreTest.php
@@ -97,6 +97,40 @@ class ElggCoreFilestoreTest extends \ElggCoreUnitTest {
 		}
 	}
 
+	function testDetectMimeType() {
+
+		$user = $this->createTestUser();
+
+		$file = new \ElggFile();
+		$file->owner_guid = $user->guid;
+		$file->setFilename('testing/filestore.txt');
+		$file->open('write');
+		$file->write('Testing!');
+		$file->close();
+
+		$mime = $file->detectMimeType(null, 'text/plain');
+
+		// mime should not be null if default is set
+		$this->assertTrue(isset($mime));
+
+		// mime of a file object should match mime of a file path that represents this file on filestore
+		$resource_mime = $file->detectMimeType($file->getFilenameOnFilestore(), 'text/plain');
+		$this->assertIdentical($mime, $resource_mime);
+
+		// calling detectMimeType statically raises strict policy warning
+		// @todo: remove this once a new static method has been implemented
+		error_reporting(E_ALL & ~E_STRICT & ~E_DEPRECATED);
+		
+		// method output should not differ between a static and a concrete call if the file path is set
+		$resource_mime_static = \ElggFile::detectMimeType($file->getFilenameOnFilestore(), 'text/plain');
+		$this->assertIdentical($resource_mime, $resource_mime_static);
+
+		error_reporting(E_ALL);
+
+		$user->delete();
+
+	}
+
 	protected function createTestUser($username = 'fileTest') {
 		$user = new \ElggUser();
 		$user->username = $username;


### PR DESCRIPTION
PHP treats $this as an instance of a calling class when ElggFile::detectMimeType is called
statically.

Fixes #9010 
