### PR TITLE
feat(tests): make it easier to bootstrap PHPUnit

### DIFF
--- a/docs/admin/upgrading.rst
+++ b/docs/admin/upgrading.rst
@@ -37,6 +37,14 @@ Basic instructions
    Any modifications should have been written within plugins, so that they are not lost on overwriting.
    If this is not the case, take care to maintain your modifications. 
 
+From 2.2 to 2.3
+===============
+
+ * PHPUnit bootstrap is deprecated by composer autoloader: Tests should no longer bootstrap themselves using ``/engine/tests/phpunit/bootstrap.php``. Instead, tests should extend ``\Elgg\TestCase``.
+ * Some core files now sniff if	``PHPUNIT_ELGG_TESTING_APPLICATION`` constant is set to determine whether Elgg is being bootstrapped for PHPUnit tests. ``phpunit.xml`` configuration needs to updated to include this constant definition.
+ * PHPUnit bootstrap no longer sets global ``$CONFIG``. Tests should use ``_elgg_services()->config`` instead.
+ * Core and tests no longer use private global values in ``$_ELGG->view_path`` and ``$_ELGG->allowed_ajax_views``
+
 Deprecations in 2.x
 ===================
 

--- a/docs/info/config.php
+++ b/docs/info/config.php
@@ -333,14 +333,6 @@ $_ELGG->translations;
 $_ELGG->registered_tag_metadata_names;
 
 /**
- * The full path for core views.
- *
- * @global string $_ELGG->view_path
- * @access private
- */
-$_ELGG->view_path;
-
-/**
  * A list of valid view types as discovered.
  *
  * @global array $_ELGG->view_types

--- a/engine/classes/Elgg/Ajax/Service.php
+++ b/engine/classes/Elgg/Ajax/Service.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elgg\Ajax;
 
 use Elgg\Amd\Config;
@@ -42,6 +43,11 @@ class Service {
 	 * @var bool
 	 */
 	private $response_sent = false;
+
+	/**
+	 * @var array
+	 */
+	private $allowed_views = [];
 
 	/**
 	 * Constructor
@@ -120,7 +126,7 @@ class Service {
 
 		$api_response = new Response();
 		$api_response->setData((object)[
-			'value' => $output,
+					'value' => $output,
 		]);
 		$api_response = $this->filterApiResponse($api_response, $hook_type);
 		$response = $this->buildHttpResponse($api_response);
@@ -200,9 +206,9 @@ class Service {
 		if ($ttl > 0) {
 			// Required to remove headers set by PHP session
 			if (!isset($allow_removing_headers)) {
-				$allow_removing_headers = !elgg_get_config('Elgg\Application_phpunit');
+				$allow_removing_headers = !defined('PHPUNIT_ELGG_TESTING_APPLICATION');
 			}
-			
+
 			if ($allow_removing_headers) {
 				header_remove('Expires');
 				header_remove('Pragma');
@@ -217,7 +223,7 @@ class Service {
 			// if we don't set Expires, Apache will add a far-off max-age and Expires for us.
 			$response->headers->set('Expires', gmdate('D, d M Y H:i:s \G\M\T', time() + $ttl));
 		}
-		
+
 		return $response;
 	}
 
@@ -261,4 +267,32 @@ class Service {
 		return $response;
 	}
 
+	/**
+	 * Register a view to be available for ajax calls
+	 *
+	 * @param string $view The view name
+	 * @return void
+	 */
+	public function registerView($view) {
+		$this->allowed_views[$view] = true;
+	}
+
+	/**
+	 * Unregister a view for ajax calls
+	 *
+	 * @param string $view The view name
+	 * @return void
+	 */
+	public function unregisterView($view) {
+		unset($this->allowed_views[$view]);
+	}
+
+	/**
+	 * Returns an array of views allowed for ajax calls
+	 * @return string[]
+	 */
+	public function getViews() {
+		return array_keys($this->allowed_views);
+	}
+	
 }

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -235,7 +235,7 @@ class Application {
 
 		$config = $this->services->config;
 
-		if ($config->getVolatile('Elgg\Application_phpunit')) {
+		if (defined('PHPUNIT_ELGG_TESTING_APPLICATION')) {
 			throw new \RuntimeException('Unit tests should not call ' . __METHOD__);
 		}
 

--- a/engine/classes/Elgg/BootService.php
+++ b/engine/classes/Elgg/BootService.php
@@ -137,7 +137,7 @@ class BootService {
 			_elgg_services()->logger->setDisplay(true);
 		}
 
-		$GLOBALS['_ELGG']->view_path = \Elgg\Application::elggDir()->getPath("/views/");
+		_elgg_services()->views->view_path = \Elgg\Application::elggDir()->getPath("/views/");
 
 		// finish boot sequence
 		_elgg_session_boot();

--- a/engine/classes/Elgg/ViewsService.php
+++ b/engine/classes/Elgg/ViewsService.php
@@ -75,6 +75,11 @@ class ViewsService {
 	private $cache;
 	
 	/**
+	 * @var string Absolute path of the views directory
+	 */
+	public $view_path;
+
+	/**
 	 * Constructor
 	 *
 	 * @param PluginHooksService $hooks  The hooks service

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -51,6 +51,8 @@ class ElggInstaller {
 
 	protected $autoLogin = TRUE;
 
+	private $view_path = '';
+
 	/**
 	 * Global Elgg configuration
 	 * 
@@ -80,6 +82,8 @@ class ElggInstaller {
 
 		$this->bootstrapEngine();
 
+		_elgg_services()->views->view_path = $this->view_path;
+		
 		_elgg_services()->setValue('session', \ElggSession::getMock());
 
 		elgg_set_viewtype('installation');
@@ -855,7 +859,7 @@ class ElggInstaller {
 		$this->CONFIG->wwwroot = $this->getBaseUrl();
 		$this->CONFIG->url = $this->CONFIG->wwwroot;
 		$this->CONFIG->path = \Elgg\Application::elggDir()->getPath() . "/";
-		$GLOBALS['_ELGG']->view_path = $this->CONFIG->path . 'views/';
+		$this->view_path = $this->CONFIG->path . 'views/';
 		$this->CONFIG->pluginspath = $this->CONFIG->path . 'mod/';
 		$this->CONFIG->context = array();
 		$this->CONFIG->entity_types = array('group', 'object', 'site', 'user');

--- a/engine/lib/deprecated-1.9.php
+++ b/engine/lib/deprecated-1.9.php
@@ -3045,7 +3045,7 @@ function elgg_view_tree($view_root, $viewtype = "") {
 	}
 
 	// Now examine core
-	$location = $GLOBALS['_ELGG']->view_path;
+	$location = _elgg_services()->views->view_path;
 	$viewtype = elgg_get_viewtype();
 	$root = $location . $viewtype . '/' . $view_root;
 

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1554,11 +1554,11 @@ function _elgg_ajax_page_handler($segments) {
 			$view = 'forms/' . implode('/', array_slice($segments, 1));
 		}
 
-		$allowed_views = $GLOBALS['_ELGG']->allowed_ajax_views;
 		$ajax_api = _elgg_services()->ajax;
-
+		$allowed_views = $ajax_api->getViews();
+		
 		// cacheable views are always allowed
-		if (!array_key_exists($view, $allowed_views) && !_elgg_services()->views->isCacheableView($view)) {
+		if (!in_array($view, $allowed_views) && !_elgg_services()->views->isCacheableView($view)) {
 			return elgg_error_response("Ajax view '$view' was not registered", REFERRER, ELGG_HTTP_FORBIDDEN);
 		}
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -241,11 +241,8 @@ function elgg_unregister_ajax_view($view) {
  * @since 1.9.0
  */
 function elgg_register_external_view($view, $cacheable = false) {
-	if (!isset($GLOBALS['_ELGG']->allowed_ajax_views)) {
-		$GLOBALS['_ELGG']->allowed_ajax_views = array();
-	}
-
-	$GLOBALS['_ELGG']->allowed_ajax_views[$view] = true;
+	
+	_elgg_services()->ajax->registerView($view);
 
 	if ($cacheable) {
 		_elgg_services()->views->registerCacheableView($view);
@@ -260,9 +257,7 @@ function elgg_register_external_view($view, $cacheable = false) {
  * @since 1.9.0
  */
 function elgg_unregister_external_view($view) {
-	if (isset($GLOBALS['_ELGG']->allowed_ajax_views[$view])) {
-		unset($GLOBALS['_ELGG']->allowed_ajax_views[$view]);
-	}
+	_elgg_services()->ajax->unregisterView($view);
 }
 
 /**
@@ -270,8 +265,6 @@ function elgg_unregister_external_view($view) {
  *
  * Views are expected to be in plugin_name/views/.  This function can
  * be used to change that location.
- *
- * @note Internal: Core view locations are stored in $CONFIG->view_path.
  *
  * @tip This is useful to optionally register views in a plugin.
  *
@@ -1786,7 +1779,7 @@ function elgg_views_boot() {
 	elgg_register_plugin_hook_handler('head', 'page', '_elgg_views_prepare_favicon_links', 1);
 	
 	// @todo the cache is loaded in load_plugins() but we need to know viewtypes earlier
-	$view_path = $GLOBALS['_ELGG']->view_path;
+	$view_path = _elgg_services()->views->view_path;
 	$viewtype_dirs = scandir($view_path);
 	foreach ($viewtype_dirs as $viewtype) {
 		if (_elgg_is_valid_viewtype($viewtype) && is_dir($view_path . $viewtype)) {

--- a/engine/tests/phpunit/Elgg/Access/AclTest.php
+++ b/engine/tests/phpunit/Elgg/Access/AclTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Elgg_Access_AclTest extends PHPUnit_Framework_TestCase {
+class Elgg_Access_AclTest extends \Elgg\TestCase {
 
 	/**
 	 * Ignoring access permissions globally shouldn't affect the results
@@ -52,7 +52,7 @@ class Elgg_Access_AclTest extends PHPUnit_Framework_TestCase {
 		 */
 		$this->markTestIncomplete();
 	}
-	
+
 	/**
 	 * Getting the readable name of a default access_id should return the expected value.
 	 */
@@ -77,6 +77,5 @@ class Elgg_Access_AclTest extends PHPUnit_Framework_TestCase {
 		 */
 		$this->markTestIncomplete();
 	}
-	
-	
+
 }

--- a/engine/tests/phpunit/Elgg/ActionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ActionsServiceTest.php
@@ -10,7 +10,6 @@ use Elgg\Http\Request;
 use Elgg\Http\ResponseFactory;
 use Elgg\I18n\Translator;
 use ElggSession;
-use PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -18,7 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @group HttpService
  * @group ActionsService
  */
-class ActionsServiceTest extends PHPUnit_Framework_TestCase {
+class ActionsServiceTest extends \Elgg\TestCase {
 
 	/**
 	 * @var ActionsService
@@ -48,7 +47,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 		_elgg_services()->setValue('session', $session);
 		_elgg_services()->session->start();
 
-		$config = _elgg_testing_config();
+		$config = $this->config();
 		_elgg_services()->setValue('config', $config);
 
 		$input = new Input();
@@ -57,7 +56,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 		$this->actions = new ActionsService($config, $session, _elgg_services()->crypto);
 		_elgg_services()->setValue('actions', $this->actions);
 
-		$this->request = _elgg_testing_request();
+		$this->request = $this->prepareHttpRequest();
 		_elgg_services()->setValue('request', $this->request);
 
 		$this->translator = new Translator();
@@ -147,7 +146,6 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($this->actions->register('test/output', "$this->actionsDir/output.php", 'public'));
 		$this->assertTrue($this->actions->register('test/output_logged_in', "$this->actionsDir/output.php", 'logged_in'));
 		$this->assertTrue($this->actions->register('test/output_admin', "$this->actionsDir/output.php", 'admin'));
-
 	}
 
 	public function testCanRegisterActionWithUnknownAccessLevel() {
@@ -162,7 +160,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 				'message' => 'Unrecognized value \'pblc\' for $access in Elgg\\ActionsService::register',
 				'level' => Logger::ERROR,
 			]
-		], $logged);
+				], $logged);
 
 		$actions = $this->actions->getAllActions();
 		$this->assertArrayHasKey('test/output', $actions);
@@ -208,7 +206,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 
 	public function testActionReturnValuesAreIgnoredIfNotResponseBuilder() {
 
-		$this->request = _elgg_testing_request('action/output6', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/output6', 'POST', [], false, true);
 		$this->assertTrue($this->actions->register('output6', "$this->actionsDir/output6.php", 'public'));
 
 		$this->createService();
@@ -216,14 +214,13 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 		ob_start();
 		$result = $this->actions->execute('output6');
 		$output = ob_get_clean();
-		
+
 		$this->assertInstanceOf(OkResponse::class, $result);
 		$this->assertEquals(ELGG_HTTP_OK, $result->getStatusCode());
 		$this->assertEquals('', $result->getContent());
 		$this->assertEquals(REFERRER, $result->getForwardURL());
 
 		$this->assertEmpty($output);
-
 	}
 
 	public function testCanGenerateValidTokens() {
@@ -276,7 +273,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanExecute() {
-		$this->request = _elgg_testing_request('action/output3', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/output3', 'POST', [], false, true);
 		$this->assertTrue($this->actions->register('output3', "$this->actionsDir/output3.php", 'public'));
 
 		$this->createService();
@@ -295,10 +292,11 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * The logic is a bit odd. See #9792
+	 * 
 	 * @dataProvider executeForwardUrlDataProvider
 	 */
 	public function testCanResolveForwardUrl($url, $expected) {
-		$this->request = _elgg_testing_request('action/fail', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/fail', 'POST', [], false, true);
 		$this->createService();
 		$result = $this->actions->execute('fail', $url);
 		$this->assertInstanceOf(ErrorResponse::class, $result);
@@ -313,9 +311,9 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 			['@me/home/', 'me/home/'],
 		];
 	}
-	
+
 	public function testCanNotExecuteWithInvalidTokens() {
-		$this->request = _elgg_testing_request('action/output3', 'POST', [
+		$this->request = $this->prepareHttpRequest('action/output3', 'POST', [
 			'__elgg_ts' => time(),
 			'__elgg_token' => 'abcdefghi123456',
 				], false, false);
@@ -339,7 +337,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanNotExecuteUnregisteredAction() {
 
-		$this->request = _elgg_testing_request('action/unregistered', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/unregistered', 'POST', [], false, true);
 		$this->createService();
 
 		$result = $this->actions->execute('unregistered', 'referrer');
@@ -352,7 +350,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanNotExecuteLoggedInActionIfLoggedOut() {
 
-		$this->request = _elgg_testing_request('action/output3', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/output3', 'POST', [], false, true);
 		$this->assertTrue($this->actions->register('output3', "$this->actionsDir/output3.php"));
 		$this->createService();
 
@@ -366,7 +364,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanNotExecuteAdminActionIfNotAdmin() {
 
-		$this->request = _elgg_testing_request('action/output3', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/output3', 'POST', [], false, true);
 		$this->assertTrue($this->actions->register('output3', "$this->actionsDir/output3.php", 'admin'));
 		$this->createService();
 
@@ -379,7 +377,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanNotExecuteIfActionFileIsMissing() {
-		$this->request = _elgg_testing_request('action/no_file', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/no_file', 'POST', [], false, true);
 		$this->assertTrue($this->actions->register('no_file', "$this->actionsDir/no_file.php", 'public'));
 		$this->createService();
 
@@ -398,7 +396,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 			return false;
 		});
 
-		$this->request = _elgg_testing_request('action/output3', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/output3', 'POST', [], false, true);
 		$this->assertTrue($this->actions->register('output3', "$this->actionsDir/output3.php", 'public'));
 		$this->createService();
 
@@ -411,7 +409,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanNotExecuteActionWithoutActionFile() {
-		$this->request = _elgg_testing_request('action/no_file', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/no_file', 'POST', [], false, true);
 		$this->assertTrue($this->actions->register('no_file', "$this->actionsDir/no_file.php", 'public'));
 		$this->createService();
 
@@ -440,7 +438,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testCanRespondToNonAjaxRequest() {
 		$this->assertTrue($this->actions->register('output3', "$this->actionsDir/output3.php", 'public'));
-		$this->request = _elgg_testing_request('action/output3', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/output3', 'POST', [], false, true);
 		$this->createService();
 
 		set_input('output', 'output3');
@@ -462,7 +460,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRespondToAjaxRequest() {
 
 		$this->assertTrue($this->actions->register('output3', "$this->actionsDir/output3.php", 'public'));
-		$this->request = _elgg_testing_request('action/output3', 'POST', [], 1, true);
+		$this->request = $this->prepareHttpRequest('action/output3', 'POST', [], 1, true);
 		$this->createService();
 
 		set_input('output', 'output3');
@@ -498,7 +496,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRespondToAjax2Request() {
 
 		$this->assertTrue($this->actions->register('output3', "$this->actionsDir/output3.php", 'public'));
-		$this->request = _elgg_testing_request('action/output3', 'POST', [], 2, true);
+		$this->request = $this->prepareHttpRequest('action/output3', 'POST', [], 2, true);
 		$this->createService();
 
 		set_input('output', 'output3');
@@ -530,7 +528,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	 * @group AjaxService
 	 */
 	public function testCanFilterAjax2Response() {
-		
+
 		$this->hooks->registerHandler(Services\AjaxResponse::RESPONSE_HOOK, 'action:output3', function($hook, $type, $api_response) {
 			/* @var $api_response Services\AjaxResponse */
 			$api_response->setTtl(1000);
@@ -539,7 +537,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 		});
 
 		$this->assertTrue($this->actions->register('output3', "$this->actionsDir/output3.php", 'public'));
-		$this->request = _elgg_testing_request('action/output3', 'POST', [], 2, true);
+		$this->request = $this->prepareHttpRequest('action/output3', 'POST', [], 2, true);
 		$this->createService();
 
 		set_input('output', 'output3');
@@ -557,7 +555,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(strtotime($date) + 1000, strtotime($expires));
 		$this->assertContains('max-age=1000', $response->headers->get('Cache-Control'));
 		$this->assertContains('private', $response->headers->get('Cache-Control'));
-		
+
 		$output = json_encode([
 			'value' => 'output3_modified',
 			'_elgg_msgs' => [
@@ -582,7 +580,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 		});
 
 		$this->assertTrue($this->actions->register('output3', "$this->actionsDir/output3.php", 'public'));
-		$this->request = _elgg_testing_request('action/output3', 'POST', [], 2, true);
+		$this->request = $this->prepareHttpRequest('action/output3', 'POST', [], 2, true);
 		$this->createService();
 
 		set_input('output', 'output3');
@@ -610,7 +608,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 		$this->hooks->registerHandler(Services\AjaxResponse::RESPONSE_HOOK, 'action:output3', [Values::class, 'getFalse']);
 
 		$this->assertTrue($this->actions->register('output3', "$this->actionsDir/output3.php", 'public'));
-		$this->request = _elgg_testing_request('action/output3', 'POST', [], 2, true);
+		$this->request = $this->prepareHttpRequest('action/output3', 'POST', [], 2, true);
 		$this->createService();
 
 		try {
@@ -627,7 +625,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testCanRespondWithErrorToNonAjaxRequest() {
 		$this->assertTrue($this->actions->register('output3', "$this->actionsDir/output3.php", 'public'));
-		$this->request = _elgg_testing_request('action/output3', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/output3', 'POST', [], false, true);
 		$this->createService();
 
 		set_input('output', 'output3');
@@ -646,7 +644,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRespondWithErrorToAjaxRequest() {
 
 		$this->assertTrue($this->actions->register('output3', "$this->actionsDir/output3.php", 'public'));
-		$this->request = _elgg_testing_request('action/output3', 'POST', [], 1, true);
+		$this->request = $this->prepareHttpRequest('action/output3', 'POST', [], 1, true);
 		$this->createService();
 
 		set_input('output', 'output3');
@@ -679,7 +677,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRespondWithErrorToAjax2Request() {
 
 		$this->assertTrue($this->actions->register('output3', "$this->actionsDir/output3.php", 'public'));
-		$this->request = _elgg_testing_request('action/output3', 'POST', [], 2, true);
+		$this->request = $this->prepareHttpRequest('action/output3', 'POST', [], 2, true);
 		$this->createService();
 
 		set_input('output', 'output3');
@@ -706,7 +704,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRespondToNonAjaxRequestFromOkResponseBuilder() {
 
 		$this->assertTrue($this->actions->register('output4', "$this->actionsDir/output4.php", 'public'));
-		$this->request = _elgg_testing_request('action/output4', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/output4', 'POST', [], false, true);
 		$this->createService();
 
 		set_input('output', ['foo', 'bar']);
@@ -726,7 +724,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRespondToNonAjaxRequestFromErrorResponseBuilder() {
 
 		$this->assertTrue($this->actions->register('output4', "$this->actionsDir/output4.php", 'public'));
-		$this->request = _elgg_testing_request('action/output4', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/output4', 'POST', [], false, true);
 		$this->createService();
 
 		set_input('output', ['foo', 'bar']);
@@ -746,7 +744,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRespondToNonAjaxRequestFromRedirectResponseBuilder() {
 
 		$this->assertTrue($this->actions->register('output4', "$this->actionsDir/output4.php", 'public'));
-		$this->request = _elgg_testing_request('action/output4', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/output4', 'POST', [], false, true);
 		$this->createService();
 
 		set_input('output', ['foo', 'bar']);
@@ -764,7 +762,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRespondToAjaxRequestFromOkResponseBuilder() {
 
 		$this->assertTrue($this->actions->register('output4', "$this->actionsDir/output4.php", 'public'));
-		$this->request = _elgg_testing_request('action/output4', 'POST', [], 1, true);
+		$this->request = $this->prepareHttpRequest('action/output4', 'POST', [], 1, true);
 		$this->createService();
 
 		set_input('output', ['foo', 'bar']);
@@ -796,7 +794,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRespondToAjaxRequestFromErrorResponseBuilder() {
 
 		$this->assertTrue($this->actions->register('output4', "$this->actionsDir/output4.php", 'public'));
-		$this->request = _elgg_testing_request('action/output4', 'POST', [], 1, true);
+		$this->request = $this->prepareHttpRequest('action/output4', 'POST', [], 1, true);
 		$this->createService();
 
 		set_input('output', ['foo', 'bar']);
@@ -828,7 +826,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRespondToAjaxRequestFromRedirectResponseBuilder() {
 
 		$this->assertTrue($this->actions->register('output4', "$this->actionsDir/output4.php", 'public'));
-		$this->request = _elgg_testing_request('action/output4', 'POST', [], 1, true);
+		$this->request = $this->prepareHttpRequest('action/output4', 'POST', [], 1, true);
 		$this->createService();
 
 		set_input('output', ['foo', 'bar']);
@@ -862,7 +860,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRespondToAjax2RequestFromOkResponseBuilder() {
 
 		$this->assertTrue($this->actions->register('output4', "$this->actionsDir/output4.php", 'public'));
-		$this->request = _elgg_testing_request('action/output4', 'POST', [], 2, true);
+		$this->request = $this->prepareHttpRequest('action/output4', 'POST', [], 2, true);
 		$this->createService();
 
 		set_input('output', ['foo', 'bar']);
@@ -894,7 +892,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRespondToAjax2RequestFromErrorResponseBuilderWithOkStatusCode() {
 
 		$this->assertTrue($this->actions->register('output4', "$this->actionsDir/output4.php", 'public'));
-		$this->request = _elgg_testing_request('action/output4', 'POST', [], 2, true);
+		$this->request = $this->prepareHttpRequest('action/output4', 'POST', [], 2, true);
 		$this->createService();
 
 		set_input('output', ['foo', 'bar']);
@@ -922,7 +920,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRespondToAjax2RequestFromErrorResponseBuilderWithErrorStatusCode() {
 
 		$this->assertTrue($this->actions->register('output4', "$this->actionsDir/output4.php", 'public'));
-		$this->request = _elgg_testing_request('action/output4', 'POST', [], 2, true);
+		$this->request = $this->prepareHttpRequest('action/output4', 'POST', [], 2, true);
 		$this->createService();
 
 		set_input('output', ['foo', 'bar']);
@@ -950,7 +948,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	public function testCanRespondToAjax2RequestFromRedirectResponseBuilder() {
 
 		$this->assertTrue($this->actions->register('output4', "$this->actionsDir/output4.php", 'public'));
-		$this->request = _elgg_testing_request('action/output4', 'POST', [], 2, true);
+		$this->request = $this->prepareHttpRequest('action/output4', 'POST', [], 2, true);
 		$this->createService();
 
 		set_input('forward_reason', ELGG_HTTP_FOUND);
@@ -977,7 +975,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRedirectOnNonAjaxRequest() {
 		$this->assertTrue($this->actions->register('output5', "$this->actionsDir/output5.php", 'public'));
-		$this->request = _elgg_testing_request('action/output5', 'POST', [], false, true);
+		$this->request = $this->prepareHttpRequest('action/output5', 'POST', [], false, true);
 		$this->createService();
 
 		set_input('output', 'foo');
@@ -991,7 +989,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRedirectOnAjaxRequest() {
 		$this->assertTrue($this->actions->register('output5', "$this->actionsDir/output5.php", 'public'));
-		$this->request = _elgg_testing_request('action/output5', 'POST', [], 1, true);
+		$this->request = $this->prepareHttpRequest('action/output5', 'POST', [], 1, true);
 		$this->createService();
 
 		set_input('output', 'foo');
@@ -1024,7 +1022,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testCanRedirectOnAjax2Request() {
 		$this->assertTrue($this->actions->register('output5', "$this->actionsDir/output5.php", 'public'));
-		$this->request = _elgg_testing_request('action/output5', 'POST', [], 2, true);
+		$this->request = $this->prepareHttpRequest('action/output5', 'POST', [], 2, true);
 		$this->createService();
 
 		set_input('output', 'foo');
@@ -1062,7 +1060,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 		});
 
 		$this->assertTrue($this->actions->register('output4', "$this->actionsDir/output4.php", 'public'));
-		$this->request = _elgg_testing_request('action/output4', 'POST', [], 2, true);
+		$this->request = $this->prepareHttpRequest('action/output4', 'POST', [], 2, true);
 		$this->createService();
 
 		set_input('output', ['foo', 'bar']);
@@ -1094,7 +1092,7 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 		$token = $this->actions->generateActionToken($ts);
 		$session_token = elgg_get_session()->get('__elgg_session');
 
-		$this->request = _elgg_testing_request('refresh_token', 'POST', [], 1);
+		$this->request = $this->prepareHttpRequest('refresh_token', 'POST', [], 1);
 		$this->createService();
 
 		set_input('pairs', [
@@ -1126,4 +1124,5 @@ class ActionsServiceTest extends PHPUnit_Framework_TestCase {
 		]);
 		$this->assertEquals($expected, $response->getContent());
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/Amd/ConfigTest.php
+++ b/engine/tests/phpunit/Elgg/Amd/ConfigTest.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Elgg\Amd;
 
-
-class ConfigTest extends \PHPUnit_Framework_TestCase {
+class ConfigTest extends \Elgg\TestCase {
 
 	public function testCanConfigureBaseUrl() {
 		$hooks = new \Elgg\PluginHooksService();
@@ -20,15 +20,15 @@ class ConfigTest extends \PHPUnit_Framework_TestCase {
 		$amdConfig->addPath('jquery', '/some/path.js');
 
 		$this->assertTrue($amdConfig->hasModule('jquery'));
-		
+
 		$configArray = $amdConfig->getConfig();
-		
+
 		$this->assertEquals(array('/some/path'), $configArray['paths']['jquery']);
 
 		$amdConfig->removePath('jquery', '/some/path.js');
 		$this->assertFalse($amdConfig->hasModule('jquery'));
 	}
-	
+
 	public function testCanConfigureModuleShims() {
 		$hooks = new \Elgg\PluginHooksService();
 		$amdConfig = new \Elgg\Amd\Config($hooks);
@@ -52,14 +52,14 @@ class ConfigTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($amdConfig->hasShim('jquery'));
 		$this->assertFalse($amdConfig->hasModule('jquery'));
 	}
-	
+
 	public function testCanRequireUnregisteredAmdModules() {
 		$hooks = new \Elgg\PluginHooksService();
 		$amdConfig = new \Elgg\Amd\Config($hooks);
 		$amdConfig->addDependency('jquery');
-		
+
 		$configArray = $amdConfig->getConfig();
-		
+
 		$this->assertEquals(array('jquery'), $configArray['deps']);
 
 		$this->assertTrue($amdConfig->hasDependency('jquery'));
@@ -71,8 +71,8 @@ class ConfigTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-     * @expectedException \InvalidParameterException
-     */
+	 * @expectedException \InvalidParameterException
+	 */
 	public function testThrowsOnBadShim() {
 		$hooks = new \Elgg\PluginHooksService();
 		$amdConfig = new \Elgg\Amd\Config($hooks);
@@ -108,7 +108,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(
 			'exports' => 'jquery.fn.ajaxform',
 			'deps' => array('jquery')
-		), $configArray['shim']['jquery.form']);
+				), $configArray['shim']['jquery.form']);
 
 		$this->assertArrayHasKey('jquery.form', $configArray['paths']);
 		$this->assertEquals(array('http://foobar.com'), $configArray['paths']['jquery.form']);
@@ -120,19 +120,19 @@ class ConfigTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($amdConfig->hasModule('jquery.form'));
 		$this->assertFalse($amdConfig->hasShim('jquery.form'));
 	}
-	
+
 	public function testGetConfigTriggersTheConfigAmdPluginHook() {
 		$hooks = new \Elgg\PluginHooksService();
 		$amdConfig = new \Elgg\Amd\Config($hooks);
-		
+
 		$test_input = ['test' => 'test_' . time()];
-	
+
 		$hooks->registerHandler('config', 'amd', function() use ($test_input) {
 			return $test_input;
 		});
-	
+
 		$config = $amdConfig->getConfig();
 		$this->assertEquals($test_input, $config);
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/Amd/ViewFilterTest.php
+++ b/engine/tests/phpunit/Elgg/Amd/ViewFilterTest.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Elgg\Amd;
 
-
-class ViewFilterTest extends \PHPUnit_Framework_TestCase {
+class ViewFilterTest extends \Elgg\TestCase {
 
 	public function testHandlesShortViewNames() {
 		$viewFilter = new \Elgg\Amd\ViewFilter();
@@ -53,5 +53,5 @@ class ViewFilterTest extends \PHPUnit_Framework_TestCase {
 		$filteredContent = $viewFilter->filter('js/foobar/my/mod.jst', $originalContent);
 		$this->assertEquals($originalContent, $filteredContent);
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/Application/CacheHandlerTest.php
+++ b/engine/tests/phpunit/Elgg/Application/CacheHandlerTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Elgg\Application;
 
-class CacheHandlerTest extends \PHPUnit_Framework_TestCase {
+class CacheHandlerTest extends \Elgg\TestCase {
 
 	/**
 	 * @var CacheHandler
@@ -9,7 +10,9 @@ class CacheHandlerTest extends \PHPUnit_Framework_TestCase {
 	protected $handler;
 
 	public function setUp() {
-		$this->handler = new CacheHandler(_elgg_testing_application(), _elgg_testing_config(), []);
+		$app = elgg();
+		$config = _elgg_services()->config;
+		$this->handler = new CacheHandler($app, $config, []);
 	}
 
 	protected function _testParseFail($input) {
@@ -21,7 +24,7 @@ class CacheHandlerTest extends \PHPUnit_Framework_TestCase {
 			'ts' => '1234',
 			'viewtype' => 'default',
 			'view' => 'hel/8lo-wo_rl.d.js',
-		), $this->handler->parsePath('/cache/1234/default/hel/8lo-wo_rl.d.js'));
+				), $this->handler->parsePath('/cache/1234/default/hel/8lo-wo_rl.d.js'));
 	}
 
 	public function testCantParseDoubleDot() {
@@ -47,21 +50,21 @@ class CacheHandlerTest extends \PHPUnit_Framework_TestCase {
 	public function testCanHandleConditionalRequests() {
 		$this->markTestIncomplete();
 	}
-	
+
 	public function testGetViewFileTypeHandlesJs() {
 		$this->markTestIncomplete("getViewFileType() is private/protected");
-		
+
 		$type = $this->handler->getViewFileType('js/some/view.js');
-		
+
 		$this->assertEquals('js', $type);
 	}
-	
+
 	public function testGetContentTypeHandlesJs() {
 		$this->markTestIncomplete("getContentType() is private/protected");
-		
+
 		$mediaType = $this->handler->getContentType('view.js');
-		
+
 		$this->assertEquals('application/javascript', $mediaType);
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/Application/ServeFileHandlerTest.php
+++ b/engine/tests/phpunit/Elgg/Application/ServeFileHandlerTest.php
@@ -2,9 +2,7 @@
 
 namespace Elgg\Application;
 
-use PHPUnit_Framework_TestCase;
-
-class ServeFileHandlerTest extends PHPUnit_Framework_TestCase {
+class ServeFileHandlerTest extends \Elgg\TestCase {
 
 	/**
 	 * @var ServeFileHandler
@@ -17,8 +15,6 @@ class ServeFileHandlerTest extends PHPUnit_Framework_TestCase {
 	protected $file;
 
 	public function setUp() {
-		$app = _elgg_testing_application();
-		$dataroot = _elgg_testing_config()->getDataPath();
 
 		$session = \ElggSession::getMock();
 		_elgg_services()->setValue('session', $session);
@@ -90,7 +86,7 @@ class ServeFileHandlerTest extends PHPUnit_Framework_TestCase {
 
 		sleep(1); // sometimes tests are too fast
 		$this->file->setModifiedTime();
-		
+
 		$response = $this->handler->getResponse($request);
 		$this->assertEquals(403, $response->getStatusCode());
 	}
@@ -199,4 +195,5 @@ class ServeFileHandlerTest extends PHPUnit_Framework_TestCase {
 		$response = $this->handler->getResponse($request);
 		$this->assertEquals(304, $response->getStatusCode());
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/ApplicationTest.php
+++ b/engine/tests/phpunit/Elgg/ApplicationTest.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace Elgg;
 
-class ApplicationTest extends \PHPUnit_Framework_TestCase {
+class ApplicationTest extends \Elgg\TestCase {
 
 	function testElggReturnsApp() {
-		$app = _elgg_testing_application();
-
-		$this->assertSame($app, elgg());
+		$this->assertInstanceOf(Application::class, elgg());
 	}
 
 	function testStartsTimer() {
@@ -21,10 +20,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 		$app = new Application($services);
 
 		$names = [
-			//'config',
+				//'config',
 		];
 
-		foreach	($names as $name) {
+		foreach ($names as $name) {
 			$this->assertSame($services->{$name}, $app->{$name});
 		}
 	}
@@ -60,5 +59,5 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 	function testRunBootsAndRoutes() {
 		$this->markTestIncomplete();
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/Assets/ExternalFilesTest.php
+++ b/engine/tests/phpunit/Elgg/Assets/ExternalFilesTest.php
@@ -1,23 +1,23 @@
 <?php
+
 namespace Elgg\Assets;
 
-
-class ExternalFilesTest extends \PHPUnit_Framework_TestCase {
+class ExternalFilesTest extends \Elgg\TestCase {
 
 	public function testPreservesInputConfigData() {
 		$config = new \stdClass();
 		$list = new \ElggPriorityList();
-		$obj1 = (object)array(
-			'name' => 'bar1',
-			'url' => '#',
-			'loaded' => false,
-			'location' => 'custom_location'
+		$obj1 = (object) array(
+					'name' => 'bar1',
+					'url' => '#',
+					'loaded' => false,
+					'location' => 'custom_location'
 		);
-		$obj2 = (object)array(
-			'name' => 'bar2',
-			'url' => 'http://elgg.org/',
-			'loaded' => true,
-			'location' => 'custom_location'
+		$obj2 = (object) array(
+					'name' => 'bar2',
+					'url' => 'http://elgg.org/',
+					'loaded' => true,
+					'location' => 'custom_location'
 		);
 
 		$list->add($obj1, 600);
@@ -36,14 +36,14 @@ class ExternalFilesTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(array(
 			300 => 'http://elgg.org/'
-		), $externalFiles->getLoadedFiles('foo', 'custom_location'));
+				), $externalFiles->getLoadedFiles('foo', 'custom_location'));
 
 		$externalFiles->load('foo', 'bar1');
 
 		$this->assertEquals(array(
 			300 => 'http://elgg.org/',
 			600 => '#'
-		), $externalFiles->getLoadedFiles('foo', 'custom_location'));
+				), $externalFiles->getLoadedFiles('foo', 'custom_location'));
 	}
 
 	public function testRegisterItemsAndLoad() {
@@ -61,14 +61,14 @@ class ExternalFilesTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(array(
 			300 => 'http://elgg.org/'
-		), $externalFiles->getLoadedFiles('foo', 'custom_location'));
+				), $externalFiles->getLoadedFiles('foo', 'custom_location'));
 
 		$externalFiles->load('foo', 'bar1');
 
 		$this->assertEquals(array(
 			300 => 'http://elgg.org/',
 			600 => '#'
-		), $externalFiles->getLoadedFiles('foo', 'custom_location'));
+				), $externalFiles->getLoadedFiles('foo', 'custom_location'));
 
 		$externalFiles->load('foo', 'bar3');
 
@@ -76,14 +76,14 @@ class ExternalFilesTest extends \PHPUnit_Framework_TestCase {
 			300 => 'http://elgg.org/',
 			500 => 'http://community.elgg.org/',
 			600 => '#'
-		), $externalFiles->getLoadedFiles('foo', 'custom_location'));
+				), $externalFiles->getLoadedFiles('foo', 'custom_location'));
 
 		$this->assertTrue($externalFiles->unregister('foo', 'bar1'));
 
 		$this->assertEquals(array(
 			300 => 'http://elgg.org/',
 			500 => 'http://community.elgg.org/'
-		), $externalFiles->getLoadedFiles('foo', 'custom_location'));
+				), $externalFiles->getLoadedFiles('foo', 'custom_location'));
 
 		$this->assertFalse($externalFiles->unregister('foo', 'bar1'));
 
@@ -91,9 +91,9 @@ class ExternalFilesTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(array(
 			0 => ''
-		), $externalFiles->getLoadedFiles('foo', ''));
+				), $externalFiles->getLoadedFiles('foo', ''));
 
 		$this->assertEquals(array(), $externalFiles->getLoadedFiles('nonexistent', 'custom_location'));
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/Cache/LRUCacheTest.php
+++ b/engine/tests/phpunit/Elgg/Cache/LRUCacheTest.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace Elgg\Cache;
 
-use PHPUnit_Framework_TestCase as TestCase;
+class LRUCacheTest extends \Elgg\TestCase {
 
-class LRUCacheTest extends TestCase {
 	public function testOldestItemsGetDroppedWhenUnused() {
 		$pool = new LRUCache(4);
 
@@ -69,5 +69,5 @@ class LRUCacheTest extends TestCase {
 		$this->setExpectedException('\InvalidArgumentException');
 		$pool = new LRUCache("abc");
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/Cache/Pool/InMemoryTest.php
+++ b/engine/tests/phpunit/Elgg/Cache/Pool/InMemoryTest.php
@@ -1,43 +1,59 @@
 <?php
+
 namespace Elgg\Cache\Pool;
 
-class InMemoryTest extends \PHPUnit_Framework_TestCase implements TestCase {
+class InMemoryTest extends \Elgg\TestCase implements TestCase {
+
 	public function testGetDoesNotRegenerateValueFromCallbackOnHit() {
 		$pool = new InMemory();
 
-		$pool->get('foo', function() { return 1; });
-		$result = $pool->get('foo', function() { return 2; });
+		$pool->get('foo', function() {
+			return 1;
+		});
+		$result = $pool->get('foo', function() {
+			return 2;
+		});
 		$this->assertEquals(1, $result);
 	}
-	
+
 	public function testGetRegeneratesValueFromCallbackOnMiss() {
 		$pool = new InMemory();
-		
-		$result = $pool->get('foo', function() { return 1; });
+
+		$result = $pool->get('foo', function() {
+			return 1;
+		});
 		$this->assertEquals(1, $result);
 	}
-	
+
 	public function testInvalidateForcesTheSpecifiedValueToBeRegenerated() {
 		$pool = new InMemory();
 
-		$result = $pool->get('foo', function() { return 1; });
+		$result = $pool->get('foo', function() {
+			return 1;
+		});
 		$this->assertEquals(1, $result);
 		$pool->invalidate('foo');
 
-		$result = $pool->get('foo', function() { return 2; });
+		$result = $pool->get('foo', function() {
+			return 2;
+		});
 		$this->assertEquals(2, $result);
 	}
 
 	public function testPutOverridesGetCallback() {
 		$pool = new InMemory();
 
-		$result = $pool->get('foo', function() { return 1; });
+		$result = $pool->get('foo', function() {
+			return 1;
+		});
 		$this->assertEquals(1, $result);
 
 		$pool->put('foo', 2);
 
-		$result = $pool->get('foo', function() { return 3; });
+		$result = $pool->get('foo', function() {
+			return 3;
+		});
 		$this->assertEquals(2, $result);
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/Cache/Pool/NoopTest.php
+++ b/engine/tests/phpunit/Elgg/Cache/Pool/NoopTest.php
@@ -1,22 +1,28 @@
 <?php
+
 namespace Elgg\Cache\Pool;
 
-class NoopTest extends \PHPUnit_Framework_TestCase implements TestCase {
+class NoopTest extends \Elgg\TestCase implements TestCase {
+
 	public function testGetDoesNotRegenerateValueFromCallbackOnHit() {
 		// Noop never hits, so nothing to test here
 		$this->assertTrue(true);
 	}
-	
+
 	public function testGetRegeneratesValueFromCallbackOnMiss() {
 		$pool = new Noop();
-		
-		$result = $pool->get('foo', function() { return 1; });
+
+		$result = $pool->get('foo', function() {
+			return 1;
+		});
 		$this->assertEquals(1, $result);
-		
-		$result = $pool->get('foo', function() { return 2; });
+
+		$result = $pool->get('foo', function() {
+			return 2;
+		});
 		$this->assertEquals(2, $result);
 	}
-	
+
 	public function testInvalidateForcesTheSpecifiedValueToBeRegenerated() {
 		// All values are always regenerated. Nothing to test here...
 		$this->assertTrue(true);
@@ -26,14 +32,14 @@ class NoopTest extends \PHPUnit_Framework_TestCase implements TestCase {
 		$pool = new Noop();
 		$increment = function() {
 			static $counter;
-			
+
 			if (!isset($counter)) {
 				$counter = 0;
 			}
-			
+
 			return $counter++;
 		};
-		
+
 		$this->assertEquals(0, $pool->get('foo', $increment));
 		$this->assertEquals(1, $pool->get('foo', $increment));
 		$pool->put('foo', 4);
@@ -41,5 +47,5 @@ class NoopTest extends \PHPUnit_Framework_TestCase implements TestCase {
 		$pool->invalidate('foo');
 		$this->assertEquals(3, $pool->get('foo', $increment));
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/Cache/Pool/StashWrapperTest.php
+++ b/engine/tests/phpunit/Elgg/Cache/Pool/StashWrapperTest.php
@@ -1,33 +1,42 @@
 <?php
+
 namespace Elgg\Cache\Pool;
 
-use Stash;
-
-class StashWrapperTest extends \PHPUnit_Framework_TestCase implements TestCase {
+class StashWrapperTest extends \Elgg\TestCase implements \Elgg\Cache\Pool\TestCase {
 
 	public function testGetDoesNotRegenerateValueFromCallbackOnHit() {
 		$pool = StashWrapper::createEphemeral();
 
-		$pool->get('foo', function() { return 1; });
-		$result = $pool->get('foo', function() { return 2; });
+		$pool->get('foo', function() {
+			return 1;
+		});
+		$result = $pool->get('foo', function() {
+			return 2;
+		});
 		$this->assertEquals(1, $result);
 	}
-	
+
 	public function testGetRegeneratesValueFromCallbackOnMiss() {
 		$pool = StashWrapper::createEphemeral();
-		
-		$result = $pool->get('foo', function() { return 1; });
+
+		$result = $pool->get('foo', function() {
+			return 1;
+		});
 		$this->assertEquals(1, $result);
 	}
-	
+
 	public function testInvalidateForcesTheSpecifiedValueToBeRegenerated() {
 		$pool = StashWrapper::createEphemeral();
 
-		$result = $pool->get('foo', function() { return 1; });
+		$result = $pool->get('foo', function() {
+			return 1;
+		});
 		$this->assertEquals(1, $result);
 		$pool->invalidate('foo');
 
-		$result = $pool->get('foo', function() { return 2; });
+		$result = $pool->get('foo', function() {
+			return 2;
+		});
 		$this->assertEquals(2, $result);
 	}
 
@@ -36,7 +45,9 @@ class StashWrapperTest extends \PHPUnit_Framework_TestCase implements TestCase {
 
 		foreach (array('123', 123) as $key) {
 			$pool->put($key, 'foo');
-			$pool->get($key, function () { return 'foo'; });
+			$pool->get($key, function () {
+				return 'foo';
+			});
 			$pool->invalidate($key);
 		}
 	}
@@ -56,7 +67,9 @@ class StashWrapperTest extends \PHPUnit_Framework_TestCase implements TestCase {
 	public function testGetComplainsAboutInvalidKeys($key) {
 		$pool = StashWrapper::createEphemeral();
 		$this->setExpectedException('PHPUnit_Framework_Error_Warning', 'assert');
-		$pool->get($key, function () { return 'foo'; });
+		$pool->get($key, function () {
+			return 'foo';
+		});
 	}
 
 	/**
@@ -94,4 +107,5 @@ class StashWrapperTest extends \PHPUnit_Framework_TestCase implements TestCase {
 		$pool = StashWrapper::createEphemeral();
 		$this->markTestIncomplete();
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/Cache/Pool/TestCase.php
+++ b/engine/tests/phpunit/Elgg/Cache/Pool/TestCase.php
@@ -1,10 +1,12 @@
 <?php
+
 namespace Elgg\Cache\Pool;
 
 interface TestCase {
+
 	public function testGetDoesNotRegenerateValueFromCallbackOnHit();
 
 	public function testGetRegeneratesValueFromCallbackOnMiss();
-	
+
 	public function testInvalidateForcesTheSpecifiedValueToBeRegenerated();
 }

--- a/engine/tests/phpunit/Elgg/Cache/SimpleCacheTest.php
+++ b/engine/tests/phpunit/Elgg/Cache/SimpleCacheTest.php
@@ -1,38 +1,41 @@
 <?php
+
 namespace Elgg\Cache;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use \Elgg\TestCase as TestCase;
 
 class SimpleCacheTest extends TestCase {
+
 	public function testGetUrlHandlesSingleArgument() {
 		$this->markTestIncomplete();
 		$simpleCache = new SimpleCache();
-		
+
 		$view = 'view.js';
 		$url = $simpleCache->getUrl($view);
-		
+
 		$this->assertTrue(preg_match("#default/view.js#", $url));
 	}
-	
+
 	public function testGetUrlHandlesTwoArguments() {
 		$this->markTestIncomplete();
 		$simpleCache = new SimpleCache();
-		
+
 		$url = $simpleCache->getUrl('js', 'view.js');
-		
+
 		$this->assertTrue(preg_match("#default/view.js$#", $url));
 	}
-	
+
 	public function testGetUrlHandlesTwoArgumentsWhereSecondArgHasRedundantPrefix() {
 		$this->markTestIncomplete();
 		$simpleCache = new SimpleCache();
-		
+
 		$url = $simpleCache->getUrl('js', 'js/view.js');
-		
+
 		$this->assertTrue(preg_match("#default/view.js$#", $url));
 	}
-	
+
 	public function testRespectsViewAliases() {
 		$this->markTestIncomplete();
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/CommitMessageGitHookTest.php
+++ b/engine/tests/phpunit/Elgg/CommitMessageGitHookTest.php
@@ -1,10 +1,12 @@
 <?php
+
 namespace Elgg;
 
 /**
  * Tests the commit message validation shell script used by the git hook and travis
  */
-class CommitMessageGitHookTest extends \PHPUnit_Framework_TestCase {
+class CommitMessageGitHookTest extends \Elgg\TestCase {
+
 	protected $scriptsDir;
 	protected $filesDir;
 	protected $validateScript;
@@ -20,7 +22,7 @@ class CommitMessageGitHookTest extends \PHPUnit_Framework_TestCase {
 
 		parent::setUp();
 	}
-	
+
 	/**
 	 * Test failures for missing input
 	 */
@@ -30,13 +32,13 @@ class CommitMessageGitHookTest extends \PHPUnit_Framework_TestCase {
 		$result = $this->runCmd($cmd, $output);
 		$this->assertFalse($result, $output);
 	}
-	
+
 	public function testRejectsEmptyFileInput() {
 		$cmd = "$this->validateScript /dev/null";
 		$result = $this->runCmd($cmd, $output);
 		$this->assertFalse($result, $output);
 	}
-	
+
 	public function testRejectsEmptyPipeInput() {
 		$cmd = "echo '' | $this->validateScript";
 		$result = $this->runCmd($cmd, $output);
@@ -54,7 +56,7 @@ class CommitMessageGitHookTest extends \PHPUnit_Framework_TestCase {
 		$result = $this->runCmd($cmd, $output);
 		$this->assertTrue($result, $output);
 	}
-	
+
 	public function testAcceptsValidPipeInput() {
 		$msg = escapeshellarg(file_get_contents("{$this->filesDir}valid.txt"));
 		$cmd = "echo $msg | $this->validateScript";
@@ -80,12 +82,12 @@ class CommitMessageGitHookTest extends \PHPUnit_Framework_TestCase {
 	 */
 	protected function runCmd($cmd, &$output, array $env = array()) {
 		$descriptorspec = array(
-			0 => array("pipe", "r"),// stdin
-			1 => array("pipe", "w"),// stdout
-			2 => array("pipe", "w"),// stderr
+			0 => array("pipe", "r"), // stdin
+			1 => array("pipe", "w"), // stdout
+			2 => array("pipe", "w"), // stderr
 		);
 		$defaultEnv = array(
-			'PATH' => getenv('PATH'),// we need to copy PATH variable to run php without specifying absolute path
+			'PATH' => getenv('PATH'), // we need to copy PATH variable to run php without specifying absolute path
 		);
 		$env = array_merge($defaultEnv, $env);
 
@@ -99,4 +101,5 @@ class CommitMessageGitHookTest extends \PHPUnit_Framework_TestCase {
 
 		return $exit > 0 ? false : true;
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/CommitMessageTest.php
+++ b/engine/tests/phpunit/Elgg/CommitMessageTest.php
@@ -1,19 +1,21 @@
 <?php
+
 namespace Elgg;
 
 /**
  * Tests the commit message validator
  */
-class CommitMessageTest extends \PHPUnit_Framework_TestCase {
+class CommitMessageTest extends \Elgg\TestCase {
+
 	public function assertInvalidCommitMessages(array $msgs) {
 		$msg = new CommitMessage();
 
 		foreach ($msgs as $text) {
 			$msg->setMsg($text);
 			$this->assertFalse($msg->isValidFormat(), $text);
-		}		
+		}
 	}
-	
+
 	public function testRejectsMessagesWithoutSummary() {
 		$this->assertInvalidCommitMessages(array(
 			'chore(test):',
@@ -21,13 +23,13 @@ class CommitMessageTest extends \PHPUnit_Framework_TestCase {
 			"chore(test):\n",
 		));
 	}
-	
+
 	public function testRejectsMessagesWithoutType() {
 		$this->assertInvalidCommitMessages(array(
 			'A bad commit message',
 		));
 	}
-	
+
 	public function testRejectsMessagesWithoutComponent() {
 		$this->assertInvalidCommitMessages(array(
 			'chore: Summary',
@@ -35,14 +37,14 @@ class CommitMessageTest extends \PHPUnit_Framework_TestCase {
 			'chore(test):Summary',
 		));
 	}
-	
+
 	public function assertIgnoreCommitMessages(array $ignored) {
 		foreach ($ignored as $msg) {
 			$msg = new CommitMessage($msg);
 			$this->assertTrue($msg->shouldIgnore(), $msg);
 		}
 	}
-	
+
 	public function testShouldIgnoreMerges() {
 		$this->assertIgnoreCommitMessages(array(
 			'Merge pull request',
@@ -51,7 +53,7 @@ class CommitMessageTest extends \PHPUnit_Framework_TestCase {
 			'Merge release 1.8.18 into master.',
 		));
 	}
-	
+
 	public function testShouldIgnoreReverts() {
 		$this->assertIgnoreCommitMessages(array(
 			'Revert "fix(amd): removed elgg_require_js for backwards compatibility"
@@ -59,13 +61,13 @@ class CommitMessageTest extends \PHPUnit_Framework_TestCase {
 			This reverts commit 76584089bee2b3246c736edb6b250e149acf906f.
 
 			Conflicts:
-				engine/lib/views.php'		
+				engine/lib/views.php'
 		));
 	}
 
 	public function testCanParseMessagesWithoutBody() {
 		$text = "chore(test): Summary";
-		
+
 		$msg = new CommitMessage($text);
 
 		$this->assertTrue($msg->isValidFormat());
@@ -131,7 +133,7 @@ ___TEXT;
 	}
 
 	public function testGetLengthyLinesFindsLinesOverTheMaxLineLength() {
-		$text =<<<___MSG
+		$text = <<<___MSG
 chore(test): But with long line
 
 The long line is down here. This line is much longer than the other.
@@ -164,4 +166,5 @@ ___TEXT;
 		$expected = "These are lines of text\nAnd more text";
 		$this->assertSame($expected, CommitMessage::removeComments($text));
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/ContextTest.php
+++ b/engine/tests/phpunit/Elgg/ContextTest.php
@@ -1,63 +1,65 @@
 <?php
+
 namespace Elgg;
 
-class ContextTest extends \PHPUnit_Framework_TestCase {
+class ContextTest extends \Elgg\TestCase {
+
 	public function testPeekAndPopReturnNullByDefault() {
 		$context = new Context();
-		
+
 		$this->assertNull($context->peek());
 		$this->assertNull($context->pop());
-		
+
 		// TODO: remove once global state is fully deprecated (2.0)
 		_elgg_services()->setValue('context', new Context());
-		
+
 		$this->assertNull(elgg_get_context());
 		$this->assertNull(elgg_pop_context());
 	}
-	
+
 	public function testPopReturnsAndRemovesTheMostRecentlyPushedContext() {
 		$context = new Context();
 
 		$context->push('foo');
 		$context->push('bar');
-		
+
 		$this->assertEquals('bar', $context->pop());
 		$this->assertEquals('foo', $context->pop());
-		
+
 		// TODO: remove once global state is fully deprecated (2.0)
 		_elgg_services()->setValue('context', new Context());
 
 		elgg_push_context('foo');
 		elgg_push_context('bar');
-		
+
 		$this->assertEquals('bar', elgg_pop_context());
 		$this->assertEquals('foo', elgg_pop_context());
 	}
-	
+
 	public function testSetReplacesTheMostRecentlyPushedContext() {
 		$context = new Context();
-		
+
 		$context->push('foo');
 		$context->set('bar');
-		
+
 		$this->assertNotTrue($context->contains('foo'));
 		$this->assertEquals('bar', $context->pop());
 		$this->assertNotEquals('foo', $context->pop());
-		
+
 		// TODO: remove once global state is fully deprecated (2.0)
 		_elgg_services()->setValue('context', new Context());
 
 		elgg_push_context('foo');
 		elgg_set_context('bar');
-		
+
 		$this->assertNotTrue(elgg_in_context('foo'));
 		$this->assertEquals('bar', elgg_pop_context());
 		$this->assertNotEquals('foo', elgg_pop_context());
 	}
-	
+
 	public function testPeekReturnsTheMostRecentlyPushedContext() {
 		$context = new Context();
-		
+
 		$context->push('foo');
 		$this->assertEquals('foo', $context->peek());
 		$context->push('bar');
@@ -67,7 +69,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase {
 
 		// TODO: remove once global state is fully deprecated (2.0)
 		_elgg_services()->setValue('context', new Context());
-		
+
 		elgg_push_context('foo');
 		$this->assertEquals('foo', elgg_get_context());
 		elgg_push_context('bar');
@@ -75,35 +77,35 @@ class ContextTest extends \PHPUnit_Framework_TestCase {
 		elgg_pop_context();
 		$this->assertEquals('foo', elgg_get_context());
 	}
-	
+
 	public function testContainsTellsYouIfAGivenContextIsInTheCurrentStack() {
 		$context = new Context();
-		
+
 		$context->push('foo');
 		$context->push('bar');
 		$context->push('baz');
-		
+
 		$this->assertTrue($context->contains('foo'));
 		$this->assertTrue($context->contains('bar'));
 		$this->assertTrue($context->contains('baz'));
-		
+
 		$popped = $context->pop();
-		
+
 		$this->assertFalse($context->contains($popped));
 
 		// TODO: remove once global state is fully deprecated (2.0)
 		_elgg_services()->setValue('context', new Context());
-		
+
 		elgg_push_context('foo');
 		elgg_push_context('bar');
 		elgg_push_context('baz');
-		
+
 		$this->assertTrue(elgg_in_context('foo'));
 		$this->assertTrue(elgg_in_context('bar'));
 		$this->assertTrue(elgg_in_context('baz'));
-		
+
 		$popped = elgg_pop_context();
-		
+
 		$this->assertFalse(elgg_in_context($popped));
 	}
 
@@ -160,4 +162,5 @@ class ContextTest extends \PHPUnit_Framework_TestCase {
 		$context->push("HELLO");
 		$this->assertEquals("HELLO", $context->peek());
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/Database/ConfigTest.php
+++ b/engine/tests/phpunit/Elgg/Database/ConfigTest.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Elgg\Database;
 
-
-class ConfigTest extends \PHPUnit_Framework_TestCase {
+class ConfigTest extends \Elgg\TestCase {
 
 	public function testGetTablePrefix() {
 		$CONFIG = new \stdClass();
@@ -136,5 +136,5 @@ class ConfigTest extends \PHPUnit_Framework_TestCase {
 		$connConf = $conf->getConnectionConfig(\Elgg\Database\Config::READ);
 		$this->assertEquals($ans[$connConf['host']], $connConf);
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/Database/MetastringsTest.php
+++ b/engine/tests/phpunit/Elgg/Database/MetastringsTest.php
@@ -1,22 +1,20 @@
 <?php
+
 namespace Elgg\Database;
 
-class MetastringsTest extends \PHPUnit_Framework_TestCase {
+class MetastringsTest extends \Elgg\TestCase {
 
 	/**
 	 * Check that in both case sensitive and case insensitive you are always getting an ID
 	 */
 	public function testMetastringIsAlwaysAddedWhenGettingItsID() {
-		
+
 		// test case sensitive (should return id)
 		//$this->assertNotEmpty(elgg_get_metastring_id(time() . "_a", true));
-		
 		//test case insensitive (should return array with ids)
 		//$this->assertNotEmpty(elgg_get_metastring_id(time() . "_b", false));
-		
 		// marked as incomplete as there is no way to clean up the just created metastring ids
 		$this->markTestIncomplete();
-		
 	}
 
 }

--- a/engine/tests/phpunit/Elgg/Database/MutexTest.php
+++ b/engine/tests/phpunit/Elgg/Database/MutexTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Elgg\Database;
 
-class MutexTest extends \PHPUnit_Framework_TestCase {
+class MutexTest extends \Elgg\TestCase {
 
 	public function testMutexLocksIfNotAlreadyLocked() {
 		$this->markTestIncomplete();
@@ -14,4 +15,5 @@ class MutexTest extends \PHPUnit_Framework_TestCase {
 	public function testUnlockingFailsIfWrongNamespace() {
 		$this->markTestIncomplete();
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/Database/Plugins.php
+++ b/engine/tests/phpunit/Elgg/Database/Plugins.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Elgg\Database;
 
-class PluginsTest extends \PHPUnit_Framework_TestCase {
+class PluginsTest extends \Elgg\TestCase {
 
 	/**
 	 * Check that plugins service is able to handle plugin user settings
@@ -9,16 +10,17 @@ class PluginsTest extends \PHPUnit_Framework_TestCase {
 	public function testSetGetAndUnsetUserSetting() {
 		// TODO Use these once the class becomes testable:
 		/*
-		$plugins = new \Elgg\Database\Plugins();
-		$user_guid = 123;
+		  $plugins = new \Elgg\Database\Plugins();
+		  $user_guid = 123;
 
-		$plugins->setUserSetting('foo', 'bar', $user_guid, 'plugin_id');
-		$this->assertSame('bar', $plugins->getUserSetting('foo', $user_guid, 'plugin_id'));
+		  $plugins->setUserSetting('foo', 'bar', $user_guid, 'plugin_id');
+		  $this->assertSame('bar', $plugins->getUserSetting('foo', $user_guid, 'plugin_id'));
 
-		$plugins->unsetUserSetting('foo', $user_guid, 'plugin_id');
-		$this->assertSame(null, $plugins->getUserSetting('foo', $user_guid, 'plugin_id'));
-		*/
+		  $plugins->unsetUserSetting('foo', $user_guid, 'plugin_id');
+		  $this->assertSame(null, $plugins->getUserSetting('foo', $user_guid, 'plugin_id'));
+		 */
 
 		$this->markTestIncomplete();
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/Database/PluginsTest.php
+++ b/engine/tests/phpunit/Elgg/Database/PluginsTest.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Elgg\Database;
 
-
-class PluginsTest extends \PHPUnit_Framework_TestCase {
+class PluginsTest extends \Elgg\TestCase {
 
 	public function testAfterPluginLoadActiveCheckIsFree() {
 		$this->markTestIncomplete();
@@ -15,4 +15,5 @@ class PluginsTest extends \PHPUnit_Framework_TestCase {
 	public function testPluginDeactivateAltersIsActive() {
 		$this->markTestIncomplete();
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/Database/RelationshipsTest.php
+++ b/engine/tests/phpunit/Elgg/Database/RelationshipsTest.php
@@ -1,30 +1,30 @@
 <?php
+
 namespace Elgg\Database;
 
-class RelationshipsTest extends \PHPUnit_Framework_TestCase {
+class RelationshipsTest extends \Elgg\TestCase {
 
 	private $guids;
-	
+
 	/**
 	 * Create the entities used for each test
 	 */
 	protected function setUp() {
 		$this->markTestSkipped("Skipped test as Elgg can not yet run PHP Unit tests that interact with the database");
-		
+
 		$this->guids = array();
-		
+
 		$obj1 = new \ElggObject();
 		$obj1->save();
-		
+
 		$this->guids[] = $obj1->guid;
-		
+
 		$obj2 = new \ElggObject();
 		$obj2->save();
-		
+
 		$this->guids[] = $obj2->guid;
-		
 	}
-	
+
 	/**
 	 * Remove the entities that are created for each test
 	 */
@@ -34,42 +34,42 @@ class RelationshipsTest extends \PHPUnit_Framework_TestCase {
 			$e->delete();
 		}
 	}
-	
+
 	/**
 	 * Check that you can get entities by filtering them on relationship time created lower
 	 */
 	public function testGetEntitiesFromRelationshipFilterByTimeCreatedLower() {
-		
+
 		// get a timestamp before creating the relationship
 		$ts_lower = time() - 1;
-		
+
 		add_entity_relationship($this->guids[0], 'testGetEntitiesFromRelationship', $this->guids[1]);
-		
+
 		// get a timestamp after creating the relationship
 		$ts_upper = time() + 1;
-		
+
 		// check that if ts_lower is before the relationship you get the just created entity
 		$options = array(
 			'relationship' => 'testGetEntitiesFromRelationship',
 			'relationship_guid' => $this->guids[0],
 			'relationship_created_time_lower' => $ts_lower
 		);
-		
+
 		$es = elgg_get_entities_from_relationship($options);
 		$this->assertTrue(is_array($es));
 		$this->assertIdentical(count($es), 1);
-		
+
 		foreach ($es as $e) {
 			$this->assertEqual($this->guids[1], $e->guid);
-		}	
-		
+		}
+
 		// check that if ts_lower is after the relationship you get no entities
 		$options = array(
 			'relationship' => 'testGetEntitiesFromRelationship',
 			'relationship_guid' => $this->guids[0],
 			'relationship_created_time_lower' => $ts_upper
 		);
-		
+
 		$es = elgg_get_entities_from_relationship($options);
 		$this->assertTrue(is_array($es));
 		$this->assertIdentical(count($es), 0);
@@ -82,34 +82,34 @@ class RelationshipsTest extends \PHPUnit_Framework_TestCase {
 
 		// get a timestamp before creating the relationship
 		$ts_lower = time() - 1;
-		
+
 		add_entity_relationship($this->guids[0], 'testGetEntitiesFromRelationship', $this->guids[1]);
-		
+
 		// get a timestamp after creating the relationship
 		$ts_upper = time() + 1;
-		
+
 		// check that if ts_upper is after the relationship you get the just created entity
 		$options = array(
 			'relationship' => 'testGetEntitiesFromRelationship',
 			'relationship_guid' => $this->guids[0],
 			'relationship_created_time_upper' => $ts_upper
 		);
-		
+
 		$es = elgg_get_entities_from_relationship($options);
 		$this->assertTrue(is_array($es));
 		$this->assertIdentical(count($es), 1);
-		
+
 		foreach ($es as $e) {
 			$this->assertEqual($this->guids[1], $e->guid);
 		}
-		
+
 		// check that if ts_upper is before the relationship you get no entities
 		$options = array(
 			'relationship' => 'testGetEntitiesFromRelationship',
 			'relationship_guid' => $this->guids[0],
 			'relationship_created_time_upper' => $ts_lower
 		);
-		
+
 		$es = elgg_get_entities_from_relationship($options);
 		$this->assertTrue(is_array($es));
 		$this->assertIdentical(count($es), 0);
@@ -122,12 +122,12 @@ class RelationshipsTest extends \PHPUnit_Framework_TestCase {
 
 		// get a timestamp before creating the relationship
 		$ts_lower = time() - 1;
-		
+
 		add_entity_relationship($this->guids[0], 'testGetEntitiesFromRelationship', $this->guids[1]);
-		
+
 		// get a timestamp after creating the relationship
 		$ts_upper = time() + 1;
-		
+
 		// check that if relationship time created is between lower and upper you get the just created entity
 		$options = array(
 			'relationship' => 'testGetEntitiesFromRelationship',
@@ -135,15 +135,15 @@ class RelationshipsTest extends \PHPUnit_Framework_TestCase {
 			'relationship_created_time_lower' => $ts_lower,
 			'relationship_created_time_upper' => $ts_upper
 		);
-		
+
 		$es = elgg_get_entities_from_relationship($options);
 		$this->assertTrue(is_array($es));
 		$this->assertIdentical(count($es), 1);
-		
+
 		foreach ($es as $e) {
 			$this->assertEqual($this->guids[1], $e->guid);
 		}
-		
+
 		// check that if  ts_lower > ts_upper you get no entities
 		$options = array(
 			'relationship' => 'testGetEntitiesFromRelationship',
@@ -151,7 +151,7 @@ class RelationshipsTest extends \PHPUnit_Framework_TestCase {
 			'relationship_created_time_lower' => $ts_upper,
 			'relationship_created_time_upper' => $ts_lower
 		);
-		
+
 		$es = elgg_get_entities_from_relationship($options);
 		$this->assertTrue(is_array($es));
 		$this->assertIdentical(count($es), 0);

--- a/engine/tests/phpunit/Elgg/DatabaseTest.php
+++ b/engine/tests/phpunit/Elgg/DatabaseTest.php
@@ -1,15 +1,15 @@
 <?php
 
-class Elgg_DatabaseTest extends PHPUnit_Framework_TestCase {
-	
+class Elgg_DatabaseTest extends \Elgg\TestCase {
+
 	/**
 	 * @dataProvider scriptsWithOneStatement
 	 */
 	public function test_runSqlScript_withOneStatement($script) {
 		$db = $this->getDbMock();
 		$db->expects($this->exactly(1))
-			->method('updateData')
-			->with($this->matchesRegularExpression("/^INSERT INTO test_sometable \(`key`\)\sVALUES \('Value(?: -- not a comment)?'\)$/"));
+				->method('updateData')
+				->with($this->matchesRegularExpression("/^INSERT INTO test_sometable \(`key`\)\sVALUES \('Value(?: -- not a comment)?'\)$/"));
 		$db->runSqlScript($this->getFixture($script));
 	}
 
@@ -20,7 +20,7 @@ class Elgg_DatabaseTest extends PHPUnit_Framework_TestCase {
 			array('one_statement_with_comments.sql'),
 		);
 	}
-	
+
 	/**
 	 * @dataProvider scriptsWithMultipleStatements
 	 * @todo Use @see withConsecutive() to test consecutive method calls after upgrading to PHPUnit 4.
@@ -38,7 +38,7 @@ class Elgg_DatabaseTest extends PHPUnit_Framework_TestCase {
 		$this->expectExecutedStatement($db2, 2, $this->matches("INSERT INTO test_sometable (`key`) VALUES ('Value 3')"));
 		$db2->runSqlScript($this->getFixture($script));
 	}
-	
+
 	public function scriptsWithMultipleStatements() {
 		return array(
 			array('multiple_statements.sql'),
@@ -78,38 +78,39 @@ class Elgg_DatabaseTest extends PHPUnit_Framework_TestCase {
 
 	private function getFixture($filename) {
 		return dirname(__FILE__) .
-			DIRECTORY_SEPARATOR . '..' .
-			DIRECTORY_SEPARATOR . 'test_files' .
-			DIRECTORY_SEPARATOR . 'sql' .
-			DIRECTORY_SEPARATOR . $filename;
+				DIRECTORY_SEPARATOR . '..' .
+				DIRECTORY_SEPARATOR . 'test_files' .
+				DIRECTORY_SEPARATOR . 'sql' .
+				DIRECTORY_SEPARATOR . $filename;
 	}
-	
+
 	/**
 	 * @return \Elgg\Database|PHPUnit_Framework_MockObject_MockObject
 	 */
-	private function getDbMock()
-	{
+	private function getDbMock() {
 		return $this->getMock(
-			\Elgg\Database::class,
-			array('updateData'),
-			array(
-				 new \Elgg\Database\Config((object) array('dbprefix' => 'test_')),
-				_elgg_services()->logger
-			)
+						\Elgg\Database::class, array('updateData'), array(
+					new \Elgg\Database\Config((object) array('dbprefix' => 'test_')),
+					_elgg_services()->logger
+						)
 		);
 	}
-		
+
 	/**
 	 * @param PHPUnit_Framework_MockObject_MockObject $db
 	 * @param int $index
 	 * @param PHPUnit_Framework_MockObject_Matcher $matcher
 	 */
-	private function expectExecutedStatement($db, $index, $matcher)
-	{
+	private function expectExecutedStatement($db, $index, $matcher) {
 		$db->expects($this->at($index))->method('updateData')->with($matcher);
 	}
+
 }
 
 class Elgg_DatabaseTestObj {
-    public function __invoke() {}
+
+	public function __invoke() {
+		
+	}
+
 }

--- a/engine/tests/phpunit/Elgg/DeprecationWrapperTest.php
+++ b/engine/tests/phpunit/Elgg/DeprecationWrapperTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Elgg;
 
-class DeprecationWrapperTest extends \PHPUnit_Framework_TestCase {
+class DeprecationWrapperTest extends \Elgg\TestCase {
 
 	public $last_stack_line = '';
 
@@ -93,17 +94,27 @@ class DeprecationWrapperTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals('value', $obj->{'0'});
 		$this->assertEquals("$file:$line", $this->last_stack_line);
 	}
+
 }
 
 class DeprecationWrapperTestObj1 {
+
 	public $foo = 'foo';
-	public function foo() { return 'foo'; }
-	public function __toString() { return 'foo'; }
+
+	public function foo() {
+		return 'foo';
+	}
+
+	public function __toString() {
+		return 'foo';
+	}
+
 }
 
-
 class DeprecationWrapperTestObj2 extends \ArrayObject {
+
 	public $data = array();
+
 	public function offsetSet($offset, $value) {
 		if (is_null($offset)) {
 			$this->data[] = $value;
@@ -111,14 +122,17 @@ class DeprecationWrapperTestObj2 extends \ArrayObject {
 			$this->data[$offset] = $value;
 		}
 	}
+
 	public function offsetExists($offset) {
 		return array_key_exists($offset, $this->data);
 	}
+
 	public function offsetUnset($offset) {
 		unset($this->data[$offset]);
 	}
+
 	public function offsetGet($offset) {
 		return isset($this->data[$offset]) ? $this->data[$offset] : null;
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/Di/DiContainerTest.php
+++ b/engine/tests/phpunit/Elgg/Di/DiContainerTest.php
@@ -1,9 +1,8 @@
 <?php
-namespace Elgg\Di;
 
 namespace Elgg\Di;
 
-class DiContainerTest extends \PHPUnit_Framework_TestCase {
+class DiContainerTest extends \Elgg\TestCase {
 
 	const TEST_CLASS = '\Elgg\Di\DiContainerTestObject';
 
@@ -66,8 +65,7 @@ class DiContainerTest extends \PHPUnit_Framework_TestCase {
 		$di->setFactory('foo', 'not-a-real-callable');
 
 		$this->setExpectedException(
-			'\Elgg\Di\FactoryUncallableException',
-			"Factory for 'foo' was uncallable: 'not-a-real-callable'");
+				'\Elgg\Di\FactoryUncallableException', "Factory for 'foo' was uncallable: 'not-a-real-callable'");
 		$di->foo;
 	}
 
@@ -76,8 +74,7 @@ class DiContainerTest extends \PHPUnit_Framework_TestCase {
 		$di->setFactory('foo', array('fakeClass', 'not-a-real-callable'));
 
 		$this->setExpectedException(
-			'\Elgg\Di\FactoryUncallableException',
-			"Factory for 'foo' was uncallable: 'fakeClass::not-a-real-callable'");
+				'\Elgg\Di\FactoryUncallableException', "Factory for 'foo' was uncallable: 'fakeClass::not-a-real-callable'");
 		$di->foo;
 	}
 
@@ -86,8 +83,7 @@ class DiContainerTest extends \PHPUnit_Framework_TestCase {
 		$di->setFactory('foo', array($this, 'not-a-real-callable'));
 
 		$this->setExpectedException(
-			'\Elgg\Di\FactoryUncallableException',
-			"Factory for 'foo' was uncallable: Elgg\\Di\\DiContainerTest->not-a-real-callable");
+				'\Elgg\Di\FactoryUncallableException', "Factory for 'foo' was uncallable: Elgg\\Di\\DiContainerTest->not-a-real-callable");
 		$di->foo;
 	}
 
@@ -105,26 +101,26 @@ class DiContainerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertSame($di, $di->remove('foo'));
 		$this->assertFalse($di->has('foo'));
 	}
-	
+
 	public function testSetClassNames() {
 		$di = new \Elgg\Di\DiContainer();
 		$di->setClassName('foo', self::TEST_CLASS);
 
 		$this->assertInstanceOf(self::TEST_CLASS, $di->foo);
-		
+
 		$this->setExpectedException('InvalidArgumentException', 'Class names must be valid PHP class names');
 		$di->setClassName('foo', array());
 	}
-	
+
 	public function testSettingInvalidClassNameThrows() {
 		$di = new \Elgg\Di\DiContainer();
-		
+
 		$euro = "\xE2\x82\xAC";
-		
+
 		$di->setClassName('foo1', "Foo2{$euro}3");
 		$di->setClassName('foo2', "\\Foo2{$euro}3");
 		$di->setClassName('foo3', "Foo2{$euro}3\\Foo2{$euro}3");
-		
+
 		$this->setExpectedException('InvalidArgumentException', 'Class names must be valid PHP class names');
 		$di->setClassName('foo', 'Not Valid');
 	}
@@ -144,32 +140,44 @@ class DiContainerTest extends \PHPUnit_Framework_TestCase {
 		try {
 			$di->setValue('foo_', 'foo');
 			$this->fail('setValue did not throw');
-		} catch (\InvalidArgumentException $e) {}
+		} catch (\InvalidArgumentException $e) {
+
+		}
 
 		$this->assertFalse($di->has('foo_'));
 
 		try {
-			$di->setFactory('foo_', function () {});
+			$di->setFactory('foo_', function () {
+
+			});
 			$this->fail('setFactory did not throw');
-		} catch (\InvalidArgumentException $e) {}
+		} catch (\InvalidArgumentException $e) {
+
+		}
 
 		try {
 			$di->remove('foo_');
 			$this->fail('remove did not throw');
-		} catch (\InvalidArgumentException $e) {}
+		} catch (\InvalidArgumentException $e) {
+
+		}
 
 		try {
 			$di->_foo;
 			$this->fail('->_foo did not throw');
-		} catch (MissingValueException $e) {}
+		} catch (MissingValueException $e) {
+
+		}
 	}
+
 }
 
-
 class DiContainerTestObject {
+
 	public $di;
+
 	public function __construct($di = null) {
 		$this->di = $di;
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
+++ b/engine/tests/phpunit/Elgg/Di/ServiceProviderTest.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elgg\Di;
 
 use phpDocumentor\Reflection\DocBlock;
 use Zend\Mail\Transport\InMemory;
 
-class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
+class ServiceProviderTest extends \Elgg\TestCase {
 
 	public function setUp() {
 		$sp = _elgg_services();
@@ -22,7 +23,7 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
 		];
 
 		$skipped_names = [
-			//'service' => 'reason can't be loaded in phpunit',
+				//'service' => 'reason can't be loaded in phpunit',
 		];
 
 		if (isset($skipped_names[$name])) {
@@ -78,4 +79,5 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
 
 		return $sets;
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/EntityDirLocatorTest.php
+++ b/engine/tests/phpunit/Elgg/EntityDirLocatorTest.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace Elgg;
 
+class EntityDirLocatorTest extends \Elgg\TestCase {
 
-class EntityDirLocatorTest extends \PHPUnit_Framework_TestCase {
 	public $guids = array(
 		1,
 		4999,

--- a/engine/tests/phpunit/Elgg/EntityIconServiceTest.php
+++ b/engine/tests/phpunit/Elgg/EntityIconServiceTest.php
@@ -2,7 +2,7 @@
 
 namespace Elgg;
 
-class EntityIconServiceTest extends \PHPUnit_Framework_TestCase {
+class EntityIconServiceTest extends \Elgg\TestCase {
 
 	/**
 	 * @var \Elgg\Config
@@ -60,7 +60,7 @@ class EntityIconServiceTest extends \PHPUnit_Framework_TestCase {
 
 		$this->mocks = new \Elgg\Tests\EntityMocks($this);
 
-		$this->config = _elgg_testing_config();
+		$this->config = $this->config();
 		$this->hooks = new \Elgg\PluginHooksService();
 		$path_key = \Elgg\Application::GET_PATH_KEY;
 		$this->request = \Elgg\Http\Request::create("?$path_key=action/upload");
@@ -884,11 +884,11 @@ class EntityIconServiceTest extends \PHPUnit_Framework_TestCase {
 			[75, 125, 'small', 40, 40, true],
 			[75, 125, 'tiny', 25, 25, true],
 			[75, 125, 'topbar', 16, 16, true],
-			// there is a problem in get_resized_image_from_existing_file()
-			// we expect the large icon to fill the container when in cropping mode
-			// however since the icon is set to not upscale, we end up with a 20x20 image
-			// See #9663
-			//[75, 125, 'large', 75, 125, true, 200, 200],
+				// there is a problem in get_resized_image_from_existing_file()
+				// we expect the large icon to fill the container when in cropping mode
+				// however since the icon is set to not upscale, we end up with a 20x20 image
+				// See #9663
+				//[75, 125, 'large', 75, 125, true, 200, 200],
 		];
 	}
 

--- a/engine/tests/phpunit/Elgg/EntityPreloaderTest.php
+++ b/engine/tests/phpunit/Elgg/EntityPreloaderTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Elgg;
 
-class EntityPreloaderTest extends \PHPUnit_Framework_TestCase {
+class EntityPreloaderTest extends \Elgg\TestCase {
 
 	/**
 	 * @var \PHPUnit_Framework_MockObject_MockObject
@@ -27,7 +28,7 @@ class EntityPreloaderTest extends \PHPUnit_Framework_TestCase {
 			'foo',
 			array('0', array()),
 			array(
-				(object)array('foo' => 123),
+				(object) array('foo' => 123),
 				array('bar' => 234),
 			),
 		);
@@ -42,35 +43,41 @@ class EntityPreloaderTest extends \PHPUnit_Framework_TestCase {
 		$this->obj->_callable_entity_loader = array($this->mock, 'load');
 		$this->mock->expects($this->once())->method('load')->with(array('guids' => array(234, 345)));
 		$this->obj->preload(array(
-			(object)array('foo' => 23,),
-			(object)array('bar' => 234,),
-			(object)array('bar' => 345,),
-		), array('foo', 'bar'));
+			(object) array('foo' => 23,),
+			(object) array('bar' => 234,),
+			(object) array('bar' => 345,),
+				), array('foo', 'bar'));
 	}
 
 	public function testOnlyLoadsIfMoreThanOne() {
 		$this->obj->_callable_entity_loader = array($this->mock, 'load');
 		$this->mock->expects($this->never())->method('load');
 		$this->obj->preload(array(
-			(object)array('foo' => 23,),
-			(object)array('bar' => 234,),
-		), array('foo', 'bar'));
+			(object) array('foo' => 23,),
+			(object) array('bar' => 234,),
+				), array('foo', 'bar'));
 	}
 
 	public function testQuietlyIgnoresMissingProperty() {
 		$this->obj->_callable_entity_loader = array($this->mock, 'load');
 		$this->mock->expects($this->once())->method('load')->with(array('guids' => array(234, 345)));
 		$this->obj->preload(array(
-			(object)array('foo' => 234),
-			(object)array(),
-			(object)array('bar' => 345)
-		), array('foo', 'bar'));
+			(object) array('foo' => 234),
+			(object) array(),
+			(object) array('bar' => 345)
+				), array('foo', 'bar'));
 	}
+
 }
 
 class PreloaderMock_20140623 {
+
 	function isCached($guid) {
 		return $guid < 100;
 	}
-	function load($opts) {}
+
+	function load($opts) {
+		
+	}
+
 }

--- a/engine/tests/phpunit/Elgg/EventsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/EventsServiceTest.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Elgg;
 
-
-class EventsServiceTest extends \PHPUnit_Framework_TestCase {
+class EventsServiceTest extends \Elgg\TestCase {
 
 	public $counter = 0;
 
@@ -47,7 +47,7 @@ class EventsServiceTest extends \PHPUnit_Framework_TestCase {
 		$events->registerHandler('foo', 'bar', array($this, 'incrementCounter'));
 
 		$this->assertTrue($events->trigger('foo', 'bar', null, array(
-			\Elgg\EventsService::OPTION_STOPPABLE => false
+					\Elgg\EventsService::OPTION_STOPPABLE => false
 		)));
 		$this->assertEquals($this->counter, 1);
 	}
@@ -69,5 +69,5 @@ class EventsServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->counter++;
 		return true;
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/Filesystem/Directory/FlyTest.php
+++ b/engine/tests/phpunit/Elgg/Filesystem/Directory/FlyTest.php
@@ -1,13 +1,15 @@
 <?php
+
 namespace Elgg\Filesystem\Directory;
 
 use Elgg\Filesystem\DirectoryTest;
 
 class FlyTest extends DirectoryTest {
-	
+
 	public function emptyDirectoryProvider() {
 		return [
 			[Fly::createInMemory()],
 		];
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/Filesystem/DirectoryTest.php
+++ b/engine/tests/phpunit/Elgg/Filesystem/DirectoryTest.php
@@ -1,15 +1,16 @@
 <?php
+
 namespace Elgg\Filesystem;
 
-abstract class DirectoryTest extends \PHPUnit_Framework_TestCase {
+abstract class DirectoryTest extends \Elgg\TestCase {
 
-    /**
-     * Returns an array of one-element arrays. Those elements should
-     * be fresh (empty) directory instances that use the relevant implementation.
-     * 
-     * @return array
-     */
-    abstract public function emptyDirectoryProvider();
+	/**
+	 * Returns an array of one-element arrays. Those elements should
+	 * be fresh (empty) directory instances that use the relevant implementation.
+	 * 
+	 * @return array
+	 */
+	abstract public function emptyDirectoryProvider();
 
 	/**
 	 * @dataProvider emptyDirectoryProvider
@@ -26,7 +27,7 @@ abstract class DirectoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(3, count($directory->getDirectories()));
 		$this->assertEquals(1, count($directory->getDirectories('', false)));
 	}
-	
+
 	/**
 	 * @dataProvider emptyDirectoryProvider
 	 */
@@ -45,7 +46,7 @@ abstract class DirectoryTest extends \PHPUnit_Framework_TestCase {
 			$this->assertEquals(2, count($directory->getDirectories($path, false)));
 		}
 	}
-	
+
 	/**
 	 * @dataProvider emptyDirectoryProvider
 	 */
@@ -65,23 +66,31 @@ abstract class DirectoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(1, count($directory->chroot('/foo/bar')->getFiles()));
 		$this->assertEquals(1, count($directory->chroot('foo/bar')->getFiles()));
 	}
-	
+
 	/**
 	 * @dataProvider emptyDirectoryProvider
 	 */
 	public function testCanGetAnyFileInThisDirectoryEvenIfTheFileDoesNotExistYet(Directory $directory) {
 		$this->assertFalse($directory->getFile('foo.php')->exists());
 	}
-	
+
 	/**
 	 * @dataProvider emptyDirectoryProvider
 	 */
 	public function testPathsCannotContainDots(Directory $directory) {
 		$funcs = [
-			function () use ($directory) { $directory->chroot('.'); },
-			function () use ($directory) { $directory->chroot('..'); },
-			function () use ($directory) { $directory->getFile('.'); },
-			function () use ($directory) { $directory->getFile('..'); },
+			function () use ($directory) {
+				$directory->chroot('.');
+			},
+			function () use ($directory) {
+				$directory->chroot('..');
+			},
+			function () use ($directory) {
+				$directory->getFile('.');
+			},
+			function () use ($directory) {
+				$directory->getFile('..');
+			},
 		];
 
 		foreach ($funcs as $i => $f) {
@@ -121,4 +130,5 @@ abstract class DirectoryTest extends \PHPUnit_Framework_TestCase {
 			$this->assertEquals('bang', $dir->getFile('bang.php')->getContents());
 		}
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/Filesystem/FileTest.php
+++ b/engine/tests/phpunit/Elgg/Filesystem/FileTest.php
@@ -1,17 +1,19 @@
 <?php
+
 namespace Elgg\Filesystem;
 
-class FileTest extends \PHPUnit_Framework_TestCase {
-	
+class FileTest extends \Elgg\TestCase {
+
 	public function testCanCheckForItsOwnExistence() {
 		$directory = Directory\InMemory::fromArray([
-			'/foo/bar/bar.php' => 'bar',
+					'/foo/bar/bar.php' => 'bar',
 		]);
-		
+
 		$realfile = new File($directory, '/foo/bar/bar.php');
 		$nonfile = new File($directory, '/foo/baz.php');
 
 		$this->assertTrue($realfile->exists());
 		$this->assertFalse($nonfile->exists());
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/Forms/StickyForms.php
+++ b/engine/tests/phpunit/Elgg/Forms/StickyForms.php
@@ -1,17 +1,17 @@
 <?php
+
 namespace Elgg\Forms;
 
-use PHPUnit_Framework_TestCase as TestCase;
+class StickyFormsTest extends \Elgg\TestCase {
 
-class StickyFormsTest extends TestCase {
 	public function testIsStickyReturnsTrueForFormsMarkedAsSticky() {
 		$this->markTestIncomplete();
 	}
-	
+
 	public function testIsStickyReturnsFalseForClearedStickyForms() {
 		$this->markTestIncomplete();
 	}
-	
+
 	/**
 	 * It's important to test that this information is actually stored in the
 	 * session because that is a meaningful implementation detail that guarantees
@@ -21,4 +21,5 @@ class StickyFormsTest extends TestCase {
 	public function testMakeStickyFormStoresInputsInTheSession() {
 		$this->markTestIncomplete();
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/HooksRegistrationServiceTest.php
+++ b/engine/tests/phpunit/Elgg/HooksRegistrationServiceTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Elgg;
 
-class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
+class HooksRegistrationServiceTest extends \Elgg\TestCase {
 
 	/**
 	 * @var HooksRegistrationService
@@ -13,9 +14,11 @@ class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
 
 		$this->mock = $this->getMockForAbstractClass('\Elgg\HooksRegistrationService');
 	}
-	
+
 	public function testCanRegisterHandlers() {
-		$f = function () {};
+		$f = function () {
+
+		};
 
 		$this->assertTrue($this->mock->registerHandler('foo', 'bar', 'callback1'));
 		$this->assertTrue($this->mock->registerHandler('foo', 'bar', $f));
@@ -37,7 +40,7 @@ class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
 		// check possibly invalid callbacks
 		$this->assertFalse($this->mock->registerHandler('foo', 'bar', 1234));
 	}
-	
+
 	public function testCanUnregisterHandlers() {
 		$o = new HooksRegistrationServiceTest_invokable();
 
@@ -49,19 +52,18 @@ class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->mock->registerHandler('foo', 'bar', [$o, '__invoke'], 300);
 
 		$this->assertTrue($this->mock->unregisterHandler(
-			'foo', 'bar', 'callback2'));
+						'foo', 'bar', 'callback2'));
 		$this->assertTrue($this->mock->unregisterHandler(
-			'foo', 'bar', HooksRegistrationServiceTest_invokable::KLASS . '::__invoke'));
+						'foo', 'bar', HooksRegistrationServiceTest_invokable::KLASS . '::__invoke'));
 		$this->assertTrue($this->mock->unregisterHandler(
-			'foo', 'bar', [HooksRegistrationServiceTest_invokable::KLASS, '__invoke']));
+						'foo', 'bar', [HooksRegistrationServiceTest_invokable::KLASS, '__invoke']));
 		$this->assertTrue($this->mock->unregisterHandler(
-			'foo', 'bar', [$o, '__invoke']));
+						'foo', 'bar', [$o, '__invoke']));
 
 		$expected = [
 			'foo' => [
 				'bar' => [
 					500 => ['callback1'],
-
 					// only one removed
 					150 => ['callback2'],
 				]
@@ -72,7 +74,7 @@ class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
 		// check unregistering things that aren't registered
 		$this->assertFalse($this->mock->unregisterHandler('foo', 'bar', 'not_valid'));
 	}
-	
+
 	public function testCanClearMultipleHandlersAtOnce() {
 		$o = new HooksRegistrationServiceTest_invokable();
 
@@ -80,7 +82,7 @@ class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->mock->registerHandler('foo', 'baz', 'callback1', 10);
 		$this->mock->registerHandler('foo', 'bar', 'callback2', 100);
 		$this->mock->registerHandler('foo', 'bar', 'callback2', 150);
-		
+
 		$expected = [
 			'foo' => [
 				'baz' => [
@@ -90,7 +92,7 @@ class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
 		];
 		// clearHandlers should remove everything registrered for 'foo', 'bar', but not 'foo', 'baz'
 		$this->mock->clearHandlers('foo', 'bar');
-		
+
 		$this->assertSame($expected, $this->mock->getAllHandlers());
 	}
 
@@ -151,9 +153,15 @@ class HooksRegistrationServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->mock->restore();
 		$this->assertEquals($handlers1, $this->mock->getAllHandlers());
 	}
+
 }
 
 class HooksRegistrationServiceTest_invokable {
+
 	const KLASS = __CLASS__;
-	function __invoke() {}
+
+	function __invoke() {
+		
+	}
+
 }

--- a/engine/tests/phpunit/Elgg/Http/InputTest.php
+++ b/engine/tests/phpunit/Elgg/Http/InputTest.php
@@ -1,31 +1,31 @@
 <?php
+
 namespace Elgg\Http;
 
-use PHPUnit_Framework_TestCase as TestCase;
+class InputTest extends \Elgg\TestCase {
 
-class InputTest extends TestCase {
-	
 	public function testGetInputDefaultsToProvidedDefaultValue() {
 		$this->markTestIncomplete();
 	}
-	
+
 	public function testGetInputTriggersValidateInputHookIfAndOnlyIfFilteringIsEnabled() {
 		$this->markTestIncomplete();
 	}
-	
+
 	public function testGetInputCanBeOverriddenBySetInput() {
 		$this->markTestIncomplete();
 	}
-	
+
 	public function testGetInputChecksBothPostAndGetParams() {
 		$this->markTestIncomplete();
 	}
-	
+
 	public function testGetInputPushesInputContextDuringFiltering() {
 		$this->markTestIncomplete();
 	}
-	
+
 	public function testFilterTagsGlobal() {
 		$this->markTestIncomplete();
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/Http/OkResponseTest.php
+++ b/engine/tests/phpunit/Elgg/Http/OkResponseTest.php
@@ -4,13 +4,12 @@ namespace Elgg\Http;
 
 use ElggObject;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
 use stdClass;
 
 /**
  * @group HttpService
  */
-class OkResponseTest extends PHPUnit_Framework_TestCase {
+class OkResponseTest extends \Elgg\TestCase {
 
 	public $class;
 

--- a/engine/tests/phpunit/Elgg/Http/RequestTest.php
+++ b/engine/tests/phpunit/Elgg/Http/RequestTest.php
@@ -1,9 +1,8 @@
 <?php
+
 namespace Elgg\Http;
 
-use PHPUnit_Framework_TestCase as TestCase;
-
-class RequestTest extends TestCase {
+class RequestTest extends \Elgg\TestCase {
 
 	public function testCanDetectElggPath() {
 		$req = new Request([

--- a/engine/tests/phpunit/Elgg/Http/ResponseFactoryTest.php
+++ b/engine/tests/phpunit/Elgg/Http/ResponseFactoryTest.php
@@ -10,7 +10,6 @@ use Elgg\PluginHooksService;
 use Elgg\SystemMessagesService;
 use ElggSession;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
 use SecurityException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -21,7 +20,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
  * @group HttpService
  * @group HttpResponses
  */
-class ResponseFactoryTest extends PHPUnit_Framework_TestCase {
+class ResponseFactoryTest extends \Elgg\TestCase {
 
 	/**
 	 *
@@ -73,8 +72,8 @@ class ResponseFactoryTest extends PHPUnit_Framework_TestCase {
 
 		$this->session = ElggSession::getMock();
 		$this->session->start();
-		
-		$this->config = _elgg_testing_config();
+
+		$this->config = $this->config();
 		$this->hooks = new PluginHooksService();
 		$this->input = new Input();
 		$this->request = $this->createRequest('', 'GET');
@@ -117,7 +116,7 @@ class ResponseFactoryTest extends PHPUnit_Framework_TestCase {
 		if ($xhr) {
 			$request->headers->set('X-Requested-With', 'XMLHttpRequest');
 		}
-		
+
 		return $request;
 	}
 
@@ -141,7 +140,7 @@ class ResponseFactoryTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanPrepareResponse() {
-		
+
 		$service = $this->createService();
 
 		elgg_set_http_header('X-Elgg-Testing: 1');
@@ -228,14 +227,14 @@ class ResponseFactoryTest extends PHPUnit_Framework_TestCase {
 		$response = $service->prepareResponse('foo');
 		$sent_response = $service->send($response);
 		$this->assertInstanceOf(Response::class, $sent_response);
-		$this->assertEquals($sent_response,$service->send($response));
+		$this->assertEquals($sent_response, $service->send($response));
 
 		$output = ob_get_clean();
 		$this->assertEquals('foo', $output);
 	}
 
 	public function testCanNotSendModifiedResponse() {
-		
+
 		$service = $this->createService();
 
 		$response = $service->prepareResponse('foo');
@@ -260,7 +259,6 @@ class ResponseFactoryTest extends PHPUnit_Framework_TestCase {
 		$response2 = $service->prepareResponse('bar');
 		$this->assertEquals($response, $service->send($response2));
 	}
-
 
 	public function testCanSendAjaxResponseFromOutput() {
 		$service = $this->createService();
@@ -287,7 +285,6 @@ class ResponseFactoryTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($json_response, $service->send($service->prepareResponse('bar')));
 	}
 
-
 	public function testCanSendAjaxResponseFromApiResponse() {
 		$service = $this->createService();
 
@@ -298,7 +295,7 @@ class ResponseFactoryTest extends PHPUnit_Framework_TestCase {
 
 		$api_response = new \Elgg\Ajax\Response();
 		$api_response->setData((object) [
-			'value' => $data,
+					'value' => $data,
 		]);
 
 		$response = $service->send($this->ajax->respondFromApiResponse($api_response));
@@ -314,7 +311,7 @@ class ResponseFactoryTest extends PHPUnit_Framework_TestCase {
 		$service = $this->createService();
 		$api_response = new \Elgg\Ajax\Response();
 		$api_response->setData((object) [
-			'value' => 'foo',
+					'value' => 'foo',
 		]);
 		ob_start();
 		$json_response = $this->ajax->respondFromApiResponse($api_response);
@@ -397,4 +394,5 @@ class ResponseFactoryTest extends PHPUnit_Framework_TestCase {
 			['foo/bar/ajax', 'path:foo/bar/ajax'],
 		];
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/Http/WebAppManifestResourceTest.php
+++ b/engine/tests/phpunit/Elgg/Http/WebAppManifestResourceTest.php
@@ -1,9 +1,8 @@
 <?php
+
 namespace Elgg\Http;
 
-use PHPUnit_Framework_TestCase as TestCase;
-
-class WebAppManifestResourceTest extends TestCase {
+class WebAppManifestResourceTest extends \Elgg\TestCase {
 
 	public function testPagesExposeARelManifestLink() {
 		$this->markTestIncomplete();

--- a/engine/tests/phpunit/Elgg/I18n/MessageTranslatorTest.php
+++ b/engine/tests/phpunit/Elgg/I18n/MessageTranslatorTest.php
@@ -1,47 +1,48 @@
 <?php
+
 namespace Elgg\I18n;
 
-use PHPUnit_Framework_TestCase as TestCase;
+class MessageTranslatorTest extends \Elgg\TestCase {
 
-class MessageTranslatorTest extends TestCase {
 	public function setUp() {
 		$this->english = Locale::parse('en');
 		$this->spanish = Locale::parse('es');
 	}
-	
+
 	public function testKeyIsReturnedIfNoTranslationCanBeFound() {
 		$messages = new ArrayMessageBundle([]);
 		$translator = new MessageTranslator(Locale::parse('en'), $messages);
-		
+
 		$this->assertEquals('foobar', $translator->translate('foobar'));
 	}
-	
+
 	public function testTranslateReturnsTranslationForSpecifiedLocaleIfAvailable() {
 		$messages = new ArrayMessageBundle([
 			'en' => ['one' => 'one'],
 			'es' => ['one' => 'uno'],
 		]);
 		$translator = new MessageTranslator(Locale::parse('en'), $messages);
-		
+
 		$this->assertEquals('uno', $translator->translate('one', [], Locale::parse('es')));
 	}
-	
+
 	public function testTranslateReturnsTranslationForDefaultLocaleIfNoLocaleWasSpecified() {
 		$messages = new ArrayMessageBundle([
 			'en' => ['one' => 'one'],
 			'es' => ['one' => 'uno'],
 		]);
 		$translator = new MessageTranslator(Locale::parse('en'), $messages);
-		
+
 		$this->assertEquals('one', $translator->translate('one', []));
 	}
-	
+
 	public function testFallsBackToLanguageIfTranslationForSpecifiedLanguageIsNotAvailable() {
 		$messages = new ArrayMessageBundle([
 			'en' => ['one' => 'one'],
 		]);
 		$translator = new MessageTranslator(Locale::parse('en'), $messages);
-		
+
 		$this->assertEquals('one', $translator->translate('one', [], Locale::parse('es')));
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/I18n/TranslatorTest.php
+++ b/engine/tests/phpunit/Elgg/I18n/TranslatorTest.php
@@ -1,10 +1,10 @@
 <?php
+
 namespace Elgg\I18n;
 
 use Elgg\Logger;
-use PHPUnit_Framework_TestCase as TestCase;
 
-class TranslatorTest extends TestCase {
+class TranslatorTest extends \Elgg\TestCase {
 
 	public $key = '__elgg_php_unit:test_key';
 
@@ -62,7 +62,7 @@ class TranslatorTest extends TestCase {
 				'message' => "Missing English translation for \"{$this->key}b\" language key",
 				'level' => Logger::NOTICE,
 			]
-		], $logged);
+				], $logged);
 
 		// has fallback key
 		$this->translator->addTranslation('en', ["{$this->key}b" => 'Dummy']);
@@ -76,10 +76,11 @@ class TranslatorTest extends TestCase {
 				'message' => "Missing es translation for \"{$this->key}b\" language key",
 				'level' => Logger::NOTICE,
 			]
-		], $logged);
+				], $logged);
 	}
 
 	public function testDoesNotProcessArgsOnKey() {
 		$this->assertEquals('nonexistent:%s', $this->translator->translate('nonexistent:%s', [1]));
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/Json/EmptyKeyEncodingTest.php
+++ b/engine/tests/phpunit/Elgg/Json/EmptyKeyEncodingTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Elgg\Json;
 
-class EmptyKeyEncodingTest extends \PHPUnit_Framework_TestCase {
+class EmptyKeyEncodingTest extends \Elgg\TestCase {
 
 	function testRoundTrip() {
 		$json = <<<EOL
@@ -43,4 +44,5 @@ EOL;
 
 		$this->assertEquals('{"":"foo"}', $json);
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/LoggerTest.php
+++ b/engine/tests/phpunit/Elgg/LoggerTest.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Elgg;
 
-
-class LoggerTest extends \PHPUnit_Framework_TestCase {
+class LoggerTest extends \Elgg\TestCase {
 
 	public function testLoggingOff() {
 		$logger = $this->getLoggerInstance();
@@ -41,7 +41,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals([
 			['message' => 'Testing', 'level' => Logger::ERROR],
-		], $captured);
+				], $captured);
 
 		$hooks->restore();
 	}
@@ -65,11 +65,11 @@ class LoggerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals([
 			['message' => 'Test2', 'level' => Logger::WARNING],
-		], $logger->enable());
+				], $logger->enable());
 
 		$this->assertEquals([
 			['message' => 'Test1', 'level' => Logger::ERROR],
-		], $logger->enable());
+				], $logger->enable());
 
 		$this->assertEquals(0, $num_processed);
 
@@ -85,5 +85,5 @@ class LoggerTest extends \PHPUnit_Framework_TestCase {
 		$sp = _elgg_services();
 		return new \Elgg\Logger($mock, $sp->config, $sp->context);
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/Mail/MailerTest.php
+++ b/engine/tests/phpunit/Elgg/Mail/MailerTest.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Elgg\Mail;
 
 use Zend\Mail\Transport\InMemory as InMemoryTransport;
 
-class MailerTest extends \PHPUnit_Framework_TestCase {
+class MailerTest extends \Elgg\TestCase {
 
 	public $hookArgs = [];
 
@@ -30,9 +31,9 @@ class MailerTest extends \PHPUnit_Framework_TestCase {
 		$subject_expected = "You & me < she.";
 
 		elgg_send_email("Frōm <from@elgg.org>", "Tō <to@elgg.org>", $subject, $body);
-		
+
 		$message = $this->mailer->getLastMessage();
-		
+
 		$this->assertEquals('Tō', $message->getTo()->get('to@elgg.org')->getName());
 		$this->assertEquals('Frōm', $message->getFrom()->get('from@elgg.org')->getName());
 		$this->assertEquals($subject_expected, $message->getSubject());
@@ -86,4 +87,5 @@ class MailerTest extends \PHPUnit_Framework_TestCase {
 	function handleEmailHookTrue() {
 		return true;
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/MethodMatcherTest.php
+++ b/engine/tests/phpunit/Elgg/MethodMatcherTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Elgg;
 
-class MethodMatcherTest extends \PHPUnit_Framework_TestCase {
+class MethodMatcherTest extends \Elgg\TestCase {
 
 	public function testMatchesStrings() {
 		$matcher = new MethodMatcher('stdClass', 'bar');
@@ -27,6 +28,9 @@ class MethodMatcherTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($matcher->matches([new \stdClass(), 'BAR']));
 		$this->assertFalse($matcher->matches([new MethodMatcherTestObject, 'bar']));
 	}
+
 }
 
-class MethodMatcherTestObject {}
+class MethodMatcherTestObject {
+
+}

--- a/engine/tests/phpunit/Elgg/Notifications/NotificationsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/NotificationsServiceTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Elgg\Notifications;
 
-class NotificationsServiceTest extends \PHPUnit_Framework_TestCase {
+class NotificationsServiceTest extends \Elgg\TestCase {
 
 	protected $session;
 
@@ -9,28 +10,28 @@ class NotificationsServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->hooks = new \Elgg\PluginHooksService();
 		$this->queue = new \Elgg\Queue\MemoryQueue();
 		$dbMock = $this->getMockBuilder('\Elgg\Database')
-			->disableOriginalConstructor()
-			->getMock();
+				->disableOriginalConstructor()
+				->getMock();
 		$this->sub = new \Elgg\Notifications\SubscriptionsService($dbMock);
 		$this->translator = new \Elgg\I18n\Translator();
 		$this->session = \ElggSession::getMock();
 
 		// User mock that supports calling $user->isBanned()
 		$user_123 = $this->getMockBuilder('\ElggEntity')
-			->disableOriginalConstructor()
-			->getMock();
+				->disableOriginalConstructor()
+				->getMock();
 		$user_123->expects($this->any())
-			->method('isBanned')
-			->will($this->returnValue(false));
+				->method('isBanned')
+				->will($this->returnValue(false));
 
 		// Database mock that returns the user_123
 		$this->entities = $this->getMockBuilder('\Elgg\Database\EntityTable')
-			->disableOriginalConstructor()
-			->getMock();
+				->disableOriginalConstructor()
+				->getMock();
 		$this->entities->expects($this->any())
-			->method('get')
-			->with($this->equalTo('123'))
-			->will($this->returnValue($user_123));
+				->method('get')
+				->with($this->equalTo('123'))
+				->will($this->returnValue($user_123));
 
 		// Event class has dependency on elgg_get_logged_in_user_guid()
 		_elgg_services()->setValue('session', $this->session);
@@ -112,8 +113,8 @@ class NotificationsServiceTest extends \PHPUnit_Framework_TestCase {
 
 		$mock = $this->getMock('\Elgg\PluginHooksService', array('trigger'));
 		$mock->expects($this->once())
-			->method('trigger')
-			->with('enqueue', 'notification', $params, true);
+				->method('trigger')
+				->with('enqueue', 'notification', $params, true);
 		$service = new \Elgg\Notifications\NotificationsService($this->sub, $this->queue, $mock, $this->session, $this->translator, $this->entities);
 		$service->registerEvent('object', 'bar');
 		$service->enqueueEvent('create', 'object', $object);
@@ -122,8 +123,8 @@ class NotificationsServiceTest extends \PHPUnit_Framework_TestCase {
 	public function testStoppingEnqueueEvent() {
 		$mock = $this->getMock('\Elgg\PluginHooksService', array('trigger'));
 		$mock->expects($this->once())
-			->method('trigger')
-			->will($this->returnValue(false));
+				->method('trigger')
+				->will($this->returnValue(false));
 		$service = new \Elgg\Notifications\NotificationsService($this->sub, $this->queue, $mock, $this->session, $this->translator, $this->entities);
 
 		$service->registerEvent('object', 'bar');
@@ -140,14 +141,10 @@ class NotificationsServiceTest extends \PHPUnit_Framework_TestCase {
 
 	public function testProcessQueueThreeEvents() {
 		$mock = $this->getMock(
-				'\Elgg\Notifications\SubscriptionsService',
-				array('getSubscriptions'),
-				array(),
-				'',
-				false);
+				'\Elgg\Notifications\SubscriptionsService', array('getSubscriptions'), array(), '', false);
 		$mock->expects($this->exactly(3))
-			->method('getSubscriptions')
-			->will($this->returnValue(array()));
+				->method('getSubscriptions')
+				->will($this->returnValue(array()));
 		$service = new \Elgg\Notifications\NotificationsService($mock, $this->queue, $this->hooks, $this->session, $this->translator, $this->entities);
 
 		$service->registerEvent('object', 'bar');
@@ -162,13 +159,9 @@ class NotificationsServiceTest extends \PHPUnit_Framework_TestCase {
 
 	public function testProcessQueueTimesout() {
 		$mock = $this->getMock(
-				'\Elgg\Notifications\SubscriptionsService',
-				array('getSubscriptions'),
-				array(),
-				'',
-				false);
+				'\Elgg\Notifications\SubscriptionsService', array('getSubscriptions'), array(), '', false);
 		$mock->expects($this->exactly(0))
-			->method('getSubscriptions');
+				->method('getSubscriptions');
 		$service = new \Elgg\Notifications\NotificationsService($mock, $this->queue, $this->hooks, $this->session, $this->translator, $this->entities);
 
 		$service->registerEvent('object', 'bar');
@@ -180,5 +173,5 @@ class NotificationsServiceTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(0, $service->processQueue(time()));
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
@@ -1,38 +1,26 @@
 <?php
+
 namespace Elgg\Notifications;
 
-
-class SubscriptionsServiceTest extends \PHPUnit_Framework_TestCase {
+class SubscriptionsServiceTest extends \Elgg\TestCase {
 
 	public function setUp() {
 		$this->containerGuid = 42;
 
 		// mock \ElggObject that has a container guid
 		$object = $this->getMock(
-				'\ElggObject',
-				array('getContainerGUID'),
-				array(),
-				'',
-				false);
+				'\ElggObject', array('getContainerGUID'), array(), '', false);
 		$object->expects($this->any())
 				->method('getContainerGUID')
 				->will($this->returnValue($this->containerGuid));
 
 		// mock event that holds the mock object
 		$this->event = $this->getMock(
-				'\Elgg\Notifications\Event',
-				array('getObject'),
-				array(),
-				'',
-				false);
+				'\Elgg\Notifications\Event', array('getObject'), array(), '', false);
 		$this->event->expects($this->any())
 				->method('getObject')
 				->will($this->returnValue($object));
-		$this->db = $this->getMock('\Elgg\Database',
-				array('getData', 'getTablePrefix', 'sanitizeString'),
-				array(),
-				'',
-				false
+		$this->db = $this->getMock('\Elgg\Database', array('getData', 'getTablePrefix', 'sanitizeString'), array(), '', false
 		);
 		$this->db->expects($this->any())
 				->method('getTablePrefix')
@@ -52,11 +40,7 @@ class SubscriptionsServiceTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetSubscriptionsWithBadObject() {
 		$this->event = $this->getMock(
-				'\Elgg\Notifications\Event',
-				array('getObject'),
-				array(),
-				'',
-				false);
+				'\Elgg\Notifications\Event', array('getObject'), array(), '', false);
 		$this->event->expects($this->any())
 				->method('getObject')
 				->will($this->returnValue(null));
@@ -134,5 +118,5 @@ class SubscriptionsServiceTest extends \PHPUnit_Framework_TestCase {
 		}
 		return $obj;
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/PageOwnerTest.php
+++ b/engine/tests/phpunit/Elgg/PageOwnerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Elgg_PageOwnerTest extends PHPUnit_Framework_TestCase {
+class Elgg_PageOwnerTest extends \Elgg\TestCase {
 
 	/**
 	 * It should be possible to set and unset a page owner even if that results in no page owner at all.
@@ -12,19 +12,17 @@ class Elgg_PageOwnerTest extends PHPUnit_Framework_TestCase {
 		 *  2. Unset page owner
 		 *  3. Assert that fetching page owner results in the expected page owner
 		 */
-		
 		// check if setting to false returns 0
 		elgg_set_page_owner_guid(1);
 		$this->assertEquals(1, elgg_get_page_owner_guid());
 		elgg_set_page_owner_guid(false);
 		$this->assertEquals(0, elgg_get_page_owner_guid());
-		
+
 		// check if setting to null returns 0
 		elgg_set_page_owner_guid(1);
 		$this->assertEquals(1, elgg_get_page_owner_guid());
 		elgg_set_page_owner_guid(null);
 		$this->assertEquals(0, elgg_get_page_owner_guid());
-		
 	}
 
 }

--- a/engine/tests/phpunit/Elgg/PersistentLoginTest.php
+++ b/engine/tests/phpunit/Elgg/PersistentLoginTest.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Elgg;
 
-
-class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
+class PersistentLoginTest extends \Elgg\TestCase {
 
 	/**
 	 * @var \ElggSession
@@ -67,27 +67,27 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 
 		// mock DB
 		$this->dbMock = $this->getMockBuilder('\Elgg\Database')
-			->disableOriginalConstructor()
-			->getMock();
+				->disableOriginalConstructor()
+				->getMock();
 		// use addslashes as ->sanitizeString (my local CLI doesn't have MySQL)
 		$this->dbMock->expects($this->any())
-			->method('sanitizeString')
-			->will($this->returnCallback(array($this, 'mock_sanitizeString')));
+				->method('sanitizeString')
+				->will($this->returnCallback(array($this, 'mock_sanitizeString')));
 
 		$this->cryptoMock = $this->getMockBuilder('\ElggCrypto')
-			->setConstructorArgs([_elgg_services()->siteSecret])
-			->getMock();
+				->setConstructorArgs([_elgg_services()->siteSecret])
+				->getMock();
 		$this->cryptoMock->expects($this->any())
-			->method('getRandomString')
-			->will($this->returnValue(str_repeat('a', 31)));
+				->method('getRandomString')
+				->will($this->returnValue(str_repeat('a', 31)));
 
 		$this->svc = $this->getSvcWithCookie("");
 	}
 
 	function testLoginSavesHashAndPutsTokenInCookieAndSession() {
 		$this->dbMock->expects($this->once())
-			->method('insertData')
-			->will($this->returnCallback(array($this, 'mock_insertData')));
+				->method('insertData')
+				->will($this->returnCallback(array($this, 'mock_insertData')));
 
 		$this->svc->makeLoginPersistent($this->user123);
 
@@ -99,8 +99,8 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 		$this->svc = $this->getSvcWithCookie($this->mockToken);
 
 		$this->dbMock->expects($this->once())
-			->method('deleteData')
-			->will($this->returnCallback(array($this, 'mock_deleteData')));
+				->method('deleteData')
+				->will($this->returnCallback(array($this, 'mock_deleteData')));
 
 		$this->svc->removePersistentLogin();
 
@@ -111,7 +111,7 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 
 	function testRemoveWithoutCookieCantDeleteHash() {
 		$this->dbMock->expects($this->never())
-			->method('deleteData');
+				->method('deleteData');
 
 		$this->svc->removePersistentLogin();
 
@@ -122,8 +122,8 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 
 	function testGettingUserFromKnownHashReturnsUser() {
 		$this->dbMock->expects($this->once())
-			->method('getDataRow')
-			->will($this->returnCallback(array($this, 'mock_getDataRow')));
+				->method('getDataRow')
+				->will($this->returnCallback(array($this, 'mock_getDataRow')));
 
 		$user = $this->svc->getUserFromHash($this->mockHash);
 
@@ -132,8 +132,8 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 
 	function testGettingUserFromMissingHashReturnsNull() {
 		$this->dbMock->expects($this->once())
-			->method('getDataRow')
-			->will($this->returnValue(array()));
+				->method('getDataRow')
+				->will($this->returnValue(array()));
 
 		$user = $this->svc->getUserFromHash($this->mockHash);
 
@@ -142,8 +142,8 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 
 	function testGettingMissingUserFromKnownHashReturnsNull() {
 		$this->dbMock->expects($this->once())
-			->method('getDataRow')
-			->will($this->returnValue((object)array('guid' => 234)));
+				->method('getDataRow')
+				->will($this->returnValue((object) array('guid' => 234)));
 
 		$user = $this->svc->getUserFromHash($this->mockHash);
 
@@ -155,15 +155,15 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 		$modifier = $this->user123;
 
 		$this->dbMock->expects($this->exactly(2))
-			->method('deleteData');
+				->method('deleteData');
 		// Here we can't make an expectation on mock_deleteAll because one
 		// of the calls deletes all, and another deletes only a single hash.
 		// We'd have to fix mock_deleteAll to handle it.
 		// @todo replace this with a real DB test
 
 		$this->dbMock->expects($this->once())
-			->method('insertData')
-			->will($this->returnCallback(array($this, 'mock_insertData')));
+				->method('insertData')
+				->will($this->returnCallback(array($this, 'mock_insertData')));
 
 		$this->svc = $this->getSvcWithCookie('notempty');
 		$this->svc->handlePasswordChange($subject, $modifier);
@@ -177,10 +177,10 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 		$modifier = $this->user123;
 
 		$this->dbMock->expects($this->once())
-			->method('deleteData')
-			->will($this->returnCallback(array($this, 'mock_deleteAll')));
+				->method('deleteData')
+				->will($this->returnCallback(array($this, 'mock_deleteAll')));
 		$this->dbMock->expects($this->never())
-			->method('insertData');
+				->method('insertData');
 
 		$this->svc->handlePasswordChange($subject, $modifier);
 
@@ -193,10 +193,10 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 		$modifier = $this->getMockElggUser(234);
 
 		$this->dbMock->expects($this->atLeastOnce())
-			->method('deleteData')
-			->will($this->returnCallback(array($this, 'mock_deleteAll')));
+				->method('deleteData')
+				->will($this->returnCallback(array($this, 'mock_deleteAll')));
 		$this->dbMock->expects($this->never())
-			->method('insertData');
+				->method('insertData');
 
 		$this->svc->handlePasswordChange($subject, $modifier);
 
@@ -206,8 +206,8 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 
 	function testGettingUserFromValidClientReturnsUser() {
 		$this->dbMock->expects($this->once())
-			->method('getDataRow')
-			->will($this->returnValue((object)array('guid' => 123)));
+				->method('getDataRow')
+				->will($this->returnValue((object) array('guid' => 123)));
 
 		$this->svc = $this->getSvcWithCookie($this->mockToken);
 
@@ -218,8 +218,8 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 
 	function testGetPersistedUser_invalidModernToken() {
 		$this->dbMock->expects($this->once())
-			->method('getDataRow')
-			->will($this->returnValue(array()));
+				->method('getDataRow')
+				->will($this->returnValue(array()));
 
 		$this->svc = $this->getSvcWithCookie('z' . str_repeat('b', 31));
 
@@ -233,8 +233,8 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 
 	function testBootSessionWithInvalidLegacyTokenCausesDelayAndFailure() {
 		$this->dbMock->expects($this->once())
-			->method('getDataRow')
-			->will($this->returnValue(array()));
+				->method('getDataRow')
+				->will($this->returnValue(array()));
 
 		$this->svc = $this->getSvcWithCookie(str_repeat('b', 32));
 
@@ -250,7 +250,7 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 		$this->svc = $this->getSvcWithCookie('');
 
 		$this->dbMock->expects($this->never())
-			->method('deleteData');
+				->method('deleteData');
 
 		$this->svc->replaceLegacyToken($this->user123);
 
@@ -260,7 +260,7 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 
 	function testModernTokenCookiesAreNotReplaced() {
 		$this->dbMock->expects($this->never())
-			->method('deleteData');
+				->method('deleteData');
 
 		$this->svc->replaceLegacyToken($this->user123);
 
@@ -272,9 +272,9 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 		$this->svc = $this->getSvcWithCookie(str_repeat('a', 32));
 
 		$this->dbMock->expects($this->atLeastOnce())
-			->method('deleteData');
+				->method('deleteData');
 		$this->dbMock->expects($this->once())
-			->method('insertData');
+				->method('insertData');
 
 		$this->svc->replaceLegacyToken($this->user123);
 
@@ -285,17 +285,17 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 	// mock \ElggUser which will return the GUID on ->guid reads
 	function getMockElggUser($guid) {
 		$user = $this->getMockBuilder('\ElggUser')
-			->disableOriginalConstructor()
-			->getMock();
+				->disableOriginalConstructor()
+				->getMock();
 		$user->expects($this->any())
-			->method('__get')
-			->with('guid')
-			->will($this->returnValue((int)$guid));
+				->method('__get')
+				->with('guid')
+				->will($this->returnValue((int) $guid));
 		return $user;
 	}
 
 	function mock_get_user($guid) {
-		if ((int)$guid === 123) {
+		if ((int) $guid === 123) {
 			return $this->user123;
 		}
 		return null;
@@ -330,8 +330,7 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 		);
 		$time = $this->thirtyDaysAgo + (30 * 86400);
 		$svc = new \Elgg\PersistentLoginService(
-			$this->dbMock, $this->session, $this->cryptoMock,
-			$cookie_config, $cookie_token, $time);
+				$this->dbMock, $this->session, $this->cryptoMock, $cookie_config, $cookie_token, $time);
 
 		$svc->_callable_get_user = array($this, 'mock_get_user');
 		$svc->_callable_generateToken = array($this, 'mock_generateToken');
@@ -354,11 +353,12 @@ class PersistentLoginTest extends \PHPUnit_Framework_TestCase {
 		$pattern = "~SELECT guid FROM users_remember_me_cookies\\s+WHERE code = '{$this->mockHash}'~";
 		$this->assertSame(1, preg_match($pattern, $sql));
 
-		return (object)array('guid' => 123);
+		return (object) array('guid' => 123);
 	}
 
 	function mock_deleteAll($sql) {
 		$pattern = "~DELETE FROM users_remember_me_cookies\\s+WHERE guid = '123'+~";
 		$this->assertSame(1, preg_match($pattern, $sql));
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/PluginHooksServiceTest.php
+++ b/engine/tests/phpunit/Elgg/PluginHooksServiceTest.php
@@ -1,27 +1,27 @@
 <?php
+
 namespace Elgg;
 
+class PluginHooksServiceTest extends \Elgg\TestCase {
 
-class PluginHooksServiceTest extends \PHPUnit_Framework_TestCase {
-	
 	public function testTriggerCallsRegisteredHandlers() {
 		$hooks = new \Elgg\PluginHooksService();
-		
+
 		$this->setExpectedException('InvalidArgumentException');
-		
+
 		$hooks->registerHandler('foo', 'bar', array('\Elgg\PluginHooksServiceTest', 'throwInvalidArg'));
 
 		$hooks->trigger('foo', 'bar');
 	}
-	
+
 	public function testCanPassParamsAndChangeReturnValue() {
 		$hooks = new \Elgg\PluginHooksService();
 		$hooks->registerHandler('foo', 'bar', array('\Elgg\PluginHooksServiceTest', 'changeReturn'));
-		
+
 		$returnval = $hooks->trigger('foo', 'bar', array(
 			'testCase' => $this,
-		), 1);
-		
+				), 1);
+
 		$this->assertEquals(2, $returnval);
 	}
 
@@ -58,5 +58,5 @@ class PluginHooksServiceTest extends \PHPUnit_Framework_TestCase {
 	public static function throwInvalidArg() {
 		throw new \InvalidArgumentException();
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/RouterTest.php
+++ b/engine/tests/phpunit/Elgg/RouterTest.php
@@ -9,7 +9,6 @@ use Elgg\Http\Request;
 use Elgg\Http\ResponseFactory;
 use Elgg\I18n\Translator;
 use ElggSession;
-use PHPUnit_Framework_TestCase;
 use stdClass;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -18,7 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @group HttpService
  * @group RouterService
  */
-class RouterTest extends PHPUnit_Framework_TestCase {
+class RouterTest extends \Elgg\TestCase {
 
 	/**
 	 * @var PluginHooksService
@@ -63,13 +62,13 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 		_elgg_services()->setValue('session', $session);
 		_elgg_services()->session->start();
 
-		$config = _elgg_testing_config();
+		$config = $this->config();
 		_elgg_services()->setValue('config', $config);
 
 		$input = new Input();
 		_elgg_services()->setValue('input', $input);
 
-		$this->request = _elgg_testing_request('', 'GET');
+		$this->request = $this->prepareHttpRequest('', 'GET');
 		_elgg_services()->setValue('request', $this->request);
 
 		$this->translator = new Translator();
@@ -122,7 +121,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 		$path = "hello/1/\xE2\x82\xAC"; // euro sign
 
 		ob_start();
-		$handled = $this->router->route(_elgg_testing_request($path));
+		$handled = $this->router->route($this->prepareHttpRequest($path));
 		ob_end_clean();
 		$this->assertTrue($handled);
 
@@ -147,7 +146,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 		$this->router->unregisterPageHandler('hello');
 
 		ob_start();
-		$this->router->route(_elgg_testing_request('hello'));
+		$this->router->route($this->prepareHttpRequest('hello'));
 		$output = ob_get_clean();
 
 		$response = _elgg_services()->responseFactory->getSentResponse();
@@ -173,7 +172,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 		$this->hooks->registerHandler('route', 'bar', array($this, 'bar_route_handler'));
 
 		ob_start();
-		$this->router->route(_elgg_testing_request('bar/baz'));
+		$this->router->route($this->prepareHttpRequest('bar/baz'));
 		ob_end_clean();
 
 		$this->assertEquals(1, $this->fooHandlerCalls);
@@ -194,7 +193,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 		$this->hooks->registerHandler('route', 'bar', array($this, 'bar_route_identifier'));
 
 		ob_start();
-		$this->router->route(_elgg_testing_request('bar/baz'));
+		$this->router->route($this->prepareHttpRequest('bar/baz'));
 		ob_end_clean();
 
 		$this->assertEquals(1, $this->fooHandlerCalls);
@@ -208,7 +207,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 		$this->hooks->registerHandler('route', 'foo', array($this, 'bar_route_override'));
 
 		ob_start();
-		$this->router->route(_elgg_testing_request('foo'));
+		$this->router->route($this->prepareHttpRequest('foo'));
 		$result = ob_get_clean();
 
 		$this->assertEquals("Page handler override from hook", $result);
@@ -259,7 +258,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			];
 		});
 
-		$this->request = _elgg_testing_request('foo/bar/baz');
+		$this->request = $this->prepareHttpRequest('foo/bar/baz');
 
 		$this->createService();
 
@@ -283,7 +282,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			return false;
 		});
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET');
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET');
 		$this->createService();
 
 		$this->route();
@@ -304,7 +303,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			return false;
 		});
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET');
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET');
 		$this->createService();
 
 		$this->assertTrue($this->route());
@@ -325,7 +324,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			return elgg_error_response('', REFERRER, ELGG_HTTP_BAD_REQUEST);
 		});
 
-		$this->request = _elgg_testing_request('foo/bar', 'GET');
+		$this->request = $this->prepareHttpRequest('foo/bar', 'GET');
 		$this->createService();
 
 		elgg_register_page_handler('foo', function() {
@@ -343,7 +342,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToNonAjaxRequestFromOkResponseBuilder() {
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET');
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET');
 		$this->createService();
 
 		elgg_register_page_handler('foo', function($segments, $identifier) {
@@ -362,7 +361,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToNonAjaxRequestFromErrorResponseBuilder() {
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET');
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET');
 		$this->createService();
 
 		elgg_register_page_handler('foo', function($segments, $identifier) {
@@ -384,7 +383,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToNonAjaxRequestFromRedirectResponseBuilder() {
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET');
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET');
 		$this->createService();
 
 		elgg_register_page_handler('foo', function($segments, $identifier) {
@@ -403,7 +402,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToNonAjaxRequestInNonDefaultViewtype() {
 
-		$this->request = _elgg_testing_request('phpunit', 'GET', ['view' => 'json']);
+		$this->request = $this->prepareHttpRequest('phpunit', 'GET', ['view' => 'json']);
 		$this->createService();
 
 		elgg_register_page_handler('phpunit', function() {
@@ -423,7 +422,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToNonAjaxRequestForPageThatForwards() {
 
-		$this->request = _elgg_testing_request('phpunit', 'GET');
+		$this->request = $this->prepareHttpRequest('phpunit', 'GET');
 		$this->createService();
 
 		elgg_register_page_handler('phpunit', function() {
@@ -439,7 +438,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanRespondToNonAjaxRequestForPageThatForwardsToErrorPage() {
-		$this->request = _elgg_testing_request('phpunit', 'GET');
+		$this->request = $this->prepareHttpRequest('phpunit', 'GET');
 		$this->createService();
 
 		elgg_register_page_handler('phpunit', function() {
@@ -470,7 +469,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			_elgg_services()->responseFactory->redirect('error', ELGG_HTTP_INTERNAL_SERVER_ERROR);
 		});
 
-		$this->request = _elgg_testing_request('phpunit', 'GET');
+		$this->request = $this->prepareHttpRequest('phpunit', 'GET');
 		$this->createService();
 
 		elgg_register_page_handler('phpunit', function() {
@@ -502,7 +501,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			return false;
 		});
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET', [], 1);
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET', [], 1);
 		$this->createService();
 
 		$this->assertTrue($this->route());
@@ -528,7 +527,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			return false;
 		});
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET', [], 1);
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET', [], 1);
 		$this->createService();
 
 		$this->assertTrue($this->route());
@@ -559,7 +558,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToAjaxRequestFromOkResponseBuilder() {
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET', [], 1);
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET', [], 1);
 		$this->createService();
 
 		elgg_register_page_handler('foo', function($segments, $identifier) {
@@ -583,7 +582,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToAjaxRequestFromErrorResponseBuilder() {
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET', [], 1);
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET', [], 1);
 		$this->createService();
 
 		elgg_register_page_handler('foo', function($segments, $identifier) {
@@ -607,7 +606,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToAjaxRequestFromRedirectResponseBuilder() {
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET', [], 1);
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET', [], 1);
 		$this->createService();
 
 		elgg_register_page_handler('foo', function($segments, $identifier) {
@@ -644,7 +643,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToAjaxRequestInNonDefaultViewtype() {
 
-		$this->request = _elgg_testing_request('phpunit', 'GET', ['view' => 'json'], 1);
+		$this->request = $this->prepareHttpRequest('phpunit', 'GET', ['view' => 'json'], 1);
 		$this->createService();
 
 		elgg_register_page_handler('phpunit', function() {
@@ -667,7 +666,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToAjaxRequestForPageThatForwards() {
 
-		$this->request = _elgg_testing_request('phpunit', 'GET', [], 1);
+		$this->request = $this->prepareHttpRequest('phpunit', 'GET', [], 1);
 		$this->createService();
 
 		elgg_register_page_handler('phpunit', function() {
@@ -702,7 +701,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanRespondToAjaxRequestForPageThatForwardsToErrorPage() {
-		$this->request = _elgg_testing_request('phpunit', 'GET', [], 1);
+		$this->request = $this->prepareHttpRequest('phpunit', 'GET', [], 1);
 		$this->createService();
 
 		elgg_register_page_handler('phpunit', function() {
@@ -746,7 +745,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			return false;
 		});
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET', [], 2);
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET', [], 2);
 		$this->createService();
 
 		$this->assertTrue($this->route());
@@ -776,7 +775,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			return false;
 		});
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET', [], 2);
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET', [], 2);
 		$this->createService();
 
 		$this->assertTrue($this->route());
@@ -801,7 +800,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToAjax2RequestFromOkResponseBuilder() {
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET', [], 2);
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET', [], 2);
 		$this->createService();
 
 		elgg_register_page_handler('foo', function($segments, $identifier) {
@@ -829,7 +828,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToAjax2RequestFromErrorResponseBuilder() {
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET', [], 2);
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET', [], 2);
 		$this->createService();
 
 		elgg_register_page_handler('foo', function($segments, $identifier) {
@@ -855,7 +854,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToAjax2RequestFromRedirectResponseBuilder() {
 
-		$this->request = _elgg_testing_request('foo/bar/baz', 'GET', [], 2);
+		$this->request = $this->prepareHttpRequest('foo/bar/baz', 'GET', [], 2);
 		$this->createService();
 
 		elgg_register_page_handler('foo', function($segments, $identifier) {
@@ -886,7 +885,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToAjax2RequestInNonDefaultViewtype() {
 
-		$this->request = _elgg_testing_request('phpunit', 'GET', ['view' => 'json'], 2);
+		$this->request = $this->prepareHttpRequest('phpunit', 'GET', ['view' => 'json'], 2);
 		$this->createService();
 
 		elgg_register_page_handler('phpunit', function() {
@@ -915,7 +914,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToAjax2RequestForPageThatForwards() {
 
-		$this->request = _elgg_testing_request('phpunit', 'GET', [], 2);
+		$this->request = $this->prepareHttpRequest('phpunit', 'GET', [], 2);
 		$this->createService();
 
 		elgg_register_page_handler('phpunit', function() {
@@ -944,7 +943,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanRespondToAjax2RequestForPageThatForwardsToErrorPage() {
-		$this->request = _elgg_testing_request('phpunit', 'GET', [], 2);
+		$this->request = $this->prepareHttpRequest('phpunit', 'GET', [], 2);
 		$this->createService();
 
 		elgg_register_page_handler('phpunit', function() {
@@ -975,7 +974,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testCanRespondToUnregisteredRoute() {
 
-		$this->request = _elgg_testing_request('unknown', 'GET');
+		$this->request = $this->prepareHttpRequest('unknown', 'GET');
 		$this->createService();
 
 		// Normally we would assert that this is false, but since PHPUnit is sending it's own headers
@@ -995,7 +994,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 		 */
 		$this->markTestSkipped();
 
-		$this->request = _elgg_testing_request('ajax/view/unallowed', 'GET');
+		$this->request = $this->prepareHttpRequest('ajax/view/unallowed', 'GET');
 		$this->createService();
 
 		$this->assertTrue($this->route());
@@ -1007,7 +1006,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondWithErrorToAjaxViewRequestForUnallowedView() {
 
-		$this->request = _elgg_testing_request('ajax/view/unallowed', 'GET', [], 1);
+		$this->request = $this->prepareHttpRequest('ajax/view/unallowed', 'GET', [], 1);
 		$this->createService();
 
 		$this->route();
@@ -1022,7 +1021,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertTrue(_elgg_services()->views->isCacheableView('cacheable.xml'));
 
-		$this->request = _elgg_testing_request('ajax/view/cacheable.xml', 'GET', [], 1);
+		$this->request = $this->prepareHttpRequest('ajax/view/cacheable.xml', 'GET', [], 1);
 		$this->createService();
 
 		$this->route();
@@ -1036,7 +1035,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToAjaxViewRequestForCSS() {
 
-		$this->request = _elgg_testing_request('ajax/view/css/styles.css', 'GET', [], 1);
+		$this->request = $this->prepareHttpRequest('ajax/view/css/styles.css', 'GET', [], 1);
 		$this->createService();
 
 		$this->route();
@@ -1051,7 +1050,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testCanRespondToAjaxViewRequestForJS() {
 
-		$this->request = _elgg_testing_request('ajax/view/js/javascript.js', 'GET', [], 1);
+		$this->request = $this->prepareHttpRequest('ajax/view/js/javascript.js', 'GET', [], 1);
 		$this->createService();
 
 		$this->route();
@@ -1070,10 +1069,10 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			'query_value' => 'hello',
 		];
 
-		elgg_register_ajax_view('query_view');
-
-		$this->request = _elgg_testing_request('ajax/view/query_view', 'GET', $vars, 1);
+		$this->request = $this->prepareHttpRequest('ajax/view/query_view', 'GET', $vars, 1);
 		$this->createService();
+
+		elgg_register_ajax_view('query_view');
 
 		$this->route();
 
@@ -1100,10 +1099,10 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			'query_value' => 'hello',
 		];
 
-		elgg_register_ajax_view('query_view');
-
-		$this->request = _elgg_testing_request('ajax/view/query_view', 'GET', $vars, 1);
+		$this->request = $this->prepareHttpRequest('ajax/view/query_view', 'GET', $vars, 1);
 		$this->createService();
+
+		elgg_register_ajax_view('query_view');
 
 		$this->route();
 
@@ -1124,10 +1123,10 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			'error' => 'error',
 		];
 
-		elgg_register_ajax_view('forwards');
-
-		$this->request = _elgg_testing_request('ajax/view/forwards', 'GET', $vars, 1);
+		$this->request = $this->prepareHttpRequest('ajax/view/forwards', 'GET', $vars, 1);
 		$this->createService();
+
+		elgg_register_ajax_view('forwards');
 
 		$this->route();
 
@@ -1159,7 +1158,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testCanRespondWithErrorToAjax2ViewRequestForUnallowedView() {
 
-		$this->request = _elgg_testing_request('ajax/view/unallowed', 'GET', [], 2);
+		$this->request = $this->prepareHttpRequest('ajax/view/unallowed', 'GET', [], 2);
 		$this->createService();
 
 		$this->route();
@@ -1183,7 +1182,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertTrue(_elgg_services()->views->isCacheableView('cacheable.xml'));
 
-		$this->request = _elgg_testing_request('ajax/view/cacheable.xml', 'GET', [], 2);
+		$this->request = $this->prepareHttpRequest('ajax/view/cacheable.xml', 'GET', [], 2);
 		$this->createService();
 
 		$this->route();
@@ -1208,7 +1207,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testCanRespondToAjax2ViewRequestForCSS() {
 
-		$this->request = _elgg_testing_request('ajax/view/css/styles.css', 'GET', [], 2);
+		$this->request = $this->prepareHttpRequest('ajax/view/css/styles.css', 'GET', [], 2);
 		$this->createService();
 
 		$this->route();
@@ -1233,7 +1232,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testCanRespondToAjax2ViewRequestForJS() {
 
-		$this->request = _elgg_testing_request('ajax/view/js/javascript.js', 'GET', [], 2);
+		$this->request = $this->prepareHttpRequest('ajax/view/js/javascript.js', 'GET', [], 2);
 		$this->createService();
 
 		$this->route();
@@ -1261,10 +1260,10 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			'query_value' => 'hello',
 		];
 
-		elgg_register_ajax_view('query_view');
-
-		$this->request = _elgg_testing_request('ajax/view/query_view', 'GET', $vars, 2);
+		$this->request = $this->prepareHttpRequest('ajax/view/query_view', 'GET', $vars, 2);
 		$this->createService();
+
+		elgg_register_ajax_view('query_view');
 
 		$this->route();
 
@@ -1300,10 +1299,10 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			'query_value' => 'hello',
 		];
 
-		elgg_register_ajax_view('query_view');
-
-		$this->request = _elgg_testing_request('ajax/view/query_view', 'GET', $vars, 2);
+		$this->request = $this->prepareHttpRequest('ajax/view/query_view', 'GET', $vars, 2);
 		$this->createService();
+
+		elgg_register_ajax_view('query_view');
 
 		$this->route();
 
@@ -1331,10 +1330,10 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			'error' => 'error',
 		];
 
-		elgg_register_ajax_view('forwards');
-
-		$this->request = _elgg_testing_request('ajax/view/forwards', 'GET', $vars, 2);
+		$this->request = $this->prepareHttpRequest('ajax/view/forwards', 'GET', $vars, 2);
 		$this->createService();
+
+		elgg_register_ajax_view('forwards');
 
 		$this->route();
 
@@ -1363,10 +1362,10 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			'query_value' => 'hello',
 		];
 
-		elgg_register_ajax_view('forms/query_view');
-
-		$this->request = _elgg_testing_request('ajax/form/query_view', 'GET', $vars, 1);
+		$this->request = $this->prepareHttpRequest('ajax/form/query_view', 'GET', $vars, 1);
 		$this->createService();
+
+		elgg_register_ajax_view('forms/query_view');
 
 		$this->route();
 
@@ -1393,10 +1392,10 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			'query_value' => 'hello',
 		];
 
-		elgg_register_ajax_view('form/query_view');
-
-		$this->request = _elgg_testing_request('ajax/form/query_view', 'GET', $vars, 1);
+		$this->request = $this->prepareHttpRequest('ajax/form/query_view', 'GET', $vars, 1);
 		$this->createService();
+
+		elgg_register_ajax_view('form/query_view');
 
 		$this->route();
 
@@ -1417,10 +1416,10 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			'query_value' => 'hello',
 		];
 
-		elgg_register_ajax_view('forms/query_view');
-
-		$this->request = _elgg_testing_request('ajax/form/query_view', 'GET', $vars, 2);
+		$this->request = $this->prepareHttpRequest('ajax/form/query_view', 'GET', $vars, 2);
 		$this->createService();
+
+		elgg_register_ajax_view('forms/query_view');
 
 		$this->route();
 
@@ -1456,10 +1455,10 @@ class RouterTest extends PHPUnit_Framework_TestCase {
 			'query_value' => 'hello',
 		];
 
-		elgg_register_ajax_view('form/query_view');
-
-		$this->request = _elgg_testing_request('ajax/form/query_view', 'GET', $vars, 2);
+		$this->request = $this->prepareHttpRequest('ajax/form/query_view', 'GET', $vars, 2);
 		$this->createService();
+
+		elgg_register_ajax_view('form/query_view');
 
 		$this->route();
 

--- a/engine/tests/phpunit/Elgg/Structs/Collection/InMemoryTest.php
+++ b/engine/tests/phpunit/Elgg/Structs/Collection/InMemoryTest.php
@@ -1,23 +1,23 @@
 <?php
+
 namespace Elgg\Structs\Collection;
 
-use PHPUnit_Framework_TestCase as TestCase;
+class InMemoryTest extends \Elgg\TestCase {
 
-class InMemoryTest extends TestCase {
 	public function testCountIsAccurate() {
 		$zeroItems = InMemory::fromArray([]);
 		$this->assertEquals(0, count($zeroItems));
-		
+
 		$oneItem = InMemory::fromArray(['one']);
 		$this->assertEquals(1, count($oneItem));
-		
+
 		$twoItems = InMemory::fromArray(['one', 'two']);
 		$this->assertEquals(2, count($twoItems));
 	}
-	
+
 	public function testContainsDoesNotImplicitlyCastSimilarValues() {
 		$collection = InMemory::fromArray(['1', false]);
-		
+
 		$this->assertTrue($collection->contains('1'));
 		$this->assertTrue($collection->contains(false));
 
@@ -25,25 +25,25 @@ class InMemoryTest extends TestCase {
 		$this->assertFalse($collection->contains(0));
 		$this->assertFalse($collection->contains(''));
 	}
-	
+
 	public function testIsTraversable() {
 		$collection = InMemory::fromArray(['one', 'two', 'three']);
-		
+
 		$items = array();
 		foreach ($collection as $item) {
 			$items[] = $item;
 		}
-		
+
 		$this->assertEquals(array('one', 'two', 'three'), $items);
 	}
-	
+
 	public function testIsFilterable() {
 		$collection = InMemory::fromArray([0, 1, 2, 3, 4]);
-		
+
 		$filtered = $collection->filter(function($number) {
 			return $number > 2;
 		});
-		
+
 		$this->assertFalse($filtered->contains(0));
 		$this->assertFalse($filtered->contains(1));
 		$this->assertFalse($filtered->contains(2));
@@ -52,14 +52,14 @@ class InMemoryTest extends TestCase {
 		$this->assertEquals(2, count($filtered));
 		$this->assertNotSame($filtered, $collection);
 	}
-	
+
 	public function testIsMappable() {
 		$collection = InMemory::fromArray([0, 1, 2, 3, 4]);
-		
+
 		$mapped = $collection->map(function($number) {
 			return $number * 2;
 		});
-		
+
 		$this->assertTrue($mapped->contains(0));
 		$this->assertTrue($mapped->contains(2));
 		$this->assertTrue($mapped->contains(4));
@@ -68,4 +68,5 @@ class InMemoryTest extends TestCase {
 		$this->assertEquals(5, count($mapped));
 		$this->assertNotSame($mapped, $collection);
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/SystemMessagesServiceTest.php
+++ b/engine/tests/phpunit/Elgg/SystemMessagesServiceTest.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Elgg;
 
 use Elgg\SystemMessages\RegisterSet;
 
-class SystemMessagesServiceTest extends \PHPUnit_Framework_TestCase {
+class SystemMessagesServiceTest extends \Elgg\TestCase {
 
 	/**
 	 * @var SystemMessagesService
@@ -30,7 +31,7 @@ class SystemMessagesServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals([
 			'success' => ['s1', 's2', 's3'],
 			'error' => ['e1', 'e2', 'e3'],
-		], $this->svc->dumpRegister());
+				], $this->svc->dumpRegister());
 
 		$this->assertEmpty($this->svc->dumpRegister());
 	}
@@ -47,15 +48,15 @@ class SystemMessagesServiceTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals([
 			'success' => ['s2', 's3'],
-		], $this->svc->dumpRegister('success'));
+				], $this->svc->dumpRegister('success'));
 
 		$this->assertEquals([
 			'success' => [],
-		], $this->svc->dumpRegister('success'));
+				], $this->svc->dumpRegister('success'));
 
 		$this->assertEquals([
 			'error' => ['e1', 'e2', 'e3'],
-		], $this->svc->dumpRegister('error'));
+				], $this->svc->dumpRegister('error'));
 
 		$this->assertEmpty($this->svc->dumpRegister());
 	}
@@ -86,15 +87,15 @@ class SystemMessagesServiceTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals([
 			'success' => ['s2'],
-		], $this->svc->dumpRegister('success'));
+				], $this->svc->dumpRegister('success'));
 
 		$this->assertEquals([
 			'error' => ['e1'],
-		], $this->svc->dumpRegister('error'));
+				], $this->svc->dumpRegister('error'));
 
 		$this->assertEquals([
 			'notice' => ['n1', 'n2'],
-		], $this->svc->dumpRegister());
+				], $this->svc->dumpRegister());
 	}
 
 	function testSystemMessagesFunction() {
@@ -115,9 +116,10 @@ class SystemMessagesServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals([
 			'notice' => ['n1'],
 			'success' => ['s1', 's2']
-		], system_messages(null, ''));
+				], system_messages(null, ''));
 
 		// clean up
 		_elgg_services()->setValue('systemMessages', $old_svc);
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/TagsTest.php
+++ b/engine/tests/phpunit/Elgg/TagsTest.php
@@ -1,26 +1,26 @@
 <?php
 
-class Elgg_TagsTest extends PHPUnit_Framework_TestCase {
+class Elgg_TagsTest extends \Elgg\TestCase {
 
 	/**
 	 * When providing a string to the string_to_tag_array function it should explode it based on a comma and return an array
 	 */
 	public function testStringToTagArrayReturnsArray() {
-		
+
 		// test if it returns an array with 1 item
 		$single_tag = string_to_tag_array("a");
-		$this->assertCount(1, $single_tag);		
-		
+		$this->assertCount(1, $single_tag);
+
 		// test if it returns an array with 3 item
 		$multiple_tags = string_to_tag_array("a,b,c");
 		$this->assertCount(3, $multiple_tags);
 	}
-	
+
 	/**
 	 * When providing a non-string the string_to_tag_array function should return the original value
 	 */
 	public function testStringToTagArrayReturnsOriginalValue() {
-		
+
 		// test if the original value (int) 1 is returned
 		$result = string_to_tag_array(1);
 		$this->assertEquals(1, $result);

--- a/engine/tests/phpunit/Elgg/TestCase.php
+++ b/engine/tests/phpunit/Elgg/TestCase.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Elgg;
+
+use Elgg\Di\ServiceProvider;
+use Elgg\Http\Request;
+use stdClass;
+use Zend\Mail\Transport\InMemory as InMemoryTransport;
+
+abstract class TestCase extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * Constructs a test case with the given name.
+	 * Boostraps testing environment
+	 * 
+	 * @param string $name
+	 * @param array  $data
+	 * @param string $dataName
+	 */
+	public function __construct($name = NULL, array $data = array(), $dataName = '') {
+		self::bootstrap();
+		parent::__construct($name, $data, $dataName);
+	}
+
+	/**
+	 * Boostraps test suite
+	 *
+	 * @global stdClass $CONFIG Global config
+	 * @global stdClass $_ELGG  Global vars
+	 * @return void
+	 */
+	public static function bootstrap() {
+
+		date_default_timezone_set('America/Los_Angeles');
+
+		error_reporting(E_ALL | E_STRICT);
+
+		$config = new Config((object) self::getTestingConfigArray());
+		$sp = new ServiceProvider($config);
+
+		$sp->setValue('mailer', new InMemoryTransport());
+
+		$sp->siteSecret->setTestingSecret('z1234567890123456789012345678901');
+
+		// persistentLogin service needs this set to instantiate without calling DB
+		$sp->config->getCookieConfig();
+
+		$app = new Application($sp);
+		Application::$_instance = $app;
+
+		// loadCore bails on repeated calls, so we need to manually inject this to make
+		// sure it happens before each test.
+		$app->loadCore();
+		_elgg_services($sp);
+
+		_elgg_filestore_boot();
+	}
+
+	/**
+	 * Returns default testing configuration array
+	 * @return array
+	 */
+	public static function getTestingConfigArray() {
+		return [
+			'Config_file' => false,
+			'dbprefix' => 'elgg_',
+			'boot_complete' => false,
+			'wwwroot' => 'http://localhost/',
+			'path' => __DIR__ . '/../../../../',
+			'dataroot' => __DIR__ . '/../test_files/dataroot/',
+			'cacheroot' => __DIR__ . '/../test_files/cacheroot/',
+			'site_guid' => 1,
+			'AutoloaderManager_skip_storage' => true,
+			'simplecache_enabled' => false,
+			'system_cache_enabled' => false,
+			'Elgg\Application_phpunit' => true,
+			// \Elgg\Config::get() falls back to loading config values from database
+			// for undefined keys. This flag ensures we do not attempt reading data
+			// from database during tests
+			'site_config_loaded' => true,
+			'icon_sizes' => array(
+				'topbar' => array('w' => 16, 'h' => 16, 'square' => true, 'upscale' => true),
+				'tiny' => array('w' => 25, 'h' => 25, 'square' => true, 'upscale' => true),
+				'small' => array('w' => 40, 'h' => 40, 'square' => true, 'upscale' => true),
+				'medium' => array('w' => 100, 'h' => 100, 'square' => true, 'upscale' => true),
+				'large' => array('w' => 200, 'h' => 200, 'square' => false, 'upscale' => false),
+				'master' => array('w' => 550, 'h' => 550, 'square' => false, 'upscale' => false),
+			),
+		];
+	}
+
+	/**
+	 * Get/set Config for testing purposes
+	 *
+	 * @staticvar \Elgg\Config $inst
+	 * @param Config $config Config
+	 * @return Config
+	 */
+	public static function config(Config $config = null) {
+		if ($config) {
+			_elgg_services()->setValue('config', $config);
+		}
+		return _elgg_services()->config;
+	}
+
+	/**
+	 * Create an HTTP request
+	 *
+	 * @param string $uri             URI of the request
+	 * @param string $method          HTTP method
+	 * @param array  $parameters      Query/Post parameters
+	 * @param int    $ajax            AJAX api version (0 for non-ajax)
+	 * @param bool   $add_csrf_tokens Add CSRF tokens
+	 * @return Request
+	 */
+	public static function prepareHttpRequest($uri = '', $method = 'GET', $parameters = [], $ajax = 0, $add_csrf_tokens = false) {
+		$site_url = elgg_get_site_url();
+		$path = substr(elgg_normalize_url($uri), strlen($site_url));
+		$path_key = Application::GET_PATH_KEY;
+
+		if ($add_csrf_tokens) {
+			$ts = time();
+			$parameters['__elgg_ts'] = $ts;
+			$parameters['__elgg_token'] = _elgg_services()->actions->generateActionToken($ts);
+		}
+
+		$request = Request::create("?$path_key=" . urlencode($path), $method, $parameters);
+
+		$cookie_name = _elgg_services()->config->getCookieConfig()['session']['name'];
+		$session_id = _elgg_services()->session->getId();
+		$request->cookies->set($cookie_name, $session_id);
+
+		$request->headers->set('Referer', elgg_normalize_url('phpunit'));
+
+		if ($ajax) {
+			$request->headers->set('X-Requested-With', 'XMLHttpRequest');
+			if ($ajax >= 2) {
+				$request->headers->set('X-Elgg-Ajax-API', (string) $ajax);
+			}
+		}
+
+		return $request;
+	}
+
+}
+
+/**
+ * We require BC to keep test cases extending PHPUnit_Framework_TestCase backward compatible.
+ * @todo: remove in 3.0
+ */
+require dirname(dirname(__FILE__)) . '/bootstrap.php';

--- a/engine/tests/phpunit/Elgg/TestCaseTest.php
+++ b/engine/tests/phpunit/Elgg/TestCaseTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Elgg;
+
+class TestCaseTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * Test that legacy bootstrap has been autoloaded and
+	 * stay BC with older test cases
+	 */
+	public function testIsBoostrapped() {
+		$this->assertInstanceOf(Di\ServiceProvider::class, _elgg_services());
+		$this->assertInstanceOf(Application::class, _elgg_testing_application());
+		$this->assertInstanceof(Config::class, _elgg_testing_config());
+		$this->assertInstanceOf(Http\Request::class, _elgg_testing_request());
+	}
+
+}

--- a/engine/tests/phpunit/Elgg/Tests/EntityMocks.php
+++ b/engine/tests/phpunit/Elgg/Tests/EntityMocks.php
@@ -7,7 +7,7 @@ use ElggGroup;
 use ElggObject;
 use ElggUser;
 use LogicException;
-use PHPUnit_Framework_TestCase;
+
 
 /**
  * Create test doubles for Elgg entities
@@ -17,7 +17,7 @@ use PHPUnit_Framework_TestCase;
 class EntityMocks {
 	
 	/**
-	 * @var PHPUnit_Framework_TestCase
+	 * @var \Elgg\TestCase
 	 */
 	private $test;
 
@@ -34,9 +34,9 @@ class EntityMocks {
 	/**
 	 * Constructor
 	 *
-	 * @param PHPUnit_Framework_TestCase $test Test case
+	 * @param \Elgg\TestCase $test Test case
 	 */
-	public function __construct(PHPUnit_Framework_TestCase $test) {
+	public function __construct(\Elgg\TestCase $test) {
 		$this->test = $test;
 		$this->iterator = 100; // some random offset
 	}

--- a/engine/tests/phpunit/Elgg/TimerTest.php
+++ b/engine/tests/phpunit/Elgg/TimerTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Elgg;
 
-class TimerTest extends \PHPUnit_Framework_TestCase {
+class TimerTest extends \Elgg\TestCase {
 
 	/**
 	 * @var Timer
@@ -51,4 +52,5 @@ class TimerTest extends \PHPUnit_Framework_TestCase {
 		$this->timer->end(['1', 'a']);
 		$this->assertTrue($this->timer->hasEnded(['1', 'a']));
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/TravisValidateCommitMsgTest.php
+++ b/engine/tests/phpunit/Elgg/TravisValidateCommitMsgTest.php
@@ -1,17 +1,19 @@
 <?php
+
 namespace Elgg;
 
 /**
  * Tests the travis shell script
  */
 class TravisValidateCommitMsgTest extends CommitMessageGitHookTest {
+
 	protected $travisScript;
 
 	public function setUp() {
 		parent::setUp();
 
 		$this->travisScript = $this->scriptsDir . 'travis/check_commit_msgs.sh';
-		
+
 		$this->markTestSkipped('Testing against particular SHAs is too flaky.');
 	}
 
@@ -144,4 +146,5 @@ class TravisValidateCommitMsgTest extends CommitMessageGitHookTest {
 		$result = $this->runCmd($cmd, $output);
 		$this->assertTrue($result, $output);
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/UpdateServiceTest.php
+++ b/engine/tests/phpunit/Elgg/UpdateServiceTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Elgg;
 
-class UpgradeServiceTest extends \PHPUnit_Framework_TestCase {
+class UpgradeServiceTest extends \Elgg\TestCase {
 
 	/**
 	 * @var \Elgg\UpgradeService
@@ -31,9 +32,9 @@ class UpgradeServiceTest extends \PHPUnit_Framework_TestCase {
 			$this->assertTrue(is_array($result));
 			$this->assertArrayHasKey("failure", $result);
 			$this->assertFalse($result["failure"]);
-
 		} catch (Exception $e) {
 			$this->fail($e->getMessage());
 		}
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/UserCapabilitiesTest.php
+++ b/engine/tests/phpunit/Elgg/UserCapabilitiesTest.php
@@ -6,9 +6,8 @@ use Elgg\Database\EntityTable;
 use Elgg\Database\EntityTable\UserFetchFailureException;
 use Elgg\Tests\EntityMocks;
 use ElggSession;
-use PHPUnit_Framework_TestCase;
 
-class UserCapabilitiesTest extends PHPUnit_Framework_TestCase {
+class UserCapabilitiesTest extends \Elgg\TestCase {
 
 	/**
 	 * @var PluginHooksService
@@ -28,7 +27,7 @@ class UserCapabilitiesTest extends PHPUnit_Framework_TestCase {
 	public function setUp() {
 
 		$this->mocks = new EntityMocks($this);
-		
+
 		$this->hooks = new PluginHooksService();
 
 		$this->entities = $this->getMockBuilder('\Elgg\Database\EntityTable')
@@ -96,7 +95,7 @@ class UserCapabilitiesTest extends PHPUnit_Framework_TestCase {
 		$entity = $this->mocks->getObject([
 			'owner_guid' => $user->guid,
 		]);
-		
+
 		$this->assertTrue($entity->canEdit($user->guid));
 
 		$this->hooks->registerHandler('permissions_check', 'object', function($hook, $type, $return, $params) use ($entity, $user) {
@@ -165,7 +164,7 @@ class UserCapabilitiesTest extends PHPUnit_Framework_TestCase {
 			'owner_guid' => $owner->guid,
 			'container_guid' => $container->guid,
 		]);
-		
+
 		$this->assertTrue($entity->canWriteToContainer($owner->guid));
 		$this->assertTrue($entity->canWriteToContainer($container->guid));
 		$this->assertEquals($entity->canEdit($owner->guid), $entity->canDelete($owner->guid));
@@ -199,10 +198,9 @@ class UserCapabilitiesTest extends PHPUnit_Framework_TestCase {
 		});
 
 		$this->assertFalse($entity->canWriteToContainer($owner->guid, 'object', 'bar'));
-		
+
 		// Should still be able to write to container without particular entity type specified
 		$this->assertTrue($entity->canWriteToContainer($owner->guid));
-		
 	}
 
 	/**
@@ -333,7 +331,7 @@ class UserCapabilitiesTest extends PHPUnit_Framework_TestCase {
 					'owner_guid' => $owner->guid,
 					'entity_guid' => $entity->guid,
 		]);
-		
+
 		$this->assertTrue($annotation->canEdit($owner->guid));
 
 		$viewer = $this->mocks->getUser();
@@ -384,7 +382,7 @@ class UserCapabilitiesTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertFalse($annotation->canEdit($owner->guid));
 	}
-	
+
 	/**
 	 * @group UserCapabilities
 	 */
@@ -425,7 +423,7 @@ class UserCapabilitiesTest extends PHPUnit_Framework_TestCase {
 	 * @group UserCapabilities
 	 */
 	public function testCanOverrideCommentingPermissionsWithAHook() {
-		
+
 		$owner = $this->mocks->getUser();
 		$entity = $this->mocks->getObject([
 			'owner_guid' => $owner->guid,
@@ -495,15 +493,16 @@ class UserCapabilitiesTest extends PHPUnit_Framework_TestCase {
 			'owner_guid' => $owner->guid,
 		]);
 
-		$entity->canAnnotate($owner->guid, function() {return 'annotation_name';});
+		$entity->canAnnotate($owner->guid, function() {
+			return 'annotation_name';
+		});
 	}
-
 
 	/**
 	 * @group UserCapabilities
 	 */
 	public function testCanAnnotateByDefault() {
-		
+
 		$viewer = $this->mocks->getUser();
 		$owner = $this->mocks->getUser();
 		$entity = $this->mocks->getObject([
@@ -516,7 +515,6 @@ class UserCapabilitiesTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($entity->canAnnotate($owner->guid, ''));
 		$this->assertTrue($entity->canAnnotate($owner->guid, false)); //BC
 		$this->assertTrue($entity->canAnnotate($owner->guid, null)); //BC
-
 		// All other users can annotate
 		$this->assertTrue($entity->canAnnotate($viewer->guid));
 		$this->assertTrue($viewer->canAnnotate($viewer->guid, 'baz'));
@@ -573,7 +571,6 @@ class UserCapabilitiesTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($entity->canAnnotate($owner->guid, 'baz'));
 	}
 
-
 	/**
 	 * @group UserCapabilities
 	 */
@@ -610,4 +607,5 @@ class UserCapabilitiesTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertTrue($entity->canAnnotate($owner->guid, 'baz'));
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/ViewsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ViewsServiceTest.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Elgg;
 
-
-class ViewsServiceTest extends \PHPUnit_Framework_TestCase {
+class ViewsServiceTest extends \Elgg\TestCase {
 
 	/**
 	 * @var PluginHooksService
@@ -13,25 +13,24 @@ class ViewsServiceTest extends \PHPUnit_Framework_TestCase {
 	 * @var ViewsService
 	 */
 	protected $views;
-
 	protected $viewsDir;
 
 	public function setUp() {
 		$this->viewsDir = dirname(dirname(__FILE__)) . "/test_files/views";
-		
+
 		$this->hooks = new PluginHooksService();
 		$logger = $this->getMock('\Elgg\Logger', array(), array(), '', false);
-		
+
 		$this->views = new ViewsService($this->hooks, $logger);
 		$this->views->autoregisterViews('', "$this->viewsDir/default", 'default');
 
 		// supports deprecation wrapper for $vars['user'] 
 		_elgg_services()->setValue('session', \ElggSession::getMock());
 	}
-	
+
 	public function testCanExtendViews() {
 		$this->views->extendView('foo', 'bar');
-		
+
 		// Unextending valid extension succeeds.
 		$this->assertTrue($this->views->unextendView('foo', 'bar'));
 
@@ -47,17 +46,17 @@ class ViewsServiceTest extends \PHPUnit_Framework_TestCase {
 	public function testRegistersPhpFilesAsViews() {
 		$this->assertTrue($this->views->viewExists('js/interpreted.js'));
 	}
-	
+
 	public function testRegistersStaticFilesAsViews() {
 		$this->assertTrue($this->views->viewExists('js/static.js'));
 	}
-	
+
 	public function testUsesPhpToRenderNonStaticViews() {
 		$this->assertEquals("// PHPin", $this->views->renderView('js/interpreted.js', array(
-			'in' => 'in',
+					'in' => 'in',
 		)));
 	}
-	
+
 	public function testDoesNotUsePhpToRenderStaticViews() {
 		$expected = file_get_contents("$this->viewsDir/default/js/static.js");
 		$this->assertEquals($expected, $this->views->renderView('js/static.js'));
@@ -75,7 +74,7 @@ class ViewsServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($expected, $this->views->renderView('hello.js'));
 
 		$this->assertEquals("// PHPin", $this->views->renderView('hello/world.js', array(
-			'in' => 'in',
+					'in' => 'in',
 		)));
 	}
 
@@ -88,21 +87,21 @@ class ViewsServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->views->registerViewtypeFallback('mobile');
 		$this->assertTrue($this->views->doesViewtypeFallBack('mobile'));
 	}
-	
+
 	public function testViewsCanExistBasedOnViewtypeFallback() {
 		$this->views->registerViewtypeFallback('mobile');
 		$this->assertTrue($this->views->viewExists('js/interpreted.js', 'mobile'));
 		$this->assertEquals('// PHP', $this->views->renderView('js/interpreted.js', array(), false, 'mobile'));
 	}
-	
+
 	public function testCanRegisterViewsAsCacheable() {
 		$this->assertFalse($this->views->isCacheableView('js/interpreted.js'));
-		
+
 		$this->views->registerCacheableView('js/interpreted.js');
-		
+
 		$this->assertTrue($this->views->isCacheableView('js/interpreted.js'));
 	}
-	
+
 	public function testStaticViewsAreAlwaysCacheable() {
 		$this->assertTrue($this->views->isCacheableView('js/static.js'));
 	}
@@ -135,11 +134,11 @@ class ViewsServiceTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertSame("123", $this->views->renderView('js/interpreted.js'));
 	}
-	
+
 	public function testThrowsOnCircularAliases() {
 		$this->markTestIncomplete();
 	}
-	
+
 	public function testEmitsDeprecationWarningWhenOldViewNameIsReferenced() {
 		$this->markTestIncomplete();
 		// elgg_view
@@ -151,7 +150,7 @@ class ViewsServiceTest extends \PHPUnit_Framework_TestCase {
 		// elgg_set_view_location
 		// elgg_get_view_location
 	}
-	
+
 	/**
 	 * @dataProvider getExampleNormalizedViews
 	 */
@@ -171,7 +170,7 @@ class ViewsServiceTest extends \PHPUnit_Framework_TestCase {
 		$list = $this->views->getViewList('foo');
 		$this->assertEquals([
 			500 => 'foo',
-		], $list);
+				], $list);
 
 		$this->views->extendView('foo', 'bar');
 		$this->views->extendView('foo', 'bing', 499);
@@ -181,22 +180,19 @@ class ViewsServiceTest extends \PHPUnit_Framework_TestCase {
 			499 => 'bing',
 			500 => 'foo',
 			501 => 'bar',
-		], $list);
+				], $list);
 	}
-	
+
 	public function getExampleNormalizedViews() {
 		return [
 			// [canonical, alias]
-			
 			// js namespace should be removed and .js added to all JS views
 			['view.js', 'js/view'],
 			['view.js', 'js/view.js'],
 			['view.css', 'js/view.css'],
 			['view.png', 'js/view.png'],
-			
 			// ".form" in this case is not an extension, just a delimiter. Ignore.
 			['jquery.form.js', 'js/jquery.form'],
-			
 			// css namespace should be removed and .css added to all CSS views
 			['view.css', 'css/view'],
 			['view.css', 'css/view.css'],
@@ -204,5 +200,5 @@ class ViewsServiceTest extends \PHPUnit_Framework_TestCase {
 			['view.jpg', 'css/view.jpg'],
 		];
 	}
-}
 
+}

--- a/engine/tests/phpunit/Elgg/WidgetsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/WidgetsServiceTest.php
@@ -1,69 +1,69 @@
 <?php
+
 namespace Elgg;
 
-
-class WidgetsServiceTest extends \PHPUnit_Framework_TestCase {
+class WidgetsServiceTest extends \Elgg\TestCase {
 
 	public function elgg_set_config($key, $val) {
 		//do nothing, that's only for BC
 	}
-	
+
 	public function testRegisterTypeParametersControl() {
 		$service = new \Elgg\WidgetsService(array($this, 'elgg_set_config'));
-		
+
 		$definition = \Elgg\WidgetDefinition::factory([
-			'id' => 'widget_test',
-			'name' => 'Widget name',
+					'id' => 'widget_test',
+					'name' => 'Widget name',
 		]);
 		$this->assertTrue($service->registerType($definition));
-		
+
 		$definition->id = null;
 		$this->assertFalse($service->registerType($definition));
 	}
-	
+
 	/**
 	 * Tests register, exists and unregisrer
 	 */
 	public function testCanRegisterType() {
 		$service = new \Elgg\WidgetsService(array($this, 'elgg_set_config'));
-		
+
 		$this->assertFalse($service->validateType('widget_type'));
 		$this->assertFalse($service->validateType('not_registered_widget'));
 
 		$this->assertTrue($service->registerType(\Elgg\WidgetDefinition::factory([
-			'id' => 'widget_type',
-			'name' => 'Widget name1',
-			'description' => 'Widget description1',
+							'id' => 'widget_type',
+							'name' => 'Widget name1',
+							'description' => 'Widget description1',
 		])));
 		$this->assertTrue($service->registerType(\Elgg\WidgetDefinition::factory([
-			'id' => 'widget_type_con',
-			'name' => 'Widget name2',
-			'description' => 'Widget description2',
-			'context' => ['dashboard', 'profile'],
+							'id' => 'widget_type_con',
+							'name' => 'Widget name2',
+							'description' => 'Widget description2',
+							'context' => ['dashboard', 'profile'],
 		])));
 		$this->assertTrue($service->registerType(\Elgg\WidgetDefinition::factory([
-			'id' => 'widget_type_mul',
-			'name' => 'Widget name3',
-			'description' => 'Widget description3',
-			'context' => ['all'],
-			'multiple' => true,
+							'id' => 'widget_type_mul',
+							'name' => 'Widget name3',
+							'description' => 'Widget description3',
+							'context' => ['all'],
+							'multiple' => true,
 		])));
 		$this->assertTrue($service->registerType(\Elgg\WidgetDefinition::factory([
-			'id' => 'widget_type_con_mul',
-			'name' => 'Widget name4',
-			'description' => 'Widget description4',
-			'context' => ['dashboard', 'settings'],
-			'multiple' => true,
+							'id' => 'widget_type_con_mul',
+							'name' => 'Widget name4',
+							'description' => 'Widget description4',
+							'context' => ['dashboard', 'settings'],
+							'multiple' => true,
 		])));
 		//overwrite
 		$this->assertTrue($service->registerType(\Elgg\WidgetDefinition::factory([
-			'id' => 'widget_type_con_mul',
-			'name' => 'Widget name5',
-			'description' => 'Widget description5',
-			'context' => ['dashboard', 'settings'],
-			'multiple' => true,
+							'id' => 'widget_type_con_mul',
+							'name' => 'Widget name5',
+							'description' => 'Widget description5',
+							'context' => ['dashboard', 'settings'],
+							'multiple' => true,
 		])));
-		
+
 		$this->assertTrue($service->validateType('widget_type'));
 		$this->assertTrue($service->validateType('widget_type_con'));
 		$this->assertTrue($service->validateType('widget_type_mul'));
@@ -72,6 +72,7 @@ class WidgetsServiceTest extends \PHPUnit_Framework_TestCase {
 
 		return $service;
 	}
+
 	/**
 	 * Tests register and unregister widgets with hook
 	 */
@@ -79,23 +80,23 @@ class WidgetsServiceTest extends \PHPUnit_Framework_TestCase {
 		$service = new \Elgg\WidgetsService(array($this, 'elgg_set_config'));
 
 		$this->assertFalse($service->validateType('hook_widget'));
-		
+
 		_elgg_services()->hooks->registerHandler('handlers', 'widgets', [$this, 'registerWidgetsHookHandler']);
 		$this->assertArrayHasKey('hook_widget', $service->getTypes());
-		
+
 		_elgg_services()->hooks->unregisterHandler('handlers', 'widgets', [$this, 'registerWidgetsHookHandler']);
 		$this->assertArrayNotHasKey('hook_widget', $service->getTypes());
-		
+
 		_elgg_services()->hooks->registerHandler('handlers', 'widgets', [$this, 'registerWidgetsHookHandler']);
 		$this->assertArrayHasKey('hook_widget', $service->getTypes());
-				
+
 		_elgg_services()->hooks->registerHandler('handlers', 'widgets', [$this, 'unregisterWidgetsHookHandler']);
 		$this->assertArrayNotHasKey('hook_widget', $service->getTypes());
-		
+
 		_elgg_services()->hooks->unregisterHandler('handlers', 'widgets', [$this, 'registerWidgetsHookHandler']);
 		_elgg_services()->hooks->unregisterHandler('handlers', 'widgets', [$this, 'unregisterWidgetsHookHandler']);
 	}
-	
+
 	/**
 	 * Register a widget
 	 *
@@ -108,11 +109,11 @@ class WidgetsServiceTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function registerWidgetsHookHandler($hook, $type, $value, $params) {
 		$value[] = \Elgg\WidgetDefinition::factory([
-			'id' => 'hook_widget',
-			'name' => 'hook_widget name',
-			'description' => 'hook_widget description',
+					'id' => 'hook_widget',
+					'name' => 'hook_widget name',
+					'description' => 'hook_widget description',
 		]);
-		
+
 		return $value;
 	}
 
@@ -133,7 +134,7 @@ class WidgetsServiceTest extends \PHPUnit_Framework_TestCase {
 				break;
 			}
 		}
-		
+
 		return $value;
 	}
 
@@ -142,7 +143,7 @@ class WidgetsServiceTest extends \PHPUnit_Framework_TestCase {
 	 * @param \Elgg\WidgetsService $service
 	 */
 	public function testRegistrationParametersPreserveContext($service) {
-		
+
 		$params = array(
 			//exact, context, expected
 			array(false, 'all', array('widget_type', 'widget_type_mul')),
@@ -154,37 +155,37 @@ class WidgetsServiceTest extends \PHPUnit_Framework_TestCase {
 			array(true, 'profile', array('widget_type_con')),
 			array(true, 'settings', array('widget_type_con_mul')),
 		);
-		
+
 		//is returned set of ids the same as expected
 		foreach ($params as $case) {
 			list($exact, $context, $expected) = $case;
 			sort($expected);
 			$actual = array_keys($service->getTypes([
-				'context' => $context,
-				'exact' => $exact,
+						'context' => $context,
+						'exact' => $exact,
 			]));
 			sort($actual);
 			$this->assertEquals($expected, $actual);
 		}
-		
+
 		return $service;
 	}
-	
+
 	/**
 	 * @depends testRegistrationParametersPreserveContext
 	 * @param \Elgg\WidgetsService $service
 	 */
 	public function testRegistrationParametersPreserveMultiple($service) {
-		
+
 		$resps = array(
 			'widget_type' => false,
 			'widget_type_con' => false,
 			'widget_type_mul' => true,
 			'widget_type_con_mul' => true,
 		);
-		
+
 		$contexts = array('all', 'dashboard', 'profile', 'settings');
-		
+
 		foreach (array(false, true) as $exact) {
 			foreach ($contexts as $context) {
 				$items = $service->getTypes([
@@ -200,25 +201,25 @@ class WidgetsServiceTest extends \PHPUnit_Framework_TestCase {
 				}
 			}
 		}
-		
+
 		return $service;
 	}
-	
+
 	/**
 	 * @depends testRegistrationParametersPreserveMultiple
 	 * @param \Elgg\WidgetsService $service
 	 */
 	public function testRegistrationParametersPreserveNameDescription($service) {
-		
+
 		$resps = array(
 			'widget_type' => array('Widget name1', 'Widget description1'),
 			'widget_type_con' => array('Widget name2', 'Widget description2'),
 			'widget_type_mul' => array('Widget name3', 'Widget description3'),
 			'widget_type_con_mul' => array('Widget name5', 'Widget description5'),
 		);
-		
+
 		$contexts = array('all', 'dashboard', 'profile', 'settings');
-		
+
 		foreach (array(false, true) as $exact) {
 			foreach ($contexts as $context) {
 				$items = $service->getTypes([
@@ -236,10 +237,10 @@ class WidgetsServiceTest extends \PHPUnit_Framework_TestCase {
 				}
 			}
 		}
-		
+
 		return $service;
 	}
-	
+
 	/**
 	 * @depends testRegistrationParametersPreserveNameDescription
 	 * @param \Elgg\WidgetsService $service
@@ -251,14 +252,12 @@ class WidgetsServiceTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($service->unregisterType('widget_type_mul'));
 		$this->assertTrue($service->unregisterType('widget_type_con_mul'));
 		$this->assertFalse($service->unregisterType('widget_not_registered'));
-		
+
 		$this->assertFalse($service->validateType('widget_type'));
 		$this->assertFalse($service->validateType('widget_type_con'));
 		$this->assertFalse($service->validateType('widget_type_mul'));
 		$this->assertFalse($service->validateType('not_registered_widget'));
 	}
-	
+
 	//TODO get, view, create, canEditLayout, defaultWidgetsInit, createDefault, defaultWidgetsPermissionsOverride
-
 }
-

--- a/engine/tests/phpunit/Elgg/lib/output/FormatAttributesTest.php
+++ b/engine/tests/phpunit/Elgg/lib/output/FormatAttributesTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Elgg\lib\output;
 
-class FormatAttributesTest extends \PHPUnit_Framework_TestCase {
+class FormatAttributesTest extends \Elgg\TestCase {
 
 	public function testGeneralUsage() {
 		$attrs = [
@@ -10,7 +11,7 @@ class FormatAttributesTest extends \PHPUnit_Framework_TestCase {
 			'c' => true,
 			'd' => null, // ignored
 			'e' => ['&', '&amp;', '<', '&lt;'],
-			'f' => (object)['foo' => 'bar'], // ignored
+			'f' => (object) ['foo' => 'bar'], // ignored
 		];
 		$expected = 'a="Hello &amp; &amp; &lt; &lt;" c="c" e="&amp; &amp; &lt; &lt;"';
 
@@ -36,4 +37,5 @@ class FormatAttributesTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals($expected, elgg_format_attributes($attrs));
 	}
+
 }

--- a/engine/tests/phpunit/ElggAutoPTest.php
+++ b/engine/tests/phpunit/ElggAutoPTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggAutoPTest extends \PHPUnit_Framework_TestCase {
+class ElggAutoPTest extends \Elgg\TestCase {
 
 	/**
 	 * @var \ElggAutoP
@@ -10,7 +10,7 @@ class ElggAutoPTest extends \PHPUnit_Framework_TestCase {
 	public function setUp() {
 		$this->_autop = new \ElggAutoP();
 	}
-	
+
 	public function testDomRoundtrip() {
 		$d = dir(__DIR__ . '/test_files/autop');
 		$in = file_get_contents($d->path . "/domdoc_in.html");
@@ -22,7 +22,7 @@ class ElggAutoPTest extends \PHPUnit_Framework_TestCase {
 		$doc->loadHTML("<html><meta http-equiv='content-type' content='text/html; charset=utf-8'><body>"
 				. $in . '</body></html>');
 		$serialized = $doc->saveHTML();
-		list(,$out) = explode('<body>', $serialized, 2);
+		list(, $out) = explode('<body>', $serialized, 2);
 		list($out) = explode('</body>', $out, 2);
 		$out = $this->flattenString($out);
 
@@ -48,7 +48,7 @@ class ElggAutoPTest extends \PHPUnit_Framework_TestCase {
 				$tests[] = $m[1];
 			}
 		}
-
+		
 		$data = array();
 		foreach ($tests as $test) {
 			$data[] = array(
@@ -68,4 +68,5 @@ class ElggAutoPTest extends \PHPUnit_Framework_TestCase {
 		$r = preg_replace('/[\n\r]+/', '', $string);
 		return $r;
 	}
+
 }

--- a/engine/tests/phpunit/ElggBreadcrumbsTest.php
+++ b/engine/tests/phpunit/ElggBreadcrumbsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggBreadcrumbsTest extends \PHPUnit_Framework_TestCase {
+class ElggBreadcrumbsTest extends \Elgg\TestCase {
 
 //	public function setUp() {
 //		// TODO run each test in better isolation
@@ -19,7 +19,7 @@ class ElggBreadcrumbsTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(
 			array('title' => 'title 1', 'link' => null),
 			array('title' => 'title 2', 'link' => 'path2')
-		), elgg_get_breadcrumbs());
+				), elgg_get_breadcrumbs());
 	}
 
 	public function testCrumbsCanBePopped() {
@@ -34,7 +34,7 @@ class ElggBreadcrumbsTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(array(
 			array('title' => 'title 1', 'link' => null),
-		), elgg_get_breadcrumbs());
+				), elgg_get_breadcrumbs());
 
 		$this->assertEquals(array('title' => 'title 1', 'link' => null), elgg_pop_breadcrumb());
 
@@ -53,7 +53,7 @@ class ElggBreadcrumbsTest extends \PHPUnit_Framework_TestCase {
 				'title' => str_repeat('abcd ', 100),
 				'link' => null,
 			),
-		), elgg_get_breadcrumbs());
+				), elgg_get_breadcrumbs());
 	}
 
 	public function testCrumbsAreExcerpted() {
@@ -66,7 +66,7 @@ class ElggBreadcrumbsTest extends \PHPUnit_Framework_TestCase {
 				'title' => elgg_get_excerpt(str_repeat('abcd ', 100), 100),
 				'link' => null,
 			),
-		), elgg_get_breadcrumbs());
+				), elgg_get_breadcrumbs());
 	}
 
 	public function testCrumbTitlesAreEscaped() {
@@ -113,4 +113,5 @@ class ElggBreadcrumbsTest extends \PHPUnit_Framework_TestCase {
 		$html = elgg_view('navigation/breadcrumbs');
 		$this->assertFalse(strpos($html, 'Bar'));
 	}
+
 }

--- a/engine/tests/phpunit/ElggCoreUrlHelpersTest.php
+++ b/engine/tests/phpunit/ElggCoreUrlHelpersTest.php
@@ -4,7 +4,7 @@
  * @see \ElggCoreHelpersTest
  * @todo migrate similar simpletest tests to this class
  */
-class ElggCoreUrlHelpersTest extends \PHPUnit_Framework_TestCase {
+class ElggCoreUrlHelpersTest extends \Elgg\TestCase {
 
 	/**
 	 * Test if elgg_http_add_url_query_elements() preserves original url when no params are passed
@@ -24,12 +24,10 @@ class ElggCoreUrlHelpersTest extends \PHPUnit_Framework_TestCase {
 			array('https://example.com/path', array(), 'https://example.com/path'),
 			array('http://example-time.com', array(), 'http://example-time.com?'),
 			array('http://example-time.com/path', array(), 'http://example-time.com/path'),
-
 			array('ftp://example.com/', array(), 'ftp://example.com/'),
 			array('ftp://example.com/file', array(), 'ftp://example.com/file'),
 			array('app://endpoint', array(), 'app://endpoint?'),
 			array('app://endpoint/path', array(), 'app://endpoint/path'),
-
 			array('https://example.com?foo=123&bar=abc', array(), 'https://example.com?foo=123&bar=abc'),
 			array('https://example.com/path?foo=123&bar=abc', array(), 'https://example.com/path?foo=123&bar=abc'),
 		);
@@ -57,12 +55,10 @@ class ElggCoreUrlHelpersTest extends \PHPUnit_Framework_TestCase {
 			array('https://example.com/path', array('foo' => 'bar'), 'https://example.com/path?foo=bar'),
 			array('http://example-time.com', array('foo' => 'bar'), 'http://example-time.com?foo=bar'),
 			array('http://example-time.com/path', array('foo' => 'bar'), 'http://example-time.com/path?foo=bar'),
-
 			array('ftp://example.com/', array('foo' => 'bar'), 'ftp://example.com/?foo=bar'),
 			array('ftp://example.com/file', array('foo' => 'bar'), 'ftp://example.com/file?foo=bar'),
 			array('app://endpoint', array('foo' => 'bar'), 'app://endpoint?foo=bar'),
 			array('app://endpoint/path', array('foo' => 'bar'), 'app://endpoint/path?foo=bar'),
-
 			array('https://example.com?foo=123&bar=abc', array('foo2' => 'bar2'), 'https://example.com?foo=123&bar=abc&foo2=bar2'),
 			array('https://example.com/path?foo=123&bar=abc', array('foo' => 'bar'), 'https://example.com/path?foo=bar&bar=abc'),
 			array('https://example.com?foo=123&bar=abc', array('foo2' => 'bar2', '123' => 456), 'https://example.com?foo=123&bar=abc&foo2=bar2&123=456'),
@@ -86,7 +82,6 @@ class ElggCoreUrlHelpersTest extends \PHPUnit_Framework_TestCase {
 			array('?foo=bar', array('foo' => null), '?'),
 			array('/?foo=bar', array('foo' => null), '/'),
 			array('/path?foo=bar', array('foo' => null), '/path'),
-
 			array('example.com', array('foo' => null), 'example.com'),
 			array('example.com?foo=bar', array('foo' => null), 'example.com'),
 			array('example.com/path?foo=bar', array('foo' => null), 'example.com/path'),
@@ -98,12 +93,10 @@ class ElggCoreUrlHelpersTest extends \PHPUnit_Framework_TestCase {
 			array('https://example.com/path?foo=bar', array('foo' => null), 'https://example.com/path'),
 			array('http://example-time.com?foo=bar', array('foo' => null), 'http://example-time.com?'),
 			array('http://example-time.com/path?foo=bar', array('foo' => null), 'http://example-time.com/path'),
-
 			array('ftp://example.com/?foo=bar', array('foo' => null), 'ftp://example.com/'),
 			array('ftp://example.com/file?foo=bar', array('foo' => null), 'ftp://example.com/file'),
 			array('app://endpoint?foo=bar', array('foo' => null), 'app://endpoint?'),
 			array('app://endpoint/path?foo=bar', array('foo' => null), 'app://endpoint/path'),
-
 			//add and delete at the same time
 			array('https://example.com?foo=123&bar=abc', array('foo' => null, 'foo2' => 'bar2'), 'https://example.com?bar=abc&foo2=bar2'),
 			array('https://example.com/path?bar=abc&foo=123', array('foo' => null, 'foo2' => 'bar'), 'https://example.com/path?bar=abc&foo2=bar'),
@@ -119,4 +112,5 @@ class ElggCoreUrlHelpersTest extends \PHPUnit_Framework_TestCase {
 			}
 		}
 	}
+
 }

--- a/engine/tests/phpunit/ElggCoreViewtypeTest.php
+++ b/engine/tests/phpunit/ElggCoreViewtypeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggCoreViewtypeTest extends \PHPUnit_Framework_TestCase {
+class ElggCoreViewtypeTest extends \Elgg\TestCase {
 
 	protected function setUp() {
 		global $CURRENT_SYSTEM_VIEWTYPE, $CONFIG;
@@ -61,4 +61,5 @@ class ElggCoreViewtypeTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse(_elgg_is_valid_viewtype(123));
 		$this->assertFalse(_elgg_is_valid_viewtype(''));
 	}
+
 }

--- a/engine/tests/phpunit/ElggCryptoTest.php
+++ b/engine/tests/phpunit/ElggCryptoTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggCryptoTest extends \PHPUnit_Framework_TestCase {
+class ElggCryptoTest extends \Elgg\TestCase {
 
 	/**
 	 * @var PHPUnit_Framework_MockObject_MockObject
@@ -13,13 +13,13 @@ class ElggCryptoTest extends \PHPUnit_Framework_TestCase {
 	 */
 	protected function setUp() {
 		$this->stub = $this->getMockBuilder('\ElggCrypto')
-			->setMethods(array('getRandomBytes'))
-			->setConstructorArgs([_elgg_services()->siteSecret])
-			->getMock();
+				->setMethods(array('getRandomBytes'))
+				->setConstructorArgs([_elgg_services()->siteSecret])
+				->getMock();
 
 		$this->stub->expects($this->any())
-			->method('getRandomBytes')
-			->will($this->returnCallback(array($this, 'mock_getRandomBytes')));
+				->method('getRandomBytes')
+				->will($this->returnCallback(array($this, 'mock_getRandomBytes')));
 	}
 
 	protected function getCrypto() {
@@ -121,4 +121,5 @@ class ElggCryptoTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertNotEquals($t1, $t2);
 	}
+
 }

--- a/engine/tests/phpunit/ElggEntityTest.php
+++ b/engine/tests/phpunit/ElggEntityTest.php
@@ -4,7 +4,7 @@
  * This requires elgg_get_logged_in_user_guid() in session.php, the access 
  * constants defined in entities.php, and elgg_normalize_url() in output.php
  */
-class ElggEntityTest extends \PHPUnit_Framework_TestCase {
+class ElggEntityTest extends \Elgg\TestCase {
 
 	/** @var \ElggEntity */
 	protected $obj;
@@ -44,15 +44,15 @@ class ElggEntityTest extends \PHPUnit_Framework_TestCase {
 	public function testSettingIntegerAttributes() {
 		foreach (array('access_id', 'owner_guid', 'container_guid') as $name) {
 			$this->obj->$name = '77';
-			$this->assertSame(77, $this->obj->$name);			
+			$this->assertSame(77, $this->obj->$name);
 		}
 	}
 
 	public function testSettingUnsettableAttributes() {
 		foreach (array('guid', 'time_updated', 'last_action') as $name) {
 			$this->obj->$name = 'foo';
-			$this->assertNotEquals('foo', $this->obj->$name);			
-		}		
+			$this->assertNotEquals('foo', $this->obj->$name);
+		}
 	}
 
 	public function testSettingMetadataNoDatabase() {
@@ -73,17 +73,17 @@ class ElggEntityTest extends \PHPUnit_Framework_TestCase {
 		$this->obj->access_id = 2;
 		$this->obj->time_created = 123456789;
 
-		$this->assertEquals($this->obj->getGUID(), $this->obj->guid );
-		$this->assertEquals($this->obj->getType(), $this->obj->type );
+		$this->assertEquals($this->obj->getGUID(), $this->obj->guid);
+		$this->assertEquals($this->obj->getType(), $this->obj->type);
 
 		// Note: before save() subtype returns string, int after
 		// see https://github.com/Elgg/Elgg/issues/5920#issuecomment-25246298
-		$this->assertEquals($this->obj->getSubtype(), $this->obj->subtype );
+		$this->assertEquals($this->obj->getSubtype(), $this->obj->subtype);
 
-		$this->assertEquals($this->obj->getOwnerGUID(), $this->obj->owner_guid );
-		$this->assertEquals($this->obj->getAccessID(), $this->obj->access_id );
-		$this->assertEquals($this->obj->getTimeCreated(), $this->obj->time_created );
-		$this->assertEquals($this->obj->getTimeUpdated(), $this->obj->time_updated );
+		$this->assertEquals($this->obj->getOwnerGUID(), $this->obj->owner_guid);
+		$this->assertEquals($this->obj->getAccessID(), $this->obj->access_id);
+		$this->assertEquals($this->obj->getTimeCreated(), $this->obj->time_created);
+		$this->assertEquals($this->obj->getTimeUpdated(), $this->obj->time_updated);
 	}
 
 	public function testUnsetAttribute() {
@@ -96,15 +96,11 @@ class ElggEntityTest extends \PHPUnit_Framework_TestCase {
 	 * @expectedException InvalidParameterException
 	 */
 	public function testSaveWithoutType() {
-		$db = $this->getMock('\Elgg\Database',
-			array('getData', 'getTablePrefix', 'sanitizeString'),
-			array(),
-			'',
-			false
+		$db = $this->getMock('\Elgg\Database', array('getData', 'getTablePrefix', 'sanitizeString'), array(), '', false
 		);
 		$db->expects($this->any())
-			->method('sanitizeString')
-			->will($this->returnArgument(0));
+				->method('sanitizeString')
+				->will($this->returnArgument(0));
 		_elgg_services()->setValue('db', $db);
 
 		// requires type to be set
@@ -153,4 +149,5 @@ class ElggEntityTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($this->obj->getLatitude(), $lat);
 		$this->assertEquals($this->obj->getLongitude(), $long);
 	}
+
 }

--- a/engine/tests/phpunit/ElggExtenderTest.php
+++ b/engine/tests/phpunit/ElggExtenderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggExtenderTest extends \PHPUnit_Framework_TestCase {
+class ElggExtenderTest extends \Elgg\TestCase {
 
 	public function testSettingAndGettingAttribute() {
 		$obj = $this->getMockForAbstractClass('\ElggExtender');
@@ -27,6 +27,7 @@ class ElggExtenderTest extends \PHPUnit_Framework_TestCase {
 		$obj = $this->getMockForAbstractClass('\ElggExtender');
 		$obj->setValue('36', 'integer');
 		$this->assertSame(36, $obj->value);
-		$this->assertEquals('integer', $obj->value_type);		
+		$this->assertEquals('integer', $obj->value_type);
 	}
+
 }

--- a/engine/tests/phpunit/ElggFileTest.php
+++ b/engine/tests/phpunit/ElggFileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggFileTest extends \PHPUnit_Framework_TestCase {
+class ElggFileTest extends \Elgg\TestCase {
 
 	/**
 	 * @var \ElggFile

--- a/engine/tests/phpunit/ElggGroupTest.php
+++ b/engine/tests/phpunit/ElggGroupTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggGroupTest extends \PHPUnit_Framework_TestCase {
+class ElggGroupTest extends \Elgg\TestCase {
 
 	protected function setUp() {
 		// required by \ElggEntity when setting the owner/container

--- a/engine/tests/phpunit/ElggMenuItemTest.php
+++ b/engine/tests/phpunit/ElggMenuItemTest.php
@@ -3,9 +3,10 @@
 /**
  * Depends on elgg_normalize_url() in output.php
  */
-class ElggMenuItemTest extends \PHPUnit_Framework_TestCase {
+class ElggMenuItemTest extends \Elgg\TestCase {
 
 	protected function setUp() {
+
 	}
 
 	public function testFactoryNoNameOrText() {
@@ -14,7 +15,7 @@ class ElggMenuItemTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testFactoryNoHref() {
-		$item = \ElggMenuItem::factory(array('name' => 'test','text' => 'test'));
+		$item = \ElggMenuItem::factory(array('name' => 'test', 'text' => 'test'));
 		$this->assertEquals('', $item->getHref());
 	}
 
@@ -139,13 +140,13 @@ class ElggMenuItemTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($item->inContext('file'));
 	}
 
-/*
- * This requires elgg_in_context()
-	public function testInContextAgainstRequestContext() {
-		$item = new \ElggMenuItem('name', 'text', 'url');
-		$item->setContext(array('blog', 'bookmarks'));
-	}
-*/
+	/*
+	 * This requires elgg_in_context()
+	  public function testInContextAgainstRequestContext() {
+	  $item = new \ElggMenuItem('name', 'text', 'url');
+	  $item->setContext(array('blog', 'bookmarks'));
+	  }
+	 */
 
 	public function testSetLinkClassWithString() {
 		$item = new \ElggMenuItem('name', 'text', 'url');
@@ -224,6 +225,7 @@ class ElggMenuItemTest extends \PHPUnit_Framework_TestCase {
 				'message' => 'Second argument of elgg_register_menu_item() must be an instance of ElggMenuItem or an array of menu item factory options',
 				'level' => 400,
 			],
-		], $logged);
+				], $logged);
 	}
+
 }

--- a/engine/tests/phpunit/ElggObjectTest.php
+++ b/engine/tests/phpunit/ElggObjectTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggObjectTest extends \PHPUnit_Framework_TestCase {
+class ElggObjectTest extends \Elgg\TestCase {
 
 	protected function setUp() {
 		// required by \ElggEntity when setting the owner/container

--- a/engine/tests/phpunit/ElggPriorityListTest.php
+++ b/engine/tests/phpunit/ElggPriorityListTest.php
@@ -1,6 +1,7 @@
 <?php
 
-class ElggPriorityListTest extends \PHPUnit_Framework_TestCase {
+class ElggPriorityListTest extends \Elgg\TestCase {
+
 	public function testAdd() {
 		$pl = new \ElggPriorityList();
 		$elements = array(
@@ -90,7 +91,7 @@ class ElggPriorityListTest extends \PHPUnit_Framework_TestCase {
 		$pl = new \ElggPriorityList();
 
 		$elements = array();
-		for ($i=0; $i<3; $i++) {
+		for ($i = 0; $i < 3; $i++) {
 			$element = new \stdClass();
 			$element->name = "Test Element $i";
 			$element->someAttribute = rand(0, 9999);
@@ -194,7 +195,7 @@ class ElggPriorityListTest extends \PHPUnit_Framework_TestCase {
 
 	public function testPriorityCollision() {
 		$pl = new \ElggPriorityList();
-		
+
 		$elements = array(
 			5 => 'Test element 5',
 			6 => 'Test element 6',
@@ -218,7 +219,7 @@ class ElggPriorityListTest extends \PHPUnit_Framework_TestCase {
 			0 => 'Test element 0',
 			5 => 'Test element 5',
 		);
-		
+
 		$pl = new \ElggPriorityList($elements);
 
 		foreach ($pl as $priority => $element) {
@@ -270,5 +271,5 @@ class ElggPriorityListTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertSame($elements_sorted_string, $test_elements);
 	}
-   
+
 }

--- a/engine/tests/phpunit/ElggRelationshipTest.php
+++ b/engine/tests/phpunit/ElggRelationshipTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggRelationshipTest extends \PHPUnit_Framework_TestCase {
+class ElggRelationshipTest extends \Elgg\TestCase {
 
 	public function testSettingAndGettingAttribute() {
 		$obj = $this->getRelationshipMock();
@@ -18,4 +18,5 @@ class ElggRelationshipTest extends \PHPUnit_Framework_TestCase {
 		// and deprecation is not test-friendly yet.
 		return $this->getMockForAbstractClass('\ElggRelationship', array(), '', false);
 	}
+
 }

--- a/engine/tests/phpunit/ElggSessionTest.php
+++ b/engine/tests/phpunit/ElggSessionTest.php
@@ -1,10 +1,10 @@
 <?php
+
 /**
  * Many methods for \ElggSession pass through to the storage class so we
  * don't test them here.
  */
-
-class ElggSessionTest extends \PHPUnit_Framework_TestCase {
+class ElggSessionTest extends \Elgg\TestCase {
 
 	public function testStart() {
 		$session = \ElggSession::getMock();
@@ -33,4 +33,5 @@ class ElggSessionTest extends \PHPUnit_Framework_TestCase {
 		$this->assertNotEquals($id, $session->getId());
 		$this->assertTrue($session->has('__elgg_session'));
 	}
+
 }

--- a/engine/tests/phpunit/ElggSiteTest.php
+++ b/engine/tests/phpunit/ElggSiteTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggSiteTest extends \PHPUnit_Framework_TestCase {
+class ElggSiteTest extends \Elgg\TestCase {
 
 	protected function setUp() {
 		// required by \ElggEntity when setting the owner/container

--- a/engine/tests/phpunit/ElggUpgradeTest.php
+++ b/engine/tests/phpunit/ElggUpgradeTest.php
@@ -1,6 +1,7 @@
 <?php
 
-class ElggUpgradeTest extends PHPUnit_Framework_TestCase {
+class ElggUpgradeTest extends \Elgg\TestCase {
+
 	/**
 	 * @var ElggUpgrade
 	 */
@@ -16,7 +17,7 @@ class ElggUpgradeTest extends PHPUnit_Framework_TestCase {
 
 		$this->obj->_callable_egefps = array($this, 'mock_egefps');
 	}
-	
+
 	public function mock_egefps($options) {
 		return array();
 	}
@@ -100,17 +101,16 @@ class ElggUpgradeTest extends PHPUnit_Framework_TestCase {
 	public function testCanFindUpgradesByPath() {
 		$this->obj->_callable_egefps = array($this, 'mock_egefps_for_path');
 		$upgrade = $this->obj->getUpgradeFromPath('test');
-		$this->assertTrue((bool)$upgrade);
+		$this->assertTrue((bool) $upgrade);
 	}
 
 	public function testCanFindUpgradesByFullUrl() {
 		$this->obj->_callable_egefps = array($this, 'mock_egefps_for_full_url');
 		$this->obj->upgrade_url = elgg_normalize_url('test');
 		$upgrade = $this->obj->getUpgradeFromPath('test');
-		$this->assertTrue((bool)$upgrade);
+		$this->assertTrue((bool) $upgrade);
 		$this->assertSame('test', $upgrade->upgrade_url);
 	}
 
 	// can't test save without db mocking
-
 }

--- a/engine/tests/phpunit/ElggUserTest.php
+++ b/engine/tests/phpunit/ElggUserTest.php
@@ -1,12 +1,12 @@
 <?php
 
-class ElggUserTest extends \PHPUnit_Framework_TestCase {
+class ElggUserTest extends \Elgg\TestCase {
 
 	protected function setUp() {
 		// required by \ElggEntity when setting the owner/container
 		_elgg_services()->setValue('session', \ElggSession::getMock());
 	}
-	
+
 	public function testCanConstructWithoutArguments() {
 		$this->assertNotNull(new \ElggUser());
 	}
@@ -15,8 +15,8 @@ class ElggUserTest extends \PHPUnit_Framework_TestCase {
 		$obj = new \ElggUser();
 		foreach (array('prev_last_action', 'last_login', 'prev_last_login') as $name) {
 			$obj->$name = 'foo';
-			$this->assertNotEquals('foo', $obj->$name);			
-		}		
+			$this->assertNotEquals('foo', $obj->$name);
+		}
 	}
 
 }

--- a/engine/tests/phpunit/ElggViewHelpersTest.php
+++ b/engine/tests/phpunit/ElggViewHelpersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ElggViewHelpersTest extends \PHPUnit_Framework_TestCase {
+class ElggViewHelpersTest extends \Elgg\TestCase {
 
 	public function test_elgg_prepend_css_path() {
 		// basic tests
@@ -22,4 +22,5 @@ class ElggViewHelpersTest extends \PHPUnit_Framework_TestCase {
 
 		// more complete: https://github.com/mrclay/minify/blob/master/tests/MinifyCSSUriRewriterTest.php
 	}
+
 }

--- a/engine/tests/phpunit/bootstrap.php
+++ b/engine/tests/phpunit/bootstrap.php
@@ -1,72 +1,45 @@
 <?php
 
-use Zend\Mail\Transport\InMemory as InMemoryTransport;
+/**
+ * Instead of relying on this bootstrap, which leads to unreliable global state,
+ * test cases should extend \Elgg\TestCase, which resets service providers
+ * during test initialization making sure altered state does not
+ * flow over to the next test case.
+ * 
+ * @deprecated 2.3
+ */
 
-require_once __DIR__ . '/../../../vendor/autoload.php';
+if (!defined('PHPUNIT_ELGG_TESTING_APPLICATION')) {
+	// this value is set by phpunit.xml
+	return;
+}
 
-date_default_timezone_set('America/Los_Angeles');
-
-error_reporting(E_ALL | E_STRICT);
+\Elgg\TestCase::bootstrap();
 
 /**
  * Get/set an Application for testing purposes
  *
  * @param \Elgg\Application $app Elgg Application
  * @return \Elgg\Application
+ * @deprecated 2.3 Use elgg() instead
  */
 function _elgg_testing_application(\Elgg\Application $app = null) {
-	static $inst;
 	if ($app) {
-		$inst = $app;
+		\Elgg\Application::$_instance = $app;
 	}
-	return $inst;
+	return elgg();
 }
 
 /**
- * This is here as a temporary solution only. Instead of adding more global
- * state to this file as we migrate tests, try to refactor the code to be
- * testable without global state.
+ * Set/get testing config
+ *
+ * @staticvar \Elgg\Config $inst
+ * @param \Elgg\Config $config Config
+ * @return \Elgg\Config
+ * @depreated 2.3 Use _elgg_services() to access config
  */
-global $CONFIG;
-$CONFIG = (object) [
-	'Config_file' => false,
-	'dbprefix' => 'elgg_',
-	'boot_complete' => false,
-	'wwwroot' => 'http://localhost/',
-	'path' => __DIR__ . '/../../../',
-	'dataroot' => __DIR__ . '/test_files/dataroot/',
-	'cacheroot' => __DIR__ . '/test_files/cacheroot/',
-	'site_guid' => 1,
-	'AutoloaderManager_skip_storage' => true,
-	'simplecache_enabled' => false,
-	'system_cache_enabled' => false,
-	'Elgg\Application_phpunit' => true,
-	// \Elgg\Config::get() falls back to loading config values from database
-	// for undefined keys. This flag ensures we do not attempt reading data
-	// from database during tests
-	'site_config_loaded' => true,
-	'icon_sizes' => array(
-		'topbar' => array('w' => 16, 'h' => 16, 'square' => true, 'upscale' => true),
-		'tiny' => array('w' => 25, 'h' => 25, 'square' => true, 'upscale' => true),
-		'small' => array('w' => 40, 'h' => 40, 'square' => true, 'upscale' => true),
-		'medium' => array('w' => 100, 'h' => 100, 'square' => true, 'upscale' => true),
-		'large' => array('w' => 200, 'h' => 200, 'square' => false, 'upscale' => false),
-		'master' => array('w' => 550, 'h' => 550, 'square' => false, 'upscale' => false),
-	),
-];
-
-global $_ELGG;
-$_ELGG = (object) [
-	'view_path' => __DIR__ . '/../../../views/',
-	'allowed_ajax_views' => [],
-];
-
 function _elgg_testing_config(\Elgg\Config $config = null) {
-	static $inst;
-	if ($config) {
-		$inst = $config;
-	}
-	return $inst;
+	return \Elgg\TestCase::config($config);
 }
 
 /**
@@ -78,55 +51,8 @@ function _elgg_testing_config(\Elgg\Config $config = null) {
  * @param int    $ajax            AJAX api version (0 for non-ajax)
  * @param bool   $add_csrf_tokens Add CSRF tokens
  * @return \Elgg\Http\Request
+ * @deprecated 2.3
  */
 function _elgg_testing_request($uri = '', $method = 'GET', $parameters = [], $ajax = 0, $add_csrf_tokens = false) {
-	$site_url = elgg_get_site_url();
-	$path = substr(elgg_normalize_url($uri), strlen($site_url));
-	$path_key = \Elgg\Application::GET_PATH_KEY;
-
-	if ($add_csrf_tokens) {
-		$ts = time();
-		$parameters['__elgg_ts'] = $ts;
-		$parameters['__elgg_token'] = _elgg_services()->actions->generateActionToken($ts);
-	}
-
-	$request = \Elgg\Http\Request::create("?$path_key=" . urlencode($path), $method, $parameters);
-
-	$cookie_name = _elgg_services()->config->getCookieConfig()['session']['name'];
-	$session_id = _elgg_services()->session->getId();
-	$request->cookies->set($cookie_name, $session_id);
-
-	$request->headers->set('Referer', elgg_normalize_url('phpunit'));
-
-	if ($ajax) {
-		$request->headers->set('X-Requested-With', 'XMLHttpRequest');
-		if ($ajax >= 2) {
-			$request->headers->set('X-Elgg-Ajax-API', (string) $ajax);
-		}
-	}
-
-	return $request;
+	return \Elgg\TestCase::prepareHttpRequest($uri, $method, $parameters, $ajax, $add_csrf_tokens);
 }
-
-// PHPUnit will serialize globals between tests, so let's not introduce any globals here.
-call_user_func(function () use ($CONFIG) {
-	$config = new \Elgg\Config($CONFIG);
-	_elgg_testing_config($config);
-
-	$sp = new \Elgg\Di\ServiceProvider($config);
-
-	$sp->setValue('mailer', new InMemoryTransport());
-
-	$sp->siteSecret->setTestingSecret('z1234567890123456789012345678901');
-
-	$app = new \Elgg\Application($sp);
-	$app->loadCore();
-
-	// persistentLogin service needs this set to instantiate without calling DB
-	_elgg_services()->config->getCookieConfig();
-
-	global $GLOBALS;
-	$GLOBALS['DEFAULT_FILE_STORE'] = new \ElggDiskFilestore($CONFIG->dataroot);
-
-	_elgg_testing_application($app);
-});

--- a/engine/tests/phpunit/test_files/autop/typical-post.exp.html
+++ b/engine/tests/phpunit/test_files/autop/typical-post.exp.html
@@ -13,7 +13,7 @@
 </blockquote>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus enim ante, mattis eget imperdiet nec, <a href="http://google.com/">pharetra </a>vel velit. Sed at euismod nibh. Praesent lacus tellus, posuere et convallis a, mollis et tellus.</p>
 <pre><code>&lt;?php
-class DataTest extends \PHPUnit_Framework_TestCase
+class DataTest extends \Elgg\TestCase
 {
     /**
      * @dataProvider provider
@@ -55,7 +55,7 @@ class DataTest extends \PHPUnit_Framework_TestCase
 </blockquote>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus enim ante, mattis eget imperdiet nec, <a href="http://google.com/">pharetra </a>vel velit. Sed at euismod nibh. Praesent lacus tellus, posuere et convallis a, mollis et tellus.</p>
 <pre><code>&lt;?php
-class DataTest extends \PHPUnit_Framework_TestCase
+class DataTest extends \Elgg\TestCase
 {
     /**
      * @dataProvider provider

--- a/engine/tests/phpunit/test_files/autop/typical-post.in.html
+++ b/engine/tests/phpunit/test_files/autop/typical-post.in.html
@@ -13,7 +13,7 @@ Maecenas elit lorem, varius sed condimentum ac, cursus et magna. Nam ut massa id
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus enim ante, mattis eget imperdiet nec, <a href="http://google.com/">pharetra </a>vel velit. Sed at euismod nibh. Praesent lacus tellus, posuere et convallis a, mollis et tellus.
 
 <pre><code>&lt;?php
-class DataTest extends \PHPUnit_Framework_TestCase
+class DataTest extends \Elgg\TestCase
 {
     /**
      * @dataProvider provider
@@ -58,7 +58,7 @@ Maecenas elit lorem, varius sed condimentum ac, cursus et magna. Nam ut massa id
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus enim ante, mattis eget imperdiet nec, <a href="http://google.com/">pharetra </a>vel velit. Sed at euismod nibh. Praesent lacus tellus, posuere et convallis a, mollis et tellus.
 
 <pre><code>&lt;?php
-class DataTest extends \PHPUnit_Framework_TestCase
+class DataTest extends \Elgg\TestCase
 {
     /**
      * @dataProvider provider

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit bootstrap="./engine/tests/phpunit/bootstrap.php">
+<phpunit bootstrap="./vendor/autoload.php">
 	<testsuites>
 		<testsuite name="All Tests">
 			<directory>./engine/tests/phpunit/</directory>
@@ -16,4 +16,7 @@
 			<directory suffix=".php">/docs</directory>
 		</blacklist>
 	</filter>
+	<php>
+		<const name="PHPUNIT_ELGG_TESTING_APPLICATION" value="true"/>
+	</php>
 </phpunit>


### PR DESCRIPTION
Deprecates /engine/tests/phpunit/bootstrap.php in favour of composer autoloader.
Adds \Elgg\TestCase class that should be extended by individual test cases.
