### PR TITLE
feature(relationships): it's now possible to directly query a set of relationships

### DIFF
--- a/engine/lib/relationships.php
+++ b/engine/lib/relationships.php
@@ -30,6 +30,23 @@ function delete_relationship($id) {
 }
 
 /**
+ * Get relationships matching the given options
+ *
+ * @param array $options Array in format:
+ *
+ *  relationship => null|array Array of relationship names (relationship IN ("relationship1", ...))
+ *
+ *  guid_one => null|array Array of GUIDs for entity one (guid_one IN (GUID1, ...)
+ *
+ *  guid_two => null|array Array of GUIDs for entity two (guid_two IN (GUID1, ...)
+ *
+ * @return \ElggRelationship[]
+ */
+function elgg_get_relationships(array $options = array()) {
+	return _elgg_services()->relationshipsTable->getRelationships($options);
+}
+
+/**
  * Create a relationship between two entities. E.g. friendship, group membership, site membership.
  *
  * This function lets you make the statement "$guid_one is a $relationship of $guid_two". In the statement,


### PR DESCRIPTION
Earlier you needed to first get entities from a relationship and then process relationships one by one for each entity. Now it is possible to query the relationships directly.

Fixes #7299
