### PR TITLE
[DOC] Remove the ''system_cache'' directory to flush the cache

### DIFF
--- a/docs/guides/views/simplecache.rst
+++ b/docs/guides/views/simplecache.rst
@@ -26,6 +26,7 @@ You can regenerate the Simplecache at any time by:
 - In the admin panel click on 'Flush the caches'
 - Enabling or disabling a plugin
 - Reordering your plugins
+- Removing your ``datadir/system_cache`` 
 
 Using the Simplecache in your plugins
 -------------------------------------


### PR DESCRIPTION
Added as a last resort, because other methods were
not applicable to me while migrating an ELGG installation to a new
server:
- upgrade.php: did not flush
- I have no access to admin panel
