### PR TITLE
feature(core): sites can preview features before the next major release

### DIFF
--- a/actions/admin/site/early_access.php
+++ b/actions/admin/site/early_access.php
@@ -1,0 +1,11 @@
+<?php
+
+foreach (_elgg_get_known_features() as $feature) {
+	set_config("feat:$feature", 'on' === get_input("feat_" . md5($feature)));
+}
+
+elgg_flush_caches();
+
+system_message(elgg_echo("admin:configuration:success"));
+
+forward(REFERER);

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -225,6 +225,7 @@ function _elgg_admin_init() {
 	elgg_register_action('admin/site/unlock_upgrade', '', 'admin');
 	elgg_register_action('admin/site/set_robots', '', 'admin');
 	elgg_register_action('admin/site/set_maintenance_mode', '', 'admin');
+	elgg_register_action('admin/site/early_access', '', 'admin');
 
 	elgg_register_action('admin/upgrades/upgrade_comments', '', 'admin');
 	elgg_register_action('admin/upgrades/upgrade_datadirs', '', 'admin');
@@ -298,6 +299,9 @@ function _elgg_admin_init() {
 	elgg_register_admin_menu_item('configure', 'settings', null, 100);
 	elgg_register_admin_menu_item('configure', 'basic', 'settings', 10);
 	elgg_register_admin_menu_item('configure', 'advanced', 'settings', 20);
+	if (_elgg_get_known_features()) {
+		elgg_register_admin_menu_item('configure', 'early_access', 'settings', 30);
+	}
 	// plugin settings are added in _elgg_admin_add_plugin_settings_menu() via the admin page handler
 	// for performance reasons.
 

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -267,6 +267,44 @@ function get_config($name, $site_guid = 0) {
 }
 
 /**
+ * Is this feature enabled?
+ *
+ * @param string   $feature Feature name. E.g. "3.0:the_name"
+ * @param string[] $_known  Known feature list (for testing)
+ *
+ * @return bool
+ * @access private
+ * @since 2.2
+ */
+function _elgg_feature_is_enabled($feature, array $_known = null) {
+	if ($_known === null) {
+		$_known = _elgg_get_known_features();
+	}
+
+	if (!in_array($feature, $_known)) {
+		// unknown features assumed on
+		return true;
+	}
+
+	return (bool)elgg_get_config("feat:$feature");
+}
+
+/**
+ * Get a list of known features
+ *
+ * @return string[] E.g. ["3.0:cool_river", "3.0:new_login"]
+ * @access private
+ * @since 2.2
+ */
+function _elgg_get_known_features() {
+	return [
+		// should be of form "x.x:shortname" where x.x is the major/minor version in which
+		// the option must be removed and will become automatically enabled.
+		// For each string, add a translation for "feature:label:<feature>" and "feature:help:<feature>".
+	];
+}
+
+/**
  * @access private
  */
 function _elgg_config_test($hook, $type, $tests) {

--- a/languages/en.php
+++ b/languages/en.php
@@ -504,6 +504,8 @@ return array(
 	'admin:settings' => 'Settings',
 	'admin:settings:basic' => 'Basic Settings',
 	'admin:settings:advanced' => 'Advanced Settings',
+	'admin:settings:early_access' => 'Preview Features',
+	'admin:settings:early_access:description' => 'The following features are optional now, but will be permanently enabled in the next major version.',
 	'admin:site:description' => "This admin panel allows you to control global settings for your site. Choose an option below to get started.",
 	'admin:site:opt:linktext' => "Configure site...",
 	'admin:settings:in_settings_file' => 'This setting is configured in settings.php',

--- a/views/default/admin/settings/early_access.php
+++ b/views/default/admin/settings/early_access.php
@@ -1,0 +1,3 @@
+<?php
+
+echo elgg_view_form('admin/site/early_access');

--- a/views/default/forms/admin/site/early_access.php
+++ b/views/default/forms/admin/site/early_access.php
@@ -1,0 +1,17 @@
+<?php
+
+echo "<p>" . elgg_echo('admin:settings:early_access:description') . "</p>";
+
+foreach (_elgg_get_known_features() as $feature) {
+
+	$help = elgg_language_key_exists("feature:help:$feature") ? elgg_echo("feature:help:$feature") : '';
+
+	echo elgg_view_input('checkbox', [
+		'name' => "feat_" . md5($feature),
+		'checked' => _elgg_feature_is_enabled($feature),
+		'label' => elgg_echo("feature:label:$feature"),
+		'help' => $help,
+	]);
+}
+
+echo elgg_view('input/submit', ['value' => elgg_echo('save')]);


### PR DESCRIPTION
A user-facing feature can be added to core in a minor release such that it has to be enabled to be used, but will automatically be enabled in the next major release.

These options are displayed in Admin > Configuration > Preview Features.

Currently this does not clean up settings for stale features.

Fixes #9711
