### PR TITLE
fix(cache): internal Stash pool wrapper works again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-xml": "*",
         "mrclay/minify": "~2.0",
         "knplabs/gaufrette": "~0.1.0",
-        "tedivm/stash": "~0.12",
+        "tedivm/stash": "0.14.*",
         "ircmaxell/password-compat": "~1.0",
         "roave/security-advisories": "dev-master"
     },

--- a/engine/classes/Elgg/Cache/StashPool.php
+++ b/engine/classes/Elgg/Cache/StashPool.php
@@ -41,7 +41,7 @@ final class StashPool implements Pool {
 
 			$result = call_user_func($callback);
 
-			$item->set($result);
+			$this->stash->save($item->set($result));
 		}
 
 		return $result;


### PR DESCRIPTION
Stash released a big BC breaking change in 0.14. Until they commit to SemVer and go 1.0 we can't trust minor version bumps.

Fixes #9374
