### PR TITLE
feature(cache): allow cache to be written to install root

### DIFF
--- a/docs/admin/duplicate-installation.rst
+++ b/docs/admin/duplicate-installation.rst
@@ -90,7 +90,7 @@ If you don't have shell access to your server and have to ftp the data, you may 
 
 .. note::
    
-   You also need to delete the views cache on the test server after the copy process. This is a directory called ``views_simplecache`` in your data directory and the directory called ``system_cache`` .
+   You also need to delete the views cache on the test server after the copy process. This is a directory called ``views_simplecache`` in your data directory (or ``cache`` directory in your public root if ``public_cache`` is enabled) and the directory called ``system_cache`` .
 
 Edit settings.php
 =================

--- a/docs/admin/performance.rst
+++ b/docs/admin/performance.rst
@@ -83,17 +83,9 @@ It is recommended that you do this on your development platform if you are writi
 This cache is automatically flushed when a plugin is enabled, disabled or reordered,
 or when upgrade.php is executed.
 
-For best performance, you can also create a symlink from ``/cache/`` in your www
-root dir to the ``/views_simplecache/`` directory in the data directory you
-configured when you installed Elgg:
-
-.. code:: shell
-
-    cd /path/to/wwwroot/
-    ln -s /path/to/dataroot/views_simplecache/ cache
-
-If your webserver supports following symlinks, this will serve files straight off
-disk without booting up PHP each time.
+For best performance, set ``$CONFIG->public_cache = true``. This way simplecache views
+will be generated and served from your site's root, rather than proxied from
+dataroot by ``\Elgg\Application\CacheHandler``.
 
 System cache
 ------------

--- a/elgg-config/settings.example.php
+++ b/elgg-config/settings.example.php
@@ -133,6 +133,15 @@ $CONFIG->dbprefix = '{{dbprefix}}';
 //$CONFIG->simplecache_enabled = true;
 
 /**
+ * Public cache
+ *
+ * If enabled, simplecache views will be placed in /root/cache rather than
+ * /dataroot/views_simplecache. This will allow cacheable views to be served
+ * directly from the server without booting the engine
+ */
+//$CONFIG->public_cache = false;
+
+/**
  * Enable the boot cache
  *
  * Elgg can store most non-user-specific boot up data in a cache. If you want to

--- a/engine/classes/Elgg/Application/CacheHandler.php
+++ b/engine/classes/Elgg/Application/CacheHandler.php
@@ -120,7 +120,8 @@ class CacheHandler {
 		$this->handle304($etag);
 
 		// trust the client but check for an existing cache file
-		$filename = $config->getVolatile('dataroot') . "views_simplecache/$ts/$viewtype/$view";
+		$cache_path = rtrim($this->getPath(), '/');
+		$filename = "{$cache_path}/{$ts}/{$viewtype}/{$view}";
 		if (file_exists($filename)) {
 			$this->sendCacheHeaders($etag);
 			readfile($filename);
@@ -137,7 +138,7 @@ class CacheHandler {
 
 		$lastcache = (int)$config->get('lastcache');
 
-		$filename = $config->getVolatile('dataroot') . "views_simplecache/$lastcache/$viewtype/$view";
+		$filename = "$cache_path/$lastcache/$viewtype/$view";
 
 		if ($lastcache == $ts) {
 			$this->sendCacheHeaders($etag);
@@ -400,6 +401,19 @@ class CacheHandler {
 		header('HTTP/1.1 403 Forbidden');
 		echo $msg;
 		exit;
+	}
+
+	/**
+	 * Returns the path of the cache directory
+	 * @return string
+	 */
+	protected function getPath() {
+		if ($this->config->getVolatile('public_cache')) {
+			$cache_path = \Elgg\Filesystem\Directory\Local::root()->getPath() . "cache/";
+		} else {
+			$cache_path = $this->config->getVolatile('dataroot') . "views_simplecache/";
+		}
+		return $cache_path;
 	}
 }
 

--- a/engine/classes/Elgg/Cache/SimpleCache.php
+++ b/engine/classes/Elgg/Cache/SimpleCache.php
@@ -164,7 +164,12 @@ class SimpleCache {
 	 * @return string
 	 */
 	private function getPath() {
-		return realpath($this->config->getDataPath() . "/views_simplecache");
+		if ($this->config->get('public_cache')) {
+			$cache_path = \Elgg\Filesystem\Directory\Local::root()->getPath() . "cache";
+		} else {
+			$cache_path = $this->config->get('dataroot') . "views_simplecache";
+		}
+		return $cache_path;
 	}
 
 	/**

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -183,6 +183,9 @@ function elgg_disable_simplecache() {
  * @access private
  */
 function _elgg_rmdir($dir, $empty = false) {
+	if (!is_dir($dir)) {
+		mkdir($dir, 0700, true);
+	}
 	$files = array_diff(scandir($dir), array('.', '..'));
 	
 	foreach ($files as $file) {


### PR DESCRIPTION
Adds public_cache config, which allows the cache handler to write cacheable
views to the /cache directory in install root
