### PR TITLE
docs(faqs): fixed typo in IDE section

### DIFF
--- a/docs/appendix/faqs/development.rst
+++ b/docs/appendix/faqs/development.rst
@@ -1,8 +1,8 @@
 Development
 ===========
 
-What should I use to edit php code
-----------------------------------
+What should I use to edit php code?
+-----------------------------------
 
 There are two main options: text editor or `integrated development environment`_ (IDE).
 
@@ -14,7 +14,7 @@ If you are new to software development or do not have much experience with IDEs,
 Integrated Development Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-An IDE does just what it's name implies: it includes a set of tools that you would normally use separately. Most IDEs will include source code control which will allow you to directly commit and update your code from your cvs repository. It may have an FTP client built into it to make the transfer of files to a remote server easier. It will have syntax checking to catch errors before you try to execute the code on a server.
+An IDE does just what its name implies: it includes a set of tools that you would normally use separately. Most IDEs will include source code control which will allow you to directly commit and update your code from your cvs repository. It may have an FTP client built into it to make the transfer of files to a remote server easier. It will have syntax checking to catch errors before you try to execute the code on a server.
 
 The two most popular free IDEs for PHP developers are Eclipse_ and NetBeans_. Eclipse has two different plugins for working with PHP code: PDT_ and PHPEclipse_.
 


### PR DESCRIPTION
Fixed the possessive form of "it" under the IDE section.
