### PR TITLE
It's now easier to alter translations for notifications

### DIFF
--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -183,7 +183,7 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			$queue_name = \Elgg\Notifications\NotificationsService::QUEUE_NAME;
 			$queue = new \Elgg\Queue\DatabaseQueue($queue_name, $c->db);
 			$sub = new \Elgg\Notifications\SubscriptionsService($c->db);
-			return new \Elgg\Notifications\NotificationsService($sub, $queue, $c->hooks, $c->session, $c->translator);
+			return new \Elgg\Notifications\NotificationsService($sub, $queue, $c->hooks, $c->session, $c->translator, $c->entityTable);
 		});
 
 		$this->setFactory('persistentLogin', function(ServiceProvider $c) {

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -158,7 +158,7 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setFactory('logger', function(ServiceProvider $c) {
 			return $this->resolveLoggerDependencies('logger');
 		});
-		
+
 		// TODO(evan): Support configurable transports...
 		$this->setClassName('mailer', 'Zend\Mail\Transport\Sendmail');
 
@@ -183,7 +183,7 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			$queue_name = \Elgg\Notifications\NotificationsService::QUEUE_NAME;
 			$queue = new \Elgg\Queue\DatabaseQueue($queue_name, $c->db);
 			$sub = new \Elgg\Notifications\SubscriptionsService($c->db);
-			return new \Elgg\Notifications\NotificationsService($sub, $queue, $c->hooks, $c->session);
+			return new \Elgg\Notifications\NotificationsService($sub, $queue, $c->hooks, $c->session, $c->translator);
 		});
 
 		$this->setFactory('persistentLogin', function(ServiceProvider $c) {

--- a/engine/classes/Elgg/Notifications/NotificationsService.php
+++ b/engine/classes/Elgg/Notifications/NotificationsService.php
@@ -7,7 +7,7 @@ use ElggEntity;
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
  *
  * @access private
- * 
+ *
  * @package    Elgg.Core
  * @subpackage Notifications
  * @since      1.9.0
@@ -27,6 +27,9 @@ class NotificationsService {
 
 	/** @var \ElggSession */
 	protected $session;
+
+	/** @var \Elgg\I18n\Translator */
+	protected $translator;
 
 	/** @var array Registered notification events */
 	protected $events = array();
@@ -48,12 +51,18 @@ class NotificationsService {
 	 * @param \Elgg\PluginHooksService                 $hooks         Plugin hook service
 	 * @param \ElggSession                             $session       Session service
 	 */
-	public function __construct(\Elgg\Notifications\SubscriptionsService $subscriptions,
-			\Elgg\Queue\Queue $queue, \Elgg\PluginHooksService $hooks, \ElggSession $session) {
+	public function __construct(
+			\Elgg\Notifications\SubscriptionsService $subscriptions,
+			\Elgg\Queue\Queue $queue,
+			\Elgg\PluginHooksService $hooks,
+			\ElggSession $session,
+			\Elgg\I18n\Translator $translator) {
+
 		$this->subscriptions = $subscriptions;
 		$this->queue = $queue;
 		$this->hooks = $hooks;
 		$this->session = $session;
+		$this->translator = $translator;
 	}
 
 	/**
@@ -128,10 +137,10 @@ class NotificationsService {
 
 	/**
 	 * Add a notification event to the queue
-	 * 
+	 *
 	 * @param string   $action Action name
 	 * @param string   $type   Type of the object of the action
-	 * @param \ElggData $object The object of the action 
+	 * @param \ElggData $object The object of the action
 	 * @return void
 	 * @access private
 	 */
@@ -175,7 +184,7 @@ class NotificationsService {
 		$count = 0;
 
 		// @todo grab mutex
-		
+
 		$ia = $this->session->setIgnoreAccess(true);
 
 		while (time() < $stopTime) {
@@ -275,8 +284,9 @@ class NotificationsService {
 			'object' => $object,
 		);
 
-		$subject = _elgg_services()->translator->translate('notification:subject', array($actor->name), $language);
-		$body = _elgg_services()->translator->translate('notification:body', array($object->getURL()), $language);
+		$subject = $this->translator->translate('notification:subject', array($actor->name), $language);
+		$body = $this->translator->translate('notification:body', array($object->getURL()), $language);
+
 		$notification = new \Elgg\Notifications\Notification($event->getActor(), $recipient, $language, $subject, $body, '', $params);
 
 		$type = 'notification:' . $event->getDescription();
@@ -307,7 +317,7 @@ class NotificationsService {
 
 	/**
 	 * Register a deprecated notification handler
-	 * 
+	 *
 	 * @param string $method  Method name
 	 * @param string $handler Handler callback
 	 * @return void
@@ -318,7 +328,7 @@ class NotificationsService {
 
 	/**
 	 * Get a deprecated notification handler callback
-	 * 
+	 *
 	 * @param string $method Method name
 	 * @return callback|null
 	 */
@@ -333,7 +343,7 @@ class NotificationsService {
 	/**
 	 * Provides a way to incrementally wean Elgg's notifications code from the
 	 * global $NOTIFICATION_HANDLERS
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getMethodsAsDeprecatedGlobal() {
@@ -346,7 +356,7 @@ class NotificationsService {
 
 	/**
 	 * Get the notification body using a pre-Elgg 1.9 plugin hook
-	 * 
+	 *
 	 * @param \Elgg\Notifications\Notification $notification Notification
 	 * @param \Elgg\Notifications\Event        $event        Event
 	 * @param string                           $method       Method
@@ -373,7 +383,7 @@ class NotificationsService {
 
 	/**
 	 * Set message subject for deprecated notification code
-	 * 
+	 *
 	 * @param string $type    Entity type
 	 * @param string $subtype Entity subtype
 	 * @param string $subject Subject line
@@ -396,7 +406,7 @@ class NotificationsService {
 
 	/**
 	 * Get the deprecated subject
-	 * 
+	 *
 	 * @param string $type    Entity type
 	 * @param string $subtype Entity subtype
 	 * @return string
@@ -422,7 +432,7 @@ class NotificationsService {
 
 	/**
 	 * Is someone using the deprecated override
-	 * 
+	 *
 	 * @param \Elgg\Notifications\Event $event Event
 	 * @return boolean
 	 */


### PR DESCRIPTION
Instead of using the `[prepare, notification:action:type:subtype]` plugin hook, it's now possible to alter the notification subject and body just by adding translation for the keys:
- `notification:subject:<action>:<type>:<subtype>`
- `notification:body:<action>:<type>:<subtype>`

For example in mod/blog/languages/en.php:

``` php
return array(
    'notification:subject:publish:object:blog' => '%s posted a new blog: %s',
);
```
