### PR TITLE
feature(export): now triggers a generic to:object hook for annotation…

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -14,6 +14,8 @@ From 2.2 to 2.3
 
 Deprecated APIs
 ---------------
+
+ * Registering for ``to:object`` hook by the extender name: Use ``to:object, annotation`` and ``to:object, metadata`` hooks instead.
  * ``ajax_forward_hook()``: No longer used as handler for `'forward','all'` hook. Ajax response is now wrapped by the ``ResponseFactory``
  * ``ajax_action_hook()``: No longer used as handler for `'action','all'` hook. Output buffering now starts before the hook is triggered in ``ActionsService``
  * ``elgg_error_page_handler()``: No longer used as a handler for `'forward',<error_code>` hooks

--- a/engine/classes/ElggExtender.php
+++ b/engine/classes/ElggExtender.php
@@ -182,8 +182,16 @@ abstract class ElggExtender extends \ElggData {
 		$object->value = $this->value;
 		$object->time_created = date('c', $this->getTimeCreated());
 		$object->read_access = $this->access_id;
-		$params = array($this->getSubtype() => $this);
-		return _elgg_services()->hooks->trigger('to:object', $this->getSubtype(), $params, $object);
+		$params = array(
+			$this->getSubtype() => $this, // deprecated use
+			$this->getType() => $this,
+		);
+		if (_elgg_services()->hooks->hasHandler('to:object', $this->getSubtype())) {
+			_elgg_services()->deprecation->sendNotice("Triggering 'to:object' hook by extender name '{$this->getSubtype()}' has been deprecated. "
+			. "Use the generic 'to:object','{$this->getType()}' hook instead.", '2.3');
+			$object = _elgg_services()->hooks->trigger('to:object', $this->getSubtype(), $params, $object);
+		}
+		return _elgg_services()->hooks->trigger('to:object', $this->getType(), $params, $object);
 	}
 
 	/*


### PR DESCRIPTION
… and metadata

Triggering to:object hook for annotation/metadata name is inefficient and is
disrepant with the rest of data types (entity, river_item). This deprecates the
old hook and triggers a generic hook with "annotation" and "metadata" as a hook type
