### PR TITLE
fix(memcache): don't store a copy of $CONFIG in file objects

### DIFF
--- a/engine/classes/ElggFile.php
+++ b/engine/classes/ElggFile.php
@@ -446,4 +446,30 @@ class ElggFile extends \ElggObject {
 
 		return true;
 	}
+
+	/**
+	 * Get property names to serialize.
+	 *
+	 * @return string[]
+	 */
+	public function __sleep() {
+		return array_diff(array_keys(get_object_vars($this)), array(
+			// Don't persist filestore, which contains CONFIG
+			// https://github.com/Elgg/Elgg/issues/9081#issuecomment-152859856
+			'filestore',
+
+			// a resource
+			'handle',
+		));
+	}
+
+	/**
+	 * Reestablish filestore property
+	 *
+	 * @return void
+	 * @throws ClassNotFoundException
+	 */
+	public function __wakeup() {
+		$this->getFilestore();
+	}
 }


### PR DESCRIPTION
Since filestore objects keep a copy of $CONFIG as a property, this would get serialized with the ElggFile. We add a __sleep method to filter out this property when serializing, and __wakeup to reinitialize it.

Fixes #9081
