### PR TITLE
chore(tests): eliminates setTimeout race in ElggSpinnerTest

### DIFF
--- a/js/tests/ElggSpinnerTest.js
+++ b/js/tests/ElggSpinnerTest.js
@@ -20,24 +20,24 @@ define(function(require) {
 		});
 
 		it("start() adds the body class after 20ms", function(done) {
-			expect($(visible_selector).length).toBe(0);
-			spinner.start();
-
-			setTimeout(function() {
+			$(spinner).one('_testing_show', function () {
 				expect($(visible_selector).length).toBe(1);
 				done();
-			}, 100);
+			});
+
+			expect($(visible_selector).length).toBe(0);
+			spinner.start();
 		});
 
 		it("stop() removes the body class", function(done) {
-			spinner.start();
-
-			setTimeout(function() {
+			$(spinner).one('_testing_show', function () {
 				expect($(visible_selector).length).toBe(1);
 				spinner.stop();
 				expect($(visible_selector).length).toBe(0);
 				done();
-			}, 100);
+			});
+
+			spinner.start();
 		});
 	});
 });

--- a/views/default/js/elgg/spinner.js
+++ b/views/default/js/elgg/spinner.js
@@ -6,12 +6,13 @@ define(function (require) {
 
 	$('body').append('<div class="elgg-spinner"><div class="elgg-ajax-loader"></div></div>');
 
-	return {
+	var module = {
 		start: function () {
 			active = true;
 			setTimeout(function () {
 				if (active) {
 					$('body').addClass('elgg-spinner-active');
+					$(module).triggerHandler('_testing_show');
 				}
 			}, SHOW_DELAY);
 		},
@@ -21,4 +22,6 @@ define(function (require) {
 			$('body').removeClass('elgg-spinner-active');
 		}
 	};
+
+	return module;
 });


### PR DESCRIPTION
Even though the class should be added at 20ms, with a wait of 100ms tests were still failing. Apparently there's no way to reliably test that a timeout of a particular period is used, so now the module fires a test event, allowing the test to directly listen instead of guessing how long to wait. This still at least tests that there is _some_ delay.

(I think this will finally fix the fragility of this test.)
