### PR TITLE
fix(discussion): correctly check permissions before showing reply form

### DIFF
--- a/mod/discussions/views/default/discussion/replies.php
+++ b/mod/discussions/views/default/discussion/replies.php
@@ -6,24 +6,32 @@
  * @uses $vars['show_add_form'] Display add form or not
  */
 
-$show_add_form = elgg_extract('show_add_form', $vars, true);
+$topic = elgg_extract('topic', $vars);
+if (!elgg_instanceof($topic, 'object', 'discussion')) {
+	elgg_log("discussion/replies view expects \$vars['topic'] to be a discussion object", 'ERROR');
+	return;
+}
 
-echo '<div id="group-replies" class="elgg-comments">';
+$show_add_form = elgg_extract('show_add_form', $vars);
+if (!isset($show_add_form)) {
+	$show_add_form = $topic->canWriteToContainer(0, 'object', 'discussion_reply');
+}
 
 $replies = elgg_list_entities(array(
 	'type' => 'object',
 	'subtype' => 'discussion_reply',
-	'container_guid' => $vars['topic']->getGUID(),
+	'container_guid' => $topic->guid,
 	'reverse_order_by' => true,
 	'distinct' => false,
 	'url_fragment' => 'group-replies',
 ));
 
-echo $replies;
-
 if ($show_add_form) {
 	$form_vars = array('class' => 'mtm');
-	echo elgg_view_form('discussion/reply/save', $form_vars, $vars);
+	$replies .= elgg_view_form('discussion/reply/save', $form_vars, $vars);
 }
+?>
 
-echo '</div>';
+<div id="group-replies" class="elgg-comments">
+	<?= $replies ?>
+</div>

--- a/mod/discussions/views/default/resources/discussion/view.php
+++ b/mod/discussions/views/default/resources/discussion/view.php
@@ -29,22 +29,13 @@ elgg_push_breadcrumb($topic->title);
 
 $params = array(
 	'topic' => $topic,
-	'show_add_form' => false,
+	'show_add_form' => $topic->canWriteToContainer(0, 'object', 'discussion_reply'),
 );
 
 $content = elgg_view_entity($topic, array('full_view' => true));
+$content .= elgg_view('discussion/replies', $params);
 if ($topic->status == 'closed') {
-	$content .= elgg_view('discussion/replies', $params);
 	$content .= elgg_view('discussion/closed');
-} elseif (elgg_instanceof($container, 'group')) {
-	// Allow only group members to reply to a discussion within a group
-	if ($container->canWriteToContainer(0, 'object', 'discussion')) {
-		$params['show_add_form'] = true;
-	}
-	$content .= elgg_view('discussion/replies', $params);
-} else {
-	$params['show_add_form'] = true;
-	$content .= elgg_view('discussion/replies', $params);
 }
 
 $params = array(


### PR DESCRIPTION
Reply form is no longer shown if the viewer can not reply to a discussion (`canWriteToContainer()`).

Removes group write permissions check form the discussion view:
a) it was duplicating the logic present in `container_permissions_check` hook,
b) an assumption that the user must be allowed to write a discussion to a group to post a reply is inaccurate (e.g. only group owner might be able to create new discussions, while group members might be allowed to post replies).
