### PR TITLE
feature(actions): refresh tokens without booting the engine

### DIFF
--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -426,6 +426,12 @@ class Application {
 			return true;
 		}
 
+		if (0 === strpos($path, '/refresh-token')) {
+			$this->bootCore(true);
+			$this->services->actions->handleRefreshTokenRequest($this->services->request)->send();
+			return true;
+		}
+
 		if ($path === '/rewrite.php') {
 			require Directory\Local::root()->getPath("install.php");
 			return true;

--- a/engine/classes/Elgg/BootService.php
+++ b/engine/classes/Elgg/BootService.php
@@ -27,11 +27,21 @@ class BootService {
 	const DEFAULT_BOOT_CACHE_TTL = 0;
 
 	/**
+	 * @var bool
+	 */
+	private $booted = false;
+
+	/**
 	 * Boots the engine
 	 *
 	 * @return void
 	 */
 	public function boot() {
+		if ($this->booted) {
+			return;
+		}
+		$this->booted = true;
+
 		// Register the error handlers
 		set_error_handler('_elgg_php_error_handler');
 		set_exception_handler('_elgg_php_exception_handler');

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -106,7 +106,9 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			return new \Elgg\Database\AccessCollections($c->config->get('site_guid'));
 		});
 
-		$this->setClassName('actions', \Elgg\ActionsService::class);
+		$this->setFactory('actions', function(ServiceProvider $c) {
+			return new \Elgg\ActionsService($c->config, $c->session, $c->crypto);
+		});
 
 		$this->setClassName('adminNotices', \Elgg\Database\AdminNotices::class);
 

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -527,6 +527,7 @@ class ElggSite extends \ElggEntity {
 			'forgotpassword',
 			'changepassword',
 			'refresh_token',
+			'refresh-token',
 			'ajax/view/languages.js',
 			'upgrade\.php',
 			'css/.*',

--- a/engine/lib/actions.php
+++ b/engine/lib/actions.php
@@ -270,24 +270,11 @@ function ajax_action_hook() {
  * Send an updated CSRF token
  *
  * @access private
+ * @deprecated 2.2
  */
 function _elgg_csrf_token_refresh() {
-
-	if (!elgg_is_xhr()) {
-		return false;
-	}
-
-	$ts = time();
-	$token = generate_action_token($ts);
-	$data = array(
-		'__elgg_ts' => $ts,
-		'__elgg_token' => $token,
-		'logged_in' => elgg_is_logged_in(),
-	);
-
-	header("Content-Type: application/json;charset=utf-8");
-	echo json_encode($data);
-
+	elgg_deprecated_notice('/refresh_token page handler has been deprecated. Use /refresh-token', '2.2');
+	_elgg_services()->actions->handleRefreshTokenRequest(_elgg_services()->request)->send();
 	return true;
 }
 

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -2025,9 +2025,6 @@ define('REFERRER', -1);
 define('REFERER', -1);
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
-	$events->registerHandler('boot', 'system', function () {
-		_elgg_services()->boot->boot();
-	}, 1);
 	$events->registerHandler('cache:flush', 'system', function () {
 		_elgg_services()->boot->invalidateCache();
 	});

--- a/engine/tests/phpunit/Elgg/ActionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ActionsServiceTest.php
@@ -1,100 +1,186 @@
 <?php
+
 namespace Elgg;
 
 class ActionsServiceTest extends \PHPUnit_Framework_TestCase {
 
+	/**
+	 * @var \Elgg\ActionsService
+	 */
+	private $actions;
+
 	public function setUp() {
 		$this->actionsDir = dirname(dirname(__FILE__)) . "/test_files/actions";
+
+		$session = \ElggSession::getMock();
+		_elgg_services()->setValue('session', $session);
+		_elgg_services()->session->start();
+
+		$config = _elgg_testing_config();
+		_elgg_services()->setValue('config', $config);
+
+		$this->actions = new \Elgg\ActionsService($config, $session, _elgg_services()->crypto);
+		_elgg_services()->setValue('actions', $this->actions);
+	}
+
+	function createRequest($uri = '', $method = 'POST', $parameters = []) {
+		$site_url = elgg_get_site_url();
+		$path = substr(elgg_normalize_url($uri), strlen($site_url));
+		$path_key = \Elgg\Application::GET_PATH_KEY;
+		$request = \Elgg\Http\Request::create("?$path_key=$path", $method, $parameters);
+
+		$cookie_name = _elgg_services()->config->getCookieConfig()['session']['name'];
+		$session_id = _elgg_services()->session->getId();
+		$request->cookies->set($cookie_name, $session_id);
+		return $request;
 	}
 
 	/**
 	 * Tests register, exists and unregisrer
+	 * @group ActionsService
 	 */
 	public function testCanRegisterFilesAsActions() {
-		$actions = new \Elgg\ActionsService();
-		
-		$this->assertFalse($actions->exists('test/output'));
-		$this->assertFalse($actions->exists('test/not_registered'));
 
-		$this->assertTrue($actions->register('test/output', "$this->actionsDir/output.php", 'public'));
-		$this->assertTrue($actions->register('test/non_ex_file', "$this->actionsDir/non_existing_file.php", 'public'));
-		
-		$this->assertTrue($actions->exists('test/output'));
-		$this->assertFalse($actions->exists('test/non_ex_file'));
-		$this->assertFalse($actions->exists('test/not_registered'));
-		
-		return $actions;
+		$this->assertFalse($this->actions->exists('test/output'));
+		$this->assertFalse($this->actions->exists('test/not_registered'));
+
+		$this->assertTrue($this->actions->register('test/output', "$this->actionsDir/output.php", 'public'));
+		$this->assertTrue($this->actions->register('test/non_ex_file', "$this->actionsDir/non_existing_file.php", 'public'));
+
+		$this->assertTrue($this->actions->exists('test/output'));
+		$this->assertFalse($this->actions->exists('test/non_ex_file'));
+		$this->assertFalse($this->actions->exists('test/not_registered'));
+
+		return $this->actions;
 	}
-	
+
 	/**
 	 * @depends testCanRegisterFilesAsActions
+	 * @group ActionsService
 	 */
 	public function testCanUnregisterActions($actions) {
 
 		$this->assertTrue($actions->unregister('test/output'));
 		$this->assertTrue($actions->unregister('test/non_ex_file'));
 		$this->assertFalse($actions->unregister('test/not_registered'));
-	
+
 		$this->assertFalse($actions->exists('test/output'));
 		$this->assertFalse($actions->exists('test/non_ex_file'));
 		$this->assertFalse($actions->exists('test/not_registered'));
 	}
-	
+
 	/**
 	 * Tests overwriting existing action
+	 * @group ActionsService
 	 */
 	public function testCanOverrideRegisteredActions() {
-		$actions = new \Elgg\ActionsService();
-		
-		$this->assertFalse($actions->exists('test/output'));
-		
-		$this->assertTrue($actions->register('test/output', "$this->actionsDir/output.php", 'public'));
-		
-		$this->assertTrue($actions->exists('test/output'));
-		
-		$this->assertTrue($actions->register('test/output', "$this->actionsDir/output2.php", 'public'));
-		
-		$this->assertTrue($actions->exists('test/output'));
-	}
-	
-	public function testActionsAccessLevels() {
-		$actions = new \Elgg\ActionsService();
-		
-		$this->assertFalse($actions->exists('test/output'));
-		$this->assertFalse($actions->exists('test/not_registered'));
 
-		$this->assertTrue($actions->register('test/output', "$this->actionsDir/output.php", 'public'));
-		$this->assertTrue($actions->register('test/output_logged_in', "$this->actionsDir/output.php", 'logged_in'));
-		$this->assertTrue($actions->register('test/output_admin', "$this->actionsDir/output.php", 'admin'));
-		
+		$this->assertFalse($this->actions->exists('test/output'));
+
+		$this->assertTrue($this->actions->register('test/output', "$this->actionsDir/output.php", 'public'));
+
+		$this->assertTrue($this->actions->exists('test/output'));
+
+		$this->assertTrue($this->actions->register('test/output', "$this->actionsDir/output2.php", 'public'));
+
+		$this->assertTrue($this->actions->exists('test/output'));
+	}
+
+	/**
+	 * @group ActionsService
+	 */
+	public function testActionsAccessLevels() {
+
+		$this->assertFalse($this->actions->exists('test/output'));
+		$this->assertFalse($this->actions->exists('test/not_registered'));
+
+		$this->assertTrue($this->actions->register('test/output', "$this->actionsDir/output.php", 'public'));
+		$this->assertTrue($this->actions->register('test/output_logged_in', "$this->actionsDir/output.php", 'logged_in'));
+		$this->assertTrue($this->actions->register('test/output_admin', "$this->actionsDir/output.php", 'admin'));
+
 		//TODO finish this test
 		$this->markTestIncomplete("Can't test execution due to missing configuration.php dependencies");
-// 		$actions->execute('test/not_registered');
+		//$this->actions->execute('test/not_registered');
 	}
 
+	/**
+	 * @group ActionsService
+	 */
 	public function testActionReturnValuesAreIgnored() {
 		$this->markTestIncomplete();
 	}
-	
-	//TODO call non existing
 
-	
-	//TODO token generation/validation
-// 	public function testGenerateValidateTokens() {
-// 		$actions = new \Elgg\ActionsService();
-		
-// 		$i = 40;
-		
-// 		while ($i-->0) {
-// 			$timestamp = rand(100000000, 2000000000);
-// 			$token = $actions->generateActionToken($timestamp);
-// 			$this->assertTrue($actions->validateActionToken(false, $token, $timestamp));
-// 			$this->assertFalse($actions->validateActionToken(false, $token, $timestamp+1));
-// 			$this->assertFalse($actions->validateActionToken(false, $token, $timestamp-1));
-// 		}
-		
-// 	}
-	
+	/**
+	 * @group ActionsService
+	 */
+	public function testCanGenerateValidTokens() {
+
+		$timeout = $this->actions->getActionTokenTimeout();
+		for ($i = 1; $i <= 100; $i++) {
+			$timestamp = rand(time(), time() + $timeout);
+			$token = $this->actions->generateActionToken($timestamp);
+			$this->assertTrue($this->actions->validateActionToken(false, $token, $timestamp), "Test failed at pass $i");
+			$this->assertFalse($this->actions->validateActionToken(false, $token, $timestamp + 1), "Test failed at pass $i");
+			$this->assertFalse($this->actions->validateActionToken(false, $token, $timestamp - 1), "Test failed at pass $i");
+		}
+	}
+
+	/**
+	 * @group ActionsService
+	 */
+	public function testCanNotValidateExpiredToken() {
+		$timeout = $this->actions->getActionTokenTimeout();
+		$timestamp = time() - $timeout - 10;
+		$token = $this->actions->generateActionToken($timestamp);
+		$this->assertFalse($this->actions->validateActionToken(false, $token, $timestamp));
+	}
+
+	/**
+	 * @group ActionsService
+	 */
+	public function testCanNotValidateTokenAfterSessionExpiry() {
+		$timeout = $this->actions->getActionTokenTimeout();
+		$timestamp = time();
+		$token = $this->actions->generateActionToken($timestamp);
+		_elgg_services()->session->invalidate();
+		_elgg_services()->session->start();
+		$this->assertFalse($this->actions->validateActionToken(false, $token, $timestamp));
+	}
+
+	/**
+	 * @group ActionsService
+	 */
+	public function testRefreshTokenSends400ForNonAjaxRequest() {
+		$request = $this->createRequest('refresh-token', 'GET');
+		_elgg_services()->setValue('request', $request);
+
+		$response = $this->actions->handleRefreshTokenRequest($request);
+		$this->assertEquals(400, $response->getStatusCode());
+	}
+
+	/**
+	 * @group ActionsService
+	 */
+	public function testRefreshTokenSendsValidToken() {
+
+		$request = $this->createRequest('refresh-token', 'GET');
+		$request->headers->set('X-Requested-With', 'XMLHttpRequest');
+		_elgg_services()->setValue('request', $request);
+
+		$response = $this->actions->handleRefreshTokenRequest($request);
+		$this->assertEquals(200, $response->getStatusCode());
+
+		$content = $response->getContent();
+		$this->assertNotEmpty($content);
+		$this->assertNotEmpty($json = json_decode($content, true));
+
+		$this->assertArrayHasKey('__elgg_ts', $json);
+		$this->assertArrayHasKey('__elgg_token', $json);
+		$this->assertArrayHasKey('logged_in', $json);
+
+		$this->assertEquals($json['__elgg_token'], $this->actions->generateActionToken($json['__elgg_ts']));
+		$this->assertTrue($this->actions->validateActionToken(false, $json['__elgg_token'], $json['__elgg_ts']));
+	}
+
 	//TODO gatekeeper?
 }
-

--- a/engine/tests/phpunit/bootstrap.php
+++ b/engine/tests/phpunit/bootstrap.php
@@ -41,6 +41,10 @@ $CONFIG = (object)[
 	'simplecache_enabled' => false,
 	'system_cache_enabled' => false,
 	'Elgg\Application_phpunit' => true,
+	// \Elgg\Config::get() falls back to loading config values from database
+	// for undefined keys. This flag ensures we do not attempt reading data
+	// from database during tests
+	'site_config_loaded' => true,
 ];
 
 global $_ELGG;

--- a/js/lib/security.js
+++ b/js/lib/security.js
@@ -35,7 +35,7 @@ elgg.security.setToken = function(json) {
  * @private
  */
 elgg.security.refreshToken = function() {
-	elgg.getJSON('refresh_token', {
+	elgg.getJSON('refresh-token', {
 		success: function(data) {
 			if (data && data.__elgg_ts && data.__elgg_token) {
 				elgg.security.setToken(data);


### PR DESCRIPTION
Introduces /refresh-token handler that refreshes tokens without booting engine.
