### PR TITLE
fix(install): Set default timezone on installation

### DIFF
--- a/elgg-config/settings.example.php
+++ b/elgg-config/settings.example.php
@@ -14,6 +14,8 @@
  * @subpackage Configuration
  */
 
+date_default_timezone_set('{{timezone}}');
+
 global $CONFIG;
 if (!isset($CONFIG)) {
 	$CONFIG = new \stdClass;

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -356,6 +356,12 @@ class ElggInstaller {
 				'value' => 'elgg_',
 				'required' => TRUE,
 				),
+			'timezone' => array(
+				'type' => 'dropdown',
+				'value' => 'UTC',
+				'options' => \DateTimeZone::listIdentifiers(),
+				'required' => TRUE
+			)
 		);
 
 		if ($this->checkSettingsFile()) {

--- a/install.php
+++ b/install.php
@@ -1,4 +1,7 @@
 <?php
+
+date_default_timezone_set('UTC');
+
 $autoload_path = __DIR__ . '/vendor/autoload.php';
 $autoload_available = include_once($autoload_path);
 if (!$autoload_available) {

--- a/install/cli/travis_installer.php
+++ b/install/cli/travis_installer.php
@@ -43,6 +43,9 @@ $params = array(
 	'email' => 'admin@travis.elgg.org',
 	'username' => 'admin',
 	'password' => 'fancypassword',
+	
+	// timezone
+	'timezone' => 'UTC'
 );
 
 // install and create the .htaccess file

--- a/install/languages/en.php
+++ b/install/languages/en.php
@@ -59,12 +59,14 @@ If you are ready to proceed, click the Next button.",
 	'install:database:label:dbname' => 'Database Name',
 	'install:database:label:dbhost' => 'Database Host',
 	'install:database:label:dbprefix' => 'Database Table Prefix',
+	'install:database:label:timezone' => "Timezone",
 
 	'install:database:help:dbuser' => 'User that has full privileges to the MySQL database that you created for Elgg',
 	'install:database:help:dbpassword' => 'Password for the above database user account',
 	'install:database:help:dbname' => 'Name of the Elgg database',
 	'install:database:help:dbhost' => 'Hostname of the MySQL server (usually localhost)',
 	'install:database:help:dbprefix' => "The prefix given to all of Elgg's tables (usually elgg_)",
+	'install:database:help:timezone' => "The default timezone in which the site will operate",
 
 	'install:settings:instructions' => 'We need some information about the site as we configure Elgg. If you haven\'t <a href="http://learn.elgg.org/en/1.x/intro/install.html#create-a-data-folder" target="_blank">created a data directory</a> for Elgg, you need to do so now.',
 


### PR DESCRIPTION
Timezone is set to UTC for the duration of the installation before settings.php is created
Settings.php now contains date_default_timezone_set() with the selected timezone

Fixes #8845
