### PR TITLE
fix(i18n): admin-created accounts now get site language instead of admin's language

### DIFF
--- a/actions/useradd.php
+++ b/actions/useradd.php
@@ -15,6 +15,10 @@ $password2 = get_input('password2', null, false);
 $email = get_input('email');
 $name = get_input('name');
 
+// This param is not included in the useradd form by default,
+// but it allows sites to easily add the feature if necessary.
+$language = get_input('language', elgg_get_config('language'));
+
 $admin = get_input('admin');
 if (is_array($admin)) {
 	$admin = $admin[0];
@@ -46,6 +50,10 @@ try {
 		$new_user->admin_created = TRUE;
 		// @todo ugh, saving a guid as metadata!
 		$new_user->created_by_guid = elgg_get_logged_in_user_guid();
+
+		// The user language is set also by register_user(), but it defaults to
+		// language of the current user (admin), so we need to fix it here.
+		$new_user->language = $language;
 
 		$subject = elgg_echo('useradd:subject', array(), $new_user->language);
 		$body = elgg_echo('useradd:body', array(


### PR DESCRIPTION
Fixes #9454
