### PR TITLE
docs(cache): added instructions for flushing cache from disk

### DIFF
--- a/docs/guides/views/simplecache.rst
+++ b/docs/guides/views/simplecache.rst
@@ -24,6 +24,9 @@ You can regenerate the Simplecache at any time by:
 - In the admin panel click on 'Flush the caches'
 - Enabling or disabling a plugin
 - Reordering your plugins
+- Removing your ``datadir/system_cache``
+- Removing your ``datadir/views_simplecache``
+
 
 Using the Simplecache in your plugins
 -------------------------------------


### PR DESCRIPTION
I have documented to remove the ''system_cache'' and the ''views_simplecache'' directory
to flush the cache as a last resort, because other methods were
not applicable to me while migrating an ELGG installation to a new server:
- upgrade.php: did not flush
- I have no access to the ELGG admin panel
