### PR TITLE
fix(river): custom joins can now reference default joined tables

### DIFF
--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -215,7 +215,7 @@ function _elgg_get_metastring_based_objects($options) {
 		$options['joins'] = array($options['joins']);
 	}
 
-	$joins = $options['joins'];
+	$joins = array();
 	$joins[] = "JOIN {$db_prefix}entities e ON n_table.entity_guid = e.guid";
 
 	// evaluate selects
@@ -232,7 +232,7 @@ function _elgg_get_metastring_based_objects($options) {
 	$custom_callback = ($options['callback'] == 'row_to_elggmetadata'
 						|| $options['callback'] == 'row_to_elggannotation');
 	$is_calculation = $options['metastring_calculation'] ? true : false;
-	
+
 	if ($custom_callback || $is_calculation) {
 		$joins[] = "JOIN {$db_prefix}metastrings n on n_table.name_id = n.id";
 		$joins[] = "JOIN {$db_prefix}metastrings v on n_table.value_id = v.id";
@@ -241,13 +241,8 @@ function _elgg_get_metastring_based_objects($options) {
 		$selects[] = 'v.string as value';
 	}
 
-	foreach ($joins as $i => $join) {
-		if ($join === false) {
-			return false;
-		} elseif (empty($join)) {
-			unset($joins[$i]);
-		}
-	}
+	// add optional joins
+	$joins = array_merge($joins, $options['joins']);
 
 	// metastrings
 	$metastring_clauses = _elgg_get_metastring_sql('n_table', $options['metastring_names'],
@@ -282,6 +277,14 @@ function _elgg_get_metastring_based_objects($options) {
 		$query = "SELECT count($distinct e.guid) as calculation FROM {$db_prefix}$type n_table";
 	} else {
 		$query = "SELECT {$options['metastring_calculation']}(v.string) as calculation FROM {$db_prefix}$type n_table";
+	}
+
+	foreach ($joins as $i => $join) {
+		if ($join === false) {
+			return false;
+		} elseif (empty($join)) {
+			unset($joins[$i]);
+		}
 	}
 
 	// remove identical join clauses


### PR DESCRIPTION
When building more complex queries there may be a need to reference table aliases introduced by the default joins in _elgg_get_metastring_based_objects and elgg_get_river. This fix ensures that the default join table aliases are available when defining custom joins - which is a requirement for building effective and efficient queries.

Fixes #8580
