### PR TITLE
chore(services): use local methods instead of global helper functions

### DIFF
--- a/engine/classes/Elgg/Database/AccessCollections.php
+++ b/engine/classes/Elgg/Database/AccessCollections.php
@@ -67,7 +67,7 @@ class AccessCollections {
 			return $cache[$hash];
 		}
 		
-		$access_array = get_access_array($user_guid, $site_guid, $flush);
+		$access_array = $this->getAccessArray($user_guid, $site_guid, $flush);
 		$access = "(" . implode(",", $access_array) . ")";
 	
 		if ($init_finished) {
@@ -235,9 +235,9 @@ class AccessCollections {
 			'owner_guid_column' => 'owner_guid',
 			'guid_column' => 'guid',
 		);
-	
+
 		$options = array_merge($defaults, $options);
-	
+
 		// just in case someone passes a . at the end
 		$options['table_alias'] = rtrim($options['table_alias'], '.');
 	
@@ -274,7 +274,7 @@ class AccessCollections {
 	
 		// include standard accesses (public, logged in, access collections)
 		if (!$options['ignore_access']) {
-			$access_list = get_access_list($options['user_guid']);
+			$access_list = $this->getAccessList($options['user_guid']);
 			$clauses['ors'][] = "$table_alias{$options['access_column']} IN {$access_list}";
 		}
 	
@@ -325,9 +325,9 @@ class AccessCollections {
 		$ia = elgg_set_ignore_access(false);
 	
 		if (!isset($user)) {
-			$access_bit = _elgg_get_access_where_sql();
+			$access_bit = $this->getWhereSql();
 		} else {
-			$access_bit = _elgg_get_access_where_sql(array('user_guid' => $user->getGUID()));
+			$access_bit = $this->getWhereSql(array('user_guid' => $user->guid));
 		}
 	
 		elgg_set_ignore_access($ia);
@@ -444,14 +444,14 @@ class AccessCollections {
 			return false;
 		}
 	
-		$collection = get_access_collection($collection_id);
+		$collection = $this->get($collection_id);
 	
 		if (!$user || !$collection) {
 			return false;
 		}
 	
-		$write_access = get_write_access_array($user->guid, 0, true);
-	
+		$write_access = $this->getWriteAccessArray($user->guid, 0, true);
+
 		// don't ignore access when checking users.
 		if ($user_guid) {
 			return array_key_exists($collection_id, $write_access);

--- a/engine/classes/Elgg/Database/Annotations.php
+++ b/engine/classes/Elgg/Database/Annotations.php
@@ -46,7 +46,7 @@ class Annotations {
 	 * @return bool
 	 */
 	function delete($id) {
-		$annotation = elgg_get_annotation_from_id($id);
+		$annotation = $this->get($id);
 		if (!$annotation) {
 			return false;
 		}
@@ -132,7 +132,7 @@ class Annotations {
 	
 		$annotation_id = (int)$annotation_id;
 	
-		$annotation = elgg_get_annotation_from_id($annotation_id);
+		$annotation = $this->get($annotation_id);
 		if (!$annotation) {
 			return false;
 		}
@@ -167,7 +167,7 @@ class Annotations {
 	
 		if ($result !== false) {
 			// @todo add plugin hook that sends old and new annotation information before db access
-			$obj = elgg_get_annotation_from_id($annotation_id);
+			$obj = $this->get($annotation_id);
 			_elgg_services()->events->trigger('update', 'annotation', $obj);
 		}
 	

--- a/engine/classes/Elgg/Database/Plugins.php
+++ b/engine/classes/Elgg/Database/Plugins.php
@@ -125,7 +125,7 @@ class Plugins {
 			$id_map[$plugin->getID()] = $i;
 		}
 	
-		$physical_plugins = _elgg_get_plugin_dirs_in_dir($mod_dir);
+		$physical_plugins = $this->getDirsInDir($mod_dir);
 	
 		if (!$physical_plugins) {
 			return false;
@@ -162,7 +162,7 @@ class Plugins {
 				$plugin->deactivate();
 			}
 			// remove the priority.
-			$name = _elgg_namespace_plugin_private_setting('internal', 'priority');
+			$name = $this->namespacePrivateSetting('internal', 'priority');
 			remove_private_setting($plugin->guid, $name);
 			if ($plugin->isEnabled()) {
 				$plugin->disable();
@@ -171,8 +171,9 @@ class Plugins {
 	
 		access_show_hidden_entities($old_access);
 		elgg_set_ignore_access($old_ia);
-	
-		_elgg_reindex_plugin_priorities();
+
+		$this->reindexPriorities();
+
 	
 		return true;
 	}
@@ -230,9 +231,7 @@ class Plugins {
 	 * @return bool
 	 */
 	function exists($id) {
-		$plugin = elgg_get_plugin_from_id($id);
-	
-		return ($plugin) ? true : false;
+		return (bool)$this->get($id);
 	}
 	
 	/**
@@ -243,7 +242,7 @@ class Plugins {
 	 */
 	function getMaxPriority() {
 		$db_prefix = get_config('dbprefix');
-		$priority = _elgg_namespace_plugin_private_setting('internal', 'priority');
+		$priority = $this->namespacePrivateSetting('internal', 'priority');
 		$plugin_subtype = get_subtype_id('object', 'plugin');
 	
 		$q = "SELECT MAX(CAST(ps.value AS unsigned)) as max
@@ -288,7 +287,7 @@ class Plugins {
 			return false;
 		}
 	
-		$plugin = elgg_get_plugin_from_id($plugin_id);
+		$plugin = $this->get($plugin_id);
 	
 		if (!$plugin) {
 			return false;
@@ -367,7 +366,7 @@ class Plugins {
 	 */
 	function find($status = 'active', $site_guid = null) {
 		$db_prefix = get_config('dbprefix');
-		$priority = _elgg_namespace_plugin_private_setting('internal', 'priority');
+		$priority = $this->namespacePrivateSetting('internal', 'priority');
 	
 		if (!$site_guid) {
 			$site_guid = elgg_get_site_entity()->guid;
@@ -440,7 +439,7 @@ class Plugins {
 	 * @access private
 	 */
 	function setPriorities(array $order) {
-		$name = _elgg_namespace_plugin_private_setting('internal', 'priority');
+		$name = $this->namespacePrivateSetting('internal', 'priority');
 	
 		$plugins = elgg_get_plugins('any');
 		if (!$plugins) {
@@ -497,7 +496,7 @@ class Plugins {
 	 * @access private
 	 */
 	function reindexPriorities() {
-		return _elgg_set_plugin_priorities(array());
+		return $this->setPriorities([]);
 	}
 	
 	/**
@@ -559,7 +558,7 @@ class Plugins {
 	function getProvides($type = null, $name = null) {
 		global $ELGG_PLUGINS_PROVIDES_CACHE;
 		if (!isset($ELGG_PLUGINS_PROVIDES_CACHE)) {
-			$active_plugins = elgg_get_plugins('active');
+			$active_plugins = $this->find('active');
 		
 			$provides = array();
 	
@@ -638,7 +637,7 @@ class Plugins {
 	 * @access private
 	 */
 	function checkProvides($type, $name, $version = null, $comparison = 'ge') {
-		$provided = _elgg_get_plugins_provides($type, $name);
+		$provided = $this->getProvides($type, $name);
 		if (!$provided) {
 			return array(
 				'status' => false,
@@ -1058,7 +1057,7 @@ class Plugins {
 			}
 		}
 	
-		$prefix = _elgg_namespace_plugin_private_setting('user_setting', '', $options['plugin_id']);
+		$prefix = $this->namespacePrivateSetting('user_setting', '', $options['plugin_id']);
 		$options['private_setting_name_prefix'] = $prefix;
 	
 		return elgg_get_entities_from_private_settings($options);

--- a/engine/classes/Elgg/Database/SubtypeTable.php
+++ b/engine/classes/Elgg/Database/SubtypeTable.php
@@ -64,11 +64,11 @@ class SubtypeTable {
 		}
 	
 		if ($SUBTYPE_CACHE === null) {
-			_elgg_populate_subtype_cache();
+			$this->populateCache();
 		}
 	
 		// use the cache before hitting database
-		$result = _elgg_retrieve_cached_subtype($type, $subtype);
+		$result = $this->retrieveFromCache($type, $subtype);
 		if ($result !== null) {
 			return $result->id;
 		}
@@ -92,7 +92,7 @@ class SubtypeTable {
 		}
 	
 		if ($SUBTYPE_CACHE === null) {
-			_elgg_populate_subtype_cache();
+			$this->populateCache();
 		}
 	
 		if (isset($SUBTYPE_CACHE[$subtype_id])) {
@@ -115,7 +115,7 @@ class SubtypeTable {
 		global $SUBTYPE_CACHE;
 	
 		if ($SUBTYPE_CACHE === null) {
-			_elgg_populate_subtype_cache();
+			$this->populateCache();
 		}
 	
 		foreach ($SUBTYPE_CACHE as $obj) {
@@ -161,11 +161,11 @@ class SubtypeTable {
 		global $SUBTYPE_CACHE;
 	
 		if ($SUBTYPE_CACHE === null) {
-			_elgg_populate_subtype_cache();
+			$this->populateCache();
 		}
 		
 		// use the cache before going to the database
-		$obj = _elgg_retrieve_cached_subtype($type, $subtype);
+		$obj = $this->retrieveFromCache($type, $subtype);
 		if ($obj) {
 			return $obj->class;
 		}
@@ -191,7 +191,7 @@ class SubtypeTable {
 		}
 	
 		if ($SUBTYPE_CACHE === null) {
-			_elgg_populate_subtype_cache();
+			$this->populateCache();
 		}
 		
 		if (isset($SUBTYPE_CACHE[$subtype_id])) {
@@ -228,7 +228,7 @@ class SubtypeTable {
 			return 0;
 		}
 	
-		$id = get_subtype_id($type, $subtype);
+		$id = $this->getId($type, $subtype);
 	
 		if (!$id) {
 			// In cache we store non-SQL-escaped strings because that's what's returned by query
@@ -296,13 +296,13 @@ class SubtypeTable {
 	function update($type, $subtype, $class = '') {
 		global $SUBTYPE_CACHE;
 	
-		$id = get_subtype_id($type, $subtype);
+		$id = $this->getId($type, $subtype);
 		if (!$id) {
 			return false;
 		}
 	
 		if ($SUBTYPE_CACHE === null) {
-			_elgg_populate_subtype_cache();
+			$this->populateCache();
 		}
 	
 		$unescaped_class = $class;

--- a/engine/classes/Elgg/Forms/StickyForms.php
+++ b/engine/classes/Elgg/Forms/StickyForms.php
@@ -24,7 +24,7 @@ class StickyForms {
 	 */
 	public function makeStickyForm($form_name) {
 	
-		elgg_clear_sticky_form($form_name);
+		$this->clearStickyForm($form_name);
 	
 		$session = _elgg_services()->session;
 		$data = $session->get('sticky_forms', array());

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -172,28 +172,6 @@ function get_subtype_from_id($subtype_id) {
 }
 
 /**
- * Retrieve subtype from the cache.
- *
- * @param string $type
- * @param string $subtype
- * @return \stdClass|null
- *
- * @access private
- */
-function _elgg_retrieve_cached_subtype($type, $subtype) {
-	return _elgg_services()->subtypeTable->retrieveFromCache($type, $subtype);
-}
-
-/**
- * Fetch all suptypes from DB to local cache.
- *
- * @access private
- */
-function _elgg_populate_subtype_cache() {
-	return _elgg_services()->subtypeTable->populateCache();
-}
-
-/**
  * Return the class name for a registered type and subtype.
  *
  * Entities can be registered to always be loaded as a certain class

--- a/engine/lib/plugins.php
+++ b/engine/lib/plugins.php
@@ -47,21 +47,6 @@ define('ELGG_PLUGIN_USER_SETTING_PREFIX', 'plugin:user_setting:');
  */
 define('ELGG_PLUGIN_INTERNAL_PREFIX', 'elgg:internal:');
 
-
-/**
- * Returns a list of plugin directory names from a base directory.
- *
- * @param string $dir A dir to scan for plugins. Defaults to config's plugins_path.
- *                    Must have a trailing slash.
- *
- * @return array Array of directory names (not full paths)
- * @since 1.8.0
- * @access private
- */
-function _elgg_get_plugin_dirs_in_dir($dir = null) {
-	return _elgg_services()->plugins->getDirsInDir($dir);
-}
-
 /**
  * Discovers plugins in the plugins_path setting and creates \ElggPlugin
  * entities for them if they don't exist.  If there are plugins with entities
@@ -149,35 +134,6 @@ function elgg_get_plugins($status = 'active', $site_guid = null) {
 }
 
 /**
- * Reorder plugins to an order specified by the array.
- * Plugins not included in this array will be appended to the end.
- *
- * @note This doesn't use the \ElggPlugin->setPriority() method because
- *       all plugins are being changed and we don't want it to automatically
- *       reorder plugins.
- *
- * @param array $order An array of plugin ids in the order to set them
- * @return bool
- * @since 1.8.0
- * @access private
- */
-function _elgg_set_plugin_priorities(array $order) {
-	return _elgg_services()->plugins->setPriorities($order);
-}
-
-/**
- * Reindexes all plugin priorities starting at 1.
- *
- * @todo Can this be done in a single sql command?
- * @return bool
- * @since 1.8.0
- * @access private
- */
-function _elgg_reindex_plugin_priorities() {
-	return _elgg_services()->plugins->reindexPriorities();
-}
-
-/**
  * Namespaces a string to be used as a private setting name for a plugin.
  *
  * For user_settings, two namespaces are added: a user setting namespace and the
@@ -194,29 +150,6 @@ function _elgg_reindex_plugin_priorities() {
  */
 function _elgg_namespace_plugin_private_setting($type, $name, $id = null) {
 	return _elgg_services()->plugins->namespacePrivateSetting($type, $name, $id);
-}
-
-/**
- * Returns an array of all provides from all active plugins.
- *
- * Array in the form array(
- * 	'provide_type' => array(
- * 		'provided_name' => array(
- * 			'version' => '1.8',
- * 			'provided_by' => 'provider_plugin_id'
- *  	)
- *  )
- * )
- *
- * @param string $type The type of provides to return
- * @param string $name A specific provided name to return. Requires $provide_type.
- *
- * @return array
- * @since 1.8.0
- * @access private
- */
-function _elgg_get_plugins_provides($type = null, $name = null) {
-	return _elgg_services()->plugins->getProvides($type, $name);
 }
 
 /**


### PR DESCRIPTION
Removes
- _elgg_retrieve_cached_subtype
- _elgg_populate_subtype_cache
- _elgg_get_plugin_dirs_in_dir
- _elgg_set_plugin_priorities
- _elgg_reindex_plugin_priorities
- _elgg_get_plugins_provides
