### PR TITLE
WIP fix(js): elgg.echo's fallback behavior is unaffected by unrelated keys

### DIFF
--- a/js/lib/languages.js
+++ b/js/lib/languages.js
@@ -34,30 +34,32 @@ elgg.get_language = function() {
 /**
  * Translates a string
  *
- * @param {String} key      The string to translate
- * @param {Array}  argv     vsprintf support
- * @param {String} language The language to display it in
+ * @param {String} key      Message key
+ * @param {Array}  argv     vsprintf() arguments
+ * @param {String} language Desired language
  *
- * @return {String} The translation
+ * @return {String} The translation or the given key if no translation available
  */
 elgg.echo = function(key, argv, language) {
-	//elgg.echo('str', 'en')
+
+	// handle elgg.echo('str', 'en')
 	if (elgg.isString(argv)) {
 		language = argv;
 		argv = [];
+	} else {
+		argv = argv || [];
 	}
 
-	//elgg.echo('str', [...], 'en')
+	language = language || elgg.get_language();
+
 	var translations = elgg.config.translations,
-		dlang = elgg.get_language(),
-		map;
+		list = [language, elgg.get_language()],
+		lang;
 
-	language = language || dlang;
-	argv = argv || [];
-
-	map = translations[language] || translations[dlang];
-	if (map && map[key]) {
-		return vsprintf(map[key], argv);
+	while (lang = list.shift()) {
+		if (translations[lang] && elgg.isString(translations[lang][key])) {
+			return vsprintf(translations[lang][key], argv);
+		}
 	}
 
 	return key;

--- a/js/tests/ElggLanguagesTest.js
+++ b/js/tests/ElggLanguagesTest.js
@@ -21,13 +21,36 @@ define(function(require) {
 				expect(elgg.echo('hello')).toBe('Hello!');
 				expect(elgg.echo('hello', 'es')).toBe('Hola!');			
 			});
-			
+
 			it("falls back to the default language", function() {
 				elgg.add_translation('en', {
 					'hello': 'Hello!'
 				});
-				
+
 				expect(elgg.echo('hello', 'es')).toBe('Hello!');
+			});
+
+			it("returns the key on failure", function() {
+				expect(elgg.echo('hello')).toBe('hello');
+			});
+
+			it("falls back even if an unrelated key exists in the requested language", function () {
+				elgg.add_translation('en', {
+					'hello': 'Hello!'
+				});
+				elgg.add_translation('es', {
+					'goodbye': 'Adios!'
+				});
+
+				expect(elgg.echo('hello', 'es')).toBe('Hello!');
+			});
+
+			it("recognizes empty string as a valid translation", function () {
+				elgg.add_translation('en', {
+					'void': ''
+				});
+
+				expect(elgg.echo('void')).toBe('');
 			});
 		});
 	});


### PR DESCRIPTION
Before this fix, an unrelated key in the requested language would confuse elgg.echo and it would not fall back to the English version.

Also this recognizes `""` as a valid translation.

Fixes #9652
