### PR TITLE
perf(http): serve-file URLs can respond without booting core

### DIFF
--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -232,6 +232,10 @@ class Application {
 
 		$config = $this->services->config;
 
+		if ($config->getVolatile('Elgg\Application_phpunit')) {
+			throw new \RuntimeException('Unit tests should not call ' . __METHOD__);
+		}
+
 		if ($config->getVolatile('boot_complete')) {
 			return;
 		}
@@ -392,7 +396,7 @@ class Application {
 		}
 
 		if (0 === strpos($path, '/serve-file/')) {
-			(new Application\ServeFileHandler($this))->getResponse($this->services->request)->send();
+			$this->services->serveFileHandler->getResponse($this->services->request)->send();
 			return true;
 		}
 

--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -22,6 +22,11 @@ class Config implements Services\Config {
 	private $settings_loaded = false;
 
 	/**
+	 * @var bool
+	 */
+	private $cookies_configured = false;
+
+	/**
 	 * Constructor
 	 *
 	 * @internal Access this object via Elgg\Application::$config
@@ -78,6 +83,42 @@ class Config implements Services\Config {
 	 */
 	public function getPluginsPath() {
 		return $this->config->pluginspath;
+	}
+
+	/**
+	 * Set up and return the cookie configuration array resolved from settings.php
+	 *
+	 * @return array
+	 */
+	public function getCookieConfig() {
+		$c = $this->config;
+
+		if ($this->cookies_configured) {
+			return $c->cookies;
+		}
+
+		$this->loadSettingsFile();
+
+		// set cookie values for session and remember me
+		if (!isset($c->cookies)) {
+			$c->cookies = array();
+		}
+		if (!isset($c->cookies['session'])) {
+			$c->cookies['session'] = array();
+		}
+		$session_defaults = session_get_cookie_params();
+		$session_defaults['name'] = 'Elgg';
+		$c->cookies['session'] = array_merge($session_defaults, $c->cookies['session']);
+		if (!isset($c->cookies['remember_me'])) {
+			$c->cookies['remember_me'] = array();
+		}
+		$session_defaults['name'] = 'elggperm';
+		$session_defaults['expire'] = strtotime("+30 days");
+		$c->cookies['remember_me'] = array_merge($session_defaults, $c->cookies['remember_me']);
+
+		$this->cookies_configured = true;
+
+		return $c->cookies;
 	}
 
 	/**

--- a/engine/classes/Elgg/Database/SiteSecret.php
+++ b/engine/classes/Elgg/Database/SiteSecret.php
@@ -22,6 +22,35 @@ namespace Elgg\Database;
 class SiteSecret {
 
 	/**
+	 * @var Datalist
+	 */
+	private $datalist;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Datalist $datalist Datalist table
+	 */
+	public function __construct(Datalist $datalist) {
+		$this->datalist = $datalist;
+	}
+
+	/**
+	 * @var string
+	 */
+	private $test_secret = '';
+
+	/**
+	 * Set a secret to be used in testing
+	 *
+	 * @param string $secret Testing site secret. 32 alphanums starting with "z"
+	 * @return void
+	 */
+	public function setTestingSecret($secret) {
+		$this->test_secret = $secret;
+	}
+
+	/**
 	 * Initialise the site secret (32 bytes: "z" to indicate format + 186-bit key in Base64 URL).
 	 *
 	 * Used during installation and saves as a datalist.
@@ -34,7 +63,7 @@ class SiteSecret {
 	function init() {
 		$secret = 'z' . _elgg_services()->crypto->getRandomString(31);
 
-		if (_elgg_services()->datalist->set('__site_secret__', $secret)) {
+		if ($this->datalist->set('__site_secret__', $secret)) {
 			return $secret;
 		}
 
@@ -52,9 +81,13 @@ class SiteSecret {
 	 * @access private
 	 */
 	function get($raw = false) {
-		$secret = _elgg_services()->datalist->get('__site_secret__');
+		if ($this->test_secret) {
+			$secret = $this->test_secret;
+		} else {
+			$secret = $this->datalist->get('__site_secret__');
+		}
 		if (!$secret) {
-			$secret = init_site_secret();
+			$secret = $this->init();
 		}
 
 		if ($raw) {
@@ -86,7 +119,7 @@ class SiteSecret {
 	 * @access private
 	 */
 	function getStrength() {
-		$secret = get_site_secret();
+		$secret = $this->get();
 		if ($secret[0] !== 'z') {
 			$rand_max = getrandmax();
 			if ($rand_max < pow(2, 16)) {
@@ -98,5 +131,4 @@ class SiteSecret {
 		}
 		return 'strong';
 	}
-
 }

--- a/engine/classes/Elgg/FileService/File.php
+++ b/engine/classes/Elgg/FileService/File.php
@@ -87,7 +87,7 @@ class File {
 		}
 
 		$relative_path = '';
-		$root_prefix = _elgg_services()->config->get('dataroot');
+		$root_prefix = _elgg_services()->config->getDataPath();
 		$path = $this->file->getFilenameOnFilestore();
 		if (substr($path, 0, strlen($root_prefix)) == $root_prefix) {
 			$relative_path = substr($path, strlen($root_prefix));
@@ -124,7 +124,7 @@ class File {
 		}
 
 		ksort($data);
-		$mac = elgg_build_hmac($data)->getToken();
+		$mac = _elgg_services()->crypto->getHmac($data)->getToken();
 
 		$url_segments = array(
 			'serve-file',

--- a/engine/classes/ElggCrypto.php
+++ b/engine/classes/ElggCrypto.php
@@ -1,4 +1,7 @@
 <?php
+
+use \Elgg\Database\SiteSecret;
+
 /**
  * \ElggCrypto
  *
@@ -18,6 +21,20 @@ class ElggCrypto {
 	 * Character set for hexadecimal
 	 */
 	const CHARS_HEX = '0123456789abcdef';
+
+	/**
+	 * @var SiteSecret
+	 */
+	private $siteSecret;
+
+	/**
+	 * Constructor
+	 *
+	 * @param SiteSecret $siteSecret Secret service
+	 */
+	public function __construct(SiteSecret $siteSecret) {
+		$this->siteSecret = $siteSecret;
+	}
 
 	/**
 	 * Generate a string of highly randomized bytes (over the full 8-bit range).
@@ -168,7 +185,7 @@ class ElggCrypto {
 	 */
 	public function getHmac($data, $algo = 'sha256', $key = '') {
 		if (!$key) {
-			$key = _elgg_services()->siteSecret->get(true);
+			$key = $this->siteSecret->get(true);
 		}
 		return new Elgg\Security\Hmac($key, [$this, 'areEqual'], $data, $algo);
 	}

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -836,7 +836,7 @@ class ElggInstaller {
 				$this->CONFIG->site_id = $this->CONFIG->site_guid;
 				$this->CONFIG->site = get_entity($this->CONFIG->site_guid);
 				$this->CONFIG->dataroot = _elgg_services()->datalist->get('dataroot');
-				_elgg_configure_cookies($this->CONFIG);
+				_elgg_services()->config->getCookieConfig();
 				_elgg_session_boot();
 			}
 

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -293,33 +293,6 @@ function _elgg_load_site_config() {
 }
 
 /**
- * Set up CONFIG->cookies. (this is for unit testing)
- *
- * @see phpunit/bootstrap.php
- *
- * @param stdClass $CONFIG Elgg's config object
- * @access private
- */
-function _elgg_configure_cookies($CONFIG) {
-	// set cookie values for session and remember me
-	if (!isset($CONFIG->cookies)) {
-		$CONFIG->cookies = array();
-	}
-	if (!isset($CONFIG->cookies['session'])) {
-		$CONFIG->cookies['session'] = array();
-	}
-	$session_defaults = session_get_cookie_params();
-	$session_defaults['name'] = 'Elgg';
-	$CONFIG->cookies['session'] = array_merge($session_defaults, $CONFIG->cookies['session']);
-	if (!isset($CONFIG->cookies['remember_me'])) {
-		$CONFIG->cookies['remember_me'] = array();
-	}
-	$session_defaults['name'] = 'elggperm';
-	$session_defaults['expire'] = strtotime("+30 days");
-	$CONFIG->cookies['remember_me'] = array_merge($session_defaults, $CONFIG->cookies['remember_me']);
-}
-
-/**
  * Loads configuration related to Elgg as an application
  *
  * This runs on the engine boot and loads from the datalists database table.
@@ -353,7 +326,7 @@ function _elgg_load_application_config() {
 	$GLOBALS['_ELGG']->view_path = \Elgg\Application::elggDir()->getPath("/views/");
 
 	// set cookie values for session and remember me
-	_elgg_configure_cookies($CONFIG);
+	_elgg_services()->config->getCookieConfig();
 
 	if (!is_memcache_available()) {
 		_elgg_services()->datalist->loadAll();

--- a/engine/tests/phpunit/Elgg/PersistentLoginTest.php
+++ b/engine/tests/phpunit/Elgg/PersistentLoginTest.php
@@ -74,7 +74,9 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 			->method('sanitizeString')
 			->will($this->returnCallback(array($this, 'mock_sanitizeString')));
 
-		$this->cryptoMock = $this->getMockBuilder('\ElggCrypto')->getMock();
+		$this->cryptoMock = $this->getMockBuilder('\ElggCrypto')
+			->setConstructorArgs([_elgg_services()->siteSecret])
+			->getMock();
 		$this->cryptoMock->expects($this->any())
 			->method('getRandomString')
 			->will($this->returnValue(str_repeat('a', 31)));

--- a/engine/tests/phpunit/ElggCryptoTest.php
+++ b/engine/tests/phpunit/ElggCryptoTest.php
@@ -14,11 +14,16 @@ class ElggCryptoTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp() {
 		$this->stub = $this->getMockBuilder('\ElggCrypto')
 			->setMethods(array('getRandomBytes'))
+			->setConstructorArgs([_elgg_services()->siteSecret])
 			->getMock();
 
 		$this->stub->expects($this->any())
 			->method('getRandomBytes')
 			->will($this->returnCallback(array($this, 'mock_getRandomBytes')));
+	}
+
+	protected function getCrypto() {
+		return new \ElggCrypto(_elgg_services()->siteSecret);
 	}
 
 	function mock_getRandomBytes($length) {
@@ -47,7 +52,7 @@ class ElggCryptoTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	function testGeneratesMacInBase64Url() {
-		$crypto = new ElggCrypto();
+		$crypto = $this->getCrypto();
 		$key = 'a very bad key';
 		$data = '1';
 		$expected = 'nL0lgXrVWgGK0Cmr9_PjqQcR2_PzuAHH114AsPZk-AM';
@@ -57,7 +62,7 @@ class ElggCryptoTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	function testStringCastAffectsMacs() {
-		$crypto = new ElggCrypto();
+		$crypto = $this->getCrypto();
 		$key = 'a very bad key';
 
 		$t1 = $crypto->getHmac(1234, 'sha256', $key)->getToken();
@@ -67,7 +72,7 @@ class ElggCryptoTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	function testMacAlteredByVaryingData() {
-		$crypto = new ElggCrypto();
+		$crypto = $this->getCrypto();
 		$key = 'a very bad key';
 
 		$t1 = $crypto->getHmac('1234', 'sha256', $key)->getToken();
@@ -77,7 +82,7 @@ class ElggCryptoTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	function testMacAlteredByVaryingKey() {
-		$crypto = new ElggCrypto();
+		$crypto = $this->getCrypto();
 		$key1 = 'a very bad key';
 		$key2 = 'b very bad key';
 
@@ -88,7 +93,7 @@ class ElggCryptoTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	function testCanAcceptDataAsArray() {
-		$crypto = new ElggCrypto();
+		$crypto = $this->getCrypto();
 		$key = 'a very bad key';
 
 		$token = $crypto->getHmac([12, 34], 'sha256', $key)->getToken();
@@ -98,7 +103,7 @@ class ElggCryptoTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	function testMacAlteredByArrayModification() {
-		$crypto = new ElggCrypto();
+		$crypto = $this->getCrypto();
 		$key = 'a very bad key';
 
 		$t1 = $crypto->getHmac([12, 34], 'sha256', $key)->getToken();
@@ -108,7 +113,7 @@ class ElggCryptoTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	function testMacAlteredByArrayTypeModification() {
-		$crypto = new ElggCrypto();
+		$crypto = $this->getCrypto();
 		$key = 'a very bad key';
 
 		$t1 = $crypto->getHmac([12, 34], 'sha256', $key)->getToken();

--- a/engine/tests/phpunit/bootstrap.php
+++ b/engine/tests/phpunit/bootstrap.php
@@ -29,6 +29,7 @@ function _elgg_testing_application(\Elgg\Application $app = null) {
  */
 global $CONFIG;
 $CONFIG = (object)[
+	'Config_file' => false,
 	'dbprefix' => 'elgg_',
 	'boot_complete' => false,
 	'wwwroot' => 'http://localhost/',
@@ -37,6 +38,7 @@ $CONFIG = (object)[
 	'site_guid' => 1,
 	'AutoloaderManager_skip_storage' => true,
 	'simplecache_enabled' => false,
+	'Elgg\Application_phpunit' => true,
 ];
 
 global $_ELGG;
@@ -58,13 +60,16 @@ call_user_func(function () use ($CONFIG) {
 	_elgg_testing_config($config);
 	
 	$sp = new \Elgg\Di\ServiceProvider($config);
+
 	$sp->setValue('mailer', new InMemoryTransport());
+
+	$sp->siteSecret->setTestingSecret('z1234567890123456789012345678901');
 
 	$app = new \Elgg\Application($sp);
 	$app->loadCore();
 
 	// persistentLogin service needs this set to instantiate without calling DB
-	_elgg_configure_cookies($CONFIG);
+	_elgg_services()->config->getCookieConfig();
 
 	_elgg_testing_application($app);
 });


### PR DESCRIPTION
Ensures unit tests can't call Application::bootCore
Fixes ServeFileHandler tests so request objects have cookies.
Injects specific services into ServeFileHandler.
Injects siteSecret into ElggCrypto.
Gets ServeFileHandler from service provider.
Moves cookie config to Elgg\Config`
Fixes site secret in PHPUnit bootstrap.
Ensures settings file loaded before Database is set up.
Ensures local settings.php isn't loaded in units (we don't want to override`wwwroot`, etc).
