### PR TITLE
Object listing

### DIFF
--- a/mod/blog/views/default/object/blog.php
+++ b/mod/blog/views/default/object/blog.php
@@ -86,9 +86,9 @@ if ($full) {
 		'metadata' => $metadata,
 		'subtitle' => $subtitle,
 		'content' => $excerpt,
+		'icon' => $owner_icon,
 	);
 	$params = $params + $vars;
-	$list_body = elgg_view('object/elements/summary', $params);
+	echo elgg_view('object/elements/summary', $params);
 
-	echo elgg_view_image_block($owner_icon, $list_body);
 }

--- a/mod/bookmarks/views/default/object/bookmarks.php
+++ b/mod/bookmarks/views/default/object/bookmarks.php
@@ -111,9 +111,9 @@ HTML;
 		'metadata' => $metadata,
 		'subtitle' => $subtitle,
 		'content' => $content,
+		'icon' => $owner_icon,
 	);
 	$params = $params + $vars;
-	$body = elgg_view('object/elements/summary', $params);
+	echo elgg_view('object/elements/summary', $params);
 	
-	echo elgg_view_image_block($owner_icon, $body);
 }

--- a/mod/developers/views/default/theme_sandbox/components.php
+++ b/mod/developers/views/default/theme_sandbox/components.php
@@ -9,6 +9,9 @@ echo elgg_view_module('theme-sandbox-demo', 'Image Block (.elgg-image-block)', $
 $body = elgg_view('theme_sandbox/components/list');
 echo elgg_view_module('theme-sandbox-demo', 'List (.elgg-list)', $body);
 
+$body = elgg_view('theme_sandbox/components/summary_listing');
+echo elgg_view_module('theme-sandbox-demo', 'Summary Listing (object/elements/summary)', $body);
+
 $body = elgg_view('theme_sandbox/components/table', array('class' => 'elgg-table'));
 echo elgg_view_module('theme-sandbox-demo', 'Table (.elgg-table)', $body);
 

--- a/mod/developers/views/default/theme_sandbox/components.php
+++ b/mod/developers/views/default/theme_sandbox/components.php
@@ -12,6 +12,9 @@ echo elgg_view_module('theme-sandbox-demo', 'List (.elgg-list)', $body);
 $body = elgg_view('theme_sandbox/components/summary_listing');
 echo elgg_view_module('theme-sandbox-demo', 'Summary Listing (object/elements/summary)', $body);
 
+$body = elgg_view('theme_sandbox/components/full_listing');
+echo elgg_view_module('theme-sandbox-demo', 'Full Listing (object/elements/full)', $body);
+
 $body = elgg_view('theme_sandbox/components/table', array('class' => 'elgg-table'));
 echo elgg_view_module('theme-sandbox-demo', 'Table (.elgg-table)', $body);
 

--- a/mod/developers/views/default/theme_sandbox/components.php
+++ b/mod/developers/views/default/theme_sandbox/components.php
@@ -6,6 +6,9 @@
 $body = elgg_view('theme_sandbox/components/image_block');
 echo elgg_view_module('theme-sandbox-demo', 'Image Block (.elgg-image-block)', $body);
 
+$body = elgg_view('theme_sandbox/components/image_block_alt');
+echo elgg_view_module('theme-sandbox-demo', 'Image Block (.elgg-image-block) with .elgg-image-alt', $body);
+
 $body = elgg_view('theme_sandbox/components/list');
 echo elgg_view_module('theme-sandbox-demo', 'List (.elgg-list)', $body);
 

--- a/mod/developers/views/default/theme_sandbox/components/full_listing.php
+++ b/mod/developers/views/default/theme_sandbox/components/full_listing.php
@@ -1,0 +1,31 @@
+<?php
+
+$ipsum = elgg_view('developers/ipsum');
+
+$object = new ThemeSandboxObject();
+$object->title = 'Test Object';
+$object->description = $ipsum;
+$object->tags = ['tag 1', 'tag 2', 'tag 3'];
+
+$summary = elgg_view('object/elements/summary', [
+	'entity' => $object,
+	'subtitle' => 'Listing subtitle',
+	'class' => 'theme-sandbox-summary-listing',
+	'metadata' => elgg_view_menu('entity', [
+		'entity' => $object,
+		'handler' => 'theme-sandbox',
+		'class' => 'elgg-menu-hz',
+	]),
+]);
+
+$icon = elgg_view_entity_icon($object, 'small');
+
+echo elgg_view('object/elements/full', [
+	'entity' => $object,
+	'summary' => $summary,
+	'icon' => $icon,
+	'body' => elgg_view('output/longtext', [
+		'value' => $object->description,
+	]),
+	'class' => 'theme-sandbox-full-listing',
+]);

--- a/mod/developers/views/default/theme_sandbox/components/image_block.php
+++ b/mod/developers/views/default/theme_sandbox/components/image_block.php
@@ -3,4 +3,7 @@ $ipsum = elgg_view('developers/ipsum');
 
 $user = new ElggUser();
 $image = elgg_view_entity_icon($user, 'small');
-echo elgg_view_image_block($image, "$ipsum $ipsum $ipsum $ipsum $ipsum $ipsum $ipsum");
+echo elgg_view_image_block($image, "$ipsum $ipsum $ipsum $ipsum $ipsum $ipsum $ipsum", [
+	'class' => 'theme-sandbox-image-block',
+	'data-type' => 'user',
+]);

--- a/mod/developers/views/default/theme_sandbox/components/image_block_alt.php
+++ b/mod/developers/views/default/theme_sandbox/components/image_block_alt.php
@@ -1,0 +1,11 @@
+<?php
+$ipsum = elgg_view('developers/ipsum');
+
+$user = new ElggUser();
+$image = elgg_view_entity_icon($user, 'small');
+$image_alt = elgg_view_icon('user-plus');
+echo elgg_view_image_block($image, "$ipsum $ipsum $ipsum $ipsum $ipsum $ipsum $ipsum", [
+	'class' => 'theme-sandbox-image-block',
+	'data-type' => 'user',
+	'image_alt' => $image_alt,
+]);

--- a/mod/developers/views/default/theme_sandbox/components/summary_listing.php
+++ b/mod/developers/views/default/theme_sandbox/components/summary_listing.php
@@ -7,6 +7,8 @@ $object->title = 'Test Object';
 $object->description = $ipsum;
 $object->tags = ['tag 1', 'tag 2', 'tag 3'];
 
+$icon = elgg_view_entity_icon($object, 'small');
+
 echo elgg_view('object/elements/summary', [
 	'entity' => $object,
 	'subtitle' => 'Listing subtitle',
@@ -17,4 +19,5 @@ echo elgg_view('object/elements/summary', [
 		'class' => 'elgg-menu-hz',
 	]),
 	'content' => elgg_get_excerpt($object->description),
+	'icon' => $icon,
 ]);

--- a/mod/developers/views/default/theme_sandbox/components/summary_listing.php
+++ b/mod/developers/views/default/theme_sandbox/components/summary_listing.php
@@ -1,0 +1,20 @@
+<?php
+
+$ipsum = elgg_view('developers/ipsum');
+
+$object = new ThemeSandboxObject();
+$object->title = 'Test Object';
+$object->description = $ipsum;
+$object->tags = ['tag 1', 'tag 2', 'tag 3'];
+
+echo elgg_view('object/elements/summary', [
+	'entity' => $object,
+	'subtitle' => 'Listing subtitle',
+	'class' => 'theme-sandbox-summary-listing',
+	'metadata' => elgg_view_menu('entity', [
+		'entity' => $object,
+		'handler' => 'theme-sandbox',
+		'class' => 'elgg-menu-hz',
+	]),
+	'content' => elgg_get_excerpt($object->description),
+]);

--- a/mod/discussions/views/default/object/discussion.php
+++ b/mod/discussions/views/default/object/discussion.php
@@ -113,9 +113,9 @@ HTML;
 		'subtitle' => $subtitle,
 		'tags' => $tags,
 		'content' => $excerpt,
+		'icon' => $poster_icon,
 	);
 	$params = $params + $vars;
-	$list_body = elgg_view('object/elements/summary', $params);
-
-	echo elgg_view_image_block($poster_icon, $list_body);
+	echo elgg_view('object/elements/summary', $params);
+	
 }

--- a/mod/discussions/views/default/object/discussion_reply.php
+++ b/mod/discussions/views/default/object/discussion_reply.php
@@ -66,8 +66,7 @@ $params = array(
 	'metadata' => $metadata,
 	'subtitle' => $subtitle,
 	'content' => $content,
+	'icon' => $poster_icon,
 );
 $params = $params + $vars;
-$list_body = elgg_view('object/elements/summary', $params);
-
-echo elgg_view_image_block($poster_icon, $list_body);
+echo elgg_view('object/elements/summary', $params);

--- a/mod/embed/views/default/embed/item.php
+++ b/mod/embed/views/default/embed/item.php
@@ -26,14 +26,13 @@ if ($owner) {
 	$subtitle = '';
 }
 
+$image = elgg_view_entity_icon($entity, 'small', array('link_class' => 'embed-insert'));
+
 $params = array(
 	'title' => $title,
 	'entity' => $entity,
 	'subtitle' => $subtitle,
 	'tags' => FALSE,
+	'icon' => $image,
 );
-$body = elgg_view('object/elements/summary', $params);
-
-$image = elgg_view_entity_icon($entity, 'small', array('link_class' => 'embed-insert'));
-
-echo elgg_view_image_block($image, $body);
+echo elgg_view('object/elements/summary', $params);

--- a/mod/file/views/default/object/file.php
+++ b/mod/file/views/default/object/file.php
@@ -93,9 +93,9 @@ if ($full && !elgg_in_context('gallery')) {
 		'metadata' => $metadata,
 		'subtitle' => $subtitle,
 		'content' => $excerpt,
+		'icon' => $file_icon,
 	);
 	$params = $params + $vars;
-	$list_body = elgg_view('object/elements/summary', $params);
+	echo elgg_view('object/elements/summary', $params);
 
-	echo elgg_view_image_block($file_icon, $list_body);
 }

--- a/mod/pages/views/default/object/page_top.php
+++ b/mod/pages/views/default/object/page_top.php
@@ -119,9 +119,9 @@ if ($full) {
 		'metadata' => $metadata,
 		'subtitle' => $subtitle,
 		'content' => $excerpt,
+		'icon' => $page_icon,
 	);
 	$params = $params + $vars;
-	$list_body = elgg_view('object/elements/summary', $params);
+	echo elgg_view('object/elements/summary', $params);
 
-	echo elgg_view_image_block($page_icon, $list_body);
 }

--- a/mod/thewire/views/default/object/thewire.php
+++ b/mod/thewire/views/default/object/thewire.php
@@ -51,11 +51,11 @@ $params = array(
 	'subtitle' => $subtitle,
 	'content' => thewire_filter($post->description),
 	'tags' => false,
+	'icon' => $owner_icon,
+	'class' => 'thewire-post',
 );
 $params = $params + $vars;
-$list_body = elgg_view('object/elements/summary', $params);
-
-echo elgg_view_image_block($owner_icon, $list_body, array('class' => 'thewire-post'));
+echo elgg_view('object/elements/summary', $params);
 
 if ($post->reply) {
 	echo "<div class=\"thewire-parent hidden\" id=\"thewire-previous-{$post->guid}\">";

--- a/views/default/object/elements/full.php
+++ b/views/default/object/elements/full.php
@@ -11,6 +11,9 @@
  * @uses $vars['header_params'] Vars to pass to the header image block wrapper
  */
 $entity = elgg_extract('entity', $vars);
+if (!$entity instanceof ElggEntity) {
+	elgg_log("object/elements/full expects an ElggEntity in \$vars['entity']", 'ERROR');
+}
 
 $class = (array) elgg_extract('class', $vars, []);
 $class[] = 'elgg-listing-full';

--- a/views/default/object/elements/full.php
+++ b/views/default/object/elements/full.php
@@ -1,37 +1,29 @@
 <?php
+
 /**
- * Object full rendering
+ * Object full view
  *
- * Sample output:
- * <div class="elgg-content">
- *     <div class="elgg-image-block">
- *     </div>
- *     <div class="elgg-output">
- *     </div>
- * </div>
- *
- * @uses $vars['entity']   ElggEntity
- * @uses $vars['icon']     HTML for the content icon
- * @uses $vars['summary']  HTML for the content summary
- * @uses $vars['body']     HTML for the content body
- * @uses $vars['class']    Optional additional class for the content wrapper
+ * @uses $vars['entity']        ElggEntity
+ * @uses $vars['icon']          HTML for the content icon
+ * @uses $vars['summary']       HTML for the content summary
+ * @uses $vars['body']          HTML for the content body
+ * @uses $vars['class']         Optional additional class for the content wrapper
+ * @uses $vars['header_params'] Vars to pass to the header image block wrapper
  */
+$entity = elgg_extract('entity', $vars);
 
-$icon = elgg_extract('icon', $vars);
-$summary = elgg_extract('summary', $vars);
-$body = elgg_extract('body', $vars);
-$class = elgg_extract('class', $vars);
-if ($class) {
-	$class = "elgg-content clearfix $class";
-} else {
-	$class = "elgg-content clearfix";
-}
+$class = (array) elgg_extract('class', $vars, []);
+$class[] = 'elgg-listing-full';
+$class[] = 'elgg-content';
+$class[] = 'clearfix';
+unset($vars['class']);
 
-$header = elgg_view_image_block($icon, $summary);
+$header = elgg_view('object/elements/full/header', $vars);
+$body = elgg_view('object/elements/full/body', $vars);
 
-echo <<<HTML
-<div class="$class">
-$header
-$body
-</div>
-HTML;
+echo elgg_format_element('div', [
+	'class' => $class,
+	'data-guid' => $entity->guid,
+		], $header . $body);
+
+

--- a/views/default/object/elements/full/body.php
+++ b/views/default/object/elements/full/body.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Outputs object full view
+ * @uses $vars['body'] Body
+ */
+
+$body = elgg_extract('body', $vars);
+if (!$body) {
+	return;
+}
+
+echo $body;

--- a/views/default/object/elements/full/header.php
+++ b/views/default/object/elements/full/header.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Object full view header
+ *
+ * @uses $vars['icon']        HTML for the content icon
+ * @uses $vars['summary']     HTML for the content summary
+ * @uses $vars['header_params'] Vars to pass to image block/header wrapper
+ */
+
+$icon = elgg_extract('icon', $vars);
+$summary = elgg_extract('summary', $vars);
+
+$header_params = (array) elgg_extract('header_params', $vars, []);
+$class = (array) elgg_extract('class', $header_params, []);
+$class = 'elgg-listing-full-header';
+$header_params['class'] = implode(' ', $class);
+
+echo elgg_view_image_block($icon, $summary, $header_params);

--- a/views/default/object/elements/full/header.php
+++ b/views/default/object/elements/full/header.php
@@ -13,7 +13,7 @@ $summary = elgg_extract('summary', $vars);
 
 $header_params = (array) elgg_extract('header_params', $vars, []);
 $class = (array) elgg_extract('class', $header_params, []);
-$class = 'elgg-listing-full-header';
+$class[] = 'elgg-listing-full-header';
 $header_params['class'] = implode(' ', $class);
 
 echo elgg_view_image_block($icon, $summary, $header_params);

--- a/views/default/object/elements/summary.php
+++ b/views/default/object/elements/summary.php
@@ -12,6 +12,9 @@
  * @uses $vars['class']     Class selector
  */
 $entity = elgg_extract('entity', $vars);
+if (!$entity instanceof ElggEntity) {
+	elgg_log("object/elements/summary expects an ElggEntity in \$vars['entity']", 'ERROR');
+}
 
 $title = elgg_extract('title', $vars, '');
 if ($title === '' && $entity instanceof ElggEntity) {

--- a/views/default/object/elements/summary.php
+++ b/views/default/object/elements/summary.php
@@ -2,6 +2,8 @@
 
 /**
  * Object summary
+ * Passing an 'icon' with the variables will wrap the listing in an image block. In that case,
+ * variables not listed in @uses (e.g. image_alt) will be passed to the image block.
  *
  * @uses $vars['entity']    ElggEntity
  * @uses $vars['title']     Title link (optional) false = no title, '' = default
@@ -9,7 +11,8 @@
  * @uses $vars['subtitle']  HTML for the subtitle (optional)
  * @uses $vars['tags']      HTML for the tags (default is tags on entity, pass false for no tags)
  * @uses $vars['content']   HTML for the entity content (optional)
- * @uses $vars['class']     Class selector
+ * @uses $vars['icon']      Object icon. If set, the listing will be wrapped with an image block
+ * @uses $vars['class']     Class selector for the image block
  */
 $entity = elgg_extract('entity', $vars);
 if (!$entity instanceof ElggEntity) {
@@ -37,4 +40,21 @@ $subtitle = elgg_view('object/elements/summary/subtitle', $vars);
 $extensions = elgg_view('object/summary/extend', $vars);
 $content = elgg_view('object/elements/summary/content', $vars);
 
-echo $metadata . $title . $subtitle . $tags . $extensions . $content;
+$summary = $metadata . $title . $subtitle . $tags . $extensions . $content;
+
+$icon = elgg_extract('icon', $vars);
+if (isset($icon)) {
+	$params = $vars;
+	foreach (['title', 'metadata', 'subtitle', 'tags', 'content', 'icon', 'class'] as $key) {
+		unset($params[$key]);
+	}
+	$class = (array) elgg_extract('class', $vars, []);
+	$class[] = 'elgg-listing-summary';
+	$params['class'] = $class;
+
+	$params['data-guid'] = $entity->guid;
+	
+	echo elgg_view_image_block($icon, $summary, $params);
+} else {
+	echo $summary;
+}

--- a/views/default/object/elements/summary.php
+++ b/views/default/object/elements/summary.php
@@ -1,13 +1,7 @@
 <?php
+
 /**
  * Object summary
- *
- * Sample output
- * <ul class="elgg-menu elgg-menu-entity"><li>Public</li><li>Like this</li></ul>
- * <h3><a href="">Title</a></h3>
- * <p class="elgg-subtext">Posted 3 hours ago by George</p>
- * <p class="elgg-tags"><a href="">one</a>, <a href="">two</a></p>
- * <div class="elgg-content">Excerpt text</div>
  *
  * @uses $vars['entity']    ElggEntity
  * @uses $vars['title']     Title link (optional) false = no title, '' = default
@@ -15,45 +9,29 @@
  * @uses $vars['subtitle']  HTML for the subtitle (optional)
  * @uses $vars['tags']      HTML for the tags (default is tags on entity, pass false for no tags)
  * @uses $vars['content']   HTML for the entity content (optional)
+ * @uses $vars['class']     Class selector
  */
+$entity = elgg_extract('entity', $vars);
 
-$entity = $vars['entity'];
-
-$title_link = elgg_extract('title', $vars, '');
-if ($title_link === '') {
-	if (isset($entity->title)) {
-		$text = $entity->title;
-	} else {
-		$text = $entity->name;
-	}
-	$params = array(
-		'text' => elgg_get_excerpt($text, 100),
+$title = elgg_extract('title', $vars, '');
+if ($title === '' && $entity instanceof ElggEntity) {
+	$vars['title'] = elgg_view('output/url', [
+		'text' => elgg_get_excerpt($entity->getDisplayName(), 100),
 		'href' => $entity->getURL(),
-		'is_trusted' => true,
-	);
-	$title_link = elgg_view('output/url', $params);
+	]);
 }
-
-$metadata = elgg_extract('metadata', $vars, '');
-$subtitle = elgg_extract('subtitle', $vars, '');
-$content = elgg_extract('content', $vars, '');
 
 $tags = elgg_extract('tags', $vars, '');
 if ($tags === '') {
-	$tags = elgg_view('output/tags', array('tags' => $entity->tags));
+	$tags = elgg_view('output/tags', [
+		'entity' => $entity,
+	]);
 }
 
-if ($metadata) {
-	echo $metadata;
-}
-if ($title_link) {
-	echo "<h3>$title_link</h3>";
-}
-echo "<div class=\"elgg-subtext\">$subtitle</div>";
-echo $tags;
+$metadata = elgg_view('object/elements/summary/metadata', $vars);
+$title = elgg_view('object/elements/summary/title', $vars);
+$subtitle = elgg_view('object/elements/summary/subtitle', $vars);
+$extensions = elgg_view('object/summary/extend', $vars);
+$content = elgg_view('object/elements/summary/content', $vars);
 
-echo elgg_view('object/summary/extend', $vars);
-
-if ($content) {
-	echo "<div class=\"elgg-content\">$content</div>";
-}
+echo $metadata . $title . $subtitle . $tags . $extensions . $content;

--- a/views/default/object/elements/summary/content.php
+++ b/views/default/object/elements/summary/content.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Outputs object summary content
+ * @uses $vars['content'] Summary content
+ */
+
+$content = elgg_extract('content', $vars);
+if (!$content) {
+	return;
+}
+?>
+<div class="elgg-listing-summary-content elgg-content"><?= $content ?></div>

--- a/views/default/object/elements/summary/metadata.php
+++ b/views/default/object/elements/summary/metadata.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Outputs object metadata
+ * @uses $vars['metadata'] Metadata/menu
+ */
+
+$metadata = elgg_extract('metadata', $vars);
+if (!$metadata) {
+	return;
+}
+echo $metadata;

--- a/views/default/object/elements/summary/subtitle.php
+++ b/views/default/object/elements/summary/subtitle.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Outputs object subtitle
+ * @uses $vars['subtitle'] Subtitle
+ */
+$subtitle = elgg_extract('subtitle', $vars);
+if (!$subtitle) {
+	return;
+}
+?>
+<div class="elgg-listing-summary-subtitle elgg-subtext"><?= $subtitle ?></div>

--- a/views/default/object/elements/summary/title.php
+++ b/views/default/object/elements/summary/title.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Outputs object title
+ * @uses $vars['title'] Title
+ */
+
+$title = elgg_extract('title', $vars);
+if (!$title) {
+	return;
+}
+?>
+<h3 class="elgg-listing-summary-title"><?= $title ?></h3>

--- a/views/default/page/components/image_block.php
+++ b/views/default/page/components/image_block.php
@@ -15,38 +15,41 @@
  * @uses $vars['body']        HTML content of the body block
  * @uses $vars['image']       HTML content of the image block
  * @uses $vars['image_alt']   HTML content of the alternate image block
- * @uses $vars['class']       Optional additional class for media element
+ * @uses $vars['class']       Optional additional class (or an array of classes) for media element
  * @uses $vars['id']          Optional id for the media element
  */
 
 $body = elgg_extract('body', $vars, '');
+unset($vars['body']);
+
 $image = elgg_extract('image', $vars, '');
+unset($vars['image']);
+
 $alt_image = elgg_extract('image_alt', $vars, '');
+unset($vars['image_alt']);
 
-$class = 'elgg-image-block';
-$additional_class = elgg_extract('class', $vars, '');
-if ($additional_class) {
-	$class = "$class $additional_class";
-}
+$class = (array) elgg_extract('class', $vars, []);
+$class[] = 'elgg-image-block';
+$class[] = 'clearfix';
+unset($vars['class']);
 
-$id = '';
-if (isset($vars['id'])) {
-	$id = "id=\"{$vars['id']}\"";
-}
-
-
-$body = "<div class=\"elgg-body\">$body</div>";
+$body = elgg_format_element('div', [
+	'class' => 'elgg-body',
+], $body);
 
 if ($image) {
-	$image = "<div class=\"elgg-image\">$image</div>";
+	$image = elgg_format_element('div', [
+		'class' => 'elgg-image',
+	], $image);
 }
 
 if ($alt_image) {
-	$alt_image = "<div class=\"elgg-image-alt\">$alt_image</div>";
+	$alt_image = elgg_format_element([
+		'class' => 'elgg-image-alt',
+	], $alt_image);
 }
 
-echo <<<HTML
-<div class="$class clearfix" $id>
-	$image$alt_image$body
-</div>
-HTML;
+$params = $vars;
+$params['class'] = $class;
+
+echo elgg_format_element('div', $params, $image . $alt_image . $body);

--- a/views/default/page/components/image_block.php
+++ b/views/default/page/components/image_block.php
@@ -44,7 +44,7 @@ if ($image) {
 }
 
 if ($alt_image) {
-	$alt_image = elgg_format_element([
+	$alt_image = elgg_format_element('div', [
 		'class' => 'elgg-image-alt',
 	], $alt_image);
 }


### PR DESCRIPTION
**feature(views): improves usability of object listing views**

Improves usability of summary and full view listings by wrapping listing components in their own views, which should allow plugins to target listing elements via hooks and override individual parts without having to hijack an entire view.

Adds class selectors to make it easier to style object listings.

**feature(views): image block wrapper attributes can now be passed via `$vars`**

`page/components/image_block` now accepts additional attributes to be passed to the wrapper div with `$vars`.
