### PR TITLE
chore(tests): capture and test errors in menu tests

### DIFF
--- a/engine/tests/phpunit/ElggMenuItemTest.php
+++ b/engine/tests/phpunit/ElggMenuItemTest.php
@@ -197,11 +197,33 @@ class ElggMenuItemTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testArgumentTypeValidationOnItemRegistration() {
+		_elgg_services()->logger->disable();
+
 		$this->assertTrue(elgg_register_menu_item('foo', new \ElggMenuItem('foo', 'bar', 'url')));
 		$this->assertTrue(elgg_register_menu_item('foo', array('name' => 'foo', 'text' => 'bar')));
 		$this->assertFalse(elgg_register_menu_item('foo', array()));
 		$this->assertFalse(elgg_register_menu_item('foo', array('text' => 'bar')));
 		$this->assertFalse(elgg_register_menu_item('foo', 'bar'));
 		$this->assertFalse(elgg_register_menu_item('foo', new stdClass()));
+
+		$logged = _elgg_services()->logger->enable();
+		$this->assertEquals([
+			[
+				'message' => 'Unable to add menu item \'MISSING NAME\' to \'foo\' menu',
+				'level' => 300,
+			],
+			[
+				'message' => 'Unable to add menu item \'MISSING NAME\' to \'foo\' menu',
+				'level' => 300,
+			],
+			[
+				'message' => 'Second argument of elgg_register_menu_item() must be an instance of ElggMenuItem or an array of menu item factory options',
+				'level' => 400,
+			],
+			[
+				'message' => 'Second argument of elgg_register_menu_item() must be an instance of ElggMenuItem or an array of menu item factory options',
+				'level' => 400,
+			],
+		], $logged);
 	}
 }


### PR DESCRIPTION
Instead of dumping them into the logs, we can now verify them.
