### PR TITLE
feature(forms): makes form views extendable via dedicated footer view

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1285,6 +1285,10 @@ function elgg_view_river_item($item, array $vars = array()) {
  * sets the action by default to "action/$action".  Automatically wraps the forms/$action
  * view with a <form> tag and inserts the anti-csrf security tokens.
  *
+ * If the view "forms/{$action}-footer" exists, it will be rendered, passing in the $body_vars
+ * as parameters. If content is rendered, it's wrapped in a div (see the input/form-footer view)
+ * and added to the form body.
+ *
  * @tip This automatically appends elgg-form-action-name to the form's class. It replaces any
  * slashes with dashes (blog/save becomes elgg-form-blog-save)
  *
@@ -1308,17 +1312,34 @@ function elgg_view_river_item($item, array $vars = array()) {
  * @param string $action    The name of the action. An action name does not include
  *                          the leading "action/". For example, "login" is an action name.
  * @param array  $form_vars $vars environment passed to the "input/form" view
- * @param array  $body_vars $vars environment passed to the "forms/$action" view
+ * @param array  $body_vars $vars environment passed to the "forms/$action" and "forms/{$action}-footer" views
  *
  * @return string The complete form
  */
 function elgg_view_form($action, $form_vars = array(), $body_vars = array()) {
-	global $CONFIG;
 
-	$defaults = array(
-		'action' => $CONFIG->wwwroot . "action/$action",
-		'body' => elgg_view("forms/$action", $body_vars)
-	);
+	// TODO cleanup watching implementation
+	$footer_rendered = false;
+	$watcher = function () use (&$footer_rendered) {
+		$footer_rendered = true;
+	};
+
+	elgg_register_plugin_hook_handler('view_vars', "forms/$action-footer", $watcher);
+	$body = elgg_view("forms/$action", $body_vars);
+	elgg_unregister_plugin_hook_handler('view_vars', "forms/$action-footer", $watcher);
+
+	$defaults = [
+		'action' => elgg_get_site_url() . "action/$action",
+		'body' => $body,
+	];
+
+	// add footer if not rendered during forms view
+	if (!$footer_rendered && elgg_view_exists("forms/$action-footer")) {
+		$defaults['body'] .=  elgg_view("input/form-footer", [
+			'action' => $action,
+			'body_vars' => $body_vars,
+		]);
+	}
 
 	// append elgg-form class to any class options set
 	$form_vars['class'] = (array) elgg_extract('class', $form_vars, []);

--- a/mod/blog/views/default/forms/blog/save-footer.php
+++ b/mod/blog/views/default/forms/blog/save-footer.php
@@ -1,0 +1,48 @@
+<?php
+$blog = get_entity($vars['guid']);
+
+$action_buttons = '';
+$delete_link = '';
+$preview_button = '';
+
+if ($vars['guid']) {
+	// add a delete button if editing
+	$delete_url = "action/blog/delete?guid={$vars['guid']}";
+	$delete_link = elgg_view('output/url', array(
+		'href' => $delete_url,
+		'text' => elgg_echo('delete'),
+		'class' => 'elgg-button elgg-button-delete float-alt',
+		'confirm' => true,
+	));
+}
+
+// published blogs do not get the preview button
+if (!$vars['guid'] || ($blog && $blog->status != 'published')) {
+	$preview_button = elgg_view('input/submit', array(
+		'value' => elgg_echo('preview'),
+		'name' => 'preview',
+		'class' => 'elgg-button-submit mls',
+	));
+}
+
+$save_button = elgg_view('input/submit', array(
+	'value' => elgg_echo('save'),
+	'name' => 'save',
+));
+$action_buttons = $save_button . $preview_button . $delete_link;
+
+$save_status = elgg_echo('blog:save_status');
+if ($vars['guid']) {
+	$entity = get_entity($vars['guid']);
+	$saved = date('F j, Y @ H:i', $entity->time_created);
+} else {
+	$saved = elgg_echo('never');
+}
+
+?><div class="elgg-foot">
+	<div class="elgg-subtext mbm">
+		<?= $save_status ?> <span class="blog-save-status-time"><?= $saved ?></span>
+	</div>
+
+	<?= $action_buttons ?>
+</div>

--- a/mod/blog/views/default/forms/blog/save.php
+++ b/mod/blog/views/default/forms/blog/save.php
@@ -13,36 +13,6 @@ if ($draft_warning) {
 	$draft_warning = '<span class="mbm elgg-text-help">' . $draft_warning . '</span>';
 }
 
-$action_buttons = '';
-$delete_link = '';
-$preview_button = '';
-
-if ($vars['guid']) {
-	// add a delete button if editing
-	$delete_url = "action/blog/delete?guid={$vars['guid']}";
-	$delete_link = elgg_view('output/url', array(
-		'href' => $delete_url,
-		'text' => elgg_echo('delete'),
-		'class' => 'elgg-button elgg-button-delete float-alt',
-		'confirm' => true,
-	));
-}
-
-// published blogs do not get the preview button
-if (!$vars['guid'] || ($blog && $blog->status != 'published')) {
-	$preview_button = elgg_view('input/submit', array(
-		'value' => elgg_echo('preview'),
-		'name' => 'preview',
-		'class' => 'elgg-button-submit mls',
-	));
-}
-
-$save_button = elgg_view('input/submit', array(
-	'value' => elgg_echo('save'),
-	'name' => 'save',
-));
-$action_buttons = $save_button . $preview_button . $delete_link;
-
 $title_label = elgg_echo('title');
 $title_input = elgg_view('input/text', array(
 	'name' => 'title',
@@ -63,14 +33,6 @@ $body_input = elgg_view('input/longtext', array(
 	'id' => 'blog_description',
 	'value' => $vars['description']
 ));
-
-$save_status = elgg_echo('blog:save_status');
-if ($vars['guid']) {
-	$entity = get_entity($vars['guid']);
-	$saved = date('F j, Y @ H:i', $entity->time_created);
-} else {
-	$saved = elgg_echo('never');
-}
 
 $status_label = elgg_echo('status');
 $status_input = elgg_view('input/select', array(
@@ -156,15 +118,7 @@ $categories_input
 	$status_input
 </div>
 
-<div class="elgg-foot">
-	<div class="elgg-subtext mbm">
-	$save_status <span class="blog-save-status-time">$saved</span>
-	</div>
-
-	$guid_input
-	$container_guid_input
-
-	$action_buttons
-</div>
+$guid_input
+$container_guid_input
 
 ___HTML;

--- a/mod/bookmarks/views/default/forms/bookmarks/save-footer.php
+++ b/mod/bookmarks/views/default/forms/bookmarks/save-footer.php
@@ -1,0 +1,3 @@
+<div class="elgg-foot">
+	<?= elgg_view('input/submit', array('value' => elgg_echo("save"))) ?>
+</div>

--- a/mod/bookmarks/views/default/forms/bookmarks/save.php
+++ b/mod/bookmarks/views/default/forms/bookmarks/save.php
@@ -49,7 +49,6 @@ if ($categories) {
 		'entity_subtype' => 'bookmarks',
 	)); ?>
 </div>
-<div class="elgg-foot">
 <?php
 
 echo elgg_view('input/hidden', array('name' => 'container_guid', 'value' => $container_guid));
@@ -57,8 +56,3 @@ echo elgg_view('input/hidden', array('name' => 'container_guid', 'value' => $con
 if ($guid) {
 	echo elgg_view('input/hidden', array('name' => 'guid', 'value' => $guid));
 }
-
-echo elgg_view('input/submit', array('value' => elgg_echo("save")));
-
-?>
-</div>

--- a/mod/discussions/views/default/forms/discussion/reply/save-footer.php
+++ b/mod/discussions/views/default/forms/discussion/reply/save-footer.php
@@ -1,0 +1,31 @@
+<?php
+$inline = elgg_extract('inline', $vars, false);
+
+$reply = elgg_extract('entity', $vars);
+
+if ($reply && $reply->canEdit()) {
+	$submit_text = elgg_echo('save');
+} else {
+	$submit_text = elgg_echo('reply');
+}
+
+$cancel_button = '';
+if ($reply) {
+	$cancel_button = elgg_view('input/button', array(
+		'value' => elgg_echo('cancel'),
+		'class' => 'elgg-button-cancel mlm',
+		'href' => $entity ? $entity->getURL() : '#',
+	));
+}
+
+$submit_input = elgg_view('input/submit', array('value' => $submit_text));
+
+if ($inline) {
+	echo $submit_input;
+} else {
+	echo <<<FORM
+	<div class="foot">
+		$submit_input $cancel_button
+	</div>
+FORM;
+}

--- a/mod/discussions/views/default/forms/discussion/reply/save.php
+++ b/mod/discussions/views/default/forms/discussion/reply/save.php
@@ -32,34 +32,20 @@ if ($reply && $reply->canEdit()) {
 	));
 
 	$reply_label = elgg_echo("discussion:reply:edit");
-	$submit_text = elgg_echo('save');
 } else {
 	$reply_label = elgg_echo("reply:this");
-	$submit_text = elgg_echo('reply');
 }
-
-$cancel_button = '';
-if ($reply) {
-	$cancel_button = elgg_view('input/button', array(
-		'value' => elgg_echo('cancel'),
-		'class' => 'elgg-button-cancel mlm',
-		'href' => $entity ? $entity->getURL() : '#',
-	));
-}
-
-$submit_input = elgg_view('input/submit', array('value' => $submit_text));
 
 if ($inline) {
 	$description_input = elgg_view('input/text', array(
 		'name' => 'description',
-		'value' => $value
+		'value' => $value,
 	));
 
 echo <<<FORM
 	$description_input
 	$topic_guid_input
 	$reply_guid_input
-	$submit_input
 FORM;
 } else {
 	$description_input = elgg_view('input/longtext', array(
@@ -72,11 +58,7 @@ echo <<<FORM
 		<label>$reply_label</label>
 		$description_input
 	</div>
-	<div class="foot">
-		$reply_guid_input
-		$topic_guid_input
-		$submit_input $cancel_button
-	</div>
+	$reply_guid_input
+	$topic_guid_input
 FORM;
 }
-

--- a/mod/discussions/views/default/forms/discussion/save-footer.php
+++ b/mod/discussions/views/default/forms/discussion/save-footer.php
@@ -1,0 +1,6 @@
+<?php
+
+echo elgg_view_input('submit', [
+	'value' => elgg_echo('save'),
+	'field_class' => 'elgg-foot',
+]);

--- a/mod/discussions/views/default/forms/discussion/save.php
+++ b/mod/discussions/views/default/forms/discussion/save.php
@@ -62,11 +62,6 @@ $fields = [
 		'name' => 'topic_guid',
 		'value' => $guid,
 	],
-	[
-		'type' => 'submit',
-		'value' => elgg_echo('save'),
-		'field_class' => 'elgg-foot',
-	]
 ];
 
 foreach ($fields as $field) {

--- a/mod/file/views/default/forms/file/upload-footer.php
+++ b/mod/file/views/default/forms/file/upload-footer.php
@@ -1,0 +1,14 @@
+<?php
+
+$guid = elgg_extract('guid', $vars, null);
+
+if ($guid) {
+	$submit_label = elgg_echo('save');
+} else {
+	$submit_label = elgg_echo('upload');
+}
+
+echo elgg_view_input('submit', [
+	'value' => $submit_label,
+	'field_class' => 'elgg-foot',
+]);

--- a/mod/file/views/default/forms/file/upload.php
+++ b/mod/file/views/default/forms/file/upload.php
@@ -18,10 +18,8 @@ $guid = elgg_extract('guid', $vars, null);
 
 if ($guid) {
 	$file_label = elgg_echo("file:replace");
-	$submit_label = elgg_echo('save');
 } else {
 	$file_label = elgg_echo("file:file");
-	$submit_label = elgg_echo('upload');
 }
 
 // Get post_max_size and upload_max_filesize
@@ -82,11 +80,6 @@ $fields = [
 		'name' => 'file_guid',
 		'value' => $guid,
 	],
-	[
-		'type' => 'submit',
-		'value' => $submit_label,
-		'field_class' => 'elgg-foot',
-	]
 ];
 
 foreach ($fields as $field) {

--- a/mod/groups/views/default/forms/groups/edit-footer.php
+++ b/mod/groups/views/default/forms/groups/edit-footer.php
@@ -1,0 +1,30 @@
+<?php
+
+/* @var ElggGroup $entity */
+$entity = elgg_extract("entity", $vars, false);
+
+?>
+<div class="elgg-foot">
+	<?php
+
+	if ($entity) {
+		echo elgg_view("input/hidden", array(
+			"name" => "group_guid",
+			"value" => $entity->getGUID(),
+		));
+	}
+
+	echo elgg_view("input/submit", array("value" => elgg_echo("save")));
+
+	if ($entity) {
+		$delete_url = "action/groups/delete?guid=" . $entity->getGUID();
+		echo elgg_view("output/url", array(
+			"text" => elgg_echo("groups:delete"),
+			"href" => $delete_url,
+			"confirm" => elgg_echo("groups:deletewarning"),
+			"class" => "elgg-button elgg-button-delete float-alt",
+		));
+	}
+
+	?>
+</div>

--- a/mod/groups/views/default/forms/groups/edit.php
+++ b/mod/groups/views/default/forms/groups/edit.php
@@ -20,30 +20,4 @@ echo elgg_view("groups/edit/access", $vars);
 // build the group tools options
 echo elgg_view("groups/edit/tools", $vars);
 
-// display the save button and some additional form data
-?>
-<div class="elgg-foot">
-<?php
-
-if ($entity) {
-	echo elgg_view("input/hidden", array(
-		"name" => "group_guid",
-		"value" => $entity->getGUID(),
-	));
-}
-
-echo elgg_view("input/submit", array("value" => elgg_echo("save")));
-
-if ($entity) {
-	$delete_url = "action/groups/delete?guid=" . $entity->getGUID();
-	echo elgg_view("output/url", array(
-		"text" => elgg_echo("groups:delete"),
-		"href" => $delete_url,
-		"confirm" => elgg_echo("groups:deletewarning"),
-		"class" => "elgg-button elgg-button-delete float-alt",
-	));
-}
-
 elgg_pop_context();
-?>
-</div>

--- a/views/default/input/form-footer.php
+++ b/views/default/input/form-footer.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Render and wrap a form footer
+ *
+ * @uses $vars['action']    Action name
+ * @uses $vars['body_vars'] Form body vars passed to elgg_view_form()
+ */
+$action = elgg_extract('action', $vars);
+if (!$action) {
+	elgg_log('The "action" view parameter is required', 'ERROR');
+	return;
+}
+
+$body_vars = elgg_extract('body_vars', $vars);
+
+$footer = elgg_view("forms/$action-footer", $body_vars);
+if (!$footer) {
+	return;
+}
+
+$class[] = 'elgg-form-footer';
+$class[] = 'elgg-form-footer-' . preg_replace('/[^a-z0-9]/i', '-', $action);
+
+echo elgg_format_element('div', [
+	'class' => $class,
+], $footer);


### PR DESCRIPTION
After rendering the `forms/<action>` view, `elgg_view_form()` renders the view `forms/<action>-footer` if it exists. Authors should move submit and other footer actions to the footer view so that the `forms/<action>` view can be extended directly.

This converts several bundled forms to this format.
- [ ] Deal with issue: Overridden forms (in existing plugins) will end up with two footers
