### PR TITLE
fix(http): cache handler sends 304 responses more reliably

### DIFF
--- a/engine/classes/Elgg/CacheHandler.php
+++ b/engine/classes/Elgg/CacheHandler.php
@@ -57,9 +57,14 @@ class CacheHandler {
 
 		$etag = "\"$ts\"";
 		// If is the same ETag, content didn't change.
-		if (isset($server_vars['HTTP_IF_NONE_MATCH']) && trim($server_vars['HTTP_IF_NONE_MATCH']) === $etag) {
-			header("HTTP/1.1 304 Not Modified");
-			exit;
+		if (isset($server_vars['HTTP_IF_NONE_MATCH'])) {
+			// strip -gzip for #9427
+			$if_none_match = str_replace('-gzip', '', trim($server_vars['HTTP_IF_NONE_MATCH']));
+			if ($if_none_match === $etag) {
+				header("HTTP/1.1 304 Not Modified");
+				header("ETag: $etag");
+				exit;
+			}
 		}
 
 		$filename = $this->config->dataroot . 'views_simplecache/' . md5("$viewtype|$view");


### PR DESCRIPTION
Apache 2.4+ adds `-gzip` to ETags when it applies deflate to a response. This strips it from request `If-None-Match` headers so we match it more reliably and send 304 responses.

Fixes #9427
