### PR TITLE
feat(js): adds elgg/popup AMD module

### DIFF
--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -434,6 +434,98 @@ The ``elgg/spinner`` module can be used to create an Ajax loading indicator fixe
 
 .. note:: The ``elgg/Ajax`` module uses the spinner by default.
 
+Module ``elgg/popup``
+-----------------------
+
+The ``elgg/popup`` module can be used to display an overlay positioned relatively to its anchor (trigger).
+
+The ``elgg/popup`` module is loaded by default, and binding a popup module to an anchor is as simple as adding ``elgg-popup``
+class and defining target module with a ``href`` (or ``data-href``) attribute. Popup module positioning can be defined with
+``data-position`` attribute of the anchor element.
+
+.. $.position(): http://api.jqueryui.com/position/
+
+.. code:: php
+
+   echo elgg_format_element('div', [
+      'class' => 'elgg-module-popup hidden',
+      'id' => 'popup-module',
+   ], 'Popup module content');
+
+   // Simple anchor
+   echo elgg_view('output/url', [
+      'href' => '#popup-module',
+      'text' => 'Show popup',
+      'class' => 'elgg-popup',
+   ]);
+
+   // Button with custom positioning of the popup
+   echo elgg_format_element('button', [
+      'class' => 'elgg-popup elgg-button elgg-button-submit',
+      'text' => 'Show popup',
+      'data-href' => '#popup-module',
+      'data-position' => json_encode([
+         'my' => 'center bottom',
+         'at' => 'center top',
+      ]),
+   ]);
+
+
+The ``elgg/popup`` module allows you to build out more complex UI/UX elements. You can open and close
+popup modules programmatically:
+
+.. code:: js
+
+   define(function(require) {
+      var $ = require('jquery');
+      $(document).on('click', '.elgg-button-popup', function(e) {
+
+         e.preventDefault();
+
+         var $trigger = $(this);
+         var $target = $('#my-target');
+		 var $close = $target.find('.close');
+
+         require(['elgg/popup'], function(popup) {
+		   popup.open($trigger, $target, {
+			  'collision': 'fit none'
+		   });
+
+           $close.on('click', popup.close);
+		 });
+      });
+   });
+
+You can use ``getOptions, ui.popup`` plugin hook to manipulate the position of the popup before it has been opened.
+You can use jQuery ``open`` and ``close`` events to manipulate popup module after it has been opened or closed.
+
+.. code:: js
+
+   define(function(require) {
+
+      var elgg = require('elgg');
+      var $ = require('jquery');
+
+      $('#my-target').on('open', function() {
+         var $module = $(this);
+         var $trigger = $module.data('trigger');
+
+         elgg.ajax('ajax/view/my_module', {
+            beforeSend: function() {
+               $trigger.hide();
+               $module.html('').addClass('elgg-ajax-loader');
+            },
+            success: function(output) {
+               $module.removeClass('elgg-ajax-loader').html(output);
+            }
+         });
+      }).on('close', function() {
+         var $trigger = $(this).data('trigger');
+         $trigger.show();
+      });
+   });
+
+
 Module ``elgg/widgets``
 -----------------------
 

--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -18,7 +18,12 @@ elgg.ui.init = function () {
 
 	$(document).on('click', '[rel=toggle]', elgg.ui.toggles);
 
-	$(document).on('click', '[rel=popup]', elgg.ui.popupOpen);
+	// Bind popup modules to their anchor elements
+	// Not checking if elements are present, as we want bindings to work with HTML added to DOM on AJAX calls
+	// @todo: Use elgg/booted module once #8319 is merged
+	require(['elgg/popup'], function(popup) {
+		popup.bind($('[rel="popup"],.elgg-popup'));
+	});
 
 	$(document).on('click', '.elgg-menu-page .elgg-menu-parent', elgg.ui.toggleMenu);
 
@@ -100,87 +105,30 @@ elgg.ui.toggles = function(event) {
  *
  * @param {Object} event
  * @return void
+ * @deprecated 2.1
  */
 elgg.ui.popupOpen = function(event) {
+	elgg.deprecated_notice('elgg.ui.popupOpen() has been deprecated and should not be called directly. Use elgg/popup AMD module instead', '2.1');
+
 	event.preventDefault();
 	event.stopPropagation();
 
-	var target = elgg.getSelectorFromUrlFragment($(this).toggleClass('elgg-state-active').attr('href'));
-	var $target = $(target);
-
-	// emit a hook to allow plugins to position and control popups
-	var params = {
-		targetSelector: target,
-		target: $target,
-		source: $(this)
-	};
-
-	var options = {
-		my: 'center top',
-		at: 'center bottom',
-		of: $(this),
-		collision: 'fit fit'
-	};
-
-	options = elgg.trigger_hook('getOptions', 'ui.popup', params, options);
-
-	// allow plugins to cancel event
-	if (!options) {
-		return;
-	}
-
-	// hide if already open
-	if ($target.is(':visible')) {
-		$target.fadeOut();
-		$(document).off('click', elgg.ui.popupClose);
-		return;
-	}
-
-	$target.appendTo('body')
-		.fadeIn()
-		.position(options);
-
-	$(document)
-		.off('click', 'body', elgg.ui.popupClose)
-		.on('click', 'body', elgg.ui.popupClose);
+	var $elem = $(this);
+	require(['elgg/popup'], function(popup) {
+		popup.open($elem);
+	});
 };
 
 /**
  * Catches clicks that aren't in a popup and closes all popups.
+ * @deprecated 2.1
  */
 elgg.ui.popupClose = function(event) {
-	$eventTarget = $(event.target);
-	var inTarget = false;
-	var $popups = $('[rel=popup]');
-
-	// if the click event target isn't in a popup target, fade all of them out.
-	$popups.each(function(i, e) {
-		var target = elgg.getSelectorFromUrlFragment($(e).attr('href')) + ':visible';
-		var $target = $(target);
-
-		if (!$target.is(':visible')) {
-			return;
-		}
-
-		// didn't click inside the target
-		if ($eventTarget.closest(target).length > 0) {
-			inTarget = true;
-			return false;
-		}
+	elgg.deprecated_notice('elgg.ui.popupClose() has been deprecated and should not be called directly. Use elgg/popup AMD module instead', '2.1');
+	
+	require(['elgg/popup'], function(popup) {
+		popup.close();
 	});
-
-	if (!inTarget) {
-		$popups.each(function(i, e) {
-			var $e = $(e);
-			var $target = $(elgg.getSelectorFromUrlFragment($e.attr('href')) + ':visible');
-			if ($target.length > 0) {
-				$target.fadeOut();
-				$e.removeClass('elgg-state-active');
-			}
-		});
-
-		$(document).off('click', elgg.ui.popupClose);
-	}
 };
 
 /**

--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -193,48 +193,38 @@ elgg.ui.initHoverMenu = function(parent) {
 
 	// avatar contextual menu
 	$(document).on('click', ".elgg-avatar > .elgg-icon-hover-menu", function(e) {
-		var $placeholder = $(this).parent().find(".elgg-menu-hover.elgg-ajax-loader");
+
+		var $icon = $(this);
+
+		var $placeholder = $icon.parent().find(".elgg-menu-hover.elgg-ajax-loader");
 
 		if ($placeholder.length) {
 			loadMenu($placeholder.attr("rel"));
 		}
 
 		// check if we've attached the menu to this element already
-		var $hovermenu = $(this).data('hovermenu') || null;
+		var $hovermenu = $icon.data('hovermenu') || null;
 
 		if (!$hovermenu) {
-			$hovermenu = $(this).parent().find(".elgg-menu-hover");
-			$(this).data('hovermenu', $hovermenu);
+			$hovermenu = $icon.parent().find(".elgg-menu-hover");
+			$icon.data('hovermenu', $hovermenu);
 		}
 
-		// close hovermenu if arrow is clicked & menu already open
-		if ($hovermenu.css('display') == "block") {
-			$hovermenu.fadeOut();
-		} else {
-			$avatar = $(this).closest(".elgg-avatar");
-
-			// @todo Use jQuery-ui position library instead -- much simpler
-			var offset = $avatar.offset();
-			var top = $avatar.height() + offset.top + 'px';
-			var left = $avatar.width() - 15 + offset.left + 'px';
-
-			$hovermenu.appendTo('body')
-					.css('position', 'absolute')
-					.css("top", top)
-					.css("left", left)
-					.fadeIn('normal');
-		}
-
-		// hide any other open hover menus
-		$(".elgg-menu-hover:visible").not($hovermenu).fadeOut();
+		require(['elgg/popup'], function(popup) {
+			if ($hovermenu.is(':visible')) {
+				// close hovermenu if arrow is clicked & menu already open
+				popup.close($hovermenu);
+			} else {
+				popup.open($icon, $hovermenu, {
+					'my': 'left top',
+					'at': 'right-15px bottom',
+					'of': $icon.closest(".elgg-avatar"),
+					'collision': 'none none'
+				});
+			}
+		});
 	});
 
-	// hide avatar menu when user clicks elsewhere
-	$(document).click(function(event) {
-		if ($(event.target).parents(".elgg-avatar").length === 0) {
-			$(".elgg-menu-hover").fadeOut();
-		}
-	});
 };
 
 /**

--- a/mod/developers/views/default/theme_sandbox/javascript.php
+++ b/mod/developers/views/default/theme_sandbox/javascript.php
@@ -7,7 +7,7 @@ $body = elgg_view('theme_sandbox/javascript/lightbox');
 echo elgg_view_module('theme-sandbox-demo', 'Lightbox (.elgg-lightbox)', $body);
 
 $body = elgg_view('theme_sandbox/javascript/popup');
-echo elgg_view_module('theme-sandbox-demo', 'Popup (rel=popup)', $body);
+echo elgg_view_module('theme-sandbox-demo', 'Popup (.elgg-popup)', $body);
 
 $body = elgg_view('theme_sandbox/javascript/toggle');
 echo elgg_view_module('theme-sandbox-demo', 'Toggle (rel=toggle)', $body);

--- a/mod/developers/views/default/theme_sandbox/javascript/popup.js
+++ b/mod/developers/views/default/theme_sandbox/javascript/popup.js
@@ -1,0 +1,24 @@
+define(function (require) {
+
+	var elgg = require('elgg');
+	var $ = require('jquery');
+
+	$('#elgg-popup-test2').on('open', function () {
+		var $module = $(this);
+		var $trigger = $module.data('trigger');
+
+		elgg.ajax('ajax/view/developers/ajax', {
+			beforeSend: function () {
+				$trigger.addClass('elgg-state-disabled').prop('disabled', true);
+				$module.html('').addClass('elgg-ajax-loader');
+			},
+			success: function (output) {
+				$module.removeClass('elgg-ajax-loader').html(output);
+			}
+		});
+	}).on('close', function () {
+		var $trigger = $(this).data('trigger');
+		$trigger.removeClass('elgg-state-disabled').prop('disabled', false);
+	});
+	
+});

--- a/mod/developers/views/default/theme_sandbox/javascript/popup.php
+++ b/mod/developers/views/default/theme_sandbox/javascript/popup.php
@@ -9,7 +9,26 @@ $link = elgg_view('output/url', array(
 ));
 
 echo $link;
+
 echo elgg_view_module('popup', 'Popup Test', $ipsum, array(
 	'id' => 'elgg-popup-test',
 	'class' => 'hidden theme-sandbox-content-thin',
 ));
+
+$button = elgg_format_element('button', array(
+	'class' => 'elgg-popup elgg-button elgg-button-submit mll',
+	'data-href' => "#elgg-popup-test2",
+	'data-position' => json_encode(array(
+		'my' => 'left top',
+		'at' => 'left bottom',
+	)),
+), 'Load content in a popup');
+
+echo $button;
+
+echo elgg_format_element('div', array(
+	'id' => 'elgg-popup-test2',
+	'class' => 'hidden theme-sandbox-content-thin elgg-module-popup',
+), '');
+
+elgg_require_js('theme_sandbox/javascript/popup');

--- a/views/default/elgg/popup.js
+++ b/views/default/elgg/popup.js
@@ -1,0 +1,172 @@
+define(function (require) {
+
+	var elgg = require('elgg');
+	var $ = require('jquery');
+	require('jquery-ui');
+
+	var popup = {
+		ready: false,
+		/**
+		 * Initializes a popup module
+		 * - Binds an event to hide visible popup modules on a click event outside of their DOM stack
+		 * - Binds an event to reposition the popup when window is scrolled or resized
+		 *
+		 * This method is called before the popup module is displayed
+		 * 
+		 * @returns {void}
+		 */
+		init: function () {
+			if (popup.ready) {
+				return;
+			}
+			$(document).on('click', function (e) {
+				var $eventTargets = $(e.target).parents().andSelf();
+				if ($eventTargets.is('[data-popup]')) {
+					return;
+				}
+				popup.close();
+			});
+
+			// Adding this magic so that popups with fixed position stick to their parent element
+			$(window).on('scroll resize', function () {
+				$('[data-popup]:visible').each(function () {
+					var position = $(this).data('position');
+					if (position) {
+						$(this).position(position);
+					}
+				});
+			});
+			popup.ready = true;
+		},
+		/**
+		 * Shortcut to bind a click event on a set of $triggers
+		 *
+		 * Set the 'class="elgg-popup"' of the $trigger and set the href to target the
+		 * item you want to toggle (<a class="elgg-popup" href="#id-of-target">).
+		 *
+		 * This method is called by core JS UI library for all [rel="popup"],.elgg-popup elements,
+		 * but can be called by plugins to bind other triggers
+		 *
+		 * @param {jQuery} $triggers A set of triggers to bind
+		 * @returns {void}
+		 */
+		bind: function ($triggers) {
+			$triggers.each(function () {
+				$(this).off('click.popup')
+						.on('click.popup', function (e) {
+							if (e.isDefaultPrevented()) {
+								return;
+							}
+							e.preventDefault();
+							e.stopPropagation();
+							popup.open($(this));
+						});
+			});
+		},
+		/**
+		 * Shows a $target element at a given position
+		 * If no $target element is provided, determines it by parsing href and data-href attributes of the $trigger
+		 *
+		 * This function emits the getOptions, ui.popup hook that plugins can register for to provide custom
+		 * positioning for elements.  The handler is passed the following params:
+		 *	targetSelector: The selector used to find the popup
+		 *	target:         The popup jQuery element as found by the selector
+		 *	source:         The jquery element whose click event initiated a popup.
+		 *
+		 * The return value of the function is used as the options object to .position().
+		 * Handles can also return false to abort the default behvior and override it with their own.
+		 *
+		 * @param {jQuery} $trigger Trigger element
+		 * @param {jQuery} $target  Target popup module
+		 * @param {object} position Positioning data of the $target module
+		 * @return void
+		 */
+		open: function ($trigger, $target, position) {
+			if (typeof $trigger === 'undefined' || !$trigger.length) {
+				return;
+			}
+
+			if (typeof $target === 'undefined') {
+				var href = $trigger.attr('href') || $trigger.data('href') || '';
+				var targetSelector = elgg.getSelectorFromUrlFragment(href);
+				$target = $(targetSelector);
+			} else {
+				$target.uniqueId();
+				var targetSelector = '#' + $target.attr('id');
+			}
+
+			if (!$target.length) {
+				return;
+			}
+
+			position = position || {
+				my: 'center top',
+				at: 'center bottom',
+				of: $trigger,
+				collision: 'fit fit'
+			};
+
+			$.extend(position, $trigger.data('position'));
+
+			// emit a hook to allow plugins to position and control popups
+			var params = {
+				targetSelector: targetSelector,
+				target: $target,
+				source: $trigger
+			};
+
+			position = elgg.trigger_hook('getOptions', 'ui.popup', params, position);
+
+			if (!position) {
+				return;
+			}
+
+			popup.init();
+			popup.close();
+
+			$trigger.addClass('elgg-state-active');
+
+			$target.data('trigger', $trigger); // used to remove elgg-state-active class when popup is closed
+			$target.data('position', position); // used to reposition the popup module on window manipulations
+
+			// @todo: in 3.0, do not append to 'body' and use fixed positioning with z-indexes instead
+			$target.appendTo('body')
+					.fadeIn()
+					.addClass('elgg-state-active')
+					.attr('data-popup', true)
+					.position(position);
+
+			$target.trigger('open');
+		},
+		/**
+		 * Hides a set of $targets. If not defined, closes all visible popup modules
+		 *
+		 * @param {jQuery} $targets
+		 * @returns {undefined}
+		 */
+		close: function ($targets) {
+			if (typeof $targets === 'undefined') {
+				$targets = $('[data-popup]');
+			}
+			$targets.each(function () {
+				var $target = $(this);
+				if (!$target.is(':visible')) {
+					return;
+				}
+
+				var $trigger = $target.data('trigger');
+				if ($trigger.length) {
+					$trigger.removeClass('elgg-state-active');
+				}
+
+				$target.fadeOut()
+						.removeClass('elgg-state-active')
+						.removeAttr('data-popup');
+
+				$target.trigger('close');
+			});
+		}
+	};
+	return popup;
+
+});


### PR DESCRIPTION
Converts JS popup to an AMD module subsequently allowing plugins to
invoke and close popup programmically.
Popups can now be bound with .elgg-popup class in addition to rel=popup.
Popup positioning details can be passed with data- attributes of the trigger.
