### PR TITLE
fix(groups): link to membership requests page is visible again

### DIFF
--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -75,7 +75,7 @@ function groups_init() {
 
 	// invitation request actions
 	elgg_register_plugin_hook_handler('register', 'menu:invitationrequest', 'groups_invitationrequest_menu_setup');
-	
+
 	// group members tabs
 	elgg_register_plugin_hook_handler('register', 'menu:groups_members', 'groups_members_menu_setup');
 
@@ -106,7 +106,7 @@ function groups_init() {
 
 	// Add tests
 	elgg_register_plugin_hook_handler('unit_test', 'system', 'groups_test');
-	
+
 	// allow to be liked
 	elgg_register_plugin_hook_handler('likes:is_likable', 'group:', 'Elgg\Values::getTrue');
 }
@@ -266,10 +266,16 @@ function groups_page_handler($page) {
 				echo elgg_view_resource('groups/members', $vars);
 			}
 			break;
+		case 'profile':
+			// Page owner and context need to be set before elgg_view() is
+			// called so they'll be available in the [pagesetup, system] event
+			// that is used for registering items for the sidebar menu.
+			// @see groups_setup_sidebar_menus()
+			elgg_push_context('group_profile');
+			elgg_set_page_owner_guid($page[1]);
 		case 'activity':
 		case 'edit':
 		case 'invite':
-		case 'profile':
 		case 'requests':
 			echo elgg_view_resource("groups/{$page[0]}", [
 				'guid' => $page[1],
@@ -790,25 +796,25 @@ function groups_invitationrequest_menu_setup($hook, $type, $menu, $params) {
  * @return void|ElggMenuItem[]
  */
 function groups_members_menu_setup($hook, $type, $menu, $params) {
-	
+
 	$entity = elgg_extract('entity', $params);
 	if (empty($entity) || !($entity instanceof ElggGroup)) {
 		return;
 	}
-	
+
 	$menu[] = ElggMenuItem::factory([
 		'name' => 'alpha',
 		'text' => elgg_echo('sort:alpha'),
 		'href' => "groups/members/{$entity->getGUID()}",
 		'priority' => 100
 	]);
-	
+
 	$menu[] = ElggMenuItem::factory([
 		'name' => 'newest',
 		'text' => elgg_echo('sort:newest'),
 		'href' => "groups/members/{$entity->getGUID()}/newest",
 		'priority' => 200
 	]);
-	
+
 	return $menu;
 }

--- a/mod/groups/views/default/resources/groups/profile.php
+++ b/mod/groups/views/default/resources/groups/profile.php
@@ -1,13 +1,10 @@
 <?php
 
 $guid = elgg_extract('guid', $vars);
-elgg_set_page_owner_guid($guid);
 
 // turn this into a core function
 global $autofeed;
 $autofeed = true;
-
-elgg_push_context('group_profile');
 
 elgg_entity_gatekeeper($guid, 'group');
 


### PR DESCRIPTION
Page owner and context are now set before `elgg_view()` gets called for the first time. This makes sure that they are available in the handler that registers the menu item on `[pagesetup, system]` event.
