### PR TITLE
fix(groups): clarify notification status strings

### DIFF
--- a/mod/groups/languages/en.php
+++ b/mod/groups/languages/en.php
@@ -29,8 +29,8 @@ return array(
 	'groups:my_status' => 'My status',
 	'groups:my_status:group_owner' => 'You own this group',
 	'groups:my_status:group_member' => 'You are in this group',
-	'groups:subscribed' => 'Group notifications on',
-	'groups:unsubscribed' => 'Group notifications off',
+	'groups:subscribed' => 'Group notifications are on',
+	'groups:unsubscribed' => 'Group notifications are off',
 
 	'groups:members:title' => 'Members of %s',
 	'groups:members:more' => "View all members",


### PR DESCRIPTION
Make it clearer that notification status strings denote status and are
not calls to action
