### PR TITLE
chore(db): allign all GUID columns to be of the same type

### DIFF
--- a/engine/lib/upgrades/2016032300-2.1.1-schema_column_align-2d5edc276a8aee13.php
+++ b/engine/lib/upgrades/2016032300-2.1.1-schema_column_align-2d5edc276a8aee13.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Elgg 2.1.1 upgrade 2016032300
+ * schema_column_align
+ *
+ * Align all GUID columns to be of the same type
+ */
+
+$dbprefix = elgg_get_config('dbprefix');
+
+// Access collection membership
+update_data("ALTER TABLE {$dbprefix}access_collection_membership MODIFY COLUMN user_guid bigint(20) unsigned NOT NULL");
+
+// Config
+update_data("ALTER TABLE {$dbprefix}config MODIFY COLUMN site_guid bigint(20) unsigned NOT NULL");
+
+// Private settings
+update_data("ALTER TABLE {$dbprefix}private_settings MODIFY COLUMN entity_guid bigint(20) unsigned NOT NULL");
+
+// River
+update_data("ALTER TABLE {$dbprefix}river MODIFY COLUMN subject_guid bigint(20) unsigned NOT NULL");
+update_data("ALTER TABLE {$dbprefix}river MODIFY COLUMN object_guid bigint(20) unsigned NOT NULL");
+update_data("ALTER TABLE {$dbprefix}river MODIFY COLUMN target_guid bigint(20) unsigned NOT NULL");
+
+// System log
+update_data("ALTER TABLE {$dbprefix}system_log MODIFY COLUMN performed_by_guid bigint(20) unsigned NOT NULL");
+update_data("ALTER TABLE {$dbprefix}system_log MODIFY COLUMN owner_guid bigint(20) unsigned NOT NULL");

--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -4,7 +4,7 @@
 
 -- record membership in an access collection
 CREATE TABLE `prefix_access_collection_membership` (
-  `user_guid` int(11) NOT NULL,
+  `user_guid` bigint(20) unsigned NOT NULL,
   `access_collection_id` int(11) NOT NULL,
   PRIMARY KEY (`user_guid`,`access_collection_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
@@ -54,7 +54,7 @@ CREATE TABLE `prefix_api_users` (
 CREATE TABLE `prefix_config` (
   `name` varchar(255) NOT NULL,
   `value` text NOT NULL,
-  `site_guid` int(11) NOT NULL,
+  `site_guid` bigint(20) unsigned NOT NULL,
   PRIMARY KEY (`name`,`site_guid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
@@ -180,7 +180,7 @@ CREATE TABLE `prefix_objects_entity` (
 -- settings for an entity
 CREATE TABLE `prefix_private_settings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `entity_guid` int(11) NOT NULL,
+  `entity_guid` bigint(20) unsigned NOT NULL,
   `name` varchar(128) NOT NULL,
   `value` text NOT NULL,
   PRIMARY KEY (`id`),
@@ -209,9 +209,9 @@ CREATE TABLE `prefix_river` (
   `action_type` varchar(32) NOT NULL,
   `access_id` int(11) NOT NULL,
   `view` text NOT NULL,
-  `subject_guid` int(11) NOT NULL,
-  `object_guid` int(11) NOT NULL,
-  `target_guid` int(11) NOT NULL,
+  `subject_guid` bigint(20) unsigned NOT NULL,
+  `object_guid` bigint(20) unsigned NOT NULL,
+  `target_guid` bigint(20) unsigned NOT NULL,
   `annotation_id` int(11) NOT NULL,
   `posted` int(11) NOT NULL,
   `enabled` enum('yes','no') NOT NULL DEFAULT 'yes',
@@ -245,8 +245,8 @@ CREATE TABLE `prefix_system_log` (
   `object_type` varchar(50) NOT NULL,
   `object_subtype` varchar(50) NOT NULL,
   `event` varchar(50) NOT NULL,
-  `performed_by_guid` int(11) NOT NULL,
-  `owner_guid` int(11) NOT NULL,
+  `performed_by_guid` bigint(20) unsigned NOT NULL,
+  `owner_guid` bigint(20) unsigned NOT NULL,
   `access_id` int(11) NOT NULL,
   `enabled` enum('yes','no') NOT NULL DEFAULT 'yes',
   `time_created` int(11) NOT NULL,

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2015062900;
+$version = 2016032300;
 
 $composerJson = file_get_contents(dirname(__FILE__) . "/composer.json");
 if ($composerJson === false) {


### PR DESCRIPTION
Not all GUID columns were of the same datatype, this could cause
problems in (very) large databases

fixes #1430
- [ ] rebased for 2.x
- [ ] new upgrade file
- [ ] mention in docs/admin/upgrading.rst
