### PR TITLE
feature(routing): allow more reliable URL path rewriting

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -18,7 +18,6 @@ System hooks
 	* headers
 	* params
 
-
 **page_owner, system**
 	Filter the page_owner for the current page. No options are passed.
 
@@ -296,8 +295,11 @@ Routing
 =======
 
 **route, <identifier>**
-    Allows altering the parameters used to route requests. ``identifier`` is the first URL segment,
-    registered with ``elgg_register_page_handler()``.
+    Allows applying logic or returning a response before the page handler is called. See :doc:`routing`
+    for details.
+
+**route:rewrite, <identifier>**
+	Allows altering the site-relative URL path. See :doc:`routing` for details.
 
 **ajax_response, path:<path>**
     Filters ajax responses before they're sent back to the ``elgg/Ajax`` module. This hook type will

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -297,6 +297,8 @@ class Application {
 			elgg_set_viewtype('default');
 		}
 
+		$this->allowPathRewrite();
+
 		// @todo deprecate as plugins can use 'init', 'system' event
 		$events->trigger('plugins_boot', 'system');
 
@@ -576,5 +578,21 @@ class Application {
 		$_GET[self::GET_PATH_KEY] = '/' . trim($_GET[self::GET_PATH_KEY], '/');
 
 		return $_GET[self::GET_PATH_KEY];
+	}
+
+	/**
+	 * Allow plugins to rewrite the path.
+	 *
+	 * @return void
+	 */
+	private function allowPathRewrite() {
+		$request = $this->services->request;
+		$new = $this->services->router->allowRewrite($request);
+		if ($new === $request) {
+			return;
+		}
+
+		$this->services->setValue('request', $new);
+		_elgg_set_initial_context($new);
 	}
 }

--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -2,77 +2,19 @@
 namespace Elgg\Http;
 
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
-use Symfony\Component\HttpFoundation\ParameterBag;
-use Symfony\Component\HttpFoundation\FileBag;
-use Symfony\Component\HttpFoundation\ServerBag;
-use Symfony\Component\HttpFoundation\HeaderBag;
 use Elgg\Application;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * Elgg HTTP request.
  *
- * Represents an HTTP request.
- *
- * Some methods were pulled from Symfony. They are
- * Copyright (c) 2004-2013 Fabien Potencier
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- * 
- * @package    Elgg.Core
- * @subpackage Http
- * @since      1.9.0
  * @access private
  */
 class Request extends SymfonyRequest {
 
 	/**
-	 * {@inheritDoc}
-	 */
-	public function initialize(array $query = array(), array $request = array(), array $attributes = array(),
-			array $cookies = array(), array $files = array(), array $server = array(), $content = null) {
-		$this->request = new ParameterBag($this->stripSlashesIfMagicQuotes($request));
-		$this->query = new ParameterBag($this->stripSlashesIfMagicQuotes($query));
-		$this->attributes = new ParameterBag($attributes);
-		$this->cookies = new ParameterBag($this->stripSlashesIfMagicQuotes($cookies));
-		$this->files = new FileBag($files);
-		$this->server = new ServerBag($server);
-		$this->headers = new HeaderBag($this->server->getHeaders());
-
-		$this->content = $content;
-		$this->languages = null;
-		$this->charsets = null;
-		$this->encodings = null;
-		$this->acceptableContentTypes = null;
-		$this->pathInfo = null;
-		$this->requestUri = null;
-		$this->baseUrl = null;
-		$this->basePath = null;
-		$this->method = null;
-		$this->format = null;
-	}
-
-	/**
-	 * Get URL segments from the path info
+	 * Get the Elgg URL segments
 	 *
-	 * @see \Elgg\Http\Request::getPathInfo()
-	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function getUrlSegments() {
 		$path = trim($this->query->get(Application::GET_PATH_KEY), '/');
@@ -84,7 +26,20 @@ class Request extends SymfonyRequest {
 	}
 
 	/**
-	 * Get first URL segment from the path info
+	 * Get a cloned request with new Elgg URL segments
+	 *
+	 * @param string[] $segments URL segments
+	 *
+	 * @return Request
+	 */
+	public function setUrlSegments(array $segments) {
+		$query = $this->query->all();
+		$query[Application::GET_PATH_KEY] = '/' . implode('/', $segments);
+		return $this->duplicate($query);
+	}
+
+	/**
+	 * Get first Elgg URL segment
 	 *
 	 * @see \Elgg\Http\Request::getUrlSegments()
 	 *
@@ -114,19 +69,5 @@ class Request extends SymfonyRequest {
 		}
 
 		return $ip;
-	}
-
-	/**
-	 * Strip slashes if magic quotes is on
-	 *
-	 * @param mixed $data Data to strip slashes from
-	 * @return mixed
-	 */
-	protected function stripSlashesIfMagicQuotes($data) {
-		if (get_magic_quotes_gpc()) {
-			return _elgg_stripslashes_deep($data);
-		} else {
-			return $data;
-		}
 	}
 }

--- a/engine/lib/input.php
+++ b/engine/lib/input.php
@@ -394,48 +394,6 @@ function input_livesearch_page_handler($page) {
 }
 
 /**
- * Strip slashes from array keys
- *
- * @param array $array Array of values
- *
- * @return array Sanitized array
- * @access private
- */
-function _elgg_stripslashes_arraykeys($array) {
-	if (is_array($array)) {
-		$array2 = array();
-		foreach ($array as $key => $data) {
-			if ($key != stripslashes($key)) {
-				$array2[stripslashes($key)] = $data;
-			} else {
-				$array2[$key] = $data;
-			}
-		}
-		return $array2;
-	} else {
-		return $array;
-	}
-}
-
-/**
- * Strip slashes
- *
- * @param mixed $value The value to remove slashes from
- *
- * @return mixed
- * @access private
- */
-function _elgg_stripslashes_deep($value) {
-	if (is_array($value)) {
-		$value = _elgg_stripslashes_arraykeys($value);
-		$value = array_map('_elgg_stripslashes_deep', $value);
-	} else {
-		$value = stripslashes($value);
-	}
-	return $value;
-}
-
-/**
  * Initialize the input library
  *
  * @return void
@@ -444,32 +402,6 @@ function _elgg_stripslashes_deep($value) {
 function _elgg_input_init() {
 	// register an endpoint for live search / autocomplete.
 	elgg_register_page_handler('livesearch', 'input_livesearch_page_handler');
-
-	// backward compatible for plugins directly accessing globals
-	if (get_magic_quotes_gpc()) {
-		$_POST = array_map('_elgg_stripslashes_deep', $_POST);
-		$_GET = array_map('_elgg_stripslashes_deep', $_GET);
-		$_COOKIE = array_map('_elgg_stripslashes_deep', $_COOKIE);
-		$_REQUEST = array_map('_elgg_stripslashes_deep', $_REQUEST);
-		if (!empty($_SERVER['REQUEST_URI'])) {
-			$_SERVER['REQUEST_URI'] = stripslashes($_SERVER['REQUEST_URI']);
-		}
-		if (!empty($_SERVER['QUERY_STRING'])) {
-			$_SERVER['QUERY_STRING'] = stripslashes($_SERVER['QUERY_STRING']);
-		}
-		if (!empty($_SERVER['HTTP_REFERER'])) {
-			$_SERVER['HTTP_REFERER'] = stripslashes($_SERVER['HTTP_REFERER']);
-		}
-		if (!empty($_SERVER['PATH_INFO'])) {
-			$_SERVER['PATH_INFO'] = stripslashes($_SERVER['PATH_INFO']);
-		}
-		if (!empty($_SERVER['PHP_SELF'])) {
-			$_SERVER['PHP_SELF'] = stripslashes($_SERVER['PHP_SELF']);
-		}
-		if (!empty($_SERVER['PATH_TRANSLATED'])) {
-			$_SERVER['PATH_TRANSLATED'] = stripslashes($_SERVER['PATH_TRANSLATED']);
-		}
-	}
 }
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {

--- a/engine/lib/pageowner.php
+++ b/engine/lib/pageowner.php
@@ -7,6 +7,8 @@
  * @subpackage PageOwner
  */
 
+use Elgg\Http\Request;
+
 /**
  * Gets the guid of the entity that owns the current page.
  *
@@ -276,23 +278,13 @@ function elgg_set_context_stack(array $stack) {
 }
 
 /**
- * Initializes the page owner functions
+ * Set an initial context if using index.php front controller.
  *
- * @note This is on the 'boot, system' event so that the context is set up quickly.
- *
+ * @param Request $request Elgg HTTP request
  * @return void
  * @access private
  */
-function page_owner_boot() {
-	
-	elgg_register_plugin_hook_handler('page_owner', 'system', 'default_page_owner_handler');
-
-	// Bootstrap the context stack by setting its first entry to the handler.
-	// This is the first segment of the URL and the handler is set by the rewrite rules.
-	// @todo this does not work for actions
-
-	$request = _elgg_services()->request;
-
+function _elgg_set_initial_context(\Elgg\Http\Request $request) {
 	// don't do this for *_handler.php, etc.
 	if (basename($request->server->get('SCRIPT_FILENAME')) === 'index.php') {
 		$context = $request->getFirstUrlSegment();
@@ -300,8 +292,20 @@ function page_owner_boot() {
 			$context = 'main';
 		}
 
-		elgg_set_context($context);
+		_elgg_services()->context->set($context);
 	}
+}
+
+/**
+ * Initializes the page owner functions
+ *
+ * @return void
+ * @access private
+ */
+function page_owner_boot() {
+	elgg_register_plugin_hook_handler('page_owner', 'system', 'default_page_owner_handler');
+
+	_elgg_set_initial_context(_elgg_services()->request);
 }
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {


### PR DESCRIPTION
Adds an early called `route:rewrite` hook expressly for URL rewriting. Changes there update the request object and affect the default context, and functions like current_page_url().

Removes legacy magic quotes-related code.

Fixes #9388
