### PR TITLE
fix(installer): no longer redirects in loop during installation

### DIFF
--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -240,6 +240,11 @@ class Config implements Services\Config {
 
 		// No settings means a fresh install
 		if (!is_file($path)) {
+			if ($this->getVolatile('installer_running')) {
+				$this->settings_loaded = true;
+				return;
+			}
+
 			header("Location: install.php");
 			exit;
 		}


### PR DESCRIPTION
`Elgg\Config::loadSettingsFile` now recognizes when it's in the installer and no longer redirects if no settings file is found.

Fixes #9486
