### PR TITLE
feature(search): search hooks now preserve custom joins and wheres

### DIFF
--- a/mod/search/search_hooks.php
+++ b/mod/search/search_hooks.php
@@ -17,15 +17,18 @@
  */
 function search_objects_hook($hook, $type, $value, $params) {
 
+	$params['joins'] = (array) elgg_extract('joins', $params, array());
+	$params['wheres'] = (array) elgg_extract('wheres', $params, array());
+	
 	$db_prefix = elgg_get_config('dbprefix');
 
 	$join = "JOIN {$db_prefix}objects_entity oe ON e.guid = oe.guid";
-	$params['joins'] = array($join);
+	array_unshift($params['joins'], $join);
+
 	$fields = array('title', 'description');
-
 	$where = search_get_where_sql('oe', $fields, $params);
-
-	$params['wheres'] = array($where);
+	$params['wheres'][] = $where;
+	
 	$params['count'] = TRUE;
 	$count = elgg_get_entities($params);
 	
@@ -64,18 +67,20 @@ function search_objects_hook($hook, $type, $value, $params) {
  * @return array
  */
 function search_groups_hook($hook, $type, $value, $params) {
+
+	$params['joins'] = (array) elgg_extract('joins', $params, array());
+	$params['wheres'] = (array) elgg_extract('wheres', $params, array());
+	
 	$db_prefix = elgg_get_config('dbprefix');
 
 	$query = sanitise_string($params['query']);
 
 	$join = "JOIN {$db_prefix}groups_entity ge ON e.guid = ge.guid";
-	$params['joins'] = array($join);
+	array_unshift($params['joins'], $join);
 	
 	$fields = array('name', 'description');
-
 	$where = search_get_where_sql('ge', $fields, $params);
-
-	$params['wheres'] = array($where);
+	$params['wheres'][] = $where;
 
 	// override subtype -- All groups should be returned regardless of subtype.
 	$params['subtype'] = ELGG_ENTITIES_ANY_VALUE;
@@ -119,13 +124,16 @@ function search_groups_hook($hook, $type, $value, $params) {
  * @return array
  */
 function search_users_hook($hook, $type, $value, $params) {
+
+	$params['joins'] = (array) elgg_extract('joins', $params, array());
+	$params['wheres'] = (array) elgg_extract('wheres', $params, array());
+	
 	$db_prefix = elgg_get_config('dbprefix');
 
 	$query = sanitise_string($params['query']);
 
-	$params['joins'] = array(
-		"JOIN {$db_prefix}users_entity ue ON e.guid = ue.guid",
-	);
+	$join = "JOIN {$db_prefix}users_entity ue ON e.guid = ue.guid";
+	array_unshift($params['joins'], $join);
 		
 	// username and display name
 	$fields = array('username', 'name');
@@ -149,9 +157,9 @@ function search_users_hook($hook, $type, $value, $params) {
 		// $md_where .= " AND " . search_get_where_sql('msv', array('string'), $params, FALSE);
 		$md_where = "(({$clauses['wheres'][0]}) AND msv.string LIKE '%$query%')";
 		
-		$params['wheres'] = array("(($where) OR ($md_where))");
+		$params['wheres'][] = "(($where) OR ($md_where))";
 	} else {
-		$params['wheres'] = array("$where");
+		$params['wheres'][] = "$where";
 	}
 	
 	// override subtype -- All users should be returned regardless of subtype.
@@ -220,6 +228,10 @@ function search_users_hook($hook, $type, $value, $params) {
  * @return array
  */
 function search_tags_hook($hook, $type, $value, $params) {
+
+	$params['joins'] = (array) elgg_extract('joins', $params, array());
+	$params['wheres'] = (array) elgg_extract('wheres', $params, array());
+
 	$db_prefix = elgg_get_config('dbprefix');
 
 	$valid_tag_names = elgg_get_registered_tag_metadata_names();


### PR DESCRIPTION
Search hooks can now be triggered with custom joins and wheres. Previously, those
would always be replaced for object, group and user searches.
