### PR TITLE
feature(widgets): widget layout owner can now be set explicitly

### DIFF
--- a/views/default/elgg/widgets.js
+++ b/views/default/elgg/widgets.js
@@ -63,10 +63,13 @@ define('elgg/widgets', ['elgg', 'jquery'], function (elgg, $) {
 			$(this).unbind('click', widgets.add);
 		}
 
+		var $layout = $(this).closest('.elgg-layout-widgets');
+		var page_owner_guid = $layout.data('pageOwnerGuid') || elgg.get_page_owner_guid();
+
 		elgg.action('widgets/add', {
 			data: {
 				handler: type,
-				page_owner_guid: elgg.get_page_owner_guid(),
+				page_owner_guid: page_owner_guid,
 				context: $("input[name='widget_context']").val(),
 				show_access: $("input[name='show_access']").val(),
 				default_widgets: $("input[name='default_widgets']").val() || 0

--- a/views/default/page/layouts/widgets.php
+++ b/views/default/page/layouts/widgets.php
@@ -7,14 +7,31 @@
  * @uses $vars['show_add_widgets'] Display the add widgets button and panel (true)
  * @uses $vars['exact_match']      Widgets must match the current context (false)
  * @uses $vars['show_access']      Show the access control (true)
+ * @uses $vars['owner_guid']       Widget owner GUID (optional, defaults to page owner GUID)
  */
 
 $num_columns = elgg_extract('num_columns', $vars, 3);
 $show_add_widgets = elgg_extract('show_add_widgets', $vars, true);
 $exact_match = elgg_extract('exact_match', $vars, false);
 $show_access = elgg_extract('show_access', $vars, true);
+$owner_guid = elgg_extract('owner_guid', $vars);
 
-$owner = elgg_get_page_owner_entity();
+$page_owner = elgg_get_page_owner_entity();
+if ($owner_guid) {
+	$owner = get_entity($owner_guid);
+} else {
+	$owner = $page_owner;
+}
+
+if (!$owner) {
+	elgg_log('Can not resolve owner entity for widget layout', 'ERROR');
+	return;
+}
+
+// Underlying views and functions assume that the page owner is the owner of the widgets
+if ($owner->guid != $page_owner->guid) {
+	elgg_set_page_owner_guid($owner->guid);
+}
 
 $widget_types = elgg_get_widget_types();
 
@@ -23,7 +40,12 @@ elgg_push_context('widgets');
 
 $widgets = elgg_get_widgets($owner->guid, $context);
 
-echo '<div class="elgg-layout-widgets">';
+$layout_attrs = elgg_format_attributes(array(
+	'class' => 'elgg-layout-widgets',
+	'data-page-owner-guid' => $owner->guid,
+));
+
+echo "<div $layout_attrs>";
 
 if (elgg_can_edit_widget_layout($context)) {
 	if ($show_add_widgets) {
@@ -66,3 +88,9 @@ elgg_pop_context();
 echo elgg_view('graphics/ajax_loader', array('id' => 'elgg-widget-loader'));
 
 echo '</div>';
+
+
+// Restore original page owner
+if ($owner->guid != $page_owner->guid) {
+	elgg_set_page_owner_guid($page_owner->guid);
+}


### PR DESCRIPTION
Widget layout view now accepts $vars[owner_guid], which allows plugins
to set an owner of the widgets other than the page owner.

Fixes #7023
