### PR TITLE
fix(search): hooks no longer reset group subtype

### DIFF
--- a/mod/search/search_hooks.php
+++ b/mod/search/search_hooks.php
@@ -84,9 +84,6 @@ function search_groups_hook($hook, $type, $value, $params) {
 	$where = search_get_where_sql('ge', $fields, $params);
 	$params['wheres'][] = $where;
 
-	// override subtype -- All groups should be returned regardless of subtype.
-	$params['subtype'] = ELGG_ENTITIES_ANY_VALUE;
-
 	$params['count'] = TRUE;
 	$count = elgg_get_entities($params);
 	
@@ -173,9 +170,7 @@ function search_users_hook($hook, $type, $value, $params) {
 	} else {
 		$params['wheres'][] = "$where";
 	}
-	
-	// override subtype -- All users should be returned regardless of subtype.
-	$params['subtype'] = ELGG_ENTITIES_ANY_VALUE;
+
 	$params['count'] = true;
 	$count = elgg_get_entities($params);
 


### PR DESCRIPTION
Registering custom group subtypes with elgg_register_entity_type()
would result in the same results appearing for all group subtypes. This
allows groups subtypes to be searched individually.
