### PR TITLE
Allow non-expiring URLs in file service

### DIFF
--- a/engine/classes/Elgg/FileService/File.php
+++ b/engine/classes/Elgg/FileService/File.php
@@ -108,7 +108,7 @@ class File {
 
 		$data = array(
 			'expires' => isset($this->expires) ? $this->expires : 0,
-			'last_updated' => filemtime($this->file->getFilenameOnFilestore()),
+			'last_updated' => $this->expires ? filemtime($this->file->getFilenameOnFilestore()) : 0,
 			'disposition' => $this->disposition == self::INLINE ? 'i' : 'a',
 			'path' => $relative_path,
 		);

--- a/engine/lib/filestore.php
+++ b/engine/lib/filestore.php
@@ -564,15 +564,17 @@ function _elgg_filestore_test($hook, $type, $value) {
 /**
  * Returns file's download URL
  *
- * @param \ElggFile $file       File object or entity
- * @param bool      $use_cookie Limit URL validity to current session only
- * @param string    $expires    URL expiration, as a string suitable for strtotime()
+ * @param \ElggFile    $file       File object or entity
+ * @param bool         $use_cookie Limit URL validity to current session only
+ * @param string|false $expires    URL expiration, as a string suitable for strtotime() or false for non-expiring URLs
  * @return string
  */
 function elgg_get_download_url(\ElggFile $file, $use_cookie = true, $expires = '+2 hours') {
 	$file_svc = new Elgg\FileService\File();
 	$file_svc->setFile($file);
-	$file_svc->setExpires($expires);
+	if ($expires) {
+		$file_svc->setExpires($expires);
+	}
 	$file_svc->setDisposition('attachment');
 	$file_svc->bindSession($use_cookie);
 	return $file_svc->getURL();

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -394,7 +394,11 @@ function file_set_icon_url($hook, $type, $url, $params) {
 			$readfile = new ElggFile();
 			$readfile->owner_guid = $file->owner_guid;
 			$readfile->setFilename($thumbfile);
-			$thumb_url = elgg_get_inline_url($readfile, true);
+			if (elgg_in_context('embed')) {
+				$thumb_url = elgg_get_inline_url($readfile, false, false);
+			} else {
+				$thumb_url = elgg_get_inline_url($readfile, true);
+			}
 			if ($thumb_url) {
 				return $thumb_url;
 			}


### PR DESCRIPTION
File service no longer validates last updated time if expire time is set to `false`.
etag values are always populated from actual filemtime
