### PR TITLE
feat(lists): list item views are now aware of their position in the list

### DIFF
--- a/views/default/page/components/gallery.php
+++ b/views/default/page/components/gallery.php
@@ -50,9 +50,12 @@ if (isset($vars['item_class'])) {
 
 $nav = ($pagination) ? elgg_view('navigation/pagination', $vars) : '';
 
+$index = 0;
 $list_items = '';
 foreach ($items as $item) {
-	$item_view = elgg_view_list_item($item, $vars);
+	$item_view_vars = $vars;
+	$item_view_vars['list_item_index'] = $index;
+	$item_view = elgg_view_list_item($item, $item_view_vars);
 	if (!$item_view) {
 		continue;
 	}
@@ -66,6 +69,7 @@ foreach ($items as $item) {
 	}
 
 	$list_items .= elgg_format_element('li', $li_attrs, $item_view);
+	$index++;
 }
 
 if ($position == 'before' || $position == 'both') {

--- a/views/default/page/components/list.php
+++ b/views/default/page/components/list.php
@@ -50,9 +50,12 @@ if (isset($vars['item_class'])) {
 
 $nav = ($pagination) ? elgg_view('navigation/pagination', $vars) : '';
 
+$index = 0;
 $list_items = '';
 foreach ($items as $item) {
-	$item_view = elgg_view_list_item($item, $vars);
+	$item_view_vars = $vars;
+	$item_view_vars['list_item_index'] = $index;
+	$item_view = elgg_view_list_item($item, $item_view_vars);
 	if (!$item_view) {
 		continue;
 	}
@@ -75,6 +78,7 @@ foreach ($items as $item) {
 	}
 
 	$list_items .= elgg_format_element('li', $li_attrs, $item_view);
+	$index++;
 }
 
 if ($position == 'before' || $position == 'both') {


### PR DESCRIPTION
List items views now receive "list_item_index" with $vars.
This index can be used by item and extending views to output
position specific elements, e.g. list controls after each 10th
list item
- [x] Trigger Travis rebuild after #9842 is merged
