### PR TITLE
feature(menus): adds menu service for more orderly menu construction

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -83,13 +83,16 @@ System hooks
 	In ``elgg_view_layout()``, filters the return value of the layout view.
 
 **parameters, menu:<menu_name>**
-	Triggered by ``elgg_view_menu()``. Used to change menu variables (like sort order) before it is generated.
+	Triggered by ``elgg_view_menu()``. Used to change menu variables (like sort order) before rendering.
 
 **register, menu:<menu_name>**
-	Triggered by ``elgg_view_menu()``. Used to add dynamic menu items.
+	Filters the initial list of menu items pulled from configuration, before the menu has been split into
+	sections. Triggered by ``elgg_view_menu()`` and ``elgg()->menus->getMenu()``.
 
 **prepare, menu:<menu_name>**
-	Trigger by ``elgg_view_menu()``. Used to sort, add, remove, and modify menu items.
+	Filters the array of menu sections before they're displayed. Each section is a string key mapping to
+	an area of menu items. This is a good hook to sort, add, remove, and modify menu items. Triggered by
+	``elgg_view_menu()`` and ``elgg()->menus->prepareMenu()``.
 
 **creating, river**
 	Triggered before a river item is created. Return false to prevent river item from being created.

--- a/docs/guides/menus.rst
+++ b/docs/guides/menus.rst
@@ -79,7 +79,7 @@ Examples
 	/**
 	 * Change the URL of the "Albums" menu item in the owner_block menu
 	 */
-	function my_owner_block_menu_handler($hook, $type, $menu, $params) {
+	function my_owner_block_menu_handler($hook, $type, $items, $params) {
 		$owner = $params['entity'];
 
 		// Owner can be either user or a group, so we
@@ -93,7 +93,7 @@ Examples
 				break;
 		}
 
-		foreach ($menu as $key => $item) {
+		foreach ($items as $key => $item) {
 			if ($item->getName() == 'albums') {
 				// Set the new URL
 				$item->setURL($url);
@@ -101,7 +101,7 @@ Examples
 			}
 		}
 
-		return $menu;
+		return $items;
 	}
 
 **Example 2:** Modify the ``entity`` menu for the ``ElggBlog`` objects
@@ -121,7 +121,7 @@ Examples
 	/**
 	 * Customize the entity menu for ElggBlog objects
 	 */
-	function my_entity_menu_handler($hook, $type, $menu, $params) {
+	function my_entity_menu_handler($hook, $type, $items, $params) {
 		// The entity can be found from the $params parameter
 		$entity = $params['entity'];
 
@@ -131,11 +131,11 @@ Examples
 			return $menu;
 		}
 
-		foreach ($menu as $key => $item) {
+		foreach ($items as $key => $item) {
 			switch ($item->getName()) {
 				case 'likes':
 					// Remove the "likes" menu item
-					unset($menu[$key]);
+					unset($items[$key]);
 					break;
 				case 'edit':
 					// Change the "Edit" text into a custom icon
@@ -144,7 +144,7 @@ Examples
 			}
 		}
 
-		return $menu;
+		return $items;
 	}
 
 Creating a new menu
@@ -163,12 +163,14 @@ in alphapetical order:
 
 .. code-block:: php
 
+	// in a resource view
 	echo elgg_view_menu('my_menu', array('sort_by' => 'title'));
 
 You can now add new items to the menu like this:
 
 .. code-block:: php
 
+	// in plugin init
 	elgg_register_menu_item('my_menu', array(
 		'name' => 'my_page',
 		'href' => 'path/to/my_page',

--- a/docs/guides/services.rst
+++ b/docs/guides/services.rst
@@ -7,3 +7,9 @@ class will offer a set of service objects for plugins to use.
 .. note::
 
     If you have a useful idea, you can :doc:`add a new service </contribute/services>`!
+
+Menus
+-----
+
+``elgg()->menus`` provides low-level methods for constructing menus. In general, menus should be
+passed to ``elgg_view_menu`` for rendering instead of manual rendering.

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -14,6 +14,8 @@ use Elgg\Filesystem\Directory;
  * The full path is necessary to work around this: https://bugs.php.net/bug.php?id=55726
  *
  * @since 2.0.0
+ *
+ * @property-read \Elgg\Menu\Service $menus
  */
 class Application {
 
@@ -41,6 +43,7 @@ class Application {
 	 */
 	private static $public_services = [
 		//'config' => true,
+		'menus' => true,
 	];
 
 	/**

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -39,6 +39,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\Http\Input                         $input
  * @property-read \Elgg\Logger                             $logger
  * @property-read Mailer                                   $mailer
+ * @property-read \Elgg\Menu\Service                       $menus
  * @property-read \Elgg\Cache\MetadataCache                $metadataCache
  * @property-read \Elgg\Database\MetadataTable             $metadataTable
  * @property-read \Elgg\Database\MetastringsTable          $metastringsTable
@@ -191,6 +192,10 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 
 		// TODO(evan): Support configurable transports...
 		$this->setClassName('mailer', 'Zend\Mail\Transport\Sendmail');
+
+		$this->setFactory('menus', function(ServiceProvider $c) {
+			return new \Elgg\Menu\Service($c->hooks, $c->config);
+		});
 
 		$this->setFactory('metadataCache', function (ServiceProvider $c) {
 			return new \Elgg\Cache\MetadataCache($c->session);

--- a/engine/classes/Elgg/Menu/Menu.php
+++ b/engine/classes/Elgg/Menu/Menu.php
@@ -1,0 +1,69 @@
+<?php
+namespace Elgg\Menu;
+
+use ElggMenuItem;
+
+/**
+ * A complete menu, sorted, filtered by the "prepare" hook, and split into sections.
+ *
+ * This also encapsulates parameters to be passed to views.
+ */
+class Menu {
+
+	/**
+	 * @var array
+	 */
+	private $params;
+
+	/**
+	 * Constructor
+	 *
+	 * @param array $params Params. Must include:
+	 *                      "name" menu name
+	 *                      "menu" array of sections (each an array of items)
+	 * @access private
+	 * @internal Do not use. Use the `elgg()->menus` service methods instead.
+	 */
+	public function __construct(array $params) {
+		$this->params = $params;
+	}
+
+	/**
+	 * Get all menu sections
+	 *
+	 * @return ElggMenuItem[][]
+	 */
+	public function getSections() {
+		return $this->params['menu'];
+	}
+
+	/**
+	 * Get a single menu section
+	 *
+	 * @param string $name    Section name
+	 * @param mixed  $default Value to return if section is not found
+	 *
+	 * @return ElggMenuItem[]|null
+	 */
+	public function getSection($name, $default = null) {
+		return isset($this->params['menu'][$name]) ? $this->params['menu'][$name] : $default;
+	}
+
+	/**
+	 * Get the menu's name
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return $this->params['name'];
+	}
+
+	/**
+	 * Get the menu parameters
+	 *
+	 * @return array
+	 */
+	public function getParams() {
+		return $this->params;
+	}
+}

--- a/engine/classes/Elgg/Menu/Service.php
+++ b/engine/classes/Elgg/Menu/Service.php
@@ -1,0 +1,134 @@
+<?php
+namespace Elgg\Menu;
+
+use Elgg\PluginHooksService;
+use Elgg\Config;
+use ElggMenuBuilder;
+
+/**
+ * Methods to construct and prepare menus for rendering
+ */
+class Service {
+
+	/**
+	 * @var PluginHooksService
+	 */
+	private $hooks;
+
+	/**
+	 * @var Config
+	 */
+	private $config;
+
+	/**
+	 * Constructor
+	 *
+	 * @param PluginHooksService $hooks  Plugin hooks
+	 * @param Config             $config Elgg config
+	 * @access private
+	 * @internal Do not use. Use `elgg()->menus`.
+	 */
+	public function __construct(PluginHooksService $hooks, Config $config) {
+		$this->hooks = $hooks;
+		$this->config = $config;
+	}
+
+	/**
+	 * Build a full menu, pulling items from configuration and the "register" menu hooks.
+	 *
+	 * Parameters are filtered by the "parameters" hook.
+	 *
+	 * @param string $name   Menu name
+	 * @param array  $params Hook/view parameters
+	 *
+	 * @return Menu
+	 */
+	public function getMenu($name, array $params = []) {
+		return $this->prepareMenu($this->getUnpreparedMenu($name, $params));
+	}
+
+	/**
+	 * Build an unprepared menu.
+	 *
+	 * @param string $name   Menu name
+	 * @param array  $params Hook/view parameters
+	 *
+	 * @return UnpreparedMenu
+	 */
+	public function getUnpreparedMenu($name, array $params = []) {
+		$menus = $this->config->getVolatile('menus');
+		$items = [];
+		if ($menus && isset($menus[$name])) {
+			$items = elgg_extract($name, $menus, []);
+		}
+
+		$params['name'] = $name;
+
+		$params = $this->hooks->trigger('parameters', "menu:$name", $params, $params);
+
+		if (!isset($params['sort_by'])) {
+			$params['sort_by'] = 'priority';
+		}
+
+		$items = $this->hooks->trigger('register', "menu:$name", $params, $items);
+
+		return new UnpreparedMenu($params, $items);
+	}
+
+	/**
+	 * Split a menu into sections, and pass it through the "prepare" hook
+	 *
+	 * @param UnpreparedMenu $menu Menu
+	 *
+	 * @return Menu
+	 */
+	public function prepareMenu(UnpreparedMenu $menu) {
+		$name = $menu->getName();
+		$params = $menu->getParams();
+		$sort_by = $menu->getSortBy();
+
+		$builder = new ElggMenuBuilder($menu->getItems());
+		$params['menu'] = $builder->getMenu($sort_by);
+		$params['selected_item'] = $builder->getSelected();
+
+		$params['menu'] = $this->hooks->trigger('prepare', "menu:$name", $params, $params['menu']);
+
+		return new Menu($params);
+	}
+
+	/**
+	 * Combine several menus into one
+	 *
+	 * Unprepared menus will be built separately, then combined, with items reassigned to sections
+	 * named after their origin menu. The returned menu must be prepared before display.
+	 *
+	 * @param string[] $names    Menu names
+	 * @param array    $params   Menu params
+	 * @param string   $new_name Combined menu name (used for the prepare hook)
+	 *
+	 * @return UnpreparedMenu
+	 */
+	function combineMenus(array $names = [], array $params = [], $new_name = '') {
+		if (!$new_name) {
+			$new_name = implode('__' , $names);
+		}
+
+		$all_items = [];
+		foreach ($names as $name) {
+			$items = $this->getMenu($name, $params)->getItems();
+
+			foreach ($items as $item) {
+				$section = $item->getSection();
+				if ($section == 'default') {
+					$item->setSection($name);
+				}
+				$item->setData('menu_name', $name);
+				$all_items[] = $item;
+			}
+		}
+
+		$params['name'] = $new_name;
+
+		return new UnpreparedMenu($params, $all_items);
+	}
+}

--- a/engine/classes/Elgg/Menu/UnpreparedMenu.php
+++ b/engine/classes/Elgg/Menu/UnpreparedMenu.php
@@ -1,0 +1,89 @@
+<?php
+namespace Elgg\Menu;
+
+use ElggMenuItem;
+
+/**
+ * Linear set of menu items collected from configuration and the "register" hook.
+ *
+ * This also encapsulates parameters to be passed to hooks and views.
+ */
+class UnpreparedMenu {
+
+	/**
+	 * @var ElggMenuItem[]
+	 */
+	private $items;
+
+	/**
+	 * @var array
+	 */
+	private $params;
+
+	/**
+	 * Constructor
+	 *
+	 * @param array          $params Parameters to be passed to the "prepare" hook and views.
+	 *                               Must include value for "name".
+	 * @param ElggMenuItem[] $items  Menu items
+	 *
+	 * @access private
+	 * @internal Do not use. Use the `elgg()->menus` service methods instead.
+	 */
+	public function __construct(array $params, array $items) {
+		$this->params = $params;
+		$this->items = $items;
+	}
+
+	/**
+	 * Set how this menu should be sorted
+	 *
+	 * @see ElggMenuBuilder::sort
+	 *
+	 * @param string|callable $sort_by Sort strategy "text", "name", "priority", or callback
+	 *
+	 * @return void
+	 */
+	public function setSortBy($sort_by = 'text') {
+		$this->params['sort_by'] = $sort_by;
+	}
+
+	/**
+	 * Get the designated (or default) sort strategy
+	 *
+	 * @see setSortBy
+	 * @see ElggMenuBuilder::sort
+	 *
+	 * @return string|callable
+	 */
+	public function getSortBy() {
+		return elgg_extract('sort_by', $this->params, 'text');
+	}
+
+	/**
+	 * Get the menu name
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return $this->params['name'];
+	}
+
+	/**
+	 * Get the menu items
+	 *
+	 * @return ElggMenuItem[]
+	 */
+	public function getItems() {
+		return $this->items;
+	}
+
+	/**
+	 * Get the menu parameters
+	 *
+	 * @return array
+	 */
+	public function getParams() {
+		return $this->params;
+	}
+}

--- a/engine/classes/ElggMenuItem.php
+++ b/engine/classes/ElggMenuItem.php
@@ -581,7 +581,7 @@ class ElggMenuItem {
 	 * 
 	 * This is reserved for the \ElggMenuBuilder.
 	 *
-	 * @param array $children Array of \ElggMenuItems
+	 * @param ElggMenuItem[] $children Array of items
 	 * @return void
 	 * @access private
 	 */
@@ -594,7 +594,7 @@ class ElggMenuItem {
 	 * 
 	 * This is reserved for the \ElggMenuBuilder.
 	 *
-	 * @return array
+	 * @return ElggMenuItem[]
 	 * @access private
 	 */
 	public function getChildren() {

--- a/mod/profile/views/default/profile/owner_block.php
+++ b/mod/profile/views/default/profile/owner_block.php
@@ -18,18 +18,13 @@ $icon = elgg_view_entity_icon($user, 'large', array(
 ));
 
 // grab the actions and admin menu items from user hover
-$menu = elgg_trigger_plugin_hook('register', "menu:user_hover", array('entity' => $user), array());
-$builder = new ElggMenuBuilder($menu);
-$menu = $builder->getMenu();
-$menu = elgg_trigger_plugin_hook('prepare', "menu:user_hover", array(
-	'menu' => $menu,
+$menu = elgg()->menus->getMenu('user_hover', [
 	'entity' => $user,
 	'username' => $user->username,
-	'name' => 'user_hover',
-), $menu);
+]);
 
-$actions = elgg_extract('action', $menu, array());
-$admin = elgg_extract('admin', $menu, array());
+$actions = $menu->getSection('action', []);
+$admin = $menu->getSection('admin', []);
 
 $profile_actions = '';
 if (elgg_is_logged_in() && $actions) {

--- a/views/default/forms/admin/menu/save.php
+++ b/views/default/forms/admin/menu/save.php
@@ -7,11 +7,11 @@
 $num_featured_items = 6;
 
 // get site menu items
-$menu = elgg_get_config('menus');
-$menu = $menu['site'];
-$builder = new ElggMenuBuilder($menu);
-$menu = $builder->getMenu('name');
-$menu_items = $menu['default'];
+$menu = elgg()->menus->getUnpreparedMenu('site', [
+	'sort_by' => 'name',
+]);
+
+$menu_items = $menu->getItems();
 
 $featured_menu_names = elgg_get_config('site_featured_menu_names');
 


### PR DESCRIPTION
A dedicated menu service provides tools for constructing menus such that hooks and other steps are not forgotten, and not performed more than once.

`elgg()->menus->getMenu` builds a complete menu with all hooks pre-triggered, or `getUnpreparedMenu` can just return a linear menu before the items have been split into sections and run through the `prepare` hook.

In either case, passing these objects to `elgg_view_menu()` completes the preparation process before passing the menu to a view.

Fixes #9508
