### PR TITLE
chore(tests): Upgrades Jasmine and Karma

### DIFF
--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -1,82 +1,76 @@
 // Karma configuration
-// Generated on Sat Jun 01 2013 02:15:20 GMT-0400 (EDT)
+// Generated on Fri May 22 2015 12:59:26 GMT-0400 (EDT)
+
+module.exports = function(config) {
+	config.set({
+
+		// base path that will be used to resolve all patterns (eg. files, exclude)
+		basePath: '../..',
 
 
-// base path, that will be used to resolve files and exclude
-basePath = '../..';
+		// frameworks to use
+		// available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+		frameworks: ['jasmine', 'requirejs'],
 
 
-// list of files / patterns to load in the browser
-files = [
-  JASMINE,
-  JASMINE_ADAPTER,
-  REQUIRE,
-  REQUIRE_ADAPTER,
-  'vendors/jquery/jquery-1.11.0.min.js',
-  'vendors/jquery/jquery-migrate-1.2.1.min.js',
-  'vendors/sprintf.js',
-  'js/lib/elgglib.js',
-  'js/lib/hooks.js',
-  'js/classes/*.js',
-  'js/lib/*.js',
+		// list of files / patterns to load in the browser
+		files: [
+			'vendors/jquery/jquery-1.11.0.min.js',
+			'vendors/jquery/jquery-migrate-1.2.1.min.js',
+			'vendors/sprintf.js',
+			'js/lib/elgglib.js',
+			'js/lib/hooks.js',
+			'js/classes/*.js',
+			'js/lib/*.js',
 
-  {pattern:'js/tests/*Test.js',included: false},
-  {pattern:'views/default/js/**/*.js',included:false},
-  
-  'js/tests/requirejs.config.js',
-];
+			{pattern:'js/tests/*Test.js',included: false},
+			{pattern:'views/default/js/**/*.js',included:false},
+
+			'js/tests/requirejs.config.js',
+		],
 
 
-// list of files to exclude
-exclude = [
-
-];
-
-
-// test results reporter to use
-// possible values: 'dots', 'progress', 'junit'
-reporters = ['progress'];
+		// list of files to exclude
+		exclude: [
+		],
 
 
-hostname = process.env.IP || 'localhost';
+		// preprocess matching files before serving them to the browser
+		// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+		preprocessors: {
+		},
 
 
-// web server port
-port = process.env.PORT || 9876;
+		// test results reporter to use
+		// possible values: 'dots', 'progress'
+		// available reporters: https://npmjs.org/browse/keyword/karma-reporter
+		reporters: ['progress'],
 
 
-// cli runner port
-runnerPort = 0;
+		// web server port
+		port: 9876,
 
 
-// enable / disable colors in the output (reporters and logs)
-colors = true;
+		// enable / disable colors in the output (reporters and logs)
+		colors: true,
 
 
-// level of logging
-// possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
-logLevel = LOG_INFO;
+		// level of logging
+		// possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+		logLevel: config.LOG_INFO,
 
 
-// enable / disable watching file and executing tests whenever any file changes
-autoWatch = true;
+		// enable / disable watching file and executing tests whenever any file changes
+		autoWatch: false,
 
 
-// Start these browsers, currently available:
-// - Chrome
-// - ChromeCanary
-// - Firefox
-// - Opera
-// - Safari (only Mac)
-// - PhantomJS
-// - IE (only Windows)
-browsers = ['PhantomJS'];
+		// start these browsers
+		// available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+		browsers: ['PhantomJS'],
 
 
-// If browser does not capture in given timeout [ms], kill it
-captureTimeout = 60000;
-
-
-// Continuous Integration mode
-// if true, it capture browsers, run tests and exit
-singleRun = false;
+		// Continuous Integration mode
+		// if true, Karma captures browsers, runs the tests and exits
+		singleRun: false
+	});
+};

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "Elgg",
   "description": "Elgg is an award-winning social networking engine, delivering the building blocks that enable businesses, schools, universities and associations to create their own fully-featured social networks and applications.",
-  "dependencies": {
-  },
+  "dependencies": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/Elgg/Elgg.git"
@@ -13,7 +12,7 @@
   },
   "homepage": "https://github.com/Elgg/Elgg",
   "scripts": {
-    "test": "karma start js/tests/karma.conf.js --single-run"
+    "test": "node_modules/karma/bin/karma start js/tests/karma.conf.js --single-run"
   },
   "devDependencies": {
     "elgg-conventional-changelog": "~0.1.2",
@@ -23,7 +22,10 @@
     "grunt-contrib-watch": "~0.6.1",
     "grunt-exec": "~0.4.6",
     "grunt-open": "~0.2.3",
-    "karma": "~0.8.8",
+    "karma": "^0.12.32",
+    "karma-jasmine": "~0.2.0",
+    "karma-phantomjs-launcher": "~0.1",
+    "karma-requirejs": "~0.2",
     "load-grunt-config": "~0.16.0",
     "phantomjs": "~1.9.7-14"
   }


### PR DESCRIPTION
Updates karma & jasmine (2.x eases async testing considerably)

(1.10 release script fails due to old karma version. This may not be strictly necessary to release but seems like a good idea)
