### PR TITLE
deprecate(entity): removes the tables_split and tables_loaded properties

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -79,20 +79,6 @@ abstract class ElggEntity extends \ElggData implements
 	 * Holds the original (persisted) attribute values that have been changed but not yet saved.
 	 */
 	protected $orig_attributes = array();
-
-	/**
-	 * Tells how many tables are going to need to be searched in order to fully populate this object
-	 *
-	 * @var int
-	 */
-	protected $tables_split;
-	
-	/**
-	 * Tells how many tables describing object have been loaded thus far
-	 *
-	 * @var int
-	 */
-	protected $tables_loaded;
 	
 	/**
 	 * Initialize the attributes array.
@@ -116,24 +102,6 @@ abstract class ElggEntity extends \ElggData implements
 		$this->attributes['time_updated'] = null;
 		$this->attributes['last_action'] = null;
 		$this->attributes['enabled'] = "yes";
-
-		// There now follows a bit of a hack
-		/* Problem: To speed things up, some objects are split over several tables,
-		 * this means that it requires n number of database reads to fully populate
-		 * an entity. This causes problems for caching and create events
-		 * since it is not possible to tell whether a subclassed entity is complete.
-		 *
-		 * Solution: We have two counters, one 'tables_split' which tells whatever is
-		 * interested how many tables are going to need to be searched in order to fully
-		 * populate this object, and 'tables_loaded' which is how many have been
-		 * loaded thus far.
-		 *
-		 * If the two are the same then this object is complete.
-		 *
-		 * Use: isFullyLoaded() to check
-		 */
-		$this->tables_split = 1;
-		$this->tables_loaded = 0;
 	}
 
 	/**
@@ -201,8 +169,8 @@ abstract class ElggEntity extends \ElggData implements
 			// quick return if value is not changing
 			return;
 		}
-		if (array_key_exists($name, $this->attributes)) {
 
+		if (array_key_exists($name, $this->attributes)) {
 			// if an attribute is 1 (integer) and it's set to "1" (string), don't consider that a change.
 			if (is_int($this->attributes[$name])
 					&& is_string($value)
@@ -244,9 +212,15 @@ abstract class ElggEntity extends \ElggData implements
 					$this->attributes[$name] = $value;
 					break;
 			}
-		} else {
-			$this->setMetadata($name, $value);
+			return;
 		}
+
+		if ($name === 'tables_split' || $name === 'tables_loaded') {
+			elgg_deprecated_notice("Do not read/write ->tables_split or ->tables_loaded.", "2.1");
+			return;
+		}
+
+		$this->setMetadata($name, $value);
 	}
 
 	/**
@@ -293,6 +267,11 @@ abstract class ElggEntity extends \ElggData implements
 				elgg_deprecated_notice("Use getSubtype()", 1.9);
 			}
 			return $this->attributes[$name];
+		}
+
+		if ($name === 'tables_split' || $name === 'tables_loaded') {
+			elgg_deprecated_notice("Do not read/write ->tables_split or ->tables_loaded.", "2.1");
+			return 2;
 		}
 
 		return $this->getMetadata($name);
@@ -1464,12 +1443,12 @@ abstract class ElggEntity extends \ElggData implements
 	}
 
 	/**
-	 * Tests to see whether the object has been fully loaded.
+	 * Tests to see whether the object has been persisted.
 	 *
 	 * @return bool
 	 */
 	public function isFullyLoaded() {
-		return ! ($this->tables_loaded < $this->tables_split);
+		return (bool)$this->guid;
 	}
 
 	/**
@@ -1737,11 +1716,6 @@ abstract class ElggEntity extends \ElggData implements
 			$objarray = (array) $row;
 			foreach ($objarray as $key => $value) {
 				$this->attributes[$key] = $value;
-			}
-
-			// Increment the portion counter
-			if (!$this->isFullyLoaded()) {
-				$this->tables_loaded++;
 			}
 
 			// guid needs to be an int  https://github.com/elgg/elgg/issues/4111

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -25,7 +25,6 @@ class ElggGroup extends \ElggEntity
 
 		$this->attributes['type'] = "group";
 		$this->attributes += self::getExternalAttributes();
-		$this->tables_split = 2;
 	}
 
 	/**
@@ -520,7 +519,6 @@ class ElggGroup extends \ElggEntity
 		}
 
 		$this->attributes = $attrs;
-		$this->tables_loaded = 2;
 		$this->loadAdditionalSelectValues($attr_loader->getAdditionalSelectValues());
 		_elgg_cache_entity($this);
 

--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -32,7 +32,6 @@ class ElggObject extends \ElggEntity {
 
 		$this->attributes['type'] = "object";
 		$this->attributes += self::getExternalAttributes();
-		$this->tables_split = 2;
 	}
 
 	/**
@@ -107,7 +106,6 @@ class ElggObject extends \ElggEntity {
 		}
 
 		$this->attributes = $attrs;
-		$this->tables_loaded = 2;
 		$this->loadAdditionalSelectValues($attr_loader->getAdditionalSelectValues());
 		_elgg_cache_entity($this);
 

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -38,7 +38,6 @@ class ElggSite extends \ElggEntity {
 
 		$this->attributes['type'] = "site";
 		$this->attributes += self::getExternalAttributes();
-		$this->tables_split = 2;
 	}
 
 	/**
@@ -117,7 +116,6 @@ class ElggSite extends \ElggEntity {
 		}
 
 		$this->attributes = $attrs;
-		$this->tables_loaded = 2;
 		$this->loadAdditionalSelectValues($attr_loader->getAdditionalSelectValues());
 		_elgg_cache_entity($this);
 

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -31,7 +31,6 @@ class ElggUser extends \ElggEntity
 
 		$this->attributes['type'] = "user";
 		$this->attributes += self::getExternalAttributes();
-		$this->tables_split = 2;
 	}
 
 	/**
@@ -118,7 +117,6 @@ class ElggUser extends \ElggEntity
 		}
 
 		$this->attributes = $attrs;
-		$this->tables_loaded = 2;
 		$this->loadAdditionalSelectValues($attr_loader->getAdditionalSelectValues());
 		_elgg_cache_entity($this);
 

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -128,9 +128,7 @@ function _elgg_retrieve_cached_entity($guid) {
 	global $ENTITY_CACHE;
 
 	if (isset($ENTITY_CACHE[$guid])) {
-		if ($ENTITY_CACHE[$guid]->isFullyLoaded()) {
-			return $ENTITY_CACHE[$guid];
-		}
+		return $ENTITY_CACHE[$guid];
 	}
 
 	return false;

--- a/engine/tests/ElggCoreUnitTest.php
+++ b/engine/tests/ElggCoreUnitTest.php
@@ -89,7 +89,6 @@ class IdenticalEntityExpectation extends EqualExpectation {
 	protected function entityToFilteredArray($entity) {
 		$skippedKeys = array('last_action');
 		$array = (array)$entity;
-		unset($array["\0*\0tables_loaded"]);
 		foreach ($skippedKeys as $key) {
 			// See: http://www.php.net/manual/en/language.types.array.php#language.types.array.casting
 			$array["\0*\0attributes"][$key] = null;


### PR DESCRIPTION
Makes sure that 3rd party subclasses don't end up reading/writing metadata with these names.

These properties were not really needed since 33c786c (#446), but isFullyLoaded() was not altered as needed.

This allows isFullyLoaded() to return true for freshly-saved entities.
