### PR TITLE
fix(comments): unifies behavior after adding new comment/discussion reply

### DIFF
--- a/actions/comment/save.php
+++ b/actions/comment/save.php
@@ -9,7 +9,6 @@
 $entity_guid = (int) get_input('entity_guid', 0, false);
 $comment_guid = (int) get_input('comment_guid', 0, false);
 $comment_text = get_input('generic_comment');
-$is_edit_page = (bool) get_input('is_edit_page', false, false);
 
 if (empty($comment_text)) {
 	register_error(elgg_echo("generic_comment:blank"));
@@ -100,8 +99,13 @@ if ($comment_guid) {
 	system_message(elgg_echo('generic_comment:posted'));
 }
 
-if ($is_edit_page) {
-	forward($comment->getURL());
+// return to activity page if posted from there
+if (!empty($_SERVER['HTTP_REFERER'])) {
+	// don't redirect to URLs from client without verifying within site
+	$site_url = preg_quote(elgg_get_site_url(), '~');
+	if (preg_match("~^{$site_url}activity(/|\\z)~", $_SERVER['HTTP_REFERER'], $m)) {
+		forward("{$m[0]}#elgg-object-{$comment->guid}");
+	}
 }
 
-forward(REFERER);
+forward($comment->getURL());

--- a/mod/aalborg_theme/views/default/elements/components.css
+++ b/mod/aalborg_theme/views/default/elements/components.css
@@ -264,7 +264,8 @@
 }
 
 /* Comment highlighting that automatically fades away */
-.elgg-comments .elgg-state-highlight {
+.elgg-comments .elgg-state-highlight,
+.elgg-river-comments .elgg-state-highlight {
 	-webkit-animation: comment-highlight 5s; /* Chrome, Safari, Opera */
 	animation: comment-highlight 5s;
 }

--- a/mod/discussions/actions/discussion/reply/save.php
+++ b/mod/discussions/actions/discussion/reply/save.php
@@ -75,4 +75,13 @@ if ($reply_guid) {
 	system_message(elgg_echo('discussion:post:success'));
 }
 
-forward(REFERER);
+// return to activity page if posted from there
+if (!empty($_SERVER['HTTP_REFERER'])) {
+	// don't redirect to URLs from client without verifying within site
+	$site_url = preg_quote(elgg_get_site_url(), '~');
+	if (preg_match("~^{$site_url}activity(/|\\z)~", $_SERVER['HTTP_REFERER'], $m)) {
+		forward("{$m[0]}#elgg-object-{$reply->guid}");
+	}
+}
+
+forward($reply->getURL());

--- a/views/default/elements/components.css.php
+++ b/views/default/elements/components.css.php
@@ -248,7 +248,8 @@
 }
 
 /* Comment highlighting that automatically fades away */
-.elgg-comments .elgg-state-highlight {
+.elgg-comments .elgg-state-highlight,
+.elgg-river-comments .elgg-state-highlight {
 	-webkit-animation: comment-highlight 5s; /* Chrome, Safari, Opera */
 	animation: comment-highlight 5s;
 }

--- a/views/default/forms/comment/save.php
+++ b/views/default/forms/comment/save.php
@@ -4,10 +4,9 @@
  *
  * @package Elgg
  *
- * @uses ElggEntity  $vars['entity']       The entity being commented
- * @uses ElggComment $vars['comment']      The comment being edited
- * @uses bool        $vars['inline']       Show a single line version of the form?
- * @uses bool        $vars['is_edit_page'] Is this form on its own page?
+ * @uses ElggEntity  $vars['entity']  The entity being commented
+ * @uses ElggComment $vars['comment'] The comment being edited
+ * @uses bool        $vars['inline']  Show a single line version of the form?
  */
 
 if (!elgg_is_logged_in()) {
@@ -21,7 +20,6 @@ $comment = elgg_extract('comment', $vars);
 /* @var ElggComment $comment */
 
 $inline = elgg_extract('inline', $vars, false);
-$is_edit_page = elgg_extract('is_edit_page', $vars, false);
 
 $entity_guid_input = '';
 if ($entity) {
@@ -71,18 +69,12 @@ if ($inline) {
 		'required' => true
 	));
 
-	$is_edit_page_input = elgg_view('input/hidden', array(
-		'name' => 'is_edit_page',
-		'value' => (int)$is_edit_page,
-	));
-
 	echo <<<FORM
 <div>
 	<label>$comment_label</label>
 	$comment_input
 </div>
 <div class="elgg-foot">
-	$is_edit_page_input
 	$comment_guid_input
 	$entity_guid_input
 	$submit_input $cancel_button

--- a/views/default/resources/comments/edit.php
+++ b/views/default/resources/comments/edit.php
@@ -27,7 +27,6 @@ elgg_push_breadcrumb($title);
 $params = array(
 	'entity' => $target,
 	'comment' => $comment,
-	'is_edit_page' => true,
 );
 $content = elgg_view_form('comment/save', null, $params);
 


### PR DESCRIPTION
We forward to either the comment/reply URL or to the activity page if it was posted from there.

If returning to the activity page, the new comment/reply is jumped to and highlighted as it would be on the object/topic page.

Fixes #8130
- [x] remove `BC with 1.x:` from comments
