### PR TITLE
fix(actions): referrer path is now parsed correctly

### DIFF
--- a/actions/entity/delete.php
+++ b/actions/entity/delete.php
@@ -40,7 +40,7 @@ if (!$forward_url) {
 	$referrer_url = !empty($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '';
 	$site_url = elgg_get_site_url();
 	if ($referrer_url && 0 == strpos($referrer_url, $site_url)) {
-		$referrer_path = substr($referrer_url, 0, strlen($site_url));
+		$referrer_path = substr($referrer_url, strlen($site_url));
 		$segments = explode('/', $referrer_path);
 		if (in_array($guid, $segments)) {
 			// referrer URL contains a reference to the entity that will be deleted


### PR DESCRIPTION
substr() arguments were incorrect
