### PR TITLE
feature(forms): allow custom required indicators for field labels

### DIFF
--- a/views/default/elements/forms/label.php
+++ b/views/default/elements/forms/label.php
@@ -4,6 +4,7 @@
  * Form input label view
  *
  * @uses $vars['label'] HTML content of the label element
+ * @uses $vars['required_indicator'] Override required indicator with a custom view, or set to a false value to not render it
  * @uses $vars['id'] ID attribute of the input element
  */
 $label = elgg_extract('label', $vars, '');
@@ -15,10 +16,16 @@ if (!$label) {
 }
 
 if ($required) {
-	$label .= elgg_format_element('span', [
-		'title' => elgg_echo('field:required'),
-		'class' => 'elgg-required-indicator',
-	], "&ast;");
+	$indicator = elgg_extract('required_indicator', $vars);
+	if (!isset($indicator)) {
+		$indicator = elgg_format_element('span', [
+			'title' => elgg_echo('field:required'),
+			'class' => 'elgg-required-indicator',
+				], "&ast;");
+	}
+	if ($indicator) {
+		$label .= $indicator;
+	}
 }
 
 echo elgg_format_element('label', [


### PR DESCRIPTION
You can now pass required_indicator parameter to elgg_view_input() to override
default indicator view
