### PR TITLE
chore(views): reverts the registered lightbox CSS from 2.1

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -18,7 +18,6 @@ Deprecated APIs
  * ``elgg.ui.river`` JavaScript library: Remove calls to ``elgg_load_js('elgg.ui.river')`` from plugin code. Update ``core/river/filter`` and ``forms/comment/save``, if overwritten, to require component AMD modules
  * ``elgg.ui.popupOpen()`` and ``elgg.ui.popupClose()`` methods in ``elgg.ui`` JS library: Use ``elgg/popup`` module instead.
  * ``lightbox.js`` library: Do not use ``elgg_load_js('lightbox.js');`` unless your code references deprecated ``elgg.ui.lightbox`` namespace. Use ``elgg/lightbox`` AMD module instead.
- * ``lightbox.css`` library: Lightbox CSS now extends ``elgg.css``. Calls to ``elgg_require_css('lightbox.css')`` have no effect.
 
 Deprecated Views
 ----------------

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -243,7 +243,8 @@ function _elgg_admin_init() {
 	elgg_register_action('profile/fields/reorder', '', 'admin');
 
 	elgg_register_simplecache_view('admin.css');
-	elgg_extend_view('admin.css', 'colorbox.css');
+	
+	elgg_load_css('lightbox');
 
 	elgg_register_js('jquery.jeditable', elgg_get_simplecache_url('jquery.jeditable.js'));
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1688,7 +1688,8 @@ function elgg_views_boot() {
 
 	elgg_register_simplecache_view('elgg/init.js');
 
-	elgg_extend_view('elgg.css', 'colorbox.css');
+	elgg_register_css('lightbox', elgg_get_simplecache_url('lightbox/elgg-colorbox-theme/colorbox.css'));
+	elgg_load_css('lightbox');
 
 	// provide warning to use elgg/lightbox AMD
 	elgg_register_js('lightbox', elgg_get_simplecache_url('lightbox.js'));

--- a/engine/views.php
+++ b/engine/views.php
@@ -26,10 +26,7 @@ return [
 		/**
 		 * __DIR__ should be utilized when referring to assets that are checked in to version control.
 		 */
-		"/" => [
-			dirname(__DIR__) . "/_graphics",
-			dirname(__DIR__) . "/views/default/lightbox/elgg-colorbox-theme",
-		],
+		"/" => dirname(__DIR__) . "/_graphics",
 
 		"elgg/ui.avatar_cropper.js" => dirname(__DIR__) . "/js/lib/ui.avatar_cropper.js",
 		"elgg/ui.friends_picker.js" => dirname(__DIR__) . "/js/lib/ui.friends_picker.js",


### PR DESCRIPTION
Fixes #9690

cc @hypeJunction 
