### PR TITLE
feature(db): allows using parameterized queries in core DB functions

### DIFF
--- a/engine/classes/Elgg/Application/Database.php
+++ b/engine/classes/Elgg/Application/Database.php
@@ -39,36 +39,36 @@ class Database extends ElggDb {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getData($query, $callback = '') {
-		return $this->db->getData($query, $callback);
+	public function getData($query, $callback = '', array $params = []) {
+		return $this->db->getData($query, $callback, $params);
 	}
 
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getDataRow($query, $callback = '') {
-		return $this->db->getDataRow($query, $callback);
+	public function getDataRow($query, $callback = '', array $params = []) {
+		return $this->db->getDataRow($query, $callback, $params);
 	}
 
 	/**
 	 * {@inheritdoc}
 	 */
-	public function insertData($query) {
-		return $this->db->insertData($query);
+	public function insertData($query, array $params = []) {
+		return $this->db->insertData($query, $params);
 	}
 
 	/**
 	 * {@inheritdoc}
 	 */
-	public function updateData($query, $getNumRows = false) {
-		return $this->db->updateData($query, $getNumRows);
+	public function updateData($query, $getNumRows = false, array $params = []) {
+		return $this->db->updateData($query, $getNumRows, $params);
 	}
 
 	/**
 	 * {@inheritdoc}
 	 */
-	public function deleteData($query) {
-		return $this->db->deleteData($query);
+	public function deleteData($query, array $params = []) {
+		return $this->db->deleteData($query, $params);
 	}
 
 	/**
@@ -157,9 +157,9 @@ class Database extends ElggDb {
 	 *
 	 * @deprecated 2.1 This method will not be available on this class in 3.0
 	 */
-	public function registerDelayedQuery($query, $type, $handler = "") {
+	public function registerDelayedQuery($query, $type, $handler = "", array $params = []) {
 		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
-		return $this->db->registerDelayedQuery($query, $type, $handler);
+		return $this->db->registerDelayedQuery($query, $type, $handler, $params);
 	}
 
 	/**

--- a/engine/classes/Elgg/Database/SubtypeTable.php
+++ b/engine/classes/Elgg/Database/SubtypeTable.php
@@ -234,15 +234,17 @@ class SubtypeTable {
 				'class' => $class,
 			);
 	
-			$type = $this->db->sanitizeString($type);
-			$subtype = $this->db->sanitizeString($subtype);
-			$class = $this->db->sanitizeString($class);
-	
-			$id = $this->db->insertData("
+			$sql = "
 				INSERT INTO {$this->db->getTablePrefix()}entity_subtypes
-					(type, subtype, class) VALUES
-					('$type', '$subtype', '$class')
-			");
+					(type,  subtype,  class) VALUES
+					(:type, :subtype, :class)
+			";
+			$params = [
+				':type' => $type,
+				':subtype' => $subtype,
+				':class' => $class,
+			];
+			$id = $this->db->insertData($sql, $params);
 			
 			// add entry to cache
 			$cache_obj->id = $id;
@@ -267,13 +269,15 @@ class SubtypeTable {
 	 * @see update_subtype()
 	 */
 	function remove($type, $subtype) {
-		$type = $this->db->sanitizeString($type);
-		$subtype = $this->db->sanitizeString($subtype);
-	
-		$success = $this->db->deleteData("
+		$sql = "
 			DELETE FROM {$this->db->getTablePrefix()}entity_subtypes
-			WHERE type = '$type' AND subtype = '$subtype'
-		");
+			WHERE type = :type AND subtype = :subtype
+		";
+		$params = [
+			':type' => $type,
+			':subtype' => $subtype,
+		];
+		$success = $this->db->deleteData($sql, $params);
 		
 		if ($success) {
 			// invalidate the cache
@@ -302,20 +306,21 @@ class SubtypeTable {
 			$this->populateCache();
 		}
 	
-		$unescaped_class = $class;
-	
-		$type = $this->db->sanitizeString($type);
-		$subtype = $this->db->sanitizeString($subtype);
-		$class = $this->db->sanitizeString($class);
-		
-		$success = $this->db->updateData("
+		$sql = "
 			UPDATE {$this->db->getTablePrefix()}entity_subtypes
-			SET type = '$type', subtype = '$subtype', class = '$class'
-			WHERE id = $id
-		");
+			SET type = :type, subtype = :subtype, class = :class
+			WHERE id = :id
+		";
+		$params = [
+			':type' => $type,
+			':subtype' => $subtype,
+			':class' => $class,
+			':id' => $id,
+		];
+		$success = $this->db->updateData($sql, false, $params);
 	
 		if ($success && isset($this->cache[$id])) {
-			$this->cache[$id]->class = $unescaped_class;
+			$this->cache[$id]->class = $class;
 		}
 	
 		return $success;

--- a/engine/lib/database.php
+++ b/engine/lib/database.php
@@ -11,44 +11,49 @@
 /**
  * Queue a query for running during shutdown that writes to the database
  *
- * @param string $query   The query to execute
- * @param string $handler The optional handler for processing the result
+ * @param string   $query    The query to execute
+ * @param callable $callback The optional callback for processing. The callback will receive a
+ *                           \Doctrine\DBAL\Driver\Statement object
+ * @param array    $params   Query params. E.g. [1, 'steve'] or [':id' => 1, ':name' => 'steve']
  *
  * @return boolean
  */
-function execute_delayed_write_query($query, $handler = "") {
-	return _elgg_services()->db->registerDelayedQuery($query, 'write', $handler);
+function execute_delayed_write_query($query, $callback = null, array $params = []) {
+	return _elgg_services()->db->registerDelayedQuery($query, 'write', $callback, $params);
 }
 
 /**
  * Queue a query for running during shutdown that reads from the database
  *
- * @param string $query   The query to execute
- * @param string $handler The optional handler for processing the result
+ * @param string   $query    The query to execute
+ * @param callable $callback The optional callback for processing. The callback will receive a
+ *                           \Doctrine\DBAL\Driver\Statement object
+ * @param array    $params   Query params. E.g. [1, 'steve'] or [':id' => 1, ':name' => 'steve']
  *
  * @return boolean
  */
-function execute_delayed_read_query($query, $handler = "") {
-	return _elgg_services()->db->registerDelayedQuery($query, 'read', $handler);
+function execute_delayed_read_query($query, $callback = null, array $params = []) {
+	return _elgg_services()->db->registerDelayedQuery($query, 'read', $callback, $params);
 }
 
 /**
  * Retrieve rows from the database.
  *
- * Queries are executed with {@link execute_query()} and results
+ * Queries are executed with {@link \Elgg\Database::getResults} and results
  * are retrieved with {@link \PDO::fetchObject()}.  If a callback
  * function $callback is defined, each row will be passed as the single
  * argument to $callback.  If no callback function is defined, the
  * entire result set is returned as an array.
  *
- * @param mixed  $query    The query being passed.
- * @param string $callback Optionally, the name of a function to call back to on each row
+ * @param string   $query    The query being passed.
+ * @param callable $callback Optionally, the name of a function to call back to on each row
+ * @param array    $params   Query params. E.g. [1, 'steve'] or [':id' => 1, ':name' => 'steve']
  *
  * @return array An array of database result objects or callback function results. If the query
  *               returned nothing, an empty array.
  */
-function get_data($query, $callback = "") {
-	return _elgg_services()->db->getData($query, $callback);
+function get_data($query, $callback = null, array $params = []) {
+	return _elgg_services()->db->getData($query, $callback, $params);
 }
 
 /**
@@ -58,53 +63,58 @@ function get_data($query, $callback = "") {
  * matched.  If a callback function $callback is specified, the row will be passed
  * as the only argument to $callback.
  *
- * @param mixed  $query    The query to execute.
- * @param string $callback A callback function
+ * @param string   $query    The query to execute.
+ * @param callable $callback A callback function to apply to the row
+ * @param array    $params   Query params. E.g. [1, 'steve'] or [':id' => 1, ':name' => 'steve']
  *
  * @return mixed A single database result object or the result of the callback function.
  */
-function get_data_row($query, $callback = "") {
-	return _elgg_services()->db->getDataRow($query, $callback);
+function get_data_row($query, $callback = null, array $params = []) {
+	return _elgg_services()->db->getDataRow($query, $callback, $params);
 }
 
 /**
  * Insert a row into the database.
  *
- * @note Altering the DB invalidates all queries in {@link $DB_QUERY_CACHE}.
+ * @note Altering the DB invalidates all queries in the query cache
  *
- * @param mixed $query The query to execute.
+ * @param string $query  The query to execute.
+ * @param array  $params Query params. E.g. [1, 'steve'] or [':id' => 1, ':name' => 'steve']
  *
  * @return int|false The database id of the inserted row if a AUTO_INCREMENT field is
  *                   defined, 0 if not, and false on failure.
  */
-function insert_data($query) {
-	return _elgg_services()->db->insertData($query);
+function insert_data($query, array $params = []) {
+	return _elgg_services()->db->insertData($query, $params);
 }
 
 /**
  * Update a row in the database.
  *
- * @note Altering the DB invalidates all queries in {@link $DB_QUERY_CACHE}.
+ * @note Altering the DB invalidates all queries in the query cache
  *
- * @param string $query The query to run.
+ * @param string $query        The query to run.
+ * @param array  $params       Query params. E.g. [1, 'steve'] or [':id' => 1, ':name' => 'steve']
+ * @param bool   $get_num_rows Return the number of rows affected (default: false).
  *
  * @return bool
  */
-function update_data($query) {
-	return _elgg_services()->db->updateData($query);
+function update_data($query, array $params = [], $get_num_rows = false) {
+	return _elgg_services()->db->updateData($query, $get_num_rows, $params);
 }
 
 /**
  * Remove a row from the database.
  *
- * @note Altering the DB invalidates all queries in {@link $DB_QUERY_CACHE}.
+ * @note Altering the DB invalidates all queries in the query cache
  *
- * @param string $query The SQL query to run
+ * @param string $query  The SQL query to run
+ * @param array  $params Query params. E.g. [1, 'steve'] or [':id' => 1, ':name' => 'steve']
  *
  * @return int|false The number of affected rows or false on failure
  */
-function delete_data($query) {
-	return _elgg_services()->db->deleteData($query);
+function delete_data($query, array $params = []) {
+	return _elgg_services()->db->deleteData($query, $params);
 }
 
 /**
@@ -132,24 +142,26 @@ function run_sql_script($scriptlocation) {
 }
 
 /**
- * Alias of elgg()->getDb()->sanitizeString()
+ * Sanitizes a string for use in a query
  *
  * @see Elgg\Database::sanitizeString
  *
  * @param string $string The string to sanitize
  * @return string
+ * @deprecated Use query parameters where possible
  */
 function sanitize_string($string) {
 	return _elgg_services()->db->sanitizeString($string);
 }
 
 /**
- * Alias of elgg()->getDb()->sanitizeString()
+ * Alias of sanitize_string
  *
  * @see Elgg\Database::sanitizeString
  *
  * @param string $string The string to sanitize
  * @return string
+ * @deprecated Use query parameters where possible
  */
 function sanitise_string($string) {
 	return _elgg_services()->db->sanitizeString($string);
@@ -158,21 +170,26 @@ function sanitise_string($string) {
 /**
  * Sanitizes an integer for database use.
  *
+ * @see Elgg\Database::sanitizeInt
+ *
  * @param int  $int    Value to be sanitized
  * @param bool $signed Whether negative values should be allowed (true)
  * @return int
+ * @deprecated Use query parameters where possible
  */
 function sanitize_int($int, $signed = true) {
 	return _elgg_services()->db->sanitizeInt($int, $signed);
 }
 
 /**
- * Sanitizes an integer for database use.
- * Wrapper function for alternate English spelling (@see sanitize_int)
+ * Alias of sanitize_int
+ *
+ * @see sanitize_int
  *
  * @param int  $int    Value to be sanitized
  * @param bool $signed Whether negative values should be allowed (true)
  * @return int
+ * @deprecated Use query parameters where possible
  */
 function sanitise_int($int, $signed = true) {
 	return sanitize_int($int, $signed);
@@ -245,6 +262,21 @@ function _elgg_db_run_delayed_queries() {
 }
 
 /**
+ * Runs unit tests for the database
+ *
+ * @param string $hook   unit_test
+ * @param string $type   system
+ * @param array  $value  Array of tests
+ *
+ * @return array
+ * @access private
+ */
+function _elgg_db_test($hook, $type, $value) {
+	$value[] = elgg_get_engine_path() . '/tests/ElggDataFunctionsTest.php';
+	return $value;
+}
+
+/**
  * Registers shutdown functions for database profiling and delayed queries.
  *
  * @access private
@@ -252,6 +284,7 @@ function _elgg_db_run_delayed_queries() {
 function _elgg_db_init() {
 	register_shutdown_function('_elgg_db_run_delayed_queries');
 	register_shutdown_function('_elgg_db_log_profiling_data');
+	elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_db_test');
 }
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {

--- a/engine/tests/ElggDataFunctionsTest.php
+++ b/engine/tests/ElggDataFunctionsTest.php
@@ -1,0 +1,237 @@
+<?php
+
+class ElggDataFunctionsTest extends \ElggCoreUnitTest {
+
+	private $prefix;
+
+	/**
+	 * @var ElggUser
+	 */
+	private $user;
+
+	public function setUp() {
+		$this->prefix = _elgg_services()->db->getTablePrefix();
+
+		$users = elgg_get_entities([
+			'type' => 'user',
+			'limit' => 1,
+			'order_by' => 'e.guid ASC',
+		]);
+		$this->user = $users[0];
+	}
+
+	public function testCanGetData() {
+		$row1 = get_data("
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = '" . sanitize_string($this->user->username) . "'
+		");
+		$row1 = $row1[0];
+
+		$row2 = get_data("
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = ?
+		", null, [$this->user->username]);
+		$row2 = $row2[0];
+
+		$row3 = get_data("
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = :username
+		", null, [
+			':username' => $this->user->username,
+		]);
+		$row3 = $row3[0];
+
+		$row4 = get_data("
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = :username
+		", function ($row) {
+			return (array)$row;
+		}, [
+			':username' => $this->user->username,
+		]);
+		$row4 = $row4[0];
+
+		$this->assertIsA($row1, 'stdClass');
+		$this->assertSame($row1->username, $this->user->username);
+		$this->assertEqual($row1, $row2);
+		$this->assertEqual($row1, $row3);
+		$this->assertIsA($row4, 'array');
+		$this->assertEqual((array)$row1, $row4);
+	}
+
+	public function testCanGetDataRow() {
+		$row1 = get_data_row("
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = '" . sanitize_string($this->user->username) . "'
+		");
+
+		$row2 = get_data_row("
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = ?
+		", null, [$this->user->username]);
+
+		$row3 = get_data_row("
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = :username
+		", null, [
+			':username' => $this->user->username,
+		]);
+
+		$this->assertIsA($row1, 'stdClass');
+		$this->assertEqual($row1->username, $this->user->username);
+		$this->assertEqual($row1, $row2);
+		$this->assertEqual($row1, $row3);
+	}
+
+	public function testCanInsert() {
+		$time = time();
+
+		$id1 = insert_data("
+			INSERT INTO {$this->prefix}entity_relationships
+			       (guid_one, relationship, guid_two, time_created)
+			VALUES ({$this->user->guid}, 'test_self1', {$this->user->guid}, $time)
+			ON DUPLICATE KEY UPDATE time_created = $time
+		");
+		$id2 = insert_data("
+			INSERT INTO {$this->prefix}entity_relationships
+			       (guid_one, relationship, guid_two, time_created)
+			VALUES (:guid1,   :rel,         :guid2,   :time)
+			ON DUPLICATE KEY UPDATE time_created = :time
+		", [
+			':guid1' => $this->user->guid,
+			':guid2' => $this->user->guid,
+			':rel' => 'test_self2',
+			':time' => $time,
+		]);
+
+		$rows = get_data("
+			SELECT *
+			FROM {$this->prefix}entity_relationships
+			WHERE guid_one = ?
+			  AND guid_two = ?
+			  AND time_created = ?
+			ORDER BY id ASC
+		", null, [$this->user->guid, $this->user->guid, $time]);
+
+		$this->assertIsA($id1, 'int');
+		$this->assertIsA($id2, 'int');
+		$this->assertEqual($rows[0]->id, $id1);
+		$this->assertEqual($rows[1]->id, $id2);
+
+		remove_entity_relationship($this->user->guid, 'test_self1', $this->user->guid);
+		remove_entity_relationship($this->user->guid, 'test_self2', $this->user->guid);
+	}
+
+	public function testCanUpdate() {
+		add_entity_relationship($this->user->guid, 'test_self1', $this->user->guid);
+		$rel = check_entity_relationship($this->user->guid, 'test_self1', $this->user->guid);
+
+		$res = update_data("
+			UPDATE {$this->prefix}entity_relationships
+			SET relationship = 'test_self2'
+			WHERE id = {$rel->id}
+		");
+		$rel = get_relationship($rel->id);
+
+		$this->assertIdentical($res, true);
+		$this->assertEqual($rel->relationship, 'test_self2');
+
+		$num_rows = update_data("
+			UPDATE {$this->prefix}entity_relationships
+			SET relationship = 'test_self3'
+			WHERE id = {$rel->id}
+		", [], true);
+		$rel = get_relationship($rel->id);
+
+		$this->assertIdentical($num_rows, 1);
+		$this->assertEqual($rel->relationship, 'test_self3');
+
+		$num_rows = update_data("
+			UPDATE {$this->prefix}entity_relationships
+			SET relationship = :rel
+			WHERE id = :id
+		", [
+			':rel' => 'test_self4',
+			':id' => $rel->id,
+		], true);
+		$rel = get_relationship($rel->id);
+
+		$this->assertIdentical($num_rows, 1);
+		$this->assertEqual($rel->relationship, 'test_self4');
+
+		$rel->delete();
+	}
+
+	public function testCanDelete() {
+		$new_rel = function () {
+			add_entity_relationship($this->user->guid, 'test_self1', $this->user->guid);
+			return check_entity_relationship($this->user->guid, 'test_self1', $this->user->guid);
+		};
+
+		$rel = $new_rel();
+		$res = delete_data("
+			DELETE FROM {$this->prefix}entity_relationships
+			WHERE id = {$rel->id}
+		");
+		$this->assertIdentical($res, 1);
+		$this->assertFalse(check_entity_relationship($this->user->guid, 'test_self1', $this->user->guid));
+
+		$rel = $new_rel();
+		$res = delete_data("
+			DELETE FROM {$this->prefix}entity_relationships
+			WHERE id = :id
+		", [
+			':id' => $rel->id,
+		]);
+		$this->assertIdentical($res, 1);
+		$this->assertFalse(check_entity_relationship($this->user->guid, 'test_self1', $this->user->guid));
+	}
+
+	public function testCanSanitize() {
+		$data = [
+			"'" => "\\'",
+			"\"" => "\\\"",
+			"\\" => "\\\\",
+			"\n" => "\\n",
+			"\r" => "\\r",
+		];
+		foreach ($data as $in => $out) {
+			$this->assertIdentical($out, sanitize_string($in));
+		}
+	}
+
+	public function testCanDelayQuery() {
+		$sql = "
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = :username
+		";
+		$params = [
+			':username' => $this->user->username,
+		];
+
+		// capture what's passed to callback
+		$captured = null;
+		$callback = function ($stmt) use (&$captured) {
+			$captured = $stmt;
+			return $stmt;
+		};
+		execute_delayed_read_query($sql, $callback, $params);
+
+		_elgg_services()->db->executeDelayedQueries();
+
+		/* @var \Doctrine\DBAL\Driver\Statement $captured */
+
+		$this->assertIsA($captured, \Doctrine\DBAL\Driver\Statement::class);
+
+		$rows = $captured->fetchAll(\PDO::FETCH_OBJ);
+		$this->assertEqual($rows[0]->username, $this->user->username);
+	}
+}


### PR DESCRIPTION
Elgg's DB functions: `get_data`, `get_data_rows`, `insert_data`, `delete_data`, `update_data`, `execute_delayed_write_query`, and `execute_delayed_read_query` now all accept a `$params` array.

Params can be a numeric array of values to correspond to positional (`?`) placeholders in the query, or can be an associative array of values with keys like `:foo` corresponding to named (e.g. `:foo`) placeholders.

The function `update_data` now has an argument to instruct it to return the number of rows affected.

This softly deprecates `sanitize_*`, nudges devs toward parameterized queries, and converts a few existing queries to params.
