### PR TITLE
feature(files): adds ElggFile::getPathFromDataRoot

### DIFF
--- a/engine/classes/ElggFile.php
+++ b/engine/classes/ElggFile.php
@@ -80,6 +80,18 @@ class ElggFile extends \ElggObject {
 	}
 
 	/**
+	 * Returns path relative to the filestore (data directory) root
+	 *
+	 * @return string
+	 */
+	public function getPathFromDataRoot() {
+		$filestore_params = $this->filestore->getParameters();
+		$filestore_root = elgg_extract('dir_root', $filestore_params);
+		$full_path = $this->getFilenameOnFilestore();
+		return substr($full_path, strlen($filestore_root));
+	}
+
+	/**
 	 * Return the size of the filestore associated with this file
 	 *
 	 * @param string $prefix         Storage prefix
@@ -276,13 +288,13 @@ class ElggFile extends \ElggObject {
 	 */
 	public function delete() {
 		$fs = $this->getFilestore();
-		
+
 		$result = $fs->delete($this);
-		
+
 		if ($this->getGUID() && $result) {
 			$result = parent::delete();
 		}
-		
+
 		return $result;
 	}
 

--- a/engine/tests/ElggCoreFilestoreTest.php
+++ b/engine/tests/ElggCoreFilestoreTest.php
@@ -48,6 +48,25 @@ class ElggCoreFilestoreTest extends \ElggCoreUnitTest {
 		$this->assertFalse(file_exists($filepath));
 	}
 
+	public function testPathFromDataRoot() {
+
+		// create a user to own the file
+		$user = $this->createTestUser();
+		$dir = new \Elgg\EntityDirLocator($user->guid);
+
+		// setup a test file
+		$file = new \ElggFile();
+		$file->owner_guid = $user->guid;
+		$file->setFilename('testing/filestore.txt');
+		$file->open('write');
+		$file->write('Testing!');
+		$this->assertTrue($file->close());
+
+		$this->assertIdentical($file->getPathFromDataRoot(), $dir . 'testing/filestore.txt');
+
+		$user->delete();
+	}
+
 	function testElggFileDelete() {
 		global $CONFIG;
 		


### PR DESCRIPTION
Adds a convenience method to retrieve relative path to the file from the
filestore root.

Fixes #9137
