### PR TITLE
perf(config): removes config "siteemail" value

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -128,6 +128,7 @@ Miscellaneous API changes
  * ``elgg_gatekeeper`` and ``elgg_admin_gatekeeper`` no longer report ``login`` or ``admin`` as forward reason, but ``403``
  * ``Application::getDb()`` no longer returns an instance of ``Elgg\Database``, but rather a ``Elgg\Application\Database``
  * ``$CONFIG`` is no longer available as a local variable inside plugin ``start.php`` files.
+ * ``elgg_get_config('siteemail')`` is no longer available. Use ``elgg_get_site_entity()->email``.
 
 JavaScript hook calling order may change
 ----------------------------------------

--- a/docs/info/config.php
+++ b/docs/info/config.php
@@ -120,14 +120,6 @@ $CONFIG->auto_disable_plugins;
 $CONFIG->sitedescription;
 
 /**
- * The site email from the current site object.
- *
- * @global string $CONFIG->siteemail
- * @deprecated 2.1 Use elgg_get_site_entity()->email
- */
-$CONFIG->siteemail;
-
-/**
  * The default "limit" used in site queries.
  *
  * @global int $CONFIG->default_limit

--- a/engine/classes/Elgg/BootService.php
+++ b/engine/classes/Elgg/BootService.php
@@ -145,15 +145,10 @@ class BootService {
 		_elgg_services()->translator->loadTranslations();
 
 		// we always need site->email and user->icontime, so load them together
-		$preload_md_guids = [$CONFIG->site_guid];
 		$user_guid = _elgg_services()->session->getLoggedInUserGuid();
 		if ($user_guid) {
-			$preload_md_guids[] = $user_guid;
+			_elgg_services()->metadataCache->populateFromEntities([$user_guid]);
 		}
-		_elgg_services()->metadataCache->populateFromEntities($preload_md_guids);
-
-		// TODO get rid of in 3.0, then we can drop the metadata preload for anon visitors
-		$CONFIG->siteemail = $CONFIG->site->email;
 
 		// gives hint to get() how to approach missing values
 		$CONFIG->site_config_loaded = true;

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -94,10 +94,7 @@ function elgg_get_engine_path() {
  * @since 1.8.0
  */
 function elgg_get_config($name, $site_guid = 0) {
-	if ($name === 'siteemail') {
-		$msg = 'The config value "siteemail" is deprecated. Use elgg_get_site_entity()->email';
-		elgg_deprecated_notice($msg, '2.1');
-	} else if ($name == 'icon_sizes') {
+	if ($name == 'icon_sizes') {
 		$msg = 'The config value "icon_sizes" is deprecated. Use elgg_get_icon_sizes()';
 		elgg_deprecated_notice($msg, '2.2');
 	}


### PR DESCRIPTION
Thanks to this change, the boot sequence no longer needs to preload the site entity metadata. For logged out requests, no metadata is needed during boot at all. When the boot cache is enabled, only two queries are needed to boot the vast majority of logged out requests.

Fixes #9096

BREAKING CHANGE:
`elgg_get_config('siteemail')` no longer returns the site email address.
