### PR TITLE
feature(files): introduces API to simplify file embeds

### DIFF
--- a/engine/classes/ElggFile.php
+++ b/engine/classes/ElggFile.php
@@ -18,6 +18,10 @@
  *
  * @package    Elgg.Core
  * @subpackage DataModel.File
+ *
+ * @property string $thumbnail  Path to small thumbnail relative to file owner's filestore directory
+ * @property string $smallthumb Path to medium thumbnail relative to file owner\'s filestore directory
+ * @property string $largethumb Path to large/master thumbnail relative to file owner\'s filestore diretory
  */
 class ElggFile extends \ElggObject {
 

--- a/mod/file/actions/file/upload.php
+++ b/mod/file/actions/file/upload.php
@@ -109,60 +109,10 @@ if (isset($_FILES['upload']['name']) && !empty($_FILES['upload']['name'])) {
 
 	$guid = $file->save();
 
-	// if image, we need to create thumbnails (this should be moved into a function)
-	if ($guid && $file->simpletype == "image") {
-		$file->icontime = time();
-		
-		$thumbnail = get_resized_image_from_existing_file($file->getFilenameOnFilestore(), 60, 60, true);
-		if ($thumbnail) {
-			$thumb = new ElggFile();
-			$thumb->setMimeType($_FILES['upload']['type']);
-
-			$thumb->setFilename($prefix."thumb".$filestorename);
-			$thumb->open("write");
-			$thumb->write($thumbnail);
-			$thumb->close();
-
-			$file->thumbnail = $prefix."thumb".$filestorename;
-			unset($thumbnail);
-		}
-
-		$thumbsmall = get_resized_image_from_existing_file($file->getFilenameOnFilestore(), 153, 153, true);
-		if ($thumbsmall) {
-			$thumb->setFilename($prefix."smallthumb".$filestorename);
-			$thumb->open("write");
-			$thumb->write($thumbsmall);
-			$thumb->close();
-			$file->smallthumb = $prefix."smallthumb".$filestorename;
-			unset($thumbsmall);
-		}
-
-		$thumblarge = get_resized_image_from_existing_file($file->getFilenameOnFilestore(), 600, 600, false);
-		if ($thumblarge) {
-			$thumb->setFilename($prefix."largethumb".$filestorename);
-			$thumb->open("write");
-			$thumb->write($thumblarge);
-			$thumb->close();
-			$file->largethumb = $prefix."largethumb".$filestorename;
-			unset($thumblarge);
-		}
-	} elseif ($file->icontime) {
-		// if it is not an image, we do not need thumbnails
-		unset($file->icontime);
-		
-		$thumb = new ElggFile();
-		
-		$thumb->setFilename($prefix . "thumb" . $filestorename);
-		$thumb->delete();
-		unset($file->thumbnail);
-		
-		$thumb->setFilename($prefix . "smallthumb" . $filestorename);
-		$thumb->delete();
-		unset($file->smallthumb);
-		
-		$thumb->setFilename($prefix . "largethumb" . $filestorename);
-		$thumb->delete();
-		unset($file->largethumb);
+	if ($guid && $file->simpletype == 'image') {
+		elgg_create_thumbnails($file);
+	} else if ($file->icontime) {
+		elgg_clear_thumbnails($file);
 	}
 } else {
 	// not saving a file but still need to save the entity to push attributes to database

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -376,25 +376,14 @@ function file_set_icon_url($hook, $type, $url, $params) {
 	$file = $params['entity'];
 	$size = $params['size'];
 	if (elgg_instanceof($file, 'object', 'file')) {
-		// thumbnails get first priority
-		if ($file->thumbnail) {
-			switch ($size) {
-				case "small":
-					$thumbfile = $file->thumbnail;
-					break;
-				case "medium":
-					$thumbfile = $file->smallthumb;
-					break;
-				case "large":
-				default:
-					$thumbfile = $file->largethumb;
-					break;
-			}
 
-			$readfile = new ElggFile();
-			$readfile->owner_guid = $file->owner_guid;
-			$readfile->setFilename($thumbfile);
-			$thumb_url = elgg_get_inline_url($readfile, true);
+		// thumbnails get first priority
+		$thumbnail = elgg_get_thumbnail($file, $size);
+		if ($thumbnail instanceof ElggFile && $thumbnail->exists()) {
+			if (elgg_in_context('embed')) {
+				return elgg_get_embed_url($file, $size);
+			}
+			$thumb_url = elgg_get_inline_url($thumbnail, true);
 			if ($thumb_url) {
 				return $thumb_url;
 			}


### PR DESCRIPTION
Adds elgg_get_thumbnail(), elgg_create_thumbnails() and elgg_clear_thumbnails()
for a more consitent approach to working with file thumbnails.

Adds elgg_get_embed_url() and embed-file handler to serve files for inline
embeds.

Moves filestore instantiation to system boot event.

Fixes #9582
