### PR TITLE
fix(comments): email subject hook now validates array structure

### DIFF
--- a/engine/lib/comments.php
+++ b/engine/lib/comments.php
@@ -280,8 +280,12 @@ function _elgg_comments_notification_email_subject($hook, $type, $returnvalue, $
 		return;
 	}
 
+	if (empty($returnvalue['params']['notification'])) {
+		return;
+	}
+	
 	/** @var Elgg\Notifications\Notification */
-	$notification = elgg_extract('notification', $returnvalue['params']);
+	$notification = $returnvalue['params']['notification'];
 
 	if ($notification instanceof Elgg\Notifications\Notification) {
 		$object = elgg_extract('object', $notification->params);


### PR DESCRIPTION
When called directly elgg_send_email() would trigger a hook
without params being set, which resulted in email subject handler
in emitting a warning.

Fixes #9772
