### PR TITLE
fix(installer): installer no longer fails on PHP 7

### DIFF
--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -836,6 +836,7 @@ class ElggInstaller {
 				$this->CONFIG->site_id = $this->CONFIG->site_guid;
 				$this->CONFIG->site = get_entity($this->CONFIG->site_guid);
 				$this->CONFIG->dataroot = _elgg_services()->datalist->get('dataroot');
+				_elgg_configure_cookies($this->CONFIG);
 				_elgg_session_boot();
 			}
 


### PR DESCRIPTION
`_elgg_session_boot()` uses the persistent login service, which depends on cookie settings we weren't setting in the installer.

Fixes #9314

(note: not tested)
