### PR TITLE
fix(views): locations specified in /engine/views.php are modifiable

### DIFF
--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -258,6 +258,7 @@ class Application {
 			// Elgg is installed as a composer dep, so try to treat the root directory
 			// as a custom plugin that is always loaded last and can't be disabled...
 			if (!elgg_get_config('system_cache_loaded')) {
+				// configure view locations for the custom plugin (not Elgg core)
 				$viewsFile = Directory\Local::root()->getFile('views.php');
 				if ($viewsFile->exists()) {
 					$viewsSpec = $viewsFile->includeFile();
@@ -266,6 +267,7 @@ class Application {
 					}
 				}
 
+				// find views for the custom plugin (not Elgg core)
 				_elgg_services()->views->registerPluginViews(Directory\Local::root()->getPath());
 			}
 			

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1508,14 +1508,20 @@ function _elgg_views_send_header_x_frame_options() {
  * @elgg_event_handler boot system
  */
 function elgg_views_boot() {
-	if (!elgg_get_config('system_cache_loaded')) {
-		_elgg_services()->views->registerPluginViews(realpath(__DIR__ . '/../../'));
-	}
-	
 	global $CONFIG;
 
 	if (!elgg_get_config('system_cache_loaded')) {
+		// Core view files in /views
 		_elgg_services()->views->registerPluginViews(realpath(__DIR__ . '/../../'));
+
+		// Core view definitions in /engine/views.php
+		$file = dirname(__DIR__) . '/views.php';
+		if (is_file($file)) {
+			$spec = (include $file);
+			if (is_array($spec)) {
+				_elgg_services()->views->mergeViewsSpec($spec);
+			}
+		}
 	}
 
 	// on every page
@@ -1575,16 +1581,6 @@ function elgg_views_boot() {
 	foreach ($viewtype_dirs as $viewtype) {
 		if (_elgg_is_valid_viewtype($viewtype) && is_dir($view_path . $viewtype)) {
 			elgg_register_viewtype($viewtype);
-		}
-	}
-
-	// Declared views. Unlike plugins, Elgg's root views/ is never scanned, so Elgg cannot override
-	// these view traditional view files.
-	$file = dirname(__DIR__) . '/views.php';
-	if (is_file($file)) {
-		$spec = (include $file);
-		if (is_array($spec)) {
-			_elgg_services()->views->mergeViewsSpec($spec);
 		}
 	}
 


### PR DESCRIPTION
When simplecache is on, all view locations are loaded from cache, so no dir scanning/configuration should be done. In `elgg_views_boot`, we'd forgotten to scan `engine/views.php` based on this condition. This moves the scanning to the top and into the system cache conditional block.

This also gets rid of duplicated code that causes a double scan of the core view files.

Fixes #9308
