### PR TITLE
fix(access): fixes guid column name in metadata queries

### DIFF
--- a/engine/classes/Elgg/Cache/MetadataCache.php
+++ b/engine/classes/Elgg/Cache/MetadataCache.php
@@ -154,7 +154,10 @@ class MetadataCache {
 			'order_by' => 'n_table.entity_guid, n_table.time_created ASC, n_table.id ASC',
 
 			// @todo don't know why this is necessary
-			'wheres' => array(_elgg_get_access_where_sql(array('table_alias' => 'n_table'))),
+			'wheres' => array(_elgg_get_access_where_sql(array(
+				'table_alias' => 'n_table',
+				'guid_column' => 'entity_guid',
+			))),
 		);
 		$data = _elgg_services()->metadataTable->getAll($options);
 

--- a/engine/classes/Elgg/Database/MetadataTable.php
+++ b/engine/classes/Elgg/Database/MetadataTable.php
@@ -529,7 +529,10 @@ class MetadataTable {
 		// only supported on values.
 		$binary = ($case_sensitive) ? ' BINARY ' : '';
 	
-		$access = _elgg_get_access_where_sql(array('table_alias' => 'n_table'));
+		$access = _elgg_get_access_where_sql(array(
+			'table_alias' => 'n_table',
+			'guid_column' => 'entity_guid',
+		));
 	
 		$return = array (
 			'joins' => array (),
@@ -641,7 +644,10 @@ class MetadataTable {
 				// for comparing
 				$trimmed_operand = trim(strtolower($operand));
 	
-				$access = _elgg_get_access_where_sql(array('table_alias' => "n_table{$i}"));
+				$access = _elgg_get_access_where_sql(array(
+					'table_alias' => "n_table{$i}",
+					'guid_column' => 'entity_guid',
+				));
 
 				// certain operands can't work well with strings that can be interpreted as numbers
 				// for direct comparisons like IN, =, != we treat them as strings
@@ -735,7 +741,10 @@ class MetadataTable {
 					$return['joins'][] = "JOIN {$this->metastringsTable->getTableName()} msv{$i}
 						on n_table{$i}.value_id = msv{$i}.id";
 	
-					$access = _elgg_get_access_where_sql(array('table_alias' => "n_table{$i}"));
+					$access = _elgg_get_access_where_sql(array(
+						'table_alias' => "n_table{$i}",
+						'guid_column' => 'entity_guid',
+					));
 	
 					$return['wheres'][] = "(msn{$i}.string = '$name' AND $access)";
 					if (isset($order_by['as']) && $order_by['as'] == 'integer') {

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -258,7 +258,10 @@ function _elgg_get_metastring_based_objects($options) {
 		$wheres = array_merge($wheres, $metastring_clauses['wheres']);
 		$joins = array_merge($joins, $metastring_clauses['joins']);
 	} else {
-		$wheres[] = _elgg_get_access_where_sql(array('table_alias' => 'n_table'));
+		$wheres[] = _elgg_get_access_where_sql(array(
+			'table_alias' => 'n_table',
+			'guid_column' => 'entity_guid',
+		));
 	}
 
 	$distinct = $options['distinct'] ? "DISTINCT " : "";
@@ -438,7 +441,10 @@ function _elgg_get_metastring_sql($table, $names = null, $values = null,
 		$wheres[] = $values_where;
 	}
 
-	$wheres[] = _elgg_get_access_where_sql(array('table_alias' => $table));
+	$wheres[] = _elgg_get_access_where_sql(array(
+		'table_alias' => $table,
+		'guid_column' => 'entity_guid',
+	));
 
 	if ($where = implode(' AND ', $wheres)) {
 		$return['wheres'][] = "($where)";


### PR DESCRIPTION
get_sql hook with custom queries was resulting in WSOD due to incorrect
guid column name in metadata queries. This passes correct guid column name
to _elgg_get_access_where_sql(), when querying metadata table
