### PR TITLE
fix(notifications): users are again unsubscribed when friendship and …

### DIFF
--- a/mod/notifications/start.php
+++ b/mod/notifications/start.php
@@ -20,8 +20,7 @@ function notifications_plugin_init() {
 	elgg_unextend_view('forms/account/settings', 'core/settings/account/notifications');
 
 	// update notifications based on relationships changing
-	elgg_register_event_handler('delete', 'member', 'notifications_relationship_remove');
-	elgg_register_event_handler('delete', 'friend', 'notifications_relationship_remove');
+	elgg_register_event_handler('delete', 'relationship', 'notifications_relationship_remove');
 
 	// update notifications when new friend or access collection membership
 	elgg_register_event_handler('create', 'relationship', 'notifications_update_friend_notify');
@@ -106,19 +105,20 @@ function notifications_plugin_pagesetup() {
 /**
  * Update notifications when a relationship is deleted
  *
- * @param string $event
- * @param string $object_type
- * @param object $relationship
+ * @param string            $event        "delete"
+ * @param string            $object_type  "relationship"
+ * @param \ElggRelationship $relationship Relationship obj
+ * @return void
  */
 function notifications_relationship_remove($event, $object_type, $relationship) {
-	$NOTIFICATION_HANDLERS = _elgg_services()->notifications->getMethodsAsDeprecatedGlobal();
-
-	$user_guid = $relationship->guid_one;
-	$object_guid = $relationship->guid_two;
-
-	// loop through all notification types
-	foreach($NOTIFICATION_HANDLERS as $method => $foo) {
-		remove_entity_relationship($user_guid, "notify{$method}", $object_guid);
+	
+	if (!in_array($relationship->relationship, ['member', 'friend'])) {
+		return;
+	}
+	
+	$methods = array_keys(_elgg_services()->notifications->getMethodsAsDeprecatedGlobal());
+	foreach($methods as $method) {
+		remove_entity_relationship($relationship->guid_one, "notify{$method}", $relationship->guid_two);
 	}
 }
 


### PR DESCRIPTION
…membership are deleted

Plugins was not updated to use the new event name, leading to users
still receiving notifiations from groups they are not members of and
users they are no longer friends with
