### PR TITLE
fix(cache): cache handler now works with mod_deflate

### DIFF
--- a/engine/classes/Elgg/Application/CacheHandler.php
+++ b/engine/classes/Elgg/Application/CacheHandler.php
@@ -280,9 +280,16 @@ class CacheHandler {
 	 * @return void
 	 */
 	protected function handle304($etag) {
-		// If is the same ETag, content didn't change.
-		if (isset($this->server_vars['HTTP_IF_NONE_MATCH'])
-			&& trim($this->server_vars['HTTP_IF_NONE_MATCH']) === $etag) {
+
+		if (!isset($this->server_vars['HTTP_IF_NONE_MATCH'])) {
+			return;
+		}
+		$http_if_none_match = trim($this->server_vars['HTTP_IF_NONE_MATCH']);
+
+		// Strip out "-gzip" suffixes added by mod_deflate
+		$http_if_none_match = str_replace('-gzip', '', $http_if_none_match);
+		if ($http_if_none_match === $etag) {
+			// If is the same ETag, content didn't change.
 			header("HTTP/1.1 304 Not Modified");
 			exit;
 		}


### PR DESCRIPTION
Due due rewrites of Etag values taking place with mod_deflate enabled
CacheHandler was unable to match request If-None-Match headers with
response Etags, thus resulting in all cacheable resources being reloaded
on each request. This strips -gzip suffixes from request values before
comparing them to Etag

Fixes #9427
- [ ] rebase for 1.12
