### PR TITLE
feature(walledgarden): routing now respects walled garden policies

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -841,8 +841,14 @@ Other
 	)
 
 **public_pages, walled_garden**
-	Filter the URLs that are can be seen by logged out users if Walled Garden is
-	enabled. ``$value`` is an array of regex strings that will allow access if matched.
+	Filters a list of URLs (paths) that can be seen by logged out users in a walled garden mode.
+	Handlers must return an array of regex strings that will allow access if matched.
+	Please note that system public routes are passed as the default value to the hook,
+	and plugins must take care to not accidentally override these values.
+
+	The ``$params`` array contains:
+
+	 * ``url`` - URL of the page being tested for public accessibility
 
 **volatile, metadata**
 	Triggered when exporting an entity through the export handler. This is rare.

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -111,6 +111,8 @@ All the functions in ``engine/lib/deprecated-1.10.php`` were removed. See https:
  * ``ElggSite::removeEntity``
  * ``ElggSite::removeObject``
  * ``ElggSite::removeUser``
+ * ``ElggSite::isPublicPage``: Logic moved to the router and should not be accessed directly
+ * ``ElggSite::checkWalledGarden``: Logic moved to the router and should not be accessed directly
  * ``ElggUser::countObjects``: Use ``elgg_get_entities()``
  * ``Logger::getClassName``: Use ``get_class()``
  * ``Elgg\Application\Database::getTablePrefix``: Read the ``prefix`` property

--- a/engine/classes/Elgg/Router.php
+++ b/engine/classes/Elgg/Router.php
@@ -50,6 +50,20 @@ class Router {
 			$identifier = array_shift($segments);
 		} else {
 			$identifier = '';
+			$segments = [];
+		}
+
+		$is_walled_garden = _elgg_services()->config->get('walled_garden');
+		$is_logged_in = _elgg_services()->session->isLoggedIn();
+		$url = elgg_normalize_url($identifier . '/' . implode('/', $segments));
+		
+		if ($is_walled_garden && !$is_logged_in && !$this->isPublicPage($url)) {
+			if (!elgg_is_xhr()) {
+				_elgg_services()->session->set('last_forward_from', current_page_url());
+			}
+			register_error(_elgg_services()->translator->translate('loggedinrequired'));
+			_elgg_services()->responseFactory->redirect('', 'walled_garden');
+			return false;
 		}
 
 		// return false to stop processing the request (because you handled it)
@@ -91,7 +105,7 @@ class Router {
 			}
 			
 			$output = ob_get_clean();
-
+			
 			if ($response === false) {
 				return headers_sent();
 			}
@@ -181,6 +195,73 @@ class Router {
 		$segments = $new['segments'];
 		array_unshift($segments, $new['identifier']);
 		return $request->setUrlSegments($segments);
+	}
+
+	/**
+	 * Checks if the page should be allowed to be served in a walled garden mode
+	 *
+	 * Pages are registered to be public by {@elgg_plugin_hook public_pages walled_garden}.
+	 *
+	 * @param string $url Defaults to the current URL
+	 *
+	 * @return bool
+	 * @since 3.0
+	 */
+	public function isPublicPage($url = '') {
+		if (empty($url)) {
+			$url = current_page_url();
+		}
+
+		$parts = parse_url($url);
+		unset($parts['query']);
+		unset($parts['fragment']);
+		$url = elgg_http_build_url($parts);
+		$url = rtrim($url, '/') . '/';
+
+		$site_url = _elgg_services()->config->getSiteUrl();
+
+		if ($url == $site_url) {
+			// always allow index page
+			return true;
+		}
+
+		// default public pages
+		$defaults = array(
+			'walled_garden/.*',
+			'action/.*',
+			'login',
+			'register',
+			'forgotpassword',
+			'changepassword',
+			'refresh_token',
+			'ajax/view/languages.js',
+			'upgrade\.php',
+			'css/.*',
+			'js/.*',
+			'cache/[0-9]+/\w+/.*',
+			'cron/.*',
+			'services/.*',
+			'serve-file/.*',
+			'robots.txt',
+			'favicon.ico',
+		);
+
+		$params = [
+			'url' => $url,
+		];
+
+		$public_routes = _elgg_services()->hooks->trigger('public_pages', 'walled_garden', $params, $defaults);
+		
+		$site_url = preg_quote($site_url);
+		foreach ($public_routes as $public_route) {
+			$pattern = "`^{$site_url}{$public_route}/*$`i";
+			if (preg_match($pattern, $url)) {
+				return true;
+			}
+		}
+
+		// non-public page
+		return false;
 	}
 
 }

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1817,14 +1817,25 @@ function _elgg_walled_garden_index() {
  * @access private
  */
 function _elgg_walled_garden_init() {
+	if (!elgg_get_config('walled_garden')) {
+		return;
+	}
+
 	elgg_register_css('elgg.walled_garden', elgg_get_simplecache_url('walled_garden.css'));
 
 	elgg_register_plugin_hook_handler('register', 'menu:walled_garden', '_elgg_walled_garden_menu');
-	
-	// check for external page view
-	$site = elgg_get_site_entity();
-	if ($site) {
-		$site->checkWalledGarden();
+
+	elgg_register_page_handler('walled_garden', '_elgg_walled_garden_ajax_handler');
+
+	if (elgg_get_config('default_access') == ACCESS_PUBLIC) {
+		elgg_set_config('default_access', ACCESS_LOGGED_IN);
+	}
+
+	elgg_register_plugin_hook_handler('access:collections:write', 'all', '_elgg_walled_garden_remove_public_access', 9999);
+
+	if (!elgg_is_logged_in()) {
+		// override the front page
+		elgg_register_page_handler('', '_elgg_walled_garden_index');
 	}
 }
 


### PR DESCRIPTION
Adds a new Router method to decouple routing logic from ElggSite

BREAKING CHANGE
Walled garden initialization has been decoupled from the site instance,
and is now part of the routing policies.
ElggSite::checkWalledGarden() and ElggSite::isPublicPage() have been removed.

Refs #9881
