### PR TITLE
WIP feature(relationships): adds function to query a set of relationships

### DIFF
--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -14,6 +14,8 @@ use Elgg\Filesystem\Directory;
  * The full path is necessary to work around this: https://bugs.php.net/bug.php?id=55726
  *
  * @since 2.0.0
+ *
+ * @property-read \Elgg\Database\QueryService $queries
  */
 class Application {
 
@@ -41,6 +43,7 @@ class Application {
 	 */
 	private static $public_services = [
 		//'config' => true,
+		'queries' => true,
 	];
 
 	/**

--- a/engine/classes/Elgg/Database/QueryBuilder.php
+++ b/engine/classes/Elgg/Database/QueryBuilder.php
@@ -1,0 +1,133 @@
+<?php
+namespace Elgg\Database;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Query builder based on Doctrine DBAL
+ *
+ * Arguments accepting table names can auto-prepend the Elgg prefix. Simply pass these in as "{table}".
+ *
+ * <code>
+ * $qb = elgg_get_query_builder();
+ * $qb->select('e.*')
+ *    ->from('{entities}', 'e')
+ *    ->setMaxResults(2);
+ * $rows = get_data($qb);
+ * </code>
+ *
+ * @link http://doctrine-orm.readthedocs.org/projects/doctrine-dbal/en/stable/reference/query-builder.html
+ */
+class QueryBuilder extends \Doctrine\DBAL\Query\QueryBuilder {
+
+	/**
+	 * @var string
+	 */
+	private $prefix;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Connection $connection Connection
+	 * @param string     $prefix     Table prefix
+	 */
+	public function __construct(Connection $connection, $prefix) {
+		$this->prefix = $prefix;
+		parent::__construct($connection);
+	}
+
+	/**
+	 * If a string starts with "{" assume "{table}" and return "elgg_table"
+	 *
+	 * @param string $table Table name. E.g. "custom_table" or "{table}"
+	 * @return string
+	 */
+	private function prefixTable($table) {
+		// note we pass through empty values because some methods pass null through this
+		if ($table && $table[0] === '{') {
+			return $this->prefix . trim($table, '{}');
+		}
+		return $table;
+	}
+
+	/**
+	 * Create a set for use in with an IN operator
+	 *
+	 * @param mixed $values Value(s) to place in set
+	 * @param int   $type   SQL type (e.g. \PDO::PARAM_INT)
+	 *
+	 * @return string
+	 */
+	public function createSet($values, $type = \PDO::PARAM_STR) {
+		if (!is_array($values)) {
+			$values = [$values];
+		}
+
+		$placeHolders = array_map(function ($value) use ($type) {
+			return $this->createNamedParameter($value, $type);
+		}, $values);
+
+		return "(" . implode(',', $placeHolders) . ")";
+	}
+
+	/**
+	 * Not implemented.
+	 *
+	 * @throws \BadMethodCallException
+	 * @return void
+	 * @internal
+	 */
+	public function execute() {
+		throw new \BadMethodCallException(__METHOD__ . ' is not implemented. Pass this object to one of '
+			. 'Elgg\'s functions that accepts queries, like get_data(), insert_data(), etc.');
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function from($from, $alias = null) {
+		return parent::from($this->prefixTable($from), $alias);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function insert($insert = null) {
+		return parent::insert($this->prefixTable($insert));
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function delete($delete = null, $alias = null) {
+		return parent::delete($this->prefixTable($delete), $alias);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function update($update = null, $alias = null) {
+		return parent::update($this->prefixTable($update), $alias);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function innerJoin($fromAlias, $join, $alias, $condition = null) {
+		return parent::innerJoin($fromAlias, $this->prefixTable($join), $alias, $condition);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function join($fromAlias, $join, $alias, $condition = null) {
+		return parent::join($fromAlias, $this->prefixTable($join), $alias, $condition);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function leftJoin($fromAlias, $join, $alias, $condition = null) {
+		return parent::leftJoin($fromAlias, $this->prefixTable($join), $alias, $condition);
+	}
+}

--- a/engine/classes/Elgg/Database/QueryService.php
+++ b/engine/classes/Elgg/Database/QueryService.php
@@ -1,0 +1,80 @@
+<?php
+namespace Elgg\Database;
+
+use Elgg\Database;
+
+/**
+ * Factory for query builder objects
+ */
+class QueryService {
+
+	/**
+	 * @var Database
+	 */
+	private $db;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Database $db Elgg database
+	 * @access private
+	 * @internal
+	 */
+	public function __construct(Database $db) {
+		$this->db = $db;
+	}
+
+	/**
+	 * Build a select query
+	 *
+	 * @see QueryBuilder::select
+	 *
+	 * @param mixed $select The selection expressions.
+	 *
+	 * @return QueryBuilder
+	 */
+	public function select($select = null) {
+		return $this->db->getQueryBuilder('read')->select($select);
+	}
+
+	/**
+	 * Build an update query
+	 *
+	 * @see QueryBuilder::update
+	 *
+	 * @param string $update The table whose rows are subject to the update.
+	 * @param string $alias  The table alias used in the constructed query.
+	 *
+	 * @return QueryBuilder
+	 */
+	public function update($update = null, $alias = null) {
+		return $this->db->getQueryBuilder('write')->update($update, $alias);
+	}
+
+	/**
+	 * Build an insert query
+	 *
+	 * @see QueryBuilder::insert
+	 *
+	 * @param string $insert The table into which the rows should be inserted.
+	 *
+	 * @return QueryBuilder
+	 */
+	public function insert($insert = null) {
+		return $this->db->getQueryBuilder('write')->insert($insert);
+	}
+
+	/**
+	 * Build a delete query
+	 *
+	 * @see QueryBuilder::delete
+	 *
+	 * @param string $delete The table whose rows are subject to the deletion.
+	 * @param string $alias  The table alias used in the constructed query.
+	 *
+	 * @return QueryBuilder
+	 */
+	public function delete($delete = null, $alias = null) {
+		return $this->db->getQueryBuilder('write')->delete($delete, $alias);
+	}
+}

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -47,6 +47,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\PersistentLoginService             $persistentLogin
  * @property-read \Elgg\Database\Plugins                   $plugins
  * @property-read \Elgg\Database\PrivateSettingsTable      $privateSettings
+ * @property-read \Elgg\Database\QueryService              $queries
  * @property-read \Elgg\Database\QueryCounter              $queryCounter
  * @property-read \Elgg\Http\Request                       $request
  * @property-read \Elgg\Database\RelationshipsTable        $relationshipsTable
@@ -239,6 +240,10 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 
 		$this->setFactory('privateSettings', function(ServiceProvider $c) {
 			return new \Elgg\Database\PrivateSettingsTable($c->db, $c->entityTable);
+		});
+
+		$this->setFactory('queries', function(ServiceProvider $c) {
+			return new \Elgg\Database\QueryService($c->db);
 		});
 
 		$this->setFactory('queryCounter', function(ServiceProvider $c) {

--- a/engine/classes/Elgg/OrderBy.php
+++ b/engine/classes/Elgg/OrderBy.php
@@ -1,0 +1,104 @@
+<?php
+namespace Elgg;
+use Doctrine\DBAL\Query\QueryBuilder;
+
+/**
+ * Representation of an SQL ordering
+ *
+ * @internal
+ * @access private
+ */
+class OrderBy {
+	private $expression = '';
+	private $direction = '';
+
+	/**
+	 * Constructor
+	 *
+	 * @param string $expression SQL expression to order by. E.g. "e.guid"
+	 * @param string $direction  "ASC" or "DESC"
+	 */
+	public function __construct($expression, $direction) {
+		if (empty($expression)) {
+			throw new \InvalidArgumentException('$expression cannot be empty');
+		}
+		if (!in_array($direction, ['ASC', 'DESC'])) {
+			throw new \InvalidArgumentException('$direction must be ASC or DESC');
+		}
+
+		$this->expression = $expression;
+		$this->direction = $direction;
+	}
+
+	/**
+	 * Get the expression
+	 *
+	 * @return string
+	 */
+	public function getExpression() {
+		return $this->expression;
+	}
+
+	/**
+	 * Get the direction
+	 *
+	 * @return string
+	 */
+	public function getDirection() {
+		return $this->direction;
+	}
+
+	/**
+	 * Make an OrderBy from a string
+	 *
+	 * @param string $str Order by. E.g. "expr", "expr ASC", or "expr DESC"
+	 * @return OrderBy
+	 */
+	public static function fromString($str) {
+		$str = trim($str);
+		if (!preg_match('~^(\S+)(?:\s+(asc|desc))?\\z~i', $str, $m)) {
+			throw new \InvalidArgumentException('An ordering must be "expr", "expr ASC", or "expr DESC"');
+		}
+		$expression = $m[1];
+		$direction = isset($m[2]) ? strtoupper($m[2]) : 'ASC';
+		return new self($expression, $direction);
+	}
+
+	/**
+	 * Apply orderings from an options array to a query builder
+	 *
+	 * @param QueryBuilder $qb      Query builder
+	 * @param array        $options Options array
+	 * @param string       $key     Options key
+	 * @return void
+	 * @throws \InvalidArgumentException
+	 */
+	public static function addToQueryBuilder(QueryBuilder $qb, array $options, $key = 'order_by') {
+		if (empty($options['order_by'])) {
+			return;
+		}
+
+		if (is_string($options[$key])) {
+			$options[$key] = explode(',', $options[$key]);
+		}
+		if (!is_array($options[$key])) {
+			throw new \InvalidArgumentException("option '$key' should be a set of orderings");
+		}
+
+		$order_bys = array_map(function ($el) use ($key) {
+			if ($el instanceof OrderBy) {
+				return $el;
+			}
+			if (is_string($el)) {
+				return OrderBy::fromString($el);
+			}
+
+			throw new \InvalidArgumentException("option '$key' should be a set of orderings");
+		}, $options[$key]);
+		/* @var OrderBy[] $order_bys */
+
+		foreach ($order_bys as $order_by) {
+			$qb->addOrderBy($order_by->expression, $order_by->direction);
+		}
+	}
+}

--- a/engine/lib/database.php
+++ b/engine/lib/database.php
@@ -8,11 +8,22 @@
  * @subpackage Database
  */
 
+use Elgg\Database\QueryBuilder;
+
+/**
+ * Get an Elgg query builder instance (based on Doctrine DBAL)
+ *
+ * @return QueryBuilder
+ */
+function elgg_get_query_builder() {
+	return _elgg_services()->db->getQueryBuilder();
+}
+
 /**
  * Queue a query for running during shutdown that writes to the database
  *
- * @param string $query   The query to execute
- * @param string $handler The optional handler for processing the result
+ * @param string|QueryBuilder $query   The query to execute
+ * @param string              $handler The optional handler for processing the result
  *
  * @return boolean
  */
@@ -23,8 +34,8 @@ function execute_delayed_write_query($query, $handler = "") {
 /**
  * Queue a query for running during shutdown that reads from the database
  *
- * @param string $query   The query to execute
- * @param string $handler The optional handler for processing the result
+ * @param string|QueryBuilder $query   The query to execute
+ * @param string              $handler The optional handler for processing the result
  *
  * @return boolean
  */
@@ -41,8 +52,8 @@ function execute_delayed_read_query($query, $handler = "") {
  * argument to $callback.  If no callback function is defined, the
  * entire result set is returned as an array.
  *
- * @param mixed  $query    The query being passed.
- * @param string $callback Optionally, the name of a function to call back to on each row
+ * @param string|QueryBuilder $query    The query being passed.
+ * @param callable            $callback Optionally, the name of a function to call back to on each row
  *
  * @return array An array of database result objects or callback function results. If the query
  *               returned nothing, an empty array.
@@ -58,8 +69,8 @@ function get_data($query, $callback = "") {
  * matched.  If a callback function $callback is specified, the row will be passed
  * as the only argument to $callback.
  *
- * @param mixed  $query    The query to execute.
- * @param string $callback A callback function
+ * @param string|QueryBuilder $query    The query to execute.
+ * @param callable            $callback A callback function
  *
  * @return mixed A single database result object or the result of the callback function.
  */
@@ -72,7 +83,7 @@ function get_data_row($query, $callback = "") {
  *
  * @note Altering the DB invalidates all queries in {@link $DB_QUERY_CACHE}.
  *
- * @param mixed $query The query to execute.
+ * @param string|QueryBuilder $query The query to execute.
  *
  * @return int|false The database id of the inserted row if a AUTO_INCREMENT field is
  *                   defined, 0 if not, and false on failure.
@@ -86,7 +97,7 @@ function insert_data($query) {
  *
  * @note Altering the DB invalidates all queries in {@link $DB_QUERY_CACHE}.
  *
- * @param string $query The query to run.
+ * @param string|QueryBuilder $query The query to run.
  *
  * @return bool
  */
@@ -99,7 +110,7 @@ function update_data($query) {
  *
  * @note Altering the DB invalidates all queries in {@link $DB_QUERY_CACHE}.
  *
- * @param string $query The SQL query to run
+ * @param string|QueryBuilder $query The SQL query to run
  *
  * @return int|false The number of affected rows or false on failure
  */
@@ -132,24 +143,26 @@ function run_sql_script($scriptlocation) {
 }
 
 /**
- * Alias of elgg()->getDb()->sanitizeString()
+ * Sanitizes a string for use in a query
  *
  * @see Elgg\Database::sanitizeString
  *
  * @param string $string The string to sanitize
  * @return string
+ * @deprecated Use elgg_get_query_builder() where possible
  */
 function sanitize_string($string) {
 	return _elgg_services()->db->sanitizeString($string);
 }
 
 /**
- * Alias of elgg()->getDb()->sanitizeString()
+ * Alias of sanitize_string
  *
  * @see Elgg\Database::sanitizeString
  *
  * @param string $string The string to sanitize
  * @return string
+ * @deprecated Use elgg_get_query_builder() where possible
  */
 function sanitise_string($string) {
 	return _elgg_services()->db->sanitizeString($string);
@@ -158,21 +171,26 @@ function sanitise_string($string) {
 /**
  * Sanitizes an integer for database use.
  *
+ * @see Elgg\Database::sanitizeInt
+ *
  * @param int  $int    Value to be sanitized
  * @param bool $signed Whether negative values should be allowed (true)
  * @return int
+ * @deprecated Use elgg_get_query_builder() where possible
  */
 function sanitize_int($int, $signed = true) {
 	return _elgg_services()->db->sanitizeInt($int, $signed);
 }
 
 /**
- * Sanitizes an integer for database use.
- * Wrapper function for alternate English spelling (@see sanitize_int)
+ * Alias of sanitize_int
+ *
+ * @see sanitize_int
  *
  * @param int  $int    Value to be sanitized
  * @param bool $signed Whether negative values should be allowed (true)
  * @return int
+ * @deprecated Use elgg_get_query_builder() where possible
  */
 function sanitise_int($int, $signed = true) {
 	return sanitize_int($int, $signed);

--- a/engine/lib/database.php
+++ b/engine/lib/database.php
@@ -11,15 +11,6 @@
 use Elgg\Database\QueryBuilder;
 
 /**
- * Get an Elgg query builder instance (based on Doctrine DBAL)
- *
- * @return QueryBuilder
- */
-function elgg_get_query_builder() {
-	return _elgg_services()->db->getQueryBuilder();
-}
-
-/**
  * Queue a query for running during shutdown that writes to the database
  *
  * @param string|QueryBuilder $query   The query to execute

--- a/engine/lib/relationships.php
+++ b/engine/lib/relationships.php
@@ -30,6 +30,23 @@ function delete_relationship($id) {
 }
 
 /**
+ * Get relationships matching the given options
+ *
+ * @param array $options Array in format:
+ *
+ *  relationship => null|array Array of relationship names (relationship IN ("relationship1", ...))
+ *
+ *  guid_one => null|array Array of GUIDs for entity one (guid_one IN (GUID1, ...)
+ *
+ *  guid_two => null|array Array of GUIDs for entity two (guid_two IN (GUID1, ...)
+ *
+ * @return \ElggRelationship[]
+ */
+function elgg_get_relationships(array $options = array()) {
+	return _elgg_services()->relationshipsTable->getRelationships($options);
+}
+
+/**
  * Create a relationship between two entities. E.g. friendship, group membership, site membership.
  *
  * This function lets you make the statement "$guid_one is a $relationship of $guid_two". In the statement,


### PR DESCRIPTION
Earlier you needed to first get entities from a relationship and then process relationships one by one for each entity. Now it is possible to query the relationships directly.

Fixes #7299

**feature(services): Adds a service for building and executing queries**

`elgg()->queries` has methods `select`, `update`, `update`, and `delete` for creating query builder objects usable for programmatically building SQL.

Instead of a result statement, the builder object's `execute` method returns the output of the corresponding Elgg database function, e.g. `get_data`, `update_data`, etc.

The builder extends Doctrine's to auto-prefix tables and create parameter sets for use with in `IN` operator.

Softly deprecates the "sanitize" functions in favor of the query builder.
- [ ] Add docs to elgg_get_relationships and for "queries" service
- [ ] break testCanFetchRelationships() into separate tests
- [ ] test for OrderBy
- [ ] tests for query builder acceptance in DB
- [ ] move DB additions into 1 commit
