### PR TITLE
fix(session): Session is again available in the shutdown event

### DIFF
--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1407,6 +1407,8 @@ function _elgg_normalize_plural_options_array($options, $singulars) {
  *
  * @see http://www.php.net/register-shutdown-function
  *
+ * @internal This is registered in engine/start.php
+ *
  * @return void
  * @see register_shutdown_hook()
  * @access private
@@ -1916,10 +1918,7 @@ function _elgg_init() {
 	elgg_register_js('elgg.ui.river', 'js/lib/ui.river.js');
 
 	elgg_register_css('jquery.imgareaselect', 'vendors/jquery/jquery.imgareaselect/css/imgareaselect-deprecated.css');
-	
-	// Trigger the shutdown:system event upon PHP shutdown.
-	register_shutdown_function('_elgg_shutdown_hook');
-	
+
 	// Sets a blacklist of words in the current language.
 	// This is a comma separated list in word:blacklist.
 	// @todo possibly deprecate

--- a/engine/start.php
+++ b/engine/start.php
@@ -24,6 +24,16 @@
 global $START_MICROTIME;
 $START_MICROTIME = microtime(true);
 
+// we need to register for shutdown before Symfony registers the session_write_close() function
+// https://github.com/Elgg/Elgg/issues/9243
+register_shutdown_function(function () {
+	// There are cases where we may exit before this function is defined.
+	// TODO move this to Application::create in 2.0
+	if (function_exists('_elgg_shutdown_hook')) {
+		_elgg_shutdown_hook();
+	}
+});
+
 /**
  * Configuration values.
  *


### PR DESCRIPTION
Fixes #9243

(when merging into 2.0 the shutdown registration should move to `\Elgg\Application::create`)
