### PR TITLE
chore(releases): commits can build release notes for the next release

### DIFF
--- a/docs/contribute/code.rst
+++ b/docs/contribute/code.rst
@@ -158,6 +158,23 @@ or symlink to it in the directory ``.git/hooks/commit-msg``.
     chmod u+x .scripts/validate_commit_msg.php
     ln -s .scripts/validate_commit_msg.php .git/hooks/commit-msg/validate_commit_msg.php
 
+Adding release notes
+--------------------
+
+If a commit adds a critical change that users/developers should know about (e.g. deprecates an API), you may want
+to add notes to the next release. Just add them to the top of ``CHANGELOG.md`` with a line break in between. E.g.
+
+.. code::
+
+	These are notes to go with the 9.0.1 release.
+
+	<a name="9.0.0"></a>
+	### 9.0.0  (2025-01-01)
+
+	...
+
+.. note:: Release notes may not contain the string ``<a name="``.
+
 Rewriting commit messages
 -------------------------
 If your PR does not conform to the standard commit message format, we'll ask you to rewrite it.

--- a/docs/contribute/releases.rst
+++ b/docs/contribute/releases.rst
@@ -47,6 +47,8 @@ Install the prerequisites:
    easy_install sphinx-intl
    easy_install transifex-client
 
+Check the top of ``CHANGELOG.md`` for any release notes. Clean and tighten language if necessary. The release script will update this file.
+
 Run the ``release.php`` script. For example, to release 1.9.1:
 
 .. code:: sh

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "node_modules/karma/bin/karma start js/tests/karma.conf.js --single-run"
   },
   "devDependencies": {
-    "elgg-conventional-changelog": "~0.1.2",
+    "elgg-conventional-changelog": "~0.1.4",
     "grunt": "~0.4.5",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-connect": "~0.9.0",


### PR DESCRIPTION
Commits can add notes to the top of `CHANGELOG.md`. When the next release is built, these notes are placed between the new version header and the contributors list.

In all tagged releases, changelog will appear as usual, but work branches may have notes for the next release at the top.

Fixes #9489
