### PR TITLE
elgg_view_input()

### DIFF
--- a/docs/guides/actions.rst
+++ b/docs/guides/actions.rst
@@ -137,6 +137,9 @@ This is done as follows:
 This lets a plugin extend an existing action without the need to replace the whole action. In the case of the captcha plugin it allows the plugin to provide captcha support in a very loosely coupled way.
 
 
+Forms
+=====
+
 To output a form, use the elgg_view_form function like so:
 
 .. code:: php
@@ -181,6 +184,100 @@ Now when you call ``elgg_view_form('example')``, Elgg will produce:
        <input type="submit" class="elgg-button elgg-button-submit" value="Submit">
      </fieldset>
    </form>
+
+
+Inputs
+------
+
+To render a form input, use one of the bundled input views, which cover all standard
+HTML input elements. See individual view files for a list of accepted parameters.
+
+.. code:: php
+
+   echo elgg_view('input/select', array(
+      'required' => true,
+      'name' => 'status',
+      'options_values' => array(
+         'draft' => elgg_echo('status:draft'),
+         'published' => elgg_echo('status:published'),
+      ),
+      // most input views will render additional parameters passed to the view
+      // as tag attributes
+      'data-rel' => 'blog',
+   ));
+
+The above example will render a dropdown select input:
+
+.. code:: html
+
+   <select required="required" name="status" data-rel="blog" class="elgg-input-dropdown">
+      <option value="draft">Draft</option>
+      <option value="published">Published</option>
+   </select>
+
+To ensure consistency in field markup, use ``elgg_view_input()``, which accepts
+all the parameters of the input being rendered, as well as ``label`` and ``help``
+parameters (both of which are optional and accept HTML or text).
+
+.. code:: php
+
+   echo elgg_view_input('select', array(
+      'required' => true,
+      'name' => 'status',
+      'options_values' => array(
+         'draft' => elgg_echo('status:draft'),
+         'published' => elgg_echo('status:published'),
+      ),
+      'data-rel' => 'blog',
+      'label' => elgg_echo('blog:status:label'),
+      'help' => elgg_view_icon('help') . elgg_echo('blog:status:help'),
+   ));
+
+The above will generate the following markup:
+
+.. code:: html
+
+   <div class="elgg-field elgg-field-required">
+      <label for="elgg-field-1" class="elgg-field-label">Blog status<span title="Required" class="elgg-required-indicator">*</span></label>
+      <select required="required" name="status" data-rel="blog" id="elgg-field-1" class="elgg-input-dropdown">
+         <option value="draft">Draft</option>
+         <option value="published">Published</option>
+      </select>
+      <div class="elgg-field-help elgg-text-help">
+         <span class="elgg-icon-help elgg-icon"></span>This indicates whether or not the blog is visible in the feed
+      </div>
+   </div>
+
+
+Input types
+-----------
+
+A list of bundled input types/views:
+
+* ``input/text`` - renders a text input ``<input type="text">``
+* ``input/plaintext`` - renders a textarea ``<textarea></textarea>``
+* ``input/longtext`` - renders a WYSIWYG text input
+* ``input/url`` - renders a url input ``<input type="url">``
+* ``input/email`` - renders an email input ``<input type="email">``
+* ``input/checkbox`` - renders a single checkbox ``<input type="checkbox">``
+* ``input/checkboxes`` - renders a set of checkboxes with the same name
+* ``input/radio`` - renders one or more radio buttons ``<input type="radio">``
+* ``input/submit`` - renders a submit button ``<input type="submit">``
+* ``input/button`` - renders a button ``<button></button>``
+* ``input/file`` - renders a file input ``<input type="file">``
+* ``input/select`` - renders a select input ``<select></select>``
+* ``input/hidden`` - renders a hidden input ``<input type="hidden">``
+* ``input/password`` - renders a password input ``<input type="password">``
+* ``input/date`` - renders a jQuery datepicker
+
+* ``input/access`` - renders an Elgg access level select
+* ``input/tags`` - renders an Elgg tags input
+* ``input/autocomplete`` - renders an Elgg entity autocomplete
+* ``input/captcha`` - placeholder view for plugins to extend
+* ``input/friendspicker`` - renders an Elgg friend picker
+* ``input/userpicker`` - renders an Elgg user autocomplete
+* ``input/location`` renders an Elgg location input
+
 
 Files and images
 ================

--- a/docs/tutorials/blog.rst
+++ b/docs/tutorials/blog.rst
@@ -67,28 +67,34 @@ which we will create in a moment. Here is the content of
 
 .. code:: php
 
+    echo elgg_view_input('text', [
+        'name' => 'title',
+        'label' => elgg_echo('title'),
+        'required' => true,
+    ]);
 
-    <div>
-        <label for="title"><?= elgg_echo("title"); ?></label><br />
-        <?= elgg_view('input/text', ['name' => 'title', 'id' => 'title']); ?>
-    </div>
+    echo elgg_view_input('longtext', [
+        'name' => 'body',
+        'label' => elgg_echo('body'),
+        'required' => true,
+    ]);
 
-    <div>
-        <label for="body"><?= elgg_echo("body"); ?></label><br />
-        <?= elgg_view('input/longtext', ['name' => 'body', 'id' => 'body']); ?>
-    </div>
+    echo elgg_view_input('tags', [
+        'name' => 'tags',
+        'label' => elgg_echo('tags'),
+        'help' => elgg_echo('tags:help'),
+    ]);
 
-    <div>
-        <label for="tags"><?= elgg_echo("tags"); ?></label><br />
-        <?= elgg_view('input/tags', ['name' => 'tags', 'id' => 'tags']); ?>
-    </div>
+    echo elgg_view_input('submit', array(
+        'value' => elgg_echo('save'),
+        'field_class' => 'elgg-foot',
+    ));
 
-    <div>
-        <?= elgg_view('input/submit', ['value' => elgg_echo('save')]); ?>
-    </div>
 
-Notice how the form is calling input views like ``input/longtext``.
-These are built into Elgg and make it easy to add form components.
+Notice how the form is calling ``elgg_view_input()`` to render inputs. This helper function maintains
+consistency in field markup, and is used as a shortcut for rendering field elements, such as label,
+help text, and input. See :doc:`/guides/actions`.
+
 You can see a complete list of input views in the ``/vendor/elgg/elgg/views/default/input/`` directory.
 
 The action file

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1269,6 +1269,58 @@ function elgg_view_form($action, $form_vars = array(), $body_vars = array()) {
 }
 
 /**
+ * Renders a form field
+ * 
+ * @param string $input_type Input type, used to generate an input view ("input/$input_type")
+ * @param array  $vars       Fields and input vars.
+ *                           Field vars contain both field and input params. 'label', 'help',
+ *                           and 'field_class' params will not be passed on to the input view.
+ *                           Others, including 'required' and 'id', will be available to the
+ *                           input view. Both 'label' and 'help' params accept HTML, and
+ *                           will be printed unescaped within their wrapper element.
+ * @return string
+ */
+function elgg_view_input($input_type, array $vars = array()) {
+
+	static $id_num;
+
+	if (!elgg_view_exists("input/$input_type")) {
+		return '';
+	}
+
+	$id = elgg_extract('id', $vars);
+	if (!$id) {
+		$id_num++;
+		$id = "elgg-field-$id_num";
+		$vars['id'] = $id;
+	}
+
+	$vars['input_type'] = $input_type;
+
+	$label = elgg_view('elements/forms/label', $vars);
+	unset($vars['label']);
+
+	$help = elgg_view('elements/forms/help', $vars);
+	unset($vars['help']);
+
+	$required = elgg_extract('required', $vars);
+
+	$field_class = (array) elgg_extract('field_class', $vars, array());
+	unset($vars['field_class']);
+
+	$input = elgg_view("elements/forms/input", $vars);
+
+	return elgg_view('elements/forms/field', array(
+		'label' => $label,
+		'help' => $help,
+		'required' => $required,
+		'id' => $id,
+		'input' => $input,
+		'class' => $field_class,
+	));
+}
+
+/**
  * Create a tagcloud for viewing
  *
  * @see elgg_get_tags

--- a/languages/en.php
+++ b/languages/en.php
@@ -1475,4 +1475,7 @@ Please do not reply to this email.",
 	"za" => "Zuang",
 	"zh" => "Chinese",
 	"zu" => "Zulu",
+
+	"field:required" => 'Required',
+
 );

--- a/mod/aalborg_theme/views/default/elements/forms.css.php
+++ b/mod/aalborg_theme/views/default/elements/forms.css.php
@@ -6,7 +6,7 @@
 /* ***************************************
 	Form Elements
 *************************************** */
-fieldset > div {
+fieldset > div, .elgg-field {
 	margin-bottom: 15px;
 }
 fieldset > div:last-child {
@@ -16,13 +16,23 @@ fieldset > div:last-child {
 	border-top: 1px solid #DCDCDC;
 	padding: 10px 0;
 }
-label {
+label, .elgg-field-label {
 	font-weight: bold;
 	color: #333;
 	font-size: 110%;
 }
-label.elgg-state-disabled {
+.elgg-field-label {
+	display: block;
+}
+label.elgg-state-disabled, .elgg-field-label.elgg-state-disabled {
 	opacity: 0.6;
+}
+.elgg-required-indicator {
+	font-size: 110%;
+	font-weight: bold;
+	color: #C24000;
+	display: inline;
+	padding: 0 5px;
 }
 input, textarea {
 	border: 1px solid #DCDCDC;

--- a/mod/developers/views/default/theme_sandbox/forms.php
+++ b/mod/developers/views/default/theme_sandbox/forms.php
@@ -1,161 +1,134 @@
 <?php
-
 $ipsum = elgg_view('developers/ipsum');
-
 ?><form action="#">
 	<fieldset>
 		<legend>Fieldset Legend</legend>
-		<div>
-			<label for="f1">Text input (.elgg-input-text):</label>
-			<?php echo elgg_view('input/text', array(
-					'name' => 'f1',
-					'id' => 'f1',
-					'value' => 'input text',
-					));
-			?>
-		</div>
-		<div>
-			<label for="f2">Password input (.elgg-input-password):</label>
-			<?php echo elgg_view('input/password', array(
-					'name' => 'f2',
-					'id' => 'f2',
-					'value' => 'password',
-					));
-			?>
-		</div>
-		<div>
-			<label for="f3">Radio input (.elgg-input-radios):</label><br />
-			<?php echo elgg_view('input/radio', array(
-					'name' => 'f3',
-					'id' => 'f3',
-					'options' => array('a (.elgg-input-radio)' => 1, 'b (.elgg-input-radio)' => 2),
-					));
-			?>
-		</div>
-		<div>
-			<label for="f4">Checkboxes input (.elgg-input-checkboxes):</label><br />
-			<?php echo elgg_view('input/checkboxes', array(
-					'name' => 'f4',
-					'id' => 'f4',
-					'options' => array('a (.elgg-input-checkbox)' => 1, 'b (.elgg-input-checkbox)' => 2),
-					));
-			?>
-		</div>
-		<div>
-			<label for="f5">Select input (dropdown) (.elgg-input-dropdown):</label><br />
-			<?php echo elgg_view('input/select', array(
-					'name' => 'f5',
-					'id' => 'f5',
-					'options' => array('option 1', 'option 2'),
-					));
-			?>
-		</div>
-		<div>
-			<label for="f51">Select input (multiselect) (.elgg-input-dropdown):</label><br />
-			<?php echo elgg_view('input/select', array(
-					'name' => 'f51[]',
-					'id' => 'f51',
-					'options_values' => array('value 1' => 'option 1', 'value 2' => 'option 2', 'value 3' => 'option 3'),
-					'multiple' => true,
-					));
-			?>
-		</div>
-		<div>
-			<label for="f6">Access input (.elgg-input-access):</label><br />
-			<?php echo elgg_view('input/access', array(
-					'name' => 'f6',
-					'id' => 'f6',
-					'value' => ACCESS_PUBLIC,
-					));
-			?>
-		</div>
-		<div>
-			<label for="f7">File input (.elgg-input-file):</label>
-			<?php echo elgg_view('input/file', array(
-					'name' => 'f7',
-					'id' => 'f7',
-					));
-			?>
-		</div>
-		<div>
-			<label for="f8">URL input (.elgg-input-url):</label>
-			<?php echo elgg_view('input/url', array(
-					'name' => 'f8',
-					'id' => 'f8',
-					'value' => 'http://elgg.org/',
-					));
-			?>
-		</div>
-		<div>
-			<label for="f9">Tags input (.elgg-input-tags):</label>
-			<?php echo elgg_view('input/tags', array(
-					'name' => 'f9',
-					'id' => 'f9',
-					'value' => 'one, two, three',
-					));
-			?>
-		</div>
-		<div>
-			<label for="f10">Email input (.elgg-input-email):</label>
-			<?php echo elgg_view('input/email', array(
-					'name' => 'f10',
-					'id' => 'f10',
-					'value' => 'noone@elgg.org',
-					));
-			?>
-		</div>
-		<div>
-			<label for="f11">Autocomplete input (.elgg-input-autocomplete):</label>
-			<?php echo elgg_view('input/autocomplete', array(
-					'name' => 'f11',
-					'id' => 'f11',
-					'match_on' => array('groups', 'friends'),
-					));
-			?>
-		</div>
-		<div>
-			<label for="f12">Date input (.elgg-input-date):</label>
-			<?php echo elgg_view('input/date', array(
-					'name' => 'f12',
-					'id' => 'f12',
-					'value' => '2012-12-31',
-					));
-			?>
-		</div>
-		<div>
-			<label for="f13">User picker input (.elgg-user-picker):</label>
-			<?php echo elgg_view('input/userpicker', array(
-					'name' => 'f13',
-					'id' => 'f13',
-					));
-			?>
-		</div>
-		<div>
-			<label for="f16">User picker input (with max 1 results) (.elgg-user-picker):</label>
-			<?php echo elgg_view('input/userpicker', array(
-					'name' => 'f16',
-					'id' => 'f16',
-					'limit' => 1
-					));
-			?>
-		</div>
-		<div>
-			<label for="f15">Plain textarea input (.elgg-input-plaintext):</label>
-			<?php echo elgg_view('input/plaintext', array(
-					'name' => 'f15',
-					'id' => 'f15',
-					'value' => $ipsum,
-					));
-			?>
-		</div>
-		<div>
-			<label for="f14">Long textarea input (.elgg-input-longtext):</label>
-			<?php echo elgg_view('input/longtext', array(
-					'name' => 'f14',
-					'id' => 'f14',
-					'value' => $ipsum,
-					));
-			?>
-		</div>
+		<?php
+		echo elgg_view_input('text', array(
+			'required' => true,
+			'name' => 'f1',
+			'id' => 'f1',
+			'value' => 'input text',
+			'label' => 'Text input (.elgg-input-text):',
+			'help' => 'This is how help text looks',
+		));
+
+		echo elgg_view_input('password', array(
+			'name' => 'f2',
+			'id' => 'f2',
+			'value' => 'password',
+			'label' => 'Password input (.elgg-input-password):',
+		));
+
+		echo elgg_view_input('radio', array(
+			'name' => 'f3',
+			'id' => 'f3',
+			'options' => array(
+				'a (.elgg-input-radio)' => 1,
+				'b (.elgg-input-radio)' => 2
+			),
+			'label' => 'Radio input (.elgg-input-radios):',
+		));
+
+		echo elgg_view_input('checkboxes', array(
+			'name' => 'f4',
+			'id' => 'f4',
+			'options' => array(
+				'a (.elgg-input-checkbox)' => 1,
+				'b (.elgg-input-checkbox)' => 2
+			),
+			'label' => 'Checkboxes input (.elgg-input-checkboxes):',
+		));
+
+		echo elgg_view_input('select', array(
+			'name' => 'f5',
+			'id' => 'f5',
+			'options' => array('option 1', 'option 2'),
+			'label' => 'Select input (dropdown) (.elgg-input-dropdown):',
+		));
+
+		echo elgg_view_input('select', array(
+			'name' => 'f51[]',
+			'id' => 'f51',
+			'options_values' => array('value 1' => 'option 1', 'value 2' => 'option 2', 'value 3' => 'option 3'),
+			'multiple' => true,
+			'label' => 'Select input (multiselect) (.elgg-input-dropdown):',
+		));
+
+		echo elgg_view_input('access', array(
+			'name' => 'f6',
+			'id' => 'f6',
+			'value' => ACCESS_PUBLIC,
+			'label' => 'Access input (.elgg-input-access):',
+		));
+
+		echo elgg_view_input('file', array(
+			'name' => 'f7',
+			'id' => 'f7',
+			'label' => 'File input (.elgg-input-file):',
+		));
+
+		echo elgg_view_input('url', array(
+			'name' => 'f8',
+			'id' => 'f8',
+			'value' => 'http://elgg.org/',
+			'label' => 'URL input (.elgg-input-url):',
+		));
+
+		echo elgg_view_input('tags', array(
+			'name' => 'f9',
+			'id' => 'f9',
+			'value' => 'one, two, three',
+			'label' => 'Tags input (.elgg-input-tags):',
+		));
+
+		echo elgg_view_input('email', array(
+			'name' => 'f10',
+			'id' => 'f10',
+			'value' => 'noone@elgg.org',
+			'label' => 'Email input (.elgg-input-email):',
+		));
+
+		echo elgg_view_input('autocomplete', array(
+			'name' => 'f11',
+			'id' => 'f11',
+			'match_on' => array('groups', 'friends'),
+			'label' => 'Autocomplete input (.elgg-input-autocomplete):',
+		));
+
+		echo elgg_view_input('date', array(
+			'name' => 'f12',
+			'id' => 'f12',
+			'value' => '2012-12-31',
+			'label' => 'Date input (.elgg-input-date):',
+		));
+
+		echo elgg_view_input('userpicker', array(
+			'name' => 'f13',
+			'id' => 'f13',
+			'label' => 'User picker input (.elgg-user-picker):',
+		));
+
+		echo elgg_view_input('userpicker', array(
+			'name' => 'f16',
+			'id' => 'f16',
+			'limit' => 1,
+			'label' => 'User picker input (with max 1 results) (.elgg-user-picker):',
+		));
+
+		echo elgg_view_input('plaintext', array(
+			'name' => 'f15',
+			'id' => 'f15',
+			'value' => $ipsum,
+			'label' => 'Plain textarea input (.elgg-input-plaintext):',
+		));
+
+		echo elgg_view_input('longtext', array(
+			'name' => 'f14',
+			'id' => 'f14',
+			'value' => $ipsum,
+			'label' => 'Long textarea input (.elgg-input-longtext):',
+		));
+		?>
 	</fieldset>
 </form>

--- a/views/default/admin.css.php
+++ b/views/default/admin.css.php
@@ -463,11 +463,22 @@ label {
 	font-size: 110%;
 }
 label.elgg-state-disabled,
-input.elgg-state-disabled {
+input.elgg-state-disabled,
+.elgg-field-label.elgg-state-disabled {
 	opacity: 0.6;
 }
+.elgg-field-label {
+	display: block;
+}
+.elgg-required-indicator {
+	font-size: 110%;
+	font-weight: bold;
+	color: #C24000;
+	display: inline;
+	padding: 0 5px;
+}
 
-fieldset > div {
+fieldset > div, .elgg-field {
 	margin-bottom: 15px;
 }
 fieldset > div:last-child {

--- a/views/default/elements/forms/field.php
+++ b/views/default/elements/forms/field.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Form field view
+ *
+ * @uses $vars['input'] Form input element
+ * @uses $vars['id'] ID attribute of the input element
+ * @uses $vars['required'] Required or optional input
+ * @uses $vars['label'] HTML content of the label element
+ * @uses $vars['help'] HTML content of the help element
+ */
+$input = elgg_extract('input', $vars);
+if (!$input) {
+	return;
+}
+
+$label = elgg_extract('label', $vars, '');
+$help = elgg_extract('help', $vars, '');
+
+$field_class = (array) elgg_extract('class', $vars, array());
+$field_class[] = 'elgg-field';
+if (elgg_extract('required', $vars)) {
+	$field_class[] = "elgg-field-required";
+}
+
+$field = $label . $input . $help;
+
+echo elgg_format_element('div', [
+	'class' => $field_class,
+		], $field);
+

--- a/views/default/elements/forms/help.php
+++ b/views/default/elements/forms/help.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Form input help text view
+ *
+ * @uses $vars['help'] HTML content of the help element
+ */
+$help = elgg_extract('help', $vars, '');
+if (!$help) {
+	return;
+}
+
+echo elgg_format_element('div', [
+	'class' => 'elgg-field-help elgg-text-help',
+		], $help);

--- a/views/default/elements/forms/input.php
+++ b/views/default/elements/forms/input.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Helper view that can be used to filter vars for all input views
+ */
+$input_type = elgg_extract('input_type', $vars);
+unset($vars['input_type']);
+
+echo elgg_view("input/$input_type", $vars);

--- a/views/default/elements/forms/label.php
+++ b/views/default/elements/forms/label.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Form input label view
+ *
+ * @uses $vars['label'] HTML content of the label element
+ * @uses $vars['id'] ID attribute of the input element
+ */
+$label = elgg_extract('label', $vars, '');
+$id = elgg_extract('id', $vars);
+$required = elgg_extract('required', $vars);
+
+if (!$label) {
+	return;
+}
+
+if ($required) {
+	$label .= elgg_format_element('span', [
+		'title' => elgg_echo('field:required'),
+		'class' => 'elgg-required-indicator',
+	], "&ast;");
+}
+
+echo elgg_format_element('label', [
+	'for' => $id,
+	'class' => 'elgg-field-label'
+		], $label);


### PR DESCRIPTION
Adds new api to generate form fields with a standard markup

``` html
<div class="elgg-field elgg-field-required">
    <label for="f1" class="elgg-field-label">Text input (.elgg-input-text):</label>
    <input value="input text" type="text" required="required" name="f1" id="f1" class="elgg-input-text">
    <div class="elgg-field-help elgg-text-help">This is how help text looks</div>
</div>
```
