### PR TITLE
deprecate(metadata): metadata access control is deprecated

### DIFF
--- a/docs/design/database.rst
+++ b/docs/design/database.rst
@@ -393,10 +393,12 @@ Under the hood, metadata is stored as an instance of the
 practice (although if you're interested, see the ``ElggMetadata`` class
 reference). What you need to know is:
 
--  Metadata has an owner and access ID, both of which may be different
+-  Metadata has an owner and access ID (see note below), both of which may be different
    to the owner of the entity it's attached to
 -  You can potentially have multiple items of each type of metadata
    attached to a single entity
+
+.. note:: Metadata's ``access_id`` value will be ignored in Elgg 3.0 and all metadata values will be available in all contexts.
 
 The simple case
 ---------------
@@ -425,7 +427,7 @@ Or to add a couple of tags to an object:
 When adding metadata like this:
 
 -  The owner is set to the currently logged-in user
--  Access permissions are inherited from the entity
+-  Access permissions are inherited from the entity (see note below)
 -  Reassigning a piece of metadata will overwrite the old value
 
 This is suitable for most purposes. Be careful to note which attributes
@@ -435,6 +437,8 @@ metadata. You do need to save an entity if you have changed one of its
 built in attributes. As an example, if you changed the access id of an
 ElggObject, you need to save it or the change isn't pushed to the
 database.
+
+.. note:: Metadata's ``access_id`` value will be ignored in Elgg 3.0 and all metadata values will be available in all contexts.
 
 Reading metadata
 ~~~~~~~~~~~~~~~~
@@ -495,6 +499,8 @@ the example of a date of birth attached to a user):
 .. code:: php
 
     create_metadata($user_guid, 'dob', $dob_timestamp, 'integer', $_SESSION['guid'], $access_id);
+
+.. note:: ``$access_id`` will be ignored in Elgg 3.0 and all metadata values will be available in all contexts. Always set it to ``ACCESS_PUBLIC`` for compatibility with Elgg 3.0.
 
 For multiple values, you will need to iterate through and call
 ``create_metadata`` on each one. The following piece of code comes from

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -27,6 +27,7 @@ Deprecated APIs
  * ``elgg.walled_garden`` JavaScript is deprecated: Use ``elgg/walled_garden`` AMD module instead.
  * ``elgg()->getDb()->getTableprefix()`` is deprecated: Use ``elgg_get_config('dbprefix')``.
  * Private ``update_entity_last_action()`` is deprecated: Refrain from manually updating last action timestamp.
+ * Setting non-public ``access_id`` on metadata is deprecated. See below.
 
 Deprecated Views
 ----------------
@@ -70,6 +71,13 @@ Form footer rendering can now be deferred until the form view and its extensions
 
  * ``elgg_set_form_footer()`` - sets form footer for deferred rendering
  * ``elgg_get_form_footer()`` - returns currently set form footer
+
+Metadata ``access_id``
+----------------------
+
+It's now deprecated to create metadata with an explicit ``access_id`` value other than ``ACCESS_PUBLIC``.
+
+In Elgg 3.0, metadata will not be access controlled, and will be available in all contexts. If your plugin relies on access control of metadata, it would be wise to migrate storage to annotations or entities instead.
 
 New API for extracting class names from arrays
 ----------------------------------------------

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -392,8 +392,9 @@ abstract class ElggEntity extends \ElggData implements
 	 *                           Does not support associative arrays.
 	 * @param int    $owner_guid GUID of entity that owns the metadata.
 	 *                           Default is owner of entity.
-	 * @param int    $access_id  Who can read the metadata relative to the owner.
-	 *                           Default is the access level of the entity.
+	 * @param int    $access_id  Who can read the metadata relative to the owner (deprecated).
+	 *                           Default is the access level of the entity. Use ACCESS_PUBLIC for
+	 *                           compatibility with Elgg 3.0
 	 *
 	 * @return bool
 	 * @throws InvalidArgumentException
@@ -429,15 +430,21 @@ abstract class ElggEntity extends \ElggData implements
 				elgg_set_ignore_access($ia);
 			}
 
-			$owner_guid = (int)$owner_guid;
-			$access_id = ($access_id === null) ? $this->getAccessId() : (int)$access_id;
-			$owner_guid = $owner_guid ? $owner_guid : $this->getOwnerGUID();
+			$owner_guid = $owner_guid ? (int)$owner_guid : $this->owner_guid;
+
+			if ($access_id === null) {
+				$access_id = $this->access_id;
+			} elseif ($access_id != ACCESS_PUBLIC) {
+				$access_id = (int)$access_id;
+				elgg_deprecated_notice('Setting $access_id to a value other than ACCESS_PUBLIC is deprecated. '
+					. 'All metadata will be public in 3.0.', '2.3');
+			}
 
 			// add new md
 			$result = true;
 			foreach ($value as $value_tmp) {
 				// at this point $value is appended because it was cleared above if needed.
-				$md_id = create_metadata($this->getGUID(), $name, $value_tmp, $value_type,
+				$md_id = _elgg_services()->metadataTable->create($this->guid, $name, $value_tmp, $value_type,
 						$owner_guid, $access_id, true);
 				if (!$md_id) {
 					return false;
@@ -1438,7 +1445,7 @@ abstract class ElggEntity extends \ElggData implements
 	 * @throws IOException
 	 */
 	public function save() {
-		$guid = $this->getGUID();
+		$guid = $this->guid;
 		if ($guid > 0) {
 			$guid = $this->update();
 		} else {

--- a/engine/classes/ElggExtender.php
+++ b/engine/classes/ElggExtender.php
@@ -51,6 +51,11 @@ abstract class ElggExtender extends \ElggData {
 	 * @return void
 	 */
 	public function __set($name, $value) {
+		if ($name === 'access_id' && $this instanceof ElggMetadata && $value != ACCESS_PUBLIC) {
+			elgg_deprecated_notice('Setting ->access_id to a value other than ACCESS_PUBLIC is deprecated. '
+				. 'All metadata will be public in 3.0.', '2.3');
+		}
+
 		$this->attributes[$name] = $value;
 		if ($name == 'value') {
 			$this->attributes['value_type'] = detect_extender_valuetype($value);

--- a/engine/classes/ElggMetadata.php
+++ b/engine/classes/ElggMetadata.php
@@ -10,6 +10,9 @@
  *
  * @package    Elgg.Core
  * @subpackage Metadata
+ *
+ * @property int $access_id Access level of the metadata (deprecated). Only set this to ACCESS_PUBLIC
+ *                          for compatibility with Elgg 3.0
  */
 class ElggMetadata extends \ElggExtender {
 
@@ -82,6 +85,7 @@ class ElggMetadata extends \ElggExtender {
 			return update_metadata($this->id, $this->name, $this->value,
 				$this->value_type, $this->owner_guid, $this->access_id);
 		} else {
+			// using create_metadata() for deprecation notices in 2.x
 			$this->id = create_metadata($this->entity_guid, $this->name, $this->value,
 				$this->value_type, $this->owner_guid, $this->access_id);
 

--- a/engine/lib/metadata.php
+++ b/engine/lib/metadata.php
@@ -57,13 +57,21 @@ function elgg_delete_metadata_by_id($id) {
  * @param string $value          Value of the metadata
  * @param string $value_type     'text', 'integer', or '' for automatic detection
  * @param int    $owner_guid     GUID of entity that owns the metadata. Default is logged in user.
- * @param int    $access_id      Default is ACCESS_PRIVATE
+ * @param int    $access_id      Access level of the metadata (deprecated). Default in 2.x is ACCESS_PRIVATE, but
+ *                               use ACCESS_PUBLIC for compatibility with Elgg 3.0
  * @param bool   $allow_multiple Allow multiple values for one key. Default is false
  *
  * @return int|false id of metadata or false if failure
  */
 function create_metadata($entity_guid, $name, $value, $value_type = '', $owner_guid = 0,
-		$access_id = ACCESS_PRIVATE, $allow_multiple = false) {
+		$access_id = null, $allow_multiple = false) {
+
+	if ($access_id === null) {
+		$access_id = ACCESS_PRIVATE;
+	} elseif ($access_id != ACCESS_PUBLIC) {
+		elgg_deprecated_notice('Setting $access_id to a value other than ACCESS_PUBLIC is deprecated. '
+			. 'All metadata will be public in 3.0.', '2.3');
+	}
 
 	return _elgg_services()->metadataTable->create($entity_guid, $name, $value,
 		$value_type, $owner_guid, $access_id, $allow_multiple);
@@ -77,11 +85,17 @@ function create_metadata($entity_guid, $name, $value, $value_type = '', $owner_g
  * @param string $value      Metadata value
  * @param string $value_type Value type
  * @param int    $owner_guid Owner guid
- * @param int    $access_id  Access ID
+ * @param int    $access_id  Access level of the metadata (deprecated). Use ACCESS_PUBLIC for compatibility
+ *                           with Elgg 3.0
  *
  * @return bool
  */
 function update_metadata($id, $name, $value, $value_type, $owner_guid, $access_id) {
+	if ($access_id != ACCESS_PUBLIC) {
+		elgg_deprecated_notice('Setting $access_id to a value other than ACCESS_PUBLIC is deprecated. '
+			. 'All metadata will be public in 3.0.', '2.3');
+	}
+
 	return _elgg_services()->metadataTable->update($id, $name, $value,
 		$value_type, $owner_guid, $access_id);
 }
@@ -97,17 +111,24 @@ function update_metadata($id, $name, $value, $value_type, $owner_guid, $access_i
  * @param array  $name_and_values Associative array - a value can be a string, number, bool
  * @param string $value_type      'text', 'integer', or '' for automatic detection
  * @param int    $owner_guid      GUID of entity that owns the metadata
- * @param int    $access_id       Default is ACCESS_PRIVATE
+ * @param int    $access_id       Access level of the metadata (deprecated). Default in 2.x is ACCESS_PRIVATE, but
+ *                                use ACCESS_PUBLIC for compatibility with Elgg 3.0
  * @param bool   $allow_multiple  Allow multiple values for one key. Default is false
  *
  * @return bool
  */
 function create_metadata_from_array($entity_guid, array $name_and_values, $value_type, $owner_guid,
-		$access_id = ACCESS_PRIVATE, $allow_multiple = false) {
+		$access_id = null, $allow_multiple = false) {
+
+	if ($access_id === null) {
+		$access_id = ACCESS_PRIVATE;
+	} elseif ($access_id != ACCESS_PUBLIC) {
+		elgg_deprecated_notice('Setting $access_id to a value other than ACCESS_PUBLIC is deprecated. '
+			. 'All metadata will be public in 3.0.', '2.3');
+	}
 
 	return _elgg_services()->metadataTable->createFromArray($entity_guid, $name_and_values,
 		$value_type, $owner_guid, $access_id, $allow_multiple);
-
 }
 
 /**


### PR DESCRIPTION
Deprecates creating/updating metadata with explicit `access_id` values other than `ACCESS_PUBLIC`. The upgrade guide steers developers toward annotations if they need access-controlled value storage.

Refs #9050
Refs #9289
