### PR TITLE
refactor(views): deprecated optons_values for inputs, moved to options

### DIFF
--- a/views/default/core/river/filter.php
+++ b/views/default/core/river/filter.php
@@ -27,7 +27,7 @@ if (!empty($registered_entities)) {
 
 $params = array(
 	'id' => 'elgg-river-selector',
-	'options_values' => $options,
+	'options' => $options,
 );
 $selector = $vars['selector'];
 if ($selector) {

--- a/views/default/core/settings/account/language.php
+++ b/views/default/core/settings/account/language.php
@@ -14,7 +14,7 @@ if ($user) {
 	$content .= elgg_view("input/select", array(
 		'name' => 'language',
 		'value' => $user->language,
-		'options_values' => get_installed_translations()
+		'options' => get_installed_translations()
 	));
 	echo elgg_view_module('info', $title, $content);
 }

--- a/views/default/forms/admin/menu/save.php
+++ b/views/default/forms/admin/menu/save.php
@@ -40,7 +40,7 @@ for ($i=0; $i<$num_featured_items; $i++) {
 	}
 
 	echo elgg_view('input/select', array(
-		'options_values' => $dropdown_values,
+		'options' => $dropdown_values,
 		'name' => 'featured_menu_names[]',
 		'value' => $current_value
 	));

--- a/views/default/forms/admin/site/advanced/content_access.php
+++ b/views/default/forms/admin/site/advanced/content_access.php
@@ -5,7 +5,7 @@
 
 $default_access_label = elgg_echo('installation:sitepermissions');
 $default_access_input = elgg_view('input/access', array(
-	'options_values' => array(
+	'options' => array(
 		ACCESS_PRIVATE => elgg_echo("PRIVATE"),
 		ACCESS_FRIENDS => elgg_echo("access:friends:label"),
 		ACCESS_LOGGED_IN => elgg_echo("LOGGED_IN"),

--- a/views/default/forms/admin/site/advanced/debugging.php
+++ b/views/default/forms/admin/site/advanced/debugging.php
@@ -13,7 +13,7 @@ $debug_options = array(
 
 $debug_label = elgg_echo('installation:debug:label');
 $debug_input = elgg_view('input/select', array(
-	'options_values' => $debug_options,
+	'options' => $debug_options,
 	'name' => 'debug',
 	'value' => elgg_get_config('debug'),
 ));

--- a/views/default/forms/admin/site/set_maintenance_mode.php
+++ b/views/default/forms/admin/site/set_maintenance_mode.php
@@ -16,7 +16,7 @@ echo '<p>' . elgg_echo('admin:maintenance_mode:instructions') . '</p>';
 echo '<div><label>' . elgg_echo('admin:maintenance_mode:mode_label') . ': ';
 echo elgg_view('input/select', array(
 	'name' => 'mode',
-	'options_values' => array(
+	'options' => array(
 		'1' => elgg_echo('on'),
 		'0' => elgg_echo('off'),
 	),

--- a/views/default/forms/admin/site/update_basic.php
+++ b/views/default/forms/admin/site/update_basic.php
@@ -21,7 +21,7 @@ $form_body .= "<div>" . elgg_echo('installation:language');
 $form_body .= elgg_view("input/select", array(
 	'name' => 'language',
 	'value' => elgg_get_config('language'),
-	'options_values' => $languages,
+	'options' => $languages,
 )) . "</div>";
 
 $form_body .= '<div class="elgg-foot">';

--- a/views/default/forms/profile/fields/add.php
+++ b/views/default/forms/profile/fields/add.php
@@ -7,7 +7,7 @@ $label_text = elgg_echo('profile:label');
 $type_text = elgg_echo('profile:type');
 
 $label_control = elgg_view('input/text', array('name' => 'label'));
-$type_control = elgg_view('input/select', array('name' => 'type', 'options_values' => array(
+$type_control = elgg_view('input/select', array('name' => 'type', 'options' => array(
 	'text' => elgg_echo('profile:field:text'),
 	'longtext' => elgg_echo('profile:field:longtext'),
 	'tags' => elgg_echo('profile:field:tags'),

--- a/views/default/input/access.php
+++ b/views/default/input/access.php
@@ -4,7 +4,8 @@
  * Displays a dropdown input field
  *
  * @uses $vars['value']                  The current value, if any
- * @uses $vars['options_values']         Array of value => label pairs (overrides default)
+ * @uses $vars['options']                Array of value => label pairs (overrides default)
+ * @uses $vars['options_values']         Alias for $vars['options'] since 2.0-beta3.
  * @uses $vars['name']                   The name of the input field
  * @uses $vars['entity']                 Optional. The entity for this access control (uses access_id)
  * @uses $vars['class']                  Additional CSS class
@@ -16,9 +17,15 @@
  *
  */
 
-// bail if set to a unusable value
+// options_values is aliased to options, the options_values format is moved to the options key.
 if (isset($vars['options_values'])) {
-	if (!is_array($vars['options_values']) || empty($vars['options_values'])) {
+	$vars['options'] = $vars['options_values'];
+	unset($vars['options_values']);
+}
+
+// bail if set to a unusable value
+if (isset($vars['options'])) {
+	if (!is_array($vars['options']) || empty($vars['options'])) {
 		return;
 	}
 }
@@ -68,19 +75,19 @@ if (!$params['container_guid'] && $container) {
 if (!isset($vars['value']) || $vars['value'] == ACCESS_DEFAULT) {
 	if ($entity) {
 		$vars['value'] = $entity->access_id;
-	} else if (empty($vars['options_values']) || !is_array($vars['options_values'])) {
+	} else if (empty($vars['options']) || !is_array($vars['options'])) {
 		$vars['value'] = get_default_access(null, $params);
 	} else {
-		$options_values_ids = array_keys($vars['options_values']);
-		$vars['value'] = $options_values_ids[0];
+		$options_ids = array_keys($vars['options']);
+		$vars['value'] = $options_ids[0];
 	}
 }
 
 $params['value'] = $vars['value'];
 
 // don't call get_write_access_array() unless we need it
-if (!isset($vars['options_values'])) {
-	$vars['options_values'] = get_write_access_array(0, 0, false, $params);
+if (!isset($vars['options'])) {
+	$vars['options'] = get_write_access_array(0, 0, false, $params);
 }
 
 if (!isset($vars['disabled'])) {
@@ -88,10 +95,10 @@ if (!isset($vars['disabled'])) {
 }
 
 // if access is set to a value not present in the available options, add the option
-if (!isset($vars['options_values'][$vars['value']])) {
+if (!isset($vars['options'][$vars['value']])) {
 	$acl = get_access_collection($vars['value']);
 	$display = $acl ? $acl->name : elgg_echo('access:missing_name');
-	$vars['options_values'][$vars['value']] = $display;
+	$vars['options'][$vars['value']] = $display;
 }
 
 // should we tell users that public/logged-in access levels will be ignored?

--- a/views/default/input/select.php
+++ b/views/default/input/select.php
@@ -9,16 +9,14 @@
  * @subpackage Core
  *
  * @uses $vars['value']          The current value or an array of current values if multiple is true
- * @uses $vars['options']        An array of strings or arrays representing the options
- *                               for the dropdown field. If an array is passed,
- *                               the "text" key is used as its text, all other
- *                               elements in the array are used as attributes.
- * @uses $vars['options_values'] An associative array of "value" => "option"
+ * @uses $vars['options']        An associative array of "value" => "option"
  *                               where "value" is the name and "option" is
  *                               the value displayed on the button. Replaces
  *                               $vars['options'] when defined. When "option"
- *                               is passed as an array, the same behaviour is used
- *                               as when the $vars['options'] is passed an array to.
+ *                               is passed as an array, the "text" key is
+ *                               used as its text, all other elements in
+ *                               the array are used as attributes.
+ * @uses $vars['options_values'] Alias for $vars['options'] since 2.0-beta3.
  * @uses $vars['multiple']       If true, multiselect of values will be allowed in the select box
  * @uses $vars['class']          Additional CSS class
  */
@@ -29,14 +27,16 @@ $vars['class'][] = 'elgg-input-dropdown';
 $defaults = array(
 	'disabled' => false,
 	'value' => '',
-	'options_values' => array(),
 	'options' => array(),
 );
 
 $vars = array_merge($defaults, $vars);
 
-$options_values = $vars['options_values'];
-unset($vars['options_values']);
+// options_values is aliased to potions, the options_values format is moved to the options key.
+if (isset($vars['options_values'])) {
+	$vars['options'] = $vars['options_values'];
+	unset($vars['options_values']);
+}
 
 $options = $vars['options'];
 unset($vars['options']);
@@ -49,56 +49,33 @@ $vars['multiple'] = !empty($vars['multiple']);
 
 // Add trailing [] to name if multiple is enabled to allow the form to send multiple values
 if ($vars['multiple'] && !empty($vars['name']) && is_string($vars['name'])) {
-    if (substr($vars['name'], -2) != '[]') {
-        $vars['name'] = $vars['name'] . '[]';
-    }
+	if (substr($vars['name'], -2) != '[]') {
+		$vars['name'] = $vars['name'] . '[]';
+	}
 }
 
 $options_list = '';
 
-if ($options_values) {
-	foreach ($options_values as $opt_value => $option) {
+foreach ($options as $opt_value => $option) {
 
-		$option_attrs = array(
-			'value' => $opt_value,
-			'selected' => in_array((string)$opt_value, $value),
-		);
+	$option_attrs = array(
+		'value' => $opt_value,
+		'selected' => in_array((string)$opt_value, $value),
+	);
 
-		if (is_array($option)) {
-			$text = elgg_extract('text', $option, '');
-			unset($option['text']);
-			if (!$text) {
-				elgg_log('No text defined for input/select option with value "' . $opt_value . '"', 'ERROR');
-			}
-
-			$option_attrs = array_merge($option_attrs, $option);
-		} else {
-			$text = $option;
+	if (is_array($option)) {
+		$text = elgg_extract('text', $option, '');
+		unset($option['text']);
+		if (!$text) {
+			elgg_log('No text defined for input/select option with value "' . $opt_value . '"', 'ERROR');
 		}
 
-		$options_list .= elgg_format_element('option', $option_attrs, $text);
+		$option_attrs = array_merge($option_attrs, $option);
+	} else {
+		$text = $option;
 	}
-} else {
-	if (is_array($options)) {
-		foreach ($options as $option) {
 
-			$option_attrs = ['selected' => in_array((string)$option, $value)];
-
-			if (is_array($option)) {
-				$text = elgg_extract('text', $option, '');
-				unset($option['text']);
-				if (!$text) {
-					elgg_log('No text defined for input/select option', 'ERROR');
-				}
-
-				$option_attrs = array_merge($option_attrs, $option);
-			} else {
-				$text = $option;
-			}
-
-			$options_list .= elgg_format_element('option', $option_attrs, $text);
-		}
-	}
+	$options_list .= elgg_format_element('option', $option_attrs, $text);
 }
 
 echo elgg_format_element('select', $vars, $options_list);

--- a/views/default/widgets/friends/edit.php
+++ b/views/default/widgets/friends/edit.php
@@ -33,7 +33,7 @@ if (!isset($vars['entity']->icon_size)) {
 $params = array(
 	'name' => 'params[icon_size]',
 	'value' => $vars['entity']->icon_size,
-	'options_values' => array(
+	'options' => array(
 		'small' => elgg_echo('friends:small'),
 		'tiny' => elgg_echo('friends:tiny'),
 	),

--- a/views/default/widgets/river_widget/edit.php
+++ b/views/default/widgets/river_widget/edit.php
@@ -11,7 +11,7 @@ if (elgg_in_context('dashboard')) {
 	$params = array(
 		'name' => 'params[content_type]',
 		'value' => $vars['entity']->content_type,
-		'options_values' => array(
+		'options' => array(
 			'friends' => elgg_echo('river:widgets:friends'),
 			'all' => elgg_echo('river:widgets:all'),
 		),

--- a/views/installation/input/dropdown.php
+++ b/views/installation/input/dropdown.php
@@ -3,33 +3,28 @@
  * Elgg dropdown input
  * Displays a dropdown input field
  *
- * @uses $vars['value'] The current value, if any
- * @uses $vars['name'] The name of the input field
- * @uses $vars['options'] An array of strings representing the options for the dropdown field
- * @uses $vars['options_values'] An associative array of "value" => "option" where "value" is an internal name and "option" is
- * 								 the value displayed on the button. Replaces $vars['options'] when defined.
+ * @uses $vars['value']           The current value, if any
+ * @uses $vars['name']            The name of the input field
+ * @uses $vars['options']         An associative array of "value" => "option" where "value" is an internal name and "option" is
+ *                                the value displayed on the button. Replaces $vars['options'] when defined.
+ * @uses $vars['options_values']         Alias for $vars['options'] since 2.0-beta3.
  */
 
 $class = "elgg-input-dropdown";
 
+// options_values is aliased to options, the options_values format is moved to the options key.
+if (isset($vars['options_values'])) {
+	$vars['options'] = $vars['options_values'];
+	unset($vars['options_values']);
+}
 ?>
 <select name="<?php echo $vars['name']; ?>" class="<?php echo $class; ?>">
 <?php
-if (isset($vars['options_values'])) {
-	foreach ($vars['options_values'] as $value => $option) {
-		if ($value != $vars['value']) {
-			echo "<option value=\"$value\">{$option}</option>";
-		} else {
-			echo "<option value=\"$value\" selected=\"selected\">{$option}</option>";
-		}
-	}
-} else {
-	foreach ($vars['options'] as $option) {
-		if ($option != $vars['value']) {
-			echo "<option>{$option}</option>";
-		} else {
-			echo "<option selected=\"selected\">{$option}</option>";
-		}
+foreach ($vars['options'] as $value => $option) {
+	if ($value != $vars['value']) {
+		echo "<option value=\"$value\">{$option}</option>";
+	} else {
+		echo "<option value=\"$value\" selected=\"selected\">{$option}</option>";
 	}
 }
 ?>


### PR DESCRIPTION
Normalized options to options_values format and removed a some duplicated code. Updated view files to match these changes. When users still use options_values a deprecated message is shown and the value is moved to the new key. Implements issue #9112
