### PR TITLE
feature(ajax): better elgg/Ajax handling of form data

### DIFF
--- a/docs/guides/ajax.rst
+++ b/docs/guides/ajax.rst
@@ -14,7 +14,7 @@ Overview
 
 All the ajax methods perform the following:
 
-#. Client-side, the ``data`` option (if given) is filtered by the hook ``ajax_request_data``.
+#. Client-side, the ``data`` option (if given as an object) is filtered by the hook ``ajax_request_data``.
 #. The request is made to the server, either rendering a view or a form, calling an action, or loading a path.
 #. Echoed JSON is turned into a response object (``Elgg\Services\AjaxResponse``).
 #. The response object is filtered by the hook ``ajax_response``.
@@ -30,9 +30,11 @@ More notes:
 * Elgg gives you a default error handler that shows a generic message if output fails.
 * PHP exceptions or denied resource return HTTP error codes, resulting in use of the client-side error handler.
 * The default HTTP method is ``POST`` for actions, otherwise ``GET``. You can set it via ``options.method``.
+* If a non-empty ``options.data`` is given, the default method is always ``POST``.
 * For client caching, set ``options.method`` to ``"GET"`` and ``options.data.elgg_response_ttl`` to the max-age you want in seconds.
 * To save system messages for the next page load, set ``options.data.elgg_fetch_messages = 0``. You may want to do this if you intent to redirect the user based on the response.
-* To stop client-side API from requiring AMD modules required server-side with `elgg_require_js()`, set ``options.data.elgg_fetch_deps = 0``.
+* To stop client-side API from requiring AMD modules required server-side with ``elgg_require_js()``, set ``options.data.elgg_fetch_deps = 0``.
+* All methods accept a query string in the first argument. This is passed on to the fetch URL, but does not appear in the hook types.
 
 Performing actions
 ------------------
@@ -80,7 +82,11 @@ Notes for actions:
    * client-side ``"ajax_response_data", "action:do_math"`` to filter the response data (before the calling code receives it)
 * CSRF tokens are added to the request data.
 * The default method is ``POST``.
-* Using ``forward()`` in and action simply sends the response. The URL given in not returned to the client.
+* An absolute action URL can be given in place of the action name.
+* Using ``forward()`` in an action simply sends the response. The URL given in not returned to the client.
+
+.. note:: When setting ``data``, use ``ajax.objectify($form)`` instead of ``$form.serialize()``. Doing so allows the
+          ``ajax_request_data`` plugin hook to fire and other plugins to alter/piggyback on the request.
 
 Fetching data
 -------------
@@ -118,6 +124,7 @@ Notes for paths:
 
 * The 3 hooks (see Actions above) will have type ``path:<url_path>``. In this case, "path:myplugin_time".
 * If the page handler echoes a regular web page, ``output`` will be a string containing the HTML.
+* An absolute URL can be given in place of the path name.
 
 Fetching views
 --------------
@@ -236,6 +243,8 @@ Let's say when the view ``foo`` is fetched, we want to also send the server some
     });
 
 This data can be read server-side via ``get_input('bar');``.
+
+.. note:: If data was given as a string (e.g. ``$form.serialize()``), the request hooks are not triggered.
 
 Piggybacking on an Ajax response
 --------------------------------

--- a/engine/classes/Elgg/Ajax/Service.php
+++ b/engine/classes/Elgg/Ajax/Service.php
@@ -247,7 +247,7 @@ class Service {
 	 * @internal
 	 */
 	public function appendDeps($hook, $type, AjaxResponse $response, $params) {
-		$response->getData()->_deps = (array) $this->amd_config->getDependencies();
+		$response->getData()->_elgg_deps = (array) $this->amd_config->getDependencies();
 		return $response;
 	}
 

--- a/js/tests/ElggLegacyAjaxTest.js
+++ b/js/tests/ElggLegacyAjaxTest.js
@@ -1,0 +1,130 @@
+define(function(require) {
+	
+	var elgg = require('elgg');
+	
+	describe("elgg.ajax", function() {
+		var ajax;
+		
+		beforeEach(function() {
+			ajax = $.ajax;
+			
+			$.ajax = function(options) {
+				return options;
+			};
+		});
+		
+		afterEach(function() {
+			$.ajax = ajax;
+		});
+		
+		it("requests elgg.config.wwwroot by default", function() {
+			expect(elgg.ajax().url).toBe(elgg.config.wwwroot);
+		});
+		
+		it("can issue a GET using elgg.get()", function() {
+			expect(elgg.get().type).toBe('get');	
+		});
+		
+		it("can issue a POST using elgg.post()", function() {
+			expect(elgg.post().type).toBe('post');	
+		});
+	
+		it("can request JSON with elgg.getJSON()", function() {
+			expect(elgg.getJSON().dataType).toBe('json');
+		});
+	
+		describe("handleOptions", function() {
+		
+			it("accepts handleOptions()", function() {
+				expect(elgg.ajax.handleOptions()).not.toBe(undefined);
+			});
+			
+			it("accepts handleOptions(url)", function() {
+				var url = 'http://google.com',
+					result = elgg.ajax.handleOptions(url);
+				
+				expect(result.url).toBe(url);
+			});
+			
+			it("interprets a POJO as data", function() {
+				var options = {},
+					result = elgg.ajax.handleOptions(options);
+				
+				expect(result.data).toBe(options);	
+			});
+			
+			it("interprets a POJO with a data field as full options", function() {
+				var options = {data:{arg:1}},
+					result = elgg.ajax.handleOptions(options);
+				
+				expect(result).toBe(options);
+			});
+			
+			it("interprets a POJO with a function as full options", function() {
+				function func() {}
+				var options = {success: func};
+				var result = elgg.ajax.handleOptions(options);
+				
+				expect(result).toBe(options);		
+			});
+			
+			it("accepts handleOptions(url, data)", function() {
+				var url = 'url',
+					data = {arg:1},
+					result = elgg.ajax.handleOptions(url, data);
+				
+				expect(result.url).toBe(url);
+				expect(result.data).toBe(data);
+			});
+			
+			it("accepts handleOptions(url, successCallback)", function() {
+				var url = 'http://google.com',
+				result = elgg.ajax.handleOptions(url, elgg.nullFunction);
+				
+				expect(result.url).toBe(url);
+				expect(result.success).toBe(elgg.nullFunction);
+			});
+			
+			it("accepts handleOptions(url, options)", function() {
+				var url = 'url',
+				    options = {data:{arg:1}},
+				    result = elgg.ajax.handleOptions(url, options);
+				
+				expect(result.url).toBe(url);
+				expect(result.data).toBe(options.data);
+			});
+		});
+
+		describe("elgg.action()", function() {
+			it("issues a POST request", function() {
+				var result = elgg.action('action');
+				expect(result.type).toBe('post');
+			});
+			
+			it("expects a JSON response", function() {
+				var result = elgg.action('action');
+				expect(result.dataType).toBe('json');			
+			});
+	
+			it("accepts action names", function() {
+				var result = elgg.action('action');
+				expect(result.url).toBe(elgg.config.wwwroot + 'action/action');
+			});
+			
+			it("accepts action URLs", function() {
+				var result = elgg.action(elgg.config.wwwroot + 'action/action');
+				expect(result.url).toBe(elgg.config.wwwroot + 'action/action');
+			});
+			
+			it("includes CSRF tokens automatically in the request", function() {
+				var result = elgg.action('action');
+				expect(result.data.__elgg_ts).toBe(elgg.security.token.__elgg_ts);
+			});
+	
+			it("throws an exception if you don't specify an action", function() {
+				expect(function() { elgg.action(); }).toThrow();
+				expect(function() { elgg.action({}); }).toThrow();
+			});
+		});
+	});
+});

--- a/js/tests/prepare.js
+++ b/js/tests/prepare.js
@@ -2,6 +2,10 @@
 
 var elgg = elgg || {};
 
+elgg.config = elgg.config || {};
+
+elgg.config.wwwroot = 'http://www.elgg.org/';
+
 define('elgg', function() {
 	return elgg;
 });
@@ -32,7 +36,6 @@ define('elgg/init', function (require) {
 	var elgg = require('elgg');
 	var plugin = require('boot/example');
 
-	console.log(plugin);
 	plugin._init();
 
 	elgg.trigger_hook('init', 'system');

--- a/views/default/elgg/Ajax.js
+++ b/views/default/elgg/Ajax.js
@@ -3,6 +3,13 @@ define(function (require) {
 	var elgg = require('elgg');
 	var spinner = require('elgg/spinner');
 
+	var site_url = elgg.get_site_url(),
+		action_base = site_url + 'action/',
+		fragment_pattern = /#.*$/,
+		query_pattern = /\?.*$/,
+		leading_slash_pattern = /^\//,
+		slashes_pattern = /(^\/|\/$)/g;
+
 	/**
 	 * Module constructor
 	 *
@@ -29,8 +36,8 @@ define(function (require) {
 		 *     url   : {String} Path of the Ajax API endpoint (required)
 		 *     error : {Function} Error handler. Default is elgg.ajax.handleAjaxError. To cancel this altogether,
 		 *                        pass in function(){}.
-		 *     data  : {Object} Data to send to the server (optional). Unlike jQuery, you cannot set this
-		 *                      to a string.
+		 *     data  : {Object} Data to send to the server (optional). If set to a string (e.g. $.serialize)
+		 *                      then the request hook will not be called.
 		 *
 		 * @param {String} hook_type Type of the plugin hooks. If missing, the hooks will not trigger.
 		 *
@@ -38,9 +45,9 @@ define(function (require) {
 		 */
 		function fetch(options, hook_type) {
 			var orig_options,
-					params,
-					unwrapped = false,
-					result;
+				params,
+				unwrapped = false,
+				result;
 
 			function unwrap_data(data) {
 				// between the deferred and a success function, make sure this runs only once.
@@ -59,21 +66,26 @@ define(function (require) {
 
 			hook_type = hook_type || '';
 
-			if (!$.isPlainObject(options) || !options.url) {
+			if (!$.isPlainObject(options)) {
+				throw new Error('options must be a plain object with key "url"');
+			}
+			if (!options.url && hook_type !== 'path:') {
 				throw new Error('options must be a plain object with key "url"');
 			}
 
 			// ease hook filtering by making these keys always available
-			if (options.data === undefined || $.isPlainObject(options.data)) {
+			if (options.data === undefined) {
+				options.data = {};
+			}
+			if ($.isPlainObject(options.data)) {
 				options.data = options.data || {};
 			} else {
-				throw new Error('if defined, options.data must be a plain object');
+				if (typeof options.data !== 'string') {
+					throw new Error('if defined, options.data must be a plain object or string');
+				}
 			}
 
 			options.dataType = 'json';
-			if (!options.method) {
-				options.method = 'GET';
-			}
 
 			// copy of original options
 			orig_options = $.extend({}, options);
@@ -81,8 +93,17 @@ define(function (require) {
 			params = {
 				options: options
 			};
-			if (hook_type) {
+			if (hook_type && typeof options.data !== 'string') {
 				options.data = elgg.trigger_hook(Ajax.REQUEST_DATA_HOOK, hook_type, params, options.data);
+			}
+
+			// we do this here because hook may have made data non-empty, in which case we'd need to
+			// default to POST
+			if (!options.method) {
+				options.method = 'GET';
+				if (options.data && !$.isEmptyObject(options.data)) {
+					options.method = 'POST';
+				}
 			}
 
 			if ($.isArray(options.success)) {
@@ -124,17 +145,28 @@ define(function (require) {
 		 *
 		 * See fetch() for more options.
 		 *
-		 * @param {String} path    URL path. e.g. "foo/bar"
+		 * @param {String} path    path or URL. e.g. "foo/bar"
 		 * @param {Object} options {@link jQuery#ajax}. See fetch()
 		 * @returns {jqXHR}
 		 */
 		this.path = function (path, options) {
 			elgg.assertTypeOf('string', path);
 
+			// https://example.org/elgg/foo/?arg=1#bar => foo/?arg=1
+			if (path.indexOf(site_url) === 0) {
+				path = path.substr(site_url.length);
+			}
+			path = path.replace(fragment_pattern, '');
+
+			assertNotUrl(path);
+
 			options = options || {};
 			options.url = path;
-			
-			return fetch(options, 'path:' + path.replace(/\/$/, ''));
+
+			// /foo/?arg=1 => foo
+			path = path.replace(query_pattern, '').replace(slashes_pattern, '');
+
+			return fetch(options, 'path:' + path);
 		};
 
 		/**
@@ -148,9 +180,17 @@ define(function (require) {
 		 */
 		this.view = function (view, options) {
 			elgg.assertTypeOf('string', view);
+			if (view === '') {
+				throw new Error('view cannot be empty');
+			}
+
+			assertNotUrl(view);
 
 			options = options || {};
 			options.url = 'ajax/view/' + view;
+
+			// remove query
+			view = view.replace(query_pattern, '').replace(slashes_pattern, '');
 
 			return fetch(options, 'view:' + view);
 		};
@@ -160,15 +200,25 @@ define(function (require) {
 		 *
 		 * See fetch() for more options.
 		 *
-		 * @param {String} action  Action name
+		 * @param {String} action  Action name or URL
 		 * @param {Object} options {@link jQuery#ajax}. See fetch()
 		 * @returns {jqXHR}
 		 */
 		this.form = function (action, options) {
 			elgg.assertTypeOf('string', action);
+			if (action === '') {
+				throw new Error('action cannot be empty');
+			}
+
+			action = action.replace(leading_slash_pattern, '').replace(fragment_pattern, '');
+
+			assertNotUrl(action);
 
 			options = options || {};
 			options.url = 'ajax/form/' + action;
+
+			// remove query
+			action = action.replace(query_pattern, '').replace(slashes_pattern, '');
 
 			return fetch(options, 'form:' + action);
 		};
@@ -178,20 +228,80 @@ define(function (require) {
 		 *
 		 * See fetch() for more options.
 		 *
-		 * @param {String} action  Action name
+		 * @param {String} action  Action name or URL
 		 * @param {Object} options jQuery.ajax options. See fetch()
 		 * @returns {jqXHR}
 		 */
 		this.action = function (action, options) {
 			elgg.assertTypeOf('string', action);
+			if (action === '') {
+				throw new Error('action cannot be empty');
+			}
+
+			// https://example.org/elgg/action/foo/?arg=1#bar => foo/?arg=1
+			if (action.indexOf(action_base) === 0) {
+				action = action.substr(action_base.length);
+			}
+			action = action.replace(leading_slash_pattern, '').replace(fragment_pattern, '');
+
+			assertNotUrl(action);
 
 			options = options || {};
-			options.url = 'action/' + action;
-			options.data = elgg.security.addToken(options.data || {});
+			options.data = options.data || {};
+
+			// add tokens?
+			var m = action.match(/\?(.+)$/);
+			if (m && /(^|&)__elgg_ts=/.test(m[1])) {
+				// token will be in the URL
+			} else {
+				options.data = elgg.security.addToken(options.data);
+			}
+
 			options.method = options.method || 'POST';
+			options.url = 'action/' + action;
+
+			// /foo/?arg=1 => foo
+			action = action.replace(query_pattern, '').replace(slashes_pattern, '');
 
 			return fetch(options, 'action:' + action);
 		};
+
+		/**
+		 * Convert a form/element to a data object. Use this instead of $.serialize to allow other plugins
+		 * to alter the request by plugin hook.
+		 *
+		 * @param {*} el HTML element or CSS selector
+		 * @returns {Object}
+		 */
+		this.objectify = function (el) {
+			// http://stackoverflow.com/a/1186309/3779
+			var o = {};
+			var a = $(el).serializeArray();
+
+			$.each(a, function() {
+				if (o[this.name] !== undefined) {
+					if (!o[this.name].push) {
+						o[this.name] = [o[this.name]];
+					}
+					o[this.name].push(this.value || '');
+				} else {
+					o[this.name] = this.value || '';
+				}
+			});
+
+			return o;
+		};
+	}
+
+	/**
+	 * Throw if this looks like a URL.
+	 *
+	 * @param {String} arg
+	 */
+	function assertNotUrl(arg) {
+		if (/^https?:/.test(arg)) {
+			throw new Error('elgg/Ajax cannot be used with external URLs');
+		}
 	}
 
 	/**
@@ -208,19 +318,31 @@ define(function (require) {
 	 */
 	Ajax.RESPONSE_DATA_HOOK = 'ajax_response_data';
 
-	// handle system messages
-	elgg.register_hook_handler(Ajax.RESPONSE_DATA_HOOK, 'all', function (name, type, params, data) {
-		var m = data._elgg_msgs;
-		m && m.error && elgg.register_error(m.error);
-		m && m.success && elgg.system_message(m.success);
-		delete data._elgg_msgs;
+	/**
+	 * Sets up response hook for all responses
+	 * @private For testing
+	 */
+	Ajax._init_hooks = function () {
+		elgg.register_hook_handler(Ajax.RESPONSE_DATA_HOOK, 'all', function (name, type, params, data) {
+			var m = data._elgg_msgs;
+			m && m.error && elgg.register_error(m.error);
+			m && m.success && elgg.system_message(m.success);
+			delete data._elgg_msgs;
 
-		var deps = data._deps;
-		deps.length && require(deps);
-		delete data._deps;
+			var deps = data._elgg_deps;
+			deps && deps.length && Ajax._require(deps);
+			delete data._elgg_deps;
 
-		return data;
-	});
+			return data;
+		});
+	};
+
+	Ajax._init_hooks();
+
+	/**
+	 * @private For testing
+	 */
+	Ajax._require = require;
 
 	return Ajax;
 });


### PR DESCRIPTION
As `jQuery.serialize` is often used to set post data, this change allows a string form of `options.data` to be passed through. In this case, however, we do not trigger the request hook, as handlers expect an object.

Because we want requests to be hookable, we nudge devs toward a new `objectify` method, which "serializes" to an object so it can be passed through the hook.

All methods now accept a query string that gets passed to the underlying URL, but does not appear in the hook types. `action()` and `path()` accept absolute site URLs, as one might get from `$anchor.prop('href')`.

Fixes #9534
Fixes #9564
