### PR TITLE
WIP feature(js): hooks overhaul including async triggering

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -124,6 +124,18 @@ Miscellaneous API changes
  * ``elgg_list_registered_entities`` no longer supports the option ``view_type_toggle``
  * ``elgg_log`` no longer accepts the level ``"DEBUG"``
 
+JavaScript hook calling order may change
+----------------------------------------
+
+When registering for hooks, the ``all`` keyword for wildcard matching no longer has any effect
+on the order that handlers are called. To ensure your handler is called last, you must give it the
+highest priority of all matching handlers, or to ensure your handler is called first, you must give
+it the lowest priority of all matching handlers.
+
+If handlers were registered with the same priority, these are called in the order they were registered.
+
+To emulate prior behavior, Elgg core handlers registered with the ``all`` keyword have been raised in
+priority. Some of these handlers will most likely be called in a different order.
 
 From 2.0 to 2.1
 ===============

--- a/js/lib/hooks.js
+++ b/js/lib/hooks.js
@@ -6,24 +6,94 @@ elgg.provide('elgg.config.hooks');
 elgg.provide('elgg.config.instant_hooks');
 elgg.provide('elgg.config.triggered_hooks');
 
+!function() {
+	// counter for tracking registration order
+	var index = 0;
+
+	/**
+	 * Registers a hook handler with the event system.
+	 *
+	 * For best results, depend on the elgg/ready module, so plugins will have been booted.
+	 *
+	 * The special keyword "all" can be used for either the name or the type or both
+	 * and means to call that handler for all of those hooks.
+	 *
+	 * Note that handlers registering for instant hooks will be executed immediately if the instant
+	 * hook has been previously triggered.
+	 *
+	 * @param {String}   name     The hook name.
+	 * @param {String}   type     The hook type.
+	 * @param {Function} handler  Handler to call: function(hook, type, params, value)
+	 * @param {Number}   priority Priority to call the event handler
+	 * @return {Boolean}
+	 */
+	elgg.register_hook_handler = function(name, type, handler, priority) {
+		return register(name, type, handler, priority, false);
+	};
+
+	/**
+	 * Registers an asynchronous hook handler with the event system.
+	 *
+	 * Async handlers will only be called be elgg.trigger_async_hook() and will receive a 5th argument,
+	 * which is a function to resolve the value. The handler must eventually call the resolve argument
+	 * passing in the new hook value.
+	 *
+	 * @see elgg.register_hook_handler
+	 *
+	 * @param {String}   name     The hook name.
+	 * @param {String}   type     The hook type.
+	 * @param {Function} handler  Handler to call: function(hook, type, params, value, resolve)
+	 * @param {Number}   priority Priority to call the event handler
+	 * @return {Boolean}
+	 */
+	elgg.register_async_hook_handler = function(name, type, handler, priority) {
+		return register(name, type, handler, priority, true);
+	};
+
+	/**
+	 * @private
+	 */
+	function register(name, type, handler, priority, async) {
+		elgg.assertTypeOf('string', name);
+		elgg.assertTypeOf('string', type);
+		elgg.assertTypeOf('function', handler);
+
+		if (!name || !type) {
+			return false;
+		}
+
+		var hooks = elgg.config.hooks;
+
+		elgg.provide([name, type], hooks);
+
+		if (!hooks[name][type].length) {
+			hooks[name][type] = [];
+		}
+
+		// call if instant and already triggered.
+		if (elgg.is_instant_hook(name, type) && elgg.is_triggered_hook(name, type)) {
+			handler(name, type, null, null);
+		}
+
+		hooks[name][type].push({
+			priority: priority,
+			index: index++,
+			handler: handler,
+			async: async
+		});
+		return true;
+	}
+}();
+
 /**
- * Registers a hook handler with the event system.
+ * Unregister a registered handler for a hook
  *
- * For best results, depend on the elgg/ready module, so plugins will have been booted.
- *
- * The special keyword "all" can be used for either the name or the type or both
- * and means to call that handler for all of those hooks.
- *
- * Note that handlers registering for instant hooks will be executed immediately if the instant
- * hook has been previously triggered.
- *
- * @param {String}   name     Name of the plugin hook to register for
- * @param {String}   type     Type of the event to register for
- * @param {Function} handler  Handle to call
- * @param {Number}   priority Priority to call the event handler
- * @return {Boolean}
+ * @param {String}   name    The hook name.
+ * @param {String}   type    The hook type.
+ * @param {Function} handler Handle to remove
+ * @return {Boolean} Was the handler removed?
  */
-elgg.register_hook_handler = function(name, type, handler, priority) {
+elgg.unregister_hook_handler = function(name, type, handler) {
 	elgg.assertTypeOf('string', name);
 	elgg.assertTypeOf('string', type);
 	elgg.assertTypeOf('function', handler);
@@ -36,92 +106,203 @@ elgg.register_hook_handler = function(name, type, handler, priority) {
 
 	elgg.provide([name, type], hooks);
 
-	if (!(hooks[name][type] instanceof elgg.ElggPriorityList)) {
-		hooks[name][type] = new elgg.ElggPriorityList();
+	if (!hooks[name][type].length) {
+		return false;
 	}
 
-	// call if instant and already triggered.
-	if (elgg.is_instant_hook(name, type) && elgg.is_triggered_hook(name, type)) {
-		handler(name, type, null, null);
-	}
-
-	return hooks[name][type].insert(handler, priority);
-};
-
-/**
- * Emits a hook.
- *
- * Loops through all registered hooks and calls the handler functions in order.
- * Every handler function will always be called, regardless of the return value.
- *
- * @warning Handlers take the same 4 arguments in the same order as when calling this function.
- * This is different from the PHP version!
- *
- * @note Instant hooks do not support params or values.
- *
- * Hooks are called in this order:
- *	specifically registered (event_name and event_type match)
- *	all names, specific type
- *	specific name, all types
- *	all names, all types
- *
- * @param {String} name   Name of the hook to emit
- * @param {String} type   Type of the hook to emit
- * @param {Object} params Optional parameters to pass to the handlers
- * @param {Object} value  Initial value of the return. Can be mangled by handlers
- *
- * @return {Boolean}
- */
-elgg.trigger_hook = function(name, type, params, value) {
-	elgg.assertTypeOf('string', name);
-	elgg.assertTypeOf('string', type);
-
-	// mark as triggered
-	elgg.set_triggered_hook(name, type);
-
-	// default to null if unpassed
-	value = !elgg.isNullOrUndefined(value) ? value : null;
-
-	var hooks = elgg.config.hooks,
-		tempReturnValue = null,
-		returnValue = value,
-		callHookHandler = function(handler) {
-			tempReturnValue = handler(name, type, params, returnValue);
-			if (!elgg.isNullOrUndefined(tempReturnValue)) {
-				returnValue = tempReturnValue;
-			}
-		};
-
-	elgg.provide([name, type], hooks);
-	elgg.provide(['all', type], hooks);
-	elgg.provide([name, 'all'], hooks);
-	elgg.provide(['all', 'all'], hooks);
-
-	var hooksList = [];
-	
-	if (name != 'all' && type != 'all') {
-		hooksList.push(hooks[name][type]);
-	}
-
-	if (type != 'all') {
-		hooksList.push(hooks['all'][type]);
-	}
-
-	if (name != 'all') {
-		hooksList.push(hooks[name]['all']);
-	}
-
-	hooksList.push(hooks['all']['all']);
-
-	hooksList.every(function(handlers) {
-		if (handlers instanceof elgg.ElggPriorityList) {
-			handlers.forEach(callHookHandler);
+	var new_list = [],
+		ret = false;
+	$.each(hooks[name][type], function(i, registration) {
+		if (registration.handler === handler) {
+			ret = true;
+		} else {
+			new_list.push(registration);
 		}
-		return true;
 	});
 
-	return returnValue;
+	hooks[name][type] = new_list;
+	return ret;
 };
+
+!function(){
+
+	/**
+	 * Emits a synchronous hook, calling only synchronous handlers
+	 *
+	 * Loops through all registered hooks and calls the handler functions in order.
+	 * Every handler function will always be called, regardless of the return value.
+	 *
+	 * @warning Handlers take the same 4 arguments in the same order as when calling this function.
+	 * This is different from the PHP version!
+	 *
+	 * @note Instant hooks do not support params or values.
+	 *
+	 * Hooks are called in priority order.
+	 *
+	 * @param {String} name   The hook name.
+	 * @param {String} type   The hook type.
+	 * @param {Object} params Optional parameters to pass to the handlers
+	 * @param {Object} value  Initial value of the return. Can be modified by handlers
+	 *
+	 * @return {*}
+	 */
+	elgg.trigger_hook = function(name, type, params, value) {
+		return trigger(name, type, params, value, false);
+	};
+
+	/**
+	 * Emits an asynchronous hook.
+	 *
+	 * Loops through all registered hooks and calls the handler functions in order.
+	 * Every handler function will always be called, regardless of the return value.
+	 *
+	 * @param {String} name   The hook name.
+	 * @param {String} type   The hook type.
+	 * @param {Object} params Optional parameters to pass to the handlers
+	 * @param {Object} value  Initial value of the return. Can be modified by handlers
+	 *
+	 * @return {Promise}
+	 */
+	elgg.trigger_async_hook = function(name, type, params, value) {
+		return trigger(name, type, params, value, true);
+	};
+
+	/**
+	 * Time limit per async handler
+	 *
+	 * @type {Number}
+	 */
+	elgg.config.async_handler_timeout = 1000 * 20;
+
+	/**
+	 * @private
+	 */
+	function trigger(name, type, params, value, async) {
+		elgg.assertTypeOf('string', name);
+		elgg.assertTypeOf('string', type);
+
+		// mark as triggered
+		elgg.set_triggered_hook(name, type);
+
+		// default to null if unpassed
+		value = !elgg.isNullOrUndefined(value) ? value : null;
+
+		var hooks = elgg.config.hooks,
+			registrations = [],
+			push = Array.prototype.push;
+
+		elgg.provide([name, type], hooks);
+		elgg.provide(['all', type], hooks);
+		elgg.provide([name, 'all'], hooks);
+		elgg.provide(['all', 'all'], hooks);
+
+		if (hooks[name][type].length) {
+			if (name !== 'all' && type !== 'all') {
+				push.apply(registrations, hooks[name][type]);
+			}
+		}
+		if (hooks['all'][type].length) {
+			if (type !== 'all') {
+				push.apply(registrations, hooks['all'][type]);
+			}
+		}
+		if (hooks[name]['all'].length) {
+			if (name !== 'all') {
+				push.apply(registrations, hooks[name]['all']);
+			}
+		}
+		if (hooks['all']['all'].length) {
+			push.apply(registrations, hooks['all']['all']);
+		}
+
+		registrations.sort(function (a, b) {
+			// priority first
+			if (a.priority < b.priority) {
+				return -1;
+			}
+			if (a.priority > b.priority) {
+				return 1;
+			}
+
+			// then insertion order
+			return (a.index < b.index) ? -1 : 1;
+		});
+
+		if (!async) {
+			// only synchronous handlers
+			$.each(registrations, function (i, registration) {
+				if (registration.async) {
+					return;
+				}
+
+				var handler_return = registration.handler(name, type, params, value);
+				if (!elgg.isNullOrUndefined(handler_return)) {
+					value = handler_return;
+				}
+			});
+
+			return value;
+		}
+
+		/**
+		 * @param {*} value
+		 * @returns {Promise}
+		 */
+		function call_next_handler(value) {
+			var registration = registrations.shift(),
+				def = $.Deferred(),
+				handler_def = $.Deferred(),
+				handler = getAsyncHandler(registration);
+
+			handler_def.done(function (handler_return) {
+				if (!elgg.isNullOrUndefined(handler_return)) {
+					value = handler_return;
+				}
+
+				if (registrations.length) {
+					call_next_handler(value)
+						.done(def.resolve)
+						.fail(def.reject);
+				} else {
+					def.resolve(value);
+				}
+			}).fail(def.reject);
+
+			setTimeout(function () {
+				if (handler_def.state() === 'pending') {
+					def.reject(new Error('Async handler did not resolve()/reject() within time limit'));
+				}
+			}, elgg.config.async_handler_timeout);
+
+			handler(name, type, params, value, handler_def);
+
+			return def.promise();
+		}
+
+		if (!registrations.length) {
+			var def = $.Deferred();
+			def.resolve(value);
+			return def.promise();
+		}
+
+		return call_next_handler(value);
+	}
+
+	function getAsyncHandler(registration) {
+		if (registration.async) {
+			return registration.handler;
+		}
+
+		return function (h, t, p, v, deferred) {
+			try {
+				var out = registration.handler(h, t, p, v);
+			} catch (e) {
+				return deferred.reject(e);
+			}
+			deferred.resolve(out);
+		};
+	}
+}();
 
 /**
  * Registers a hook as an instant hook.

--- a/js/tests/prepare.js
+++ b/js/tests/prepare.js
@@ -32,7 +32,6 @@ define('elgg/init', function (require) {
 	var elgg = require('elgg');
 	var plugin = require('boot/example');
 
-	console.log(plugin);
 	plugin._init();
 
 	elgg.trigger_hook('init', 'system');


### PR DESCRIPTION
Asynchronous handlers can be registered. These handlers receive a 5th argument, a jQuery Deferred object on which they must call `resolve` or `reject`.

A new `trigger_async_hook()` returns a Promise and calls _all_ handlers, both async and sync. `trigger_hook()` operates as before but only calls sync handlers.

Handlers are now ordered first by the priority and then by the registration order.

Handlers can be unregistered.

BREAKING CHANGE:
To ensure your handler is called last, you must give it the highest priority of all matching handlers. To ensure your handler is called first, you must give it the lowest priority of all matching handlers. Registering with the keyword `all` no longer has any effect on calling order.
- [ ] docs for async hooks
