### PR TITLE
deprecate(db): deprecates many methods on the `Application::getDb` object

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -21,6 +21,13 @@ Deprecated APIs
  * ``elgg_get_config('siteemail')``: Use ``elgg_get_site_entity()->email``
  * URLs starting with ``/css/`` and ``/js/``: ``Use elgg_get_simplecache_url()``
 
+``Application::getDb()`` changes
+--------------------------------
+
+If you're using this low-level API, do not expect it to return an ``Elgg\Database`` instance in 3.0. It now
+returns an ``Elgg\Application\Database`` with many deprecated. These methods were never meant to be made
+public API, but we will do our best to support them in 2.x.
+
 Added ``elgg/widgets`` module
 -----------------------------
 

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -312,17 +312,20 @@ class Application {
 	}
 
 	/**
-	 * Get the Database instance for performing queries without booting Elgg
+	 * Get a Database wrapper for performing queries without booting Elgg
 	 *
 	 * If settings.php has not been loaded, it will be loaded to configure the DB connection.
 	 *
-	 * Note: Before boot, the Database instance will not yet be bound to a Logger.
+	 * @note Do not type hint on \Elgg\Database, as this will fail in 3.0. If you must type hint,
+	 *       expect an \Elgg\Application\Database.
 	 *
-	 * @return Database
+	 * @note Before boot, the Database instance will not yet be bound to a Logger.
+	 *
+	 * @return \Elgg\Application\Database
 	 */
 	public function getDb() {
 		$this->loadSettings();
-		return $this->services->db;
+		return $this->services->publicDb;
 	}
 
 	/**

--- a/engine/classes/Elgg/Application/Database.php
+++ b/engine/classes/Elgg/Application/Database.php
@@ -1,0 +1,224 @@
+<?php
+namespace Elgg\Application;
+
+use Elgg\Application;
+use Elgg\Database as ElggDb;
+use Elgg\Timer;
+use Elgg\Logger;
+
+/**
+ * Elgg 2.0 public database API
+ *
+ * This is returned by elgg()->getDb() or Application::start()->getDb(), but is only a 2.0 compatibility
+ * wrapper for the real Elgg\Database.
+ *
+ * @todo This extends \Elgg\Database because in 2.0 we promised to return that type. In 3.0 we should
+ *       no longer extend \Elgg\Database.
+ *
+ * @see \Elgg\Application::getDb for more details.
+ */
+class Database extends ElggDb {
+
+	/**
+	 * The "real" database instance
+	 *
+	 * @var ElggDb
+	 */
+	private $db;
+
+	/**
+	 * Constructor
+	 *
+	 * @param ElggDb $db The Elgg database
+	 * @access private
+	 */
+	public function __construct(ElggDb $db) {
+		$this->db = $db;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getData($query, $callback = '') {
+		return $this->db->getData($query, $callback);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getDataRow($query, $callback = '') {
+		return $this->db->getDataRow($query, $callback);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function insertData($query) {
+		return $this->db->insertData($query);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function updateData($query, $getNumRows = false) {
+		return $this->db->updateData($query, $getNumRows);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function deleteData($query) {
+		return $this->db->deleteData($query);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getTablePrefix() {
+		return $this->db->getTablePrefix();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function sanitizeInt($value, $signed = true) {
+		return $this->db->sanitizeInt($value, $signed);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function sanitizeString($value) {
+		return $this->db->sanitizeString($value);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @deprecated 2.1 This method will not be available on this class in 3.0
+	 */
+	public function fingerprintCallback($callback) {
+		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
+		return $this->db->fingerprintCallback($callback);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @deprecated 2.1 This method will not be available on this class in 3.0
+	 */
+	public function setTimer(Timer $timer) {
+		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
+		$this->db->setTimer($timer);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @deprecated 2.1 This method will not be available on this class in 3.0
+	 */
+	public function setLogger(Logger $logger) {
+		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
+		$this->db->setLogger($logger);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @deprecated 2.1 This method will not be available on this class in 3.0
+	 */
+	public function setupConnections() {
+		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
+		$this->db->setupConnections();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @deprecated 2.1 This method will not be available on this class in 3.0
+	 */
+	public function connect($type = "readwrite") {
+		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
+		$this->db->connect($type);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @deprecated 2.1 This method will not be available on this class in 3.0
+	 */
+	public function runSqlScript($scriptlocation) {
+		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
+		$this->db->runSqlScript($scriptlocation);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @deprecated 2.1 This method will not be available on this class in 3.0
+	 */
+	public function registerDelayedQuery($query, $type, $handler = "") {
+		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
+		return $this->db->registerDelayedQuery($query, $type, $handler);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @deprecated 2.1 This method will not be available on this class in 3.0
+	 */
+	public function executeDelayedQueries() {
+		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
+		$this->db->executeDelayedQueries();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @deprecated 2.1 This method will not be available on this class in 3.0
+	 */
+	public function enableQueryCache() {
+		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
+		$this->db->enableQueryCache();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @deprecated 2.1 This method will not be available on this class in 3.0
+	 */
+	public function disableQueryCache() {
+		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
+		$this->db->disableQueryCache();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @deprecated 2.1 This method will not be available on this class in 3.0
+	 */
+	public function assertInstalled() {
+		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
+		$this->db->assertInstalled();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @deprecated 2.1 This method will not be available on this class in 3.0
+	 */
+	public function getQueryCount() {
+		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
+		return $this->db->getQueryCount();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @deprecated 2.1 This method will not be available on this class in 3.0
+	 */
+	public function getServerVersion($type) {
+		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
+		return $this->db->getServerVersion($type);
+	}
+}

--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -99,10 +99,11 @@ class Database {
 	/**
 	 * Set the logger object
 	 *
-	 * @param \Elgg\Logger $logger The logger
+	 * @param Logger $logger The logger
 	 * @return void
+	 * @access private
 	 */
-	public function setLogger(\Elgg\Logger $logger) {
+	public function setLogger(Logger $logger) {
 		$this->logger = $logger;
 	}
 
@@ -133,6 +134,7 @@ class Database {
 	 *
 	 * @return void
 	 * @throws \DatabaseException
+	 * @access private
 	 */
 	public function setupConnections() {
 		if ($this->config->isDatabaseSplit()) {
@@ -152,6 +154,7 @@ class Database {
 	 *
 	 * @return void
 	 * @throws \DatabaseException
+	 * @access private
 	 */
 	public function connect($type = "readwrite") {
 		$conf = $this->config->getConnectionConfig($type);
@@ -448,6 +451,7 @@ class Database {
 	 *
 	 * @return void
 	 * @throws \DatabaseException
+	 * @access private
 	 */
 	public function runSqlScript($scriptlocation) {
 		$script = file_get_contents($scriptlocation);
@@ -498,6 +502,7 @@ class Database {
 	 * @param string $handler A callback function to pass the results array to
 	 *
 	 * @return boolean Whether registering was successful.
+	 * @access private
 	 */
 	public function registerDelayedQuery($query, $type, $handler = "") {
 		if ($type != 'read' && $type != 'write') {
@@ -549,6 +554,7 @@ class Database {
 	 * This does not take precedence over the \Elgg\Database\Config setting.
 	 * 
 	 * @return void
+	 * @access private
 	 */
 	public function enableQueryCache() {
 		if ($this->config->isQueryCacheEnabled() && $this->queryCache === null) {
@@ -564,6 +570,7 @@ class Database {
 	 * in single queries.
 	 * 
 	 * @return void
+	 * @access private
 	 */
 	public function disableQueryCache() {
 		$this->queryCache = null;
@@ -588,6 +595,7 @@ class Database {
 	 *
 	 * @return void
 	 * @throws \InstallationException
+	 * @access private
 	 */
 	public function assertInstalled() {
 
@@ -609,6 +617,7 @@ class Database {
 	 * Get the number of queries made to the database
 	 *
 	 * @return int
+	 * @access private
 	 */
 	public function getQueryCount() {
 		return $this->queryCount;
@@ -663,6 +672,7 @@ class Database {
 	 * @param string $type Connection type (Config constants, e.g. Config::READ_WRITE)
 	 *
 	 * @return string Empty if version cannot be determined
+	 * @access private
 	 */
 	public function getServerVersion($type) {
 		$driver = $this->getConnection($type)->getWrappedConnection();

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -49,6 +49,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\Database\Plugins                   $plugins
  * @property-read \Elgg\Cache\PluginSettingsCache          $pluginSettingsCache
  * @property-read \Elgg\Database\PrivateSettingsTable      $privateSettings
+ * @property-read \Elgg\Application\Database               $publicDb
  * @property-read \Elgg\Database\QueryCounter              $queryCounter
  * @property-read \Elgg\Http\Request                       $request
  * @property-read \Elgg\Database\RelationshipsTable        $relationshipsTable
@@ -246,6 +247,10 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 
 		$this->setFactory('privateSettings', function(ServiceProvider $c) {
 			return new \Elgg\Database\PrivateSettingsTable($c->db, $c->entityTable, $c->pluginSettingsCache);
+		});
+
+		$this->setFactory('publicDb', function(ServiceProvider $c) {
+			return new \Elgg\Application\Database($c->db);
 		});
 
 		$this->setFactory('queryCounter', function(ServiceProvider $c) {

--- a/engine/tests/phpunit/Elgg/DatabaseTest.php
+++ b/engine/tests/phpunit/Elgg/DatabaseTest.php
@@ -2,28 +2,6 @@
 
 class Elgg_DatabaseTest extends PHPUnit_Framework_TestCase {
 	
-	private $dbClass, $configClass;
-
-	/**
-	 * Inspect instances in DI container to get correct classnames for
-	 * Database API.
-	 */
-	public function setUp() {
-		$db = _elgg_testing_application()->getDb();
-		$this->dbClass = get_class($db);
-		
-		// Config class
-		$reflectionClass = new ReflectionClass($db);
-		$reflectionProperty = $reflectionClass->getProperty('config');
-		if (method_exists($reflectionProperty, 'setAccessible')) {
-			$reflectionProperty->setAccessible(true);
-			$config = $reflectionProperty->getValue($db);
-			$this->configClass = get_class($config);
-		} else {
-			$this->configClass = 'Elgg_Database_Config';
-		}
-	}
-	
 	/**
 	 * @dataProvider scriptsWithOneStatement
 	 */
@@ -107,15 +85,15 @@ class Elgg_DatabaseTest extends PHPUnit_Framework_TestCase {
 	}
 	
 	/**
-	 * @return PHPUnit_Framework_MockObject_MockObject
+	 * @return \Elgg\Database|PHPUnit_Framework_MockObject_MockObject
 	 */
 	private function getDbMock()
 	{
 		return $this->getMock(
-			$this->dbClass,
+			\Elgg\Database::class,
 			array('updateData'),
 			array(
-				 new $this->configClass((object) array('dbprefix' => 'test_')),
+				 new \Elgg\Database\Config((object) array('dbprefix' => 'test_')),
 				_elgg_services()->logger
 			)
 		);


### PR DESCRIPTION
This low-level API no longer returns the active `Elgg\Database`, but instead an `Elgg\Application\Database` proxy object. Many of the methods on that object are deprecated as they were never meant to be public.

This returns `Elgg\Database` to private API so we may refactor it as needed.
