### PR TITLE
fix(js): add missing elgg/lightbox#resize method

### DIFF
--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -654,6 +654,18 @@ To support gallery sets (via ``rel`` attribute), you need to bind colorbox direc
       lightbox.bind('a[rel="my-gallery"]', options, false); // 3rd attribute ensures binding is done without proxies
    });
 
+You can also resize the lightbox programmatically if needed:
+
+.. code:: js
+
+   define(function(require) {
+      var lightbox = require('elgg/lightbox');
+     
+      lightbox.resize({
+         width: '300px'
+      });
+   });
+
 Module ``elgg/ckeditor``
 ------------------------
 

--- a/mod/developers/views/default/developers/ajax.php
+++ b/mod/developers/views/default/developers/ajax.php
@@ -5,8 +5,15 @@
 
 $ipsum = elgg_view('developers/ipsum');
 
+$resize_button = elgg_view('input/button', [
+	'id' => 'elgg-lightbox-test-resize',
+	'class' => 'elgg-button elgg-button-action',
+	'value' => 'Add extra content and resize',
+]);
+
 echo '<div class="mam" style="width: 400px;">';
 echo elgg_view_module('aside', 'Lightbox Test', $ipsum, array(
-	'id' => 'elgg-lightbox-test'
+	'id' => 'elgg-lightbox-test',
+	'footer' => $resize_button,
 ));
 echo '</div>';

--- a/mod/developers/views/default/theme_sandbox/javascript/lightbox.js
+++ b/mod/developers/views/default/theme_sandbox/javascript/lightbox.js
@@ -5,4 +5,12 @@ define(function(require) {
 		width: 600
 	};
 	lightbox.bind('[rel="lightbox-gallery"]', opts, false);
+	
+	$(document).on('click', '#elgg-lightbox-test-resize', function(event) {
+		event.preventDefault();
+		$body = $('#elgg-lightbox-test').find('.elgg-body');
+		$body.append($body.html());
+		
+		lightbox.resize();
+	});
 });

--- a/mod/developers/views/default/theme_sandbox/javascript/lightbox.php
+++ b/mod/developers/views/default/theme_sandbox/javascript/lightbox.php
@@ -1,7 +1,7 @@
 <?php
 
 echo elgg_view('output/url', array(
-	'text' => 'Open lighbox',
+	'text' => 'Open lightbox',
 	'href' => "ajax/view/developers/ajax",
 	'class' => 'elgg-lightbox'
 ));
@@ -21,6 +21,9 @@ echo elgg_view('output/url', array(
 	'href' => '#lightbox-inline',
 	'class' => 'elgg-lightbox-inline mll',
 ));
+
+elgg_require_js('theme_sandbox/javascript/lightbox');
+
 ?>
 <div class="hidden">
 	<div id="lightbox-inline">
@@ -40,8 +43,6 @@ $files = elgg_get_entities_from_metadata(array(
 if (!$files) {
 	return;
 }
-
-elgg_require_js('theme_sandbox/javascript/lightbox');
 
 echo elgg_view('output/url', array(
 	'text' => 'Open photo lightbox',

--- a/views/default/elgg/lightbox.js
+++ b/views/default/elgg/lightbox.js
@@ -112,9 +112,13 @@ define('elgg/lightbox', function (require) {
 		 * Close the colorbox
 		 * @return void
 		 */
-		close: function () {
-			$.colorbox.close();
-		}
+		close: $.colorbox.close,
+		
+		/**
+		 * Resizes the colorbox
+		 * @return void
+		 */
+		resize: $.colorbox.resize
 	};
 
 	lightbox.bind(".elgg-lightbox");


### PR DESCRIPTION
Adds the missing proxy elgg/lightbox#resize method so that
plugins no longer need to use $.colorbox directly
