### PR TITLE
feature(thewire): allow multiple add forms to exist on the same page

### DIFF
--- a/mod/thewire/views/default/thewire.js
+++ b/mod/thewire/views/default/thewire.js
@@ -7,7 +7,7 @@ elgg.thewire.init = function() {
 	var callback = function() {
 		var maxLength = $(this).data('max-length');
 		if (maxLength) {
-			elgg.thewire.textCounter(this, $("#thewire-characters-remaining span"), maxLength);
+			elgg.thewire.textCounter(this, $(this).closest('form').find("#thewire-characters-remaining span"), maxLength);
 		}
 	};
 
@@ -27,15 +27,16 @@ elgg.thewire.textCounter = function(textarea, status, limit) {
 
 	var remaining_chars = limit - $(textarea).val().length;
 	status.html(remaining_chars);
+	var $submit = $(textarea).closest('form').find('#thewire-submit-button');
 
 	if (remaining_chars < 0) {
 		status.parent().addClass("thewire-characters-remaining-warning");
-		$("#thewire-submit-button").attr('disabled', 'disabled');
-		$("#thewire-submit-button").addClass('elgg-state-disabled');
+		$submit.attr('disabled', 'disabled');
+		$submit.addClass('elgg-state-disabled');
 	} else {
 		status.parent().removeClass("thewire-characters-remaining-warning");
-		$("#thewire-submit-button").removeAttr('disabled', 'disabled');
-		$("#thewire-submit-button").removeClass('elgg-state-disabled');
+		$submit.removeAttr('disabled', 'disabled');
+		$submit.removeClass('elgg-state-disabled');
 	}
 };
 


### PR DESCRIPTION
Without this change the counter is not updated correctly if there are multiple forms of the wire on the same page.

I would rather change the id references in the js to be classes, but that would be a breaking change.
