### PR TITLE
chore(i18n): cleans up Translator a bit

### DIFF
--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -40,7 +40,7 @@ function add_translation($country_code, $language_array) {
 }
 
 /**
- * Detect the current language being used by the current site or logged in user.
+ * Get the current system/user language or "en".
  *
  * @return string The language code for the site/user or "en" if not set
  */
@@ -49,12 +49,12 @@ function get_current_language() {
 }
 
 /**
- * Gets the current language in use by the system or user.
+ * Detect the current system/user language or false.
  *
  * @return string The language code (eg "en") or false if not set
  */
 function get_language() {
-	return _elgg_services()->translator->getLanguage();
+	return _elgg_services()->translator->detectLanguage();
 }
 
 /**

--- a/engine/tests/phpunit/Elgg/I18n/TranslatorTest.php
+++ b/engine/tests/phpunit/Elgg/I18n/TranslatorTest.php
@@ -11,7 +11,7 @@ class TranslatorTest extends TestCase {
 		$input_lang = 'nl';
 		_elgg_services()->input->set('hl', $input_lang);
 		
-		$lang = $translator->getLanguage();
+		$lang = $translator->detectLanguage();
 		$this->assertEquals($lang, $input_lang);
 	}
 	


### PR DESCRIPTION
`elgg_echo` and `elgg_language_key_exists` can no longer get `false` as the default language in the (rare) case that no language is set anywhere.

In `Translator`, `getLanguage` is now `detectLanguage`, which seems more apt.
