### PR TITLE
fix(core): gatekeepers now forward with a 403 reason

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -123,6 +123,7 @@ Miscellaneous API changes
  * ``elgg_list_entities`` no longer supports the option ``view_type_toggle``
  * ``elgg_list_registered_entities`` no longer supports the option ``view_type_toggle``
  * ``elgg_log`` no longer accepts the level ``"DEBUG"``
+ * ``elgg_gatekeeper`` and ``elgg_admin_gatekeeper`` no longer report ``login`` or ``admin`` as forward reason, but ``403``
 
 JavaScript hook calling order may change
 ----------------------------------------

--- a/engine/lib/pagehandler.php
+++ b/engine/lib/pagehandler.php
@@ -59,7 +59,7 @@ function elgg_gatekeeper() {
 	if (!elgg_is_logged_in()) {
 		_elgg_services()->session->set('last_forward_from', current_page_url());
 		system_message(elgg_echo('loggedinrequired'));
-		forward('/login', 'login');
+		forward('/login', '403');
 	}
 }
 
@@ -86,7 +86,7 @@ function elgg_admin_gatekeeper() {
 	if (!elgg_is_admin_logged_in()) {
 		_elgg_services()->session->set('last_forward_from', current_page_url());
 		register_error(elgg_echo('adminrequired'));
-		forward('', 'admin');
+		forward('', '403');
 	}
 }
 


### PR DESCRIPTION
fixes #8172

BREAKING CHANGE:
If you registered a hook on the forward you need to update your code if
you checked for the 'admin' and/or 'login' reason
