### PR TITLE
fix(notifications): set page context before pagesetup is fired

### DIFF
--- a/mod/notifications/start.php
+++ b/mod/notifications/start.php
@@ -41,6 +41,10 @@ function notifications_plugin_init() {
 function notifications_page_handler($page) {
 
 	elgg_gatekeeper();
+
+	// Set the context to settings
+	elgg_set_context('settings');
+
 	$current_user = elgg_get_logged_in_user_entity();
 
 	// default to personal notifications

--- a/mod/notifications/views/default/resources/notifications/groups.php
+++ b/mod/notifications/views/default/resources/notifications/groups.php
@@ -22,9 +22,6 @@ if (!isset($user) || !($user instanceof ElggUser)) {
 
 elgg_set_page_owner_guid($user->guid);
 
-// Set the context to settings
-elgg_set_context('settings');
-
 $title = elgg_echo('notifications:subscriptions:changesettings:groups');
 
 elgg_push_breadcrumb(elgg_echo('settings'), "settings/user/$user->username");

--- a/mod/notifications/views/default/resources/notifications/index.php
+++ b/mod/notifications/views/default/resources/notifications/index.php
@@ -21,9 +21,6 @@ if (!isset($user) || !($user instanceof ElggUser)) {
 
 elgg_set_page_owner_guid($user->guid);
 
-// Set the context to settings
-elgg_set_context('settings');
-
 $title = elgg_echo('notifications:subscriptions:changesettings');
 
 elgg_push_breadcrumb(elgg_echo('settings'), "settings/user/$user->username");


### PR DESCRIPTION
Due to race condition notification pages do not get the correct "settings" context
