### PR TITLE
feature(views): adds API to register view dependencies on AMD modules

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -396,6 +396,30 @@ function elgg_unextend_view($view, $view_extension) {
 }
 
 /**
+ * Registers an AMD module as a view dependency
+ * 
+ * @param string $view   View name
+ * @param string $module AMD module name
+ * @return void
+ * @since 2.2
+ */
+function elgg_require_for_view($view, $module) {
+	return _elgg_services()->views->addDep($view, $module);
+}
+
+/**
+ * Unregister an AMD module from view dependencies
+ *
+ * @param string $view   View name
+ * @param string $module AMD module name
+ * @return bool
+ * @since 2.2
+ */
+function elgg_unrequire_for_view($view, $module) {
+	return _elgg_services()->views->removeDep($view, $module);
+}
+
+/**
  * Assembles and outputs a full page.
  *
  * A "page" in Elgg is determined by the current view type and

--- a/engine/tests/phpunit/Elgg/ViewsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ViewsServiceTest.php
@@ -175,5 +175,18 @@ class ViewsServiceTest extends \PHPUnit_Framework_TestCase {
 			['view.jpg', 'css/view.jpg'],
 		];
 	}
+
+	public function testRequiredModuleIsLoadedOnViewRendering() {
+		$this->views->addDep('foo', 'static');
+		$this->views->renderView('foo');
+		$this->assertTrue(in_array('static', _elgg_services()->amdConfig->getDependencies()));
+	}
+
+	public function testCanUnrequireModuleForView() {
+		$this->views->addDep('foo', 'interpreted');
+		$this->views->removeDep('foo', 'interpreted');
+		$this->views->renderView('foo');
+		$this->assertFalse(in_array('interpreted', _elgg_services()->amdConfig->getDependencies()));
+	}
 }
 

--- a/engine/tests/phpunit/test_files/views/default/foo.php
+++ b/engine/tests/phpunit/test_files/views/default/foo.php
@@ -1,0 +1,3 @@
+<?php
+
+echo 'Hello';

--- a/mod/blog/lib/blog.php
+++ b/mod/blog/lib/blog.php
@@ -140,8 +140,6 @@ function blog_get_page_content_archive($owner_guid, $lower = 0, $upper = 0) {
  */
 function blog_get_page_content_edit($page, $guid = 0, $revision = NULL) {
 
-	elgg_require_js('elgg/blog/save_draft');
-
 	$return = array(
 		'filter' => '',
 	);
@@ -179,8 +177,6 @@ function blog_get_page_content_edit($page, $guid = 0, $revision = NULL) {
 			elgg_push_breadcrumb($blog->title, $blog->getURL());
 			elgg_push_breadcrumb(elgg_echo('edit'));
 			
-			elgg_require_js('elgg/blog/save_draft');
-
 			$content = elgg_view_form('blog/save', $vars, $body_vars);
 			$sidebar = elgg_view('blog/sidebar/revisions', $vars);
 		} else {

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -71,6 +71,8 @@ function blog_init() {
 
 	// allow to be liked
 	elgg_register_plugin_hook_handler('likes:is_likable', 'object:blog', 'Elgg\Values::getTrue');
+
+	elgg_require_for_view('forms/blog/save', 'elgg/blog/save_draft');
 }
 
 /**

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -116,6 +116,8 @@ function groups_init() {
 	// Help core resolve page owner guids from group routes
 	// Registered with an earlier priority to be called before default_page_owner_handler()
 	elgg_register_plugin_hook_handler('page_owner', 'system', 'groups_default_page_owner_handler', 400);
+
+	elgg_require_for_view('groups/edit', 'elgg/groups/edit');
 }
 
 /**

--- a/mod/groups/views/default/resources/groups/add.php
+++ b/mod/groups/views/default/resources/groups/add.php
@@ -2,8 +2,6 @@
 
 elgg_gatekeeper();
 
-elgg_require_js('elgg/groups/edit');
-
 elgg_set_page_owner_guid(elgg_get_logged_in_user_guid());
 $title = elgg_echo('groups:add');
 elgg_push_breadcrumb($title);

--- a/mod/groups/views/default/resources/groups/edit.php
+++ b/mod/groups/views/default/resources/groups/edit.php
@@ -2,8 +2,6 @@
 
 elgg_gatekeeper();
 
-elgg_require_js('elgg/groups/edit');
-
 $guid = elgg_extract('guid', $vars);
 $title = elgg_echo("groups:edit");
 $group = get_entity($guid);


### PR DESCRIPTION
elgg_require_for_view() and elgg_unrequire_for_view() can now be used to control
which AMD modules are required when the view is rendered

Refs #8373
- [ ] Resolve more discussion in #8373 before moving ahead with this
