### PR TITLE
chore(icons): removes deprecated uses of icon_sizes config value

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -410,7 +410,7 @@ Other
 		$size = '150x150';
 
 		// Use configured size if possible
-		$config = elgg_get_config('icon_sizes');
+		$config = elgg_get_icon_sizes('user');
 		$key = $params['size'];
 		if (isset($config[$key])) {
 			$size = $config[$key]['w'] . 'x' . $config[$key]['h'];

--- a/mod/twitter_api/lib/twitter_api.php
+++ b/mod/twitter_api/lib/twitter_api.php
@@ -243,7 +243,7 @@ function twitter_api_update_user_avatar($user, $file_location) {
 	// @todo Should probably check that it's an image file.
 	$file_location = str_replace('_normal.jpg', '.jpg', $file_location);
 
-	$icon_sizes = elgg_get_config('icon_sizes');
+	$icon_sizes = elgg_get_icon_sizes('user');
 
 	$filehandler = new ElggFile();
 	$filehandler->owner_guid = $user->getGUID();

--- a/views/default/icon/default.php
+++ b/views/default/icon/default.php
@@ -13,8 +13,9 @@
  */
 
 $entity = $vars['entity'];
+/* @var ElggEntity $entity */
 
-$icon_sizes = elgg_get_config('icon_sizes');
+$icon_sizes = elgg_get_icon_sizes($entity->type, $entity->getSubtype());
 // Get size
 $size = elgg_extract('size', $vars, 'medium');
 if (!array_key_exists($size, $icon_sizes)) {


### PR DESCRIPTION
Fixes #9786
