### PR TITLE
fix(entities): update attribute when assuming container_guid value

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1643,6 +1643,7 @@ abstract class ElggEntity extends \ElggData implements
 		$container_guid = $this->attributes['container_guid'];
 		if ($container_guid == 0) {
 			$container_guid = $owner_guid;
+			$this->attributes['container_guid'] = $container_guid;
 		}
 		$container_guid = (int)$container_guid;
 

--- a/engine/tests/ElggEntityTest.php
+++ b/engine/tests/ElggEntityTest.php
@@ -355,4 +355,23 @@ class ElggCoreEntityTest extends \ElggCoreUnitTest {
 
 		$object->delete();
 	}
+
+	public function testCreateWithContainerGuidEqualsZero() {
+		$user = new \ElggUser();
+		$user->save();
+
+		$object = new \ElggObject();
+		$object->owner_guid = $user->guid;
+		$object->container_guid = 0;
+
+		// If container_guid attribute is not updated with owner_guid attribute
+		// ElggEntity::getContainerEntity() would return false
+		// thus terminating save()
+		$this->assertTrue($object->save());
+
+		$this->assertEqual($user->guid, $object->getContainerGUID());
+
+		$user->delete();
+
+	}
 }


### PR DESCRIPTION
ElggEntity::create() assumes that container_guid equals to owner_guid when container_guid
is set to 0, but does so in introduced variables without propagating the changes in
attributes array. This results in discrepancies between ElggEntity::getContainerGUID()
and the value written to the database

Fixes #8981
