### PR TITLE
fix(web_services): reject requests for unavailable formats

### DIFF
--- a/mod/web_services/lib/web_services.php
+++ b/mod/web_services/lib/web_services.php
@@ -723,13 +723,18 @@ function service_handler($handler, $request) {
 	// after the handler, the first identifier is response format
 	// ex) http://example.org/services/api/rest/json/?method=test
 	$response_format = array_shift($request);
-	// Which view - xml, json, ...
-	if ($response_format && elgg_is_registered_viewtype($response_format)) {
-		elgg_set_viewtype($response_format);
-	} else {
-		// default to json
-		elgg_set_viewtype("json");
+	if (!$response_format) {
+		$response_format = 'json';
 	}
+
+	if (!ctype_alpha($response_format)) {
+		header("HTTP/1.0 400 Bad Request");
+		header("Content-type: text/plain");
+		echo "Invalid format.";
+		exit;
+	}
+
+	elgg_set_viewtype($response_format);
 
 	if (!isset($CONFIG->servicehandler) || empty($handler)) {
 		// no handlers set or bad url

--- a/mod/web_services/start.php
+++ b/mod/web_services/start.php
@@ -277,6 +277,18 @@ function elgg_ws_unregister_service_handler($handler) {
  */
 function ws_rest_handler() {
 
+	$viewtype = elgg_get_viewtype();
+
+	if (!elgg_view_exists('api/output', $viewtype)) {
+		header("HTTP/1.0 400 Bad Request");
+		header("Content-type: text/plain");
+		echo "Missing view 'api/output' in viewtype '$viewtype'.";
+		if (in_array($viewtype, ['xml', 'php'])) {
+			echo "\nEnable the 'data_views' plugin to add this view.";
+		}
+		exit;
+	}
+
 	elgg_load_library('elgg:ws');
 
 	// Register the error handler


### PR DESCRIPTION
Sends 400 responses if the format isn't likely a valid viewtype or lacks the `api/output` view in that viewtype.

Fixes #9410
- [x] investigate if/why silent fallback was intentional
