### PR TITLE
perf(river): no longer needlessly render river responses

### DIFF
--- a/mod/groups/views/default/river/group/create.php
+++ b/mod/groups/views/default/river/group/create.php
@@ -13,4 +13,7 @@ $excerpt = elgg_get_excerpt($excerpt);
 echo elgg_view('river/elements/layout', array(
 	'item' => $item,
 	'message' => $excerpt,
+
+	// truthy value to bypass responses rendering
+	'responses' => ' ',
 ));

--- a/mod/groups/views/default/river/relationship/member/create.php
+++ b/mod/groups/views/default/river/relationship/member/create.php
@@ -5,4 +5,7 @@
 
 echo elgg_view('river/elements/layout', array(
 	'item' => $vars['item'],
+
+	// truthy value to bypass responses rendering
+	'responses' => ' ',
 ));

--- a/mod/thewire/views/default/river/object/thewire/create.php
+++ b/mod/thewire/views/default/river/object/thewire/create.php
@@ -31,4 +31,7 @@ echo elgg_view('river/elements/layout', array(
 	'item' => $item,
 	'message' => $excerpt,
 	'summary' => $summary,
+
+	// truthy value to bypass responses rendering
+	'responses' => ' ',
 ));

--- a/views/default/river/elements/responses.php
+++ b/views/default/river/elements/responses.php
@@ -10,17 +10,16 @@
 $responses = elgg_extract('responses', $vars, false);
 if ($responses) {
 	echo $responses;
-	return true;
+	return;
 }
 
 $item = $vars['item'];
 /* @var ElggRiverItem $item */
 $object = $item->getObjectEntity();
-$target = $item->getTargetEntity();
 
 // annotations and comments do not have responses
-if ($item->annotation_id != 0 || !$object || elgg_instanceof($target, 'object', 'comment')) {
-	return true;
+if ($item->annotation_id != 0 || !$object || $object instanceof ElggComment) {
+	return;
 }
 
 $comment_count = $object->countComments();

--- a/views/default/river/object/comment/create.php
+++ b/views/default/river/object/comment/create.php
@@ -37,4 +37,7 @@ echo elgg_view('river/elements/layout', array(
 	'item' => $vars['item'],
 	'message' => elgg_get_excerpt($comment->description),
 	'summary' => $summary,
+
+	// truthy value to bypass responses rendering
+	'responses' => ' ',
 ));

--- a/views/default/river/relationship/friend/create.php
+++ b/views/default/river/relationship/friend/create.php
@@ -14,4 +14,7 @@ $object_icon = elgg_view_entity_icon($object, 'tiny');
 echo elgg_view('river/elements/layout', array(
 	'item' => $item,
 	'attachments' => $subject_icon . elgg_view_icon('arrow-right') . $object_icon,
+
+	// truthy value to bypass responses rendering
+	'responses' => ' ',
 ));

--- a/views/default/river/user/default/profileiconupdate.php
+++ b/views/default/river/user/default/profileiconupdate.php
@@ -24,4 +24,7 @@ echo elgg_view('river/elements/layout', array(
 		'use_hover' => false,
 		'use_link' => false,
 	)),
+
+	// truthy value to bypass responses rendering
+	'responses' => ' ',
 ));

--- a/views/default/river/user/default/profileupdate.php
+++ b/views/default/river/user/default/profileupdate.php
@@ -20,4 +20,7 @@ $string = elgg_echo('river:update:user:profile', array($subject_link));
 echo elgg_view('river/elements/layout', array(
 	'item' => $item,
 	'summary' => $string,
+
+	// truthy value to bypass responses rendering
+	'responses' => ' ',
 ));


### PR DESCRIPTION
For river items that cannot receive comments, we explicitly pass a `responses` option to the river layout, which bypasses the bulk of river/elements/responses rendering. Notably a `countComments()` query is no longer performed and an empty form is no longer rendered for each of these items.

For BC, the `div.elgg-river-responses` wrapper is still created, but contains only whitespace.

In the river/elements/responses view, we also now correctly check for comments (and their subclasses like ElggDiscussionReply) so we don't render these. The core river views do not reach to this point due to changes in this PR, so this is mainly for plugins that may have overridden those views.

Fixes #9046
