### PR TITLE
deprecate(events): deprecates the `pagesetup, system` event

### DIFF
--- a/docs/appendix/faqs/development.rst
+++ b/docs/appendix/faqs/development.rst
@@ -149,7 +149,7 @@ There are 5 :doc:`Elgg events </design/events>` that are triggered on every page
 1. boot, system
 2. plugins_boot, system
 3. init, system
-4. pagesetup, system
+4. pagesetup, system (deprecated)
 5. shutdown, system
 
 The *boot*, *system* event is triggered before the plugins get loaded. There does not appear to be any difference between the timing of the next two events: *plugins_boot*, *system* and *init*, *system* so plugins tend to use *init*, *system*. This event is triggered in ``Elgg\Application::bootCore``. The *pagesetup*, *system* event is thrown the first time ``elgg_view()`` is called. Some pages like the default ``index.php`` do not call ``elgg_view()`` so it is not triggered for them. The *shutdown*, *system* event is triggered after the page has been sent to the requester and is handled through the PHP function ``register_shutdown_function()``.

--- a/docs/guides/events-list.rst
+++ b/docs/guides/events-list.rst
@@ -21,8 +21,9 @@ System events
 	Triggered after the ``init, system`` event. All plugins are fully loaded and the engine is ready
 	to serve pages.
 
-**pagesetup, system**
+**pagesetup, system** (deprecated in 2.3)
     Called just before the first content is produced. Is triggered by ``elgg_view()``.
+    Use the menu or page shell hooks instead.
 
 **shutdown, system**
     Triggered after the page has been sent to the user. Expensive operations could be done here

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -21,6 +21,7 @@ Deprecated APIs
  * ``ajax_action_hook()``: No longer used as handler for `'action','all'` hook. Output buffering now starts before the hook is triggered in ``ActionsService``
  * ``elgg_error_page_handler()``: No longer used as a handler for `'forward',<error_code>` hooks
  * ``get_uploaded_file()`` is deprecated: Use new file uploads API instead
+ * ``pagesetup, system`` event: Use the menu or page shell hooks instead.
 
 Deprecated Views
 ----------------

--- a/engine/classes/Elgg/DeprecationService.php
+++ b/engine/classes/Elgg/DeprecationService.php
@@ -52,7 +52,13 @@ class DeprecationService {
 		$i = count($backtrace);
 
 		foreach ($backtrace as $trace) {
-			$stack[] = "[#$i] {$trace['file']}:{$trace['line']}";
+			if (empty($trace['file'])) {
+				// file/line not set for Closures
+				$stack[] = "[#$i] unknown";
+			} else {
+				$stack[] = "[#$i] {$trace['file']}:{$trace['line']}";
+			}
+
 			$i--;
 
 			if ($backtrace_level > 0) {

--- a/engine/classes/Elgg/EventsService.php
+++ b/engine/classes/Elgg/EventsService.php
@@ -44,6 +44,27 @@ class EventsService extends \Elgg\HooksRegistrationService {
 			$this->logger->error("'$name, $type' event is no longer triggered. Update your event registration "
 				. "to use '$name, relationship'");
 		}
+
+		if ($name === 'pagesetup' && $type === 'system') {
+			static $ignore = [
+				'users_pagesetup' => true,
+				'profile_pagesetup' => true,
+				'_elgg_friends_page_setup' => true,
+				'_elgg_setup_collections_menu' => true,
+				'_elgg_user_settings_menu_setup' => true,
+				'developers_setup_menu' => true,
+				'groups_setup_sidebar_menus' => true,
+				'notifications_plugin_pagesetup' => true,
+				'_elgg_admin_pagesetup' => true,
+				'aalborg_theme_pagesetup' => true,
+				'login_as_add_topbar_link' => true,
+			];
+			if (!is_string($callback) || !isset($ignore[$callback])) {
+				$msg = "Event [pagesetup, system] is deprecated. Use menu or page shell hooks.";
+				elgg_deprecated_notice($msg, '2.3', 2);
+			}
+		}
+
 		return parent::registerHandler($name, $type, $callback, $priority);
 	}
 

--- a/engine/classes/Elgg/HooksRegistrationService.php
+++ b/engine/classes/Elgg/HooksRegistrationService.php
@@ -62,10 +62,6 @@ abstract class HooksRegistrationService {
 			return false;
 		}
 		
-		if (($name == 'view' || $name == 'view_vars') && $type != 'all') {
-			$type = _elgg_services()->views->canonicalizeViewName($type);
-		}
-
 		$this->registrations[$name][$type][] = [
 			self::REG_KEY_PRIORITY => $priority,
 			self::REG_KEY_INDEX => $this->next_index,
@@ -177,7 +173,7 @@ abstract class HooksRegistrationService {
 	 *
 	 * @param string $name The name of the hook
 	 * @param string $type The type of the hook
-	 * @return array
+	 * @return callable[]
 	 * @see \Elgg\HooksRegistrationService::getAllHandlers()
 	 *
 	 * @access private

--- a/engine/classes/Elgg/PluginHooksService.php
+++ b/engine/classes/Elgg/PluginHooksService.php
@@ -61,4 +61,15 @@ class PluginHooksService extends \Elgg\HooksRegistrationService {
 		
 		return $returnvalue;
 	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function registerHandler($name, $type, $callback, $priority = 500) {
+		if (($name == 'view' || $name == 'view_vars') && $type !== 'all') {
+			$type = _elgg_services()->views->canonicalizeViewName($type);
+		}
+
+		return parent::registerHandler($name, $type, $callback, $priority);
+	}
 }


### PR DESCRIPTION
For BC, we leave core handlers bound and only give a deprecation warning for 3rd party handlers.

Moves the views/view_vars view name normalization to the PluginHooksService.
