### PR TITLE
fix(core): elgg_get_plugin_setting() respects defaults for values that haven't been cached or created.

### DIFF
--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -276,8 +276,9 @@ class ElggPlugin extends \ElggObject {
 	 */
 	public function getSetting($name, $default = null) {
 		$values = _elgg_services()->pluginSettingsCache->getAll($this->guid);
+
 		if ($values !== null) {
-			return isset($values[$name]) ? $values[$name] : null;
+			return isset($values[$name]) ? $values[$name] : $default;
 		}
 
 		$val = $this->$name;

--- a/engine/tests/ElggCorePluginsAPITest.php
+++ b/engine/tests/ElggCorePluginsAPITest.php
@@ -260,4 +260,22 @@ class ElggCorePluginsAPITest extends \ElggCoreUnitTest {
 		
 		$this->assertIdentical('profile', $test_plugin->getID());
 	}
+
+	public function testGetSettingRespectsDefaults() {
+		$plugin = elgg_get_plugin_from_id('profile');
+		if (!$plugin) {
+			return;
+		}
+
+		$cache = _elgg_services()->pluginSettingsCache;
+		$cache->setCachedValues([
+			$plugin->guid => [
+				__METHOD__ => 'foo',
+			],
+		]);
+
+		$this->assertEqual('foo', $plugin->getSetting(__METHOD__, 'bar'));
+		$cache->clearAll();
+		$this->assertEqual('bar', $plugin->getSetting(__METHOD__, 'bar'));
+	}
 }


### PR DESCRIPTION
Fixes #9781

(I just rebased this for 2.1)
