### PR TITLE
feat(install): composer asset plugin is now installed with `pre-install-cmd`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,10 @@
         "league/flysystem-memory": "^1.0"
     },
     "scripts": {
-        "pre-install-cmd": "php .scripts/check_global_requirements.php",
+        "pre-install-cmd": [
+            "composer global require \"fxp/composer-asset-plugin:~1.1.4\"",
+            "php .scripts/check_global_requirements.php"
+        ],
         "lint": [
             "phpcs --standard=vendor/elgg/sniffs/elgg.xml --warning-severity=0 --ignore=*/tests/*,*/upgrades/*,*/deprecated* engine/classes engine/lib",
             "composer validate"

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -280,7 +280,8 @@ for the ``bower-asset/*`` packages to be recognized. To install it, run:
     composer global require fxp/composer-asset-plugin
 
 If you don't do this before running ``composer install`` or ``composer create-project``,
-you will get an error message:
+Elgg will attempt to run the command automatically. Should the installation fail,
+you will see an message:
 
 .. code:: shell
 


### PR DESCRIPTION
Attempt to install composer asset plugin globally with `pre-install-cmd` script.
Add -v flag for verbose composer install on Travis
