### PR TITLE
fix(reportedcontent): forward to address if not submitted in lightbox

### DIFF
--- a/mod/reportedcontent/views/default/elgg/reportedcontent.js
+++ b/mod/reportedcontent/views/default/elgg/reportedcontent.js
@@ -16,9 +16,15 @@ define(function (require) {
 			data: $form.serialize(),
 			success: function (data) {
 				if (data.status == 0) {
-					require(['elgg/lightbox'], function(lightbox) {
-						lightbox.close();
-					});
+					if ($form.is('#colorbox *')) {
+						require(['elgg/lightbox'], function(lightbox) {
+							lightbox.close();
+						});
+					} else {
+						// redirect to address if not reported from a lightbox
+						// can not use history as it may not exist
+						location.href = $form.find('input[name="address"]').val();
+					}
 				}
 			}
 		});


### PR DESCRIPTION
doing this on 2.x because it is an edge case and too much has changed between 1.12 and 2.x related to these files, so we should not bother with it...

This fix will forward to reported address if for some reason the report form is not opening in lightbox, but as a regular page
