### PR TITLE
fix(js): AMD view filter handles short view names without `/`

### DIFF
--- a/engine/classes/Elgg/Amd/ViewFilter.php
+++ b/engine/classes/Elgg/Amd/ViewFilter.php
@@ -21,16 +21,24 @@ class ViewFilter {
 	 * @return string The AMD name (e.g., 'elgg/module'), or blank for no AMD name.
 	 */
 	private function getAmdName($name) {
-		$pieces = explode("/", $name); // [js, elgg, module.js]
-		if (count($pieces) <= 1 || $pieces[0] != 'js') {
+		if (preg_match('~^(js/)?(.+)\\.js\\z~', $name, $m)) {
+			// "js/foo/bar.js" or "foo/bar.js"
+			return $m[2];
+		}
+
+		// must be in "js/" dir
+		if (0 !== strpos($name, 'js/')) {
 			return '';
 		}
-	
-		array_shift($pieces); // [elgg, module.js]
-		$basename = basename(array_pop($pieces), ".js"); // module
-		array_push($pieces, $basename); // [elgg, module]
-		
-		return implode("/", $pieces); // elgg/module
+		$name = substr($name, 3);
+
+		// Don't allow extension. We matched ".js" above
+		if (pathinfo($name, PATHINFO_EXTENSION) !== null) {
+			return '';
+		}
+
+		// "foo/bar"
+		return $name;
 	}
 	
 	/**

--- a/engine/tests/phpunit/Elgg/Amd/ViewFilterTest.php
+++ b/engine/tests/phpunit/Elgg/Amd/ViewFilterTest.php
@@ -4,6 +4,14 @@ namespace Elgg\Amd;
 
 class ViewFilterTest extends \PHPUnit_Framework_TestCase {
 
+	public function testHandlesShortViewNames() {
+		$viewFilter = new \Elgg\Amd\ViewFilter();
+
+		$originalContent = "define({})";
+
+		$this->assertEquals('define("foo", {})', $viewFilter->filter('foo.js', $originalContent));
+	}
+
 	public function testInsertsNamesForAnonymousModules() {
 		$viewFilter = new \Elgg\Amd\ViewFilter();
 
@@ -30,11 +38,11 @@ class ViewFilterTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($originalContent, $filteredContent);
 	}
 
-	public function testIgnoresNonJsViews() {
+	public function testExtensionlessViewsMustBeInJs() {
 		$viewFilter = new \Elgg\Amd\ViewFilter();
 
-		$originalContent = "// Comment\ndefine('any/mod', {})";
-		$filteredContent = $viewFilter->filter('nonjs/foobar/my/mod.js', $originalContent);
+		$originalContent = "// Comment\ndefine({})";
+		$filteredContent = $viewFilter->filter('nonjs/foobar/my/mod', $originalContent);
 		$this->assertEquals($originalContent, $filteredContent);
 	}
 


### PR DESCRIPTION
Also renames the `testIgnoresNonJsViews` test method and makes it work.
