### PR TITLE
feature(i18n): Adds asynchronous client-side translation

### DIFF
--- a/docs/guides/i18n.rst
+++ b/docs/guides/i18n.rst
@@ -3,7 +3,7 @@ Internationalization
 
 Make your UI translatable into many different languages.
 
-If you’d like to contribute translations to Elgg, see :doc:`the contributors' guide </about/contributing>`.
+If you'd like to contribute translations to Elgg, see :doc:`the contributors' guide </about/contributing>`.
 
 The default language is ``en`` for English. Currently Elgg will always fall back to an English translation,
 even if the site's language is not English; this is a known bug.
@@ -21,10 +21,12 @@ Translations are stored in PHP files in the ``/languages`` directory of your plu
 		'example:text' => 'Some example text',
 	];
 
+The default language is "en" for English.
+
 To override an existing translation, include it in your plugin's language file, and make sure your plugin is
 ordered later on the Admin > Plugins page:
 
-.. code:: php
+.. code-block:: php
 
 	<?php // mod/better_example/languages/en.php
 
@@ -35,6 +37,24 @@ ordered later on the Admin > Plugins page:
 .. note::
 
     Unless you are overriding core's or another plugin's language strings, it is good practice for the language keys to start with your plugin name. For example: ``yourplugin:success``, ``yourplugin:title``, etc. This helps avoid conflicts with other language keys.
+
+.. warning:: Do not use spaces in your language keys. The JS API does not support them fully.
+
+Optimized client-side loading
+-----------------------------
+
+Elgg plans to optimize client-side language loading in the future. Plugins may prepare for this by providing a list of language keys that are likely to be needed (via ``elgg/echo``) on the home page or other common URLs.
+
+.. code-block:: php
+
+    <?php // in mod/example/elgg-plugin.php
+
+    return [
+        'home_language_keys' => [
+            'example:home:welcome',
+            'example:home:intro',
+        ],
+    ];
 
 Server-side API
 ===============
@@ -83,18 +103,66 @@ To first test whether ``elgg_echo()`` can find a translation:
 Javascript API
 ==============
 
-``elgg.echo(key, args)``
+This RequireJS plugin ``elgg/echo`` allows loading translations like AMD modules. To translate, register a dependency with the name ``elgg/echo!{key_name}``. The returned module will be a translator function similar to PHP's ``elgg_echo``, but with only the ``args`` argument.:
 
-This function is like ``elgg_echo`` in PHP.
+.. code-block:: javascript
 
-Client-side translations are loaded asynchronously. Ensure translations are available by requiring the "elgg" AMD module:
+	define(function(require) {
+		var intro = require("elgg/echo!example:intro");
+		var hello = require("elgg/echo!example:hello");
+
+		alert(intro());
+		alert(hello(["World"]));
+	});
+
+
+If you want a specific language, use the module name ``elgg/echo!{key_name}!{lang}``:
+
+.. code-block:: javascript
+
+	define(function(require) {
+		var hello = require("elgg/echo!example:hello!es");
+
+		alert(hello(["World"])); // ¡Hola, World!
+	});
+
+
+Like other modules, translators can be loaded on demand:
+
+.. code-block:: javascript
+
+	// in an Ajax success function...
+
+	require(["elgg/echo!example:great"], function(great) {
+		alert(great());
+	});
+
+Like ``elgg_echo``, translators for non-existent keys will return the key, but you can also directly test whether the key was found:
+
+.. code-block:: javascript
+
+	define(function(require) {
+		var lol = require("elgg/echo!nonexistentkey");
+
+		console.log(lol.found); // false
+	});
+
+.. warning:: Spaces should not be used in language keys and are not supported fully in this API.
+
+
+Legacy API
+----------
+
+``elgg.echo(key, args, language)`` is like ``elgg_echo`` in PHP, but is deprecated in favor of the ``elgg/echo`` module.
+
+Always require the "elgg" AMD module before working with ``elgg.echo``:
 
 .. code-block:: javascript
 
 	define(function(require) {
 		var elgg = require("elgg");
 
-		alert(elgg.echo('my_key'));
+		alert(elgg.echo('intro'));
 	});
 
 Translations are also available after the ``init, system`` JavaScript event.

--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -37,10 +37,10 @@ Here we define a basic module that alters the page, by passing a "definition fun
     // in views/default/myplugin/say_hello.js
 
     define(function(require) {
-        var elgg = require("elgg");
+        var hello_world = require("elgg/echo!hello_world");
         var $ = require("jquery");
 
-        $('body').append(elgg.echo('hello_world'));
+        $('body').append(hello_world());
     });
 
 The module's name is determined by the view name, which here is ``myplugin/say_hello.js``.
@@ -61,9 +61,9 @@ the greeting:
     // in views/default/myplugin/hello.js
 
     define(function(require) {
-        var elgg = require("elgg");
+        var hello_world = require("elgg/echo!hello_world");
 
-        return elgg.echo('hello_world');
+        return hello_world();
     });
 
 .. code-block:: javascript
@@ -269,13 +269,25 @@ You must depend on these modules to use ``$`` or ``$.ui`` methods. In the future
 Module ``elgg``
 ---------------
 
-``elgg.echo()``
+The ``elgg/echo`` module
 
 Translate interface text
 
 .. code:: js
 
-   elgg.echo('example:text', ['arg1']);
+    require(['elgg/echo!example:text'], function(example_text) {
+        alert(example_text());
+    });
+
+The functions below all require the ``elgg`` AMD module:
+
+.. code:: js
+
+    define(function(require) {
+        var elgg = require('elgg');
+
+        // stuff with elgg
+    });
 
 
 ``elgg.system_message()``
@@ -284,8 +296,7 @@ Display a status message to the user.
 
 .. code:: js
 
-   elgg.system_message(elgg.echo('success'));
-
+    elgg.system_message(echo_success());
 
 ``elgg.register_error()``
 
@@ -293,7 +304,7 @@ Display an error message to the user.
 
 .. code:: js
 
-   elgg.register_error(elgg.echo('error'));
+    elgg.register_error(echo_error());
 
 
 ``elgg.normalize_url()``
@@ -465,6 +476,11 @@ Module ``elgg/ready``
 
 Require this module to make sure all plugins are ready.
 
+Module ``elgg/echo``
+--------------------
+
+See the :doc:`i18n` page for details.
+
 Module ``elgg/spinner``
 -----------------------
 
@@ -487,7 +503,7 @@ The ``elgg/spinner`` module can be used to create an Ajax loading indicator fixe
 .. note:: The ``elgg/Ajax`` module uses the spinner by default.
 
 Module ``elgg/popup``
------------------------
+---------------------
 
 The ``elgg/popup`` module can be used to display an overlay positioned relatively to its anchor (trigger).
 

--- a/engine/classes/Elgg/Application/CacheHandler.php
+++ b/engine/classes/Elgg/Application/CacheHandler.php
@@ -197,8 +197,8 @@ class CacheHandler {
 	 * @return bool
 	 */
 	protected function isCacheableView($view) {
-		if (preg_match('~^languages/(.*)\.js$~', $view, $m)) {
-			return in_array($m[1],  _elgg_services()->translator->getAllLanguageCodes());
+		if (preg_match('~^languages/(early/|late/)?(.*)\.js$~', $view, $m)) {
+			return in_array($m[2],  _elgg_services()->translator->getAllLanguageCodes());
 		}
 		return _elgg_services()->views->isCacheableView($view);
 	}
@@ -369,9 +369,12 @@ class CacheHandler {
 	protected function renderView($view, $viewtype) {
 		elgg_set_viewtype($viewtype);
 
-		if ($viewtype === 'default' && preg_match("#^languages/(.*?)\\.js$#", $view, $matches)) {
+		if ($viewtype === 'default' && preg_match("#^languages/(early/|late/)?(.*?)\\.js$#", $view, $matches)) {
 			$view = "languages.js";
-			$vars = ['language' => $matches[1]];
+			$vars = ['language' => $matches[2]];
+			if (!empty($matches[1])) {
+				$vars['timing'] = substr($matches[1], 0, -1);
+			}
 		} else {
 			$vars = [];
 		}

--- a/engine/classes/Elgg/I18n/Translator.php
+++ b/engine/classes/Elgg/I18n/Translator.php
@@ -10,6 +10,8 @@ namespace Elgg\I18n;
  */
 class Translator {
 
+	const HOME_LANGUAGE_KEYS = 'home_language_keys';
+
 	/**
 	 * Global Elgg configuration
 	 *
@@ -536,6 +538,47 @@ class Translator {
 		}
 	}
 
+	/**
+	 * Get a list of language keys made available early on the client
+	 *
+	 * In 2.x this is only used if $CONFIG->EXPERIMENTAL_echo_async_only is set to true. This flag
+	 * splits the language keys between "early" and "late" modules, with the early module made a
+	 * dependency of the "elgg" module. The late module will only load if the "elgg/echo" plugin
+	 * can't find a translation. For maximum BC, "elgg/echo" shares its translations with the
+	 * elgg.echo() function.
+	 *
+	 * @return string[]
+	 * @access private
+	 */
+	public function getEarlyKeys() {
+		$keys = [
+			'js:lightbox:current',
+			'previous',
+			'next',
+			'close',
+			'hide',
+			'error',
+			'ajax:error',
+			'confirm',
+			'question:areyousure',
+			'access:comments:change',
+			'deleteconfirm',
+		];
+
+		foreach (elgg_get_plugins() as $plugin) {
+			$config = $plugin->getConfigData();
+			if (!empty($config[self::HOME_LANGUAGE_KEYS]) && is_array($config[self::HOME_LANGUAGE_KEYS])) {
+				foreach ($config[self::HOME_LANGUAGE_KEYS] as $key) {
+					if (is_string($key)) {
+						$keys[] = $key;
+					}
+				}
+			}
+		}
+
+		return array_unique($keys);
+	}
+	
 	/**
 	 * Returns an array of language codes.
 	 *

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -1,4 +1,7 @@
 <?php
+
+use Elgg\Filesystem\Directory\Local;
+
 /**
  * Stores site-side plugin settings as private data.
  *
@@ -767,6 +770,23 @@ class ElggPlugin extends \ElggObject {
 		return true;
 	}
 
+	/**
+	 * Get array data from the plugin's "elgg-plugin.php" file. Returns empty array
+	 * if there's no file.
+	 *
+	 * @return array
+	 * @access private
+	 * @internal
+	 */
+	public function getConfigData() {
+		$file = Local::fromPath($this->getPath())->getFile('elgg-plugin.php');
+		if (!$file->exists()) {
+			return [];
+		}
+
+		$config = $file->includeFile();
+		return is_array($config) ? $config : [];
+	}
 
 	// start helpers
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1776,6 +1776,7 @@ function elgg_views_boot() {
 	elgg_register_css('jquery.imgareaselect', elgg_get_simplecache_url('jquery.imgareaselect.css'));
 
 	elgg_register_ajax_view('languages.js');
+	elgg_require_js('elgg/echo');
 
 	elgg_register_plugin_hook_handler('simplecache:generate', 'js', '_elgg_views_amd');
 	elgg_register_plugin_hook_handler('simplecache:generate', 'css', '_elgg_views_minify');
@@ -1876,6 +1877,12 @@ function _elgg_get_js_site_data() {
 		// refresh token 3 times during its lifetime (in microseconds 1000 * 1/3)
 		'elgg.security.interval' => (int)_elgg_services()->actions->getActionTokenTimeout() * 333,
 		'elgg.config.language' => $language,
+
+		// If this config flag is true, the "elgg" module will depend on a tiny set of translations
+		// and load the rest on demand in the "elgg/echo" module. As the elgg.echo() function is synchronous,
+		// it will fail in some cases in this scenario, so this is setting is not officially supported, but
+		// will be the standard behavior in 3.0. After changing this setting, the simplecache must be flushed.
+		'elgg.config.use_early_language' => (bool)elgg_get_config('EXPERIMENTAL_echo_async_only'),
 	];
 }
 

--- a/js/lib/elgglib.js
+++ b/js/lib/elgglib.js
@@ -401,27 +401,17 @@ elgg.register_error = function(errors, delay) {
 };
 
 /**
- * Logs a notice about use of a deprecated function or capability
+ * Informs admin users via a console message about use of a deprecated function or capability
+ *
  * @param {String} msg         The deprecation message to display
  * @param {String} dep_version The version the function was deprecated for
  * @since 1.9
  */
 elgg.deprecated_notice = function(msg, dep_version) {
 	if (elgg.is_admin_logged_in()) {
-		var parts = elgg.release.split('.');
-		var elgg_major_version = parseInt(parts[0], 10);
-		var elgg_minor_version = parseInt(parts[1], 10);
-		var dep_major_version = Math.floor(dep_version);
-		var dep_minor_version = 10 * (dep_version - dep_major_version);
-
 		msg = "Deprecated in Elgg " + dep_version + ": " + msg;
-
-		if ((dep_major_version < elgg_major_version) || (dep_minor_version < elgg_minor_version)) {
-			elgg.register_error(msg);
-		} else {
-			if (typeof console !== "undefined") {
-				console.warn(msg);
-			}
+		if (typeof console !== "undefined") {
+			console.info(msg);
 		}
 	}
 };

--- a/js/lib/languages.js
+++ b/js/lib/languages.js
@@ -4,8 +4,17 @@
  */
 elgg.provide('elgg.config.translations');
 
+// If set to true, requested language keys will be stored in elgg._echoKeys and you'll
+// get a console message if the "late" translations are requested.
+elgg.config.language_debug = false;
+
 // default language - required by unit tests
 elgg.config.language = 'en';
+
+// this is set just before the elgg module is defined and lets the elgg/echo module
+// know which language module was depended on.
+elgg.config.initial_language_module = null;
+elgg.config.use_early_language = false;
 
 /**
  * Analagous to the php version.  Merges translations for a
@@ -44,12 +53,34 @@ elgg.get_language = function() {
  * @param {String} language Requested language. Not recommended (see above).
  *
  * @return {String} The translation or the given key if no translation available
+ * @deprecated Use the elgg/echo module
  */
 elgg.echo = function(key, argv, language) {
+	if (elgg.config.language_debug) {
+		elgg._echoKeys = elgg._echoKeys || {sync:{},async:{}};
+		elgg._echoKeys.sync[key] = true;
+	}
+
 	//elgg.echo('str', 'en')
 	if (elgg.isString(argv)) {
 		language = argv;
 		argv = [];
+	}
+
+	if (elgg.is_admin_logged_in()) {
+		// give example module syntax for usage
+		var code = 'require(';
+		var module = 'elgg/echo!' + key;
+		if (language) {
+			module += '!' + language;
+		}
+		code += JSON.stringify(module) + ')(';
+		if (argv && argv.length) {
+			code += JSON.stringify(argv);
+		}
+		code += ')';
+
+		elgg.deprecated_notice("elgg.echo() is deprecated. Use elgg/echo in your module. E.g. " + code, "2.3");
 	}
 
 	//elgg.echo('str', [...], 'en')

--- a/js/tests/ElggLanguagesTest.js
+++ b/js/tests/ElggLanguagesTest.js
@@ -7,6 +7,63 @@ define(function(require) {
 		afterEach(function() {
 			elgg.config.translations = {};
 		});
+
+		describe("elgg/echo", function() {
+
+			it("can translate without args", function(done) {
+				require([
+					"elgg/echo!next",
+					"elgg/echo!next!en",
+					"elgg/echo!next!es"
+				], function (next, next_en, next_es) {
+					expect(next()).toBe("Next");
+					expect(next.found).toBe(true);
+
+					expect(next_en()).toBe("Next");
+					expect(next_en.found).toBe(true);
+
+					expect(next_es()).toBe("Siguiente");
+					expect(next_es.found).toBe(true);
+					done();
+				});
+			});
+
+			it("can translate with args", function(done) {
+				require([
+					"elgg/echo!js:lightbox:current",
+					"elgg/echo!js:lightbox:current!es" // fallback
+				], function (current, current_es) {
+					expect(current(['one', 'three'])).toBe("image one of three");
+					expect(current.found).toBe(true);
+
+					expect(current_es(['one', 'three'])).toBe("image one of three");
+					expect(current_es.found).toBe(true);
+					done();
+				});
+			});
+
+			it("returns keys that can't be found", function(done) {
+				require(["elgg/echo!nonexistent"], function (nonexistent) {
+					expect(nonexistent()).toBe("nonexistent");
+					expect(nonexistent.found).toBe(false);
+					done();
+				});
+			});
+
+			it("loads late language set", function(done) {
+				require([
+					"elgg/echo!ajax:error",
+					"elgg/echo!ajax:error!es"
+				], function (error, error_es) {
+					expect(error()).toBe("Unexpected error");
+					expect(error.found).toBe(true);
+
+					expect(error_es()).toBe("Error inesperado");
+					expect(error_es.found).toBe(true);
+					done();
+				});
+			});
+		});
 		
 		describe("elgg.echo", function() {
 	
@@ -36,6 +93,31 @@ define(function(require) {
 				});
 
 				expect(elgg.echo('void')).toBe('');
+			});
+
+			it("helps devs to migrate", function () {
+				var tmp_depr = elgg.deprecated_notice,
+					tmp_admin = elgg.is_admin_logged_in,
+					captured;
+
+				elgg.is_admin_logged_in = function () {
+					return true;
+				};
+				elgg.deprecated_notice = function (msg) {
+					captured = msg;
+				};
+
+				elgg.echo('hello');
+				expect(captured).toContain('require("elgg/echo!hello")()');
+
+				elgg.echo('hello', [42]);
+				expect(captured).toContain('require("elgg/echo!hello")([42])');
+
+				elgg.echo('hello', 'es');
+				expect(captured).toContain('require("elgg/echo!hello!es")()');
+
+				elgg.deprecated_notice = tmp_depr;
+				elgg.is_admin_logged_in = tmp_admin;
 			});
 		});
 	});

--- a/js/tests/prepare.js
+++ b/js/tests/prepare.js
@@ -1,5 +1,4 @@
-// These modules are typically built in PHP. We can't do that with the test runner.
-
+// These modules are typically built by PHP on the server. We can't do that with the test runner.
 var elgg = elgg || {};
 
 elgg.config = elgg.config || {};
@@ -39,4 +38,19 @@ define('elgg/init', function (require) {
 	plugin._init();
 
 	elgg.trigger_hook('init', 'system');
+});
+
+define('languages/early/en', {
+	"js:lightbox:current": "image %s of %s",
+	"next": "Next"
+});
+define('languages/late/en', {
+	"ajax:error": "Unexpected error"
+});
+define('languages/early/es', {
+	//'js:lightbox:current': "imagen %s de %s",
+	'next': "Siguiente"
+});
+define('languages/late/es', {
+	"ajax:error": "Error inesperado"
 });

--- a/mod/ckeditor/elgg-plugin.php
+++ b/mod/ckeditor/elgg-plugin.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+	'home_language_keys' => [
+		'ckeditor:html',
+		'ckeditor:visual',
+	],
+];

--- a/mod/developers/elgg-plugin.php
+++ b/mod/developers/elgg-plugin.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+	'home_language_keys' => [
+		'admin:developers:settings',
+	],
+];

--- a/mod/developers/views/default/elgg/dev/amd_monitor.js
+++ b/mod/developers/views/default/elgg/dev/amd_monitor.js
@@ -14,7 +14,7 @@
 				if (!known[name]) {
 					known[name] = 1;
 					count++;
-					console.log(count + ' ' + elgg.echo('developers:amd') + '(' + name + ')', val);
+					console.log(count + ' ' + require('elgg/echo!developers:amd')() + '(' + name + ')', val);
 				}
 			});
 		}

--- a/mod/developers/views/default/elgg/dev/gear.js
+++ b/mod/developers/views/default/elgg/dev/gear.js
@@ -11,7 +11,7 @@ define(function (require) {
 	$(gear_html)
 		.appendTo('body')
 		.find('.elgg-icon')
-		.prop('title', elgg.echo('admin:developers:settings'))
+		.prop('title', require('elgg/echo!admin:developers:settings')())
 		.on('click', function () {
 			$.colorbox({
 				href: elgg.get_site_url() + 'ajax/view/developers/gear_popup',

--- a/mod/reportedcontent/elgg-plugin.php
+++ b/mod/reportedcontent/elgg-plugin.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+	'home_language_keys' => [
+		'reportedcontent:refresh',
+	],
+];

--- a/views/default/elgg.js.php
+++ b/views/default/elgg.js.php
@@ -34,6 +34,19 @@ define('jquery.colorbox');
 // as these modules will be required on each page
 echo elgg_view('elgg/popup.js');
 echo elgg_view('elgg/lightbox.js');
+echo elgg_view('elgg/echo.js');
+
+// in 3.0 mode, inline the "early" language module for the site. This is harmless if
+// it's not the user's language.
+if (elgg_get_config('EXPERIMENTAL_echo_async_only')) {
+	$site_lang = elgg_get_config('language');
+	if ($site_lang) {
+		echo elgg_view('languages.js', [
+			'language' => $site_lang,
+			'timing' => 'early',
+		]);
+	}
+}
 
 $elggDir = \Elgg\Application::elggDir();
 $files = array(
@@ -78,6 +91,12 @@ foreach ($files as $file) {
 $.extend(elgg.data, elgg._data);
 delete elgg._data;
 
+if (elgg.config.use_early_language) {
+	elgg.config.initial_language_module = 'languages/early/' + elgg.get_language();
+} else {
+	elgg.config.initial_language_module = 'languages/' + elgg.get_language();
+}
+
 // jQuery and UI must be loaded sync in 2.x but modules should depend on these AMD modules
 define('jquery', function () {
 	return jQuery;
@@ -89,7 +108,7 @@ define('jquery-ui');
 // "jquery-ui/i18n/datepicker-LANG.min" and these views are mapped in /views.php
 define('jquery-ui/datepicker', jQuery.datepicker);
 
-define('elgg', ['jquery', 'languages/' + elgg.get_language()], function($, translations) {
+define('elgg', ['jquery', elgg.config.initial_language_module], function($, translations) {
 	elgg.add_translation(elgg.get_language(), translations);
 
 	return elgg;

--- a/views/default/elgg/echo.js
+++ b/views/default/elgg/echo.js
@@ -1,0 +1,118 @@
+/**
+ * Returns a "translator" function for an individual message key.
+ *
+ * - require('elgg/echo!{key}') returns a function that outputs the translation for {key} in
+ * the default language.
+ *
+ * - require('elgg/echo!{key}!{lang}') returns a translator for language {lang}.
+ *
+ * The "elgg" module already loads the "languages/{lang}" module, so this module mostly provides a
+ * future-ready asynchronous API to the already-loaded translations.
+ *
+ * We use a named AMD module that is inlined in elgg.js, as this module is
+ * loaded on each page request and we do not want to issue an additional HTTP request
+ *
+ * @module elgg/echo
+ * @since 2.3
+ */
+define('elgg/echo', function(require) {
+
+	// TODO formalize dependency on vsprintf
+	var elgg = require('elgg');
+
+	var default_lang = elgg.get_language();
+
+	function getTranslation(lang, key, callback) {
+		if (elgg.config.language_debug) {
+			// capture requested keys
+			elgg._echoKeys = elgg._echoKeys || {sync:{},async:{}};
+			elgg._echoKeys.async[key] = true;
+		}
+
+		var translations = null;
+		if (elgg.config.translations && elgg.config.translations[lang]) {
+			translations = elgg.config.translations[lang];
+		}
+
+		if (translations && translations.hasOwnProperty(key)) {
+			callback(translations[key]);
+			return;
+		}
+
+		if (elgg.config.initial_language_module == ('languages/' + lang)) {
+			// we've loaded the full translation set and we just don't have this key
+			callback(null);
+			return;
+		}
+
+		/**
+		 * In 3.0 "elgg" will depend on the much smaller "languages/early/{lang}" module initially, and this
+		 * module will request the remaining "languages/late/{lang}" module only when needed.
+		 *
+		 * A site owner may enable the 3.0 behavior via an experimental flag in settings.php. (This mode
+		 * cannot be officially supported, as some uses of elgg.echo() will certainly fail.)
+		 */
+		require(['languages/early/' + lang], function (map) {
+			if (map.hasOwnProperty(key)) {
+				callback(map[key]);
+
+				// to benefit plugins still using elgg.echo, go ahead and merge these when we get them
+				elgg.add_translation(lang, map);
+			} else {
+				require(['languages/late/' + lang], function (map) {
+					if (elgg.config.language_debug) {
+						console.log('key "' + key + '" caused late translations to load');
+					}
+
+					callback(map.hasOwnProperty(key) ? map[key] : null);
+					elgg.add_translation(lang, map);
+				});
+			}
+		});
+	}
+
+	return { // loader plugin http://requirejs.org/docs/plugins.html#apiload
+
+		// this function takes name and calls online when it has the return value
+		load: function(name, req, onload, config) {
+
+			// turn a translation string into a translator function and pass it
+			// to online
+			function makeTranslator(translation) {
+				var f;
+
+				if (null === translation) {
+					f = function() {
+						return name;
+					};
+					f.found = false;
+
+				} else {
+					f = function(args) {
+						return vsprintf(translation, args || []);
+					};
+					f.found = true;
+				}
+
+				onload(f);
+			}
+
+			var lang = default_lang;
+			var m = name.match(/^(.*)!([a-z_]+)$/i);
+			if (m) {
+				name = m[1];
+				lang = m[2];
+			}
+
+			getTranslation(lang, name, function(translation) {
+				if (translation !== null) {
+					return makeTranslator(translation);
+				}
+				if (lang !== default_lang) {
+					return getTranslation(default_lang, name, makeTranslator);
+				}
+				makeTranslator(null);
+			});
+		}
+	};
+});

--- a/views/default/elgg/lightbox.js
+++ b/views/default/elgg/lightbox.js
@@ -27,12 +27,12 @@ define('elgg/lightbox', function (require) {
 
 			// Note: keep these in sync with /views/default/lightbox.js.php
 			var settings = {
-				current: elgg.echo('js:lightbox:current', ['{current}', '{total}']),
-				previous: elgg.echo('previous'),
-				next: elgg.echo('next'),
-				close: elgg.echo('close'),
-				xhrError: elgg.echo('error:default'),
-				imgError: elgg.echo('error:default'),
+				current: require('elgg/echo!js:lightbox:current')(['{current}', '{total}']),
+				previous: require('elgg/echo!previous')(),
+				next: require('elgg/echo!next')(),
+				close: require('elgg/echo!close')(),
+				xhrError: require('elgg/echo!ajax:error')(),
+				imgError: require('elgg/echo!error')(),
 				opacity: 0.5,
 				maxWidth: '100%',
 				// don't move colorbox on small viewports https://github.com/Elgg/Elgg/issues/5312


### PR DESCRIPTION
(unlike the last PR, this does not migrate all core uses of elgg.echo. Thankfully this one passes tests!)

Elgg currently loads over 27K (gzipped) of translations by default, in a separate HTTP request that blocks nearly all modules.

3.0 will load a tiny subset initially (inlined in elgg.js for most users) and load the rest as needed, but plugins must begin converting to an asynchronous API, which this provides as `elgg/echo`. This is a RequireJS plugin that returns translator functions with the key and language preconfigured.

Deprecates `elgg.echo()` and the deprecation message shows you how to rewrite.

Makes the JS deprecation strategy like PHP (console.info, not register_error)

Adds a convention for providing plugin configuration data via `elgg-plugin.php`.

Adds an experimental config flag to enable the 3.0 behavior. For users whose language matches the site's default, this completely eliminates the 27K languages request and instead inlines less than 1K into elgg.js. If set, users should be aware the legacy `elgg.echo()` may fail for some keys.

Fixes #8999
- [ ] rebase, removing `elgg-plugin` stuff as this is in core now.
