### PR TITLE
feature(views): view_vars handlers can preset view output

### DIFF
--- a/docs/guides/views.rst
+++ b/docs/guides/views.rst
@@ -405,6 +405,22 @@ Here we'll eliminate breadcrumbs that don't have at least one link.
 	    // returning nothing means "don't alter the returnvalue"
 	}
 
+Replacing view output completely
+--------------------------------
+
+You can pre-set the view output by setting ``$vars['__view_output']``. The value will be returned as a
+string. View extensions will not be used and the ``view`` hook will not be triggered.
+
+.. code-block:: php
+
+    elgg_register_plugin_hook_handler('view_vars', 'navigation/breadcrumbs', 'myplugin_no_page_breadcrumbs');
+
+    function myplugin_no_page_breadcrumbs($hook, $type, $vars, $params) {
+        if (elgg_in_context('pages')) {
+            return ['__view_output' => ""];
+        }
+    }
+
 Displaying entities
 ===================
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -324,20 +324,23 @@ function elgg_list_views($viewtype = 'default') {
  * The input of views can be intercepted by registering for the
  * view_vars, $view_name plugin hook.
  *
+ * If the input contains the key "__view_output", the view will output this value as a string.
+ * No extensions are used, and the "view" hook is not triggered).
+ *
  * The output of views can be intercepted by registering for the
  * view, $view_name plugin hook.
  *
  * @param string  $view     The name and location of the view to use
  * @param array   $vars     Variables to pass to the view.
- * @param boolean $bypass   This argument is ignored and will be removed eventually
- * @param boolean $ignored  This argument is ignored and will be removed eventually
+ * @param boolean $ignore1  This argument is ignored and will be removed eventually
+ * @param boolean $ignore2  This argument is ignored and will be removed eventually
  * @param string  $viewtype If set, forces the viewtype for the elgg_view call to be
  *                          this value (default: standard detection)
  *
  * @return string The parsed view
  */
-function elgg_view($view, $vars = array(), $bypass = false, $ignored = false, $viewtype = '') {
-	return _elgg_services()->views->renderView($view, $vars, $bypass, $viewtype);
+function elgg_view($view, $vars = array(), $ignore1 = false, $ignore2 = false, $viewtype = '') {
+	return _elgg_services()->views->renderView($view, $vars, $ignore1, $viewtype);
 }
 
 /**

--- a/engine/tests/phpunit/Elgg/ViewsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ViewsServiceTest.php
@@ -123,6 +123,18 @@ class ViewsServiceTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals("// Hello", $this->views->renderView('js/interpreted.js'));
 	}
+
+	public function testCanReplaceViews() {
+		$this->hooks->registerHandler('view_vars', 'js/interpreted.js', function ($h, $t, $v, $p) {
+			return ['__view_output' => 123];
+		});
+
+		$this->hooks->registerHandler('view', 'js/interpreted.js', function ($h, $t, $v, $p) {
+			$this->fail('view hook was called though __view_output was set.');
+		});
+
+		$this->assertSame("123", $this->views->renderView('js/interpreted.js'));
+	}
 	
 	public function testThrowsOnCircularAliases() {
 		$this->markTestIncomplete();


### PR DESCRIPTION
If `$vars['__view_output']` is set, the view will immediately return the value, bypassing all rendering (no extensions, no views hook).
