### PR TITLE
fix(likes): likes preloader and entity menus now consider likability

### DIFF
--- a/mod/likes/classes/Elgg/Likes/Preloader.php
+++ b/mod/likes/classes/Elgg/Likes/Preloader.php
@@ -113,8 +113,10 @@ class Preloader {
 					continue;
 				}
 
-				// don't like users #4116
-				if ($item->type == "user") {
+				$type = $item->type;
+				$subtype = $item->subtype;
+				$likable = (bool)elgg_trigger_plugin_hook('likes:is_likable', "$type:$subtype", [], false);
+				if (!$likable) {
 					continue;
 				}
 
@@ -127,11 +129,12 @@ class Preloader {
 				}
 			} elseif ($item instanceof \ElggEntity) {
 
-				if (!$item instanceof \ElggUser) {
-					continue;
+				$type = $item->type;
+				$subtype = $item->getSubtype();
+				$likable = (bool)elgg_trigger_plugin_hook('likes:is_likable', "$type:$subtype", [], false);
+				if ($likable) {
+					$guids[$item->guid] = true;
 				}
-
-				$guids[$item->guid] = true;
 			}
 		}
 		return array_keys($guids);

--- a/mod/likes/start.php
+++ b/mod/likes/start.php
@@ -96,6 +96,13 @@ function likes_entity_menu_setup($hook, $type, $return, $params) {
 	$entity = $params['entity'];
 	/* @var ElggEntity $entity */
 
+	$type = $entity->type;
+	$subtype = $entity->getSubtype();
+	$likable = (bool)elgg_trigger_plugin_hook('likes:is_likable', "$type:$subtype", [], false);
+	if (!$likable) {
+		return $return;
+	}
+
 	if ($entity->canAnnotate(0, 'likes')) {
 		$hasLiked = \Elgg\Likes\DataService::instance()->currentUserLikesEntity($entity->guid);
 		


### PR DESCRIPTION
In 2.0 we added the `likes:is_likable` hook to select which entities can receive likes but we forgot to update the preloader and the entity menu setup to check it.

Now likable entities are preloaded as they should be, and in menus for unlikable entities we no longer query to generate the likes/count view.

Fixes #9065
