### PR TITLE
fix(site): allow access to serve-file handler in walled garden mode

### DIFF
--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -534,6 +534,7 @@ class ElggSite extends \ElggEntity {
 			'cache/[0-9]+/\w+/.*',
 			'cron/.*',
 			'services/.*',
+			'serve-file/.*',
 		);
 
 		// include a hook for plugin authors to include public pages


### PR DESCRIPTION
/serve-file URLs are now treated as public.
