### PR TITLE
chore(session): removes the global $SESSION variable

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -57,6 +57,7 @@ Removed global vars
 -------------------
 
  * ``$DEFAULT_FILE_STORE``
+ * ``$SESSION``: Use the API provided by ``elgg_get_session()``
 
 Removed classes/interfaces
 --------------------------

--- a/engine/classes/Elgg/DeprecationWrapper.php
+++ b/engine/classes/Elgg/DeprecationWrapper.php
@@ -7,8 +7,8 @@ namespace Elgg;
  * Note that the wrapper will not share the type of the wrapped object and will
  * fail type hints, instanceof, etc.
  *
- * This was introduced for deprecating passing particular variabled to views
- * automatically in elgg_view(). It also used to wrap the deprecated global $SESSION.
+ * This was introduced for deprecating passing particular variables to views
+ * automatically in elgg_view().
  * It can be removed once that use is no longer required.
  *
  * Wraps:

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -9,12 +9,6 @@
  */
 
 /**
- * Elgg magic session
- * @deprecated 1.9
- */
-global $SESSION;
-
-/**
  * Gets Elgg's session object
  *
  * @return \ElggSession
@@ -437,10 +431,6 @@ function _elgg_session_boot() {
 	if ($session->has('guid')) {
 		set_last_action($session->get('guid'));
 	}
-
-	// initialize the deprecated global session wrapper
-	global $SESSION;
-	$SESSION = new \Elgg\DeprecationWrapper($session, "\$SESSION is deprecated", 1.9);
 
 	// logout a user with open session who has been banned
 	$user = $session->getLoggedInUser();


### PR DESCRIPTION
BREAKING CHANGE:
`$SESSION` is removed. Use the API given by `elgg_get_session()`
