### PR TITLE
feature(file): more consistency in mime and simple type values

### DIFF
--- a/engine/classes/ElggFile.php
+++ b/engine/classes/ElggFile.php
@@ -18,6 +18,9 @@
  *
  * @package    Elgg.Core
  * @subpackage DataModel.File
+ *
+ * @property string $mimetype   MIME type of the file
+ * @property string $simpletype Category of the file
  */
 class ElggFile extends \ElggObject {
 
@@ -111,22 +114,20 @@ class ElggFile extends \ElggObject {
 
 	/**
 	 * Get the mime type of the file.
-	 *
+	 * Returns mimetype metadata value if set, otherwise attempts to detect it.
 	 * @return string
 	 */
 	public function getMimeType() {
 		if ($this->mimetype) {
 			return $this->mimetype;
 		}
-
-		// @todo Guess mimetype if not here
+		return $this->detectMimeType();
 	}
 
 	/**
 	 * Set the mime type of the file.
 	 *
 	 * @param string $mimetype The mimetype
-	 *
 	 * @return bool
 	 */
 	public function setMimeType($mimetype) {
@@ -169,6 +170,21 @@ class ElggFile extends \ElggObject {
 			'default' => $default,
 		);
 		return _elgg_services()->hooks->trigger('mime_type', 'file', $params, $mime);
+	}
+
+	/**
+	 * Get the simple type of the file.
+	 * Returns simpletype metadata value if set, otherwise parses it from mimetype
+	 * @see elgg_get_file_simple_type
+	 *
+	 * @return string 'document', 'audio', 'video', or 'general' if the MIME type was unrecognized
+	 */
+	public function getSimpleType() {
+		if (isset($this->simpletype)) {
+			return $this->simpletype;
+		}
+		$mime_type = $this->getMimeType();
+		return elgg_get_file_simple_type($mime_type);
 	}
 
 	/**
@@ -465,7 +481,7 @@ class ElggFile extends \ElggObject {
 	 *
 	 * @return bool
 	 */
-	public function save() {
+	public function save() {	
 		if (!parent::save()) {
 			return false;
 		}

--- a/engine/tests/ElggCoreFilestoreTest.php
+++ b/engine/tests/ElggCoreFilestoreTest.php
@@ -73,64 +73,6 @@ class ElggCoreFilestoreTest extends \ElggCoreUnitTest {
 		$user->delete();
 	}
 
-	function testElggGetFileSimpletype() {
-
-		$tests = array(
-			'x-world/x-svr' => 'general',
-			'application/msword' => 'document',
-			'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'document',
-			'application/vnd.oasis.opendocument.text' => 'document',
-			'application/pdf' => 'document',
-			'application/ogg' => 'audio',
-			'text/css' => 'document',
-			'text/plain' => 'document',
-			'audio/midi' => 'audio',
-			'audio/mpeg' => 'audio',
-			'image/jpeg' => 'image',
-			'image/bmp' => 'image',
-			'video/mpeg' => 'video',
-			'video/quicktime' => 'video',
-		);
-
-		foreach ($tests as $mime_type => $simple_type) {
-			$this->assertEqual($simple_type, elgg_get_file_simple_type($mime_type));
-		}
-	}
-
-	function testDetectMimeType() {
-
-		$user = $this->createTestUser();
-
-		$file = new \ElggFile();
-		$file->owner_guid = $user->guid;
-		$file->setFilename('testing/filestore.txt');
-		$file->open('write');
-		$file->write('Testing!');
-		$file->close();
-
-		$mime = $file->detectMimeType(null, 'text/plain');
-
-		// mime should not be null if default is set
-		$this->assertTrue(isset($mime));
-
-		// mime of a file object should match mime of a file path that represents this file on filestore
-		$resource_mime = $file->detectMimeType($file->getFilenameOnFilestore(), 'text/plain');
-		$this->assertIdentical($mime, $resource_mime);
-
-		// calling detectMimeType statically raises strict policy warning
-		// @todo: remove this once a new static method has been implemented
-		error_reporting(E_ALL & ~E_STRICT & ~E_DEPRECATED);
-		
-		// method output should not differ between a static and a concrete call if the file path is set
-		$resource_mime_static = \ElggFile::detectMimeType($file->getFilenameOnFilestore(), 'text/plain');
-		$this->assertIdentical($resource_mime, $resource_mime_static);
-
-		error_reporting(E_ALL);
-
-		$user->delete();
-
-	}
-
 	protected function createTestUser($username = 'fileTest') {
 		$user = new \ElggUser();
 		$user->username = $username;

--- a/engine/tests/phpunit/ElggFileTest.php
+++ b/engine/tests/phpunit/ElggFileTest.php
@@ -9,6 +9,8 @@ class ElggFileTest extends \PHPUnit_Framework_TestCase {
 
 	protected function setUp() {
 
+		_elgg_filestore_init();
+		
 		$session = \ElggSession::getMock();
 		_elgg_services()->setValue('session', $session);
 		_elgg_services()->session->start();
@@ -27,5 +29,67 @@ class ElggFileTest extends \PHPUnit_Framework_TestCase {
 		$time = $this->file->getModifiedTime();
 		$this->file->setModifiedTime();
 		$this->assertNotEquals($time, $this->file->getModifiedTime());
+	}
+
+	/**
+	 * @group FileService
+	 */
+	public function testCanSetMimeType() {
+		unset($this->file->mimetype);
+
+		$mimetype = 'application/plain';
+		$this->file->setMimeType($mimetype);
+		$this->assertEquals($mimetype, $this->file->getMimeType());
+	}
+
+	/**
+	 * @group FileService
+	 */
+	public function testCanDetectMimeType() {
+		$mime = $this->file->detectMimeType(null, 'text/plain');
+
+		// mime should not be null if default is set
+		$this->assertNotNull($mime);
+
+		// mime of a file object should match mime of a file path that represents this file on filestore
+		$resource_mime = $this->file->detectMimeType($this->file->getFilenameOnFilestore(), 'text/plain');
+		$this->assertEquals($mime, $resource_mime);
+
+		// calling detectMimeType statically raises strict policy warning
+		// @todo: remove this once a new static method has been implemented
+		error_reporting(E_ALL & ~E_STRICT & ~E_DEPRECATED);
+
+		// method output should not differ between a static and a concrete call if the file path is set
+		$resource_mime_static = \ElggFile::detectMimeType($this->file->getFilenameOnFilestore(), 'text/plain');
+		$this->assertEquals($resource_mime, $resource_mime_static);
+	}
+
+	/**
+	 * @group FileService
+	 * @dataProvider providerSimpleTypeMap
+	 */
+	public function testCanParseSimpleType($mime_type, $simple_type) {
+		unset($this->file->simpletype);
+		$this->file->mimetype = $mime_type;
+		$this->assertEquals($simple_type, $this->file->getSimpleType());
+	}
+
+	function providerSimpleTypeMap() {
+		return array(
+			array('x-world/x-svr' , 'general'),
+			array('application/msword', 'document'),
+			array('application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'document'),
+			array('application/vnd.oasis.opendocument.text', 'document'),
+			array('application/pdf', 'document'),
+			array('application/ogg', 'audio'),
+			array('text/css', 'document'),
+			array('text/plain', 'document'),
+			array('audio/midi', 'audio'),
+			array('audio/mpeg', 'audio'),
+			array('image/jpeg', 'image'),
+			array('image/bmp', 'image'),
+			array('video/mpeg', 'video'),
+			array('video/quicktime', 'video'),
+		);
 	}
 }

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -424,7 +424,7 @@ function file_set_icon_url($hook, $type, $url, $params) {
 			'video' => 'video',
 		);
 
-		$mime = $file->mimetype;
+		$mime = $file->getMimeType();
 		if ($mime) {
 			$base_type = substr($mime, 0, strpos($mime, '/'));
 		} else {

--- a/mod/file/views/default/file/specialcontent/audio/default.php
+++ b/mod/file/views/default/file/specialcontent/audio/default.php
@@ -15,6 +15,6 @@ if (!elgg_extract('full_view', $vars, false)) {
 }
 
 $download_url = elgg_get_download_url($file);
-$mimetype = $file->mimetype;
+$mimetype = $file->getMimeType();
 
 echo "<audio controls><source src='{$download_url}' type='{$mimetype}'></audio>";

--- a/mod/file/views/default/object/file.php
+++ b/mod/file/views/default/object/file.php
@@ -45,7 +45,7 @@ if (!elgg_in_context('widgets') && !elgg_in_context('gallery')) {
 }
 
 if ($full && !elgg_in_context('gallery')) {
-	$mime = $file->mimetype;
+	$mime = $file->getMimeType();
 	$base_type = substr($mime, 0, strpos($mime,'/'));
 
 	$extra = '';


### PR DESCRIPTION
Adds ElggFile::getSimpleType and patches ElggFile::getMimeType to parse type values
if not set as metadata.

Fixes #9614
