### PR TITLE
fix(core): gitignore the settings file in the root dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ignore Elgg configuration
 /engine/settings.php
+/settings.php
 /elgg-config/settings.php
 /.htaccess
 /mod/*


### PR DESCRIPTION
As the new advice is to move the settings in the root folder, we should also ignore this
