### PR TITLE
chore(js): fixes use of this in spinner module

### DIFF
--- a/js/tests/ElggSpinnerTest.js
+++ b/js/tests/ElggSpinnerTest.js
@@ -29,6 +29,33 @@ define(function(require) {
 			}, 25);
 		});
 
+		it("start/stop can be called without 'this' set", function() {
+			spinner.start.call(undefined);
+			spinner.stop.call(undefined);
+		});
+
+		it("start(text) shows escaped text below the spinner", function(done) {
+			expect($(visible_selector).length).toBe(0);
+			spinner.start('a>b&c');
+
+			setTimeout(function() {
+				expect($(visible_selector).length).toBe(1);
+				expect($('.elgg-spinner-text').html()).toBe('a&gt;b&amp;c');
+				done();
+			}, 25);
+		});
+
+		it("start() removes any set text", function(done) {
+			spinner.start('a>b&c');
+
+			setTimeout(spinner.start, 25);
+
+			setTimeout(function() {
+				expect($('.elgg-spinner-text').html()).toBe('');
+				done();
+			}, 35);
+		});
+
 		it("stop() removes the body class", function(done) {
 			spinner.start();
 

--- a/views/default/elgg/spinner.js
+++ b/views/default/elgg/spinner.js
@@ -6,32 +6,50 @@ define(function (require) {
 
 	$('body').append('<div class="elgg-spinner"><div class="elgg-ajax-loader"></div><div class="elgg-spinner-text elgg-subtext"></div></div>');
 
-	return {
+	var spinner = {
+		/**
+		 * Activate the spinner (will appear after 20ms).
+		 *
+		 * @param {String} text Text to display below spinner (will be escaped)
+		 */
 		start: function (text) {
 			active = true;
 			
-			this.clearText();
-			
+			spinner.clearText();
+
 			setTimeout(function () {
 				if (active) {
 					$('body').addClass('elgg-spinner-active');
 				}
 			}, SHOW_DELAY);
 			
-			this.setText(text);
+			spinner.setText(text);
 		},
 
+		/**
+		 * Deactivate the spinner
+		 */
 		stop: function () {
 			active = false;
 			$('body').removeClass('elgg-spinner-active');
 		},
-		
+
+		/**
+		 * Set the text on a displayed spinner.
+		 *
+		 * @param {String} text Text to display below spinner (will be escaped)
+		 */
 		setText: function (text) {
 			$('.elgg-spinner .elgg-spinner-text').text(text);
 		},
-		
+
+		/**
+		 * Remove the text on a displayed spinner.
+		 */
 		clearText: function () {
 			$('.elgg-spinner .elgg-spinner-text').html('');
-		},
+		}
 	};
+
+	return spinner;
 });


### PR DESCRIPTION
Spinner methods are often called without the object as context, hence we cannot use `this` internally.

Adds units for this, and `start(text)`

You'll notice this problem saving the lightbox dev "gear" form.
