### PR TITLE
feature(entities): can_write_to_container() now checks logic before permissions

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -221,6 +221,12 @@ Permission hooks
 	matching the logged in user, this hook is called *twice*, and in the first call ``$params['container']``
 	will be the *owner*, not the entity's real container.
 
+**container_logic_check, <entity_type>**
+	Triggered by ``can_write_to_container()`` before triggering ``permissions_check`` and ``container_permissions_check``
+	hooks. Unlike permissions hooks, logic check can be used to prevent certain entity types from being contained
+	by other entity types, e.g. discussion replies should only be contained by discussions. This hook can also be
+	used to apply status logic, e.g. do disallow new replies for closed discussions.
+
 **permissions_check, <entity_type>**
 	Return boolean for if the user ``$params['user']`` can edit the entity ``$params['entity']``.
 

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -290,6 +290,24 @@ function can_write_to_container($user_guid = 0, $container_guid = 0, $type = 'al
 		$user_guid = $user->guid;
 	}
 
+	// Unlike permissions, logic check can be used to prevent certain entity
+	// subtypes from being contained by other entity subtype,
+	// e.g. discussion_replies should only be contained by discussion.
+	// This hook can also be used to apply status logic, e.g. do not allow
+	// new replies for closed discussions.
+	$logic_check = elgg_trigger_plugin_hook(
+			'container_logic_check',
+			$type,
+			array(
+				'container' => $container,
+				'user' => $user,
+				'subtype' => $subtype
+			));
+
+	if ($logic_check === false) {
+		return false;
+	}
+
 	$return = false;
 	if ($container) {
 		// If the user can edit the container, they can also write to it


### PR DESCRIPTION
Adds 'container_logic_check, $entity_type' hook, which can be used to
apply containment logic before checking permissions. This hook can be used
to prevent certain entity types from containing other entity types
regardless of edit and write permissions, e.g. discussion replies should
always be contained by discussions, or discussion replies should not be allowed
in closed discussions.

Fixes #9695
