### PR TITLE
chore(permissions): canEdit checks persisted attributes without reload

### DIFF
--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -155,8 +155,12 @@ class ElggObject extends \ElggEntity {
 		$title = sanitize_string($this->title);
 		$description = sanitize_string($this->description);
 
-		$query = "UPDATE {$CONFIG->dbprefix}objects_entity
-			set title='$title', description='$description' where guid=$guid";
+		$query = "
+			UPDATE {$CONFIG->dbprefix}objects_entity
+			SET title = '$title',
+				description = '$description'
+			WHERE guid = $guid
+		";
 
 		return $this->getDatabase()->updateData($query) !== false;
 	}


### PR DESCRIPTION
With `getOriginalAttributes()` we no longer have to reload the entity from the database in order to compare the persisted attributes. We use an anonymous function in canEdit() to clean up logic for the default value.

This also cleans up some SQL.

Fixes #5604

(I've manually tested this by logging in as a non-admin, and handing over group ownership to another user).
