### PR TITLE
chore(tests): fixes version of phpDocumentor/ReflectionDocBlock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,6 @@
         "elgg/sniffs": "dev-master",
         "squizlabs/php_codesniffer": "~1.5",
         "simpletest/simpletest": "~1.1",
-        "phpdocumentor/reflection-docblock": "~2.0"
+        "phpdocumentor/reflection-docblock": "2.0.4"
     }
 }


### PR DESCRIPTION
3.0 has a BC-breaking refactor, breaking `ServiceProviderTest::servicesListProvider`.

Fixes #9987
