### PR TITLE
fix(http): allows sending gzipped JavaScript on nginx < 1.5.4

### DIFF
--- a/install/config/nginx.dist
+++ b/install/config/nginx.dist
@@ -33,6 +33,7 @@ server {
 		text/plain
 		text/x-component
 		application/javascript
+		application/x-javascript
 		application/json
 		application/xml
 		application/rss+xml


### PR DESCRIPTION
Before 1.5.4, nginx sent JavaScript with application/x-javascript. This change allows our config to support both.

See http://stackoverflow.com/questions/21788833/nginx-mime-types-and-gzip
