### PR TITLE
fix(topbar): limit topbar to 990px with rest of layout

### DIFF
--- a/mod/aalborg_theme/views/default/elements/layout.css
+++ b/mod/aalborg_theme/views/default/elements/layout.css
@@ -14,6 +14,10 @@
 .elgg-page-default {
 	min-width: 800px;
 }
+.elgg-page-default .elgg-page-topbar > .elgg-inner {
+	max-width: 990px;
+	margin: 0 auto;
+}
 .elgg-page-default .elgg-page-header > .elgg-inner {
 	max-width: 990px;
 	margin: 0 auto;


### PR DESCRIPTION
Fixes #8698

BREAKING CHANGE:
The element `.elgg-page-default .elgg-page-topbar > .elgg-inner` is now constrained in width.

![limit-topbar](https://cloud.githubusercontent.com/assets/170687/12269391/2b2cff7a-b91f-11e5-9b53-3159ba1a9dfb.png)
