### PR TITLE
chore(js): deprecate using widgets init() without AMD

### DIFF
--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -434,6 +434,17 @@ The ``elgg/spinner`` module can be used to create an Ajax loading indicator fixe
 
 .. note:: The ``elgg/Ajax`` module uses the spinner by default.
 
+Module ``elgg/widgets``
+-----------------------
+
+Plugins that load a widget layout via Ajax should initialize via this module:
+
+.. code:: js
+
+   require(['elgg/widgets'], function (widgets) {
+       widgets.init();
+   });
+
 Traditional scripts
 ===================
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -19,6 +19,11 @@ Deprecated APIs
  * ``get_default_filestore``
  * ``set_default_filestore``
 
+Added ``elgg/widgets`` module
+-----------------------------
+
+If your plugin code calls ``elgg.ui.widgets.init()``, instead use the :doc:`elgg/widgets module <javascript>`.
+
 From 1.x to 2.0
 ===============
 

--- a/js/lib/ui.widgets.js
+++ b/js/lib/ui.widgets.js
@@ -8,6 +8,12 @@ elgg.provide('elgg.ui.widgets');
  */
 elgg.ui.widgets.init = function() {
 
+	// the AMD version of init sets this to avoid the deprecation warning
+	if (!elgg.ui.widgets.init._amd) {
+		elgg.deprecated_notice('Don\'t use elgg.ui.widgets directly. Use the AMD elgg/widgets module', '2.1');
+	}
+	delete elgg.ui.widgets.init._amd;
+
 	// widget layout?
 	if ($(".elgg-widgets").length === 0) {
 		return;
@@ -208,4 +214,10 @@ elgg.ui.widgets.setMinHeight = function(selector) {
 	});
 };
 
-elgg.register_hook_handler('init', 'system', elgg.ui.widgets.init);
+require(['jquery'], function ($) {
+	$(function () {
+		require(['elgg/widgets'], function (widgets) {
+			widgets.init();
+		});
+	});
+});

--- a/views/default/elgg/widgets.js
+++ b/views/default/elgg/widgets.js
@@ -1,0 +1,13 @@
+// TODO: move all elgg.ui.widget code here in 3.0
+define(function (require) {
+	var elgg = require('elgg');
+	var $ = require('jquery');
+
+	var w = $.extend({}, elgg.ui.widgets);
+	w.init = function () {
+		elgg.ui.widgets.init._amd = true;
+		elgg.ui.widgets.init();
+	};
+
+	return w;
+});


### PR DESCRIPTION
This adds the module `elgg/widgets` (just a wrapper definition for BC). Devs should require elgg/widgets if they use widget layouts.

Calling elgg.ui.widgets.init() directly results in a deprecation notice, whereas the AMD module returned init() does not.

In Elgg 3.0, `elgg.ui.widgets` will not be defined in `elgg` and the `elgg/widgets` module will only be required if there's an `.elgg-widgets` element in the page.
