### PR TITLE
Migrate group icons to new icon service

### DIFF
--- a/engine/classes/ElggFile.php
+++ b/engine/classes/ElggFile.php
@@ -503,6 +503,39 @@ class ElggFile extends \ElggObject {
 	}
 
 	/**
+	 * Transfer a file to a new owner and sets a new filename,
+	 * copies file contents to a new location.
+	 *
+	 * This is an alternative to using rename() which fails to move files to 
+	 * a non-existent directory under new owner's filestore directory
+	 * 
+	 * @param int    $owner_guid New owner's guid
+	 * @param string $filename   New filename (uses old filename if not set)
+	 * @return bool
+	 */
+	public function transfer($owner_guid, $filename = null) {
+		if (!$owner_guid) {
+			return false;
+		}
+
+		if (!$this->exists()) {
+			return false;
+		}
+		
+		if (!$filename) {
+			$filename = $this->getFilename();
+		}
+		$filestorename = $this->getFilenameOnFilestore();
+		
+		$this->owner_guid = $owner_guid;
+		$this->setFilename($filename);
+		$this->open('write');
+		$this->close();
+
+		return rename($filestorename, $this->getFilenameOnFilestore());
+	}
+
+	/**
 	 * Get property names to serialize.
 	 *
 	 * @return string[]

--- a/engine/lib/filestore.php
+++ b/engine/lib/filestore.php
@@ -494,6 +494,10 @@ function _elgg_filestore_init() {
 	// Touch entity icons if entity access id has changed
 	elgg_register_event_handler('update:after', 'object', '_elgg_filestore_touch_icons');
 	elgg_register_event_handler('update:after', 'group', '_elgg_filestore_touch_icons');
+	
+	// Move entity icons if entity owner has changed
+	elgg_register_event_handler('update:after', 'object', '_elgg_filestore_move_icons');
+	elgg_register_event_handler('update:after', 'group', '_elgg_filestore_move_icons');
 }
 
 /**
@@ -666,6 +670,68 @@ function _elgg_filestore_touch_icons($event, $type, $entity) {
 	}
 }
 
+/**
+ * Listen to entity ownership changes and update icon ownership by moving
+ * icons to their new owner's directory on filestore.
+ *
+ * This will only transfer icons that have a custom location on filestore
+ * and are owned by the entity's owner (instead of the entity itself).
+ * Even though core icon service does not store icons in the entity's owner
+ * directory, there are plugins that do (e.g. file plugin) - this handler
+ * helps such plugins avoid ownership mismatch.
+ *
+ * @param string     $event  "update:after"
+ * @param string     $type   "object"|"group"
+ * @param ElggObject $entity Entity
+ * @return void
+ * @access private
+ */
+function _elgg_filestore_move_icons($event, $type, $entity) {
+
+	$original_attributes = $entity->getOriginalAttributes();
+	if (empty($original_attributes['owner_guid'])) {
+		return;
+	}
+
+	$previous_owner_guid = $original_attributes['owner_guid'];
+	$new_owner_guid = $entity->owner_guid;
+
+	$sizes = elgg_get_icon_sizes($entity->getType(), $entity->getSubtype());
+
+	foreach ($sizes as $size => $opts) {
+		$new_icon = $entity->getIcon($size);
+		if ($new_icon->owner_guid == $entity->guid) {
+			// we do not need to update icons that are owned by the entity itself
+			continue;
+		}
+
+		if ($new_icon->owner_guid != $new_owner_guid) {
+			// a plugin implements some custom logic
+			continue;
+		}
+
+		$old_icon = new \ElggIcon();
+		$old_icon->owner_guid = $previous_owner_guid;
+		$old_icon->setFilename($new_icon->getFilename());
+		if (!$old_icon->exists()) {
+			// there is no icon to move
+			continue;
+		}
+		
+		if ($new_icon->exists()) {
+			// there is already a new icon
+			// just removing the old one
+			$old_icon->delete();
+			elgg_log("Entity $entity->guid has been transferred to a new owner but an icon was left behind under {$old_icon->getFilenameOnFilestore()}. "
+				. "Old icon has been deleted", 'NOTICE');
+			continue;
+		}
+
+		$old_icon->transfer($new_icon->owner_guid, $new_icon->getFilename());
+		elgg_log("Entity $entity->guid has been transferred to a new owner. "
+				. "Icon was moved from {$old_icon->getFilenameOnFilestore()} to {$new_icon->getFilenameOnFilestore()}.", 'NOTICE');
+	}
+}
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
 	$events->registerHandler('init', 'system', '_elgg_filestore_init', 100);

--- a/engine/tests/phpunit/ElggFileTest.php
+++ b/engine/tests/phpunit/ElggFileTest.php
@@ -225,7 +225,7 @@ class ElggFileTest extends \PHPUnit_Framework_TestCase {
 
 		$this->file->read(1);
 		$this->assertTrue($this->file->eof());
-		
+
 		$this->assertTrue($this->file->close());
 	}
 
@@ -270,7 +270,7 @@ class ElggFileTest extends \PHPUnit_Framework_TestCase {
 		$target->open('write');
 		$target->write('Testing!');
 		$target->close();
-		
+
 		$symlink = new ElggFile();
 		$symlink->owner_guid = 2;
 		$symlink->setFilename($symlink_name);

--- a/engine/tests/phpunit/ElggFileTest.php
+++ b/engine/tests/phpunit/ElggFileTest.php
@@ -376,4 +376,43 @@ class ElggFileTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse(is_link($from_filename));
 		$this->assertFalse($to->exists());
 	}
+
+	/**
+	 * @group FileService
+	 */
+	public function testCanTransferFile() {
+
+		$dataroot = elgg_get_config('dataroot');
+
+		$file = new \ElggFile();
+		$file->owner_guid = 3;
+		$file->setFilename("file-to-transfer.txt");
+		$file->setFilename("file-to-transfer.txt");
+
+		// Fail with non-existent file
+		$this->assertFalse($file->transfer(4));
+
+		$file->open('write');
+		$file->write('Transfer');
+		$file->close();
+
+		$this->assertTrue($file->transfer(4));
+		$this->assertEquals(4, $file->owner_guid);
+		$this->assertEquals("file-to-transfer.txt", $file->getFilename());
+		$this->assertEquals("{$dataroot}1/4/file-to-transfer.txt", $file->getFilenameOnFilestore());
+		$this->assertTrue($file->exists());
+		$this->assertFalse(file_exists("{$dataroot}1/3/file-to-transfer.txt"));
+
+		$this->assertTrue($file->transfer(3, 'tmp/transferred-file.txt'));
+		$this->assertEquals(3, $file->owner_guid);
+		$this->assertEquals("tmp/transferred-file.txt", $file->getFilename());
+		$this->assertEquals("{$dataroot}1/3/tmp/transferred-file.txt", $file->getFilenameOnFilestore());
+		$this->assertTrue($file->exists());
+		$this->assertFalse(file_exists("{$dataroot}1/4/file-to-transfer.txt"));
+
+		// cleanup
+		_elgg_rmdir("{$dataroot}1/3/");
+		_elgg_rmdir("{$dataroot}1/4/");
+	}
+
 }

--- a/mod/groups/actions/groups/delete.php
+++ b/mod/groups/actions/groups/delete.php
@@ -1,38 +1,23 @@
 <?php
+
 /**
  * Delete a group
+ *
+ * @todo: Deprecate and use entity/delete action instead
  */
-		
 $guid = (int) get_input('guid');
+elgg_entity_gatekeeper($guid, 'group');
+
 $entity = get_entity($guid);
 
-if (!$entity->canEdit()) {
+if (!$entity->canDelete()) {
 	register_error(elgg_echo('group:notdeleted'));
 	forward(REFERER);
 }
 
-if (($entity) && ($entity instanceof ElggGroup)) {
-	// delete group icons
-	$owner_guid = $entity->owner_guid;
-	$prefix = "groups/" . $entity->guid;
-	$imagenames = elgg_get_config('icon_sizes');
-	$img = new ElggFile();
-	$img->owner_guid = $owner_guid;
-	foreach ($imagenames as $name => $value) {
-		$img->setFilename("{$prefix}{$name}.jpg");
-		$img->delete();
-	}
-	
-	// delete original icon
-	$img->setFilename("{$prefix}.jpg");
-	$img->delete();
-
-	// delete group
-	if ($entity->delete()) {
-		system_message(elgg_echo('group:deleted'));
-	} else {
-		register_error(elgg_echo('group:notdeleted'));
-	}
+// delete group
+if ($entity->delete()) {
+	system_message(elgg_echo('group:deleted'));
 } else {
 	register_error(elgg_echo('group:notdeleted'));
 }

--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -129,8 +129,6 @@ $old_owner_guid = $is_new_group ? 0 : $group->owner_guid;
 $value = get_input('owner_guid');
 $new_owner_guid = ($value === null) ? $old_owner_guid : (int)$value;
 
-$owner_has_changed = false;
-$old_icontime = null;
 if (!$is_new_group && $new_owner_guid && $new_owner_guid != $old_owner_guid) {
 	// verify new owner is member and old owner/admin is logged in
 	if ($group->isMember(get_user($new_owner_guid)) && ($old_owner_guid == $user->guid || $user->isAdmin())) {
@@ -155,14 +153,8 @@ if (!$is_new_group && $new_owner_guid && $new_owner_guid != $old_owner_guid) {
 				}
 			}
 		}
-
-		// @todo Remove this when #4683 fixed
-		$owner_has_changed = true;
-		$old_icontime = $group->icontime;
 	}
 }
-
-$must_move_icons = ($owner_has_changed && $old_icontime);
 
 if ($is_new_group) {
 	// if new group, we need to save so group acl gets set in event handler
@@ -221,101 +213,16 @@ if ($is_new_group) {
 $has_uploaded_icon = (!empty($_FILES['icon']['type']) && substr_count($_FILES['icon']['type'], 'image/'));
 
 if ($has_uploaded_icon) {
-
-	$icon_sizes = elgg_get_config('icon_sizes');
-
-	$prefix = "groups/" . $group->guid;
-
 	$filehandler = new ElggFile();
 	$filehandler->owner_guid = $group->owner_guid;
-	$filehandler->setFilename($prefix . ".jpg");
+	$filehandler->setFilename("groups/$group->guid.jpg");
 	$filehandler->open("write");
 	$filehandler->write(get_uploaded_file('icon'));
 	$filehandler->close();
-	$filename = $filehandler->getFilenameOnFilestore();
 
-	$sizes = array('tiny', 'small', 'medium', 'large', 'master');
-
-	$thumbs = array();
-	foreach ($sizes as $size) {
-		$thumbs[$size] = get_resized_image_from_existing_file(
-			$filename,
-			$icon_sizes[$size]['w'],
-			$icon_sizes[$size]['h'],
-			$icon_sizes[$size]['square']
-		);
-	}
-
-	if ($thumbs['tiny']) { // just checking if resize successful
-		$thumb = new ElggFile();
-		$thumb->owner_guid = $group->owner_guid;
-		$thumb->setMimeType('image/jpeg');
-
-		foreach ($sizes as $size) {
-			$thumb->setFilename("{$prefix}{$size}.jpg");
-			$thumb->open("write");
-			$thumb->write($thumbs[$size]);
-			$thumb->close();
-		}
-
-		$group->icontime = time();
-	}
-}
-
-// @todo Remove this when #4683 fixed
-if ($must_move_icons) {
-	$filehandler = new ElggFile();
-	$filehandler->setFilename('groups');
-	$filehandler->owner_guid = $old_owner_guid;
-	$old_path = $filehandler->getFilenameOnFilestore();
-
-	$sizes = array('', 'tiny', 'small', 'medium', 'large');
-
-	if ($has_uploaded_icon) {
-		// delete those under old owner
-		foreach ($sizes as $size) {
-			unlink("$old_path/{$group_guid}{$size}.jpg");
-		}
-	} else {
-		// move existing to new owner
-		$filehandler->owner_guid = $group->owner_guid;
-		$new_path = $filehandler->getFilenameOnFilestore();
-
-		foreach ($sizes as $size) {
-			rename("$old_path/{$group_guid}{$size}.jpg", "$new_path/{$group_guid}{$size}.jpg");
-		}
-	}
-
-	if ($owner_changed_flag && $old_icontime) { // @todo Remove this when #4683 fixed
-
-		$filehandler = new ElggFile();
-		$filehandler->setFilename('groups');
-
-		$filehandler->owner_guid = $old_owner_guid;
-		$old_path = $filehandler->getFilenameOnFilestore();
-
-		$sizes = array('', 'tiny', 'small', 'medium', 'large');
-
-		foreach($sizes as $size) {
-			unlink("$old_path/{$group_guid}{$size}.jpg");
-		}
-	}
-
-} elseif ($owner_changed_flag && $old_icontime) { // @todo Remove this when #4683 fixed
-
-	$filehandler = new ElggFile();
-	$filehandler->setFilename('groups');
-
-	$filehandler->owner_guid = $old_owner_guid;
-	$old_path = $filehandler->getFilenameOnFilestore();
-
-	$filehandler->owner_guid = $group->owner_guid;
-	$new_path = $filehandler->getFilenameOnFilestore();
-
-	$sizes = array('', 'tiny', 'small', 'medium', 'large');
-
-	foreach($sizes as $size) {
-		rename("$old_path/{$group_guid}{$size}.jpg", "$new_path/{$group_guid}{$size}.jpg");
+	if ($filehandler->exists()) {
+		// Non existent file throws exception
+		$group->saveIconFromElggFile($filehandler);
 	}
 }
 

--- a/mod/groups/icon.php
+++ b/mod/groups/icon.php
@@ -18,10 +18,7 @@ elgg_entity_gatekeeper($guid, 'group');
 
 $group = get_entity($guid);
 
-$icon = new ElggFile();
-$icon->owner_guid = $group->owner_guid;
-$icon->setFilename("groups/{$group->guid}{$size}.jpg");
-
+$icon = $group->getIcon($size);
 $url = elgg_get_inline_url($icon, true);
 if (!$url) {
 	$url = elgg_get_simplecache_url("groups/default{$size}.gif");


### PR DESCRIPTION
**feature(file): adds `ElggFile::transfer()` for reliable renaming of files**
rename() is not a reliable option to renaming files on filestore, as the target file may be in a non-existent directory.

This adds a reliable and tested method to transfer an `ElggFile` to a new owner and copy file contents into a file with a new filename

**feature(groups): group icons are now handled by the new icon service**

Migrates group icon handling to the new API.
Moves icon ownership transfer logic out of the action file into an `update:after` event handler.
Moves icon deletion logic out of the delete action into the `delete` event handler.
- [x] Requires #9655
