### PR TITLE
perf(plugins): adds plugin settings cache and optimized loading

### DIFF
--- a/engine/classes/Elgg/Cache/PluginSettingsCache.php
+++ b/engine/classes/Elgg/Cache/PluginSettingsCache.php
@@ -1,0 +1,168 @@
+<?php
+namespace Elgg\Cache;
+
+use Elgg\Database;
+
+/**
+ * In memory cache of (non-user-specific, non-internal) plugin settings
+ *
+ * @access private
+ */
+class PluginSettingsCache {
+
+	/**
+	 * The cached values.
+	 *
+	 * @var array GUID => string[]
+	 */
+	private $values = array();
+
+	/**
+	 * GUIDs of plugins for which we will later load settings
+	 *
+	 * @var int[]
+	 */
+	private $plugin_guids = array();
+
+	/**
+	 * @var Database
+	 */
+	private $db;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Database $db Elgg Database
+	 */
+	public function __construct(Database $db) {
+		$this->db = $db;
+	}
+
+	/**
+	 * Set the settings for a plugin in the cache
+	 *
+	 * Note this does NOT invalidate any other part of the cache.
+	 *
+	 * @param int   $entity_guid The GUID of the entity
+	 * @param array $values      The settings to cache
+	 * @return void
+	 *
+	 * @access private For testing only
+	 */
+	public function inject($entity_guid, array $values) {
+		$this->values[$entity_guid] = $values;
+	}
+
+	/**
+	 * Get all the non-user, non-internal settings for a plugin
+	 *
+	 * @param int $entity_guid The GUID of the entity
+	 *
+	 * @return null|string[] null if settings are not loaded for this entity
+	 */
+	public function getAll($entity_guid) {
+		$this->lazyLoad();
+		return isset($this->values[$entity_guid]) ? $this->values[$entity_guid] : null;
+	}
+
+	/**
+	 * Clear cache for an entity
+	 *
+	 * @param int $entity_guid The GUID of the entity
+	 * @return void
+	 */
+	public function clear($entity_guid) {
+		unset($this->values[$entity_guid]);
+	}
+
+	/**
+	 * Clear entire cache
+	 *
+	 * @return void
+	 */
+	public function clearAll() {
+		$this->values = [];
+		$this->plugin_guids = [];
+	}
+
+	/**
+	 * Populate the cache from a set of plugins
+	 *
+	 * @param int|array $guids Array of GUIDs
+	 * @return void
+	 */
+	public function populateFromPlugins(array $guids) {
+		$this->plugin_guids = $guids;
+	}
+
+	/**
+	 * Lazy-load settings
+	 *
+	 * @return void
+	 */
+	protected function lazyLoad() {
+		if (!$this->plugin_guids) {
+			return;
+		}
+
+		$guids = $this->getCacheableGuids($this->plugin_guids);
+		$set = '(' . implode(',', $guids) . ')';
+
+		$db_prefix = $this->db->getTablePrefix();
+		$data = $this->db->getData("
+			SELECT entity_guid, `name`, `value`
+			FROM {$db_prefix}private_settings
+			WHERE entity_guid IN $set
+			  AND name NOT LIKE 'plugin:user_setting:%'
+			  AND name NOT LIKE 'elgg:internal:%'
+			ORDER BY entity_guid
+		");
+
+		// make sure we show all entities as loaded
+		$this->values = array_fill_keys($guids, []);
+
+		foreach ($data as $i => $row) {
+			$this->values[$row->entity_guid][$row->name] = $row->value;
+		}
+
+		$this->plugin_guids = [];
+	}
+
+	/**
+	 * Filter a set of plugin GUIDs to those having less than a preset number of settings
+	 *
+	 * If a plugin has a lot of settings, we don't bother preloading them
+	 *
+	 * @param array $guids Plugin GUIDs
+	 * @param int   $limit Limit to number of settings
+	 *
+	 * @return int[]
+	 */
+	protected function getCacheableGuids(array $guids, $limit = 30) {
+		if (!$guids) {
+			return [];
+		}
+
+		$limit = (int)($limit);
+		$db_prefix = $this->db->getTablePrefix();
+		$set = '(' . implode(',', $guids) . ')';
+
+		$sql = "
+			SELECT entity_guid
+			FROM {$db_prefix}private_settings
+			WHERE entity_guid IN $set
+			  AND name NOT LIKE 'plugin:user_setting:%'
+			  AND name NOT LIKE 'elgg:internal:%'
+			GROUP BY entity_guid
+			HAVING COUNT(*) > $limit
+		";
+		$callback = function ($row) {
+			return (int)$row->entity_guid;
+		};
+
+		$unsuitable_guids = $this->db->getData($sql, $callback);
+		$guids = array_values($guids);
+
+		return array_diff($guids, $unsuitable_guids);
+	}
+}

--- a/engine/classes/Elgg/Database/Plugins.php
+++ b/engine/classes/Elgg/Database/Plugins.php
@@ -3,6 +3,7 @@ namespace Elgg\Database;
 
 use Elgg\Cache\Pool;
 use Exception;
+use Elgg\Cache\PluginSettingsCache;
 
 /**
  * @var array cache used by elgg_get_plugins_provides function
@@ -23,27 +24,34 @@ global $ELGG_PLUGINS_PROVIDES_CACHE;
 class Plugins {
 
 	/**
-	 * @var string[] Active plugin IDs with IDs as the array keys. Missing keys imply inactive plugins.
+	 * @var string[] Active plugins, with plugin ID => GUID. Missing keys imply inactive plugins.
 	 */
-	protected $active_ids = array();
+	private $active_guids = array();
 
 	/**
-	 * @var bool Has $active_ids been populated?
+	 * @var bool Has $active_guids been populated?
 	 */
-	protected $active_ids_known = false;
+	private $active_guids_known = false;
 
 	/**
 	 * @var Pool
 	 */
-	protected $plugins_by_id;
+	private $plugins_by_id;
+
+	/**
+	 * @var PluginSettingsCache
+	 */
+	private $settings_cache;
 
 	/**
 	 * Constructor
 	 *
-	 * @param Pool $pool Cache for referencing plugins by ID
+	 * @param Pool                $pool  Cache for referencing plugins by ID
+	 * @param PluginSettingsCache $cache Plugin settings cache
 	 */
-	public function __construct(Pool $pool) {
+	public function __construct(Pool $pool, PluginSettingsCache $cache) {
 		$this->plugins_by_id = $pool;
+		$this->settings_cache = $cache;
 	}
 
 	/**
@@ -273,9 +281,9 @@ class Plugins {
 	function isActive($plugin_id, $site_guid = null) {
 		$current_site_guid = elgg_get_site_entity()->guid;
 
-		if ($this->active_ids_known
+		if ($this->active_guids_known
 				&& ($site_guid === null || $site_guid == $current_site_guid)) {
-			return isset($this->active_ids[$plugin_id]);
+			return isset($this->active_guids[$plugin_id]);
 		}
 
 		if ($site_guid) {
@@ -336,25 +344,34 @@ class Plugins {
 	
 		$return = true;
 		$plugins = $this->find('active');
-		if ($plugins) {
-			foreach ($plugins as $plugin) {
-				$id = $plugin->getID();
-				try {
-					$plugin->start($start_flags);
-					$this->active_ids[$id] = true;
-				} catch (Exception $e) {
-					$plugin->deactivate();
-					$msg = _elgg_services()->translator->translate('PluginException:CannotStart',
-									array($id, $plugin->guid, $e->getMessage()));
-					elgg_add_admin_notice("cannot_start $id", $msg);
-					$return = false;
-	
-					continue;
-				}
+		if (!$plugins) {
+			$this->active_guids_known = true;
+			return true;
+		}
+
+		// preload settings early because some plugins call them early
+		$guids = [];
+		foreach ($plugins as $plugin) {
+			$guids[] = $plugin->guid;
+		}
+		$this->settings_cache->populateFromPlugins($guids);
+
+		$return = true;
+		foreach ($plugins as $plugin) {
+			$id = $plugin->getID();
+			try {
+				$plugin->start($start_flags);
+				$this->active_guids[$id] = $plugin->guid;
+			} catch (Exception $e) {
+				$plugin->deactivate();
+				$msg = _elgg_services()->translator->translate('PluginException:CannotStart',
+								array($id, $plugin->guid, $e->getMessage()));
+				elgg_add_admin_notice("cannot_start $id", $msg);
+				$return = false;
 			}
 		}
 
-		$this->active_ids_known = true;
+		$this->active_guids_known = true;
 		return $return;
 	}
 	
@@ -607,8 +624,8 @@ class Plugins {
 	 * @access private
 	 */
 	public function invalidateIsActiveCache() {
-		$this->active_ids = array();
-		$this->active_ids_known = false;
+		$this->active_guids = array();
+		$this->active_guids_known = false;
 	}
 	
 	/**

--- a/engine/classes/Elgg/Database/PrivateSettingsTable.php
+++ b/engine/classes/Elgg/Database/PrivateSettingsTable.php
@@ -3,6 +3,7 @@ namespace Elgg\Database;
 
 use Elgg\Database;
 use Elgg\Database\EntityTable;
+use Elgg\Cache\PluginSettingsCache;
 
 /**
  * Private settings for entities
@@ -23,18 +24,23 @@ class PrivateSettingsTable {
 	/** @var EntityTable */
 	private $entities;
 
-	/** @var Name of the database table */
+	/** @var string Name of the database table */
 	private $table;
+
+	/** @var PluginSettingsCache cache for settings */
+	private $cache;
 
 	/**
 	 * Constructor
 	 *
-	 * @param Database    $db       The database
-	 * @param EntityTable $entities Entities table
+	 * @param Database            $db       The database
+	 * @param EntityTable         $entities Entities table
+	 * @param PluginSettingsCache $cache    Settings cache
 	 */
-	public function __construct(Database $db, EntityTable $entities) {
+	public function __construct(Database $db, EntityTable $entities, PluginSettingsCache $cache) {
 		$this->db = $db;
 		$this->entities = $entities;
+		$this->cache = $cache;
 		$this->table = $this->db->getTablePrefix() . 'private_settings';
 	}
 
@@ -298,6 +304,11 @@ class PrivateSettingsTable {
 	 * @return mixed The setting value, or null if does not exist
 	 */
 	public function get($entity_guid, $name) {
+		$values = $this->cache->getAll($entity_guid);
+		if (isset($values[$name])) {
+			return $values[$name];
+		}
+
 		$entity_guid = (int) $entity_guid;
 		$name = $this->db->sanitizeString($name);
 
@@ -357,6 +368,8 @@ class PrivateSettingsTable {
 	 * @return bool
 	 */
 	public function set($entity_guid, $name, $value) {
+		$this->cache->clear($entity_guid);
+
 		$entity_guid = (int) $entity_guid;
 		$name = $this->db->sanitizeString($name);
 		$value = $this->db->sanitizeString($value);
@@ -377,6 +390,8 @@ class PrivateSettingsTable {
 	 * @return bool
 	 */
 	function remove($entity_guid, $name) {
+		$this->cache->clear($entity_guid);
+
 		$entity_guid = (int) $entity_guid;
 
 		$entity = $this->entities->get($entity_guid);
@@ -399,6 +414,8 @@ class PrivateSettingsTable {
 	 * @return bool
 	 */
 	function removeAllForEntity($entity_guid) {
+		$this->cache->clear($entity_guid);
+
 		$entity_guid = (int) $entity_guid;
 
 		$entity = $this->entities->get($entity_guid);

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -44,6 +44,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\PasswordService                    $passwords
  * @property-read \Elgg\PersistentLoginService             $persistentLogin
  * @property-read \Elgg\Database\Plugins                   $plugins
+ * @property-read \Elgg\Cache\PluginSettingsCache          $pluginSettingsCache
  * @property-read \Elgg\Database\PrivateSettingsTable      $privateSettings
  * @property-read \Elgg\Database\QueryCounter              $queryCounter
  * @property-read \Elgg\Http\Request                       $request
@@ -204,11 +205,16 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		});
 
 		$this->setFactory('plugins', function(ServiceProvider $c) {
-			return new \Elgg\Database\Plugins(new Pool\InMemory());
+			$pool = new Pool\InMemory();
+			return new \Elgg\Database\Plugins($pool, $c->pluginSettingsCache);
+		});
+
+		$this->setFactory('pluginSettingsCache', function (ServiceProvider $c) {
+			return new \Elgg\Cache\PluginSettingsCache($c->db);
 		});
 
 		$this->setFactory('privateSettings', function(ServiceProvider $c) {
-			return new \Elgg\Database\PrivateSettingsTable($c->db, $c->entityTable);
+			return new \Elgg\Database\PrivateSettingsTable($c->db, $c->entityTable, $c->pluginSettingsCache);
 		});
 
 		$this->setFactory('queryCounter', function(ServiceProvider $c) {

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -275,6 +275,11 @@ class ElggPlugin extends \ElggObject {
 	 * @return mixed
 	 */
 	public function getSetting($name, $default = null) {
+		$values = _elgg_services()->pluginSettingsCache->getAll($this->guid);
+		if ($values !== null) {
+			return isset($values[$name]) ? $values[$name] : null;
+		}
+
 		$val = $this->$name;
 		return $val !== null ? $val : $default;
 	}
@@ -287,6 +292,11 @@ class ElggPlugin extends \ElggObject {
 	 * @return array An array of key/value pairs.
 	 */
 	public function getAllSettings() {
+		$values = _elgg_services()->pluginSettingsCache->getAll($this->guid);
+		if ($values !== null) {
+			return $values;
+		}
+
 		if (!$this->guid) {
 			return false;
 		}
@@ -361,6 +371,8 @@ class ElggPlugin extends \ElggObject {
 	 * @return bool
 	 */
 	public function unsetAllSettings() {
+		_elgg_services()->pluginSettingsCache->clear($this->guid);
+
 		$db_prefix = _elgg_services()->configTable->get('dbprefix');
 		$us_prefix = _elgg_namespace_plugin_private_setting('user_setting', '', $this->getID());
 		$is_prefix = _elgg_namespace_plugin_private_setting('internal', '', $this->getID());


### PR DESCRIPTION
This caches non-user/non-internal plugin settings and lazily loads all settings in a couple queries when the first one is requested. Many bundled plugins don’t use settings on every request so this avoids the overhead on those requests.

Fixes #4346
- [ ] how to test??
