### PR TITLE
feature(profiler): allow capture/display of crude profiling data

### DIFF
--- a/elgg-config/settings.example.php
+++ b/elgg-config/settings.example.php
@@ -216,3 +216,20 @@ $CONFIG->min_password_length = 6;
  * @global string $CONFIG->exception_include
  */
 $CONFIG->exception_include = '';
+
+/**
+ * To enable profiling, uncomment the following lines, and replace __some_secret__ with a
+ * secret key. When enabled, profiling data will show in the JS console.
+ */
+//if (isset($_REQUEST['__some_secret__'])) {
+//
+//	// send profiling data to the JS console?
+//	$CONFIG->enable_profiling = true;
+//
+//	// profile all queries? A page with a ton of queries could eat up memory.
+//	$CONFIG->profiling_sql = false;
+//
+//	// in the list, don't include times that don't contribute at least this much to the
+//	// total time captured. .1% by default
+//	$CONFIG->profiling_minimum_percentage = .1;
+//}

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -71,6 +71,8 @@ class Application {
 			$GLOBALS['START_MICROTIME'] = microtime(true);
 		}
 
+		$services->timer->begin([]);
+
 		/**
 		 * This was introduced in 2.0 in order to remove all internal non-API state from $CONFIG. This will
 		 * be a breaking change, but frees us to refactor in 2.x without fear of plugins depending on

--- a/engine/classes/Elgg/Cache/SystemCache.php
+++ b/engine/classes/Elgg/Cache/SystemCache.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elgg\Cache;
 
+use Elgg\Profilable;
+
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
  *
@@ -11,6 +13,8 @@ namespace Elgg\Cache;
  * @since      1.10.0
  */
 class SystemCache {
+	use Profilable;
+
 	/**
 	 * Global Elgg configuration
 	 * 
@@ -134,6 +138,10 @@ class SystemCache {
 	 * @access private
 	 */
 	function loadAll() {
+		if ($this->timer) {
+			$this->timer->begin([__METHOD__]);
+		}
+
 		$this->CONFIG->system_cache_loaded = false;
 
 		if (!_elgg_services()->views->configureFromCache($this)) {
@@ -149,6 +157,10 @@ class SystemCache {
 		// Note: We don't need view_overrides for operation. Inspector can pull this from the cache
 	
 		$this->CONFIG->system_cache_loaded = true;
+
+		if ($this->timer) {
+			$this->timer->end([__METHOD__]);
+		}
 	}
 	
 	/**

--- a/engine/classes/Elgg/Database/Plugins.php
+++ b/engine/classes/Elgg/Database/Plugins.php
@@ -2,6 +2,7 @@
 namespace Elgg\Database;
 
 use Elgg\Cache\Pool;
+use Elgg\Profilable;
 use Exception;
 
 /**
@@ -21,6 +22,7 @@ global $ELGG_PLUGINS_PROVIDES_CACHE;
  * @since 1.10.0
  */
 class Plugins {
+	use Profilable;
 
 	/**
 	 * @var string[] Active plugin IDs with IDs as the array keys. Missing keys imply inactive plugins.
@@ -307,6 +309,10 @@ class Plugins {
 	 * @access private
 	 */
 	function load() {
+		if ($this->timer) {
+			$this->timer->begin([__METHOD__]);
+		}
+
 		$plugins_path = elgg_get_plugins_path();
 		$start_flags = ELGG_PLUGIN_INCLUDE_START |
 						ELGG_PLUGIN_REGISTER_VIEWS |
@@ -354,6 +360,11 @@ class Plugins {
 		}
 
 		$this->active_ids_known = true;
+
+		if ($this->timer) {
+			$this->timer->end([__METHOD__]);
+		}
+
 		return $return;
 	}
 	

--- a/engine/classes/Elgg/Profilable.php
+++ b/engine/classes/Elgg/Profilable.php
@@ -1,0 +1,25 @@
+<?php
+namespace Elgg;
+
+/**
+ * Make an object accept a timer.
+ *
+ * @access private
+ */
+trait Profilable {
+
+	/**
+	 * @var Timer|null
+	 */
+	private $timer;
+
+	/**
+	 * Set a timer that should collect begin/end times for events
+	 *
+	 * @param Timer $timer Timer
+	 * @return void
+	 */
+	public function setTimer(Timer $timer) {
+		$this->timer = $timer;
+	}
+}

--- a/engine/classes/Elgg/Profiler.php
+++ b/engine/classes/Elgg/Profiler.php
@@ -1,0 +1,221 @@
+<?php
+namespace Elgg;
+
+/**
+ * Analyzes duration of functions, queries, and processes
+ *
+ * @access private
+ */
+class Profiler {
+
+	public $percentage_format = "%01.2f";
+	public $duration_format = "%01.6f";
+	public $minimum_percentage = 0.2;
+
+	/**
+	 * @var float Total time
+	 */
+	private $total;
+
+	/**
+	 * Return a tree of time periods from a Timer
+	 *
+	 * @param Timer $timer Timer object
+	 * @return array
+	 */
+	public function buildTree(Timer $timer) {
+		$times = $timer->getTimes();
+
+		if (!isset($times[':end'])) {
+			$times[':end'] = microtime();
+		}
+
+		$begin = $this->findBeginTime($times);
+		$end = $this->findEndTime($times);
+		$this->total = $this->diffMicrotime($begin, $end);
+
+		return $this->analyzePeriod('', $times);
+	}
+
+	/**
+	 * Turn the tree of times into a sorted list
+	 *
+	 * @param array  &$list  Output list of times to populate
+	 * @param array  $tree   Result of buildTree()
+	 * @param string $prefix Prefix of period string. Leave empty.
+	 * @return void
+	 */
+	public function flattenTree(array &$list = [], array $tree, $prefix = '') {
+		$is_root = empty($list);
+
+		if (isset($tree['periods'])) {
+			foreach ($tree['periods'] as $period) {
+				$this->flattenTree($list, $period, "{$prefix}  {$period['name']}");
+			}
+			unset($tree['periods']);
+		}
+		$tree['name'] = trim($prefix);
+		$list[] = $tree;
+
+		if ($is_root) {
+			usort($list, function ($a, $b) {
+				if ($a['duration'] == $b['duration']) {
+					return 0;
+				}
+				return ($a['duration'] > $b['duration']) ? -1 : 1;
+			});
+		}
+	}
+
+	/**
+	 * Nicely format the elapsed time values
+	 *
+	 * @param array $tree Result of buildTree()
+	 * @return array
+	 */
+	public function formatTree(array $tree) {
+		$tree['duration'] = sprintf($this->duration_format, $tree['duration']);
+		if (isset($tree['percentage'])) {
+			$tree['percentage'] = sprintf($this->percentage_format, $tree['percentage']);
+		}
+		if (isset($tree['periods'])) {
+			$tree['periods'] = array_map([$this, 'formatTree'], $tree['periods']);
+		}
+		return $tree;
+	}
+
+	/**
+	 * Append a SCRIPT element to the page output
+	 *
+	 * @param string $hook   "output"
+	 * @param string $type   "page"
+	 * @param string $html   Full page HTML
+	 * @param array  $params Hook params
+	 *
+	 * @return string
+	 */
+	public static function handlePageOutput($hook, $type, $html, $params) {
+		$profiler = new self();
+		$min_percentage = elgg_get_config('profiling_minimum_percentage');
+		if ($min_percentage !== null) {
+			$profiler->minimum_percentage = $min_percentage;
+		}
+
+		$tree = $profiler->buildTree(_elgg_services()->timer);
+		$tree = $profiler->formatTree($tree);
+		$data['tree'] = $tree;
+		$data['total'] = $tree['duration'] . " seconds";
+
+		$list = [];
+		$profiler->flattenTree($list, $tree);
+
+		$list = array_map(function ($period) {
+			return "{$period['percentage']}% ({$period['duration']}) {$period['name']}";
+		}, $list);
+
+		$data['list'] = $list;
+
+		$html .= "<script>console.log(" . json_encode($data) . ");</script>";
+
+		return $html;
+	}
+
+	/**
+	 * Analyze a time period
+	 *
+	 * @param string $name  Period name
+	 * @param array  $times Times
+	 *
+	 * @return array|bool False if missing begin/end time
+	 */
+	private function analyzePeriod($name, array $times) {
+		$begin = $this->findBeginTime($times);
+		$end = $this->findEndTime($times);
+		if ($begin === false || $end === false) {
+			return false;
+		}
+		unset($times[':begin'], $times[':end']);
+
+		$total = $this->diffMicrotime($begin, $end);
+		$ret = [
+			'name' => $name,
+			'percentage' => 100, // may be overwritten by parent
+			'duration' => $total,
+		];
+
+		foreach ($times as $times_key => $period) {
+			$period = $this->analyzePeriod($times_key, $period);
+			if ($period === false) {
+				continue;
+			}
+			$period['percentage'] = 100 * $period['duration'] / $this->total;
+			if ($period['percentage'] < $this->minimum_percentage) {
+				continue;
+			}
+			$ret['periods'][] = $period;
+		}
+
+		if (isset($ret['periods'])) {
+			usort($ret['periods'], function ($a, $b) {
+				if ($a['duration'] == $b['duration']) {
+					return 0;
+				}
+				return ($a['duration'] > $b['duration']) ? -1 : 1;
+			});
+		}
+
+		return $ret;
+	}
+
+	/**
+	 * Get the microtime start time
+	 *
+	 * @param array $times Time periods
+	 * @return string|false
+	 */
+	private function findBeginTime(array $times) {
+		if (isset($times[':begin'])) {
+			return $times[':begin'];
+		}
+		unset($times[':begin'], $times[':end']);
+		$first = reset($times);
+		if (is_array($first)) {
+			return $this->findBeginTime($first);
+		}
+		return false;
+	}
+
+	/**
+	 * Get the microtime end time
+	 *
+	 * @param array $times Time periods
+	 * @return string|false
+	 */
+	private function findEndTime(array $times) {
+		if (isset($times[':end'])) {
+			return $times[':end'];
+		}
+		unset($times[':begin'], $times[':end']);
+		$last = end($times);
+		if (is_array($last)) {
+			return $this->findEndTime($last);
+		}
+		return false;
+	}
+
+	/**
+	 * Calculate a precise time difference.
+	 *
+	 * @param string $start result of microtime()
+	 * @param string $end   result of microtime()
+	 *
+	 * @return float difference in seconds, calculated with minimum precision loss
+	 */
+	private function diffMicrotime($start, $end) {
+		list($start_usec, $start_sec) = explode(" ", $start);
+		list($end_usec, $end_sec) = explode(" ", $end);
+		$diff_sec = (int)$end_sec - (int)$start_sec;
+		$diff_usec = (float)$end_usec - (float)$start_usec;
+		return (float)$diff_sec + $diff_usec;
+	}
+}

--- a/engine/classes/Elgg/Router.php
+++ b/engine/classes/Elgg/Router.php
@@ -14,6 +14,8 @@ namespace Elgg;
  * @access private
  */
 class Router {
+	use Profilable;
+
 	private $handlers = array();
 	private $hooks;
 
@@ -61,6 +63,11 @@ class Router {
 			'handler' => $identifier, // backward compatibility
 			'segments' => $segments,
 		);
+
+		if ($this->timer) {
+			$this->timer->begin(['build page']);
+		}
+
 		$result = $this->hooks->trigger('route', $identifier, $result, $result);
 		if ($result === false) {
 			return true;

--- a/engine/classes/Elgg/Timer.php
+++ b/engine/classes/Elgg/Timer.php
@@ -1,0 +1,73 @@
+<?php
+namespace Elgg;
+
+/**
+ * Capture timing info for profiling
+ *
+ * @access private
+ */
+class Timer {
+	const MARKER_BEGIN = ':begin';
+	const MARKER_END = ':end';
+
+	private $times = [];
+
+	/**
+	 * Record the start time of a period
+	 *
+	 * @param string[] $keys Keys to identify period. E.g. ['startup', __FUNCTION__]
+	 * @return void
+	 */
+	public function begin(array $keys) {
+		$this->getTreeNode($keys)[self::MARKER_BEGIN] = microtime();
+	}
+
+	/**
+	 * Record the end time of a period
+	 *
+	 * @param string[] $keys Keys to identify period. E.g. ['startup', __FUNCTION__]
+	 * @return void
+	 */
+	public function end(array $keys) {
+		$this->getTreeNode($keys)[self::MARKER_END] = microtime();
+	}
+
+	/**
+	 * Has the end of the period been recorded?
+	 *
+	 * @param string[] $keys Keys to identify period. E.g. ['startup', __FUNCTION__]
+	 * @return bool
+	 */
+	public function hasEnded(array $keys) {
+		$node = $this->getTreeNode($keys);
+		return isset($node[self::MARKER_END]);
+	}
+
+	/**
+	 * Get the tree of recorded start/end times
+	 *
+	 * @return array
+	 */
+	public function getTimes() {
+		return $this->times;
+	}
+
+	/**
+	 * Get a reference to the period array for the given keys
+	 *
+	 * @param string[] $keys Keys to identify period. E.g. ['startup', __FUNCTION__]
+	 * @return array
+	 */
+	private function &getTreeNode(array $keys) {
+		$arr =& $this->times;
+
+		foreach ($keys as $key) {
+			if (!isset($arr[$key])) {
+				$arr[$key] = [];
+			}
+			$arr =& $arr[$key];
+		}
+
+		return $arr;
+	}
+}

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -262,6 +262,8 @@ function get_config($name, $site_guid = 0) {
  * @access private
  */
 function _elgg_load_site_config() {
+	_elgg_services()->timer->begin([__FUNCTION__]);
+
 	global $CONFIG;
 
 	$CONFIG->site_guid = (int) datalist_get('default_site');
@@ -286,6 +288,8 @@ function _elgg_load_site_config() {
 		_elgg_services()->logger->setLevel($CONFIG->debug);
 		_elgg_services()->logger->setDisplay(true);
 	}
+
+	_elgg_services()->timer->end([__FUNCTION__]);
 }
 
 /**
@@ -325,6 +329,8 @@ function _elgg_configure_cookies($CONFIG) {
  * @access private
  */
 function _elgg_load_application_config() {
+	_elgg_services()->timer->begin([__FUNCTION__]);
+
 	global $CONFIG;
 
 	$install_root = Directory\Local::root();
@@ -371,6 +377,8 @@ function _elgg_load_application_config() {
 
 	// this must be synced with the enum for the entities table
 	$CONFIG->entity_types = array('group', 'object', 'site', 'user');
+
+	_elgg_services()->timer->end([__FUNCTION__]);
 }
 
 /**

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1990,6 +1990,13 @@ function _elgg_init() {
 
 		return $result;
 	});
+
+	if (_elgg_services()->config->getVolatile('enable_profiling')) {
+		/**
+		 * @see \Elgg\Profiler::handlePageOutput
+		 */
+		elgg_register_plugin_hook_handler('output', 'page', [\Elgg\Profiler::class, 'handlePageOutput'], 999);
+	}
 }
 
 /**

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -406,6 +406,7 @@ function logout() {
  * @access private
  */
 function _elgg_session_boot() {
+	_elgg_services()->timer->begin([__FUNCTION__]);
 
 	elgg_register_action('login', '', 'public');
 	elgg_register_action('logout');
@@ -448,5 +449,6 @@ function _elgg_session_boot() {
 		return false;
 	}
 
+	_elgg_services()->timer->end([__FUNCTION__]);
 	return true;
 }

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -415,6 +415,11 @@ function elgg_unextend_view($view, $view_extension) {
  * @since  1.8
  */
 function elgg_view_page($title, $body, $page_shell = 'default', $vars = array()) {
+	$timer = _elgg_services()->timer;
+	if (!$timer->hasEnded(['build page'])) {
+		$timer->end(['build page']);
+	}
+	$timer->begin([__FUNCTION__]);
 
 	$params = array();
 	$params['identifier'] = _elgg_services()->request->getFirstUrlSegment();
@@ -456,7 +461,10 @@ function elgg_view_page($title, $body, $page_shell = 'default', $vars = array())
 	$vars['page_shell'] = $page_shell;
 
 	// Allow plugins to modify the output
-	return elgg_trigger_plugin_hook('output', 'page', $vars, $output);
+	$output = elgg_trigger_plugin_hook('output', 'page', $vars, $output);
+
+	$timer->end([__FUNCTION__]);
+	return $output;
 }
 
 /**
@@ -627,6 +635,11 @@ function _elgg_views_prepare_head($title) {
  * @return string The layout
  */
 function elgg_view_layout($layout_name, $vars = array()) {
+	$timer = _elgg_services()->timer;
+	if (!$timer->hasEnded(['build page'])) {
+		$timer->end(['build page']);
+	}
+	$timer->begin([__FUNCTION__]);
 
 	$params = array();
 	$params['identifier'] = _elgg_services()->request->getFirstUrlSegment();
@@ -646,7 +659,10 @@ function elgg_view_layout($layout_name, $vars = array()) {
 		$output = elgg_view("page/layouts/default", $params);
 	}
 
-	return elgg_trigger_plugin_hook('output:after', 'layout', $params, $output);
+	$output = elgg_trigger_plugin_hook('output:after', 'layout', $params, $output);
+
+	$timer->end([__FUNCTION__]);
+	return $output;
 }
 
 /**

--- a/engine/tests/phpunit/Elgg/TimerTest.php
+++ b/engine/tests/phpunit/Elgg/TimerTest.php
@@ -1,0 +1,54 @@
+<?php
+namespace Elgg;
+
+class TimerTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @var Timer
+	 */
+	private $timer;
+
+	public function setUp() {
+		$this->timer = new Timer();
+	}
+
+	public function testCapturesTimes() {
+		$this->timer->begin([]);
+		$this->timer->begin(['1']);
+		$this->timer->begin(['1', 'a']);
+		$this->timer->end(['1']);
+		$this->timer->end([]);
+
+		$times = $this->timer->getTimes();
+		$begin = Timer::MARKER_BEGIN;
+		$end = Timer::MARKER_END;
+
+		$this->assertEquals([$begin, 1, $end], array_keys($times));
+		$this->assertEquals([$begin, 'a', $end], array_keys($times[1]));
+		$this->assertEquals([$begin], array_keys($times[1]['a']));
+
+		$this->assertIsATime($times[$begin]);
+		$this->assertIsATime($times[1][$begin]);
+		$this->assertIsATime($times[1]['a'][$begin]);
+		$this->assertIsATime($times[1][$end]);
+		$this->assertIsATime($times[$end]);
+	}
+
+	public function assertIsATime($val) {
+		list($one, $two) = explode(' ', $val);
+		$this->assertTrue(is_numeric($one) && is_numeric($two));
+	}
+
+	public function testCanDetectEnd() {
+		$this->assertFalse($this->timer->hasEnded([]));
+
+		$this->timer->begin([]);
+		$this->assertFalse($this->timer->hasEnded([]));
+
+		$this->timer->end([]);
+		$this->assertTrue($this->timer->hasEnded([]));
+
+		$this->timer->end(['1', 'a']);
+		$this->assertTrue($this->timer->hasEnded(['1', 'a']));
+	}
+}


### PR DESCRIPTION
Via `$CONFIG` options, sites can enable the display of profiling data in the console. Data is available as a tree or a flattened list sorted by duration.

It gives you times for:
- each callable in system events (e.g. "file_init" and "aalborg_theme_pagesetup")
- total time to run start.php for all plugins
- from routing to elgg_view_page() ("how long to generate the body of the page")
- elgg_view_page()
- elgg_view_layout()
- various boot functions
- (optional) timing each query

Pros/cons:
- No xhprof/xdebug/client software required
- Not super detailed, but useful
- Tiny overhead (see Timer class)
- Could add a way to highlight certain keys while developing
- [x] inject timer into dependencies
- [x] missing TimerTest tests

Refs #9293
