### PR TITLE
Fixes various issues related to ajax tokens and ajax errors

### DIFF
--- a/js/lib/ajax.js
+++ b/js/lib/ajax.js
@@ -102,6 +102,11 @@ elgg.ajax.handleOptions = function(url, options) {
  * @private
  */
 elgg.ajax.handleAjaxError = function(xhr, status, error) {
+	if (!xhr.getAllResponseHeaders()) {
+		// user aborts (like refresh or navigate) do not have headers
+		return;
+	}
+	
 	elgg.register_error(elgg.echo('ajax:error'));
 };
 

--- a/js/lib/security.js
+++ b/js/lib/security.js
@@ -35,14 +35,17 @@ elgg.security.setToken = function(json) {
  * @private
  */
 elgg.security.refreshToken = function() {
-	elgg.getJSON('refresh_token', function(data) {
-		if (data && data.__elgg_ts && data.__elgg_token) {
-			elgg.security.setToken(data);
-			if (elgg.is_logged_in() && data.logged_in === false) {
-				elgg.session.user = null;
-				elgg.register_error(elgg.echo('session_expired'));
+	elgg.getJSON('refresh_token', {
+		success: function(data) {
+			if (data && data.__elgg_ts && data.__elgg_token) {
+				elgg.security.setToken(data);
+				if (elgg.is_logged_in() && data.logged_in === false) {
+					elgg.session.user = null;
+					elgg.register_error(elgg.echo('session_expired'));
+				}
 			}
-		}
+		},
+		error: function() {},
 	});
 };
 

--- a/js/lib/security.js
+++ b/js/lib/security.js
@@ -24,8 +24,8 @@ elgg.security.setToken = function(json) {
 	// also update all links that contain tokens and time stamps
 	$('[href*="__elgg_ts"][href*="__elgg_token"]').each(function() {
 		this.href = this.href
-			.replace(/__elgg_ts=\d*/, '__elgg_ts=' + json.__elgg_ts)
-			.replace(/__elgg_token=[0-9a-f]*/, '__elgg_token=' + json.__elgg_token);
+			.replace(/__elgg_ts=\d*/i, '__elgg_ts=' + json.__elgg_ts)
+			.replace(/__elgg_token=[0-9a-z_-]*/i, '__elgg_token=' + json.__elgg_token);
 	});
 };
 


### PR DESCRIPTION
the fix for the token replacement in the urls is important... when we swiched to sha256 encoded tokens instead of md5 the regex that replaced the tokens in the urls was broken. This means that after a token_refresh the links with action tokens are broken
