### PR TITLE
Add toggle event and auto-focus river comment input (hook version)

### DIFF
--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -73,6 +73,11 @@ elgg.ui.toggles = function(event) {
 			$elem.toggle();
 		}
 	});
+
+	elgg.trigger_hook('ui_toggle', 'system', {
+		toggler: this,
+		target_selector: target
+	});
 };
 
 /**

--- a/js/lib/ui.river.js
+++ b/js/lib/ui.river.js
@@ -12,3 +12,15 @@ elgg.ui.river.init = function() {
 };
 
 elgg.register_hook_handler('init', 'system', elgg.ui.river.init);
+
+elgg.register_hook_handler('ui_toggle', 'system', function (h, t, params) {
+	var $toggler = $(params.toggler);
+	var $target = $(params.target_selector);
+	if ($target.is('.elgg-river-responses > .elgg-form-comment-save')) {
+		if ($toggler.hasClass('elgg-state-active')) {
+			$target.find('.elgg-input-text').focus();
+		} else {
+			$toggler.blur();
+		}
+	}
+});


### PR DESCRIPTION
(elgg hook version of #9199)

feature(js): elgg.ui.toggle now triggers hook

After a toggle is activated, an hook is fired. Listers receive references to the item clicked and the target element(s) selector.

fix(river): opening comment form auto-focuses input

Also the button is blurred when the form is hidden.
