### PR TITLE
fix(views): Sticky values now get passed into views extending register/extend

### DIFF
--- a/views/default/forms/register.php
+++ b/views/default/forms/register.php
@@ -8,6 +8,11 @@
 
 if (elgg_is_sticky_form('register')) {
 	$values = elgg_get_sticky_values('register');
+
+	// Add the sticky values to $vars so views extending
+	// register/extend also get access to them.
+	$vars = array_merge($vars, $values);
+
 	elgg_clear_sticky_form('register');
 } else {
 	$values = array();


### PR DESCRIPTION
This makes sure that the custom fields added to the registration form by extending the register/extend view do not lose the entered values if registration fails and user is forwarded back to the form.
