### PR TITLE
fix(css): elgg-body elements no longer clip form and positioned elements

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -242,6 +242,15 @@ required to make the old interface work.
 If your plugin is extending any of the views or relies on any actions in the notifications plugin,
 it has to be updated.
 
+Layout of ``.elgg-body`` elements
+---------------------------------
+
+In 3.0, these elements by default no longer stretch to fill available space in a block
+context. They still clear floats and allow breaking words to wrap text.
+
+Core modules and layouts that relied on space-filling have been reworked for Flexbox and
+we encourage devs to do the same, rather than use the problematic ``overflow: hidden``.
+
 From 2.2 to 2.3
 ===============
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1279,6 +1279,9 @@ function elgg_view_comments($entity, $add_comment = true, array $vars = array())
  * Fixed width media on the side (image, icon, flash, etc.).
  * Descriptive content filling the rest of the column.
  *
+ * @note Use the $vars "image_alt" key to set an image on the right. If you do, you may pass
+ *       in an empty string for $image to have only the right image.
+ *
  * This is a shortcut for {@elgg_view page/components/image_block}.
  *
  * @param string $image The icon and other information

--- a/mod/aalborg_theme/views/default/aalborg_theme/css.php
+++ b/mod/aalborg_theme/views/default/aalborg_theme/css.php
@@ -133,6 +133,14 @@ html {
 		-moz-box-sizing: border-box;
 		box-sizing: border-box;
     }
+	.elgg-layout-one-sidebar,
+	.elgg-layout-two-sidebar {
+		display: block;
+	}
+	.elgg-layout-one-sidebar > .elgg-sidebar,
+	.elgg-layout-two-sidebar > .elgg-sidebar {
+		margin-left: 0;
+	}
     .elgg-layout-one-sidebar .elgg-main,
 	.elgg-layout-two-sidebar .elgg-main {
         width: 100%;
@@ -297,17 +305,18 @@ html {
 	}
 }
 @media (max-width: 600px) {
+	.groups-profile {
+		display: block;
+	}
 	.groups-profile-fields {
-		float: left;
-		padding-left: 0;
+		padding-top: 20px;
+	}
+	.profile > .elgg-inner {
+		display: block;
 	}
 	#profile-owner-block {
 		border-right: none;
 		width: auto;
-	}
-	#profile-details {
-		display: block;
-		float: left;
 	}
 	#groups-tools > li {
 		width: 100%;

--- a/mod/aalborg_theme/views/default/elements/components.css
+++ b/mod/aalborg_theme/views/default/elements/components.css
@@ -9,14 +9,35 @@
 *************************************** */
 .elgg-image-block {
 	padding: 10px 0;
+
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-align: start;
+	-webkit-align-items: flex-start;
+	-ms-flex-align: start;
+	align-items: flex-start;
 }
-.elgg-image-block .elgg-image {
-	float: left;
+.elgg-image-block:after {
+	display: none;
+}
+.elgg-image-block > .elgg-image {
 	margin-right: 8px;
 }
-.elgg-image-block .elgg-image-alt {
-	float: right;
+.elgg-image-block > .elgg-image-alt {
 	margin-left: 8px;
+
+	-webkit-box-ordinal-group: 2;
+	-webkit-order: 1;
+	-ms-flex-order: 1;
+	order: 1;
+}
+.elgg-image-block > .elgg-body {
+	-webkit-box-flex: 1;
+	-webkit-flex: 1;
+	-ms-flex: 1;
+	flex: 1;
 }
 
 /* ***************************************

--- a/mod/aalborg_theme/views/default/elements/layout.css
+++ b/mod/aalborg_theme/views/default/elements/layout.css
@@ -91,6 +91,49 @@
 .elgg-layout-widgets > .elgg-widgets {
 	float: right;
 }
+.elgg-layout-one-sidebar,
+.elgg-layout-two-sidebar {
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-align: start;
+	-webkit-align-items: flex-start;
+	-ms-flex-align: start;
+	align-items: flex-start;
+}
+.elgg-layout-one-sidebar > .elgg-body,
+.elgg-layout-two-sidebar > .elgg-body {
+	-webkit-box-flex: 1;
+	-webkit-flex: 1;
+	-ms-flex: 1;
+	flex: 1;
+}
+.elgg-layout-one-sidebar > .elgg-sidebar {
+	float: none;
+	margin-left: 30px;
+
+	-webkit-box-ordinal-group: 2;
+	-webkit-order: 1;
+	-ms-flex-order: 1;
+	order: 1;
+}
+.elgg-layout-two-sidebar > .elgg-sidebar {
+	float: none;
+	margin-left: 30px;
+
+	-webkit-box-ordinal-group: 3;
+	-webkit-order: 2;
+	-ms-flex-order: 2;
+	order: 2;
+}
+.elgg-layout-two-sidebar > .elgg-sidebar-alt {
+	float: none;
+	-webkit-box-ordinal-group: 1;
+	-webkit-order: 0;
+	-ms-flex-order: 0;
+	order: 0;
+}
 .elgg-sidebar {
 	position: relative;
 	padding: 32px 0 20px 30px;
@@ -116,14 +159,6 @@
 	padding-bottom: 5px;
 	border-bottom: 1px solid #EBEBEB;
 	margin-bottom: 10px;
-}
-.elgg-layout-one-sidebar .elgg-main {
-	float: left;
-	width: 72.525252%;
-}
-.elgg-layout-two-sidebar .elgg-main {
-	float: left;
-	width: 50.101010%;
 }
 
 /***** PAGE FOOTER ******/

--- a/mod/aalborg_theme/views/default/elements/modules.css
+++ b/mod/aalborg_theme/views/default/elements/modules.css
@@ -2,7 +2,7 @@
 	Modules
 *************************************** */
 .elgg-module {
-	overflow: hidden;
+	display: block;
 	margin-bottom: 20px;
 }
 
@@ -19,8 +19,6 @@
 	background-color: #F0F0F0;
 	padding: 10px;
 	margin-bottom: 10px;
-	height: auto;
-	overflow: hidden;
 	box-shadow: inset 0 0 1px #FFFFFF;
 }
 .elgg-module-info > .elgg-head * {
@@ -68,8 +66,6 @@
 .elgg-module-featured > .elgg-head {
 	background-color: #F0F0F0;
 	padding: 10px;
-	height: auto;
-	overflow: hidden;
 	border-bottom: 1px solid #DCDCDC;
 	box-shadow: inset 0 0 1px #FFFFFF;
 }
@@ -134,8 +130,6 @@
 .elgg-module-widget > .elgg-head {
 	background-color: #F0F0F0;
 	padding: 10px 0;
-	height: auto;
-	overflow: hidden;
 	box-shadow: inset 0 0 1px #FFFFFF;
 }
 .elgg-module-widget > .elgg-head h3 {
@@ -162,8 +156,6 @@ a.elgg-widget-collapsed:before {
 }
 .elgg-module-widget > .elgg-body {
 	background-color: #FFF;
-	width: 100%;
-	overflow: hidden;
 	border-top: 1px solid #DCDCDC;
 }
 .elgg-widget-edit {

--- a/mod/aalborg_theme/views/default/elements/navigation.css
+++ b/mod/aalborg_theme/views/default/elements/navigation.css
@@ -332,7 +332,6 @@
 	display: none;
 	position: absolute;
 	z-index: 10000;
-	overflow: hidden;
 	min-width: 180px;
 	max-width: 250px;
 	border: 1px solid #DEDEDE;

--- a/mod/aalborg_theme/views/default/profile/css.php
+++ b/mod/aalborg_theme/views/default/profile/css.php
@@ -13,18 +13,31 @@
 	float: left;
 	margin-bottom: 15px;
 }
-.profile .elgg-inner {
+.profile > .elgg-inner {
 	border: 1px solid #DCDCDC;
 	border-radius: 3px;
+
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-align: start;
+	-webkit-align-items: flex-start;
+	-ms-flex-align: start;
+	align-items: flex-start;
 }
 #profile-details {
 	padding: 15px;
+
+	-webkit-box-flex: 1;
+	-webkit-flex: 1;
+	-ms-flex: 1;
+	flex: 1;
 }
 
 /*** ownerblock ***/
 #profile-owner-block {
 	width: 200px;
-	float: left;
 	border-right: 1px solid #DCDCDC;
 	padding: 15px;
 }

--- a/mod/developers/views/default/page/layouts/theme_sandbox.php
+++ b/mod/developers/views/default/page/layouts/theme_sandbox.php
@@ -17,11 +17,11 @@ echo <<<HTML
 	<div class="theme-sandbox-sidebar">
 		$sidebar
 	</div>
-	<div class="theme-sandbox-main elgg-body">
+	<div class="theme-sandbox-main">
 		<div class="elgg-head clearfix">
 			$title
 		</div>
-		<div class="theme-sandbox-content elgg-body">
+		<div class="theme-sandbox-content">
 			$content
 		</div>
 	</div>

--- a/mod/developers/views/default/theme_sandbox.css
+++ b/mod/developers/views/default/theme_sandbox.css
@@ -8,14 +8,29 @@
 	text-align: center;
 }
 
+.theme-sandbox-layout {
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-align: start;
+	-webkit-align-items: flex-start;
+	-ms-flex-align: start;
+	align-items: flex-start;
+}
+
 .theme-sandbox-main {
 	padding: 20px 20px;
 	min-height: 360px;
 	position: relative;
+
+	-webkit-box-flex: 1;
+	-webkit-flex: 1;
+	-ms-flex: 1;
+	flex: 1;
 }
 
 .theme-sandbox-sidebar {
-	float: left;
 	padding: 20px 20px;
 	margin-right: 10px;
 	position: relative;

--- a/mod/developers/views/default/theme_sandbox/components/image_block.php
+++ b/mod/developers/views/default/theme_sandbox/components/image_block.php
@@ -1,9 +1,11 @@
 <?php
 $ipsum = elgg_view('developers/ipsum');
+$ipsum = "$ipsum $ipsum $ipsum $ipsum $ipsum $ipsum $ipsum";
 
 $user = new ElggUser();
 $image = elgg_view_entity_icon($user, 'small');
-echo elgg_view_image_block($image, "$ipsum $ipsum $ipsum $ipsum $ipsum $ipsum $ipsum", [
+
+echo elgg_view_image_block($image, $ipsum, [
 	'class' => 'theme-sandbox-image-block',
 	'data-type' => 'user',
 ]);

--- a/mod/developers/views/default/theme_sandbox/components/image_block_alt.php
+++ b/mod/developers/views/default/theme_sandbox/components/image_block_alt.php
@@ -1,11 +1,12 @@
 <?php
 $ipsum = elgg_view('developers/ipsum');
+$ipsum = "$ipsum $ipsum $ipsum $ipsum $ipsum $ipsum $ipsum";
 
 $user = new ElggUser();
 $image = elgg_view_entity_icon($user, 'small');
-$image_alt = elgg_view_icon('user-plus');
-echo elgg_view_image_block($image, "$ipsum $ipsum $ipsum $ipsum $ipsum $ipsum $ipsum", [
+
+echo elgg_view_image_block("", $ipsum, [
 	'class' => 'theme-sandbox-image-block',
 	'data-type' => 'user',
-	'image_alt' => $image_alt,
+	'image_alt' => $image,
 ]);

--- a/mod/groups/views/default/groups/profile/summary.php
+++ b/mod/groups/views/default/groups/profile/summary.php
@@ -22,7 +22,7 @@ if (!$owner) {
 }
 
 ?>
-<div class="groups-profile clearfix elgg-image-block">
+<div class="groups-profile elgg-image-block">
 	<div class="elgg-image">
 		<div class="groups-profile-icon">
 			<?php

--- a/mod/profile/views/default/profile/css.php
+++ b/mod/profile/views/default/profile/css.php
@@ -13,18 +13,31 @@
 	float: left;
 	margin-bottom: 15px;
 }
-.profile .elgg-inner {
+.profile > .elgg-inner {
 	border: 2px solid #eee;
 	border-radius: 8px;
 	margin: 0 5px;
+
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-align: start;
+	-webkit-align-items: flex-start;
+	-ms-flex-align: start;
+	align-items: flex-start;
 }
 #profile-details {
 	padding: 15px;
+
+	-webkit-box-flex: 1;
+	-webkit-flex: 1;
+	-ms-flex: 1;
+	flex: 1;
 }
 /*** ownerblock ***/
 #profile-owner-block {
 	width: 200px;
-	float: left;
 	background-color: #eee;
 	padding: 15px;
 }

--- a/views/default/elements/components.css.php
+++ b/views/default/elements/components.css.php
@@ -15,14 +15,35 @@
 *************************************** */
 .elgg-image-block {
 	padding: 3px 0;
+
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-align: start;
+	-webkit-align-items: flex-start;
+	-ms-flex-align: start;
+	align-items: flex-start;
+}
+.elgg-image-block:after {
+	display: none;
 }
 .elgg-image-block .elgg-image {
-	float: left;
 	margin-right: 5px;
 }
 .elgg-image-block .elgg-image-alt {
-	float: right;
 	margin-left: 5px;
+
+	-webkit-box-ordinal-group: 2;
+	-webkit-order: 1;
+	-ms-flex-order: 1;
+	order: 1;
+}
+.elgg-image-block > .elgg-body {
+	-webkit-box-flex: 1;
+	-webkit-flex: 1;
+	-ms-flex: 1;
+	flex: 1;
 }
 .elgg-avatar > a:focus > img,
 .elgg-image > a:focus > img {

--- a/views/default/elements/core.css.php
+++ b/views/default/elements/core.css.php
@@ -18,6 +18,7 @@
 
 /* Clearfix */
 .clearfix:after,
+.elgg-body:after,
 .elgg-grid:after,
 .elgg-layout:after,
 .elgg-inner:after,
@@ -35,8 +36,13 @@
 	visibility: hidden;	
 }
 
+/* Simple block that clears floats and breaks words to wrap */
+.elgg-body {
+	display: block;
+	word-wrap: break-word;
+}
+
 /* Fluid width container that does not wrap floats */
-.elgg-body,
 .elgg-col-last {
 	display: block;
 	width: auto;
@@ -46,11 +52,11 @@
 
 <?php
 /**
- * elgg-body fills the space available to it.
+ * elgg-col-last fills the space available to it. (elgg-body no longer does this)
  * It uses hidden text to expand itself. The combination of auto width, overflow
  * hidden, and the hidden text creates this effect.
  *
- * This allows us to float fixed width divs to either side of an .elgg-body div
+ * This allows us to float fixed width divs to either side of an .elgg-col-last div
  * without having to specify the body div's width.
  *
  * @todo check what happens with long <pre> tags or large images
@@ -59,7 +65,6 @@
 
 //@todo isn't this only needed if we use display:table-cell?
 ?>
-.elgg-body:after,
 .elgg-col-last:after {
 	display: block;
 	visibility: hidden;

--- a/views/default/elements/layout.css.php
+++ b/views/default/elements/layout.css.php
@@ -85,6 +85,45 @@
 .elgg-layout-two-sidebar {
 	background: transparent url(<?= elgg_get_simplecache_url("two_sidebar_background.gif"); ?>) repeat-y right top;
 }
+.elgg-layout-one-sidebar,
+.elgg-layout-two-sidebar {
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-align: start;
+	-webkit-align-items: flex-start;
+	-ms-flex-align: start;
+	align-items: flex-start;
+}
+.elgg-layout-one-sidebar > .elgg-body,
+.elgg-layout-two-sidebar > .elgg-body {
+	-webkit-box-flex: 1;
+	-webkit-flex: 1;
+	-ms-flex: 1;
+	flex: 1;
+}
+.elgg-layout-one-sidebar > .elgg-sidebar {
+	float: none;
+	-webkit-box-ordinal-group: 2;
+	-webkit-order: 1;
+	-ms-flex-order: 1;
+	order: 1;
+}
+.elgg-layout-two-sidebar > .elgg-sidebar {
+	float: none;
+	-webkit-box-ordinal-group: 3;
+	-webkit-order: 2;
+	-ms-flex-order: 2;
+	order: 2;
+}
+.elgg-layout-two-sidebar > .elgg-sidebar-alt {
+	float: none;
+	-webkit-box-ordinal-group: 1;
+	-webkit-order: 0;
+	-ms-flex-order: 0;
+	order: 0;
+}
 .elgg-layout-widgets > .elgg-widgets {
 	float: right;
 }

--- a/views/default/elements/modules.css.php
+++ b/views/default/elements/modules.css.php
@@ -4,7 +4,7 @@
 	Modules
 *************************************** */
 .elgg-module {
-	overflow: hidden;
+	display: block;
 	margin-bottom: 20px;
 }
 
@@ -131,7 +131,6 @@
 .elgg-module-widget > .elgg-head {
 	background-color: #eeeeee;
 	height: 26px;
-	overflow: hidden;
 }
 .elgg-module-widget > .elgg-head h3 {
 	float: left;
@@ -157,8 +156,6 @@ a.elgg-widget-collapsed:before {
 }
 .elgg-module-widget > .elgg-body {
 	background-color: white;
-	width: 100%;
-	overflow: hidden;
 	border-top: 2px solid #dedede;
 }
 .elgg-widget-edit {

--- a/views/default/elements/navigation.css.php
+++ b/views/default/elements/navigation.css.php
@@ -350,9 +350,6 @@
 	display: none;
 	position: absolute;
 	z-index: 10000;
-
-	overflow: hidden;
-
 	min-width: 165px;
 	max-width: 250px;
 	


### PR DESCRIPTION
Space-filling layouts like `.elgg-image-block` have been reworked to use flexbox. `.elgg-body` elements generally no longer use `overflow: hidden` to fill space by default, and so no longer clip absolutely-positioned descendant elements or the left edges of form elements.

Some apparently needless uses of `overflow: hidden` have been removed.

The one/two sidebar and theme_sandbox layouts were converted to flexbox. A use of the "alt" image block layout is included in theme_sandbox.

Fixes #5197

BREAKING CHANGE:
`.elgg-body` elements by default no longer stretch to fill available space in a block context. They still clear floats and allow breaking words to wrap text.

Elements matching `.elgg-module`, `.elgg-head`, and `.elgg-menu-hover` no longer hide overflowing content. and those matching `.elgg-image`, `#profile-owner-block`, and `elgg-sidebar` (inside layouts) no longer float, but are now positioned with flexbox.
- [x] probably needs responsive work, allow falling back to stacked
- [ ] get this tested with custom layouts
- [x] are these prefixes right? Got them from Chrome devtools
- [x] apply changes to the core and admin styles (currently only in Aalborg)
- [ ] have a plan for site owners who need to support IE.old -- if this waits for 3.0 another year will thin out these browsers more
