### PR TITLE
chore(http): add Expires to cache URLs on nginx

### DIFF
--- a/install/config/nginx.dist
+++ b/install/config/nginx.dist
@@ -52,6 +52,10 @@ server {
 		return 403;
 	}
 
+	location /cache {
+		expires 1y;
+	}
+
 	location = /rewrite.php {
 		rewrite ^(.*)$ /install.php;
 	}


### PR DESCRIPTION
Fixes #9054
- [ ] ngnix still needs to pass 404s through index.php
