### PR TITLE
feat(gatekeeper): entity gatekeeper result can now be filtered

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -291,6 +291,10 @@ Permission hooks
 **get_sql, access**
     Filters the SQL clauses used in ``_elgg_get_access_where_sql()``.
 
+**gatekeeper, <entity_type>:<entity_subtype>**
+    Filters the result of ``elgg_entity_gatekeeper()`` to prevent access to an entity that user would otherwise have access to. A handler should return false to deny access to an entity.
+
+
 Routing
 =======
 


### PR DESCRIPTION
`"gatekeeper", "$entity_type:$entity_subtype"` hook can now be used to filter the
resulf of elgg_entity_gatekeeper(). Also adds 4th argument to indicate whether
or not a forward should be issued

Refs #9483
