### PR TITLE
chore(db): no longer use INSERT DELAYED query writing to system_log

### DIFF
--- a/engine/lib/system_log.php
+++ b/engine/lib/system_log.php
@@ -239,14 +239,14 @@ function system_log($object, $event) {
 
 		// Create log if we haven't already created it
 		if (!isset($log_cache[$time][$object_id][$event])) {
-			$query = "INSERT DELAYED into {$CONFIG->dbprefix}system_log
+			$query = "INSERT into {$CONFIG->dbprefix}system_log
 				(object_id, object_class, object_type, object_subtype, event,
 				performed_by_guid, owner_guid, access_id, enabled, time_created, ip_address)
 			VALUES
 				('$object_id','$object_class','$object_type', '$object_subtype', '$event',
 				$performed_by, $owner_guid, $access_id, '$enabled', '$time', '$ip_address')";
-
-			insert_data($query);
+			
+			execute_delayed_write_query($query);
 
 			$log_cache[$time][$object_id][$event] = true;
 			$cache_size += 1;


### PR DESCRIPTION
Ref #4993 

This is one of the issues in Elgg preventing a move to InnoDB
