### PR TITLE
fix(reportedcontent): report form opens in lightbox

### DIFF
--- a/mod/reportedcontent/start.php
+++ b/mod/reportedcontent/start.php
@@ -23,6 +23,9 @@ function reportedcontent_init() {
 	if (elgg_is_logged_in()) {
 		elgg_require_js('elgg/reportedcontent');
 
+		elgg_load_js('lightbox');
+		elgg_load_css('lightbox');
+
 		// Extend footer with report content link
 		elgg_register_menu_item('extras', array(
 			'name' => 'report_this',


### PR DESCRIPTION
I think the report form was supposed to open in a lightbox (due to 'link_class' => 'elgg-lightbox' in menu item registration). But without loading the lightbox JS and CSS this failed to work.

This fix will most likely also fix https://github.com/Elgg/www.elgg.org/issues/91.
