### PR TITLE
chore(profiler): remove Elgg path from Closures in profiler data

### DIFF
--- a/engine/classes/Elgg/Profiler.php
+++ b/engine/classes/Elgg/Profiler.php
@@ -109,7 +109,9 @@ class Profiler {
 		$list = [];
 		$profiler->flattenTree($list, $tree);
 
-		$list = array_map(function ($period) {
+		$root = elgg_get_config('path');
+		$list = array_map(function ($period) use ($root) {
+			$period['name'] = str_replace("Closure $root", "Closure ", $period['name']);
 			return "{$period['percentage']}% ({$period['duration']}) {$period['name']}";
 		}, $list);
 


### PR DESCRIPTION
Instead of `(Closure /Users/steve/Sites/local/elgg-master/engine/lib/elgglib.php:2076)()`
outputs `(Closure engine/lib/elgglib.php:2076)()`
