### PR TITLE
chore(views): core can now check if a plugin view may be altered

### DIFF
--- a/engine/classes/Elgg/ViewsService.php
+++ b/engine/classes/Elgg/ViewsService.php
@@ -254,10 +254,8 @@ class ViewsService {
 	 *
 	 * @param string $view View name
 	 * @return string[]
-	 * @access private
-	 * @internal Plugins should not use this
 	 */
-	public function getViewList($view) {
+	private function getViewList($view) {
 		if (isset($this->views->extensions[$view])) {
 			return $this->views->extensions[$view];
 		} else {
@@ -460,7 +458,32 @@ class ViewsService {
 
 		$this->views->extensions[$view][$priority] = (string) $view_extension;
 		ksort($this->views->extensions[$view]);
+	}
 
+	/**
+	 * Is the given view extended?
+	 *
+	 * @param string $view View name
+	 *
+	 * @return bool
+	 * @internal Plugins should not use this
+	 * @access private
+	 */
+	public function viewIsExtended($view) {
+		return count($this->getViewList($view)) > 1;
+	}
+
+	/**
+	 * Do hook handlers exist to modify the view?
+	 *
+	 * @param string $view View name
+	 *
+	 * @return bool
+	 * @internal Plugins should not use this
+	 * @access private
+	 */
+	public function viewHasHookHandlers($view) {
+		return $this->hooks->hasHandler('view', $view) || $this->hooks->hasHandler('view_vars', $view);
 	}
 
 	/**

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1597,44 +1597,47 @@ function _elgg_views_send_header_x_frame_options() {
  * @note Always returns true if the view's location is set in /engine/views.php. Elgg does not keep
  *       track of the defaults for those locations.
  *
- * @param string $view               View name. E.g. "elgg/init.js"
- * @param string $path_from_viewtype File path relative to the viewtype directory. E.g. "elgg/init.js.php"
- * @param string $viewtype           View type
+ * <code>
+ * // check a view in core
+ * if (_elgg_view_may_be_altered('foo/bar', 'foo/bar.php')) {
+ *     // use the view for BC
+ * }
+ *
+ * // check a view in a bundled plugin
+ * $dir = __DIR__ . "/views/" . elgg_get_viewtype();
+ * if (_elgg_view_may_be_altered('foo.css', "$dir/foo.css.php")) {
+ *     // use the view for BC
+ * }
+ * </code>
+ *
+ * @param string $view     View name. E.g. "elgg/init.js"
+ * @param string $path     Absolute file path, or path relative to the viewtype directory. E.g. "elgg/init.js.php"
  *
  * @return bool
  * @access private
  */
-function _elgg_view_may_be_altered($view, $path_from_viewtype, $viewtype = '') {
-	if (!$viewtype) {
-		$viewtype = elgg_get_viewtype();
-	}
-
+function _elgg_view_may_be_altered($view, $path) {
 	$views = _elgg_services()->views;
 
-	if (count($views->getViewList($view)) > 1) {
-		// view was extended
+	if ($views->viewIsExtended($view) || $views->viewHasHookHandlers($view)) {
 		return true;
 	}
 
-	$hooks = _elgg_services()->hooks;
-
-	if ($hooks->hasHandler('view', $view) || $hooks->hasHandler('view_vars', $view)) {
-		// altered via hook
-		return true;
-	}
+	$viewtype = elgg_get_viewtype();
 
 	// check location
-	$root = dirname(dirname(__DIR__));
-	$expected_path = "$root/views/$viewtype/" . ltrim($path_from_viewtype, '/\\');
+	if (0 === strpos($path, '/') || preg_match('~^([A-Za-z]\:)?\\\\~', $path)) {
+		// absolute path
+		$expected_path = $path;
+	} else {
+		// relative path
+		$root = dirname(dirname(__DIR__));
+		$expected_path = "$root/views/$viewtype/" . ltrim($path, '/\\');
+	}
 
 	$view_path = $views->findViewFile($view, $viewtype);
 
-	if (DIRECTORY_SEPARATOR === '\\') {
-		$expected_path = strtr($expected_path, "/", "\\");
-		$view_path = strtr($view_path, "/", "\\");
-	}
-
-	return ($expected_path !== $view_path);
+	return realpath($view_path) !== realpath($expected_path);
 }
 
 /**

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -155,7 +155,8 @@ function file_page_handler($page) {
 			break;
 		case 'download':
 			elgg_deprecated_notice('/file/download page handler has been deprecated and will be removed. Use elgg_get_download_url() to build download URLs', '2.2');
-			if (_elgg_view_may_be_altered('resources/file/download', 'resources/file/download.php')) {
+			$dir = __DIR__ . "/views/" . elgg_get_viewtype();
+			if (_elgg_view_may_be_altered('resources/file/download', "$dir/resources/file/download.php")) {
 				// For BC with 2.0 if a plugin is suspected of using this view we need to use it.
 				echo elgg_view_resource('file/download', [
 					'guid' => $page[1],


### PR DESCRIPTION
`_elgg_view_may_be_altered` can now check absolute paths. This removes the unneeded 3rd argument.

Fixes the `resources/file/download` view check to actually work as designed.

Fixes #9686

cc @hypeJunction
