### PR TITLE
UX fixes in discussion reply editing

### DIFF
--- a/mod/discussions/views/default/discussion/discussion.js
+++ b/mod/discussions/views/default/discussion/discussion.js
@@ -30,6 +30,11 @@ elgg.discussion.Reply.prototype = {
 
 	showForm: function () {
 		this.getForm().slideDown('medium').data('hidden', 0);
+		var $form = this.getForm();
+		$form.slideDown('medium').data('hidden', 0);
+		$('body').animate({
+			scrollTop: $form.offset().top
+		}, 500);
 	},
 
 	loadForm: function () {

--- a/mod/discussions/views/default/discussion/discussion.js
+++ b/mod/discussions/views/default/discussion/discussion.js
@@ -34,9 +34,12 @@ elgg.discussion.Reply.prototype = {
 
 	loadForm: function () {
 		var that = this;
-
+		var spinner = require('elgg/spinner');
+		
 		// Get the form using ajax ajax/view/core/ajax/edit_comment
 		elgg.ajax('ajax/view/ajax/discussion/reply/edit?guid=' + this.guid, {
+			beforeSend: spinner.start,
+			complete: spinner.stop,
 			success: function(html) {
 				// Add the form to DOM
 				that.$item.find('.elgg-body').first().append(html);


### PR DESCRIPTION
Show spinner while loading the form
Bring form to viewport once display is toggled (in long discussion replies it's hard to locate it)
