### PR TITLE
fix(ajax): iframe-based submissions can again be recognized as XHR requests

### DIFF
--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -108,11 +108,22 @@ class Request extends SymfonyRequest {
 			// try one more
 			$ip_addresses = $this->server->get('HTTP_X_REAL_IP');
 			if ($ip_addresses) {
-				return array_pop(explode(',', $ip_addresses));
+				$ip_addresses = explode(',', $ip_addresses);
+				return array_pop($ip_addresses);
 			}
 		}
 
 		return $ip;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function isXmlHttpRequest() {
+		return (strtolower($this->headers->get('X-Requested-With')) === 'xmlhttprequest'
+			|| $this->query->get('X-Requested-With') === 'XMLHttpRequest'
+			|| $this->request->get('X-Requested-With') === 'XMLHttpRequest');
+		// GET/POST check is necessary for jQuery.form and other iframe-based "ajax". #8735
 	}
 
 	/**

--- a/engine/tests/phpunit/Elgg/Http/RequestTest.php
+++ b/engine/tests/phpunit/Elgg/Http/RequestTest.php
@@ -1,0 +1,41 @@
+<?php
+namespace Elgg\Http;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+class RequestTest extends TestCase {
+
+	public function testCanDetectElggPath() {
+		$req = new Request([
+			'__elgg_uri' => '/foo/bar/',
+		]);
+		$this->assertEquals(['foo', 'bar'], $req->getUrlSegments());
+	}
+
+	public function testClientIpChecksXRealIp() {
+		$req = new Request();
+		$req->server->set('HTTP_X_REAL_IP', '127.0.0.1');
+		$this->assertEquals('127.0.0.1', $req->getClientIp());
+	}
+
+	public function testDetectsMixedCaseXhrHeader() {
+		$req = new Request();
+		$req->headers->set('X-Requested-With', 'xmlhttprequest');
+		$this->assertTrue($req->isXmlHttpRequest());
+	}
+
+	public function testDetectsXhrFromGet() {
+		$req = new Request([
+			'X-Requested-With' => 'XMLHttpRequest',
+		]);
+		$this->assertTrue($req->isXmlHttpRequest());
+	}
+
+	public function testDetectsXhrFromPost() {
+		$req = new Request([], [
+			'X-Requested-With' => 'XMLHttpRequest',
+		]);
+		$this->assertTrue($req->isXmlHttpRequest());
+	}
+
+}


### PR DESCRIPTION
We were relying on this behavior so we return it to 1.x behavior and add tests for this and the other Request methods.

Fixes #8735
