### PR TITLE
chore(tests): increases leniency of timeout in ElggSpinnerTest

### DIFF
--- a/js/tests/ElggSpinnerTest.js
+++ b/js/tests/ElggSpinnerTest.js
@@ -26,7 +26,7 @@ define(function(require) {
 			setTimeout(function() {
 				expect($(visible_selector).length).toBe(1);
 				done();
-			}, 40);
+			}, 100);
 		});
 
 		it("stop() removes the body class", function(done) {
@@ -37,7 +37,7 @@ define(function(require) {
 				spinner.stop();
 				expect($(visible_selector).length).toBe(0);
 				done();
-			}, 40);
+			}, 100);
 		});
 	});
 });


### PR DESCRIPTION
Was still causing timeouts, even at 40ms.
