### PR TITLE
fix(core): Elgg again uses the dataroot given in settings.php

### DIFF
--- a/engine/classes/Elgg/BootService.php
+++ b/engine/classes/Elgg/BootService.php
@@ -76,7 +76,9 @@ class BootService {
 			$CONFIG->boot_cache_ttl = 0;
 		}
 
-		$CONFIG->dataroot = rtrim($datalists['dataroot'], '/\\') . DIRECTORY_SEPARATOR;
+		if (!$GLOBALS['_ELGG']->dataroot_in_settings) {
+			$CONFIG->dataroot = rtrim($datalists['dataroot'], '/\\') . DIRECTORY_SEPARATOR;
+		}
 		$CONFIG->site_guid = (int)$datalists['default_site'];
 		$CONFIG->site_id = (int)$datalists['default_site'];
 		if (!isset($CONFIG->boot_cache_ttl)) {


### PR DESCRIPTION
This makes sure that an incorrect `dataroot` value in the `datalists` DB table is not allowed to overwrite a `$CONFIG->dataroot` value set in settings.php. This problem was introduced in 2.1.0.

Fixes #9602
