### PR TITLE
feature(html): allows cleaner elgg_format_element usage

### DIFF
--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -167,13 +167,16 @@ function elgg_format_attributes(array $attrs = array()) {
 /**
  * Format an HTML element
  *
- * @param string $tag_name   The element tagName. e.g. "div". This will not be validated.
+ * @param string|array $tag_name   The element tagName. e.g. "div". This will not be validated.
+ *                                 All function arguments can be given as a single array: The array will be used
+ *                                 as $attributes, except for the keys "#tag_name", "#text", and "#options", which
+ *                                 will be extracted as the other arguments.
  *
- * @param array  $attributes The element attributes. This is passed to elgg_format_attributes().
+ * @param array        $attributes The element attributes. This is passed to elgg_format_attributes().
  *
- * @param string $text       The contents of the element. Assumed to be HTML unless encode_text is true.
+ * @param string       $text       The contents of the element. Assumed to be HTML unless encode_text is true.
  *
- * @param array  $options    Options array with keys:
+ * @param array        $options    Options array with keys:
  *
  *   encode_text   => (bool, default false) If true, $text will be HTML-escaped. Already-escaped entities
  *                    will not be double-escaped.
@@ -192,7 +195,28 @@ function elgg_format_attributes(array $attrs = array()) {
  * @since 1.9.0
  */
 function elgg_format_element($tag_name, array $attributes = array(), $text = '', array $options = array()) {
-	if (!is_string($tag_name)) {
+	if (is_array($tag_name)) {
+		$args = $tag_name;
+
+		if ($attributes !== [] || $text !== '' || $options !== []) {
+			throw new \InvalidArgumentException('If $tag_name is an array, the other arguments must not be set');
+		}
+
+		if (isset($args['#tag_name'])) {
+			$tag_name = $args['#tag_name'];
+		}
+		if (isset($args['#text'])) {
+			$text = $args['#text'];
+		}
+		if (isset($args['#options'])) {
+			$options = $args['#options'];
+		}
+
+		unset($args['#tag_name'], $args['#text'], $args['#options']);
+		$attributes = $args;
+	}
+
+	if (!is_string($tag_name) || $tag_name === '') {
 		throw new \InvalidArgumentException('$tag_name is required');
 	}
 

--- a/engine/tests/ElggCoreHelpersTest.php
+++ b/engine/tests/ElggCoreHelpersTest.php
@@ -204,7 +204,13 @@ class ElggCoreHelpersTest extends \ElggCoreUnitTest {
 			$attrs = isset($vars['attrs']) ? $vars['attrs'] : array();
 			$message = isset($vars['_msg']) ? $vars['_msg'] : null;
 			unset($vars['tag_name'], $vars['text'], $vars['_msg']);
+
 			$this->assertEqual(elgg_format_element($tag_name, $attrs, $text, $opts), $expected, $message);
+
+			$attrs['#tag_name'] = $tag_name;
+			$attrs['#text'] = $text;
+			$attrs['#options'] = $opts;
+			$this->assertEqual(elgg_format_element($attrs), $expected, $message);
 		}
 
 		try {

--- a/mod/developers/views/default/theme_sandbox/javascript/popup.php
+++ b/mod/developers/views/default/theme_sandbox/javascript/popup.php
@@ -15,7 +15,8 @@ echo elgg_view_module('popup', 'Popup Test', $ipsum, array(
 ));
 
 
-$button = elgg_format_element('button', array(
+$button = elgg_format_element(array(
+	'#tag_name' => 'button',
 	'class' => 'elgg-button elgg-button-submit mll',
 	'rel' => 'popup',
 	'data-href' => "#elgg-popup-test2",
@@ -23,13 +24,15 @@ $button = elgg_format_element('button', array(
 		'my' => 'left top',
 		'at' => 'left bottom',
 	)),
-		), 'Load content in a popup');
+	'#text' => 'Load content in a popup',
+));
 
 echo $button;
 
-echo elgg_format_element('div', array(
+echo elgg_format_element(array(
+	'#tag_name' => 'div',
 	'id' => 'elgg-popup-test2',
 	'class' => 'hidden theme-sandbox-content-thin elgg-module-popup',
-		), '');
+));
 
 elgg_require_js('theme_sandbox/javascript/popup');

--- a/mod/groups/views/default/groups/edit/tools.php
+++ b/mod/groups/views/default/groups/edit/tools.php
@@ -20,12 +20,15 @@ usort($tools, function($a, $b) {
 foreach ($tools as $group_option) {
 	$group_option_toggle_name = $group_option->name . "_enable";
 	$value = elgg_extract($group_option_toggle_name, $vars);
-	
-	echo elgg_format_element('div', [], elgg_view('input/checkbox', array(
-		'name' => $group_option_toggle_name,
-		'value' => 'yes',
-		'default' => 'no',
-		'checked' => ($value === 'yes') ? true : false,
-		'label' => $group_option->label
-	)));
+
+	echo elgg_format_element([
+		'#tag_name' => 'div',
+		'#text' => elgg_view('input/checkbox', [
+			'name' => $group_option_toggle_name,
+			'value' => 'yes',
+			'default' => 'no',
+			'checked' => ($value === 'yes') ? true : false,
+			'label' => $group_option->label,
+		]),
+	]);
 }

--- a/mod/notifications/views/default/forms/notificationsettings/groupsave.php
+++ b/mod/notifications/views/default/forms/notificationsettings/groupsave.php
@@ -41,7 +41,11 @@ if ($groups) {
 			$top_row .= '<td class="spacercolumn">&nbsp;</td>';
 		}
 		
-		$top_row .= elgg_format_element('td', ['class' => "{$method}togglefield"], elgg_echo("notification:method:{$method}"));
+		$top_row .= elgg_format_element([
+			'#tag_name' => 'td',
+			'class' => "{$method}togglefield",
+			'#text' => elgg_echo("notification:method:{$method}"),
+		]);
 		$i++;
 	}
 	$top_row .= '<td>&nbsp;</td>';

--- a/mod/notifications/views/default/notifications/subscriptions/collections.php
+++ b/mod/notifications/views/default/notifications/subscriptions/collections.php
@@ -31,7 +31,11 @@ foreach($NOTIFICATION_HANDLERS as $method => $foo) {
 		$top_row .= '<td class="spacercolumn">&nbsp;</td>';
 	}
 
-	$top_row .= elgg_format_element('td', ['class' => "{$method}togglefield"], elgg_echo("notification:method:{$method}"));
+	$top_row .= elgg_format_element([
+		'#tag_name' => 'td',
+		'#text' => elgg_echo("notification:method:{$method}"),
+		'class' => "{$method}togglefield",
+	]);
 	$i++;
 }
 
@@ -168,7 +172,11 @@ $table_attributes = [
 	'width' => '100%',
 ];
 
-$body = elgg_format_element('p', ['class' => 'margin-none'], elgg_echo('notifications:subscriptions:friends:description'));
+$body = elgg_format_element([
+	'#tag_name' => 'p',
+	'class' => 'margin-none',
+	'#text' => elgg_echo('notifications:subscriptions:friends:description'),
+]);
 $body .= elgg_format_element('table', $table_attributes, $table_data);
 
 echo elgg_view_module('info', elgg_echo('notifications:subscriptions:friends:title'), $body);

--- a/mod/notifications/views/default/notifications/subscriptions/forminternals.php
+++ b/mod/notifications/views/default/notifications/subscriptions/forminternals.php
@@ -148,7 +148,11 @@ END;
 					$top_row .= elgg_format_element('td', ['class' => 'spacercolumn'], '&nbsp;');
 				}
 
-				$top_row .= elgg_format_element('td', ['class' => "{$method}togglefield"], elgg_echo("notification:method:{$method}"));
+				$top_row .= elgg_format_element([
+					'#tag_name' => 'td',
+					'class' => "{$method}togglefield",
+					'#text' => elgg_echo("notification:method:{$method}"),
+				]);
 				$i++;
 			}
 			$top_row .= elgg_format_element('td', [], '&nbsp;');
@@ -204,10 +208,14 @@ END;
 						'href' => $friend->getURL(),
 						'text' => elgg_view_entity_icon($friend, 'tiny', ['use_hover' => false]),
 					]);
-					$name_field .= elgg_format_element('p', ['class' => 'namefieldlink'], elgg_view('output/url', [
-						'href' => $friend->getURL(),
-						'text' => $friend->name,
-					]));
+					$name_field .= elgg_format_element([
+						'#tag_name' => 'p',
+						'class' => 'namefieldlink',
+						'#text' => elgg_view('output/url', [
+							'href' => $friend->getURL(),
+							'text' => $friend->name,
+						]),
+					]);
 					
 					$friend_row = elgg_format_element('td', ['class' => 'namefield'], $name_field);
 					$friend_row .= $fields;
@@ -239,8 +247,16 @@ END;
 		$letter = elgg_substr($chararray,$letpos,1);
 	}
 		
-	$friendspicker_container = elgg_format_element('div', ['class' => 'friends-picker-container'], $friendspicker_container);
-	$friendspicker_wrapper = elgg_format_element('div', ['id' => "friends-picker{$friendspicker}"], $friendspicker_container);
+	$friendspicker_container = elgg_format_element([
+		'#tag_name' => 'div',
+		'class' => 'friends-picker-container',
+		'#text' => $friendspicker_container,
+	]);
+	$friendspicker_wrapper = elgg_format_element([
+		'#tag_name' => 'div',
+		'id' => "friends-picker{$friendspicker}",
+		'#text' => $friendspicker_container,
+	]);
 		
 	$placeholder_data .= elgg_format_element('div', ['class' => 'friends-picker-wrapper'], $friendspicker_wrapper);
 } else {

--- a/mod/notifications/views/default/notifications/subscriptions/personal.php
+++ b/mod/notifications/views/default/notifications/subscriptions/personal.php
@@ -15,7 +15,11 @@ foreach($NOTIFICATION_HANDLERS as $method => $foo) {
 		$top_row .= elgg_format_element('td', ['class' => 'spacercolumn'], '&nbsp;');
 	}
 
-	$top_row .= elgg_format_element('td', ['class' => "{$method}togglefield"], elgg_echo("notification:method:{$method}"));
+	$top_row .= elgg_format_element([
+		'#tag_name' => 'td',
+		'class' => "{$method}togglefield",
+		'#text' => elgg_echo("notification:method:{$method}"),
+	]);
 	$i++;
 }
 $top_row .= elgg_format_element('td', [], '&nbsp;');
@@ -57,7 +61,11 @@ foreach($NOTIFICATION_HANDLERS as $method => $foo) {
 	$i++;
 }
 
-$personal_row = elgg_format_element('td', ['class' => 'namefield'], elgg_format_element('p', [], elgg_echo('notifications:subscriptions:personal:description')));
+$personal_row = elgg_format_element([
+	'#tag_name' => 'td',
+	'class' => 'namefield',
+	'#text' => "<p>" . elgg_echo('notifications:subscriptions:personal:description') . "</p>",
+]);
 $personal_row .= $fields;
 $personal_row .= elgg_format_element('td', [], '&nbsp;');
 

--- a/views/default/admin/plugins/filter.php
+++ b/views/default/admin/plugins/filter.php
@@ -26,6 +26,10 @@ foreach ($categories as $key => $category) {
 	$list_items .= elgg_format_element('li', array(), $link);
 }
 
-$body = elgg_format_element('ul', ['class' => 'elgg-admin-plugins-categories elgg-admin-sidebar-menu elgg-menu-hz'], $list_items);
+$body = elgg_format_element([
+	'#tag_name' => 'ul',
+	'class' => 'elgg-admin-plugins-categories elgg-admin-sidebar-menu elgg-menu-hz',
+	'#text' => $list_items,
+]);
 
 echo elgg_view_module('', elgg_echo('filter'), $body);

--- a/views/default/core/river/filter.php
+++ b/views/default/core/river/filter.php
@@ -35,9 +35,10 @@ if ($selector) {
 }
 $select = elgg_view('input/select', $params);
 
-$attr = [
+$input = elgg_format_element([
+	'#tag_name' => 'label',
 	'class' => 'elgg-river-selector',
-];
+	'#text' => elgg_format_element('span', [], elgg_echo('filter')) . " $select",
+]);
 
-$input = elgg_format_element('label', $attr, elgg_format_element('span', [], elgg_echo('filter')) . " $select");
 echo elgg_format_element('div', ['class' => 'clearfix'], $input);

--- a/views/default/elements/forms/label.php
+++ b/views/default/elements/forms/label.php
@@ -18,10 +18,12 @@ if (!$label) {
 if ($required) {
 	$indicator = elgg_extract('required_indicator', $vars);
 	if (!isset($indicator)) {
-		$indicator = elgg_format_element('span', [
+		$indicator = elgg_format_element([
+			'#tag_name' => 'span',
 			'title' => elgg_echo('field:required'),
 			'class' => 'elgg-required-indicator',
-				], "&ast;");
+			'#text' => "&ast;",
+		]);
 	}
 	if ($indicator) {
 		$label .= $indicator;

--- a/views/default/forms/admin/menu/save.php
+++ b/views/default/forms/admin/menu/save.php
@@ -65,7 +65,11 @@ $name_input = elgg_view('input/text', ['name' => 'custom_menu_titles[]']);
 
 $url_input = elgg_view('input/text', ['name' => 'custom_menu_urls[]']);
 
-$add_menu_items .= elgg_format_element('li', ['class' => 'custom_menuitem'], "$name_str: $name_input $url_str: $url_input");
+$add_menu_items .= elgg_format_element([
+	'#tag_name' => 'li',
+	'class' => 'custom_menuitem',
+	'#text' => "$name_str: $name_input $url_str: $url_input",
+]);
 
 $add_menu = elgg_view('output/longtext', ['value' => elgg_echo('admin:add_menu_item:description')]);
 $add_menu .= elgg_format_element('ul', ['class' => 'elgg-list elgg-list-simple'], $add_menu_items);

--- a/views/default/output/access.php
+++ b/views/default/output/access.php
@@ -44,11 +44,12 @@ if (!isset($access_id)) {
 
 $access_id_string = get_readable_access_level($access_id);
 
-$attributes = array(
+echo elgg_format_element([
+	'#tag_name' => 'span',
 	'title' => elgg_echo('access:help'),
 	'class' => $access_class,
-);
-
-echo elgg_format_element('span', $attributes, $access_id_string, array(
-	'encode_text' => true,
-));
+	'#text' => $access_id_string,
+	'#options' => [
+		'encode_text' => true,
+	],
+]);


### PR DESCRIPTION
All arguments can be given as a single array, with non-attributes specified via keys `#tag_name`, `#text`, and `#options`.

Fixes #9766

(identical to #9771)
