### PR TITLE
chore(db): Application::getDb no longer returns an instance of the core DB class

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -71,6 +71,7 @@ Inheritance changes
  * ``ElggEntity`` no longer implements ``Importable``
  * ``ElggGroup`` no longer implements ``Friendable``
  * ``ElggRelationship`` no longer implements ``Importable``
+ * ``Elgg\Application\Database`` no longer extends ``Elgg\Database``.
 
 Removed hooks/events
 --------------------
@@ -124,6 +125,7 @@ Miscellaneous API changes
  * ``elgg_list_registered_entities`` no longer supports the option ``view_type_toggle``
  * ``elgg_log`` no longer accepts the level ``"DEBUG"``
  * ``elgg_gatekeeper`` and ``elgg_admin_gatekeeper`` no longer report ``login`` or ``admin`` as forward reason, but ``403``
+ * ``Application::getDb()`` no longer returns an instance of ``Elgg\Database``, but rather a ``Elgg\Application\Database``
 
 JavaScript hook calling order may change
 ----------------------------------------

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -318,9 +318,6 @@ class Application {
 	 *
 	 * If settings.php has not been loaded, it will be loaded to configure the DB connection.
 	 *
-	 * @note Do not type hint on \Elgg\Database, as this will fail in 3.0. If you must type hint,
-	 *       expect an \Elgg\Application\Database.
-	 *
 	 * @note Before boot, the Database instance will not yet be bound to a Logger.
 	 *
 	 * @return \Elgg\Application\Database

--- a/engine/classes/Elgg/Application/Database.php
+++ b/engine/classes/Elgg/Application/Database.php
@@ -1,23 +1,16 @@
 <?php
 namespace Elgg\Application;
 
-use Elgg\Application;
 use Elgg\Database as ElggDb;
-use Elgg\Timer;
-use Elgg\Logger;
 
 /**
- * Elgg 2.0 public database API
+ * Elgg 3.0 public database API
  *
- * This is returned by elgg()->getDb() or Application::start()->getDb(), but is only a 2.0 compatibility
- * wrapper for the real Elgg\Database.
- *
- * @todo This extends \Elgg\Database because in 2.0 we promised to return that type. In 3.0 we should
- *       no longer extend \Elgg\Database.
+ * This is returned by elgg()->getDb() or Application::start()->getDb().
  *
  * @see \Elgg\Application::getDb for more details.
  */
-class Database extends ElggDb {
+class Database {
 
 	/**
 	 * The "real" database instance
@@ -90,135 +83,5 @@ class Database extends ElggDb {
 	 */
 	public function sanitizeString($value) {
 		return $this->db->sanitizeString($value);
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @deprecated 2.1 This method will not be available on this class in 3.0
-	 */
-	public function fingerprintCallback($callback) {
-		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
-		return $this->db->fingerprintCallback($callback);
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @deprecated 2.1 This method will not be available on this class in 3.0
-	 */
-	public function setTimer(Timer $timer) {
-		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
-		$this->db->setTimer($timer);
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @deprecated 2.1 This method will not be available on this class in 3.0
-	 */
-	public function setLogger(Logger $logger) {
-		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
-		$this->db->setLogger($logger);
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @deprecated 2.1 This method will not be available on this class in 3.0
-	 */
-	public function setupConnections() {
-		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
-		$this->db->setupConnections();
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @deprecated 2.1 This method will not be available on this class in 3.0
-	 */
-	public function connect($type = "readwrite") {
-		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
-		$this->db->connect($type);
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @deprecated 2.1 This method will not be available on this class in 3.0
-	 */
-	public function runSqlScript($scriptlocation) {
-		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
-		$this->db->runSqlScript($scriptlocation);
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @deprecated 2.1 This method will not be available on this class in 3.0
-	 */
-	public function registerDelayedQuery($query, $type, $handler = "", array $params = []) {
-		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
-		return $this->db->registerDelayedQuery($query, $type, $handler, $params);
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @deprecated 2.1 This method will not be available on this class in 3.0
-	 */
-	public function executeDelayedQueries() {
-		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
-		$this->db->executeDelayedQueries();
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @deprecated 2.1 This method will not be available on this class in 3.0
-	 */
-	public function enableQueryCache() {
-		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
-		$this->db->enableQueryCache();
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @deprecated 2.1 This method will not be available on this class in 3.0
-	 */
-	public function disableQueryCache() {
-		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
-		$this->db->disableQueryCache();
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @deprecated 2.1 This method will not be available on this class in 3.0
-	 */
-	public function assertInstalled() {
-		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
-		$this->db->assertInstalled();
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @deprecated 2.1 This method will not be available on this class in 3.0
-	 */
-	public function getQueryCount() {
-		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
-		return $this->db->getQueryCount();
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @deprecated 2.1 This method will not be available on this class in 3.0
-	 */
-	public function getServerVersion($type) {
-		elgg_deprecated_notice(__METHOD__ . " was deprecated and will be removed in 3.0", '2.1');
-		return $this->db->getServerVersion($type);
 	}
 }


### PR DESCRIPTION
BREAKING CHANGES:
The instance returned by `Elgg\Application::getDb` no longer inherits from `Elgg\Database` and lacks several of its methods.
