### PR TITLE
feature(groups): group avatars now use serve-file handler

### DIFF
--- a/docs/admin/upgrading.rst
+++ b/docs/admin/upgrading.rst
@@ -37,6 +37,18 @@ Basic instructions
    Any modifications should have been written within plugins, so that they are not lost on overwriting.
    If this is not the case, take care to maintain your modifications. 
 
+Deprecations in 2.x
+===================
+
+2.2
+---
+
+Group avatars are now served via ``serve-file`` handler. Plugins should start using ``elgg_get_inline_url()`` and note that:
+
+ * ``groupicon`` page handler (``groups_icon_handler()``) has been deprecated
+ * ``/mod/groups/icon.php`` file has been deprecated
+
+
 From 1.x to 2.0
 ===============
 

--- a/mod/groups/icon.php
+++ b/mod/groups/icon.php
@@ -1,57 +1,30 @@
 <?php
+
 /**
  * Icon display
  *
  * @package ElggGroups
+ * @deprecated 2.2
  */
+elgg_deprecated_notice('icon.php has been depreated and should not be included. Use elgg_get_inline_url() instead.', '2.2');
 
-if (!isset($page)) {
-	die('This file cannot be called directly.');
+$guid = get_input('group_guid');
+$size = get_input('size');
+if (!isset($size) || $size === '') {
+   $size = 'medium';
 }
 
-$group_guid = get_input('group_guid');
+elgg_entity_gatekeeper($guid, 'group');
 
-/* @var ElggGroup $group */
-$group = get_entity($group_guid);
-if (!($group instanceof ElggGroup)) {
-	header("HTTP/1.1 404 Not Found");
-	exit;
+$group = get_entity($guid);
+
+$icon = new ElggFile();
+$icon->owner_guid = $group->owner_guid;
+$icon->setFilename("groups/{$group->guid}{$size}.jpg");
+
+$url = elgg_get_inline_url($icon, true);
+if (!$url) {
+	$url = elgg_get_simplecache_url("groups/default{$size}.gif");
 }
 
-// If is the same ETag, content didn't changed.
-$etag = $group->icontime . $group_guid;
-if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) == "\"$etag\"") {
-	header("HTTP/1.1 304 Not Modified");
-	exit;
-}
-
-$size = strtolower(get_input('size'));
-if (!in_array($size, array('large', 'medium', 'small', 'tiny', 'master', 'topbar')))
-	$size = "medium";
-
-$success = false;
-
-$filehandler = new ElggFile();
-$filehandler->owner_guid = $group->owner_guid;
-$filehandler->setFilename("groups/" . $group->guid . $size . ".jpg");
-
-$success = false;
-if ($filehandler->open("read")) {
-	if ($contents = $filehandler->read($filehandler->getSize())) {
-		$success = true;
-	}
-}
-
-if (!$success) {
-	$contents = elgg_view("groups/default{$size}.gif");
-	header("Content-type: image/gif");
-} else {
-	header("Content-type: image/jpeg");
-}
-
-header('Expires: ' . gmdate('D, d M Y H:i:s \G\M\T', strtotime("+10 days")), true);
-header("Pragma: public");
-header("Cache-Control: public");
-header("Content-Length: " . strlen($contents));
-header("ETag: \"$etag\"");
-echo $contents;
+forward($url);


### PR DESCRIPTION
Group avatars are now served with elgg_get_inline_url()
