### PR TITLE
fix(developers): restores missing event/hook handlers in inspector

### DIFF
--- a/engine/classes/Elgg/Debug/Inspector.php
+++ b/engine/classes/Elgg/Debug/Inspector.php
@@ -342,13 +342,14 @@ class Inspector {
 
 		foreach ($all_handlers as $hook => $types) {
 			foreach ($types as $type => $priorities) {
-				foreach ($priorities as $priority => $handlers) {
+				ksort($priorities);
 
-					array_walk($handlers, function (&$callable) use ($root, $priority) {
+				foreach ($priorities as $priority => $handlers) {
+					foreach ($handlers as $callable) {
 						$description = $this->describeCallable($callable, $root);
 						$callable = "$priority: $description";
-					});
-					$tree[$hook . ',' . $type] = $handlers;
+						$tree["$hook, $type"][] = $callable;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #9527
