### PR TITLE
fix(css): buttons no longer get cropped in admin context

### DIFF
--- a/views/default/css/admin.php
+++ b/views/default/css/admin.php
@@ -525,6 +525,7 @@ select {
 }
 
 .elgg-button {
+	display: inline-block;
 	font-size: 100%;
 	text-decoration: none;
 	border-radius: 3px;


### PR DESCRIPTION
Lack of display declaration was cutting off buttons in certain wrappers
in admin context

``` html
<div class="elgg-foot">
   <a href="#" class="elgg-button elgg-button-action elgg-requires-confirmation">Button</a>
</div>
```

![button](https://cloud.githubusercontent.com/assets/1202761/12841571/dfdc103e-cbec-11e5-842d-4d5e7003591b.png)
