### PR TITLE
Log messages no longer wrongly discarded

### DIFF
--- a/engine/classes/Elgg/Logger.php
+++ b/engine/classes/Elgg/Logger.php
@@ -202,6 +202,16 @@ class Logger {
 			$display = false;
 		}
 
+		// don't display in simplecache requests
+		$this_url = current_page_url();
+		$site_url = elgg_get_site_url();
+		if (0 === strpos($this_url, $site_url)) {
+			$path = substr($this_url, strlen($site_url));
+			if (preg_match('~^(cache|action)/~', $path)) {
+				$display = false;
+			}
+		}
+
 		if ($display == true) {
 			echo '<pre class="elgg-logger-data">';
 			echo htmlspecialchars(print_r($data, true), ENT_QUOTES, 'UTF-8');

--- a/engine/classes/Elgg/Logger.php
+++ b/engine/classes/Elgg/Logger.php
@@ -203,13 +203,9 @@ class Logger {
 		}
 
 		// don't display in simplecache requests
-		$this_url = current_page_url();
-		$site_url = elgg_get_site_url();
-		if (0 === strpos($this_url, $site_url)) {
-			$path = substr($this_url, strlen($site_url));
-			if (preg_match('~^(cache|action)/~', $path)) {
-				$display = false;
-			}
+		$path = substr(current_page_url(), strlen(elgg_get_site_url()));
+		if (preg_match('~^(cache|action)/~', $path)) {
+			$display = false;
 		}
 
 		if ($display == true) {

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1415,6 +1415,7 @@ function _elgg_shutdown_hook() {
 	global $START_MICROTIME;
 
 	try {
+		_elgg_services()->logger->setDisplay(false);
 		elgg_trigger_event('shutdown', 'system');
 
 		$time = (float)(microtime(true) - $START_MICROTIME);

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1574,7 +1574,7 @@ function _elgg_views_deprecate_removed_views() {
  * @access private
  */
 function elgg_views_handle_deprecated_views() {
-	$location = elgg_get_view_location('page_elements/contentwrapper');
+	$location = _elgg_services()->views->getViewLocation('page_elements/contentwrapper');
 	if ($location === "/var/www/views/") {
 		elgg_extend_view('page_elements/contentwrapper', 'page/elements/wrapper');
 	}

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -38,13 +38,21 @@ function developers_process_settings() {
 	ini_set('display_errors', (int)!empty($settings['display_errors']));
 
 	if (!empty($settings['screen_log'])) {
-		$cache = new ElggLogCache();
-		elgg_set_config('log_cache', $cache);
-		elgg_register_plugin_hook_handler('debug', 'log', array($cache, 'insertDump'));
-		elgg_register_plugin_hook_handler('view_vars', 'page/elements/html', function($hook, $type, $vars, $params) {
-			$vars['body'] .= elgg_view('developers/log');
-			return $vars;
-		});
+		// don't show in action/simplecache
+		$this_url = current_page_url();
+		$site_url = elgg_get_site_url();
+		if (0 === strpos($this_url, $site_url)) {
+			$path = substr($this_url, strlen($site_url));
+			if (!preg_match('~^(cache|action)/~', $path)) {
+				$cache = new ElggLogCache();
+				elgg_set_config('log_cache', $cache);
+				elgg_register_plugin_hook_handler('debug', 'log', array($cache, 'insertDump'));
+				elgg_register_plugin_hook_handler('view_vars', 'page/elements/html', function($hook, $type, $vars, $params) {
+					$vars['body'] .= elgg_view('developers/log');
+					return $vars;
+				});
+			}
+		}
 	}
 
 	if (!empty($settings['show_strings'])) {

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -39,19 +39,15 @@ function developers_process_settings() {
 
 	if (!empty($settings['screen_log'])) {
 		// don't show in action/simplecache
-		$this_url = current_page_url();
-		$site_url = elgg_get_site_url();
-		if (0 === strpos($this_url, $site_url)) {
-			$path = substr($this_url, strlen($site_url));
-			if (!preg_match('~^(cache|action)/~', $path)) {
-				$cache = new ElggLogCache();
-				elgg_set_config('log_cache', $cache);
-				elgg_register_plugin_hook_handler('debug', 'log', array($cache, 'insertDump'));
-				elgg_register_plugin_hook_handler('view_vars', 'page/elements/html', function($hook, $type, $vars, $params) {
-					$vars['body'] .= elgg_view('developers/log');
-					return $vars;
-				});
-			}
+		$path = substr(current_page_url(), strlen(elgg_get_site_url()));
+		if (!preg_match('~^(cache|action)/~', $path)) {
+			$cache = new ElggLogCache();
+			elgg_set_config('log_cache', $cache);
+			elgg_register_plugin_hook_handler('debug', 'log', array($cache, 'insertDump'));
+			elgg_register_plugin_hook_handler('view_vars', 'page/elements/html', function($hook, $type, $vars, $params) {
+				$vars['body'] .= elgg_view('developers/log');
+				return $vars;
+			});
 		}
 	}
 

--- a/mod/developers/views/default/developers/log.php
+++ b/mod/developers/views/default/developers/log.php
@@ -6,6 +6,9 @@
 $cache = elgg_get_config('log_cache');
 $items = $cache->get();
 
+// stop collecting messages
+elgg_unregister_plugin_hook_handler('debug', 'log', [$cache, 'insertDump']);
+
 $pres = array();
 if ($items) {
 	foreach ($items as $item) {

--- a/views/default/css/elgg.php
+++ b/views/default/css/elgg.php
@@ -15,10 +15,8 @@
 
 // check if there is a theme overriding the old css view and use it, if it exists
 if (elgg_view_exists('css')) {
-	ob_start();
-	$old_css_view = elgg_get_view_location('css');
-	// throw away deprecation error
-	ob_end_clean();
+	// note: _elgg_services is private API, DO NOT USE.
+	$old_css_view = _elgg_services()->views->getViewLocation('css');
 
 	if ($old_css_view != elgg_get_config('viewpath')) {
 		echo elgg_view('css', $vars);


### PR DESCRIPTION
**fix(logging): Log messages no longer discarded**

Logged messages are no longer thrown away during action and cache requests.
Also the log-to-screen feature of the developers plugin no longer throws away messages after the page display has occurred.

In both cases, these errors likely end up in the system error log.

Fixes #9244

**chore(views): removes core use of elgg_get_view_location()**

With #9244 fixed, these deprecation warning are no longer thrown away, so we instead use the private API version to avoid them.
