### PR TITLE
security(routing): HTML escapes URL segments

### DIFF
--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -14,10 +14,14 @@ class Request extends SymfonyRequest {
 	/**
 	 * Get the Elgg URL segments
 	 *
+	 * @param bool $raw If true, the segments will not be HTML escaped
 	 * @return string[]
 	 */
-	public function getUrlSegments() {
+	public function getUrlSegments($raw = false) {
 		$path = trim($this->query->get(Application::GET_PATH_KEY), '/');
+		if (!$raw) {
+			$path = htmlspecialchars($path, ENT_QUOTES, 'UTF-8');
+		}
 		if (!$path) {
 			return array();
 		}


### PR DESCRIPTION
Just in case a developer unwisely injects URL content directly into HTML, we escape `&"'<>` with HTML entities.

Would we feel safe doing this in 1.12?
