### PR TITLE
fix(entities): update attribute when assuming container_guid value

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1516,6 +1516,7 @@ abstract class ElggEntity extends \ElggData implements
 		
 		$container_guid = $this->attributes['container_guid'];
 		if ($container_guid == 0) {
+			$this->attributes['container_guid'] = $owner_guid;
 			$container_guid = $owner_guid;
 		}
 		$container_guid = (int)$container_guid;


### PR DESCRIPTION
ElggEntity::create() assumes container_guid equals owner_guid when container_guid is
set to 0, but does so in introduced variables without updating the attribute. This
results in discrepancies between ElggEntity::getContainerGUID() and the value
written to the database

Fixes #8981
