### PR TITLE
fix(annotations): fixes logic in time-based annotations searches

### DIFF
--- a/engine/classes/Elgg/Database/Annotations.php
+++ b/engine/classes/Elgg/Database/Annotations.php
@@ -369,7 +369,7 @@ class Annotations {
 			$options['annotation_created_time_lower']);
 	
 		if ($time_wheres) {
-			$options['wheres'] = array_merge($options['wheres'], $time_wheres);
+			$options['wheres'][] = $time_wheres;
 		}
 	
 		return elgg_get_entities_from_metadata($options);


### PR DESCRIPTION
`_elgg_get_entity_time_where_sql()` returns a string, so if it's not empty we just push it onto the wheres stack.

Fixes #9785
- [ ] add tests
