### PR TITLE
fix(views): resources/error view now renders sanely within /admin

### DIFF
--- a/views/default/resources/error.php
+++ b/views/default/resources/error.php
@@ -30,8 +30,10 @@ if (isset($httpCodes[$type])) {
 	header("HTTP/1.1 $type {$httpCodes[$type]}");
 }
 
-$body = elgg_view_layout('error', array(
+$layout = elgg_in_context('admin') ? 'admin' : 'error';
+
+$body = elgg_view_layout($layout, array(
 	'title' => $title,
 	'content' => $content,
 ));
-echo elgg_view_page($title, $body, 'error');
+echo elgg_view_page($title, $body, $layout);


### PR DESCRIPTION
If `forward('', '400')` is called within admin context, the admin CSS is already set up, so now we also apply the admin layout designed for that CSS.

Fixes #9327
