### PR TITLE
security(routing): HTML escapes URL segments

### DIFF
--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -71,10 +71,15 @@ class Request extends SymfonyRequest {
 	 *
 	 * @see \Elgg\Http\Request::getPathInfo()
 	 *
-	 * @return array
+	 * @param bool $raw If true, the segments will not be HTML escaped
+	 *
+	 * @return string[]
 	 */
-	public function getUrlSegments() {
+	public function getUrlSegments($raw = false) {
 		$path = trim($this->query->get('__elgg_uri'), '/');
+		if (!$raw) {
+			$path = htmlspecialchars($path, ENT_QUOTES, 'UTF-8');
+		}
 		if (!$path) {
 			return array();
 		}

--- a/engine/tests/phpunit/Elgg/Http/RequestTest.php
+++ b/engine/tests/phpunit/Elgg/Http/RequestTest.php
@@ -12,6 +12,20 @@ class RequestTest extends TestCase {
 		$this->assertEquals(['foo', 'bar'], $req->getUrlSegments());
 	}
 
+	public function testUrlSegmentsAutoHtmlEscaped() {
+		$req = new Request([
+			'__elgg_uri' => '/fo<script>alert("/ba&r/',
+		]);
+		$this->assertEquals(['fo&lt;script&gt;alert(&quot;', 'ba&amp;r'], $req->getUrlSegments());
+	}
+
+	public function testCanAccessRawUrlSegments() {
+		$req = new Request([
+			'__elgg_uri' => '/fo<script>alert("/ba&r/',
+		]);
+		$this->assertEquals(['fo<script>alert("', 'ba&r'], $req->getUrlSegments(true));
+	}
+
 	public function testClientIpChecksXRealIp() {
 		$req = new Request();
 		$req->server->set('HTTP_X_REAL_IP', '127.0.0.1');


### PR DESCRIPTION
Just in case a developer unwisely injects URL content directly into HTML, we escape `&"'<>` with HTML entities.
