### PR TITLE
feature(groups): profile buttons can now be filtered with a hook

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -478,6 +478,12 @@ Embed
 
 **embed_get_upload_sections, all**
 
+Groups
+------
+
+**profile_buttons, group**
+	Filters buttons (``ElggMenuItem`` instances) to be registered in the title menu of the group profile page
+
 HTMLawed
 --------
 

--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -7,48 +7,19 @@
  * Registers the buttons for title area of the group profile page
  *
  * @param ElggGroup $group
+ * @return void
  */
 function groups_register_profile_buttons($group) {
 
-	$actions = array();
+	$params = [
+		'entity' => $group,
+	];
 
-	// group owners
-	if ($group->canEdit()) {
-		// edit and invite
-		$url = elgg_get_site_url() . "groups/edit/{$group->getGUID()}";
-		$actions[$url] = 'groups:edit';
-		$url = elgg_get_site_url() . "groups/invite/{$group->getGUID()}";
-		$actions[$url] = 'groups:invite';
-	}
-
-	// group members
-	if ($group->isMember(elgg_get_logged_in_user_entity())) {
-		if ($group->getOwnerGUID() != elgg_get_logged_in_user_guid()) {
-			// leave
-			$url = elgg_get_site_url() . "action/groups/leave?group_guid={$group->getGUID()}";
-			$url = elgg_add_action_tokens_to_url($url);
-			$actions[$url] = 'groups:leave';
-		}
-	} elseif (elgg_is_logged_in()) {
-		// join - admins can always join.
-		$url = elgg_get_site_url() . "action/groups/join?group_guid={$group->getGUID()}";
-		$url = elgg_add_action_tokens_to_url($url);
-		if ($group->isPublicMembership() || $group->canEdit()) {
-			$actions[$url] = 'groups:join';
-		} else {
-			// request membership
-			$actions[$url] = 'groups:joinrequest';
-		}
-	}
-
-	if ($actions) {
-		foreach ($actions as $url => $text) {
-			elgg_register_menu_item('title', array(
-				'name' => $text,
-				'href' => $url,
-				'text' => elgg_echo($text),
-				'link_class' => 'elgg-button elgg-button-action',
-			));
+	$items = elgg_trigger_plugin_hook('profile_buttons', 'group', $params, []);
+	
+	if (!empty($items)) {
+		foreach ($items as $item) {
+			elgg_register_menu_item('title', $item);
 		}
 	}
 }


### PR DESCRIPTION
Due to the limitations of the title menu setup, plugins are unaware of the group
entity that the menu items in the register hook refer to. This allows plugins
to filter profile buttons on per group basis.
