### PR TITLE
fix(discussions): make sure container exists before checking permissions

### DIFF
--- a/mod/discussions/views/default/resources/discussion/add.php
+++ b/mod/discussions/views/default/resources/discussion/add.php
@@ -3,6 +3,10 @@
 elgg_gatekeeper();
 
 $guid = elgg_extract('guid', $vars);
+
+elgg_entity_gatekeeper($guid);
+elgg_group_gatekeeper(true, $guid);
+
 $container = get_entity($guid);
 
 // Make sure user has permissions to add a topic to container


### PR DESCRIPTION
Lacking or non existent guid resulted in Fatal Error

Fixes #9383
