### PR TITLE
fix(autoload): fixes bugs in class map saving

### DIFF
--- a/engine/classes/Elgg/ClassMap.php
+++ b/engine/classes/Elgg/ClassMap.php
@@ -44,8 +44,10 @@ class ClassMap {
 		if ('\\' === $class[0]) {
 			$class = substr($class, 1);
 		}
-		$this->map[$class] = $path;
-		$this->altered = true;
+		if (!isset($this->map[$class]) || $this->map[$class] !== $path) {
+			$this->map[$class] = $path;
+			$this->altered = true;
+		}
 		return $this;
 	}
 

--- a/engine/load.php
+++ b/engine/load.php
@@ -8,7 +8,7 @@
 
 $lib_dir = __DIR__ . "/lib";
 
-require_once "$lib_dir/autoloader.php";
+$autoloader_setup = (require_once "$lib_dir/autoloader.php");
 
 $autoload_path = dirname(__DIR__) . '/vendor/autoload.php';
 $autoload_available = include_once($autoload_path);
@@ -79,7 +79,7 @@ $lib_files = array(
 );
 
 // isolate global scope
-call_user_func(function () use ($lib_dir, $lib_files) {
+call_user_func(function () use ($lib_dir, $lib_files, $autoloader_setup) {
 
 	$setups = array();
 
@@ -96,6 +96,7 @@ call_user_func(function () use ($lib_dir, $lib_files) {
 	$hooks = _elgg_services()->hooks;
 
 	// run setups
+	$autoloader_setup($events, $hooks);
 	foreach ($setups as $func) {
 		$func($events, $hooks);
 	}


### PR DESCRIPTION
The autoloader class map now marks itself altered only if a path is changed or set initially. This allows `elgg_register_class()` to be called on every request without triggering a re-save.

In 1.12, the `engine/lib` loader now properly calls the setup function returned by `autoload.php`, allowing the class map to be saved. This bug does not exist in 2.x.

Refs #9744
