### PR TITLE
fix(ui): improves usability of anchors within system messages

### DIFF
--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -8,9 +8,11 @@ elgg.ui.init = function () {
 	// add user hover menus
 	elgg.ui.initHoverMenu();
 
-	//if the user clicks a system message, make it disappear
-	$('.elgg-system-messages li').live('click', function() {
-		$(this).stop().fadeOut('fast');
+	// if the user clicks a system message (not a link inside one), make it disappear
+	$('.elgg-system-messages li').live('click', function(e) {
+		if (!$(e.target).is('a')) {
+			$(this).stop().fadeOut('fast');
+		}
 	});
 
 	$('.elgg-system-messages li').animate({opacity: 0.9}, 6000);

--- a/mod/aalborg_theme/views/default/css/elements/components.php
+++ b/mod/aalborg_theme/views/default/css/elements/components.php
@@ -133,6 +133,10 @@
 .elgg-state-notice {
 	background-color: #5097CF;
 }
+.elgg-message a {
+	color: inherit;
+	text-decoration: underline;
+}
 .elgg-box-error {
 	margin-top: 10px;
 	padding: 20px;

--- a/views/default/css/admin.php
+++ b/views/default/css/admin.php
@@ -254,6 +254,10 @@ a.elgg-maintenance-mode-warning {
 	background-color: #EAF8E8;
 	border: 1px solid #AADEA2;
 }
+.elgg-message a {
+	color: inherit;
+	text-decoration: underline;
+}
 
 .elgg-admin-notices p {
 	color: #3B8BC9;

--- a/views/default/css/elements/components.php
+++ b/views/default/css/elements/components.php
@@ -134,6 +134,10 @@
 .elgg-state-notice {
 	background-color: #4690D6;
 }
+.elgg-message a {
+	color: inherit;
+	text-decoration: underline;
+}
 
 /* ***************************************
 	River

--- a/views/default/js/admin.php
+++ b/views/default/js/admin.php
@@ -14,8 +14,10 @@ elgg.admin.init = function () {
 	// system messages do not fade in admin area, instead slide up when clicked
 	$('.elgg-system-messages li').stop(true);
 	$('.elgg-system-messages li').die('click');
-	$('.elgg-system-messages li').live('click', function() {
-		$(this).stop().slideUp('medium');
+	$('.elgg-system-messages li').live('click', function(e) {
+		if (!$(e.target).is('a')) {
+			$(this).stop().slideUp('medium');
+		}
 	});
 
 	// draggable plugin reordering


### PR DESCRIPTION
Anchors no longer appear blue on red/green, but instead have the same color and are distinguished via underline.

Clicking an anchor in a message no longer dismisses the message, though success messages still will fade after 6 seconds.
