### PR TITLE
fix(js): hook trigger calls handlers in expected priority order

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -124,6 +124,18 @@ Miscellaneous API changes
  * ``elgg_list_registered_entities`` no longer supports the option ``view_type_toggle``
  * ``elgg_log`` no longer accepts the level ``"DEBUG"``
 
+JavaScript hook calling order may change
+----------------------------------------
+
+When registering for hooks, the ``all`` keyword for wildcard matching no longer has any effect
+on the order that handlers are called. To ensure your handler is called last, you must give it the
+highest priority of all matching handlers, or to ensure your handler is called first, you must give
+it the lowest priority of all matching handlers.
+
+If handlers were registered with the same priority, these are called in the order they were registered.
+
+To emulate prior behavior, Elgg core handlers registered with the ``all`` keyword have been raised in
+priority. Some of these handlers will most likely be called in a different order.
 
 From 2.0 to 2.1
 ===============

--- a/js/tests/ElggHooksTest.js
+++ b/js/tests/ElggHooksTest.js
@@ -52,6 +52,31 @@ define(function(require) {
 
 				expect(elgg.trigger_hook("fee.fum", "pow")).toBe(2);
 			});
+
+			it("calls handlers in priority order despite use of 'all'", function() {
+				var todo = [
+					'foo,bar',
+					'foo,all',
+					'all,bar',
+					'foo,bar',
+					'all,all',
+					'foo,bar'
+				];
+				var done = [];
+
+				$.each(todo, function (i, hook_type) {
+					var hook = hook_type.split(',')[0];
+					var type = hook_type.split(',')[1];
+
+					elgg.register_hook_handler(hook, type, function () {
+						done.push(hook_type);
+					}, i);
+				});
+
+				elgg.trigger_hook('foo', 'bar');
+
+				expect(done).toEqual(todo);
+			});
 		});
 		
 		describe("elgg.register_hook_handler()", function() {

--- a/js/tests/prepare.js
+++ b/js/tests/prepare.js
@@ -32,7 +32,6 @@ define('elgg/init', function (require) {
 	var elgg = require('elgg');
 	var plugin = require('boot/example');
 
-	console.log(plugin);
 	plugin._init();
 
 	elgg.trigger_hook('init', 'system');


### PR DESCRIPTION
JavaScript hook handlers are now ordered first by the priority and then by the order in which they were registered. In previous versions, handlers were segregated into 4 groups depending on use of the `all` keyword; while documented, this was poorly understood and generally unexpected.

BREAKING CHANGE:
To ensure your handler is called last, you must give it the highest priority of all matching handlers. To ensure your handler is called first, you must give it the lowest priority of all matching handlers. Registering with the keyword `all` no longer has any effect on calling order.
