### PR TITLE
feature(files): update file plugin to new file serving API

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -9,6 +9,14 @@ See the administrator guides for :doc:`how to upgrade a live site </admin/upgrad
    :local:
    :depth: 2
 
+From 2.x to 3.0
+===============
+
+Removed views
+-------------
+
+ * ``resources/file/download``
+
 From 2.0 to 2.1
 ===============
 

--- a/engine/classes/Elgg/FileService/File.php
+++ b/engine/classes/Elgg/FileService/File.php
@@ -76,7 +76,7 @@ class File {
 	}
 
 	/**
-	 * Returns publically accessible URL
+	 * Returns publicly accessible URL
 	 * @return string|false
 	 */
 	public function getURL() {

--- a/mod/file/actions/file/upload.php
+++ b/mod/file/actions/file/upload.php
@@ -68,6 +68,10 @@ if ($new_file) {
 		// user blanked title, but we need one
 		$title = $file->title;
 	}
+
+	if ($entity->access_id !== $access_id) {
+		$reset_icon_urls = true;
+	}
 }
 
 $file->title = $title;
@@ -167,6 +171,20 @@ if (isset($_FILES['upload']['name']) && !empty($_FILES['upload']['name'])) {
 } else {
 	// not saving a file but still need to save the entity to push attributes to database
 	$file->save();
+
+	if (isset($reset_icon_urls)) {
+		// we touch the thumbs because we want new URLs from \Elgg\FileService\File::getURL
+		$thumbnails = array($file->thumbnail, $file->smallthumb, $file->largethumb);
+		foreach ($thumbnails as $thumbnail) {
+			$thumbfile = new ElggFile();
+			$thumbfile->owner_guid = $file->owner_guid;
+			$thumbfile->setFilename($thumbnail);
+			if ($thumbfile->exists()) {
+				$thumb_filename = $thumbfile->getFilenameOnFilestore();
+				touch($thumb_filename);
+			}
+		}
+	}
 }
 
 // file saved so clear sticky form

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -360,11 +360,28 @@ function file_set_icon_url($hook, $type, $url, $params) {
 	$file = $params['entity'];
 	$size = $params['size'];
 	if (elgg_instanceof($file, 'object', 'file')) {
-
 		// thumbnails get first priority
 		if ($file->thumbnail) {
-			$ts = (int)$file->icontime;
-			return "mod/file/thumbnail.php?file_guid=$file->guid&size=$size&icontime=$ts";
+			switch ($size) {
+				case "small":
+					$thumbfile = $file->thumbnail;
+					break;
+				case "medium":
+					$thumbfile = $file->smallthumb;
+					break;
+				case "large":
+				default:
+					$thumbfile = $file->largethumb;
+					break;
+			}
+
+			$readfile = new ElggFile();
+			$readfile->owner_guid = $file->owner_guid;
+			$readfile->setFilename($thumbfile);
+			$thumb_url = elgg_get_inline_url($readfile, true);
+			if ($thumb_url) {
+				return $thumb_url;
+			}
 		}
 
 		$mapping = array(
@@ -383,10 +400,8 @@ function file_set_icon_url($hook, $type, $url, $params) {
 			'application/x-rar-compressed' => 'archive',
 			'application/x-stuffit' => 'archive',
 			'application/zip' => 'archive',
-
 			'text/directory' => 'vcard',
 			'text/v-card' => 'vcard',
-
 			'application' => 'application',
 			'audio' => 'music',
 			'text' => 'text',

--- a/mod/file/thumbnail.php
+++ b/mod/file/thumbnail.php
@@ -5,6 +5,8 @@
  * @package ElggFile
  */
 
+elgg_deprecated_notice('thumbnail.php is no longer in use and will be removed. Do not include or require it. Use elgg_get_inline_url() instead.', '3.0');
+
 $autoload_root = dirname(dirname(__DIR__));
 if (!is_file("$autoload_root/vendor/autoload.php")) {
 	$autoload_root = dirname(dirname(dirname($autoload_root)));
@@ -20,14 +22,12 @@ $file_guid = (int) get_input('file_guid', 0);
 $size = get_input('size', 'small');
 
 $file = get_entity($file_guid);
-if (!elgg_instanceof($file, 'object', 'file')) {
-	exit;
-}
 
-$simpletype = $file->simpletype;
-if ($simpletype == "image") {
+$thumb_url = false;
 
-	// Get file thumbnail
+// thumbnails get first priority
+if ($file && $file->thumbnail) {
+
 	switch ($size) {
 		case "small":
 			$thumbfile = $file->thumbnail;
@@ -41,22 +41,17 @@ if ($simpletype == "image") {
 			break;
 	}
 
-	// Grab the file
-	if ($thumbfile && !empty($thumbfile)) {
+	if (!empty($thumbfile)) {
 		$readfile = new ElggFile();
 		$readfile->owner_guid = $file->owner_guid;
 		$readfile->setFilename($thumbfile);
-		$mime = $file->getMimeType();
-		$contents = $readfile->grabFile();
-
-		// caching images for 10 days
-		header("Content-type: $mime");
-		header('Expires: ' . gmdate('D, d M Y H:i:s \G\M\T', strtotime("+10 days")), true);
-		header("Pragma: public", true);
-		header("Cache-Control: public", true);
-		header("Content-Length: " . strlen($contents));
-
-		echo $contents;
-		exit;
+		$thumb_url = elgg_get_inline_url($readfile, true);
 	}
 }
+
+if ($thumb_url) {
+	forward($thumb_url);
+}
+
+header('HTTP/1.1 404 Not found');
+exit;

--- a/mod/file/views/default/file/specialcontent/audio/default.php
+++ b/mod/file/views/default/file/specialcontent/audio/default.php
@@ -14,7 +14,7 @@ if (!elgg_extract('full_view', $vars, false)) {
 	return;
 }
 
-$download_url = elgg_normalize_url("file/download/{$file->getGUID()}");
+$download_url = elgg_get_download_url($file);
 $mimetype = $file->mimetype;
 
 echo "<audio controls><source src='{$download_url}' type='{$mimetype}'></audio>";

--- a/mod/file/views/default/file/specialcontent/image/default.php
+++ b/mod/file/views/default/file/specialcontent/image/default.php
@@ -9,7 +9,7 @@ $file = $vars['entity'];
 
 $image_url = $file->getIconURL('large');
 $image_url = elgg_format_url($image_url);
-$download_url = elgg_get_site_url() . "file/download/{$file->getGUID()}";
+$download_url = elgg_get_download_url($file);
 
 if ($vars['full_view']) {
 	elgg_load_js('lightbox');

--- a/mod/file/views/default/resources/file/download.php
+++ b/mod/file/views/default/resources/file/download.php
@@ -3,7 +3,10 @@
  * Elgg file download.
  *
  * @package ElggFile
+ * @deprecated since version 3.0
  */
+
+elgg_deprecated_notice('/file/download resource view has been deprecated and will be removed. Use elgg_get_download_url() to build download URLs', '3.0');
 
 // Get the guid
 $file_guid = elgg_extract("guid", $vars);
@@ -15,23 +18,4 @@ if (!elgg_instanceof($file, 'object', 'file')) {
 	forward();
 }
 
-$mime = $file->getMimeType();
-if (!$mime) {
-	$mime = "application/octet-stream";
-}
-
-$filename = $file->originalfilename;
-
-// fix for IE https issue
-header("Pragma: public");
-
-header("Content-type: $mime");
-header("Content-Disposition: attachment; filename=\"$filename\"");
-header("Content-Length: {$file->getSize()}");
-
-while (ob_get_level()) {
-    ob_end_clean();
-}
-flush();
-readfile($file->getFilenameOnFilestore());
-exit;
+forward(elgg_get_download_url($file));

--- a/mod/file/views/default/resources/file/view.php
+++ b/mod/file/views/default/resources/file/view.php
@@ -34,7 +34,7 @@ $content .= elgg_view_comments($file);
 elgg_register_menu_item('title', array(
 	'name' => 'download',
 	'text' => elgg_echo('download'),
-	'href' => "file/download/$file->guid",
+	'href' => elgg_get_download_url($file),
 	'link_class' => 'elgg-button elgg-button-action',
 ));
 

--- a/mod/file/views/rss/file/enclosure.php
+++ b/mod/file/views/rss/file/enclosure.php
@@ -6,7 +6,7 @@
  */
 
 if (elgg_instanceof($vars['entity'], 'object', 'file')) {
-	$download_url = elgg_get_site_url() . 'file/download/' . $vars['entity']->getGUID();
+	$download_url = elgg_get_download_url($vars['entity']);
 	$size = $vars['entity']->getSize();
 	$mime_type = $vars['entity']->getMimeType();
 	echo <<<END


### PR DESCRIPTION
Updates file plugin to use new elgg_get_download_url() to handle downloads, and elgg_get_inline_url() to handle image thumbs.

BREAKING CHANGE:
The `resources/file/download` view is no longer used.

(this replaces #9262)
