### PR TITLE
fix(forms): remove extra spacing between longtext field label and menu

### DIFF
--- a/mod/aalborg_theme/views/default/elements/navigation.css
+++ b/mod/aalborg_theme/views/default/elements/navigation.css
@@ -454,7 +454,9 @@
 .elgg-menu-longtext {
 	float: right;
 }
-
+.elgg-field-label + .elgg-menu-longtext {
+	margin-top: -20px;
+}
 /* ***************************************
 	RIVER
 *************************************** */


### PR DESCRIPTION
_Without `elgg_view_input()`_
![longtext](https://cloud.githubusercontent.com/assets/1202761/13257242/50c98e38-da4e-11e5-9dd8-8b442467e75f.png)

_With `elgg_view_input()`_
![longtext_input_before](https://cloud.githubusercontent.com/assets/1202761/13257339/9f715eee-da4e-11e5-9452-7bdb5a939c40.png)

_After this PR_
![longtext_input](https://cloud.githubusercontent.com/assets/1202761/13257349/aad72430-da4e-11e5-9d06-a3f83200c00a.png)
