### PR TITLE
feature(ajax): Ajax service now loads required AMD modules 

### DIFF
--- a/docs/guides/ajax.rst
+++ b/docs/guides/ajax.rst
@@ -32,6 +32,7 @@ More notes:
 * The default HTTP method is ``POST`` for actions, otherwise ``GET``. You can set it via ``options.method``.
 * For client caching, set ``options.method`` to ``"GET"`` and ``options.data.elgg_response_ttl`` to the max-age you want in seconds.
 * To save system messages for the next page load, set ``options.data.elgg_fetch_messages = 0``. You may want to do this if you intent to redirect the user based on the response.
+* To stop client-side API from requiring AMD modules required server-side with `elgg_require_js()`, set ``options.data.elgg_fetch_deps = 0``.
 
 Performing actions
 ------------------
@@ -283,6 +284,18 @@ To capture the metadata send back to the client, we use the client-side ``ajax_r
 .. note:: Only ``data.value`` is returned to the ``success`` function or available via the `Deferred` interface.
 
 .. note:: Elgg uses these same hooks to deliver system messages over ``elgg/Ajax`` responses.
+
+
+Requiring AMD modules
+---------------------
+
+Each response from an Ajax service will contain a list of AMD modules required server side with `elgg_require_js()`.
+When response data is unwrapped, these modules will be loaded asynchronously - plugins should not expect these
+modules to be loaded in their `$.done()` and `$.then()` handlers and must use `require()` for any modules they depend on.
+Additionally AMD modules should not expect the DOM to have been altered by an Ajax request when they are loaded -
+DOM events should be delegated and manipulations on DOM elements should be delayed until all Ajax requests have been
+resolved.
+
 
 Legacy elgg.ajax APIs
 =====================

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -109,7 +109,7 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setClassName('adminNotices', \Elgg\Database\AdminNotices::class);
 
 		$this->setFactory('ajax', function(ServiceProvider $c) {
-			return new \Elgg\Ajax\Service($c->hooks, $c->systemMessages, $c->input);
+			return new \Elgg\Ajax\Service($c->hooks, $c->systemMessages, $c->input, $c->amdConfig);
 		});
 
 		$this->setFactory('amdConfig', function(ServiceProvider $c) {

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1692,8 +1692,6 @@ function elgg_views_boot() {
 	elgg_load_css('elgg');
 
 	elgg_register_simplecache_view('elgg/init.js');
-	elgg_require_js('elgg/init');
-	elgg_require_js('elgg/ready');
 
 	// optional stuff
 	elgg_register_js('lightbox', elgg_get_simplecache_url('lightbox.js'));

--- a/views/default/elgg.js.php
+++ b/views/default/elgg.js.php
@@ -98,3 +98,5 @@ if (!window._require_queue) {
 }
 
 elgg.trigger_hook('boot', 'system');
+
+require(['elgg/init', 'elgg/ready']);

--- a/views/default/elgg/Ajax.js
+++ b/views/default/elgg/Ajax.js
@@ -38,9 +38,9 @@ define(function (require) {
 		 */
 		function fetch(options, hook_type) {
 			var orig_options,
-				params,
-				unwrapped = false,
-				result;
+					params,
+					unwrapped = false,
+					result;
 
 			function unwrap_data(data) {
 				// between the deferred and a success function, make sure this runs only once.
@@ -133,7 +133,7 @@ define(function (require) {
 
 			options = options || {};
 			options.url = path;
-
+			
 			return fetch(options, 'path:' + path.replace(/\/$/, ''));
 		};
 
@@ -214,6 +214,11 @@ define(function (require) {
 		m && m.error && elgg.register_error(m.error);
 		m && m.success && elgg.system_message(m.success);
 		delete data._elgg_msgs;
+
+		var deps = data._deps;
+		deps.length && require(deps);
+		delete data._deps;
+
 		return data;
 	});
 


### PR DESCRIPTION
AMD modules required server-side with elgg_require_js() are now recognized
and loaded by the Ajax service upon a successfull request client-side.
