### PR TITLE
chore(tests): prevent strict warnings in PHPUnit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",
+        "sebastian/global-state": "1.0",
         "elgg/sniffs": "dev-master",
         "squizlabs/php_codesniffer": "~1.5",
         "simpletest/simpletest": "~1.1",


### PR DESCRIPTION
Fixes #9017
