### PR TITLE
deprecate(views): formally moves colorbox CSS views

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -25,6 +25,7 @@ Deprecated Views
 
  * ``elgg/ui.river.js`` is deprecated: Do not rely on simplecache URLs to work.
  * ``lightbox/settings.js`` is deprecated: Use ``getOptions, ui.lightbox`` JS plugin hook or ``data-colorbox-opts`` attribute.
+ * ``lightbox/elgg-colorbox-theme/*`` are deprecated: Use the views ``colorbox.css`` and point to images mapped to the views ``colorbox-images/*``.
 
 Added ``elgg/popup`` module
 -----------------------------
@@ -34,7 +35,7 @@ New :doc:`elgg/popup module <javascript>` can be used to build out more complex 
 Added ``elgg/lightbox`` module
 ------------------------------
 
-New :doc:`elgg/lightbox module <javascript>` can be used to open and close the lightbox programmatically.
+New :doc:`elgg/lightbox module <javascript>` can be used to open and close the lightbox programmatically. Its theme is defined by the views ``colorbox.css`` and ``colorbox-images/*``.
 
 From 2.0 to 2.1
 ===============

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1690,6 +1690,11 @@ function elgg_views_boot() {
 
 	elgg_extend_view('elgg.css', 'colorbox.css');
 
+	// TODO 3.0 move the images
+	elgg_register_simplecache_view('colorbox-images/border1.png');
+	elgg_register_simplecache_view('colorbox-images/border2.png');
+	elgg_register_simplecache_view('colorbox-images/loading.gif');
+
 	// provide warning to use elgg/lightbox AMD
 	elgg_register_js('lightbox', elgg_get_simplecache_url('lightbox.js'));
 
@@ -1741,6 +1746,30 @@ function elgg_views_boot() {
 	}
 }
 
+/**
+ * Check for deprecated view usage
+ *
+ * @return void
+ * @access private
+ */
+function _elgg_views_check_deprecations() {
+	// @deprecated 2.2 old colorbox CSS/image locations
+	$view = 'lightbox/elgg-colorbox-theme/colorbox.css';
+	if (_elgg_view_may_be_altered($view, "$view.php")) {
+		elgg_deprecated_notice('The view "lightbox/elgg-colorbox-theme/colorbox.css" is deprecated. '
+			. 'Use "colorbox.css" and make sure image paths point to the views "colorbox-images/*".', '2.2');
+	}
+
+	foreach (['border1.png', 'border2.png', 'loading.gif',] as $image) {
+		$view = "lightbox/elgg-colorbox-theme/colorbox-images/$image";
+		if (_elgg_view_may_be_altered($view, $view)) {
+			elgg_deprecated_notice("The view '$view' is deprecated. Instead override the view "
+				. "'colorbox-images/$image'.", '2.2');
+		}
+	}
+}
+
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
 	$events->registerHandler('boot', 'system', 'elgg_views_boot');
+	$events->registerHandler('cache:flush', 'system', '_elgg_views_check_deprecations');
 };

--- a/engine/views.php
+++ b/engine/views.php
@@ -26,10 +26,7 @@ return [
 		/**
 		 * __DIR__ should be utilized when referring to assets that are checked in to version control.
 		 */
-		"/" => [
-			dirname(__DIR__) . "/_graphics",
-			dirname(__DIR__) . "/views/default/lightbox/elgg-colorbox-theme",
-		],
+		"/" => dirname(__DIR__) . "/_graphics",
 
 		"elgg/ui.avatar_cropper.js" => dirname(__DIR__) . "/js/lib/ui.avatar_cropper.js",
 		"elgg/ui.friends_picker.js" => dirname(__DIR__) . "/js/lib/ui.friends_picker.js",

--- a/views/default/colorbox-images/border1.png.php
+++ b/views/default/colorbox-images/border1.png.php
@@ -1,0 +1,1 @@
+<?phpecho elgg_view('lightbox/elgg-colorbox-theme/colorbox-images/border1.png');

--- a/views/default/colorbox-images/border2.png.php
+++ b/views/default/colorbox-images/border2.png.php
@@ -1,0 +1,3 @@
+<?php
+
+echo elgg_view('lightbox/elgg-colorbox-theme/colorbox-images/border2.png');

--- a/views/default/colorbox-images/loading.gif.php
+++ b/views/default/colorbox-images/loading.gif.php
@@ -1,0 +1,3 @@
+<?php
+
+echo elgg_view('lightbox/elgg-colorbox-theme/colorbox-images/loading.gif');

--- a/views/default/colorbox.css.php
+++ b/views/default/colorbox.css.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Provides CSS for colorbox and is inlined in elgg.css
+ *
+ * @todo 3.0 move the CSS into this view, and delete all "lightbox" views
+ */
+
+echo elgg_view('lightbox/elgg-colorbox-theme/colorbox.css', [
+	'__core_usage' => true,
+]);

--- a/views/default/lightbox/elgg-colorbox-theme/colorbox.css.php
+++ b/views/default/lightbox/elgg-colorbox-theme/colorbox.css.php
@@ -1,6 +1,18 @@
+<?php
+/**
+ * @deprecated 2.2 use the colorbox.css view instead.
+ */
+
+// allow core to use this without deprecation notice
+if (!isset($vars['__core_usage'])) {
+    elgg_deprecated_notice('The view "lightbox/elgg-colorbox-theme/colorbox.css" is deprecated. '
+        . 'Use "colorbox.css" and make sure image paths point to the views "colorbox-images/*".', '2.2');
+}
+?>
 /*
     Colorbox Core Style:
     The following CSS is consistent between example themes and should not be altered.
+    <style>
 */
 #colorbox, #cboxOverlay, #cboxWrapper{position:absolute; top:0; left:0; z-index:1100; overflow:hidden;}
 #cboxWrapper {max-width:none;}


### PR DESCRIPTION
The views that begin with `lightbox/` are all deprecated. The CSS view is now `colorbox.css` and maps to images with view names `colorbox-images/*`.

For BC, all the new views consume the old views.

Fixes #9690
