### PR TITLE
feature(entities): give access to original values of modified attributes

### DIFF
--- a/docs/design/events.rst
+++ b/docs/design/events.rst
@@ -85,7 +85,7 @@ Elgg event handlers should have the following prototype:
         ...
     }
 
-If the handler returns `false`, the event is cancelled, preventing
+If the handler returns ``false``, the event is cancelled, preventing
 execution of the other handlers. All other return values are ignored.
 
 Register to handle an Elgg Event
@@ -116,6 +116,11 @@ Example:
     // user login event with priority 400.
     elgg_register_event_handler('login', 'user', 'myPlugin_handle_login', 400);
 
+.. warning::
+
+   If you handle the "update" event on an object, avoid calling ``save()`` in your event handler. For one it's
+   probably not necessary as the object is saved after the event completes, but also because ``save()`` calls
+   another "update" event and makes ``$object->getOriginalAttributes()`` no longer available.
 
 Trigger an Elgg Event
 ---------------------
@@ -186,9 +191,9 @@ Plugin hook handlers should have the following prototype:
         ...
     }
 
-If the handler returns no value (or `null` explicitly), the plugin hook value
+If the handler returns no value (or ``null`` explicitly), the plugin hook value
 is not altered. Otherwise the return value becomes the new value of the plugin
-hook. It will then be passed to the next handler as `$value`.
+hook. It will then be passed to the next handler as ``$value``.
 
 Register to handle a Plugin Hook
 --------------------------------

--- a/docs/guides/events-list.rst
+++ b/docs/guides/events-list.rst
@@ -130,9 +130,13 @@ Entity events
 
 **update, <entity type>**
     Triggered before an update for the user, group, object, and site entities. Return false to prevent update.
+    The entity method ``getOriginalAttributes()`` can be used to identify which attributes have changed since
+    the entity was last saved.
 
 **update:after, <entity type>**
     Triggered after an update for the user, group, object, and site entities.
+    The entity method ``getOriginalAttributes()`` can be used to identify which attributes have changed since
+    the entity was last saved.
 
 **delete, <entity type>**
     Triggered before entity deletion. Return false to prevent deletion.

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -74,7 +74,12 @@ abstract class ElggEntity extends \ElggData implements
 	 * in-memory that isn't sync'd back to the metadata table.
 	 */
 	protected $volatile = array();
-	
+
+	/**
+	 * Holds the original (persisted) attribute values that have been changed but not yet saved.
+	 */
+	protected $orig_attributes = array();
+
 	/**
 	 * Tells how many tables are going to need to be searched in order to fully populate this object
 	 *
@@ -197,6 +202,28 @@ abstract class ElggEntity extends \ElggData implements
 			return;
 		}
 		if (array_key_exists($name, $this->attributes)) {
+
+			// if an attribute is 1 (integer) and it's set to "1" (string), don't consider that a change.
+			if (is_int($this->attributes[$name])
+					&& is_string($value)
+					&& ((string)$this->attributes[$name] === $value)) {
+				return;
+			}
+
+			// Due to https://github.com/Elgg/Elgg/pull/5456#issuecomment-17785173, certain attributes
+			// will store empty strings as null in the DB. In the somewhat common case that we're re-setting
+			// the value to empty string, don't consider this a change.
+			if (in_array($name, ['title', 'name', 'description'])
+					&& $this->attributes[$name] === null
+					&& $value === "") {
+				return;
+			}
+
+			// keep original values
+			if ($this->guid && !array_key_exists($name, $this->orig_attributes)) {
+				$this->orig_attributes[$name] = $this->attributes[$name];
+			}
+
 			// Certain properties should not be manually changed!
 			switch ($name) {
 				case 'guid':
@@ -236,6 +263,15 @@ abstract class ElggEntity extends \ElggData implements
 		$this->__set($name, $value);
 
 		return true;
+	}
+
+	/**
+	 * Get the original values of attribute(s) that have been modified since the entity was persisted.
+	 *
+	 * @return array
+	 */
+	public function getOriginalAttributes() {
+		return $this->orig_attributes;
 	}
 
 	/**
@@ -1669,6 +1705,8 @@ abstract class ElggEntity extends \ElggData implements
 		}
 
 		_elgg_cache_entity($this);
+
+		$this->orig_attributes = [];
 
 		// Handle cases where there was no error BUT no rows were updated!
 		return $ret !== false;


### PR DESCRIPTION
Once an entity has been saved, Elgg tracks changes to its attributes, so that handlers of the `update` and `update:after` events can see which attributes are changing. Calling `$entity->getOriginalAttributes()` returns keys of changed attributes, and the original values as the array values. E.g.:

``` php
function my_update_handler($event, $type, ElggEntity $object) {
    $orig = $object->getOriginalAttributes();
    if (array_key_exists('title', $orig)) {
        // the title changed from $orig['title'] to $object->title
    }
}
```

Fixes #9187
