### PR TITLE
chore(entities): completes removal of exportable interface

### DIFF
--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -335,22 +335,6 @@ class ElggGroup extends \ElggEntity {
 		return $object;
 	}
 
-
-	// EXPORTABLE INTERFACE ////////////////////////////////////////////////////////////
-
-	/**
-	 * Return an array of fields which can be exported.
-	 *
-	 * @return array
-	 * @deprecated 1.9 Use toObject()
-	 */
-	public function getExportableValues() {
-		return array_merge(parent::getExportableValues(), array(
-			'name',
-			'description',
-		));
-	}
-
 	/**
 	 * Can a user comment on this group?
 	 *

--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -177,23 +177,6 @@ class ElggObject extends \ElggEntity {
 		return $object;
 	}
 
-	/*
-	 * EXPORTABLE INTERFACE
-	 */
-
-	/**
-	 * Return an array of fields which can be exported.
-	 *
-	 * @return array
-	 * @deprecated 1.9 Use toObject()
-	 */
-	public function getExportableValues() {
-		return array_merge(parent::getExportableValues(), array(
-			'title',
-			'description',
-		));
-	}
-
 	/**
 	 * Can a user comment on this object?
 	 *

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -480,22 +480,6 @@ class ElggUser extends \ElggEntity
 		return $object;
 	}
 
-	// EXPORTABLE INTERFACE ////////////////////////////////////////////////////////////
-
-	/**
-	 * Return an array of fields which can be exported.
-	 *
-	 * @return array
-	 * @deprecated 1.9 Use toObject()
-	 */
-	public function getExportableValues() {
-		return array_merge(parent::getExportableValues(), array(
-			'name',
-			'username',
-			'language',
-		));
-	}
-
 	/**
 	 * Can a user comment on this user?
 	 *


### PR DESCRIPTION
All the `export` and `getExportableValues` methods were to be removed from entities in #9422, but these 3 were missed.

Fixes #9865
