### PR TITLE
fix(js): don't show ajax error message when aborting request

### DIFF
--- a/js/lib/ajax.js
+++ b/js/lib/ajax.js
@@ -81,9 +81,7 @@ elgg.ajax.handleOptions = function(url, options) {
 
 	if (!elgg.isFunction(options.error)) {
 		// add a generic error handler
-		options.error = function(xhr, status, error) { 
-			elgg.ajax.handleAjaxError(xhr, status, error);
-		};
+		options.error = elgg.ajax.handleAjaxError;
 	}
 	
 	if (url) {
@@ -102,7 +100,9 @@ elgg.ajax.handleOptions = function(url, options) {
  * @private
  */
 elgg.ajax.handleAjaxError = function(xhr, status, error) {
-	elgg.register_error(elgg.echo('ajax:error'));
+	if (status !== 'abort') {
+		elgg.register_error(elgg.echo('ajax:error'));
+	}
 };
 
 /**


### PR DESCRIPTION
If the error is due to calling `xhr.abort` (not an HTTP error, timeout, or parse error), we don't show a message to the user.

Fixes #9372
