### PR TITLE
fix(walled_garden): favicon.ico page handler is now treated as public

### DIFF
--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -570,6 +570,7 @@ class ElggSite extends \ElggEntity {
 			'cron/.*',
 			'services/.*',
 			'robots.txt',
+			'favicon.ico',
 		);
 
 		// include a hook for plugin authors to include public pages


### PR DESCRIPTION
In certain installations, favicon.ico would be set as last_forward_from value
due to failing route on /favicon.ico
