### PR TITLE
chore(cache): reworks ElggMemcache and its core usage

### DIFF
--- a/engine/classes/Elgg/Cache/NullCache.php
+++ b/engine/classes/Elgg/Cache/NullCache.php
@@ -1,0 +1,58 @@
+<?php
+namespace Elgg\Cache;
+
+/**
+ * A "Null" version of ElggMemcache for use on sites without memcache setup
+ *
+ * This will eventually be replaced by something like Elgg\Cache\NullPool.
+ *
+ * @access private
+ */
+class NullCache extends \ElggSharedMemoryCache {
+
+	/**
+	 * Saves a name and value to the cache
+	 *
+	 * @param string $key  Unused
+	 * @param string $data Unused
+	 * @param int    $ttl  Unused
+	 *
+	 * @return bool
+	 */
+	public function save($key, $data, $ttl = null) {
+		return true;
+	}
+
+	/**
+	 * Retrieves data.
+	 *
+	 * @param string $key    Unused
+	 * @param int    $offset Unused
+	 * @param int    $limit  Unused
+	 *
+	 * @return mixed
+	 */
+	public function load($key, $offset = 0, $limit = null) {
+		return false;
+	}
+
+	/**
+	 * Delete data
+	 *
+	 * @param string $key Unused
+	 *
+	 * @return bool
+	 */
+	public function delete($key) {
+		return true;
+	}
+
+	/**
+	 * Clears the entire cache (does not work)
+	 *
+	 * @return true
+	 */
+	public function clear() {
+		return true;
+	}
+}

--- a/engine/classes/Elgg/Database/MetadataTable.php
+++ b/engine/classes/Elgg/Database/MetadataTable.php
@@ -203,17 +203,6 @@ class MetadataTable {
 			return false;
 		}
 	
-		// If memcached then we invalidate the cache for this entry
-		static $metabyname_memcache;
-		if ((!$metabyname_memcache) && (is_memcache_available())) {
-			$metabyname_memcache = new \ElggMemcache('metabyname_memcache');
-		}
-	
-		if ($metabyname_memcache) {
-			// @todo fix memcache (name_id is not a property of \ElggMetadata)
-			$metabyname_memcache->delete("{$md->entity_guid}:{$md->name_id}");
-		}
-	
 		$value_type = detect_extender_valuetype($value, $this->db->sanitizeString(trim($value_type)));
 	
 		$owner_guid = (int)$owner_guid;

--- a/engine/classes/Elgg/Database/UsersTable.php
+++ b/engine/classes/Elgg/Database/UsersTable.php
@@ -97,15 +97,7 @@ class UsersTable {
 					create_metadata($user_guid, 'ban_reason', $reason, '', 0, ACCESS_PUBLIC);
 				}
 	
-				// invalidate memcache for this user
-				static $newentity_cache;
-				if ((!$newentity_cache) && (is_memcache_available())) {
-					$newentity_cache = new \ElggMemcache('new_entity_cache');
-				}
-	
-				if ($newentity_cache) {
-					$newentity_cache->delete($user_guid);
-				}
+				_elgg_invalidate_memcache_for_entity($user_guid);
 	
 				// Set ban flag
 				$query = "UPDATE {$this->CONFIG->dbprefix}users_entity set banned='yes' where guid=$user_guid";
@@ -135,17 +127,8 @@ class UsersTable {
 		if (($user) && ($user->canEdit()) && ($user instanceof \ElggUser)) {
 			if (_elgg_services()->events->trigger('unban', 'user', $user)) {
 				create_metadata($user_guid, 'ban_reason', '', '', 0, ACCESS_PUBLIC);
-	
-				// invalidate memcache for this user
-				static $newentity_cache;
-				if ((!$newentity_cache) && (is_memcache_available())) {
-					$newentity_cache = new \ElggMemcache('new_entity_cache');
-				}
-	
-				if ($newentity_cache) {
-					$newentity_cache->delete($user_guid);
-				}
-	
+
+				_elgg_invalidate_memcache_for_entity($user_guid);
 	
 				$query = "UPDATE {$this->CONFIG->dbprefix}users_entity set banned='no' where guid=$user_guid";
 				return _elgg_services()->db->updateData($query);
@@ -172,18 +155,11 @@ class UsersTable {
 		if (($user) && ($user instanceof \ElggUser) && ($user->canEdit())) {
 			if (_elgg_services()->events->trigger('make_admin', 'user', $user)) {
 	
-				// invalidate memcache for this user
-				static $newentity_cache;
-				if ((!$newentity_cache) && (is_memcache_available())) {
-					$newentity_cache = new \ElggMemcache('new_entity_cache');
-				}
-	
-				if ($newentity_cache) {
-					$newentity_cache->delete($user_guid);
-				}
-	
 				$r = _elgg_services()->db->updateData("UPDATE {$this->CONFIG->dbprefix}users_entity set admin='yes' where guid=$user_guid");
+
 				_elgg_invalidate_cache_for_entity($user_guid);
+				_elgg_invalidate_memcache_for_entity($user_guid);
+
 				return $r;
 			}
 	
@@ -209,17 +185,11 @@ class UsersTable {
 			if (_elgg_services()->events->trigger('remove_admin', 'user', $user)) {
 	
 				// invalidate memcache for this user
-				static $newentity_cache;
-				if ((!$newentity_cache) && (is_memcache_available())) {
-					$newentity_cache = new \ElggMemcache('new_entity_cache');
-				}
-	
-				if ($newentity_cache) {
-					$newentity_cache->delete($user_guid);
-				}
-	
 				$r = _elgg_services()->db->updateData("UPDATE {$this->CONFIG->dbprefix}users_entity set admin='no' where guid=$user_guid");
+
 				_elgg_invalidate_cache_for_entity($user_guid);
+				_elgg_invalidate_memcache_for_entity($user_guid);
+
 				return $r;
 			}
 	
@@ -512,20 +482,41 @@ class UsersTable {
 	/**
 	 * Sets the last action time of the given user to right now.
 	 *
+	 * @see _elgg_session_boot The session boot calls this at the beginning of every request
+	 *
 	 * @param int $user_guid The user GUID
 	 *
 	 * @return void
 	 */
 	function setLastAction($user_guid) {
 		$user_guid = (int) $user_guid;
-		
 		$time = time();
 	
-		$query = "UPDATE {$this->CONFIG->dbprefix}users_entity
-			set prev_last_action = last_action,
-			last_action = {$time} where guid = {$user_guid}";
+		$query = "
+			UPDATE {$this->CONFIG->dbprefix}users_entity
+			SET prev_last_action = last_action,
+				last_action = {$time}
+			WHERE guid = {$user_guid}
+		";
 	
 		execute_delayed_write_query($query);
+
+		if (is_memcache_available()) {
+			// If we save the user to memcache during this request, then we'll end up with the
+			// old (incorrect) attributes cached (notice the above query is delayed). So it's
+			// simplest to just resave the user after all plugin code runs.
+			register_shutdown_function(function () use ($user_guid, $time) {
+				$cache = _elgg_get_memcache('new_entity_cache');
+				$user = $cache->load($user_guid);
+				if (!$user) {
+					return;
+				}
+
+				/* @var \ElggUser $user */
+				$user->prev_last_action = $user->last_action;
+				$user->storeInPersistedCache($cache, $time);
+			});
+		}
 	}
 	
 	/**
@@ -537,13 +528,25 @@ class UsersTable {
 	 */
 	function setLastLogin($user_guid) {
 		$user_guid = (int) $user_guid;
-		
 		$time = time();
 	
-		$query = "UPDATE {$this->CONFIG->dbprefix}users_entity
-			set prev_last_login = last_login, last_login = {$time} where guid = {$user_guid}";
+		$query = "
+			UPDATE {$this->CONFIG->dbprefix}users_entity
+			SET prev_last_login = last_login,
+				last_login = {$time}
+			WHERE guid = {$user_guid}
+		";
 	
 		execute_delayed_write_query($query);
+
+		if (is_memcache_available()) {
+			// If we save the user to memcache during this request, then we'll end up with the
+			// old (incorrect) attributes cached. Hence we want to invalidate as late as possible.
+			// the user object gets saved
+			register_shutdown_function(function () use ($user_guid) {
+				_elgg_invalidate_memcache_for_entity($user_guid);
+			});
+		}
 	}
 		
 }

--- a/engine/classes/Elgg/Database/UsersTable.php
+++ b/engine/classes/Elgg/Database/UsersTable.php
@@ -506,15 +506,14 @@ class UsersTable {
 			// old (incorrect) attributes cached (notice the above query is delayed). So it's
 			// simplest to just resave the user after all plugin code runs.
 			register_shutdown_function(function () use ($user_guid, $time) {
-				$cache = _elgg_get_memcache('new_entity_cache');
-				$user = $cache->load($user_guid);
+				$user = elgg_get_logged_in_user_entity();
 				if (!$user) {
 					return;
 				}
 
 				/* @var \ElggUser $user */
 				$user->prev_last_action = $user->last_action;
-				$user->storeInPersistedCache($cache, $time);
+				$user->storeInPersistedCache(_elgg_get_memcache('new_entity_cache'), $time);
 			});
 		}
 	}

--- a/engine/classes/Elgg/Database/UsersTable.php
+++ b/engine/classes/Elgg/Database/UsersTable.php
@@ -491,7 +491,13 @@ class UsersTable {
 	function setLastAction($user_guid) {
 		$user_guid = (int) $user_guid;
 		$time = time();
-	
+
+		$user = get_user($user_guid);
+		if ($user && $user->last_action == $time) {
+			// won't change
+			return;
+		}
+
 		$query = "
 			UPDATE {$this->CONFIG->dbprefix}users_entity
 			SET prev_last_action = last_action,

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -212,10 +212,9 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			if (!$servers) {
 				return null;
 			}
-			$driver = new \Stash\Driver\Memcache();
-			$driver->setOptions(array(
+			$driver = new \Stash\Driver\Memcache([
 				'servers' => $servers,
-			));
+			]);
 			return new \Stash\Pool($driver);
 		});
 

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -41,10 +41,12 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read Mailer                                   $mailer
  * @property-read \Elgg\Menu\Service                       $menus
  * @property-read \Elgg\Cache\MetadataCache                $metadataCache
+ * @property-read \Stash\Pool|null                         $memcacheStashPool
  * @property-read \Elgg\Database\MetadataTable             $metadataTable
  * @property-read \Elgg\Database\MetastringsTable          $metastringsTable
  * @property-read \Elgg\Database\Mutex                     $mutex
  * @property-read \Elgg\Notifications\NotificationsService $notifications
+ * @property-read \Elgg\Cache\NullCache                    $nullCache
  * @property-read \Elgg\PasswordService                    $passwords
  * @property-read \Elgg\PersistentLoginService             $persistentLogin
  * @property-read \Elgg\Database\Plugins                   $plugins
@@ -201,6 +203,22 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			return new \Elgg\Cache\MetadataCache($c->session);
 		});
 
+		$this->setFactory('memcacheStashPool', function(ServiceProvider $c) {
+			if (!$c->config->getVolatile('memcache')) {
+				return null;
+			}
+
+			$servers = $c->config->getVolatile('memcache_servers');
+			if (!$servers) {
+				return null;
+			}
+			$driver = new \Stash\Driver\Memcache();
+			$driver->setOptions(array(
+				'servers' => $servers,
+			));
+			return new \Stash\Pool($driver);
+		});
+
 		$this->setFactory('metadataTable', function(ServiceProvider $c) {
 			// TODO(ewinslow): Use Pool instead of MetadataCache for caching
 			return new \Elgg\Database\MetadataTable(
@@ -227,6 +245,8 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			$sub = new \Elgg\Notifications\SubscriptionsService($c->db);
 			return new \Elgg\Notifications\NotificationsService($sub, $queue, $c->hooks, $c->session, $c->translator, $c->entityTable);
 		});
+
+		$this->setClassName('nullCache', \Elgg\Cache\NullCache::class);
 
 		$this->setFactory('persistentLogin', function(ServiceProvider $c) {
 			$global_cookies_config = $c->config->getCookieConfig();

--- a/engine/classes/ElggDiskFilestore.php
+++ b/engine/classes/ElggDiskFilestore.php
@@ -21,25 +21,15 @@ class ElggDiskFilestore extends \ElggFilestore {
 	const BUCKET_SIZE = 5000;
 
 	/**
-	 * Global Elgg configuration
-	 *
-	 * @var \stdClass
-	 */
-	private $CONFIG;
-
-	/**
 	 * Construct a disk filestore using the given directory root.
 	 *
 	 * @param string $directory_root Root directory, must end in "/"
 	 */
 	public function __construct($directory_root = "") {
-		global $CONFIG;
-		$this->CONFIG = $CONFIG;
-
 		if ($directory_root) {
 			$this->dir_root = $directory_root;
 		} else {
-			$this->dir_root = $this->CONFIG->dataroot;
+			$this->dir_root = _elgg_services()->config->getDataPath();
 		}
 	}
 

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -567,15 +567,7 @@ abstract class ElggEntity extends \ElggData implements
 	 * @return mixed The value or null if not found.
 	 */
 	public function getVolatileData($name) {
-		if (!is_array($this->volatile)) {
-			$this->volatile = array();
-		}
-
-		if (array_key_exists($name, $this->volatile)) {
-			return $this->volatile[$name];
-		} else {
-			return null;
-		}
+		return array_key_exists($name, $this->volatile) ? $this->volatile[$name] : null;
 	}
 
 	/**
@@ -587,11 +579,30 @@ abstract class ElggEntity extends \ElggData implements
 	 * @return void
 	 */
 	public function setVolatileData($name, $value) {
-		if (!is_array($this->volatile)) {
-			$this->volatile = array();
-		}
-
 		$this->volatile[$name] = $value;
+	}
+
+	/**
+	 * Cache the entity in a persisted cache
+	 *
+	 * @param ElggSharedMemoryCache $cache       Memcache or null cache
+	 * @param int                   $last_action Last action time
+	 *
+	 * @return void
+	 * @access private
+	 * @internal
+	 */
+	public function storeInPersistedCache(\ElggSharedMemoryCache $cache, $last_action = 0) {
+		$tmp = $this->volatile;
+
+		// don't store volatile data
+		$this->volatile = [];
+		if ($last_action) {
+			$this->attributes['last_action'] = (int)$last_action;
+		}
+		$cache->save($this->guid, $this);
+
+		$this->volatile = $tmp;
 	}
 
 	/**
@@ -1674,13 +1685,7 @@ abstract class ElggEntity extends \ElggData implements
 		}
 
 		// If memcache is available then delete this entry from the cache
-		static $newentity_cache;
-		if ((!$newentity_cache) && (is_memcache_available())) {
-			$newentity_cache = new \ElggMemcache('new_entity_cache');
-		}
-		if ($newentity_cache) {
-			$newentity_cache->delete($guid);
-		}
+		_elgg_invalidate_memcache_for_entity($guid);
 
 		if ($ret !== false) {
 			$this->attributes['time_updated'] = $time;
@@ -1957,15 +1962,7 @@ abstract class ElggEntity extends \ElggData implements
 		}
 		
 		_elgg_invalidate_cache_for_entity($guid);
-		
-		// If memcache is available then delete this entry from the cache
-		static $newentity_cache;
-		if ((!$newentity_cache) && (is_memcache_available())) {
-			$newentity_cache = new \ElggMemcache('new_entity_cache');
-		}
-		if ($newentity_cache) {
-			$newentity_cache->delete($guid);
-		}
+		_elgg_invalidate_memcache_for_entity($guid);
 
 		// Delete contained owned and otherwise releated objects (depth first)
 		if ($recursive) {

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1485,6 +1485,7 @@ abstract class ElggEntity extends \ElggData implements
 					elgg_set_ignore_access($ia);
 				}
 			}
+			$this->storeInPersistedCache(_elgg_get_memcache('new_entity_cache'));
 		}
 		
 		return false;
@@ -1692,6 +1693,7 @@ abstract class ElggEntity extends \ElggData implements
 		}
 
 		_elgg_cache_entity($this);
+		$this->storeInPersistedCache(_elgg_get_memcache('new_entity_cache'));
 
 		$this->orig_attributes = [];
 

--- a/engine/classes/ElggMemcache.php
+++ b/engine/classes/ElggMemcache.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Memcache wrapper class.
  */
@@ -91,7 +92,10 @@ class ElggMemcache extends \ElggSharedMemoryCache {
 		}
 
 		$item = $this->stash_pool->getItem($key);
-		$result = $item->set($data, $ttl);
+
+		$item->set($data);
+		$item->expiresAfter($ttl);
+		$result = $item->save();
 
 		if ($result) {
 			_elgg_services()->logger->info("MEMCACHE: SAVE SUCCESS $key");
@@ -116,8 +120,8 @@ class ElggMemcache extends \ElggSharedMemoryCache {
 
 		$item = $this->stash_pool->getItem($key);
 
-		// no invalidation strategy allows very short TTLs
-		$value = $item->get(\Stash\Invalidation::NONE);
+		$item->setInvalidationMethod(\Stash\Invalidation::NONE);
+		$value = $item->get();
 
 		if ($item->isMiss()) {
 			_elgg_services()->logger->info("MEMCACHE: LOAD MISS $key");

--- a/engine/lib/memcache.php
+++ b/engine/lib/memcache.php
@@ -14,26 +14,7 @@
  * @return bool
  */
 function is_memcache_available() {
-	global $CONFIG;
-
-	static $memcache_available;
-
-	if ((!isset($CONFIG->memcache)) || (!$CONFIG->memcache)) {
-		return false;
-	}
-
-	// If we haven't set variable to something
-	if (($memcache_available !== true) && ($memcache_available !== false)) {
-		try {
-			$tmp = new \ElggMemcache();
-			// No exception thrown so we have memcache available
-			$memcache_available = true;
-		} catch (Exception $e) {
-			$memcache_available = false;
-		}
-	}
-
-	return $memcache_available;
+	return (bool) _elgg_services()->memcacheStashPool;
 }
 
 /**
@@ -45,13 +26,27 @@ function is_memcache_available() {
  * @access private
  */
 function _elgg_invalidate_memcache_for_entity($entity_guid) {
-	static $newentity_cache;
-	
-	if ((!$newentity_cache) && (is_memcache_available())) {
-		$newentity_cache = new \ElggMemcache('new_entity_cache');
+	_elgg_get_memcache('new_entity_cache')->delete($entity_guid);
+}
+
+/**
+ * Get a namespaced ElggMemcache object (if memcache is available) or a null cache
+ *
+ * @param string $namespace Namespace to add to all keys used
+ *
+ * @return ElggMemcache|Elgg\Cache\NullCache
+ * @access private
+ */
+function _elgg_get_memcache($namespace = 'default') {
+	static $caches = array();
+
+	$cache_pool = _elgg_services()->memcacheStashPool;
+	if (!$cache_pool) {
+		return _elgg_services()->nullCache;
 	}
-	
-	if ($newentity_cache) {
-		$newentity_cache->delete($entity_guid);
+
+	if (!isset($caches[$namespace])) {
+		$caches[$namespace] = new ElggMemcache($namespace, $cache_pool);
 	}
+	return $caches[$namespace];
 }

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -641,20 +641,6 @@ function _elgg_delete_metastring_based_object_by_id($id, $type) {
 	$obj = _elgg_get_metastring_based_object_from_id($id, $type);
 
 	if ($obj) {
-		// Tidy up if memcache is enabled.
-		// @todo only metadata is supported
-		if ($type == 'metadata') {
-			static $metabyname_memcache;
-			if ((!$metabyname_memcache) && (is_memcache_available())) {
-				$metabyname_memcache = new \ElggMemcache('metabyname_memcache');
-			}
-
-			if ($metabyname_memcache) {
-				// @todo why name_id? is that even populated?
-				$metabyname_memcache->delete("{$obj->entity_guid}:{$obj->name_id}");
-			}
-		}
-
 		if ($obj->canEdit()) {
 			// bc code for when we triggered 'delete', 'annotations' #4770
 			$result = true;

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -354,13 +354,6 @@ function login(\ElggUser $user, $persistent = false) {
 
 	elgg_trigger_after_event('login', 'user', $user);
 
-	// if memcache is enabled, invalidate the user in memcache @see https://github.com/Elgg/Elgg/issues/3143
-	if (is_memcache_available()) {
-		$guid = $user->getGUID();
-		// this needs to happen with a shutdown function because of the timing with set_last_login()
-		register_shutdown_function("_elgg_invalidate_memcache_for_entity", $guid);
-	}
-
 	return true;
 }
 

--- a/engine/tests/ElggCoreAttributeLoaderTest.php
+++ b/engine/tests/ElggCoreAttributeLoaderTest.php
@@ -27,10 +27,13 @@ class ElggCoreAttributeLoaderTest extends \ElggCoreUnitTest {
 				'selects' => array('42 as added_col2'),
 				'limit' => 1,
 			));
-			$entity = array_shift($entities);
-			$this->assertTrue($entity instanceof \ElggEntity);
-			$this->assertEqual($entity->added_col2, null, "Additional select columns are leaking to attributes for " . get_class($entity));
-			$this->assertEqual($entity->getVolatileData('select:added_col2'), 42);
+			$this->assertFalse(empty($entities));
+			if ($entities) {
+				$entity = array_shift($entities);
+				$this->assertTrue($entity instanceof \ElggEntity);
+				$this->assertEqual($entity->added_col2, null, "Additional select columns are leaking to attributes for " . get_class($entity));
+				$this->assertEqual($entity->getVolatileData('select:added_col2'), 42);
+			}
 		}
 
 		elgg_set_ignore_access($access);
@@ -60,13 +63,16 @@ class ElggCoreAttributeLoaderTest extends \ElggCoreUnitTest {
 				'selects' => array('42 as added_col3'),
 				'limit' => 1,
 			));
-			$entity = array_shift($entities);
-			$this->assertTrue($entity instanceof \ElggEntity);
-			$this->assertEqual($entity->added_col3, null, "Additional select columns are leaking to attributes for " . get_class($entity));
-			$this->assertEqual($entity->getVolatileData('select:added_col3'), 42);
+			$this->assertFalse(empty($entities));
+			if ($entities) {
+				$entity = array_shift($entities);
+				$this->assertTrue($entity instanceof \ElggEntity);
+				$this->assertEqual($entity->added_col3, null, "Additional select columns are leaking to attributes for " . get_class($entity));
+				$this->assertEqual($entity->getVolatileData('select:added_col3'), 42);
 
-			// make sure we have cached the entity
-			$this->assertNotEqual(false, _elgg_retrieve_cached_entity($entity->guid));
+				// make sure we have cached the entity
+				$this->assertNotEqual(false, _elgg_retrieve_cached_entity($entity->guid));
+			}
 		}
 
 		// run these again but with different value to make sure cache does not interfere
@@ -76,10 +82,13 @@ class ElggCoreAttributeLoaderTest extends \ElggCoreUnitTest {
 				'selects' => array('64 as added_col3'),
 				'limit' => 1,
 			));
-			$entity = array_shift($entities);
-			$this->assertTrue($entity instanceof \ElggEntity);
-			$this->assertEqual($entity->added_col3, null, "Additional select columns are leaking to attributes for " . get_class($entity));
-			$this->assertEqual($entity->getVolatileData('select:added_col3'), 64, "Failed to overwrite volatile data in cached entity");
+			$this->assertFalse(empty($entities));
+			if ($entities) {
+				$entity = array_shift($entities);
+				$this->assertTrue($entity instanceof \ElggEntity);
+				$this->assertEqual($entity->added_col3, null, "Additional select columns are leaking to attributes for " . get_class($entity));
+				$this->assertEqual($entity->getVolatileData('select:added_col3'), 64, "Failed to overwrite volatile data in cached entity");
+			}
 		}
 
 		elgg_set_ignore_access($access);

--- a/engine/tests/ElggCoreFilestoreTest.php
+++ b/engine/tests/ElggCoreFilestoreTest.php
@@ -132,6 +132,12 @@ class ElggCoreFilestoreTest extends \ElggCoreUnitTest {
 	}
 
 	protected function createTestUser($username = 'fileTest') {
+		// in case a test failure left the user
+		$user = get_user_by_username($username);
+		if ($user) {
+			return $user;
+		}
+
 		$user = new \ElggUser();
 		$user->username = $username;
 		$guid = $user->save();

--- a/engine/tests/ElggCoreMetadataAPITest.php
+++ b/engine/tests/ElggCoreMetadataAPITest.php
@@ -47,7 +47,7 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 	}
 
 	public function testElggGetEntitiesFromMetadata() {
-		global $CONFIG, $METASTRINGS_CACHE;
+		global $METASTRINGS_CACHE;
 		$METASTRINGS_CACHE = array();
 
 		$this->object->title = 'Meta Unit Test';
@@ -265,6 +265,8 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 	protected function delete_metastrings($string) {
 		global $CONFIG, $METASTRINGS_CACHE;
 		$METASTRINGS_CACHE = array();
+
+		_elgg_get_memcache('metastrings_memcache')->delete(md5($string));
 
 		$string = sanitise_string($string);
 		_elgg_services()->db->deleteData("

--- a/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
+++ b/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
@@ -32,7 +32,19 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
 
 		$obj1 = $sp->{$name};
 		$obj2 = $sp->{$name};
-		$this->assertInstanceOf($type, $obj1);
+
+		// support $type like "Foo\Bar|Baz|null"
+		$passed = false;
+		foreach (explode('|', $type) as $test_type) {
+			if ($test_type === 'null') {
+				if ($obj1 === null) {
+					$passed = true;
+				}
+			} elseif ($obj1 instanceof $test_type) {
+				$passed = true;
+			}
+		}
+		$this->assertTrue($passed, "\$obj1 did not match type $type");
 
 		if (in_array($name, $non_shared_names)) {
 			$this->assertNotSame($obj1, $obj2);

--- a/mod/garbagecollector/start.php
+++ b/mod/garbagecollector/start.php
@@ -142,14 +142,10 @@ function garbagecollector_orphaned_metastrings() {
 
 		$dead = get_data($select_query);
 		if ($dead) {
-			static $metastrings_memcache;
-			
-			if (!$metastrings_memcache) {
-				$metastrings_memcache = new \ElggMemcache('metastrings_memcache');
-			}
+			$metastrings_memcache = _elgg_get_memcache('metastrings_memcache');
 
 			foreach ($dead as $d) {
-				$metastrings_memcache->delete($d->string);
+				$metastrings_memcache->delete(md5($d->string));
 			}
 		}
 	}

--- a/mod/pages/actions/pages/delete.php
+++ b/mod/pages/actions/pages/delete.php
@@ -26,7 +26,6 @@ if (pages_is_page($page)) {
 		if ($children) {
 			$db_prefix = elgg_get_config('dbprefix');
 			$subtype_id = (int)get_subtype_id('object', 'page_top');
-			$newentity_cache = is_memcache_available() ? new ElggMemcache('new_entity_cache') : null;
 
 			foreach ($children as $child) {
 				if ($parent) {
@@ -44,9 +43,7 @@ if (pages_is_page($page)) {
 					));
 
 					_elgg_invalidate_cache_for_entity($child_guid);
-					if ($newentity_cache) {
-						$newentity_cache->delete($child_guid);
-					}
+					_elgg_invalidate_memcache_for_entity($child_guid);
 				}
 			}
 		}


### PR DESCRIPTION
(replaces #7605)

Properly loads extra query selects into memcache-loaded entities.
Properly updates the last_action/prev_last_action on current user.
Caches subtype table data.
No longer caches entity volatile data.
Adds support for the other `memcached` extension.
Adds a null cache to simplify logic.
Removes usage around metadata since it doesn't save any values.
Makes tests more resilient to failures.
Allows service provider test to support nullable types.

As we have to load full DB rows anyway, we do nothing but churn memcache trying to load and save every entity in fetched lists. This refocuses the entity strategy on single get_entity() calls.

set_last_action() no longer writes DB/cache if last_action won't change.

Fixes #7643
Fixes #7644
Fixes #7533
