### PR TITLE
chore(reportedcontent): report content icon returns as an exclamation triangle

### DIFF
--- a/mod/reportedcontent/views.php
+++ b/mod/reportedcontent/views.php
@@ -1,7 +1,0 @@
-<?php
-
-return [
-	'default' => [
-		'reportedcontent/' => __DIR__ . '/graphics',
-	],
-];

--- a/mod/reportedcontent/views/default/reportedcontent/admin_css.php
+++ b/mod/reportedcontent/views/default/reportedcontent/admin_css.php
@@ -1,12 +1,6 @@
-<?php
-/**
- * Elgg reported content admin CSS
- *
- * @package ElggReportContent
- */
-?>
-
+/* <style> */
 /* REPORTED CONTENT */
+
 .reported-content {
 	margin: 5px 0 0;
 	padding: 5px 7px 3px 9px;

--- a/mod/reportedcontent/views/default/reportedcontent/css.php
+++ b/mod/reportedcontent/views/default/reportedcontent/css.php
@@ -1,14 +1,6 @@
-<?php
-/**
- * Elgg reported content CSS
- *
- * Footer link CSS
- * 
- * @package ElggReportContent
- */
+/* <style> */
+/* REPORTED CONTENT */
 
-?>
-/* Reported Content */
-.elgg-icon-report-this {
-	background: url(<?php echo elgg_get_simplecache_url('reportedcontent/icon_reportthis.gif'); ?>) no-repeat left top;
+.elgg-icon-report-this:before {
+	content: "\f071";
 }


### PR DESCRIPTION
Fixes #8628
Fixes #9070

BREAKING CHANGE:
The report content icon is now a FontAwesome icon, however the GIF used in 1.x is still available.
