### PR TITLE
fix(js): ui bindings now wait for system init event to fire

### DIFF
--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -41,6 +41,8 @@ elgg.ui.init = function () {
 	$(elementId).addClass('elgg-state-highlight');
 
 	elgg.ui.initDatePicker();
+
+	elgg.ui.registerTogglableMenuItems('add-friend', 'remove-friend');
 };
 
 /**
@@ -391,4 +393,3 @@ elgg.ui.initAccessInputs = function () {
 
 elgg.register_hook_handler('init', 'system', elgg.ui.init);
 elgg.register_hook_handler('getOptions', 'ui.popup', elgg.ui.loginHandler);
-elgg.ui.registerTogglableMenuItems('add-friend', 'remove-friend');


### PR DESCRIPTION
UI element bindings should occur on system init event to ensure that DOM is ready and all required libraries are loaded.

This moves "add-friend" and "remove-friend" menu item toggling registration
to init,system callback rather than performing at runtime.
