### PR TITLE
fix(comments): validate array structure before calling elgg_extract()

### DIFF
--- a/engine/lib/comments.php
+++ b/engine/lib/comments.php
@@ -246,7 +246,7 @@ function _elgg_comments_permissions_override($hook, $type, $return, $params) {
  * @access private
  */
 function _elgg_comments_notification_email_subject($hook, $type, $returnvalue, $params) {
-	if (!is_array($returnvalue)) {
+	if (!is_array($returnvalue) || !is_array($returnvalue['params'])) {
 		// another hook handler returned a non-array, let's not override it
 		return;
 	}


### PR DESCRIPTION
This makes sure that params in return value are arrays before proceeding with the hook.
The bugs manifests itself during some of the test
