### PR TITLE
chore(i18n): reworks translate to walk an array internally

### DIFF
--- a/docs/guides/i18n.rst
+++ b/docs/guides/i18n.rst
@@ -34,7 +34,7 @@ ordered later on the Admin > Plugins page:
 
 .. note::
 
-   Unless you are overriding core’s or another plugin's language strings, it is good practice for the language keys to start with your plugin name. For example: ``yourplugin:success``, ``yourplugin:title``, etc. This helps avoid conflicts with other language keys.
+    Unless you are overriding core's or another plugin's language strings, it is good practice for the language keys to start with your plugin name. For example: ``yourplugin:success``, ``yourplugin:title``, etc. This helps avoid conflicts with other language keys.
 
 Server-side API
 ===============

--- a/engine/tests/phpunit/Elgg/I18n/TranslatorTest.php
+++ b/engine/tests/phpunit/Elgg/I18n/TranslatorTest.php
@@ -52,10 +52,9 @@ class TranslatorTest extends TestCase {
 	}
 
 	public function testIssuesNoticeOnMissingKey() {
+		// key is missing from all checked translations
 		_elgg_services()->logger->disable();
-
 		$this->assertEquals("{$this->key}b", $this->translator->translate("{$this->key}b"));
-
 		$logged = _elgg_services()->logger->enable();
 
 		$this->assertEquals([
@@ -64,9 +63,23 @@ class TranslatorTest extends TestCase {
 				'level' => Logger::NOTICE,
 			]
 		], $logged);
+
+		// has fallback key
+		$this->translator->addTranslation('en', ["{$this->key}b" => 'Dummy']);
+
+		_elgg_services()->logger->disable();
+		$this->assertEquals('Dummy', $this->translator->translate("{$this->key}b", [], 'es'));
+		$logged = _elgg_services()->logger->enable();
+
+		$this->assertEquals([
+			[
+				'message' => "Missing es translation for \"{$this->key}b\" language key",
+				'level' => Logger::NOTICE,
+			]
+		], $logged);
 	}
-	
-	public function testDoesNotPerformSprintfFormattingIfArgsNotProvided() {
-		$this->markTestIncomplete();
+
+	public function testDoesNotProcessArgsOnKey() {
+		$this->assertEquals('nonexistent:%s', $this->translator->translate('nonexistent:%s', [1]));
 	}
 }


### PR DESCRIPTION
No longer calls `vsprintf` on message keys.

Adds test for sending notice when falling back.

Fixes #9653
