### PR TITLE
chore(core): remove deprecated uses of can_write_to_container()

### DIFF
--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -81,18 +81,4 @@ class Request extends SymfonyRequest {
 			|| $this->request->get('X-Requested-With') === 'XMLHttpRequest');
 		// GET/POST check is necessary for jQuery.form and other iframe-based "ajax". #8735
 	}
-
-	/**
-	 * Strip slashes if magic quotes is on
-	 *
-	 * @param mixed $data Data to strip slashes from
-	 * @return mixed
-	 */
-	protected function stripSlashesIfMagicQuotes($data) {
-		if (get_magic_quotes_gpc()) {
-			return _elgg_stripslashes_deep($data);
-		} else {
-			return $data;
-		}
-	}
 }

--- a/mod/blog/actions/blog/save.php
+++ b/mod/blog/actions/blog/save.php
@@ -91,7 +91,8 @@ foreach ($values as $name => $default) {
 		case 'container_guid':
 			// this can't be empty or saving the base entity fails
 			if (!empty($value)) {
-				if (can_write_to_container($user->getGUID(), $value)) {
+				$container = get_entity($value);
+				if ($container && $container->canWriteToContainer(0, 'object', 'blog')) {
 					$values[$name] = $value;
 				} else {
 					$error = elgg_echo("blog:error:cannot_write_to_container");

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -367,11 +367,8 @@ function pages_write_permission_check($hook, $entity_type, $returnvalue, $params
  * @return bool
  */
 function pages_container_permission_check($hook, $entity_type, $returnvalue, $params) {
-	if (elgg_get_context() != "pages") {
-		return null;
-	}
-	if (elgg_get_page_owner_guid()
-			&& can_write_to_container(elgg_get_logged_in_user_guid(), elgg_get_page_owner_guid())) {
+	$container = elgg_get_page_owner_entity();
+	if ($container && $container->canWriteToContainer(0, 'object', 'page')) {
 		return true;
 	}
 	if ($page_guid = get_input('page_guid', 0)) {
@@ -380,8 +377,7 @@ function pages_container_permission_check($hook, $entity_type, $returnvalue, $pa
 		$entity = get_entity($parent_guid);
 	}
 	if (isset($entity) && pages_is_page($entity)) {
-		if (can_write_to_container(elgg_get_logged_in_user_guid(), $entity->container_guid)
-				|| in_array($entity->write_access_id, get_access_list())) {
+		if ($entity->canWriteToContainer(0, 'object', 'page') || in_array($entity->write_access_id, get_access_list())) {
 			return true;
 		}
 	}


### PR DESCRIPTION
Also no longer used `Request::stripSlashesIfMagicQuotes`
- ~~[ ] waiting on #10023~~ Separate issue.
