### PR TITLE
chore(tests): works around bug in recent PHPUnit component update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",
+        "sebastian/global-state": "1.0",
         "elgg/sniffs": "dev-master",
         "squizlabs/php_codesniffer": "~1.5",
         "simpletest/simpletest": "~1.1"


### PR DESCRIPTION
The global-state component 1.1.0 update causes the global vars $_ELGG and $CONFIG to be removed after the first test method in the suite. 
https://github.com/sebastianbergmann/global-state/issues/5

Once a fixed version is tagged we can remove this line.

Fixes #9017
