### PR TITLE
chore(tests): allow running JS tests in Chrome

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+See http://learn.elgg.org/en/2.0/contribute/docs.html

--- a/docs/contribute/code.rst
+++ b/docs/contribute/code.rst
@@ -236,7 +236,22 @@ You can also run tests continuously during development so they run on each save:
 
    karma start js/tests/karma.conf.js
 
+Debugging JS tests
+^^^^^^^^^^^^^^^^^^
 
+You can run the test suite inside Chrome dev tools:
+
+.. code::
+
+   npm run chrome
+
+This will output a URL like ``http://localhost:9876/``.
+
+#. Open the URL in Chrome, and click "Debug".
+#. Open Chrome dev tools and the Console tab.
+#. Reload the page.
+
+If you alter a test you'll have to quit Karma with ``Ctrl-c`` and restart it.
 
 Coding best practices
 =====================

--- a/js/tests/README.md
+++ b/js/tests/README.md
@@ -1,0 +1,1 @@
+See http://learn.elgg.org/en/2.0/contribute/code.html#jasmine-tests

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "homepage": "https://github.com/Elgg/Elgg",
   "scripts": {
-    "test": "node_modules/karma/bin/karma start js/tests/karma.conf.js --single-run"
+    "test": "node_modules/karma/bin/karma start js/tests/karma.conf.js --single-run",
+    "chrome": "node_modules/karma/bin/karma start js/tests/karma.conf.js --browsers Chrome"
   },
   "devDependencies": {
     "elgg-conventional-changelog": "~0.1.2",
@@ -24,6 +25,7 @@
     "grunt-open": "~0.2.3",
     "karma": "^0.12.32",
     "karma-jasmine": "~0.2.0",
+    "karma-chrome-launcher": "^0.2.3",
     "karma-phantomjs-launcher": "~0.1",
     "karma-requirejs": "~0.2",
     "load-grunt-config": "~0.16.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "karma-phantomjs-launcher": "~0.1",
     "karma-requirejs": "~0.2",
     "load-grunt-config": "~0.16.0",
-    "phantomjs": "~1.9.7-14"
+    "phantomjs": "~1.9.7-14",
+    "requirejs": "~2.2.0"
   }
 }


### PR DESCRIPTION
Adds a couple README links to docs.

Also updates `requirejs` to 2.2, as 2.1 was no longer available. Maybe due to
the kik/left-pad fiasco.
