### PR TITLE
chore(boot): allow partial boot

### DIFF
--- a/engine/classes/Elgg/BootService.php
+++ b/engine/classes/Elgg/BootService.php
@@ -27,11 +27,21 @@ class BootService {
 	const DEFAULT_BOOT_CACHE_TTL = 0;
 
 	/**
+	 * @var bool
+	 */
+	private $booted = false;
+
+	/**
 	 * Boots the engine
 	 *
 	 * @return void
 	 */
 	public function boot() {
+		if ($this->booted) {
+			return;
+		}
+		$this->booted = true;
+
 		// Register the error handlers
 		set_error_handler('_elgg_php_error_handler');
 		set_exception_handler('_elgg_php_exception_handler');

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -2025,9 +2025,6 @@ define('REFERRER', -1);
 define('REFERER', -1);
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
-	$events->registerHandler('boot', 'system', function () {
-		_elgg_services()->boot->boot();
-	}, 1);
 	$events->registerHandler('cache:flush', 'system', function () {
 		_elgg_services()->boot->invalidateCache();
 	});


### PR DESCRIPTION
`Application::bootCore(true)` partially boots the system, not starting any plugins or running any events.
