### PR TITLE
chore(tests): skip serve-file/ tests and don't allow units to boot core

### DIFF
--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -232,6 +232,10 @@ class Application {
 
 		$config = $this->services->config;
 
+		if ($config->getVolatile('Elgg\Application_phpunit')) {
+			throw new \RuntimeException('Unit tests should not call ' . __METHOD__);
+		}
+
 		if ($config->getVolatile('boot_complete')) {
 			return;
 		}

--- a/engine/tests/phpunit/Elgg/Application/ServeFileHandlerTest.php
+++ b/engine/tests/phpunit/Elgg/Application/ServeFileHandlerTest.php
@@ -72,6 +72,7 @@ class ServeFileHandlerTest extends PHPUnit_Framework_TestCase {
 	 * @group FileService
 	 */
 	public function testSends403OnFileModificationTimeMismatch () {
+		$this->markTestSkipped('this test boots core');
 
 		$file = new \Elgg\FileService\File();
 		$file->setFile($this->file);
@@ -92,6 +93,7 @@ class ServeFileHandlerTest extends PHPUnit_Framework_TestCase {
 	 * @group FileService
 	 */
 	public function testResponseCodesOnSessionRestartWithCookieEnabledForFileUrls() {
+		$this->markTestSkipped('this test boots core');
 
 		$file = new \Elgg\FileService\File();
 		$file->setFile($this->file);
@@ -113,6 +115,8 @@ class ServeFileHandlerTest extends PHPUnit_Framework_TestCase {
 	 * @group FileService
 	 */
 	public function testResponseHeadersMatchFileAttributesForInlineUrls() {
+		$this->markTestSkipped('this test boots core');
+
 		$file = new \Elgg\FileService\File();
 		$file->setFile($this->file);
 		$file->setDisposition('inline');
@@ -135,6 +139,8 @@ class ServeFileHandlerTest extends PHPUnit_Framework_TestCase {
 	 * @group FileService
 	 */
 	public function testResponseHeadersMatchFileAttributesForAttachmentUrls() {
+		$this->markTestSkipped('this test boots core');
+
 		$file = new \Elgg\FileService\File();
 		$file->setFile($this->file);
 		$file->setDisposition('attachment');

--- a/engine/tests/phpunit/ElggMenuItemTest.php
+++ b/engine/tests/phpunit/ElggMenuItemTest.php
@@ -197,11 +197,33 @@ class ElggMenuItemTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testArgumentTypeValidationOnItemRegistration() {
+		_elgg_services()->logger->disable();
+
 		$this->assertTrue(elgg_register_menu_item('foo', new \ElggMenuItem('foo', 'bar', 'url')));
 		$this->assertTrue(elgg_register_menu_item('foo', array('name' => 'foo', 'text' => 'bar')));
 		$this->assertFalse(elgg_register_menu_item('foo', array()));
 		$this->assertFalse(elgg_register_menu_item('foo', array('text' => 'bar')));
 		$this->assertFalse(elgg_register_menu_item('foo', 'bar'));
 		$this->assertFalse(elgg_register_menu_item('foo', new stdClass()));
+
+		$logged = _elgg_services()->logger->enable();
+		$this->assertEquals([
+			[
+				'message' => 'Unable to add menu item \'MISSING NAME\' to \'foo\' menu',
+				'level' => 300,
+			],
+			[
+				'message' => 'Unable to add menu item \'MISSING NAME\' to \'foo\' menu',
+				'level' => 300,
+			],
+			[
+				'message' => 'Second argument of elgg_register_menu_item() must be an instance of ElggMenuItem or an array of menu item factory options',
+				'level' => 400,
+			],
+			[
+				'message' => 'Second argument of elgg_register_menu_item() must be an instance of ElggMenuItem or an array of menu item factory options',
+				'level' => 400,
+			],
+		], $logged);
 	}
 }

--- a/engine/tests/phpunit/bootstrap.php
+++ b/engine/tests/phpunit/bootstrap.php
@@ -37,6 +37,7 @@ $CONFIG = (object)[
 	'site_guid' => 1,
 	'AutoloaderManager_skip_storage' => true,
 	'simplecache_enabled' => false,
+	'Elgg\Application_phpunit' => true,
 ];
 
 global $_ELGG;


### PR DESCRIPTION
Current implementation of ServeFileHandler boots core and this causes numerous problems. The tests were passing before because the $CONFIG happened to be missing `pluginspath` so boot was partially failing. This is too fragile a situation. The tests can be re-enabled once ServeFileHandler is refactored to avoid booting.
