### PR TITLE
feature(river): Adds hook-based permissions for river item delete action

### DIFF
--- a/actions/river/delete.php
+++ b/actions/river/delete.php
@@ -6,14 +6,22 @@
  * @subpackage Core
  */
 
-$id = get_input('id', false);
+$id = (int)get_input('id');
 
-if ($id !== false && elgg_is_admin_logged_in()) {
-	if (elgg_delete_river(array('id' => $id))) {
-		system_message(elgg_echo('river:delete:success'));
-	} else {
-		register_error(elgg_echo('river:delete:fail'));
-	}
+$items = elgg_get_river(['id' => $id]);
+if (!$items) {
+	register_error(elgg_echo('river:delete:fail'));
+	forward(REFERER);
+}
+
+$item = $items[0];
+if (!$item->canDelete()) {
+	register_error(elgg_echo('river:delete:lack_permission'));
+	forward(REFERER);
+}
+
+if ($item->delete()) {
+	system_message(elgg_echo('river:delete:success'));
 } else {
 	register_error(elgg_echo('river:delete:fail'));
 }

--- a/docs/guides/events-list.rst
+++ b/docs/guides/events-list.rst
@@ -201,6 +201,13 @@ River events
 **created, river**
 	Called after a river item is created.
 
+	.. note:: Use the plugin hook ``creating, river`` to cancel creation (or alter options).
+
+**delete:before, river**
+	Triggered before a river item is deleted. Returning false cancels the deletion.
+
+**delete:after, river**
+	Triggered after a river item was deleted.
 
 File events
 ===========

--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -95,7 +95,8 @@ System hooks
 	``elgg_view_menu()`` and ``elgg()->menus->prepareMenu()``.
 
 **creating, river**
-	Triggered before a river item is created. Return false to prevent river item from being created.
+	The options for ``elgg_create_river_item`` are filtered through this hook. You may alter values
+	or return ``false`` to cancel the item creation.
 
 **simplecache:generate, <view>**
 	Triggered when generating the cached content of a view.
@@ -261,6 +262,12 @@ Permission hooks
 
 **permissions_check:delete, <entity_type>**
 	Return boolean for if the user ``$params['user']`` can delete the entity ``$params['entity']``. Defaults to ``$entity->canEdit()``.
+
+**permissions_check:delete, river**
+	Return boolean for if the user ``$params['user']`` can delete the river item ``$params['item']``. Defaults to
+	``true`` for admins and ``false`` for other users.
+
+	.. note:: This check is not performed when using the deprecated ``elgg_delete_river()``.
 
 **permissions_check, widget_layout**
 	Return boolean for if ``$params['user']`` can edit the widgets in the context passed as

--- a/engine/classes/Elgg/UserCapabilities.php
+++ b/engine/classes/Elgg/UserCapabilities.php
@@ -6,6 +6,7 @@ use Elgg\Database\EntityTable;
 use Elgg\Database\EntityTable\UserFetchFailureException;
 use ElggAnnotation;
 use ElggEntity;
+use ElggRiverItem;
 use ElggMetadata;
 use ElggSession;
 use InvalidArgumentException;
@@ -127,6 +128,36 @@ class UserCapabilities {
 			'user' => $user
 		];
 		return $this->hooks->trigger('permissions_check:delete', $entity->getType(), $params, $return);
+	}
+
+	/**
+	 * Can a user delete this river item?
+	 *
+	 * @tip Can be overridden by registering for the "permissions_check:delete", "river" plugin hook.
+	 *
+	 * @note This is not called by elgg_delete_river().
+	 *
+	 * @param ElggRiverItem $item      River item
+	 * @param int           $user_guid The user GUID, optionally (default: logged in user)
+	 *
+	 * @return bool Whether this river item should be considered deletable by the given user.
+	 * @since 2.3
+	 * @see elgg_set_ignore_access()
+	 */
+	public function canDeleteRiverItem(ElggRiverItem $item, $user_guid = 0) {
+		try {
+			$user = $this->entities->getUserForPermissionsCheck($user_guid);
+		} catch (UserFetchFailureException $e) {
+			return false;
+		}
+
+		$return = ($user && $user->isAdmin());
+
+		$params = [
+			'item' => $item,
+			'user' => $user,
+		];
+		return $this->hooks->trigger('permissions_check:delete', 'river', $params, $return);
 	}
 
 	/**

--- a/engine/classes/ElggRiverItem.php
+++ b/engine/classes/ElggRiverItem.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * River item class.
  *
@@ -139,6 +140,47 @@ class ElggRiverItem {
 	 */
 	public function getSubtype() {
 		return 'item';
+	}
+
+	/**
+	 * Can a user delete this river item?
+	 *
+	 * @tip Can be overridden by registering for the "permissions_check:delete", "river" plugin hook.
+	 *
+	 * @note This is not called by elgg_delete_river().
+	 *
+	 * @param int $user_guid The user GUID, optionally (default: logged in user)
+	 *
+	 * @return bool Whether this river item should be considered deletable by the given user.
+	 * @since 2.3
+	 */
+	public function canDelete($user_guid = 0) {
+		return _elgg_services()->userCapabilities->canDeleteRiverItem($this, $user_guid);
+	}
+
+	/**
+	 * Delete the river item
+	 *
+	 * @return bool False if the user lacks permission or the before event is cancelled
+	 * @since 2.3
+	 */
+	public function delete() {
+		if (!$this->canDelete()) {
+			return false;
+		}
+
+		$events = _elgg_services()->events;
+		if (!$events->triggerBefore('delete', 'river', $this)) {
+			return false;
+		}
+
+		$db = _elgg_services()->db;
+		$prefix = $db->getTablePrefix();
+		_elgg_services()->db->deleteData("DELETE FROM {$prefix}river WHERE id = ?", [$this->id]);
+
+		$events->triggerAfter('delete', 'river', $this);
+
+		return true;
 	}
 
 	/**

--- a/engine/lib/deprecated-2.1.php
+++ b/engine/lib/deprecated-2.1.php
@@ -63,3 +63,116 @@ function system_messages($message = null, $register = "success", $count = false)
 	$svc->saveRegisters($set);
 	return true;
 }
+
+/**
+ * Delete river items
+ *
+ * @warning Does not fire permission hooks or delete, river events.
+ *
+ * @param array $options Parameters:
+ *   ids                  => INT|ARR River item id(s)
+ *   subject_guids        => INT|ARR Subject guid(s)
+ *   object_guids         => INT|ARR Object guid(s)
+ *   target_guids         => INT|ARR Target guid(s)
+ *   annotation_ids       => INT|ARR The identifier of the annotation(s)
+ *   action_types         => STR|ARR The river action type(s) identifier
+ *   views                => STR|ARR River view(s)
+ *
+ *   types                => STR|ARR Entity type string(s)
+ *   subtypes             => STR|ARR Entity subtype string(s)
+ *   type_subtype_pairs   => ARR     Array of type => subtype pairs where subtype
+ *                                   can be an array of subtype strings
+ *
+ *   posted_time_lower    => INT     The lower bound on the time posted
+ *   posted_time_upper    => INT     The upper bound on the time posted
+ *
+ * @return bool
+ * @since 1.8.0
+ * @deprecated 2.3 Use elgg_get_river() and call delete() on the returned item(s)
+ */
+function elgg_delete_river(array $options = array()) {
+	global $CONFIG;
+
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use elgg_get_river() and call delete() on the returned item(s)', '2.3');
+
+	$defaults = array(
+		'ids'                  => ELGG_ENTITIES_ANY_VALUE,
+
+		'subject_guids'	       => ELGG_ENTITIES_ANY_VALUE,
+		'object_guids'         => ELGG_ENTITIES_ANY_VALUE,
+		'target_guids'         => ELGG_ENTITIES_ANY_VALUE,
+		'annotation_ids'       => ELGG_ENTITIES_ANY_VALUE,
+
+		'views'                => ELGG_ENTITIES_ANY_VALUE,
+		'action_types'         => ELGG_ENTITIES_ANY_VALUE,
+
+		'types'	               => ELGG_ENTITIES_ANY_VALUE,
+		'subtypes'             => ELGG_ENTITIES_ANY_VALUE,
+		'type_subtype_pairs'   => ELGG_ENTITIES_ANY_VALUE,
+
+		'posted_time_lower'	   => ELGG_ENTITIES_ANY_VALUE,
+		'posted_time_upper'	   => ELGG_ENTITIES_ANY_VALUE,
+
+		'wheres'               => array(),
+		'joins'                => array(),
+
+	);
+
+	$options = array_merge($defaults, $options);
+
+	$singulars = array('id', 'subject_guid', 'object_guid', 'target_guid', 'annotation_id', 'action_type', 'view', 'type', 'subtype');
+	$options = _elgg_normalize_plural_options_array($options, $singulars);
+
+	$wheres = $options['wheres'];
+
+	$wheres[] = _elgg_get_guid_based_where_sql('rv.id', $options['ids']);
+	$wheres[] = _elgg_get_guid_based_where_sql('rv.subject_guid', $options['subject_guids']);
+	$wheres[] = _elgg_get_guid_based_where_sql('rv.object_guid', $options['object_guids']);
+	$wheres[] = _elgg_get_guid_based_where_sql('rv.target_guid', $options['target_guids']);
+	$wheres[] = _elgg_get_guid_based_where_sql('rv.annotation_id', $options['annotation_ids']);
+	$wheres[] = _elgg_river_get_action_where_sql($options['action_types']);
+	$wheres[] = _elgg_river_get_view_where_sql($options['views']);
+	$wheres[] = _elgg_get_river_type_subtype_where_sql('rv', $options['types'],
+		$options['subtypes'], $options['type_subtype_pairs']);
+
+	if ($options['posted_time_lower'] && is_int($options['posted_time_lower'])) {
+		$wheres[] = "rv.posted >= {$options['posted_time_lower']}";
+	}
+
+	if ($options['posted_time_upper'] && is_int($options['posted_time_upper'])) {
+		$wheres[] = "rv.posted <= {$options['posted_time_upper']}";
+	}
+
+	// see if any functions failed
+	// remove empty strings on successful functions
+	foreach ($wheres as $i => $where) {
+		if ($where === false) {
+			return false;
+		} elseif (empty($where)) {
+			unset($wheres[$i]);
+		}
+	}
+
+	// remove identical where clauses
+	$wheres = array_unique($wheres);
+
+	$query = "DELETE rv.* FROM {$CONFIG->dbprefix}river rv ";
+
+	// remove identical join clauses
+	$joins = array_unique($options['joins']);
+
+	// add joins
+	foreach ($joins as $j) {
+		$query .= " $j ";
+	}
+
+	// add wheres
+	$query .= ' WHERE ';
+
+	foreach ($wheres as $w) {
+		$query .= " $w AND ";
+	}
+	$query .= "1=1";
+
+	return delete_data($query);
+}

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -440,10 +440,10 @@ function _elgg_river_menu_setup($hook, $type, $return, $params) {
 			}
 		}
 		
-		if (elgg_is_admin_logged_in()) {
+		if ($item->canDelete()) {
 			$options = array(
 				'name' => 'delete',
-				'href' => elgg_add_action_tokens_to_url("action/river/delete?id=$item->id"),
+				'href' => elgg_add_action_tokens_to_url("action/river/delete?id={$item->id}"),
 				'text' => elgg_view_icon('delete'),
 				'title' => elgg_echo('river:delete'),
 				'confirm' => elgg_echo('deleteconfirm'),

--- a/languages/en.php
+++ b/languages/en.php
@@ -335,8 +335,10 @@ return array(
 	'river:none' => 'No activity',
 	'river:update' => 'Update for %s',
 	'river:delete' => 'Remove this activity item',
-	'river:delete:success' => 'River item has been deleted',
-	'river:delete:fail' => 'River item could not be deleted',
+	'river:delete:success' => 'Activity item has been deleted',
+	'river:delete:fail' => 'Activity item could not be deleted',
+	'river:delete:lack_permission' => 'You lack permission to delete this activity item',
+	'river:can_delete:invaliduser' => 'Cannot check canDelete for user_guid [%s] as the user does not exist.',
 	'river:subject:invalid_subject' => 'Invalid user',
 	'activity:owner' => 'View activity',
 


### PR DESCRIPTION
ElggRiverItem objects now have canDelete() and delete(). Similar to entities, canDelete uses the `permissions_check:delete, river` hook.

delete() calls the `delete:before, river` and `delete:after, river` events.

elgg_create_river_item() can now return the created `ElggRiverItem`.

This deprecates elgg_delete_river() as it cannot be fixed to use these new APIs for BC reasons.

Fixes #8936 
