### PR TITLE
feature(file): files are now displayed directly in the river

### DIFF
--- a/mod/file/views/default/river/object/file/create.php
+++ b/mod/file/views/default/river/object/file/create.php
@@ -10,7 +10,23 @@ $object = $item->getObjectEntity();
 $excerpt = strip_tags($object->description);
 $excerpt = elgg_get_excerpt($excerpt);
 
+$mime = $object->mimetype;
+$base_type = substr($mime, 0, strpos($mime,'/'));
+
+$params = array(
+	'entity' => $object,
+	'full_view' => true,
+);
+
+$attachment = '';
+if (elgg_view_exists("file/specialcontent/$mime")) {
+	$attachment = elgg_view("file/specialcontent/$mime", $params );
+} else if (elgg_view_exists("file/specialcontent/$base_type/default")) {
+	$attachment = elgg_view("file/specialcontent/$base_type/default", $params);
+}
+
 echo elgg_view('river/elements/layout', array(
 	'item' => $item,
 	'message' => $excerpt,
+	'attachments' => $attachment,
 ));


### PR DESCRIPTION
This would make river much more lively and interesting. Thanks to using the file plugin's own `file/specialcontent/<mime type>/<mime subtype>` views to display the river attachment, it is trivial to add or override the views.

Would we be interested in having this by default?
## Before:

![before](https://cloud.githubusercontent.com/assets/883920/13077924/8c6f5452-d4c4-11e5-8e13-15d29091aa0c.png)
## After:

![after](https://cloud.githubusercontent.com/assets/883920/13078050/6c9fd66e-d4c5-11e5-82e2-166421f0a958.png)
