### PR TITLE
fix(river): floated river selector no longer breaks layout

### DIFF
--- a/mod/aalborg_theme/views/default/elements/components.css
+++ b/mod/aalborg_theme/views/default/elements/components.css
@@ -199,9 +199,9 @@
 	float: right;
 	margin: 13px 0 18px;
 }
-.elgg-river-selector select {
+.elgg-river-selector * {
 	margin-left: 5px;
-	vertical-align: text-top;
+	vertical-align: middle;
 }
 
 .elgg-river-comments {

--- a/views/default/core/river/filter.php
+++ b/views/default/core/river/filter.php
@@ -39,6 +39,7 @@ $attr = [
 	'class' => 'elgg-river-selector',
 ];
 
-echo elgg_format_element('label', $attr, elgg_echo('filter') . " $select");
+$input = elgg_format_element('label', $attr, elgg_format_element('span', [], elgg_echo('filter')) . " $select");
+echo elgg_format_element('div', ['class' => 'clearfix'], $input);
 
 elgg_load_js('elgg.ui.river');


### PR DESCRIPTION
River selector label is now wrapped in a clearfix ensuring layouts stay intact
when succeeding content is inline.
Also wraps label text into a span for proper vertical alignment.

Fixes #9091
