### PR TITLE
perf(composer): composer-asset-plugin is no longer required in global scope

### DIFF
--- a/.scripts/check_global_requirements.php
+++ b/.scripts/check_global_requirements.php
@@ -1,13 +1,5 @@
 <?php
 
-exec("composer global show -i fxp/composer-asset-plugin", $output, $returnVal);
-
-if ($returnVal) {
-	echo "************************************************************************\n";
-	echo "In order to install Elgg using composer, you must first run the command:\n";
-	echo "composer global require fxp/composer-asset-plugin\n ";
-	echo "************************************************************************\n";
-	echo "\n";
-}
-
-exit($returnVal);
+/**
+ * @deprecated 2.2 Composer asset plugin is now installed in project scope
+ */

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
         "bower-asset/jquery-colorbox": "^1.5.14",
         "FortAwesome/Font-Awesome": "^4.3",
         "michelf/php-markdown": "^1.5.0",
-        "league/flysystem-memory": "^1.0"
+        "league/flysystem-memory": "^1.0",
+        "fxp/composer-asset-plugin": "^1.1.4"
     },
     "scripts": {
-        "pre-install-cmd": "php .scripts/check_global_requirements.php",
         "lint": [
             "phpcs --standard=vendor/elgg/sniffs/elgg.xml --warning-severity=0 --ignore=*/tests/*,*/upgrades/*,*/deprecated* engine/classes engine/lib",
             "composer validate"
@@ -40,7 +40,6 @@
         "test": "phpunit",
         "travis:install": [
             "composer self-update",
-            "composer global require \"fxp/composer-asset-plugin:~1.1.1\"",
             "composer install --prefer-source"
         ],
         "travis:install-with-mysql": [

--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -793,10 +793,5 @@ For example, to include jQuery, you could run the following Composer commands:
 
 .. code-block:: shell
 
-    composer global require fxp/composer-asset-plugin:~1.1.1
     composer require bower-asset/jquery:~2.0
 
-.. note::
-
-    ``fxp/composer-asset-plugin`` must be installed globally!
-    See https://github.com/francoispluchino/composer-asset-plugin for more info.

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -247,25 +247,6 @@ Using the ``view, all`` hook and checking for individual views may not work as i
 Please let us know about any other BC issues this change causes.
 We'd like to fix as many as possible to make the transition smooth.
 
-``fxp/composer-asset-plugin`` is now required to install Elgg from source
--------------------------------------------------------------------------
-
-We use ``fxp/composer-asset-plugin`` to manage our browser assets (js, css, html)
-with Composer, but it must be installed globally *before installing Elgg* in order
-for the ``bower-asset/*`` packages to be recognized. To install it, run:
-
-.. code:: shell
-
-    composer global require fxp/composer-asset-plugin
-
-If you don't do this before running ``composer install`` or ``composer create-project``,
-you will get an error message:
-
-.. code:: shell
-
-    [InvalidArgumentException]
-    Package fxp/composer-asset-plugin not found
-
 
 List of deprecated views and view arguments that have been removed
 ------------------------------------------------------------------

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -75,7 +75,6 @@ With Composer (recommended if comfortable with CLI):
 
     cd /path/to/wwwroot/
     composer self-update
-    composer global require "fxp/composer-asset-plugin:~1.1.1"
     composer create-project elgg/starter-project:dev-master .
     composer install
 


### PR DESCRIPTION
fxp/composer-asset-plugin is now installed in project scope. This simplifies the installation and update process.

Refs #9816
