### PR TITLE
chore(js): In elgg/spinner start() ignores non-strings

### DIFF
--- a/js/tests/ElggSpinnerTest.js
+++ b/js/tests/ElggSpinnerTest.js
@@ -45,10 +45,33 @@ define(function(require) {
 			}, 25);
 		});
 
+		it("start([object]) sets empty text", function(done) {
+			spinner.start({});
+
+			setTimeout(function() {
+				expect($(visible_selector).length).toBe(1);
+				expect($('.elgg-spinner-text').html()).toBe('');
+				done();
+			}, 25);
+		});
+
 		it("start() removes any set text", function(done) {
 			spinner.start('a>b&c');
 
 			setTimeout(spinner.start, 25);
+
+			setTimeout(function() {
+				expect($('.elgg-spinner-text').html()).toBe('');
+				done();
+			}, 35);
+		});
+
+		it("start([object]) removes any set text", function(done) {
+			spinner.start('a>b&c');
+
+			setTimeout(function () {
+				spinner.start({});
+			}, 25);
 
 			setTimeout(function() {
 				expect($('.elgg-spinner-text').html()).toBe('');

--- a/views/default/elgg/spinner.js
+++ b/views/default/elgg/spinner.js
@@ -22,8 +22,12 @@ define(function (require) {
 					$('body').addClass('elgg-spinner-active');
 				}
 			}, SHOW_DELAY);
-			
-			spinner.setText(text);
+
+			if (typeof text === 'string') {
+				spinner.setText(text);
+			} else {
+				spinner.setText('');
+			}
 		},
 
 		/**


### PR DESCRIPTION
Often `spinner.start` is given as an event handler, causing it to receive an event object. We only want strings to set the text.

Fixes #9769
