### PR TITLE
feature(views): lists can be rendered as tables

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -538,6 +538,12 @@ Views
     Applies to request to ``/ajax/form/<form_name>``.
     This hook can be used to modify response content, status code, forward URL, or set additional response headers.
 
+**table_columns:call, <name>**
+    When the method ``elgg()->table_columns->$name()`` is called, this hook is called to allow
+    plugins to override or provide an implementation. Handlers receive the method arguments via
+    ``$params['arguments']`` and should return an instance of ``Elgg\Views\TableColumn`` if they
+    wish to specify the column directly.
+
 Files
 =====
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -80,6 +80,17 @@ Notifications
  * ``elgg_get_notification_methods()`` can be used to obtain registered notification methods
  * Added ``ElggUser::getNotificationSettings()`` and ``ElggUser::setNotificationSetting()``
 
+Entity list functions can output tables
+---------------------------------------
+
+In functions like ``elgg_list_entities($options)``, table output is possible by setting
+``$options['list_type'] = 'table'`` and providing an array of table columns as ``$options['columns']``.
+Each column is an ``Elgg\Views\TableColumn`` object, usually created via methods on the service
+``elgg()->table_columns``.
+
+Plugins can provide or alter these factory methods (see ``Elgg\Views\TableColumn\ColumnFactory``).
+See the view ``admin/users/newest`` for a usage example.
+
 From 2.1 to 2.2
 ===============
 
@@ -137,7 +148,7 @@ Removed APIs
 Just a warning that the private entity cache functions (e.g. ``_elgg_retrieve_cached_entity``) have been removed. Some plugins may have been using them. Plugins should not use private APIs as they will more often be removed without notice.
 
 Improved ``elgg/ckeditor`` module
------------------------------------
+---------------------------------
 
 :doc:`elgg/ckeditor module <javascript>` can now be used to add WYSIWYG to a textarea programmatically with ``elgg/ckeditor#bind``.
 

--- a/docs/guides/views.rst
+++ b/docs/guides/views.rst
@@ -503,6 +503,9 @@ you can improve performance a bit by preloading all owner entities:
 
 See also :doc:`this background information on Elgg's database </design/database>`.
 
+Rendering a list with an alternate view
+---------------------------------------
+
 Since 1.11, you can define an alternative view to render list items using ``'item_view'`` parameter.
 
 In some cases, default entity views may be unsuitable for your needs.
@@ -536,6 +539,37 @@ In the second example, we want to display a list of groups the user was invited 
 Since invitations are not entities, they do not have their own views and can not be listed using ``elgg_list_*``.
 We are providing an alternative item view, that will use the group entity to display
 an invitation that contains a group name and buttons to access or reject the invitation.
+
+Rendering a list as a table
+---------------------------
+
+Since 2.3 you can render lists as tables. Set ``$options['list_type'] = 'table'`` and provide an array of
+TableColumn objects as ``$options['columns']``. The service ``elgg()->table_columns`` provides several
+methods to create column objects based around existing views (like ``page/components/column/*``), properties,
+or methods.
+
+In this example, we list the latest ``my_plugin`` objects in a table of 3 columns: entity icon, the display
+name, and a friendly format of the time.
+
+.. code-block:: php
+
+    echo elgg_list_entities([
+        'type' => 'object',
+        'subtype' => 'my_plugin',
+
+        'list_type' => 'table',
+        'columns' => [
+            elgg()->table_columns->icon(),
+            elgg()->table_columns->getDisplayName(),
+            elgg()->table_columns->time_created(null, [
+                'format' => 'friendly',
+            ]),
+        ],
+    ]);
+
+See the ``Elgg\Views\TableColumn\ColumnFactory`` class for more details on how columns are specified and
+rendered. You can add or override methods of ``elgg()->table_columns`` in a variety of ways, based on views,
+properties/methods on the items, or given functions.
 
 Related
 =======

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -16,6 +16,7 @@ use Elgg\Filesystem\Directory;
  * @since 2.0.0
  *
  * @property-read \Elgg\Menu\Service $menus
+ * @property-read \Elgg\Views\TableColumn\ColumnFactory $table_columns
  */
 class Application {
 
@@ -44,6 +45,7 @@ class Application {
 	private static $public_services = [
 		//'config' => true,
 		'menus' => true,
+		'table_columns' => true,
 	];
 
 	/**

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -71,6 +71,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\Database\SubtypeTable              $subtypeTable
  * @property-read \Elgg\Cache\SystemCache                  $systemCache
  * @property-read \Elgg\SystemMessagesService              $systemMessages
+ * @property-read \Elgg\Views\TableColumn\ColumnFactory    $table_columns
  * @property-read \Elgg\Timer                              $timer
  * @property-read \Elgg\I18n\Translator                    $translator
  * @property-read \Elgg\UpgradeService                     $upgrades
@@ -400,6 +401,8 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setFactory('systemMessages', function(ServiceProvider $c) {
 			return new \Elgg\SystemMessagesService($c->session);
 		});
+
+		$this->setClassName('table_columns', \Elgg\Views\TableColumn\ColumnFactory::class);
 
 		$this->setClassName('timer', \Elgg\Timer::class);
 

--- a/engine/classes/Elgg/Views/TableColumn.php
+++ b/engine/classes/Elgg/Views/TableColumn.php
@@ -1,0 +1,28 @@
+<?php
+namespace Elgg\Views;
+
+/**
+ * A renderer for a column of table cells and a header
+ */
+interface TableColumn {
+
+	/**
+	 * Get the rendered heading cell as HTML. Cell will be auto-wrapped with a TH element if the
+	 * returned string doesn't begin with "<th" or "<td".
+	 *
+	 * @return string e.g. "Title" or "<th>Title</th>". You must filter/escape any user content.
+	 */
+	public function renderHeading();
+
+	/**
+	 * Render a value cell as HTML. Cell will be auto-wrapped with a TD element if the returned
+	 * string doesn't begin with "<th" or "<td".
+	 *
+	 * @param mixed  $item      Object/row from which to pull the value
+	 * @param string $type      Type of object
+	 * @param array  $item_vars Parameters from the listing function
+	 *
+	 * @return string e.g. "My Great Title" or "<td>My Great Title</td>". You must filter/escape any user content.
+	 */
+	public function renderCell($item, $type, $item_vars);
+}

--- a/engine/classes/Elgg/Views/TableColumn/CallableColumn.php
+++ b/engine/classes/Elgg/Views/TableColumn/CallableColumn.php
@@ -1,0 +1,45 @@
+<?php
+namespace Elgg\Views\TableColumn;
+
+use Elgg\Views\TableColumn;
+
+/**
+ * Table column rendered by a function
+ */
+class CallableColumn implements TableColumn {
+
+	/**
+	 * @var string
+	 */
+	private $heading;
+
+	/**
+	 * @var callable
+	 */
+	private $renderer;
+
+	/**
+	 * Constructor
+	 *
+	 * @param callable $renderer Rendering function
+	 * @param string   $heading  Heading
+	 */
+	public function __construct(callable $renderer, $heading) {
+		$this->renderer = $renderer;
+		$this->heading = $heading;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function renderHeading() {
+		return $this->heading;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function renderCell($item, $type, $item_vars) {
+		return call_user_func($this->renderer, $item, $type, $item_vars);
+	}
+}

--- a/engine/classes/Elgg/Views/TableColumn/ColumnFactory.php
+++ b/engine/classes/Elgg/Views/TableColumn/ColumnFactory.php
@@ -1,0 +1,165 @@
+<?php
+namespace Elgg\Views\TableColumn;
+
+use Elgg\Values;
+use Elgg\Views\TableColumn;
+
+/**
+ * Factory for table column objects
+ *
+ * `elgg_list_entities()` can output tables by specifying `$options['list_type'] = 'table'` and
+ * by providing an array of TableColumn objects to `$options['columns']`. This service, available
+ * as `elgg()->table_columns` provides methods to create column objects based around existing views
+ * like `page/components/column/*`, properties, or methods.
+ *
+ * Numerous pre-existing methods are provided via `__call()` magic. See this method to find out how
+ * to add your own methods, override the existing ones, or completely replace a method via hook.
+ *
+ * @internal Use elgg()->table_columns to access the instance of this.
+ *
+ * @method TableColumn admin($heading = null, $vars = [])
+ * @method TableColumn banned($heading = null, $vars = [])
+ * @method TableColumn container($heading = null, $vars = [])
+ * @method TableColumn excerpt($heading = null, $vars = [])
+ * @method TableColumn icon($heading = null, $vars = [])
+ * @method TableColumn item($heading = null, $vars = [])
+ * @method TableColumn language($heading = null, $vars = [])
+ * @method TableColumn link($heading = null, $vars = [])
+ * @method TableColumn owner($heading = null, $vars = [])
+ * @method TableColumn time_created($heading = null, $vars = [])
+ * @method TableColumn time_updated($heading = null, $vars = [])
+ * @method TableColumn description($heading = null)
+ * @method TableColumn email($heading = null)
+ * @method TableColumn name($heading = null)
+ * @method TableColumn type($heading = null)
+ * @method TableColumn user($heading = null, $vars = [])
+ * @method TableColumn username($heading = null)
+ * @method TableColumn getSubtype($heading = null)
+ * @method TableColumn getDisplayName($heading = null)
+ * @method TableColumn getMimeType($heading = null)
+ * @method TableColumn getSimpleType($heading = null)
+ */
+class ColumnFactory {
+
+	/**
+	 * Make a column from one of the page/components/column/* views.
+	 *
+	 * @param string $name    Column name (view will be "page/components/column/$name")
+	 * @param string $heading Optional heading
+	 * @param array  $vars    View vars (item, item_vars, and type will be merged in)
+	 *
+	 * @return ViewColumn
+	 */
+	public function fromView($name, $heading = null, $vars = []) {
+		$view = "page/components/column/$name";
+
+		if (!is_string($heading)) {
+			if (elgg_language_key_exists("table_columns:fromView:$name")) {
+				$heading = elgg_echo("table_columns:fromView:$name");
+			} else {
+				$title = str_replace('_', ' ', $name);
+				$heading = elgg_ucwords($title);
+			}
+		}
+
+		return new ViewColumn($view, $heading, $vars);
+	}
+
+	/**
+	 * Make a column by reading a property of the item
+	 *
+	 * @param string $name    Property name. e.g. "description", "email", "type"
+	 * @param string $heading Heading
+	 *
+	 * @return CallableColumn
+	 */
+	public function fromProperty($name, $heading = null) {
+		if (!is_string($heading)) {
+			if (elgg_language_key_exists("table_columns:fromProperty:$name")) {
+				$heading = elgg_echo("table_columns:fromProperty:$name");
+			} else {
+				$title = str_replace('_', ' ', $name);
+				$heading = elgg_ucwords($title);
+			}
+		}
+
+		$renderer = function ($item) use ($name) {
+			return $item->{$name};
+		};
+
+		return new CallableColumn($renderer, $heading);
+	}
+
+	/**
+	 * Make a column by calling a method on the item
+	 *
+	 * @param string $name    Method name. e.g. "getSubtype", "getDisplayName"
+	 * @param string $heading Heading
+	 * @param array  $args    Method arguments
+	 *
+	 * @return CallableColumn
+	 */
+	public function fromMethod($name, $heading = null, $args = []) {
+		if (!is_string($heading)) {
+			if (elgg_language_key_exists("table_columns:fromMethod:$name")) {
+				$heading = elgg_echo("table_columns:fromMethod:$name");
+			} else {
+				$title = str_replace('_', ' ', $name);
+				$heading = elgg_ucwords($title);
+			}
+		}
+
+		$renderer = function ($item) use ($name, $args) {
+			return call_user_func_array([$item, $name], $args);
+		};
+
+		return new CallableColumn($renderer, $heading);
+	}
+
+	/**
+	 * Provide additional methods via hook and specified language keys.
+	 *
+	 * First, the hook `table_columns:call` is called. Details in `docs/guides/hooks-list.rst`.
+	 *
+	 * Then it checks existence of 3 language keys in order to defer processing to a local method:
+	 *
+	 * - "table_columns:fromView:$name" -> uses $this->fromView($name, ...).
+	 * - "table_columns:fromProperty:$name" -> uses $this->fromProperty($name, ...).
+	 * - "table_columns:fromMethod:$name" -> uses $this->fromMethod($name, ...).
+	 *
+	 * See the `from*()` methods for details.
+	 *
+	 * @param string $name      Method name
+	 * @param array  $arguments Arguments
+	 *
+	 * @return TableColumn
+	 */
+	public function __call($name, $arguments) {
+		// allow hook to hijack magic methods
+		$column = elgg_trigger_plugin_hook('table_columns:call', $name, [
+			'arguments' => $arguments,
+		]);
+		if ($column instanceof TableColumn) {
+			return $column;
+		}
+
+		if (elgg_language_key_exists("table_columns:fromView:$name")) {
+			array_unshift($arguments, $name);
+			return call_user_func_array([$this, 'fromView'], $arguments);
+		}
+
+		if (elgg_language_key_exists("table_columns:fromProperty:$name")) {
+			array_unshift($arguments, $name);
+			return call_user_func_array([$this, 'fromProperty'], $arguments);
+		}
+
+		if (elgg_language_key_exists("table_columns:fromMethod:$name")) {
+			array_unshift($arguments, $name);
+			return call_user_func_array([$this, 'fromMethod'], $arguments);
+		}
+
+		// empty column and error
+		_elgg_services()->logger->error(__CLASS__ . ": No method defined '$name'");
+		return new CallableColumn([Values::class, 'getNull'], '');
+	}
+}

--- a/engine/classes/Elgg/Views/TableColumn/ViewColumn.php
+++ b/engine/classes/Elgg/Views/TableColumn/ViewColumn.php
@@ -1,0 +1,62 @@
+<?php
+namespace Elgg\Views\TableColumn;
+
+use Elgg\Views\TableColumn;
+
+/**
+ * Table column rendered by a view
+ */
+class ViewColumn implements TableColumn {
+
+	/**
+	 * @var string
+	 */
+	private $heading;
+
+	/**
+	 * @var string
+	 */
+	private $view;
+
+	/**
+	 * @var array
+	 */
+	private $vars;
+
+	/**
+	 * Constructor
+	 *
+	 * @param string $view    The view to render the value
+	 * @param string $heading Heading
+	 * @param array  $vars    Vars to merge into the view vars
+	 */
+	public function __construct($view, $heading = null, $vars = []) {
+		$this->view = $view;
+		$this->vars = $vars;
+
+		if (!is_string($heading)) {
+			$heading = elgg_echo("ViewColumn:view:$view");
+		}
+		$this->heading = $heading;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function renderHeading() {
+		return $this->heading;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function renderCell($item, $type, $item_vars) {
+		$vars = $this->vars + [
+			'item' => $item,
+			'item_vars' => $item_vars,
+			'type' => $type,
+		];
+
+		return elgg_view($this->view, $vars);
+	}
+}

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -376,7 +376,8 @@ function _elgg_get_entity_time_where_sql($table, $time_created_upper = null,
  * @param array    $options Any options from $getter options plus:
  *                   item_view => STR Optional. Alternative view used to render list items
  *                   full_view => BOOL Display full view of entities (default: false)
- *                   list_type => STR 'list' or 'gallery'
+ *                   list_type => STR 'list', 'gallery', or 'table'
+ *                   columns => ARR instances of Elgg\Views\TableColumn if list_type is "table"
  *                   list_type_toggle => BOOL Display gallery / list switch
  *                   pagination => BOOL Display pagination links
  *                   no_results => STR|Closure Message to display when there are no entities

--- a/engine/lib/mb_wrapper.php
+++ b/engine/lib/mb_wrapper.php
@@ -197,6 +197,20 @@ function elgg_strtoupper() {
 }
 
 /**
+ * Wrapper for mb_convert_case($str, MB_CASE_TITLE)
+ *
+ * @param string $str String
+ * @return string
+ * @since 2.3
+ */
+function elgg_ucwords($str) {
+	if (is_callable('mb_convert_case')) {
+		return mb_convert_case($str, MB_CASE_TITLE, 'UTF-8');
+	}
+	return ucwords($str);
+}
+
+/**
  * Wrapper function for mb_substr_count(). Falls back to substr_count() if
  * mb_substr_count() isn't available.  Parameters are passed to the
  * wrapped function in the same order they are passed to this

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1037,10 +1037,12 @@ function elgg_view_entity_list($entities, array $vars = array()) {
 		$vars["pagination"] = false;
 	}
 
-	if ($vars['list_type'] != 'list') {
-		return elgg_view('page/components/gallery', $vars);
-	} else {
+	if ($vars['list_type'] == 'table') {
+		return elgg_view('page/components/table', $vars);
+	} elseif ($vars['list_type'] == 'list') {
 		return elgg_view('page/components/list', $vars);
+	} else {
+		return elgg_view('page/components/gallery', $vars);
 	}
 }
 

--- a/languages/en.php
+++ b/languages/en.php
@@ -131,6 +131,32 @@ return array(
 	'upload:error:extension' => 'Cannot save the uploaded file.',
 	'upload:error:unknown' => 'The file upload failed.',
 
+/**
+ * Table columns
+ */
+	'table_columns:fromView:admin' => 'Admin',
+	'table_columns:fromView:banned' => 'Banned',
+	'table_columns:fromView:container' => 'Container',
+	'table_columns:fromView:excerpt' => 'Description',
+	'table_columns:fromView:link' => 'Name/Title',
+	'table_columns:fromView:icon' => 'Icon',
+	'table_columns:fromView:item' => 'Item',
+	'table_columns:fromView:language' => 'Language',
+	'table_columns:fromView:owner' => 'Owner',
+	'table_columns:fromView:time_created' => 'Time Created',
+	'table_columns:fromView:time_updated' => 'Time Updated',
+	'table_columns:fromView:user' => 'User',
+
+	'table_columns:fromProperty:description' => 'Description',
+	'table_columns:fromProperty:email' => 'Email',
+	'table_columns:fromProperty:name' => 'Name',
+	'table_columns:fromProperty:type' => 'Type',
+	'table_columns:fromProperty:username' => 'Username',
+
+	'table_columns:fromMethod:getSubtype' => 'Subtype',
+	'table_columns:fromMethod:getDisplayName' => 'Name/Title',
+	'table_columns:fromMethod:getMimeType' => 'MIME Type',
+	'table_columns:fromMethod:getSimpleType' => 'Type',
 
 /**
  * User details

--- a/views/default/admin/users/newest.css
+++ b/views/default/admin/users/newest.css
@@ -1,0 +1,4 @@
+
+.elgg-newest-users td + td {
+	white-space: nowrap;
+}

--- a/views/default/admin/users/newest.php
+++ b/views/default/admin/users/newest.php
@@ -1,9 +1,24 @@
 <?php
+
+$view = "admin/users/newest.css";
+elgg_register_css($view, elgg_get_simplecache_url($view));
+elgg_load_css($view);
+
 // newest users
 $users = elgg_list_entities([
 	'type' => 'user',
 	'subtype'=> null,
 	'full_view' => false,
+	'list_type' => 'table',
+	'columns' => [
+		elgg()->table_columns->user(),
+		elgg()->table_columns->username(),
+		elgg()->table_columns->email(),
+		elgg()->table_columns->time_created(null, [
+			'format' => 'friendly',
+		]),
+	],
+	'list_class' => 'elgg-newest-users',
 ]);
 
 echo elgg_view_module('inline', elgg_echo('admin:users:newest'), $users);

--- a/views/default/page/components/column/admin.php
+++ b/views/default/page/components/column/admin.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Render "Yes" where a user is an admin
+ *
+ * @uses $vars['item']      The item being rendered
+ * @uses $vars['item_vars'] Vars received from the page/components/table view
+ * @uses $vars['type']      The item type or ""
+ */
+
+$item = $vars['item'];
+/* @var ElggUser $item */
+
+if ($item->admin === 'yes') {
+	echo elgg_echo('option:yes');
+}

--- a/views/default/page/components/column/banned.php
+++ b/views/default/page/components/column/banned.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Render "Yes" is a user is banned
+ *
+ * @uses $vars['item']      The item being rendered
+ * @uses $vars['item_vars'] Vars received from the page/components/table view
+ * @uses $vars['type']      The item type or ""
+ */
+
+$item = $vars['item'];
+/* @var ElggUser $item */
+
+if ($item->banned === 'yes') {
+	echo elgg_echo('option:yes');
+}

--- a/views/default/page/components/column/container.php
+++ b/views/default/page/components/column/container.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Render a container element
+ *
+ * @uses $vars['item']      The item being rendered
+ * @uses $vars['item_vars'] Vars received from the page/components/table view
+ * @uses $vars['type']      The item type or ""
+ * @uses $vars['link']      Set to false to not use an anchor
+ */
+
+$item = $vars['item'];
+/* @var ElggEntity $item */
+
+$link = elgg_extract('link', $vars, true);
+
+$entity = $item->getContainerEntity();
+if (!$entity) {
+	return;
+}
+
+$value = $entity->getDisplayName();
+if ($link) {
+	$value = elgg_view('output/url', [
+		'href' => $entity->getURL(),
+		'text' => $value,
+	]);
+}
+
+echo $value;

--- a/views/default/page/components/column/excerpt.php
+++ b/views/default/page/components/column/excerpt.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Render an excerpt of the description
+ *
+ * @uses $vars['item']      The item being rendered
+ * @uses $vars['item_vars'] Vars received from the page/components/table view
+ * @uses $vars['type']      The item type or ""
+ * @uses $vars['length']    The excerpt length
+ */
+
+$item = $vars['item'];
+/* @var ElggEntity $item */
+
+$length = elgg_extract('length', $vars, 250);
+
+$description = $item->description;
+
+echo elgg_get_excerpt($description, $excerpt_length);

--- a/views/default/page/components/column/icon.php
+++ b/views/default/page/components/column/icon.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Render an icon
+ *
+ * @uses $vars['item']      The item being rendered
+ * @uses $vars['item_vars'] Vars received from the page/components/table view
+ * @uses $vars['type']      The item type or ""
+ * @uses $vars['size']      The icon size
+ */
+
+$item = $vars['item'];
+/* @var ElggEntity $item */
+
+$size = elgg_extract('size', $vars, 'small');
+
+echo elgg_view_entity_icon($item, $size);

--- a/views/default/page/components/column/item.php
+++ b/views/default/page/components/column/item.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Render a regular list item
+ *
+ * @uses $vars['item']      The item being rendered
+ * @uses $vars['item_vars'] Vars received from the page/components/table view
+ * @uses $vars['type']      The item type or ""
+ */
+
+$item = $vars['item'];
+
+if ($vars['type']) {
+	// recognized type
+	echo elgg_view_list_item($item, $vars['item_vars']);
+}

--- a/views/default/page/components/column/language.php
+++ b/views/default/page/components/column/language.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Render a user's language
+ *
+ * @uses $vars['item']      The item being rendered
+ * @uses $vars['item_vars'] Vars received from the page/components/table view
+ * @uses $vars['type']      The item type or ""
+ */
+
+$item = $vars['item'];
+/* @var ElggUser $item */
+
+if (!$item->language) {
+	return;
+}
+
+echo elgg_echo($item->language);

--- a/views/default/page/components/column/link.php
+++ b/views/default/page/components/column/link.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Render a linked title
+ *
+ * @uses $vars['item']      The item being rendered
+ * @uses $vars['item_vars'] Vars received from the page/components/table view
+ * @uses $vars['type']      The item type or ""
+ */
+
+$item = $vars['item'];
+/* @var ElggEntity $item */
+
+echo elgg_view('output/url', [
+	'href' => $item->getURL(),
+	'text' => $item->getDisplayName(),
+]);

--- a/views/default/page/components/column/owner.php
+++ b/views/default/page/components/column/owner.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Render an owner element
+ *
+ * @uses $vars['item']      The item being rendered
+ * @uses $vars['item_vars'] Vars received from the page/components/table view
+ * @uses $vars['type']      The item type or ""
+ * @uses $vars['link']      Set to false to not use an anchor
+ */
+
+$item = $vars['item'];
+/* @var ElggEntity $item */
+
+$link = elgg_extract('link', $vars, true);
+
+$entity = $item->getOwnerEntity();
+if (!$entity) {
+	return;
+}
+
+$value = $entity->getDisplayName();
+if ($link) {
+	$value = elgg_view('output/url', [
+		'href' => $entity->getURL(),
+		'text' => $value,
+	]);
+}
+
+echo $value;

--- a/views/default/page/components/column/time_created.php
+++ b/views/default/page/components/column/time_created.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Render the time created
+ *
+ * @uses $vars['item']      The item being rendered
+ * @uses $vars['item_vars'] Vars received from the page/components/table view
+ * @uses $vars['type']      The item type or ""
+ * @uses $vars['format']    Date format. Use "friendly" for output/friendlytime view.
+ */
+
+$entity = $vars['item'];
+/* @var ElggEntity $entity */
+
+$format = elgg_extract('format', $vars, 'M d, Y H:i');
+
+if ($format === 'friendly') {
+	echo elgg_view('output/friendlytime', [
+		'time' => $entity->time_created,
+	]);
+	return;
+}
+
+echo date($format, $entity->time_created);

--- a/views/default/page/components/column/time_updated.php
+++ b/views/default/page/components/column/time_updated.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Render the time updated
+ *
+ * @uses $vars['item']      The item being rendered
+ * @uses $vars['item_vars'] Vars received from the page/components/table view
+ * @uses $vars['type']      The item type or ""
+ * @uses $vars['format']    Date format. Use "friendly" for output/friendlytime view.
+ */
+
+$entity = $vars['item'];
+/* @var ElggEntity $entity */
+
+$format = elgg_extract('format', $vars, 'M d, Y H:i');
+
+if ($format === 'friendly') {
+	echo elgg_view('output/friendlytime', [
+		'time' => $entity->time_updated,
+	]);
+	return;
+}
+
+echo date($format, $entity->time_updated);

--- a/views/default/page/components/column/user.php
+++ b/views/default/page/components/column/user.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Render a user icon and name
+ *
+ * @uses $vars['item']      The item being rendered
+ * @uses $vars['item_vars'] Vars received from the page/components/table view
+ * @uses $vars['type']      The item type or ""
+ */
+
+$item = $vars['item'];
+
+$vars['item_view'] = 'user/default/column';
+$vars['full_view'] = false;
+
+echo elgg_view_entity($item, $vars);

--- a/views/default/page/components/list.php
+++ b/views/default/page/components/list.php
@@ -63,8 +63,8 @@ foreach ($items as $item) {
 	$li_attrs = ['class' => $item_classes];
 
 	if ($item instanceof \ElggEntity) {
-		$guid = $item->getGUID();
-		$type = $item->getType();
+		$guid = $item->guid;
+		$type = $item->type;
 		$subtype = $item->getSubtype();
 
 		$li_attrs['id'] = "elgg-$type-$guid";

--- a/views/default/page/components/table.php
+++ b/views/default/page/components/table.php
@@ -1,0 +1,131 @@
+<?php
+
+use Elgg\Views\TableColumn;
+
+/**
+ * View a table of items
+ *
+ * @uses $vars['columns']      Array of Elgg\Views\TableColumn
+ *                             If the trimmed rendering doesn't start with "<td" or "<th", then the cell
+ *                             is auto-wrapped with a TD/TH element.
+ *
+ * @uses $vars['items']        Array of ElggEntity, ElggAnnotation or ElggRiverItem objects
+ * @uses $vars['offset']       Index of the first list item in complete list
+ * @uses $vars['limit']        Number of items per page. Only used as input to pagination.
+ * @uses $vars['count']        Number of items in the complete list
+ * @uses $vars['base_url']     Base URL of list (optional)
+ * @uses $vars['url_fragment'] URL fragment to add to links if not present in base_url (optional)
+ * @uses $vars['pagination']   Show pagination? (default: true)
+ * @uses $vars['position']     Position of the pagination: before, after, or both
+ * @uses $vars['full_view']    Show the full view of the items (default: false)
+ * @uses $vars['list_class']   Additional CSS class for the <table> element
+ * @uses $vars['item_class']   Additional CSS class for the <td> elements
+ * @uses $vars['item_view']    Alternative view to render list items
+ * @uses $vars['no_results']   Message to display if no results (string|Closure)
+ */
+$items = $vars['items'];
+$count = elgg_extract('count', $vars);
+$pagination = elgg_extract('pagination', $vars, true);
+$position = elgg_extract('position', $vars, 'after');
+$no_results = elgg_extract('no_results', $vars, '');
+$cell_views = elgg_extract('cell_views', $vars, ['page/components/table/cell/default']);
+
+$columns = elgg_extract('columns', $vars);
+/* @var TableColumn[] $columns */
+
+if (empty($columns) || !is_array($columns)) {
+	elgg_log('$vars["columns"] must be an array of ' . TableColumn::class, 'ERROR');
+	return;
+}
+
+if (!is_array($items) || count($items) == 0) {
+	if ($no_results) {
+		if ($no_results instanceof Closure) {
+			echo $no_results();
+			return;
+		}
+		echo "<p class='elgg-no-results'>$no_results</p>";
+	}
+	return;
+}
+
+// render THEAD
+$headings = '';
+foreach ($columns as $column) {
+	if (!$column instanceof TableColumn) {
+		elgg_log('$vars["columns"] must be an array of ' . TableColumn::class, 'ERROR');
+		return;
+	}
+
+	$cell = trim($column->renderHeading());
+	if (!preg_match('~^<t[dh]~i', $cell)) {
+		$cell = "<th>$cell</th>";
+	}
+	$headings .= $cell;
+}
+$headings = "<thead><tr>$headings</tr></thead>";
+
+$table_classes = ['elgg-list', 'elgg-table'];
+if (isset($vars['list_class'])) {
+	$table_classes[] = $vars['list_class'];
+}
+
+$nav = ($pagination) ? elgg_view('navigation/pagination', $vars) : '';
+
+$rows = '';
+foreach ($items as $item) {
+	$row_attrs = [
+		'class' => ['elgg-item']
+	];
+
+	if (!empty($vars['item_class'])) {
+		$row_attrs['class'][] = $vars['item_class'];
+	}
+
+	$type = '';
+	$entity = null;
+
+	if ($item instanceof \ElggEntity) {
+		$entity = $item;
+		$guid = $item->guid;
+		$type = $item->type;
+		$subtype = $item->getSubtype();
+
+		$row_attrs['class'][] = "elgg-item-$type";
+		$row_attrs['data-elgg-guid'] = $guid;
+		$row_attrs['data-elgg-type-subtype'] = "$type:$subtype";
+		if ($subtype) {
+			$row_attrs['class'][] = "elgg-item-$type-$subtype";
+		}
+
+	} else if (is_callable(array($item, 'getType'))) {
+		$type = $item->getType();
+
+		$row_attrs['data-elgg-id'] = $item->id;
+		$row_attrs['data-elgg-type'] = $type;
+	}
+
+	$row = '';
+
+	foreach	($columns as $column) {
+		$cell = trim($column->renderCell($item, $type, $vars));
+		if (!preg_match('~^<t[dh]~i', $cell)) {
+			$cell = "<td>$cell</td>";
+		}
+		$row .= $cell;
+	}
+
+	$rows .= elgg_format_element('tr', $row_attrs, $row);
+}
+
+$body = "$headings<tbody>$rows</tbody>";
+
+if ($position == 'before' || $position == 'both') {
+	echo $nav;
+}
+
+echo elgg_format_element('table', ['class' => $table_classes], $body);
+
+if ($position == 'after' || $position == 'both') {
+	echo $nav;
+}

--- a/views/default/user/default/column.php
+++ b/views/default/user/default/column.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Elgg user display
+ *
+ * @uses $vars['entity'] ElggUser entity
+ * @uses $vars['size']   Size of the icon
+ * @uses $vars['title']  Optional override for the title
+ */
+
+$entity = $vars['entity'];
+$size = elgg_extract('size', $vars, 'tiny');
+
+$icon = elgg_view_entity_icon($entity, $size, $vars);
+
+$title = elgg_extract('title', $vars);
+if (!$title) {
+	$link_params = array(
+		'href' => $entity->getUrl(),
+		'text' => $entity->name,
+	);
+	$title = elgg_view('output/url', $link_params);
+}
+
+$params = array(
+	'entity' => $entity,
+	'title' => $title,
+);
+$list_body = elgg_view('user/elements/summary', $params);
+
+echo elgg_view_image_block($icon, $list_body, $vars);

--- a/views/rss/page/components/table.php
+++ b/views/rss/page/components/table.php
@@ -1,0 +1,8 @@
+<?php
+
+$vars['pagination'] = false;
+
+// output a regular HTML table...
+elgg_set_viewtype('default');
+echo elgg_view('page/components/table', $vars);
+elgg_set_viewtype('rss');


### PR DESCRIPTION
The list view functions can now output a bordered table by setting `list_type` to `table` and specifying an array of `Elgg\Views\TableColumn` objects as `columns`.

`elgg()->table_columns` (a [`ColumnFactory`](https://github.com/mrclay/Elgg-leaf/blob/d941fa838aaced7c81f59849fd77b783d9c965df/engine/classes/Elgg/Views/TableColumn/ColumnFactory.php#L8)) includes 21 methods for creating columns based on core views and properties/methods on the item, but this factory is also highly extensible by defining your own views or overriding existing ones. Default column headings are provided via language keys, but can be overridden when creating the column.

The Newest Users admin page now shows other useful info.

Fixes #7684
Fixes #9629

``` php
$users = elgg_list_entities([
    // ...
    'list_type' => 'table',
    'columns' => [
        elgg()->table_columns->user(),
        elgg()->table_columns->username(),
        elgg()->table_columns->email(),
        elgg()->table_columns->time_created(null, [
            'format' => 'friendly',
        ]),
    ],
]);
```

<img alt="table_list_newest" src="https://cloud.githubusercontent.com/assets/170687/18527749/122700e8-7a94-11e6-8f70-1ac1d73ba9aa.png">

``` html
<table class="elgg-list elgg-table elgg-list-entity">
  <thead>
    <tr><th>User</th></tr>
  </thead>
  <tbody>
    <tr class="elgg-item elgg-item-user" data-elgg-guid="117714" data-elgg-type-subtype="user:">
      <td> ... </td>
...
```
