### PR TITLE
fix(pages): removes deprecated use of input/write_access view

### DIFF
--- a/mod/pages/views/default/forms/pages/edit.php
+++ b/mod/pages/views/default/forms/pages/edit.php
@@ -59,7 +59,14 @@ foreach ($variables as $name => $type) {
 			}
 		}
 
-		echo elgg_view($input_view, $view_vars);
+		$output = elgg_view($input_view, $view_vars);
+
+		if ($input_view === 'input/write_access' && strpos($output, "<!-- -->") !== 0) {
+			// a dev has extended input/write_access
+			elgg_deprecated_notice("The input/write_access view is deprecated. The pages plugin now uses the ['access:collections:write', 'user'] hook to alter options.", "1.11");
+		}
+
+		echo $output;
 	?>
 </div>
 <?php

--- a/mod/pages/views/default/input/write_access.php
+++ b/mod/pages/views/default/input/write_access.php
@@ -1,5 +1,11 @@
 <?php
 
+// this is just to be detected by the pages edit form for deprecation purposes.
+echo "<!-- -->";
+
 echo elgg_view('input/access', $vars);
 
-elgg_deprecated_notice("The input/write_access view is deprecated. The pages plugin now uses the ['access:collections:write', 'user'] hook to alter options.", "1.11");
+if (!elgg_extract('purpose', $vars)) {
+	// a dev has extended the page edit form
+	elgg_deprecated_notice("The input/write_access view is deprecated. The pages plugin now uses the ['access:collections:write', 'user'] hook to alter options.", "1.11");
+}


### PR DESCRIPTION
Deprecation notices will only occur if a dev has extended forms/pages/edit or input/write_access

Fixes #8327
