### PR TITLE
Autogenerate password option in Add new user form

### DIFF
--- a/actions/useradd.php
+++ b/actions/useradd.php
@@ -24,6 +24,12 @@ if (is_array($admin)) {
 	$admin = $admin[0];
 }
 
+$autogen_password = get_input('autogen_password');
+if ($autogen_password) {
+	$password = generate_random_cleartext_password();
+	$password2 = $password;
+}
+
 // no blank fields
 if ($username == '' || $password == '' || $password2 == '' || $email == '' || $name == '') {
 	register_error(elgg_echo('register:fields'));

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1348,7 +1348,13 @@ function elgg_view_input($input_type, array $vars = array()) {
 	$vars['input_type'] = $input_type;
 
 	$label = elgg_view('elements/forms/label', $vars);
-	unset($vars['label']);
+	if ($input_type == 'checkbox') {
+		$vars['label'] = $label;
+		$vars['label_tag'] = 'div';
+		$label = false;
+	} else {
+		unset($vars['label']);
+	}
 
 	$help = elgg_view('elements/forms/help', $vars);
 	unset($vars['help']);

--- a/languages/en.php
+++ b/languages/en.php
@@ -142,6 +142,7 @@ return array(
 	'password' => "Password",
 	'passwordagain' => "Password (again for verification)",
 	'admin_option' => "Make this user an admin?",
+	'autogen_password_option' => "Automatically generate a secure password?",
 
 /**
  * Access

--- a/mod/aalborg_theme/views/default/elements/forms.css.php
+++ b/mod/aalborg_theme/views/default/elements/forms.css.php
@@ -74,6 +74,10 @@ input[type="radio"] {
 	border: none;
 	width: auto;
 }
+.elgg-input-checkbox + label,
+.elgg-input-checkbox + .elgg-field-label {
+	display: inline-block;
+}
 .elgg-input-checkboxes.elgg-horizontal li,
 .elgg-input-radios.elgg-horizontal li {
 	display: inline;

--- a/mod/developers/views/default/theme_sandbox/forms.php
+++ b/mod/developers/views/default/theme_sandbox/forms.php
@@ -30,6 +30,16 @@ $ipsum = elgg_view('developers/ipsum');
 			'label' => 'Radio input (.elgg-input-radios):',
 		));
 
+		echo elgg_view_input('checkbox', array(
+			'name' => 'f4s',
+			'id' => 'f4s',
+			'value' => 1,
+			'default' => false,
+			'required' => true,
+			'label' => 'a (.elgg-input-checkbox)',
+			'help' => 'Single checkbox .elgg-input-checkbox wrapped in .elgg-input-single-checkbox',
+		));
+
 		echo elgg_view_input('checkboxes', array(
 			'name' => 'f4',
 			'id' => 'f4',

--- a/views/default/admin.css.php
+++ b/views/default/admin.css.php
@@ -584,7 +584,8 @@ select {
 }
 
 .elgg-form-useradd input[type=text],
-.elgg-form-useradd input[type=password] {
+.elgg-form-useradd input[type=password],
+.elgg-form-useradd input[type=email] {
 	width: 300px;
 }
 

--- a/views/default/admin.css.php
+++ b/views/default/admin.css.php
@@ -592,6 +592,11 @@ select {
 	max-width: 800px;
 }
 
+.elgg-input-checkbox + label,
+.elgg-input-checkbox + .elgg-field-label {
+	display: inline-block;
+}
+
 /* **************************************
      DATE PICKER
 *************************************** */

--- a/views/default/elements/forms.css.php
+++ b/views/default/elements/forms.css.php
@@ -76,6 +76,10 @@ input[type="radio"] {
 	border-radius:0;
 	width:auto;
 }
+.elgg-input-checkbox + label,
+.elgg-input-checkbox + .elgg-field-label {
+	display: inline-block;
+}
 .elgg-input-checkboxes.elgg-horizontal li,
 .elgg-input-radios.elgg-horizontal li {
 	display: inline;

--- a/views/default/forms/useradd.js
+++ b/views/default/forms/useradd.js
@@ -1,0 +1,41 @@
+define(function(require) {
+
+	var $ = require('jquery');
+
+	var checkbox_selector = 'input[type="checkbox"][name="autogen_password"]';
+
+	/**
+	 * Toggle password input visibility based on the value
+	 * of the autogenerate password checkbox
+	 *
+	 * @param {jQuery} $checkbox Checkbox input
+	 * @returns {void}
+	 */
+	function togglePasswordInput($checkbox) {
+		var $form = $checkbox.closest('.elgg-form-useradd');
+		if (!$form.length) {
+			return;
+		}
+		if ($checkbox.is(':checked')) {
+			$('[name="password"],[name="password2"]', $form).each(function() {
+				$(this).prop('required', false);
+				$(this).closest('.elgg-field').addClass('hidden');
+			});
+		} else {
+			$('[name="password"],[name="password2"]', $form).each(function() {
+				$(this).prop('required', true);
+				$(this).closest('.elgg-field').removeClass('hidden');
+			});
+		}
+	}
+
+	$(document).on('change', checkbox_selector, function() {
+		togglePasswordInput($(this));
+	});
+
+	require(['elgg/ready'], function() {
+		togglePasswordInput($(checkbox_selector));
+	});
+});
+
+

--- a/views/default/forms/useradd.php
+++ b/views/default/forms/useradd.php
@@ -19,66 +19,51 @@ $name = elgg_extract('name', $values);
 $username = elgg_extract('username', $values);
 $email = elgg_extract('email', $values);
 $admin = elgg_extract('admin', $values);
-if (is_array($admin)) {
-	$admin = array_shift($admin);
-}
 
-?>
-<div>
-	<label><?php echo elgg_echo('name');?></label><br />
-	<?php
-	echo elgg_view('input/text', array(
-		'name' => 'name',
-		'value' => $name,
-	));
-	?>
-</div>
-<div>
-	<label><?php echo elgg_echo('username'); ?></label><br />
-	<?php
-	echo elgg_view('input/text', array(
-		'name' => 'username',
-		'value' => $username,
-	));
-	?>
-</div>
-<div>
-	<label><?php echo elgg_echo('email'); ?></label><br />
-	<?php
-	echo elgg_view('input/text', array(
-		'name' => 'email',
-		'value' => $email,
-	));
-	?>
-</div>
-<div>
-	<label><?php echo elgg_echo('password'); ?></label><br />
-	<?php
-	echo elgg_view('input/password', array(
-		'name' => 'password',
-		'value' => $password,
-	));
-	?>
-</div>
-<div>
-	<label><?php echo elgg_echo('passwordagain'); ?></label><br />
-	<?php
-	echo elgg_view('input/password', array(
-		'name' => 'password2',
-		'value' => $password2,
-	));
-	?>
-</div>
-<div>
-<?php 
-	echo elgg_view('input/checkboxes', array(
-		'name' => "admin",
-		'options' => array(elgg_echo('admin_option') => 1),
-		'value' => $admin,
-	));
-?>
-</div>
+echo elgg_view_input('text', [
+	'name' => 'name',
+	'value' => $name,
+	'label' => elgg_echo('name'),
+	'required' => true,
+]);
 
-<div class="elgg-foot">
-	<?php echo elgg_view('input/submit', array('value' => elgg_echo('register'))); ?>
-</div>
+echo elgg_view_input('text', [
+	'name' => 'username',
+	'value' => $username,
+	'label' => elgg_echo('username'),
+	'required' => true,
+]);
+
+echo elgg_view_input('email', [
+	'name' => 'email',
+	'value' => $email,
+	'label' => elgg_echo('email'),
+	'required' => true,
+]);
+
+echo elgg_view_input('password', [
+	'name' => 'password',
+	'value' => $password,
+	'label' => elgg_echo('password'),
+	'required' => true,
+]);
+
+echo elgg_view_input('password', [
+	'name' => 'password2',
+	'value' => $password2,
+	'label' => elgg_echo('passwordagain'),
+	'required' => true,
+]);
+
+echo elgg_view_input('checkbox', array(
+	'name' => 'admin',
+	'value' => 1,
+	'default' => false,
+	'label' => elgg_echo('admin_option'),
+	'checked' => $admin,
+));
+
+echo elgg_view_input('submit', [
+	'value' => elgg_echo('register'),
+	'field_class' => 'elgg-foot',
+]);

--- a/views/default/forms/useradd.php
+++ b/views/default/forms/useradd.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Elgg add user form.
  *
@@ -6,6 +7,7 @@
  * @subpackage Core
  * 
  */
+elgg_require_js('forms/useradd');
 
 if (elgg_is_sticky_form('useradd')) {
 	$values = elgg_get_sticky_values('useradd');
@@ -19,6 +21,7 @@ $name = elgg_extract('name', $values);
 $username = elgg_extract('username', $values);
 $email = elgg_extract('email', $values);
 $admin = elgg_extract('admin', $values);
+$autogen_password = elgg_extract('autogen_password', $values);
 
 echo elgg_view_input('text', [
 	'name' => 'name',
@@ -40,6 +43,14 @@ echo elgg_view_input('email', [
 	'label' => elgg_echo('email'),
 	'required' => true,
 ]);
+
+echo elgg_view_input('checkbox', array(
+	'name' => 'autogen_password',
+	'value' => 1,
+	'default' => false,
+	'label' => elgg_echo('autogen_password_option'),
+	'checked' => (bool) $autogen_password,
+));
 
 echo elgg_view_input('password', [
 	'name' => 'password',

--- a/views/default/input/checkbox.php
+++ b/views/default/input/checkbox.php
@@ -18,6 +18,7 @@
  * @uses $vars['label']       Optional label string
  * @uses $vars['class']       Additional CSS class
  * @uses $vars['label_class'] Optional class for the label
+ * @uses $vars['label_tag']   HTML tag that wraps concatinated label and input. Defaults to 'label'.
  */
 
 $vars['class'] = (array) elgg_extract('class', $vars, []);
@@ -39,14 +40,16 @@ if (isset($vars['name']) && $default !== false) {
 }
 
 $label = elgg_extract('label', $vars, false);
-$label_class = elgg_extract('label_class', $vars);
+$label_class = (array) elgg_extract('label_class', $vars, []);
+$label_class[] = 'elgg-input-single-checkbox';
 unset($vars['label']);
 unset($vars['label_class']);
 
 $input = elgg_format_element('input', $vars);
 
 if (!empty($label)) {
-	echo elgg_format_element('label', ['class' => $label_class], "$input $label");
+	$html_tag = elgg_extract('label_tag', $vars, 'label', false);
+	echo elgg_format_element($html_tag, ['class' => $label_class], "$input $label");
 } else {
 	echo $input;
 }


### PR DESCRIPTION
**feature(forms): input/checkbox is now usable with elgg_view_input()**

Adds an exception to `elgg_view_input()` to render the label next to the checkbox input rather than above the input (as in other input types).
Adds default class for single checkbox inputs wrapped in an html tag with a label (`.elgg-input-single-checkbox`)
Adds an option to customize the HTML tag used to wrap the single checkbox input with a label
to avoid double wrapping with a `<label>` tag.

Fixes #9808

**chore(forms): update Add new user form to use elgg_view_input()**

Updates the admin Add new user form to use new elgg_view_input() API

**feature(forms): Add new user now has an option to autogenerate the password**

Makes it easier for admins to add new users by adding an option to autogenerate passwords.
