### PR TITLE
fix(js): again calls widgets.init in the init, system event

### DIFF
--- a/js/lib/ui.widgets.js
+++ b/js/lib/ui.widgets.js
@@ -213,11 +213,3 @@ elgg.ui.widgets.setMinHeight = function(selector) {
 		}
 	});
 };
-
-require(['jquery'], function ($) {
-	$(function () {
-		require(['elgg/widgets'], function (widgets) {
-			widgets.init();
-		});
-	});
-});

--- a/views/default/elgg/init.js.php
+++ b/views/default/elgg/init.js.php
@@ -18,6 +18,7 @@ foreach (elgg_get_plugins() as $plugin) {
 define(function (require) {
 	var Plugin = require('elgg/Plugin');
 	var elgg = require('elgg');
+	require('elgg/widgets');
 
 	var modules = [];
 	var i;

--- a/views/default/elgg/widgets.js
+++ b/views/default/elgg/widgets.js
@@ -9,5 +9,7 @@ define(function (require) {
 		elgg.ui.widgets.init();
 	};
 
+	elgg.register_hook_handler('init', 'system', w.init);
+
 	return w;
 });


### PR DESCRIPTION
In 2.0 the `widgets.init` was called on `init, system`. In 2.1 it was called whenever the `elgg/widgets` module was loaded, but this introduces the problem that plugins that worked on 2.0 no longer have a reliable blocking point to make sure `widgets.init` has been called.

Due to BC, we cannot require plugins depend on the new `elgg/widgets` module, but we can at least provide assurance that `widgets.init` will have been called after `init, system`.

Hence, we now call it in `init, system` as before, and we delay `elgg/init` until `elgg/widgets` has loaded.

Fixes #9523
