### PR TITLE
feature(ajax): improves the elgg/Ajax API and adds docs

### DIFF
--- a/engine/classes/Elgg/Ajax/Response.php
+++ b/engine/classes/Elgg/Ajax/Response.php
@@ -32,7 +32,10 @@ class Response implements \Elgg\Services\AjaxResponse {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function setData($data) {
+	public function setData(\stdClass $data) {
+		if (!property_exists($data, 'value')) {
+			throw new \InvalidArgumentException('$data must have a property "value"');
+		}
 		$this->data = $data;
 		return $this;
 	}

--- a/engine/classes/Elgg/Services/AjaxResponse.php
+++ b/engine/classes/Elgg/Services/AjaxResponse.php
@@ -28,15 +28,15 @@ interface AjaxResponse {
 	/**
 	 * Set the response data
 	 *
-	 * @param mixed $data Response data. Must be able to be encoded in JSON.
+	 * @param \stdClass $data Response data. Must be able to be encoded in JSON.
 	 * @return self
 	 */
-	public function setData($data);
+	public function setData(\stdClass $data);
 
 	/**
-	 * Get the response data
+	 * Get the response data, which will be a stdClass object with property "value"
 	 *
-	 * @return mixed
+	 * @return \stdClass
 	 */
 	public function getData();
 


### PR DESCRIPTION
Modifies the response hooks API so that handlers receive a wrapper object rather than the simple return value. This allows handlers to more reliably attach metadata to the response without the need to "wrap" the value.

Requests can specify that system messages be left in the queue. This is sometimes desirable if the client code intends to redirect/reload a page.

Prefixes with `elgg_` the server-side options.

The client-side response hook no longer fires twice.

Moves the system message delivery to hooks.

Documents using hooks to filter requests and responses.

Fixes #9404
