### PR TITLE
fix(views): datepicker input no longer overrides id attribute

### DIFF
--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -338,7 +338,7 @@ elgg.ui.initDatePicker = function() {
 					timestamp = timestamp / 1000;
 
 					var id = $(this).attr('id');
-					$('input[name="' + id + '"]').val(timestamp);
+					$('input[rel="' + id + '"]').val(timestamp);
 				}
 			},
 			nextText: '&#xBB;',

--- a/views/default/input/date.php
+++ b/views/default/input/date.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Elgg date input
  * Displays a text field with a popup date picker.
@@ -14,9 +15,7 @@
  * @uses $vars['value']     The current value, if any (as a unix timestamp)
  * @uses $vars['class']     Additional CSS class
  * @uses $vars['timestamp'] Store as a Unix timestamp in seconds. Default = false
- *                          Note: you cannot use an id with the timestamp option.
  */
-
 $vars['class'] = (array) elgg_extract('class', $vars, []);
 $vars['class'][] = 'elgg-input-date';
 
@@ -35,17 +34,28 @@ $vars = array_merge($defaults, $vars);
 $timestamp = $vars['timestamp'];
 unset($vars['timestamp']);
 
-if ($timestamp) {
-	echo elgg_view('input/hidden', ['name' => $vars['name'], 'value' => $vars['value']]);
-
-	$vars['class'][] = 'elgg-input-timestamp';
-	$vars['id'] = $vars['name'];
-	unset($vars['name']);
+// convert timestamps to text for display
+$ts_value = '';
+if (isset($vars['value'])) {
+	if (is_numeric($vars['value'])) {
+		$ts_value = $vars['value'];
+		$vars['value'] = gmdate('Y-m-d', $vars['value']);
+	} else {
+		$ts_value = strtotime($vars['value']);
+	}
 }
 
-// convert timestamps to text for display
-if (is_numeric($vars['value'])) {
-	$vars['value'] = gmdate('Y-m-d', $vars['value']);
+if ($timestamp) {
+	if (!isset($vars['id'])) {
+		$vars['id'] = $vars['name'];
+	}
+	echo elgg_view('input/hidden', [
+		'name' => $vars['name'],
+		'value' => $ts_value,
+		'rel' => $vars['id'],
+	]);
+	$vars['class'][] = 'elgg-input-timestamp';
+	unset($vars['name']);
 }
 
 echo elgg_format_element('input', $vars);


### PR DESCRIPTION
Datepicker input now respects the ID attribute, if passed with the $vars
