### PR TITLE
chore(routing): reject requests for unknown walled garden views

### DIFF
--- a/docs/guides/routing.rst
+++ b/docs/guides/routing.rst
@@ -18,6 +18,7 @@ available via ``get_input()``)
 The site URL (home page) is a special case that produces an empty string identifier and
 an empty segments array.
 
+.. warning:: URL identifier/segments should be considered potentially dangerous user input. Elgg uses ``htmlspecialchars`` to escapes HTML entities in them.
 
 Page Handler
 ============

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1790,6 +1790,9 @@ function _elgg_walled_garden_index() {
  */
 function _elgg_walled_garden_ajax_handler($page) {
 	$view = $page[0];
+	if (!elgg_view_exists("core/walled_garden/$view")) {
+		return false;
+	}
 	$params = array(
 		'content' => elgg_view("core/walled_garden/$view"),
 		'class' => 'elgg-walledgarden-single hidden',


### PR DESCRIPTION
Existing code passed arbitrary input (URL segment) into HTML attributes. Although URL segments are now HTML escaped, we should not invite risk or present bad examples to devs.
