### PR TITLE
security(passwords): removes all legacy password hashes

### DIFF
--- a/docs/admin/upgrading.rst
+++ b/docs/admin/upgrading.rst
@@ -45,6 +45,17 @@ From 2.2 to 2.3
  * PHPUnit bootstrap no longer sets global ``$CONFIG``. Tests should use ``_elgg_services()->config`` instead.
  * Core and tests no longer use private global values in ``$_ELGG->view_path`` and ``$_ELGG->allowed_ajax_views``
 
+From 2.3 to 3.0
+===============
+
+Data removal
+------------
+
+Be aware the 3.0 upgrade process will remove any remaining "legacy" password hashes. This will affect users who have never logged in under an Elgg 1.10 or later system. These users will be politely asked to reset their password.
+
+The process will also remove the old columns from the users database table, hence the table can no longer be used
+in older Elgg versions.
+
 Deprecations in 2.x
 ===================
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -30,6 +30,7 @@ All the functions in ``engine/lib/deprecated-1.9.php`` were removed. See https:/
 
  * ``get_default_filestore``
  * ``set_default_filestore``
+ * ``generate_user_password``: Use ``ElggUser::setPassword``
  * ``ElggFile::setFilestore``: ElggFile objects can no longer use custom filestores.
  * ``ElggFile::size``: Use ``getSize``
  * ``ElggDiskFilestore::makeFileMatrix``: Use ``Elgg\EntityDirLocator``
@@ -135,6 +136,8 @@ Miscellaneous API changes
 -------------------------
 
  * ``ElggGroup::removeObjectFromGroup`` requires passing in an ``ElggObject`` (no longer accepts a GUID)
+ * ``ElggUser::$salt`` no longer exists as an attribute, nor is it used for authentication
+ * ``ElggUser::$password`` no longer exists as an attribute, nor is it used for authentication
  * ``elgg_view_icon`` no longer supports ``true`` as the 2nd argument
  * ``elgg_list_entities`` no longer supports the option ``view_type_toggle``
  * ``elgg_list_registered_entities`` no longer supports the option ``view_type_toggle``
@@ -144,6 +147,11 @@ Miscellaneous API changes
  * ``$CONFIG`` is no longer available as a local variable inside plugin ``start.php`` files.
  * ``elgg_get_config('siteemail')`` is no longer available. Use ``elgg_get_site_entity()->email``.
  * The URL endpoints ``js/`` and ``css/`` are no longer supported. Use ``elgg_get_simplecache_url()``.
+
+Database schema changes
+-----------------------
+
+From the "users_entity" table, the ``password`` and ``hash`` columns have been removed.
 
 JavaScript hook calling order may change
 ----------------------------------------

--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -765,7 +765,7 @@ class EntityTable {
 		// will fetch any missing attributes.
 		$types_to_optimize = array(
 			'object' => 'title',
-			'user' => 'password',
+			'user' => 'password_hash',
 			'group' => 'name',
 			'site' => 'url',
 		);

--- a/engine/classes/Elgg/PasswordService.php
+++ b/engine/classes/Elgg/PasswordService.php
@@ -56,18 +56,6 @@ final class PasswordService {
 	}
 
 	/**
-	 * Hash a password for storage. Currently salted MD5.
-	 *
-	 * @param \ElggUser $user     The user this is being generated for.
-	 * @param string    $password Password in clear text
-	 *
-	 * @return string
-	 */
-	function generateLegacyHash(\ElggUser $user, $password) {
-		return md5($password . $user->salt);
-	}
-
-	/**
 	 * Generate and send a password request email to a given user's registered email address.
 	 *
 	 * @param int $user_guid User GUID

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -48,8 +48,6 @@ class ElggUser extends \ElggEntity
 		return [
 			'name' => null,
 			'username' => null,
-			'password' => null,
-			'salt' => null,
 			'password_hash' => null,
 			'email' => null,
 			'language' => null,
@@ -116,15 +114,13 @@ class ElggUser extends \ElggEntity
 		$guid = parent::create();
 		$name = sanitize_string($this->name);
 		$username = sanitize_string($this->username);
-		$password = sanitize_string($this->password);
-		$salt = sanitize_string($this->salt);
 		$password_hash = sanitize_string($this->password_hash);
 		$email = sanitize_string($this->email);
 		$language = sanitize_string($this->language);
 
 		$query = "INSERT into {$CONFIG->dbprefix}users_entity
-			(guid, name, username, password, salt, password_hash, email, language)
-			values ($guid, '$name', '$username', '$password', '$salt', '$password_hash', '$email', '$language')";
+			(guid, name, username, password_hash, email, language)
+			values ($guid, '$name', '$username', '$password_hash', '$email', '$language')";
 
 		$result = $this->getDatabase()->insertData($query);
 		if ($result === false) {
@@ -148,14 +144,12 @@ class ElggUser extends \ElggEntity
 		$guid = (int)$this->guid;
 		$name = sanitize_string($this->name);
 		$username = sanitize_string($this->username);
-		$password = sanitize_string($this->password);
-		$salt = sanitize_string($this->salt);
 		$password_hash = sanitize_string($this->password_hash);
 		$email = sanitize_string($this->email);
 		$language = sanitize_string($this->language);
 
 		$query = "UPDATE {$CONFIG->dbprefix}users_entity
-			SET name='$name', username='$username', password='$password', salt='$salt',
+			SET name='$name', username='$username',
 			password_hash='$password_hash', email='$email', language='$language'
 			WHERE guid = $guid";
 
@@ -198,17 +192,12 @@ class ElggUser extends \ElggEntity
 
 			case 'salt':
 			case 'password':
-				elgg_deprecated_notice("Setting salt/password directly is deprecated. Use ElggUser::setPassword().", "1.10");
-				$this->attributes[$name] = $value;
-
-				// this is emptied so that the user is not left with two usable hashes
-				$this->attributes['password_hash'] = '';
-
+				_elgg_services()->logger->error("User entities no longer contain salt/password");
 				break;
 
 			// setting this not supported
 			case 'password_hash':
-				_elgg_services()->logger->error("password_hash is now an attribute of ElggUser and cannot be set.");
+				_elgg_services()->logger->error("password_hash is a readonly attribute.");
 				break;
 
 			default:
@@ -493,18 +482,15 @@ class ElggUser extends \ElggEntity
 	}
 
 	/**
-	 * Set the necessary attributes to store a hash of the user's password. Also removes
-	 * the legacy hash/salt values.
+	 * Set the necessary attribute to store a hash of the user's password.
 	 *
-	 * @tip You must save() to persist the attributes
+	 * @tip You must save() to persist the attribute
 	 *
 	 * @param string $password The password to be hashed
 	 * @return void
 	 * @since 1.10.0
 	 */
 	public function setPassword($password) {
-		$this->attributes['salt'] = "";
-		$this->attributes['password'] = "";
 		$this->attributes['password_hash'] = _elgg_services()->passwords->generateHash($password);
 	}
 }

--- a/engine/lib/deprecated-1.10.php
+++ b/engine/lib/deprecated-1.10.php
@@ -41,18 +41,3 @@ function elgg_get_access_object() {
 
 	return _elgg_services()->session;
 }
-
-/**
- * Create a legacy password hash (salted MD5).
- *
- * @param \ElggUser $user     The user this is being generated for.
- * @param string    $password Password in clear text
- *
- * @return string
- * @access private
- * @deprecated 1.10.0 The password hashing API is not public
- */
-function generate_user_password(\ElggUser $user, $password) {
-	elgg_deprecated_notice(__FUNCTION__ . " is deprecated and will not be replaced.", "1.10");
-	return _elgg_services()->passwords->generateLegacyHash($user, $password);
-}

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -160,25 +160,12 @@ function pam_auth_userpass(array $credentials = array()) {
 		throw new \LoginException(_elgg_services()->translator->translate('LoginException:UsernameFailure'));
 	}
 
-	if (check_rate_limit_exceeded($user->guid)) {
-		throw new \LoginException(_elgg_services()->translator->translate('LoginException:AccountLocked'));
-	}
-
 	$password_svc = _elgg_services()->passwords;
 	$password = $credentials['password'];
 	$hash = $user->password_hash;
 
-	if (!$hash) {
-		// try legacy hash
-		$legacy_hash = $password_svc->generateLegacyHash($user, $password);
-		if ($user->password !== $legacy_hash) {
-			log_login_failure($user->guid);
-			throw new \LoginException(_elgg_services()->translator->translate('LoginException:PasswordFailure'));
-		}
-
-		// migrate password
-		$password_svc->forcePasswordReset($user, $password);
-		return true;
+	if (check_rate_limit_exceeded($user->guid)) {
+		throw new \LoginException(_elgg_services()->translator->translate('LoginException:AccountLocked'));
 	}
 
 	if (!$password_svc->verify($password, $hash)) {

--- a/engine/lib/upgrades/2016060300-3.0.0-remove_legacy_hashes-abd3b1d96a3da5e9.php
+++ b/engine/lib/upgrades/2016060300-3.0.0-remove_legacy_hashes-abd3b1d96a3da5e9.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Elgg 3.0.0 upgrade 2016060300
+ * remove_legacy_hashes
+ */
+
+$dbprefix = elgg_get_config('dbprefix');
+
+update_data("
+	ALTER TABLE {$dbprefix}users_entity
+	DROP KEY `password`,
+	DROP COLUMN `password`,
+	DROP COLUMN `salt`
+");

--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -280,8 +280,6 @@ CREATE TABLE `prefix_users_entity` (
   `guid` bigint(20) unsigned NOT NULL,
   `name` text NOT NULL,
   `username` varchar(128) NOT NULL DEFAULT '',
-  `password` varchar(32) NOT NULL DEFAULT '' COMMENT 'Legacy password hashes',
-  `salt` varchar(8) NOT NULL DEFAULT '' COMMENT 'Legacy password salts',
   -- 255 chars is recommended by PHP.net to hold future hash formats
   `password_hash` varchar(255) NOT NULL DEFAULT '',
   `email` text NOT NULL,
@@ -294,7 +292,6 @@ CREATE TABLE `prefix_users_entity` (
   `prev_last_login` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`guid`),
   UNIQUE KEY `username` (`username`),
-  KEY `password` (`password`),
   KEY `email` (`email`(50)),
   KEY `last_action` (`last_action`),
   KEY `last_login` (`last_login`),

--- a/engine/tests/ElggUserTest.php
+++ b/engine/tests/ElggUserTest.php
@@ -54,8 +54,6 @@ class ElggCoreUserTest extends \ElggCoreUnitTest {
 		$attributes['enabled'] = 'yes';
  		$attributes['name'] = null;
 		$attributes['username'] = null;
-		$attributes['password'] = null;
-		$attributes['salt'] = null;
 		$attributes['password_hash'] = null;
 		$attributes['email'] = null;
 		$attributes['language'] = null;

--- a/engine/tests/phpunit/Elgg/Mocks/Database/EntityTable.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Database/EntityTable.php
@@ -112,8 +112,6 @@ class EntityTable extends DbEntityTable {
 				$external_attributes = [
 					'name' => "John Doe $guid",
 					'username' => "john_doe_$guid",
-					'password' => null,
-					'salt' => null,
 					'password_hash' => null,
 					'email' => "john_doe_$guid@example.com",
 					'language' => 'en',

--- a/languages/en.php
+++ b/languages/en.php
@@ -442,6 +442,7 @@ return array(
 	'user:username:notfound' => 'Username %s not found.',
 
 	'user:password:lost' => 'Lost password',
+	'user:password:hash_missing' => 'Regretfully, we must ask you to reset your password. We have improved the security of passwords on the site, but were unable to migrate all accounts in the process.',
 	'user:password:changereq:success' => 'Successfully requested a new password, email sent',
 	'user:password:changereq:fail' => 'Could not request a new password.',
 

--- a/views/default/forms/user/requestnewpassword.php
+++ b/views/default/forms/user/requestnewpassword.php
@@ -5,6 +5,16 @@
  * @package Elgg
  * @subpackage Core
  */
+
+$username = elgg_extract('username', $vars, '');
+
+$input_attrs = [
+	'name' => 'username',
+	'value' => $username,
+];
+if (!$username) {
+	$input_attrs['autofocus'] = true;
+}
 ?>
 
 <div class="mtm">
@@ -12,11 +22,7 @@
 </div>
 <div>
 	<label><?php echo elgg_echo('loginusername'); ?></label><br />
-	<?php echo elgg_view('input/text', array(
-		'name' => 'username',
-		'autofocus' => true,
-		));
-	?>
+	<?php echo elgg_view('input/text', $input_attrs); ?>
 </div>
 <?php echo elgg_view('input/captcha'); ?>
 <div class="elgg-foot">

--- a/views/default/resources/account/forgotten_password.php
+++ b/views/default/resources/account/forgotten_password.php
@@ -12,9 +12,15 @@ if (elgg_is_logged_in()) {
 
 $title = elgg_echo("user:password:lost");
 
-$content = elgg_view_form('user/requestnewpassword', array(
-	'class' => 'elgg-form-account',
-));
+$hash_missing_username = elgg_get_session()->get('forgotpassword:hash_missing');
+if ($hash_missing_username) {
+	elgg_get_session()->remove('forgotpassword:hash_missing');
+	register_error(elgg_echo('user:password:hash_missing'));
+}
+
+$form_vars = ['class' => 'elgg-form-account'];
+$body_vars = ['username' => $hash_missing_username];
+$content = elgg_view_form('user/requestnewpassword', $form_vars, $body_vars);
 
 if (elgg_get_config('walled_garden')) {
 	elgg_load_css('elgg.walled_garden');


### PR DESCRIPTION
(warning: /upgrade.php will make your DB incompatible with 2.x, but everything else works. If we want to keep the columns, accept #10148)

In case of a site suffering a DB leak, this removes all remaining legacy password hashes. Although these were salted, the speed of MD5 makes brute force attacks on the table data practical.

Users that have logged in under an Elgg 1.10 or later system are not affected. The others, when logging in, are prompted to reset their password (via email authentication).

BREAKING CHANGE:
The `password` and `hash` columns are removed from the `users_entity` table and the attributes are removed from `ElggUser` attributes. The function `generate_new_password` is also removed.
