### PR TITLE
feature(i18n): adds a more useful mode for detecting translation existence

### DIFF
--- a/docs/guides/i18n.rst
+++ b/docs/guides/i18n.rst
@@ -5,6 +5,9 @@ Make your UI translatable into many different languages.
 
 If you’d like to contribute translations to Elgg, see :doc:`the contributors' guide </about/contributing>`.
 
+The default language is ``en`` for English. Currently Elgg will always fall back to an English translation,
+even if the site's language is not English; this is a known bug.
+
 Overview
 ========
 
@@ -12,24 +15,22 @@ Translations are stored in PHP files in the ``/languages`` directory of your plu
 
 .. code-block:: php
 
-   <?php
+	<?php // mod/example/languages/en.php
 
-   // mod/example/languages/en.php
-   return array(
-     ‘example:text’ => ‘Some example text’,
-   );
+	return [
+		'example:text' => 'Some example text',
+	];
 
-The default language is “en” for English.
-
-To change the wording of any phrase, provide a new mapping in your plugin’s ``{language}.php`` file for the associated key:
+To override an existing translation, include it in your plugin's language file, and make sure your plugin is
+ordered later on the Admin > Plugins page:
 
 .. code:: php
 
-   <?php
+	<?php // mod/better_example/languages/en.php
 
-   return array(
-     ‘example:text’ => ‘This is an example’,
-   );
+	return [
+		'example:text' => 'Some better text!',
+	];
 
 .. note::
 
@@ -47,24 +48,34 @@ Example:
 
 .. code:: php
 
-   echo elgg_echo(‘example:text’);
+	echo elgg_echo('example:text');
 
 It also supports variable replacement using sprintf syntax:
 
 .. code:: php
 
-   // ‘welcome’ => ‘Welcome to %s, %s!’
-   echo elgg_echo(‘welcome’, array(
-     elgg_get_config(‘sitename’),
-     elgg_get_logged_in_user_entity()->name,
-   ));
+	// 'welcome' => 'Welcome to %s, %s!'
+	echo elgg_echo('welcome', [
+		elgg_get_config('sitename'),
+		elgg_get_logged_in_user_entity()->name,
+	]);
 
 To force which language should be used for translation, set the third parameter:
 
 .. code:: php
 
-   echo elgg_echo(‘welcome’, array(), ‘es’);
+    echo elgg_echo('welcome', [], $user->language);
 
+To first test whether ``elgg_echo()`` can find a translation:
+
+.. code:: php
+
+	$key = 'key:that:might:not:exist';
+	if (!elgg_language_key_exists($key, '')) {
+		$key = 'fallback:key';
+	}
+
+	echo elgg_echo($key);
 
 
 Javascript API

--- a/engine/classes/Elgg/I18n/Translator.php
+++ b/engine/classes/Elgg/I18n/Translator.php
@@ -37,7 +37,8 @@ class Translator {
 	 * @return string Either the translated string, the English string,
 	 * or the original language string.
 	 */
-	function translate($message_key, $args = array(), $language = "") {
+	public function translate($message_key, $args = array(), $language = "") {
+		// TODO find a way to cache getLanguage() and get rid of this
 		static $CURRENT_LANGUAGE;
 
 		// old param order is deprecated
@@ -51,31 +52,22 @@ class Translator {
 			$args = array();
 		}
 
-		if (!isset($GLOBALS['_ELGG']->translations)) {
-			// this means we probably had an exception before translations were initialized
-			$this->registerTranslations($this->defaultPath);
-		}
-
-		if (!$CURRENT_LANGUAGE) {
-			$CURRENT_LANGUAGE = $this->getLanguage();
+		if ($CURRENT_LANGUAGE === null) {
+			$CURRENT_LANGUAGE = $this->getCurrentLanguage();
 		}
 		if (!$language) {
 			$language = $CURRENT_LANGUAGE;
 		}
 
-		if (!isset($GLOBALS['_ELGG']->translations[$language])) {
-			// The language being requested is not the same as the language of the
-			// logged in user, so we will have to load it separately. (Most likely
-			// we're sending a notification and the recipient is using a different
-			// language than the logged in user.)
-			$this->loadTranslations($language);
-		}
+		$this->assertTranslationsLoaded($language);
 
 		if (isset($GLOBALS['_ELGG']->translations[$language][$message_key])) {
 			$string = $GLOBALS['_ELGG']->translations[$language][$message_key];
+
 		} else if (isset($GLOBALS['_ELGG']->translations["en"][$message_key])) {
 			$string = $GLOBALS['_ELGG']->translations["en"][$message_key];
 			_elgg_services()->logger->notice(sprintf('Missing %s translation for "%s" language key', $language, $message_key));
+
 		} else {
 			$string = $message_key;
 			_elgg_services()->logger->notice(sprintf('Missing English translation for "%s" language key', $message_key));
@@ -103,7 +95,7 @@ class Translator {
 	 *
 	 * @return bool Depending on success
 	 */
-	function addTranslation($country_code, $language_array) {
+	public function addTranslation($country_code, $language_array) {
 
 		if (!isset($GLOBALS['_ELGG']->translations)) {
 			$GLOBALS['_ELGG']->translations = array();
@@ -125,12 +117,12 @@ class Translator {
 	}
 
 	/**
-	 * Detect the current language being used by the current site or logged in user.
+	 * Get the current system/user language or "en".
 	 *
 	 * @return string The language code for the site/user or "en" if not set
 	 */
-	function getCurrentLanguage() {
-		$language = $this->getLanguage();
+	public function getCurrentLanguage() {
+		$language = $this->detectLanguage();
 
 		if (!$language) {
 			$language = 'en';
@@ -140,11 +132,11 @@ class Translator {
 	}
 
 	/**
-	 * Gets the current language in use by the system or user.
+	 * Detect the current system/user language or false.
 	 *
 	 * @return string The language code (eg "en") or false if not set
 	 */
-	function getLanguage() {
+	public function detectLanguage() {
 		$url_lang = _elgg_services()->input->get('hl');
 		if ($url_lang) {
 			return $url_lang;
@@ -181,7 +173,7 @@ class Translator {
 	 * @param string $language Language code
 	 * @access private
 	 */
-	function loadTranslations($language = null) {
+	public function loadTranslations($language = null) {
 		if ($this->CONFIG->system_cache_enabled) {
 			$loaded = true;
 
@@ -273,7 +265,7 @@ class Translator {
 	 *
 	 * @return bool Success
 	 */
-	function registerPluginTranslations($path) {
+	public function registerPluginTranslations($path) {
 		$languages_path = rtrim($path, "\\/") . "/languages";
 
 		// don't need to have translations
@@ -294,7 +286,7 @@ class Translator {
 	 *
 	 * @return bool success
 	 */
-	function registerTranslations($path, $load_all = false, $language = null) {
+	public function registerTranslations($path, $load_all = false, $language = null) {
 		$path = sanitise_filepath($path);
 
 		// Make a note of this path just incase we need to register this language later
@@ -356,7 +348,7 @@ class Translator {
 	 *
 	 * @return void
 	 */
-	function reloadAllTranslations() {
+	public function reloadAllTranslations() {
 
 
 		static $LANG_RELOAD_ALL_RUN;
@@ -395,7 +387,7 @@ class Translator {
 	 *
 	 * @return array
 	 */
-	function getInstalledTranslations() {
+	public function getInstalledTranslations() {
 
 
 		// Ensure that all possible translations are loaded
@@ -425,7 +417,7 @@ class Translator {
 	 *
 	 * @return int
 	 */
-	function getLanguageCompleteness($language) {
+	public function getLanguageCompleteness($language) {
 
 
 		// Ensure that all possible translations are loaded
@@ -456,7 +448,7 @@ class Translator {
 	 *
 	 * @return mixed
 	 */
-	function getMissingLanguageKeys($language) {
+	public function getMissingLanguageKeys($language) {
 
 
 		// Ensure that all possible translations are loaded
@@ -479,29 +471,57 @@ class Translator {
 	}
 
 	/**
-	 * Check if a give language key exists
+	 * Check if a given language key exists
+	 *
+	 * @note Elgg 2.1+ allows passing in "" for $language. This is likely the behavior you want and
+	 *       will be the default in 3.0.
 	 *
 	 * @param string $key      The translation key
-	 * @param string $language The specific language to check
-	 *
+	 * @param string $language The specific language to check. If given "", the function will check the
+	 *                         current language and fallback language(s) (currently just English)
 	 * @return bool
 	 * @since 1.11
 	 */
-	function languageKeyExists($key, $language = 'en') {
-		if (empty($key)) {
+	public function languageKeyExists($key, $language = 'en') {
+
+		$accept_any = ($language === '');
+
+		if (!$language) {
+			$language = $this->getCurrentLanguage();
+		}
+
+		$this->assertTranslationsLoaded($language);
+
+		if (isset($GLOBALS['_ELGG']->translations[$language][$key])) {
+			return true;
+		}
+
+		if (!$accept_any) {
 			return false;
 		}
 
-		if (($language !== 'en') && !array_key_exists($language, $GLOBALS['_ELGG']->translations)) {
-			// Ensure that all possible translations are loaded
-			$this->reloadAllTranslations();
+		return isset($GLOBALS['_ELGG']->translations["en"][$key]);
+	}
+
+	/**
+	 * Make sure translations are loaded
+	 *
+	 * @param string $language Language
+	 * @return void
+	 */
+	private function assertTranslationsLoaded($language) {
+		if (!isset($GLOBALS['_ELGG']->translations)) {
+			// this means we probably had an exception before translations were initialized
+			$this->registerTranslations($this->defaultPath);
 		}
 
-		if (!array_key_exists($language, $GLOBALS['_ELGG']->translations)) {
-			return false;
+		if (!isset($GLOBALS['_ELGG']->translations[$language])) {
+			// The language being requested is not the same as the language of the
+			// logged in user, so we will have to load it separately. (Most likely
+			// we're sending a notification and the recipient is using a different
+			// language than the logged in user.)
+			$this->loadTranslations($language);
 		}
-
-		return array_key_exists($key, $GLOBALS['_ELGG']->translations[$language]);
 	}
 
 	/**

--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -40,7 +40,7 @@ function add_translation($country_code, $language_array) {
 }
 
 /**
- * Detect the current language being used by the current site or logged in user.
+ * Get the current system/user language or "en".
  *
  * @return string The language code for the site/user or "en" if not set
  */
@@ -49,12 +49,12 @@ function get_current_language() {
 }
 
 /**
- * Gets the current language in use by the system or user.
+ * Detect the current system/user language or false.
  *
  * @return string The language code (eg "en") or false if not set
  */
 function get_language() {
-	return _elgg_services()->translator->getLanguage();
+	return _elgg_services()->translator->detectLanguage();
 }
 
 /**
@@ -118,10 +118,14 @@ function get_missing_language_keys($language) {
 }
 
 /**
- * Check if a give language key exists
+ * Check if a given language key exists
+ *
+ * @note Elgg 2.1+ allows passing in "" for $language. This is likely the behavior you want and
+ *       will be the default in 3.0.
  *
  * @param string $key      The translation key
- * @param string $language The language
+ * @param string $language The specific language to check. If given "", the function will check the
+ *                         current language and fallback language(s) (currently just English)
  *
  * @return bool
  * @since 1.11

--- a/engine/tests/phpunit/Elgg/I18n/TranslatorTest.php
+++ b/engine/tests/phpunit/Elgg/I18n/TranslatorTest.php
@@ -11,7 +11,7 @@ class TranslatorTest extends TestCase {
 		$input_lang = 'nl';
 		_elgg_services()->input->set('hl', $input_lang);
 		
-		$lang = $translator->getLanguage();
+		$lang = $translator->detectLanguage();
 		$this->assertEquals($lang, $input_lang);
 	}
 	


### PR DESCRIPTION
By default, `elgg_echo($key)` checks for the translation in the current language as well as fallback languages (just English for now).

`elgg_language_key_exists($key, '')` (note the empty string) now checks the same languages, which is probably the behavior the user expects.

`elgg_echo` and `elgg_language_key_exists` can no longer get `false` as the default language in the case that no language is set anywhere.

In `Translator`, `getLanguage` is now `detectLanguage`, which seems more apt.

Docs cleanup.

Fixes #9375
- [ ] isolate the new feature in its own commit and move the others to separate PR(s).
