### PR TITLE
chore(views): input/autocomplete again works, converted to AMD

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -386,6 +386,11 @@ in the content area to use the z-index property without the "More" site menu's d
 behind these elements. If your plugin/theme overrides the elgg-menu-site class or views/default/elements/navigation.css
 please adjust the z-index value in your modified CSS file accordingly.
 
+input/autocomplete view
+-----------------------
+
+Plugins that override the ``input/autocomplete`` view will need to include the source URL in the ``data-source`` attribute of the input element, require the new ``elgg/autocomplete`` AMD module, and call its ``init`` method. The 1.x javascript library ``elgg.autocomplete`` is no longer used.
+
 Introduced third-party library for sending email
 ------------------------------------------------
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1546,8 +1546,9 @@ function elgg_views_boot() {
 	elgg_register_js('lightbox', elgg_get_simplecache_url('lightbox.js'));
 	elgg_register_css('lightbox', elgg_get_simplecache_url('lightbox/elgg-colorbox-theme/colorbox.css'));
 
-	elgg_register_js('elgg.autocomplete', elgg_get_simplecache_url('elgg/ui.autocomplete.js'));
-	elgg_register_js('jquery.ui.autocomplete.html', elgg_get_simplecache_url('jquery.ui.autocomplete.html.js'));
+	// just provides warning to use elgg/autocomplete AMD
+	elgg_register_js('elgg.autocomplete', elgg_normalize_url('js/lib/ui.autocomplete.js'));
+
 	elgg_define_js('jquery.ui.autocomplete.html', [
 		'deps' => ['jquery-ui'],
 	]);

--- a/engine/views.php
+++ b/engine/views.php
@@ -28,7 +28,6 @@ return [
 		 */
 		"/" => dirname(__DIR__) . "/_graphics",
 
-		"elgg/ui.autocomplete.js" => dirname(__DIR__) . "/js/lib/ui.autocomplete.js",
 		"elgg/ui.avatar_cropper.js" => dirname(__DIR__) . "/js/lib/ui.avatar_cropper.js",
 		"elgg/ui.friends_picker.js" => dirname(__DIR__) . "/js/lib/ui.friends_picker.js",
 		"elgg/ui.river.js" => dirname(__DIR__) . "/js/lib/ui.river.js",

--- a/js/lib/ui.autocomplete.js
+++ b/js/lib/ui.autocomplete.js
@@ -1,23 +1,3 @@
-/**
- * 
- */
-elgg.provide('elgg.autocomplete');
-
-/**
- * @requires jqueryui.autocomplete
- */
-elgg.autocomplete.init = function() {
-	$('.elgg-input-autocomplete').autocomplete({
-		source: elgg.autocomplete.url, //gets set by input/autocomplete view
-		minLength: 2,
-		html: "html",
-
-		// turn off experimental live help - no i18n support and a little buggy
-		messages: {
-			noResults: '',
-			results: function() {}
-		}
-	});
-};
-
-elgg.register_hook_handler('init', 'system', elgg.autocomplete.init);
+if (window.console) {
+	console.warn('js/lib/ui.autocomplete.js has been replaced by the elgg/autocomplete module.');
+}

--- a/views/default/elgg/autocomplete.js
+++ b/views/default/elgg/autocomplete.js
@@ -1,0 +1,28 @@
+define(function (require) {
+
+	var $ = require('jquery');
+	var elgg = require('elgg');
+	require('jquery.ui.autocomplete.html');
+
+	return {
+		init: function () {
+			$('.elgg-input-autocomplete').each(function () {
+				var $this = $(this);
+				if (!$this.data('autocompleteInitialized')) {
+					$this.data('autocompleteInitialized', true);
+					$this.autocomplete({
+						source: $this.data('source'),
+						minLength: 2,
+						html: "html",
+
+						// turn off experimental live help - no i18n support and a little buggy
+						messages: {
+							noResults: '',
+							results: function() {}
+						}
+					});
+				}
+			});
+		}
+	};
+});

--- a/views/default/input/autocomplete.php
+++ b/views/default/input/autocomplete.php
@@ -35,17 +35,15 @@ if (isset($vars['match_owner'])) {
 	$params['match_owner'] = $vars['match_owner'];
 	unset($vars['match_owner']);
 }
-$ac_url_params = http_build_query($params);
+$vars['type'] = 'text';
+$vars['data-source'] = elgg_get_site_url() . 'livesearch?' . http_build_query($params);
 
-elgg_load_js('elgg.autocomplete');
-elgg_load_js('jquery.ui.autocomplete.html');
+echo elgg_format_element('input', $vars);
 
+// inline script in case loaded via ajax
 ?>
-
 <script>
-require(['elgg'], function (elgg) {
-	elgg.provide('elgg.autocomplete');
-	elgg.autocomplete.url = "<?php echo elgg_get_site_url() . 'livesearch?' . $ac_url_params; ?>";
+require(['elgg/autocomplete'], function (autoc) {
+	autoc.init();
 });
 </script>
-<input type="text" <?php echo elgg_format_attributes($vars); ?> />


### PR DESCRIPTION
Fixes #9123

BREAKING CHANGE:
Plugins that override the `input/autocomplete` view will need to include the source URL in the `data-source` attribute of the input element, require the new `elgg/autocomplete` AMD module, and call its `init` method. The 1.x javascript library `elgg.autocomplete` is no longer used.
