### PR TITLE
chore(travis): fixes parameters of the 'sphinx-intl build' command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
          #  -W   Turn warnings into errors. This means that the build stops at the first warning and sphinx-build exits with exit status 1.
        - sphinx-build -b html -nW docs docs/_build/html
        - sphinx-build -b latex -nW docs docs/_build/latex
-       - sphinx-intl --locale-dir=docs/locale/ build
+       - sphinx-intl build --locale-dir=docs/locale/
        - sphinx-build -b html -D language=es -n docs docs/_build/html
        - phpunit --coverage-clover=coverage.clover
        - composer validate


### PR DESCRIPTION
Fixes #9127 (for 1.9)
