### PR TITLE
Add toggle event and auto-focus river comment input (jQuery version)

### DIFF
--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -55,17 +55,19 @@ elgg.ui.init = function () {
 elgg.ui.toggles = function(event) {
 	event.preventDefault();
 	var $this = $(this),
-		target = $this.data().toggleSelector;
+		selector = $this.data().toggleSelector;
 	
-	if (!target) {
+	if (!selector) {
 		// @todo we can switch to elgg.getSelectorFromUrlFragment() in 1.x if
 		// we also extend it to support href=".some-class"
-		target = $this.attr('href');
+		selector = $this.attr('href');
 	}
+
+	var $elements = $(selector);
 
 	$this.toggleClass('elgg-state-active');
 
-	$(target).each(function(index, elem) {
+	$elements.each(function(index, elem) {
 		var $elem = $(elem);
 		if ($elem.data().toggleSlide != false) {
 			$elem.slideToggle('medium');
@@ -73,6 +75,10 @@ elgg.ui.toggles = function(event) {
 			$elem.toggle();
 		}
 	});
+
+	$this.trigger('elgg_ui_toggle', [{
+		$toggled_elements: $elements
+	}]);
 };
 
 /**

--- a/js/lib/ui.river.js
+++ b/js/lib/ui.river.js
@@ -1,13 +1,26 @@
 elgg.provide('elgg.ui.river');
 
 elgg.ui.river.init = function() {
-	$('#elgg-river-selector').change(function() {
+	$(document).on('change', '#elgg-river-selector', function() {
 		var url = window.location.href;
 		if (window.location.search.length) {
 			url = url.substring(0, url.indexOf('?'));
 		}
 		url += '?' + $(this).val();
 		elgg.forward(url);
+	});
+
+	$(document).on('elgg_ui_toggle', function (e, data) {
+		var $toggle = $(e.target);
+		var $elements = data.$toggled_elements;
+
+		if ($elements.is('.elgg-river-responses > .elgg-form-comment-save')) {
+			if ($toggle.hasClass('elgg-state-active')) {
+				$elements.find('.elgg-input-text').focus();
+			} else {
+				$toggle.blur();
+			}
+		}
 	});
 };
 


### PR DESCRIPTION
(this is the jQuery event version of #9159)

feature(js): elgg.ui.toggle now triggers jQuery event

After a toggle is activated, an event is fired on the toggle element. Listeners receive a jQuery-wrapped reference to the target element(s).

fix(river): opening comment form auto-focuses input

The button is also blurred when the form is hidden.

The river filter now uses event delegation.
