### PR TITLE
fix(admin): Allow plugins to extend js/admin but deprecate it

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -199,6 +199,7 @@ We dropped support for and/or removed the following views:
  * input/datepicker (Use input/date instead)
  * input/pulldown (Use input/select instead)
  * invitefriends/formitems
+ * js/admin (Use AMD and ``elgg_require_js`` instead of extending JS views)
  * js/initialise_elgg (Use AMD and ``elgg_require_js`` instead of extending JS views)
  * members/nav
  * metatags (Use the 'head', 'page' plugin hook instead)

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -346,6 +346,19 @@ function _elgg_admin_init() {
 }
 
 /**
+ * Setup after plugins are initialized
+ *
+ * @access private
+ * @return void
+ */
+function _elgg_admin_ready() {
+	// if a plugin has extended the deprecated admin.js view, register it for simplecache loading.
+	if (elgg_view_exists('admin.js')) {
+		elgg_register_simplecache_view('admin.js');
+	}
+}
+
+/**
  * Handles any set up required for administration pages
  *
  * @return void
@@ -505,6 +518,14 @@ function _elgg_admin_page_handler($page) {
 
 	elgg_unregister_css('elgg');
 	elgg_require_js('elgg/admin');
+
+	// if a plugin has extended the deprecated admin.js view, add it to the page
+	if (elgg_view_exists('admin.js')) {
+		elgg_deprecated_notice("The view admin.js (AKA js/admin) is deprecated", "2.0");
+		elgg_register_js('elgg.deprecated.admin', elgg_get_simplecache_url('admin.js'));
+		elgg_load_js('elgg.deprecated.admin');
+	}
+
 	elgg_load_js('jquery.jeditable');
 
 	// default to dashboard
@@ -717,4 +738,5 @@ function _elgg_add_admin_widgets($event, $type, $user) {
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
 	$events->registerHandler('init', 'system', '_elgg_admin_init');
+	$events->registerHandler('ready', 'system', '_elgg_admin_ready');
 };


### PR DESCRIPTION
The view js/admin was replaced in 2.0 but this was never mentioned in the plugin upgrade guide. We're supporting it for better BC.

Fixes #9238
