### PR TITLE
adds elgg/popup AMD module

### DIFF
--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -434,6 +434,103 @@ The ``elgg/spinner`` module can be used to create an Ajax loading indicator fixe
 
 .. note:: The ``elgg/Ajax`` module uses the spinner by default.
 
+Module ``elgg/popup``
+-----------------------
+
+The ``elgg/popup`` module can be used to display an overlay positioned relatively to its anchor (trigger).
+
+The ``elgg/popup`` module is loaded by default, and binding a popup module to an anchor is as simple as adding ``rel="popup"``
+attribute and defining target module with a ``href`` (or ``data-href``) attribute. Popup module positioning can be defined with
+``data-position`` attribute of the trigger element.
+
+.. $.position(): http://api.jqueryui.com/position/
+
+.. code:: php
+
+   echo elgg_format_element('div', [
+      'class' => 'elgg-module-popup hidden',
+      'id' => 'popup-module',
+   ], 'Popup module content');
+
+   // Simple anchor
+   echo elgg_view('output/url', [
+      'href' => '#popup-module',
+      'text' => 'Show popup',
+      'rel' => 'popup',
+   ]);
+
+   // Button with custom positioning of the popup
+   echo elgg_format_element('button', [
+      'rel' => 'popup',
+      'class' => 'elgg-button elgg-button-submit',
+      'text' => 'Show popup',
+      'data-href' => '#popup-module',
+      'data-position' => json_encode([
+         'my' => 'center bottom',
+         'at' => 'center top',
+      ]),
+   ]);
+
+
+The ``elgg/popup`` module allows you to build out more complex UI/UX elements. You can open and close
+popup modules programmatically:
+
+.. code:: js
+
+   define(function(require) {
+      var $ = require('jquery');
+      $(document).on('click', '.elgg-button-popup', function(e) {
+
+         e.preventDefault();
+
+         var $trigger = $(this);
+         var $target = $('#my-target');
+		 var $close = $target.find('.close');
+
+         require(['elgg/popup'], function(popup) {
+		   popup.open($trigger, $target, {
+			  'collision': 'fit none'
+		   });
+
+           $close.on('click', popup.close);
+		 });
+      });
+   });
+
+You can use ``getOptions, ui.popup`` plugin hook to manipulate the position of the popup before it has been opened.
+You can use jQuery ``open`` and ``close`` events to manipulate popup module after it has been opened or closed.
+
+.. code:: js
+
+   define(function(require) {
+
+      var elgg = require('elgg');
+      var $ = require('jquery');
+
+      $('#my-target').on('open', function() {
+         var $module = $(this);
+         var $trigger = $module.data('trigger');
+
+         elgg.ajax('ajax/view/my_module', {
+            beforeSend: function() {
+               $trigger.hide();
+               $module.html('').addClass('elgg-ajax-loader');
+            },
+            success: function(output) {
+               $module.removeClass('elgg-ajax-loader').html(output);
+            }
+         });
+      }).on('close', function() {
+         var $trigger = $(this).data('trigger');
+         $trigger.show();
+      });
+   });
+
+Open popup modules will always contain the following data that can be accessed via ``$.data()``:
+
+ * ``trigger`` - jQuery element used to trigger the popup module to open
+ * ``position`` - An object defining popup module position that was passed to ``$.position()``
+
 Module ``elgg/widgets``
 -----------------------
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -16,11 +16,17 @@ Deprecated APIs
 ---------------
 
  * ``elgg.ui.river`` JavaScript library: Remove calls to ``elgg_load_js('elgg.ui.river')`` from plugin code. Update ``core/river/filter`` and ``forms/comment/save``, if overwritten, to require component AMD modules
+ * ``elgg.ui.popupOpen()`` and ``elgg.ui.popupClose()`` methods in ``elgg.ui`` JS library: Use ``elgg/popup`` module instead.
 
 Deprecated Views
 ----------------
 
  * ``elgg/ui.river.js`` is deprecated: Do not rely on simplecache URLs to work.
+
+Added ``elgg/popup`` module
+-----------------------------
+
+New :doc:`elgg/popup module <javascript>` can be used to build out more complex trigger-popup interactions, including binding custom anchor types and opening/closing popups programmatically.
 
 From 2.0 to 2.1
 ===============

--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -18,7 +18,9 @@ elgg.ui.init = function () {
 
 	$(document).on('click', '[rel=toggle]', elgg.ui.toggles);
 
-	$(document).on('click', '[rel=popup]', elgg.ui.popupOpen);
+	require(['elgg/popup'], function(popup) {
+		popup.bind($('[rel="popup"]'));
+	});
 
 	$(document).on('click', '.elgg-menu-page .elgg-menu-parent', elgg.ui.toggleMenu);
 
@@ -58,7 +60,7 @@ elgg.ui.toggles = function(event) {
 	event.preventDefault();
 	var $this = $(this),
 		selector = $this.data().toggleSelector;
-	
+
 	if (!selector) {
 		// @todo we can switch to elgg.getSelectorFromUrlFragment() in 1.x if
 		// we also extend it to support href=".some-class"
@@ -102,85 +104,29 @@ elgg.ui.toggles = function(event) {
  * @return void
  */
 elgg.ui.popupOpen = function(event) {
+
+	elgg.deprecated_notice('elgg.ui.popupOpen() has been deprecated and should not be called directly. Use elgg/popup AMD module instead', '2.2');
+
 	event.preventDefault();
 	event.stopPropagation();
 
-	var target = elgg.getSelectorFromUrlFragment($(this).toggleClass('elgg-state-active').attr('href'));
-	var $target = $(target);
-
-	// emit a hook to allow plugins to position and control popups
-	var params = {
-		targetSelector: target,
-		target: $target,
-		source: $(this)
-	};
-
-	var options = {
-		my: 'center top',
-		at: 'center bottom',
-		of: $(this),
-		collision: 'fit fit'
-	};
-
-	options = elgg.trigger_hook('getOptions', 'ui.popup', params, options);
-
-	// allow plugins to cancel event
-	if (!options) {
-		return;
-	}
-
-	// hide if already open
-	if ($target.is(':visible')) {
-		$target.fadeOut();
-		$(document).off('click', elgg.ui.popupClose);
-		return;
-	}
-
-	$target.appendTo('body')
-		.fadeIn()
-		.position(options);
-
-	$(document)
-		.off('click', 'body', elgg.ui.popupClose)
-		.on('click', 'body', elgg.ui.popupClose);
+	var $elem = $(this);
+	require(['elgg/popup'], function(popup) {
+		popup.open($elem);
+	});
 };
 
 /**
  * Catches clicks that aren't in a popup and closes all popups.
+ * @deprecated 2.2
  */
 elgg.ui.popupClose = function(event) {
-	$eventTarget = $(event.target);
-	var inTarget = false;
-	var $popups = $('[rel=popup]');
+	
+	elgg.deprecated_notice('elgg.ui.popupClose() has been deprecated and should not be called directly. Use elgg/popup AMD module instead', '2.2');
 
-	// if the click event target isn't in a popup target, fade all of them out.
-	$popups.each(function(i, e) {
-		var target = elgg.getSelectorFromUrlFragment($(e).attr('href')) + ':visible';
-		var $target = $(target);
-
-		if (!$target.is(':visible')) {
-			return;
-		}
-
-		// didn't click inside the target
-		if ($eventTarget.closest(target).length > 0) {
-			inTarget = true;
-			return false;
-		}
+	require(['elgg/popup'], function(popup) {
+		popup.close();
 	});
-
-	if (!inTarget) {
-		$popups.each(function(i, e) {
-			var $e = $(e);
-			var $target = $(elgg.getSelectorFromUrlFragment($e.attr('href')) + ':visible');
-			if ($target.length > 0) {
-				$target.fadeOut();
-				$e.removeClass('elgg-state-active');
-			}
-		});
-
-		$(document).off('click', elgg.ui.popupClose);
-	}
 };
 
 /**

--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -191,48 +191,38 @@ elgg.ui.initHoverMenu = function(parent) {
 
 	// avatar contextual menu
 	$(document).on('click', ".elgg-avatar > .elgg-icon-hover-menu", function(e) {
-		var $placeholder = $(this).parent().find(".elgg-menu-hover.elgg-ajax-loader");
+
+		var $icon = $(this);
+
+		var $placeholder = $icon.parent().find(".elgg-menu-hover.elgg-ajax-loader");
 
 		if ($placeholder.length) {
 			loadMenu($placeholder.attr("rel"));
 		}
 
 		// check if we've attached the menu to this element already
-		var $hovermenu = $(this).data('hovermenu') || null;
+		var $hovermenu = $icon.data('hovermenu') || null;
 
 		if (!$hovermenu) {
-			$hovermenu = $(this).parent().find(".elgg-menu-hover");
-			$(this).data('hovermenu', $hovermenu);
+			$hovermenu = $icon.parent().find(".elgg-menu-hover");
+			$icon.data('hovermenu', $hovermenu);
 		}
 
-		// close hovermenu if arrow is clicked & menu already open
-		if ($hovermenu.css('display') == "block") {
-			$hovermenu.fadeOut();
-		} else {
-			$avatar = $(this).closest(".elgg-avatar");
-
-			// @todo Use jQuery-ui position library instead -- much simpler
-			var offset = $avatar.offset();
-			var top = $avatar.height() + offset.top + 'px';
-			var left = $avatar.width() - 15 + offset.left + 'px';
-
-			$hovermenu.appendTo('body')
-					.css('position', 'absolute')
-					.css("top", top)
-					.css("left", left)
-					.fadeIn('normal');
-		}
-
-		// hide any other open hover menus
-		$(".elgg-menu-hover:visible").not($hovermenu).fadeOut();
+		require(['elgg/popup'], function(popup) {
+			if ($hovermenu.is(':visible')) {
+				// close hovermenu if arrow is clicked & menu already open
+				popup.close($hovermenu);
+			} else {
+				popup.open($icon, $hovermenu, {
+					'my': 'left top',
+					'at': 'right-15px bottom',
+					'of': $icon.closest(".elgg-avatar"),
+					'collision': 'none none'
+				});
+			}
+		});
 	});
 
-	// hide avatar menu when user clicks elsewhere
-	$(document).click(function(event) {
-		if ($(event.target).parents(".elgg-avatar").length === 0) {
-			$(".elgg-menu-hover").fadeOut();
-		}
-	});
 };
 
 /**

--- a/mod/developers/views/default/theme_sandbox/javascript/popup.js
+++ b/mod/developers/views/default/theme_sandbox/javascript/popup.js
@@ -1,0 +1,24 @@
+define(function (require) {
+
+	var elgg = require('elgg');
+	var $ = require('jquery');
+
+	$('#elgg-popup-test2').on('open', function () {
+		var $module = $(this);
+		var $trigger = $module.data('trigger');
+
+		elgg.ajax('ajax/view/developers/ajax', {
+			beforeSend: function () {
+				$trigger.addClass('elgg-state-disabled').prop('disabled', true);
+				$module.html('').addClass('elgg-ajax-loader');
+			},
+			success: function (output) {
+				$module.removeClass('elgg-ajax-loader').html(output);
+			}
+		});
+	}).on('close', function () {
+		var $trigger = $(this).data('trigger');
+		$trigger.removeClass('elgg-state-disabled').prop('disabled', false);
+	});
+
+});

--- a/mod/developers/views/default/theme_sandbox/javascript/popup.php
+++ b/mod/developers/views/default/theme_sandbox/javascript/popup.php
@@ -6,10 +6,30 @@ $link = elgg_view('output/url', array(
 	'text' => 'Popup content',
 	'href' => "#elgg-popup-test",
 	'rel' => 'popup',
-));
+		));
 
 echo $link;
 echo elgg_view_module('popup', 'Popup Test', $ipsum, array(
 	'id' => 'elgg-popup-test',
 	'class' => 'hidden theme-sandbox-content-thin',
 ));
+
+
+$button = elgg_format_element('button', array(
+	'class' => 'elgg-button elgg-button-submit mll',
+	'rel' => 'popup',
+	'data-href' => "#elgg-popup-test2",
+	'data-position' => json_encode(array(
+		'my' => 'left top',
+		'at' => 'left bottom',
+	)),
+		), 'Load content in a popup');
+
+echo $button;
+
+echo elgg_format_element('div', array(
+	'id' => 'elgg-popup-test2',
+	'class' => 'hidden theme-sandbox-content-thin elgg-module-popup',
+		), '');
+
+elgg_require_js('theme_sandbox/javascript/popup');

--- a/views/default/elgg.js.php
+++ b/views/default/elgg.js.php
@@ -25,6 +25,10 @@ echo elgg_view('sprintf.js');
 // @todo: remove in 3.x and use async calls
 echo elgg_view('elgg/widgets.js');
 
+// We use a named AMD module and inine it here in order to save HTTP requests, 
+// as this module will be required on each page
+echo elgg_view('elgg/popup.js');
+
 $elggDir = \Elgg\Application::elggDir();
 $files = array(
 	// these must come first

--- a/views/default/elgg/popup.js
+++ b/views/default/elgg/popup.js
@@ -1,0 +1,165 @@
+/**
+ * We use a named AMD module that is inlined in elgg.js, as this module is
+ * loaded on each page request and we do not want to issue an additional HTTP request
+ *
+ * @module elgg/popup
+ * @since 2.2
+ */
+define('elgg/popup', ['elgg', 'jquery', 'jquery-ui'], function (elgg, $) {
+
+	var popup = {
+		ready: false,
+		/**
+		 * Initializes a popup module and binds an event to hide visible popup
+		 * modules on a click event outside of their DOM stack.
+		 *
+		 * This method is called before the popup module is displayed.
+		 *
+		 * @return void
+		 */
+		init: function () {
+			if (popup.ready) {
+				// We only need to bind the events once
+				return;
+			}
+			$(document).on('click', function (e) {
+				var $eventTargets = $(e.target).parents().andSelf();
+				if ($eventTargets.is('.elgg-state-popped')) {
+					return;
+				}
+				popup.close();
+			});
+			popup.ready = true;
+		},
+		/**
+		 * Shortcut to bind a click event on a set of $triggers.
+		 *
+		 * Set the '[rel="popup"]' of the $trigger and set the href to target the
+		 * item you want to toggle (<a rel="popup" href="#id-of-target">).
+		 *
+		 * This method is called by core JS UI library for all [rel="popup"] elements,
+		 * but can be called by plugins to bind other triggers.
+		 *
+		 * @param {jQuery} $triggers A set of triggers to bind
+		 * @return void
+		 */
+		bind: function ($triggers) {
+			$triggers.off('click.popup')
+					.on('click.popup', function (e) {
+						if (e.isDefaultPrevented()) {
+							return;
+						}
+						e.preventDefault();
+						e.stopPropagation();
+						popup.open($(this));
+					});
+		},
+		/**
+		 * Shows a $target element at a given position
+		 * If no $target element is provided, determines it by parsing hash from href attribute of the $trigger
+		 *
+		 * This function emits the getOptions, ui.popup hook that plugins can register for to provide custom
+		 * positioning for elements.  The handler is passed the following params:
+		 *	targetSelector: The selector used to find the popup
+		 *	target:         The popup jQuery element as found by the selector
+		 *	source:         The jquery element whose click event initiated a popup.
+		 *
+		 * The return value of the function is used as the options object to .position().
+		 * Handles can also return false to abort the default behvior and override it with their own.
+		 *
+		 * @param {jQuery} $trigger Trigger element
+		 * @param {jQuery} $target  Target popup module
+		 * @param {object} position Positioning data of the $target module
+		 * @return void
+		 */
+		open: function ($trigger, $target, position) {
+			if (typeof $trigger === 'undefined' || !$trigger.length) {
+				return;
+			}
+
+			if (typeof $target === 'undefined') {
+				var href = $trigger.attr('href') || $trigger.data('href') || '';
+				var targetSelector = elgg.getSelectorFromUrlFragment(href);
+				$target = $(targetSelector);
+			} else {
+				$target.uniqueId();
+				var targetSelector = '#' + $target.attr('id');
+			}
+
+			if (!$target.length) {
+				return;
+			}
+
+			// emit a hook to allow plugins to position and control popups
+			var params = {
+				targetSelector: targetSelector,
+				target: $target,
+				source: $trigger
+			};
+
+			position = position || {
+				my: 'center top',
+				at: 'center bottom',
+				of: $trigger,
+				collision: 'fit fit'
+			};
+
+			$.extend(position, $trigger.data('position'));
+
+			position = elgg.trigger_hook('getOptions', 'ui.popup', params, position);
+
+			if (!position) {
+				return;
+			}
+
+			popup.init();
+			popup.close(); // close any open popup modules
+
+			$target.data('trigger', $trigger); // used to remove elgg-state-active class when popup is closed
+			$target.data('position', position); // used to reposition the popup module on window manipulations
+
+			// @todo: in 3.0, do not append to 'body' and use fixed positioning with z-indexes instead
+			// @todo: use css transitions instead of $.fadeOut() to avoid collisions due to slow 
+			$target.appendTo('body')
+					.fadeIn()
+					.addClass('elgg-state-active elgg-state-popped')
+					.position(position);
+
+			$trigger.addClass('elgg-state-active');
+
+			$target.trigger('open');
+		},
+		/**
+		 * Hides a set of $targets. If not defined, closes all visible popup modules.
+		 *
+		 * @param {jQuery} $targets Popup modules to hide
+		 * @return void
+		 */
+		close: function ($targets) {
+			if (typeof $targets === 'undefined') {
+				$targets = $('.elgg-state-popped');
+			}
+			if (!$targets.length) {
+				return;
+			}
+			$targets.each(function () {
+				var $target = $(this);
+				if (!$target.is(':visible')) {
+					return;
+				}
+
+				var $trigger = $target.data('trigger');
+				if ($trigger.length) {
+					$trigger.removeClass('elgg-state-active');
+				}
+
+				// @todo: use css transitions instead of $.fadeOut()
+				$target.fadeOut().removeClass('elgg-state-active elgg-state-popped');
+
+				$target.trigger('close');
+			});
+		}
+	};
+
+	return popup;
+});


### PR DESCRIPTION
Converts JS popup to an AMD module subsequently giving more freedom
to plugins to manipulate popups programmatically.
Popup target module can now be defined with data-href attribute in
addition to href attribute (suitable for use with non-anchor elements).
Popup positioning details can be passed with data-position of the trigger
(which is simpler than using the triggered plugin hook).
jQuery "open" and "close" events are now triggered when the popup is shown
and closed, allowing plugins to manipulate popup module and its contents
