### PR TITLE
deprecated(groups): groups/js view deprecated by groups/navigation AMD module

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -25,6 +25,7 @@ Deprecated Views
 ----------------
 
  * ``elgg/ui.river.js`` is deprecated: Do not rely on simplecache URLs to work.
+ * ``groups/js`` is deprecated: Use ``groups/navigation`` AMD module as a menu item dependency for "feature" and "unfeature" menu items instead.
  * ``lightbox/settings.js`` is deprecated: Use ``getOptions, ui.lightbox`` JS plugin hook or ``data-colorbox-opts`` attribute.
 
 Added ``elgg/popup`` module

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -82,7 +82,10 @@ function groups_init() {
 
 	//extend some views
 	elgg_extend_view('elgg.css', 'groups/css');
-	elgg_extend_view('elgg.js', 'groups/js');
+	if (_elgg_view_may_be_altered('groups/js', __DIR__ . '/views/default/groups/js.php')) {
+		elgg_deprecated_notice('groups/js view has been deprecated. Use AMD modules instead', '2.2');
+		elgg_extend_view('elgg.js', 'groups/js');
+	}
 
 	// Access permissions
 	elgg_register_plugin_hook_handler('access:collections:write', 'all', 'groups_write_acl_plugin_hook', 600);
@@ -448,6 +451,7 @@ function groups_entity_menu_setup($hook, $type, $return, $params) {
 			'href' => elgg_add_action_tokens_to_url("action/groups/featured?group_guid={$entity->guid}&action_type=feature"),
 			'priority' => 300,
 			'item_class' => $isFeatured ? 'hidden' : '',
+			'deps' => 'groups/navigation',
 		));
 
 		$return[] = ElggMenuItem::factory(array(
@@ -456,6 +460,7 @@ function groups_entity_menu_setup($hook, $type, $return, $params) {
 			'href' => elgg_add_action_tokens_to_url("action/groups/featured?group_guid={$entity->guid}&action_type=unfeature"),
 			'priority' => 300,
 			'item_class' => $isFeatured ? '' : 'hidden',
+			'deps' => 'groups/navigation',
 		));
 	}
 

--- a/mod/groups/views/default/groups/js.php
+++ b/mod/groups/views/default/groups/js.php
@@ -1,9 +1,11 @@
 <?php
 /**
- * Javascript for Groups forms
- *
  * @package ElggGroups
+ * @deprecated 2.2
  */
+elgg_deprecated_notice('groups/js view has been deprecated. Instead define dependency on "groups/navigation" AMD module for "feature" and "unfeature" menu items', '2.2');
 ?>
-
-elgg.ui.registerTogglableMenuItems('feature', 'unfeature');
+//<script>
+require(['elgg'], function(elgg) {
+	elgg.ui.registerTogglableMenuItems('feature', 'unfeature');
+});

--- a/mod/groups/views/default/groups/navigation.js
+++ b/mod/groups/views/default/groups/navigation.js
@@ -1,0 +1,5 @@
+define(function(require) {
+	var elgg = require('elgg');
+	require('elgg/init');
+	elgg.ui.registerTogglableMenuItems('feature', 'unfeature');
+});


### PR DESCRIPTION
groups/js was extending elgg.js without using proper require() calls.
The view is now deprecated by groups/navigation AMD module, which is
defined as dependency for "feature" and "unfeature" menu items
- [x] use `require('elgg/init')` in groups/navigation module
- [x] needs to update `_elgg_view_may_be_altered` to allow checking view in a plugin #9686
