### PR TITLE
WIP ignoring access_id in metadata

### DIFF
--- a/actions/profile/edit.php
+++ b/actions/profile/edit.php
@@ -84,6 +84,10 @@ if ($name) {
 // go through custom fields
 if (sizeof($input) > 0) {
 	foreach ($input as $shortname => $value) {
+
+		$owner->deleteAnnotations("profile:$shortname");
+
+		// for BC, keep storing fields in MD, but we'll read annotations only
 		$options = array(
 			'guid' => $owner->guid,
 			'metadata_name' => $shortname,
@@ -101,15 +105,18 @@ if (sizeof($input) > 0) {
 				// this should never be executed since the access level should always be set
 				$access_id = ACCESS_DEFAULT;
 			}
-			if (is_array($value)) {
-				$i = 0;
-				foreach ($value as $interval) {
-					$i++;
-					$multiple = ($i > 1) ? TRUE : FALSE;
-					create_metadata($owner->guid, $shortname, $interval, 'text', $owner->guid, $access_id, $multiple);
-				}
-			} else {
-				create_metadata($owner->getGUID(), $shortname, $value, 'text', $owner->getGUID(), $access_id);
+
+			if (!is_array($value)) {
+				$value = [$value];
+			}
+			foreach ($value as $interval) {
+				create_annotation($owner->guid, "profile:$shortname", $interval, 'text', $owner->guid, $access_id);
+			}
+
+			// for BC, keep storing fields in MD, but we'll read annotations only
+			foreach (array_values($value) as $i => $interval) {
+				$multiple = ($i > 0);
+				create_metadata($owner->guid, $shortname, $interval, 'text', $owner->guid, null, $multiple);
 			}
 		}
 	}

--- a/engine/classes/Elgg/Database/UsersTable.php
+++ b/engine/classes/Elgg/Database/UsersTable.php
@@ -94,7 +94,7 @@ class UsersTable {
 			if (_elgg_services()->events->trigger('ban', 'user', $user)) {
 				// Add reason
 				if ($reason) {
-					create_metadata($user_guid, 'ban_reason', $reason, '', 0, ACCESS_PUBLIC);
+					create_metadata($user_guid, 'ban_reason', $reason);
 				}
 	
 				// invalidate memcache for this user
@@ -134,7 +134,7 @@ class UsersTable {
 	
 		if (($user) && ($user->canEdit()) && ($user instanceof \ElggUser)) {
 			if (_elgg_services()->events->trigger('unban', 'user', $user)) {
-				create_metadata($user_guid, 'ban_reason', '', '', 0, ACCESS_PUBLIC);
+				create_metadata($user_guid, 'ban_reason', '');
 	
 				// invalidate memcache for this user
 				static $newentity_cache;
@@ -478,8 +478,8 @@ class UsersTable {
 	 * @return bool
 	 */
 	function setValidationStatus($user_guid, $status, $method = '') {
-		$result1 = create_metadata($user_guid, 'validated', $status, '', 0, ACCESS_PUBLIC, false);
-		$result2 = create_metadata($user_guid, 'validated_method', $method, '', 0, ACCESS_PUBLIC, false);
+		$result1 = create_metadata($user_guid, 'validated', $status);
+		$result2 = create_metadata($user_guid, 'validated_method', $method);
 		if ($result1 && $result2) {
 			return true;
 		} else {

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -294,7 +294,7 @@ abstract class ElggEntity extends \ElggData implements
 	 * @return mixed The value, or null if not found.
 	 */
 	public function getMetadata($name) {
-		$guid = $this->getGUID();
+		$guid = $this->guid;
 
 		if (!$guid) {
 			if (isset($this->temp_metadata[$name])) {
@@ -374,13 +374,11 @@ abstract class ElggEntity extends \ElggData implements
 	 *                           Does not support associative arrays.
 	 * @param int    $owner_guid GUID of entity that owns the metadata.
 	 *                           Default is owner of entity.
-	 * @param int    $access_id  Who can read the metadata relative to the owner.
-	 *                           Default is the access level of the entity.
 	 *
 	 * @return bool
 	 * @throws InvalidArgumentException
 	 */
-	public function setMetadata($name, $value, $value_type = '', $multiple = false, $owner_guid = 0, $access_id = null) {
+	public function setMetadata($name, $value, $value_type = '', $multiple = false, $owner_guid = 0) {
 
 		// normalize value to an array that we will loop over
 		// remove indexes if value already an array.
@@ -412,7 +410,6 @@ abstract class ElggEntity extends \ElggData implements
 			}
 
 			$owner_guid = (int)$owner_guid;
-			$access_id = ($access_id === null) ? $this->getAccessId() : (int)$access_id;
 			$owner_guid = $owner_guid ? $owner_guid : $this->getOwnerGUID();
 
 			// add new md
@@ -420,7 +417,7 @@ abstract class ElggEntity extends \ElggData implements
 			foreach ($value as $value_tmp) {
 				// at this point $value is appended because it was cleared above if needed.
 				$md_id = create_metadata($this->getGUID(), $name, $value_tmp, $value_type,
-						$owner_guid, $access_id, true);
+						$owner_guid, null, true);
 				if (!$md_id) {
 					return false;
 				}
@@ -433,8 +430,8 @@ abstract class ElggEntity extends \ElggData implements
 			// returning single entries instead of an array of 1 element is decided in
 			// getMetaData(), just like pulling from the db.
 
-			if ($owner_guid != 0 || $access_id !== null) {
-				$msg = "owner guid and access id cannot be used in \ElggEntity::setMetadata() until entity is saved.";
+			if ($owner_guid != 0) {
+				$msg = "owner guid cannot be used in \ElggEntity::setMetadata() until entity is saved.";
 				throw new \InvalidArgumentException($msg);
 			}
 

--- a/engine/classes/ElggExtender.php
+++ b/engine/classes/ElggExtender.php
@@ -51,6 +51,9 @@ abstract class ElggExtender extends \ElggData {
 	 * @return void
 	 */
 	public function __set($name, $value) {
+		if ($name === 'access_id' && $this instanceof ElggMetadata) {
+			$value = ACCESS_PUBLIC;
+		}
 		$this->attributes[$name] = $value;
 		if ($name == 'value') {
 			$this->attributes['value_type'] = detect_extender_valuetype($value);
@@ -112,6 +115,10 @@ abstract class ElggExtender extends \ElggData {
 						throw new \UnexpectedValueException($msg);
 						break;
 				}
+			}
+
+			if ($name === 'access_id' && $this instanceof ElggMetadata) {
+				return ACCESS_PUBLIC;
 			}
 
 			return $this->attributes[$name];

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -1628,8 +1628,8 @@ class ElggInstaller {
 		elgg_set_ignore_access(false);
 
 		// add validation data to satisfy user validation plugins
-		create_metadata($guid, 'validated', TRUE, '', 0, ACCESS_PUBLIC);
-		create_metadata($guid, 'validated_method', 'admin_user', '', 0, ACCESS_PUBLIC);
+		create_metadata($guid, 'validated', TRUE);
+		create_metadata($guid, 'validated_method', 'admin_user');
 
 		if ($login) {
 			$handler = new Elgg\Http\DatabaseSessionHandler(_elgg_services()->db);

--- a/engine/classes/ElggMetadata.php
+++ b/engine/classes/ElggMetadata.php
@@ -53,6 +53,8 @@ class ElggMetadata extends \ElggExtender {
 				$this->attributes = $metadata->attributes;
 			}
 		}
+
+		$this->attributes['access_id'] = ACCESS_PUBLIC;
 	}
 
 	/**

--- a/engine/lib/metadata.php
+++ b/engine/lib/metadata.php
@@ -57,16 +57,16 @@ function elgg_delete_metadata_by_id($id) {
  * @param string $value          Value of the metadata
  * @param string $value_type     'text', 'integer', or '' for automatic detection
  * @param int    $owner_guid     GUID of entity that owns the metadata. Default is logged in user.
- * @param int    $access_id      Default is ACCESS_PRIVATE
+ * @param int    $ignored        This argument is not used
  * @param bool   $allow_multiple Allow multiple values for one key. Default is false
  *
  * @return int|false id of metadata or false if failure
  */
 function create_metadata($entity_guid, $name, $value, $value_type = '', $owner_guid = 0,
-		$access_id = ACCESS_PRIVATE, $allow_multiple = false) {
+						$ignored = ACCESS_PRIVATE, $allow_multiple = false) {
 
 	return _elgg_services()->metadataTable->create($entity_guid, $name, $value,
-		$value_type, $owner_guid, $access_id, $allow_multiple);
+		$value_type, $owner_guid, null, $allow_multiple);
 }
 
 /**
@@ -77,13 +77,12 @@ function create_metadata($entity_guid, $name, $value, $value_type = '', $owner_g
  * @param string $value      Metadata value
  * @param string $value_type Value type
  * @param int    $owner_guid Owner guid
- * @param int    $access_id  Access ID
  *
  * @return bool
  */
-function update_metadata($id, $name, $value, $value_type, $owner_guid, $access_id) {
+function update_metadata($id, $name, $value, $value_type, $owner_guid) {
 	return _elgg_services()->metadataTable->update($id, $name, $value,
-		$value_type, $owner_guid, $access_id);
+		$value_type, $owner_guid);
 }
 
 /**
@@ -97,16 +96,16 @@ function update_metadata($id, $name, $value, $value_type, $owner_guid, $access_i
  * @param array  $name_and_values Associative array - a value can be a string, number, bool
  * @param string $value_type      'text', 'integer', or '' for automatic detection
  * @param int    $owner_guid      GUID of entity that owns the metadata
- * @param int    $access_id       Default is ACCESS_PRIVATE
+ * @param int    $ignored         This argument is not used
  * @param bool   $allow_multiple  Allow multiple values for one key. Default is false
  *
  * @return bool
  */
 function create_metadata_from_array($entity_guid, array $name_and_values, $value_type, $owner_guid,
-		$access_id = ACCESS_PRIVATE, $allow_multiple = false) {
+		$ignored = ACCESS_PRIVATE, $allow_multiple = false) {
 
 	return _elgg_services()->metadataTable->createFromArray($entity_guid, $name_and_values,
-		$value_type, $owner_guid, $access_id, $allow_multiple);
+		$value_type, $owner_guid, null, $allow_multiple);
 
 }
 

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -240,13 +240,15 @@ function _elgg_get_metastring_based_objects($options) {
 	// metastrings
 	$metastring_clauses = _elgg_get_metastring_sql('n_table', $options['metastring_names'],
 		$options['metastring_values'], null, $options['metastring_ids'],
-		$options['metastring_case_sensitive']);
+		$options['metastring_case_sensitive'], $type);
 
 	if ($metastring_clauses) {
 		$wheres = array_merge($wheres, $metastring_clauses['wheres']);
 		$joins = array_merge($joins, $metastring_clauses['joins']);
 	} else {
-		$wheres[] = _elgg_get_access_where_sql(array('table_alias' => 'n_table'));
+		if ($type === 'annotations') {
+			$wheres[] = _elgg_get_access_where_sql(array('table_alias' => 'n_table'));
+		}
 	}
 
 	$distinct = $options['distinct'] ? "DISTINCT " : "";
@@ -333,12 +335,13 @@ function _elgg_get_metastring_based_objects($options) {
  * @param array  $pairs          Name / value pairs. Not currently used.
  * @param array  $ids            Metastring IDs
  * @param bool   $case_sensitive Should name and values be case sensitive?
+ * @param string $type           "metadata" or "annotations"
  *
  * @return array
  * @access private
  */
 function _elgg_get_metastring_sql($table, $names = null, $values = null,
-	$pairs = null, $ids = null, $case_sensitive = false) {
+	$pairs = null, $ids = null, $case_sensitive = false, $type) {
 
 	if ((!$names && $names !== 0)
 		&& (!$values && $values !== 0)
@@ -426,7 +429,9 @@ function _elgg_get_metastring_sql($table, $names = null, $values = null,
 		$wheres[] = $values_where;
 	}
 
-	$wheres[] = _elgg_get_access_where_sql(array('table_alias' => $table));
+	if ($type === 'annotations') {
+		$wheres[] = _elgg_get_access_where_sql(array('table_alias' => $table));
+	}
 
 	if ($where = implode(' AND ', $wheres)) {
 		$return['wheres'][] = "($where)";

--- a/engine/lib/upgrades/2015102300-2.0.0_beta.3-profiles_to_annotations-99f15ff8bb016f55.php
+++ b/engine/lib/upgrades/2015102300-2.0.0_beta.3-profiles_to_annotations-99f15ff8bb016f55.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Elgg 2.0.0-beta.3 upgrade 2015102300
+ * profiles_to_annotations
+ *
+ * Description
+ */
+
+// upgrade code here.
+$names = array_keys(elgg_get_config('profile_fields'));
+$prefix = elgg_get_config('dbprefix');
+
+foreach ($names as $name) {
+	$metadata_name_id = elgg_get_metastring_id($name);
+	$annotation_name_id = elgg_get_metastring_id("profile:$name");
+
+	update_data("
+		INSERT INTO {$prefix}annotations
+			(entity_guid, name_id,               value_id, value_type, owner_guid, access_id, time_created, enabled)
+		SELECT entity_guid, {$annotation_name_id}, value_id, value_type, owner_guid, access_id, time_created, enabled
+		FROM {$prefix}metadata
+		WHERE name_id = {$metadata_name_id}
+		AND entity_guid IN (
+			SELECT guid FROM {$prefix}users_entity
+		)
+	");
+}

--- a/engine/tests/ElggCoreMetadataAPITest.php
+++ b/engine/tests/ElggCoreMetadataAPITest.php
@@ -82,8 +82,8 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 		$this->object->save();
 
 		$guid = $this->object->getGUID();
-		create_metadata($guid, 'tested', 'tested1', 'text', 0, ACCESS_PUBLIC, true);
-		create_metadata($guid, 'tested', 'tested2', 'text', 0, ACCESS_PUBLIC, true);
+		create_metadata($guid, 'tested', 'tested1', 'text', 0, null, true);
+		create_metadata($guid, 'tested', 'tested2', 'text', 0, null, true);
 
 		$count = (int)elgg_get_metadata(array(
 			'metadata_names' => array('tested'),

--- a/engine/tests/ElggCoreMetadataCacheTest.php
+++ b/engine/tests/ElggCoreMetadataCacheTest.php
@@ -102,46 +102,6 @@ class ElggCoreMetadataCacheTest extends \ElggCoreUnitTest {
 		$this->assertFalse($cache->isLoaded(2));
 	}
 
-	public function testCacheIsSegregatedByAccessState() {
-		$session = ElggSession::getMock();
-		$cache = new MetadataCache($session);
-		$cache->inject(1, ['foo' => 'bar']);
-
-		$session->setIgnoreAccess();
-		$this->assertFalse($cache->isLoaded(1));
-
-		$session->setIgnoreAccess(false);
-		$this->assertTrue($cache->isLoaded(1));
-
-		$user = elgg_get_entities(['type' => 'user', 'limit' => 1]);
-		$user = $user[0];
-		$cache->inject(1, ['foo' => 'bar']);
-
-		$session->setLoggedInUser($user);
-		$this->assertFalse($cache->isLoaded(1));
-	}
-
-	public function testClearActsOnAllAccessStates() {
-		$session = ElggSession::getMock();
-		$cache = new MetadataCache($session);
-
-		$session->setIgnoreAccess(false);
-		$cache->inject(1, ['foo' => 'bar']);
-
-		$session->setIgnoreAccess(true);
-		$cache->clear(1);
-		$session->setIgnoreAccess(false);
-		$this->assertFalse($cache->isLoaded(1));
-
-		$session->setIgnoreAccess(true);
-		$cache->inject(1, ['foo' => 'bar']);
-
-		$session->setIgnoreAccess(false);
-		$cache->clear(1);
-		$session->setIgnoreAccess(true);
-		$this->assertFalse($cache->isLoaded(1));
-	}
-
 	public function testMetadataReadsFillsCache() {
 		// test that reads fill cache
 		$this->obj1->setMetadata($this->name, [1, 2]);
@@ -170,7 +130,7 @@ class ElggCoreMetadataCacheTest extends \ElggCoreUnitTest {
 		// setMetadata
 		$this->cache->inject($this->guid1, ['foo' => 'bar']);
 		$this->obj1->setMetadata($this->name, $this->value);
-		$this->assertFalse($this->cache->isLoaded($this->obj1));
+		$this->assertFalse($this->cache->isLoaded($this->guid1));
 
 		// deleteMetadata
 		$this->cache->inject($this->guid1, ['foo' => 'bar']);

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -337,7 +337,7 @@ function groups_set_icon_url($hook, $type, $url, $params) {
 		$file->owner_guid = $group->owner_guid;
 		$file->setFilename("groups/" . $group->guid . "large.jpg");
 		$icontime = $file->exists() ? time() : 0;
-		create_metadata($group->guid, 'icontime', $icontime, 'integer', $group->owner_guid, ACCESS_PUBLIC);
+		create_metadata($group->guid, 'icontime', $icontime, 'integer', $group->owner_guid);
 	}
 	if ($icontime) {
 		// return thumbnail

--- a/mod/profile/views/default/profile/details.php
+++ b/mod/profile/views/default/profile/details.php
@@ -35,50 +35,56 @@ if (is_array($profile_fields) && sizeof($profile_fields) > 0) {
 			// skip about me and put at bottom
 			continue;
 		}
-		$value = $user->$shortname;
 
-		if (!is_null($value)) {
+		$annotations = $user->getAnnotations([
+			'annotation_names' => "profile:$shortname",
+			'limit' => false,
+		]);
+		$values = array_map(function (ElggAnnotation $a) {
+			return $a->value;
+		}, $annotations);
 
-			// fix profile URLs populated by https://github.com/Elgg/Elgg/issues/5232
-			// @todo Replace with upgrade script, only need to alter users with last_update after 1.8.13
-			if ($valtype == 'url' && $value == 'http://') {
-				$user->$shortname = '';
-				continue;
-			}
-
-			// validate urls
-			if ($valtype == 'url' && !preg_match('~^https?\://~i', $value)) {
-				$value = "http://$value";
-			}
-
-			// this controls the alternating class
-			$even_odd = ( 'odd' != $even_odd ) ? 'odd' : 'even';
-			?>
-			<div class="<?php echo $even_odd; ?>">
-				<b><?php echo elgg_echo("profile:{$shortname}"); ?>: </b>
-				<?php
-					$params = array(
-						'value' => $value
-					);
-					if (isset($microformats[$shortname])) {
-						$class = $microformats[$shortname];
-					} else {
-						$class = '';
-					}
-					echo "<span class=\"$class\">";
-					echo elgg_view("output/{$valtype}", $params);
-					echo "</span>";
-				?>
-			</div>
-			<?php
+		if (!$values) {
+			continue;
 		}
+		// emulate metadata API
+		$value = (count($values) === 1) ? $values[0] : $values;
+
+		// validate urls
+		if ($valtype == 'url' && !preg_match('~^https?\://~i', $value)) {
+			$value = "http://$value";
+		}
+
+		// this controls the alternating class
+		$even_odd = ( 'odd' != $even_odd ) ? 'odd' : 'even';
+		?>
+		<div class="<?php echo $even_odd; ?>">
+			<b><?php echo elgg_echo("profile:{$shortname}"); ?>: </b>
+			<?php
+				$params = array(
+					'value' => $value
+				);
+				if (isset($microformats[$shortname])) {
+					$class = $microformats[$shortname];
+				} else {
+					$class = '';
+				}
+				echo "<span class=\"$class\">";
+				echo elgg_view("output/{$valtype}", $params);
+				echo "</span>";
+			?>
+		</div>
+		<?php
 	}
 }
 
-if ($user->description) {
+$annotations = $user->getAnnotations([
+	'annotation_names' => "profile:description",
+]);
+if ($annotations && $annotations[0]->value) {
 	echo "<p class='profile-aboutme-title'><b>" . elgg_echo("profile:aboutme") . "</b></p>";
 	echo "<div class='profile-aboutme-contents'>";
-	echo elgg_view('output/longtext', array('value' => $user->description, 'class' => 'mtn'));
+	echo elgg_view('output/longtext', array('value' => $annotations[0]->value, 'class' => 'mtn'));
 	echo "</div>";
 }
 

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2015062900;
+$version = 2015102300;
 
 $composerJson = file_get_contents(dirname(__FILE__) . "/composer.json");
 if ($composerJson === false) {

--- a/views/default/forms/profile/edit.php
+++ b/views/default/forms/profile/edit.php
@@ -5,6 +5,8 @@
  * @uses vars['entity']
  */
 
+$owner = $vars['entity'];
+/* @var ElggUser $owner */
 ?>
 
 <div>
@@ -18,24 +20,19 @@ $sticky_values = elgg_get_sticky_values('profile:edit');
 $profile_fields = elgg_get_config('profile_fields');
 if (is_array($profile_fields) && count($profile_fields) > 0) {
 	foreach ($profile_fields as $shortname => $valtype) {
-		$metadata = elgg_get_metadata(array(
-			'guid' => $vars['entity']->guid,
-			'metadata_name' => $shortname,
-			'limit' => false
-		));
-		if ($metadata) {
-			if (is_array($metadata)) {
-				$value = '';
-				foreach ($metadata as $md) {
-					if (!empty($value)) {
-						$value .= ', ';
-					}
-					$value .= $md->value;
-					$access_id = $md->access_id;
+
+		$annotations = $owner->getAnnotations([
+			'annotation_names' => "profile:$shortname",
+			'limit' => false,
+		]);
+		if ($annotations) {
+			$value = '';
+			foreach ($annotations as $annotation) {
+				if (!empty($value)) {
+					$value .= ', ';
 				}
-			} else {
-				$value = $metadata->value;
-				$access_id = $metadata->access_id;
+				$value .= $annotation->value;
+				$access_id = $annotation->access_id;
 			}
 		} else {
 			$value = '';


### PR DESCRIPTION
(For #9050. When testing this patch be aware any saved/updated MD will become ACCESS_PUBLIC!)

Elgg now ignores the access_id fields of metadata, hence all metadata set previously are now visible to queries in all contexts, including logged out.

Methods to set metadata no longer accept `$access_id` arguments, or values given are ignored. ElggMetadata objects always return ACCESS_PUBLIC when the "access_id" property is read.

User profile field data is now stored in annotations, but a copy is maintained in metadata for better BC with older plugins. A field with the name "example" will be stored in annotation(s) with name "profile:example". At the time of upgrade, active profile fields will be migrated to annotation storage, but inactive profile field data will be left as inert metadata only.

BREAKING CHANGE:
Plugins can no longer rely on Elgg to "hide" metadata in queries. All metadata is assumed to be public. Plugins that read user profile fields in metadata will see all fields every time, and plugins that write user profile fields in metadata will have no effect. These plugins should instead access fields via annotations; see the profile edit actions and forms for reference.

(moved to #10270)
