### PR TITLE
feature(groups): introduced a hook to influence group tool options

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -523,6 +523,9 @@ Groups
 **profile_buttons, group**
 	Filters buttons (``ElggMenuItem`` instances) to be registered in the title menu of the group profile page
 
+**tool_options, group**
+	Use this hook to influence the available group tool options
+
 HTMLawed
 --------
 

--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -93,8 +93,9 @@ if (!$group->name) {
 	forward(REFERER);
 }
 
-// Set group tool options
-$tool_options = elgg_get_config('group_tool_options');
+// Set group tool options (only pass along saved entities)
+$tool_entity = !$is_new_group ? $group : null;
+$tool_options = groups_get_group_tool_options($tool_entity);
 if ($tool_options) {
 	foreach ($tool_options as $group_option) {
 		$option_toggle_name = $group_option->name . "_enable";

--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -51,12 +51,11 @@ function groups_prepare_form_vars($group = null) {
 	}
 
 	// handle tool options
-	$tools = elgg_get_config('group_tool_options');
-	if ($tools) {
-		foreach ($tools as $group_option) {
-			$option_name = $group_option->name . "_enable";
-			$values[$option_name] = $group_option->default_on ? 'yes' : 'no';
-		}
+	$entity = ($group instanceof \ElggGroup) ? $group : null;
+	$tools = groups_get_group_tool_options($entity);
+	foreach ($tools as $group_option) {
+		$option_name = $group_option->name . "_enable";
+		$values[$option_name] = $group_option->default_on ? 'yes' : 'no';
 	}
 
 	// get current group settings
@@ -92,4 +91,23 @@ function groups_prepare_form_vars($group = null) {
 	elgg_clear_sticky_form('groups');
 
 	return $values;
+}
+
+/**
+ * Function to return available group tool options
+ *
+ * @param \ElggGroup $group optional group
+ *
+ * @return array
+ */
+function groups_get_group_tool_options(\ElggGroup $group = null) {
+	
+	$tool_options = elgg_get_config('group_tool_options');
+	
+	$hook_params = [
+		'group_tool_options' => $tool_options,
+		'entity' => $group,
+	];
+		
+	return (array) elgg_trigger_plugin_hook('tool_options', 'group', $hook_params, $tool_options);
 }

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -16,7 +16,8 @@ elgg_register_event_handler('init', 'system', 'groups_fields_setup', 10000);
 function groups_init() {
 
 	elgg_register_library('elgg:groups', __DIR__ . '/lib/groups.php');
-
+	elgg_load_library('elgg:groups');
+	
 	// register group entities for search
 	elgg_register_entity_type('group', '');
 
@@ -241,8 +242,6 @@ function groups_setup_sidebar_menus() {
  * @return bool
  */
 function groups_page_handler($page) {
-
-	elgg_load_library('elgg:groups');
 
 	if (!isset($page[0])) {
 		$page[0] = 'all';

--- a/mod/groups/views/default/groups/edit/tools.php
+++ b/mod/groups/views/default/groups/edit/tools.php
@@ -8,20 +8,24 @@
  * @package ElggGroups
  */
 
-$tools = elgg_get_config("group_tool_options");
-if ($tools) {
-	usort($tools, create_function('$a, $b', 'return strcmp($a->label, $b->label);'));
+$tools = groups_get_group_tool_options(elgg_extract('entity', $vars));
+if (empty($tools)) {
+	return;
+}
+
+usort($tools, function($a, $b) {
+	return strcmp($a->label, $b->label);
+});
+
+foreach ($tools as $group_option) {
+	$group_option_toggle_name = $group_option->name . "_enable";
+	$value = elgg_extract($group_option_toggle_name, $vars);
 	
-	foreach ($tools as $group_option) {
-		$group_option_toggle_name = $group_option->name . "_enable";
-		$value = elgg_extract($group_option_toggle_name, $vars);
-		
-		echo elgg_format_element('div', [], elgg_view('input/checkbox', array(
-			'name' => $group_option_toggle_name,
-			'value' => 'yes',
-			'default' => 'no',
-			'checked' => ($value === 'yes') ? true : false,
-			'label' => $group_option->label
-		)));
-	}
+	echo elgg_format_element('div', [], elgg_view('input/checkbox', array(
+		'name' => $group_option_toggle_name,
+		'value' => 'yes',
+		'default' => 'no',
+		'checked' => ($value === 'yes') ? true : false,
+		'label' => $group_option->label
+	)));
 }


### PR DESCRIPTION
fixes #9497
- [x] type hint ElggGroup in groups_get_group_tool_options()
- [x] for new groups, decide between passing in null or an unsaved ElggGroup
- [x] use anon function instead of create_function()
