### PR TITLE
chore(travis): fixes parameters of the 'sphinx-intl build' command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
       script:
        - sphinx-build -b html -nW docs docs/_build/html
        - sphinx-build -b latex -nW docs docs/_build/latex
-       - sphinx-intl --locale-dir=docs/locale/ build
+       - sphinx-intl build --locale-dir=docs/locale/
        - sphinx-build -b html -D language=es -n docs docs/_build/html
 
     # End to end tests


### PR DESCRIPTION
Fixes #9127
