### PR TITLE
feature(events): Adds new handler API available for events and hooks

### DIFF
--- a/docs/design/events.rst
+++ b/docs/design/events.rst
@@ -70,9 +70,20 @@ backwards compatibility.
 Elgg Event Handlers
 -------------------
 
-Elgg event handlers should have the following prototype:
+Elgg event handlers are callables with one of the following prototypes:
 
-.. code:: php
+.. code-block:: php
+
+    <?php
+
+    /**
+     * @param \Elgg\Event $event The event object
+     *
+     * @return bool if false, the handler is requesting to cancel the event
+     */
+    function event_handler1(\Elgg\Event $event) {
+        ...
+    }
 
     /**
      * @param string $event       The name of the event
@@ -81,19 +92,26 @@ Elgg event handlers should have the following prototype:
      *
      * @return bool if false, the handler is requesting to cancel the event
      */
-    function event_handler($event, $object_type, $object) {
+    function event_handler2($event, $object_type, $object) {
         ...
     }
 
-If the handler returns ``false``, the event is cancelled, preventing
-execution of the other handlers. All other return values are ignored.
+In ``event_handler1``, the ``Event`` object has various methods for getting the name, object type,
+and object of the event. See the ``Elgg\Event`` interface for details.
+
+In both cases, if a handler returns ``false``, the event is cancelled, preventing execution of the
+other handlers. All other return values are ignored.
+
+.. note:: If the event type is "object" or "user", use type hint ``\Elgg\ObjectEvent`` or ``\Elgg\UserEvent`` instead, which clarify the return type of the ``getObject()`` method.
 
 Register to handle an Elgg Event
 --------------------------------
 
 Register your handler to an event using ``elgg_register_event_handler``:
 
-.. code:: php
+.. code-block:: php
+
+    <?php
 
     elgg_register_event_handler($event, $object_type, $handler, $priority);
 
@@ -110,11 +128,13 @@ in the framework: system, user, object, relationship, annotation, group.
 
 Example:
 
-.. code:: php
+.. code-block:: php
 
-    // Register the function myPlugin_handle_login() to handle the
-    // user login event with priority 400.
-    elgg_register_event_handler('login', 'user', 'myPlugin_handle_login', 400);
+    <?php
+
+    // Register the function myPlugin_handle_create_object() to handle the
+    // create object event with priority 400.
+    elgg_register_event_handler('create', 'object', 'myPlugin_handle_create_object', 400);
 
 .. warning::
 
@@ -122,12 +142,35 @@ Example:
    probably not necessary as the object is saved after the event completes, but also because ``save()`` calls
    another "update" event and makes ``$object->getOriginalAttributes()`` no longer available.
 
+Invokable classes as handlers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You may use a class with an ``__invoke()`` method as a handler. Just register the class name and it will be instantiated (with no arguments) for the lifetime of the event (or hook).
+
+.. code-block:: php
+
+    <?php
+
+    namespace MyPlugin;
+
+    class UpdateObjectHandler {
+        public function __invoke(\Elgg\ObjectEvent $event) {
+
+        }
+    }
+
+    // in init, system
+    elgg_register_event_handler('update', 'object', MyPlugin\UpdateObjectHandler::class);
+
+
 Trigger an Elgg Event
 ---------------------
 
 You can trigger a custom Elgg event using ``elgg_trigger_event``:
 
-.. code:: php
+.. code-block:: php
+
+    <?php
 
     if (elgg_trigger_event($event, $object_type, $object)) {
         // Proceed with doing something.
@@ -139,7 +182,9 @@ For events with ambiguous states, like logging in a user, you should use `Before
 by calling ``elgg_trigger_before_event`` or ``elgg_trigger_after_event``.
 This makes it clear for the event handler what state to expect and which events can be cancelled.
 
-.. code:: php
+.. code-block:: php
+
+    <?php
 
 	// handlers for the user, login:before event know the user isn't logged in yet.
 	if (!elgg_trigger_before_event('login', 'user', $user)) {
@@ -175,9 +220,20 @@ trigger.
 Plugin Hook Handlers
 --------------------
 
-Plugin hook handlers should have the following prototype:
+Hook handlers are callables with one of the following prototypes:
 
-.. code:: php
+.. code-block:: php
+
+    <?php
+
+    /**
+     * @param \Elgg\Hook $hook The hook object
+     *
+     * @return mixed if not null, this will be the new value of the plugin hook
+     */
+    function plugin_hook_handler1(\Elgg\Hook $hook) {
+        ...
+    }
 
     /**
      * @param string $hook    The name of the plugin hook
@@ -187,20 +243,25 @@ Plugin hook handlers should have the following prototype:
      *
      * @return mixed if not null, this will be the new value of the plugin hook
      */
-    function plugin_hook_handler($hook, $type, $value, $params) {
+    function plugin_hook_handler2($hook, $type, $value, $params) {
         ...
     }
 
-If the handler returns no value (or ``null`` explicitly), the plugin hook value
-is not altered. Otherwise the return value becomes the new value of the plugin
-hook. It will then be passed to the next handler as ``$value``.
+In ``plugin_hook_handler1``, the ``Hook`` object has various methods for getting the name, type, value,
+and parameters of the hook. See the ``Elgg\Hook`` interface for details.
+
+In both cases, if the handler returns no value (or ``null`` explicitly), the plugin hook value
+is not altered. Otherwise the returned value becomes the new value of the plugin hook, and it
+will then be available as ``$hook->getValue()`` (or ``$value``) in the next handler.
 
 Register to handle a Plugin Hook
 --------------------------------
 
 Register your handler to a plugin hook using ``elgg_register_plugin_hook_handler``:
 
-.. code:: php
+.. code-block:: php
+
+    <?php
 
     elgg_register_plugin_hook_handler($hook, $type, $handler, $priority);
 
@@ -216,7 +277,9 @@ specific to the plugin hook name.
 
 Example:
 
-.. code:: php
+.. code-block:: php
+
+    <?php
 
     // Register the function myPlugin_hourly_job() to be called with priority 400.
     elgg_register_plugin_hook_handler('cron', 'hourly', 'myPlugin_hourly_job', 400);
@@ -227,7 +290,9 @@ Trigger a Plugin Hook
 
 You can trigger a custom plugin hook using ``elgg_trigger_plugin_hook``:
 
-.. code:: php
+.. code-block:: php
+
+    <?php
 
     // filter $value through the handlers
     $value = elgg_trigger_plugin_hook($hook, $type, $params, $value);
@@ -249,14 +314,18 @@ The functions ``elgg_unregister_event_handler`` and ``elgg_unregister_plugin_hoo
 handlers already registered by another plugin or Elgg core. The parameters are in the same order as the registration
 functions, except there's no priority parameter.
 
-.. code:: php
+.. code-block:: php
+
+    <?php
 
     elgg_unregister_event_handler('login', 'user', 'myPlugin_handle_login');
 
 Anonymous functions or invokable objects cannot be unregistered, but dynamic method callbacks can be unregistered
 by giving the static version of the callback:
 
-.. code:: php
+.. code-block:: php
+
+    <?php
 
     $obj = new MyPlugin\Handlers();
     elgg_register_plugin_hook_handler('foo', 'bar', [$obj, 'handleFoo']);

--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -179,7 +179,8 @@ class Database {
 			// @todo just allow PDO exceptions
 			// http://dev.mysql.com/doc/refman/5.1/en/error-messages-server.html
 			if ($e->getCode() == 1102 || $e->getCode() == 1049) {
-				$msg = "Elgg couldn't select the database '{$conf['database']}'. Please check that the database is created and you have access to it.";
+				$msg = "Elgg couldn't select the database '{$conf['database']}'. Please check that the database "
+					. "is created and you have access to it.";
 			} else {
 				$msg = "Elgg couldn't connect to the database using the given credentials. Check the settings file.";
 			}
@@ -362,8 +363,8 @@ class Database {
 
 		if ($callback) {
 			if (!is_callable($callback)) {
-				$inspector = new \Elgg\Debug\Inspector();
-				throw new \RuntimeException('$callback must be a callable function. Given ' . $inspector->describeCallable($callback));
+				throw new \RuntimeException('$callback must be a callable function. Given '
+											. _elgg_services()->handlers->describeCallable($callback));
 			}
 			$query_id .= $this->fingerprintCallback($callback);
 		}
@@ -637,7 +638,8 @@ class Database {
 			$sql = "SELECT value FROM {$this->table_prefix}datalists WHERE name = 'installed'";
 			$this->getConnection('read')->query($sql);
 		} catch (\DatabaseException $e) {
-			throw new \InstallationException("Unable to handle this request. This site is not configured or the database is down.");
+			throw new \InstallationException("Unable to handle this request. This site is not "
+				. "configured or the database is down.");
 		}
 
 		$this->installed = true;

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -39,6 +39,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \ElggFileCache                           $fileCache
  * @property-read \ElggDiskFilestore                       $filestore
  * @property-read \Elgg\FormsService                       $forms
+ * @property-read \Elgg\HandlersService                    $handlers
  * @property-read \Elgg\PluginHooksService                 $hooks
  * @property-read \Elgg\EntityIconService                  $iconService
  * @property-read \Elgg\Http\Input                         $input
@@ -208,8 +209,12 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			);
 		});
 
-		$this->setFactory('events', function(ServiceProvider $c) {
-			return $this->resolveLoggerDependencies('events');
+		$this->setFactory('events', function (ServiceProvider $c) {
+			$events = new \Elgg\EventsService();
+			if ($c->config->getVolatile('enable_profiling')) {
+				$events->setTimer($c->timer);
+			}
+			return $events;
 		});
 
 		$this->setFactory('externalFiles', function(ServiceProvider $c) {
@@ -228,9 +233,9 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			return new \Elgg\FormsService($c->views, $c->logger);
 		});
 
-		$this->setFactory('hooks', function(ServiceProvider $c) {
-			return $this->resolveLoggerDependencies('hooks');
-		});
+		$this->setClassName('handlers', \Elgg\HandlersService::class);
+
+		$this->setClassName('hooks', \Elgg\PluginHooksService::class);
 
 		$this->setFactory('iconService', function(ServiceProvider $c) {
 			return new \Elgg\EntityIconService($c->config, $c->hooks, $c->request, $c->logger, $c->entityTable);
@@ -243,8 +248,8 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 			return new \Elgg\ImageService($imagine, $c->config);
 		});
 
-		$this->setFactory('logger', function(ServiceProvider $c) {
-			return $this->resolveLoggerDependencies('logger');
+		$this->setFactory('logger', function (ServiceProvider $c) {
+			return new \Elgg\Logger($c->hooks, $c->config, $c->context);
 		});
 
 		// TODO(evan): Support configurable transports...
@@ -453,31 +458,5 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		});
 
 		$this->setClassName('widgets', \Elgg\WidgetsService::class);
-
-	}
-
-	/**
-	 * Returns the first requested service of the logger, events, and hooks. It sets the
-	 * hooks and events up in the right order to prevent circular dependency.
-	 *
-	 * @param string $service_needed The service requested first
-	 * @return mixed
-	 */
-	protected function resolveLoggerDependencies($service_needed) {
-		$svcs['hooks'] = new \Elgg\PluginHooksService();
-
-		$svcs['logger'] = new \Elgg\Logger($svcs['hooks'], $this->config, $this->context);
-		$svcs['hooks']->setLogger($svcs['logger']);
-
-		$svcs['events'] = new \Elgg\EventsService();
-		$svcs['events']->setLogger($svcs['logger']);
-		if ($this->config->getVolatile('enable_profiling')) {
-			$svcs['events']->setTimer($this->timer);
-		}
-
-		foreach ($svcs as $key => $service) {
-			$this->setValue($key, $service);
-		}
-		return $svcs[$service_needed];
 	}
 }

--- a/engine/classes/Elgg/Event.php
+++ b/engine/classes/Elgg/Event.php
@@ -1,0 +1,38 @@
+<?php
+namespace Elgg;
+
+/**
+ * Models an event passed to event handlers
+ *
+ * @since 2.0.0
+ */
+interface Event {
+
+	/**
+	 * Get the name of the event
+	 *
+	 * @return string
+	 */
+	public function getName();
+
+	/**
+	 * Get the type of the event object
+	 *
+	 * @return string
+	 */
+	public function getType();
+
+	/**
+	 * Get the object of the event
+	 *
+	 * @return mixed
+	 */
+	public function getObject();
+
+	/**
+	 * Get the Elgg application
+	 *
+	 * @return \Elgg\Application
+	 */
+	public function elgg();
+}

--- a/engine/classes/Elgg/EventsService.php
+++ b/engine/classes/Elgg/EventsService.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elgg;
-use Elgg\Debug\Inspector;
+
+use Elgg\HooksRegistrationService\Hook;
+use Elgg\HooksRegistrationService\Event;
 
 /**
  * Service for Events
@@ -11,7 +13,7 @@ use Elgg\Debug\Inspector;
  * @subpackage Hooks
  * @since      1.9.0
  */
-class EventsService extends \Elgg\HooksRegistrationService {
+class EventsService extends HooksRegistrationService {
 	use Profilable;
 
 	const OPTION_STOPPABLE = 'stoppable';
@@ -19,30 +21,13 @@ class EventsService extends \Elgg\HooksRegistrationService {
 	const OPTION_DEPRECATION_VERSION = 'deprecation_version';
 
 	/**
-	 * @var Inspector
-	 */
-	private $inspector;
-
-	/**
-	 * Constructor
-	 *
-	 * @param Inspector $inspector Inspector
-	 */
-	public function __construct(Inspector $inspector = null) {
-		if (!$inspector) {
-			$inspector = new Inspector();
-		}
-		$this->inspector = $inspector;
-	}
-
-	/**
 	 * {@inheritdoc}
 	 */
 	public function registerHandler($name, $type, $callback, $priority = 500) {
 		if (in_array($type, ['member', 'friend', 'member_of_site', 'attached'])
 				&& in_array($name, ['create', 'update', 'delete'])) {
-			$this->logger->error("'$name, $type' event is no longer triggered. Update your event registration "
-				. "to use '$name, relationship'");
+			_elgg_services()->logger->error("'$name, $type' event is no longer triggered. "
+				. "Update your event registration to use '$name, relationship'");
 		}
 
 		return parent::registerHandler($name, $type, $callback, $priority);
@@ -55,42 +40,46 @@ class EventsService extends \Elgg\HooksRegistrationService {
 	 * @see elgg_trigger_after_event
 	 * @access private
 	 */
-	public function trigger($event, $type, $object = null, array $options = array()) {
+	public function trigger($name, $type, $object = null, array $options = array()) {
 		$options = array_merge(array(
 			self::OPTION_STOPPABLE => true,
 			self::OPTION_DEPRECATION_MESSAGE => '',
 			self::OPTION_DEPRECATION_VERSION => '',
 		), $options);
 
-		$events = $this->hasHandler($event, $type);
-		if ($events && $options[self::OPTION_DEPRECATION_MESSAGE]) {
-			elgg_deprecated_notice(
+		$handlers = $this->hasHandler($name, $type);
+		if ($handlers && $options[self::OPTION_DEPRECATION_MESSAGE]) {
+			_elgg_services()->deprecation->sendNotice(
 				$options[self::OPTION_DEPRECATION_MESSAGE],
 				$options[self::OPTION_DEPRECATION_VERSION],
 				2
 			);
 		}
 
-		$events = $this->getOrderedHandlers($event, $type);
-		$args = array($event, $type, $object);
+		$handlers = $this->getOrderedHandlers($name, $type);
+		$handler_svc = _elgg_services()->handlers;
 
-		foreach ($events as $callback) {
-			if (!is_callable($callback)) {
-				if ($this->logger) {
-					$this->logger->warn("handler for event [$event, $type] is not callable: "
-										. $this->inspector->describeCallable($callback));
-				}
-				continue;
+		// This starts as a string, but if a handler type-hints an object we convert it on-demand inside
+		// \Elgg\HandlersService::call and keep it alive during all handler calls. We do this because
+		// creating objects for every triggering is expensive.
+		$event = 'event';
+		/* @var Event|string */
+
+		foreach ($handlers as $handler) {
+			$handler_description = false;
+			if ($this->timer && $type === 'system' && $name !== 'shutdown') {
+				$handler_description = $handler_svc->describeCallable($handler) . "()";
+				$this->timer->begin(["[$name,$type]", $handler_description]);
 			}
 
-			if ($this->timer && $type === 'system' && $event !== 'shutdown') {
-				$callback_as_string = $this->inspector->describeCallable($callback) . "()";
+			list($success, $return, $event) = $handler_svc->call($handler, $event, [$name, $type, $object]);
 
-				$this->timer->begin(["[$event,$type]", $callback_as_string]);
-				$return = call_user_func_array($callback, $args);
-				$this->timer->end(["[$event,$type]", $callback_as_string]);
-			} else {
-				$return = call_user_func_array($callback, $args);
+			if ($handler_description) {
+				$this->timer->end(["[$name,$type]", $handler_description]);
+			}
+
+			if (!$success) {
+				continue;
 			}
 
 			if (!empty($options[self::OPTION_STOPPABLE]) && ($return === false)) {

--- a/engine/classes/Elgg/HandlersService.php
+++ b/engine/classes/Elgg/HandlersService.php
@@ -1,0 +1,248 @@
+<?php
+namespace Elgg;
+
+use Elgg\Di\DiContainer;
+use Elgg\HooksRegistrationService\Event;
+use Elgg\HooksRegistrationService\Hook;
+
+/**
+ * Helpers for providing callable-based APIs
+ *
+ * getType() uses code from Zend\Code\Reflection\ParameterReflection::detectType.
+ * https://github.com/zendframework/zend-code/blob/master/src/Reflection/ParameterReflection.php
+ *
+ * @copyright 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ *
+ * @access private
+ */
+class HandlersService {
+
+	/**
+	 * Call the handler with the hook/event object
+	 *
+	 * @param callable          $callable Callable
+	 * @param string|Hook|Event $object   Event object
+	 * @param array             $args     Arguments for legacy events/hooks
+	 *
+	 * @return array [success, result, object]
+	 */
+	public function call($callable, $object, $args) {
+		$original = $callable;
+
+		$callable = $this->resolveCallable($callable);
+		if (!is_callable($callable)) {
+			$type = is_string($object) ? $object : $object::EVENT_TYPE;
+			$description = $type . " [{$args[0]}, {$args[1]}]";
+			$msg = "Handler for $description is not callable: " . $this->describeCallable($original);
+			_elgg_services()->logger->warn($msg);
+
+			return [false, null, $object];
+		}
+
+		$use_object = $this->acceptsObject($callable);
+		if ($use_object) {
+			if (is_string($object)) {
+				if ($object === 'hook') {
+					$object = new Hook(elgg(), $args[0], $args[1], $args[2], $args[3]);
+				} else {
+					$object = new Event(elgg(), $args[0], $args[1], $args[2]);
+				}
+			}
+
+			$result = call_user_func($callable, $object);
+		} else {
+			// legacy arguments
+			$result = call_user_func_array($callable, $args);
+		}
+
+		return [true, $result, $object];
+	}
+
+	/**
+	 * Get the reflection interface for a callable
+	 *
+	 * @param callable $callable Callable
+	 *
+	 * @return \ReflectionFunctionAbstract
+	 */
+	public function getReflector($callable) {
+		if (is_string($callable)) {
+			if (false !== strpos($callable, '::')) {
+				$callable = explode('::', $callable);
+			} else {
+				// function
+				return new \ReflectionFunction($callable);
+			}
+		}
+		if (is_array($callable)) {
+			return new \ReflectionMethod($callable[0], $callable[1]);
+		}
+		if ($callable instanceof \Closure) {
+			return new \ReflectionFunction($callable);
+		}
+		if (is_object($callable)) {
+			return new \ReflectionMethod($callable, '__invoke');
+		}
+
+		throw new \InvalidArgumentException('invalid $callable');
+	}
+
+	/**
+	 * Resolve a callable, possibly instantiating a class name
+	 *
+	 * @param callable|string $callable Callable or class name
+	 *
+	 * @return callable|null
+	 */
+	private function resolveCallable($callable) {
+		if (is_callable($callable)) {
+			return $callable;
+		}
+
+		if (is_string($callable)
+			&& preg_match(DiContainer::CLASS_NAME_PATTERN_53, $callable)
+			&& class_exists($callable)) {
+
+			// @todo Eventually a more advanced DIC could auto-inject dependencies
+			$callable = new $callable;
+		}
+
+		return is_callable($callable) ? $callable : null;
+	}
+
+	/**
+	 * Should we pass this callable a Hook/Event object instead of the 2.0 arguments?
+	 *
+	 * @param callable $callable Callable
+	 *
+	 * @return bool
+	 */
+	private function acceptsObject($callable) {
+		// note: caching string callables didn't help any
+		$type = (string)$this->getParamTypeForCallable($callable);
+		if (0 === strpos($type, 'Elgg\\')) {
+			// probably right. We can just assume and let PHP handle it
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the type for a parameter of a callable
+	 *
+	 * @param callable $callable Callable
+	 * @param int      $index    Index of argument
+	 *
+	 * @return null|string Empty string = no type, null = no parameter
+	 */
+	public function getParamTypeForCallable($callable, $index = 0) {
+		$params = $this->getReflector($callable)->getParameters();
+		if (!isset($params[$index])) {
+			return null;
+		}
+
+		return $this->getType($params[$index]);
+	}
+
+	/**
+	 * Get the type of a parameter
+	 *
+	 * @param \ReflectionParameter $param Parameter
+	 *
+	 * @return string
+	 */
+	public function getType(\ReflectionParameter $param) {
+		// @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+		// @license   http://framework.zend.com/license/new-bsd New BSD License
+
+		if (method_exists($param, 'getType')
+				&& ($type = $param->getType())
+				&& $type->isBuiltin()) {
+			return (string)$type;
+		}
+
+		// can be dropped when dropping PHP7 support:
+		if ($param->isArray()) {
+			return 'array';
+		}
+
+		// can be dropped when dropping PHP7 support:
+		if ($param->isCallable()) {
+			return 'callable';
+		}
+
+		// ReflectionParameter::__toString() doesn't require loading class
+		if (preg_match('~\[\s\<\w+?>\s([\S]+)~s', (string)$param, $m)) {
+			if ($m[1][0] !== '$') {
+				return $m[1];
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Get a string description of a callback
+	 *
+	 * E.g. "function_name", "Static::method", "(ClassName)->method", "(Closure path/to/file.php:23)"
+	 *
+	 * @param mixed  $callable  Callable
+	 * @param string $file_root If provided, it will be removed from the beginning of file names
+	 * @return string
+	 */
+	public function describeCallable($callable, $file_root = '') {
+		if (is_string($callable)) {
+			return $callable;
+		}
+		if (is_array($callable) && array_keys($callable) === array(0, 1) && is_string($callable[1])) {
+			if (is_string($callable[0])) {
+				return "{$callable[0]}::{$callable[1]}";
+			}
+			return "(" . get_class($callable[0]) . ")->{$callable[1]}";
+		}
+		if ($callable instanceof \Closure) {
+			$ref = new \ReflectionFunction($callable);
+			$file = $ref->getFileName();
+			$line = $ref->getStartLine();
+
+			if ($file_root && 0 === strpos($file, $file_root)) {
+				$file = substr($file, strlen($file_root));
+			}
+
+			return "(Closure {$file}:{$line})";
+		}
+		if (is_object($callable)) {
+			return "(" . get_class($callable) . ")->__invoke()";
+		}
+		return print_r($callable, true);
+	}
+
+	/**
+	 * Get a string that uniquely identifies a callback across requests (for caching)
+	 *
+	 * @param callable $callable Callable
+	 *
+	 * @return string Empty if cannot uniquely identify this callable
+	 */
+	public function fingerprintCallable($callable) {
+		if (is_string($callable)) {
+			return $callable;
+		}
+		if (is_array($callable)) {
+			if (is_string($callable[0])) {
+				return "{$callable[0]}::{$callable[1]}";
+			}
+			return get_class($callable[0]) . "::{$callable[1]}";
+		}
+		if ($callable instanceof \Closure) {
+			return '';
+		}
+		if (is_object($callable)) {
+			return get_class($callable) . "::__invoke";
+		}
+		// this should not happen
+		return '';
+	}
+}

--- a/engine/classes/Elgg/Hook.php
+++ b/engine/classes/Elgg/Hook.php
@@ -1,0 +1,70 @@
+<?php
+namespace Elgg;
+
+/**
+ * Models an event passed to hook handlers
+ *
+ * @since 2.0.0
+ */
+interface Hook {
+
+	/**
+	 * Get the name of the hook
+	 *
+	 * @return string
+	 */
+	public function getName();
+
+	/**
+	 * Get the type of the hook
+	 *
+	 * @return string
+	 */
+	public function getType();
+
+	/**
+	 * Get the current value of the hook
+	 *
+	 * @return mixed
+	 */
+	public function getValue();
+
+	/**
+	 * Get the parameters passed to the trigger call
+	 *
+	 * @return mixed
+	 */
+	public function getParams();
+
+	/**
+	 * Get an element of the params array. If the params array is not an array,
+	 * the default will always be returned.
+	 *
+	 * @param string $key     The key of the value in the params array
+	 * @param mixed  $default The value to return if missing
+	 *
+	 * @return mixed
+	 */
+	public function getParam($key, $default = null);
+
+	/**
+	 * Gets the "entity" key from the params if it holds an Elgg entity
+	 *
+	 * @return \ElggEntity|null
+	 */
+	public function getEntityParam();
+
+	/**
+	 * Gets the "user" key from the params if it holds an Elgg user
+	 *
+	 * @return \ElggUser|null
+	 */
+	public function getUserParam();
+
+	/**
+	 * Get the Elgg application
+	 *
+	 * @return \Elgg\Application
+	 */
+	public function elgg();
+}

--- a/engine/classes/Elgg/HooksRegistrationService.php
+++ b/engine/classes/Elgg/HooksRegistrationService.php
@@ -34,22 +34,6 @@ abstract class HooksRegistrationService {
 	private $backups = [];
 
 	/**
-	 * @var \Elgg\Logger
-	 */
-	protected $logger;
-
-	/**
-	 * Set a logger instance, e.g. for reporting uncallable handlers
-	 *
-	 * @param \Elgg\Logger $logger The logger
-	 * @return self
-	 */
-	public function setLogger(\Elgg\Logger $logger = null) {
-		$this->logger = $logger;
-		return $this;
-	}
-	
-	/**
 	 * Registers a handler.
 	 *
 	 * @warning This doesn't check if a callback is valid to be called, only if it is in the

--- a/engine/classes/Elgg/HooksRegistrationService/Event.php
+++ b/engine/classes/Elgg/HooksRegistrationService/Event.php
@@ -1,0 +1,72 @@
+<?php
+namespace Elgg\HooksRegistrationService;
+
+use Elgg\Application;
+
+/**
+ * The object passed to invokable class name handlers
+ *
+ * @access private
+ */
+class Event implements
+	\Elgg\Event,
+	\Elgg\ObjectEvent,
+	\Elgg\UserEvent {
+
+	const EVENT_TYPE = 'event';
+
+	private $elgg;
+	private $name;
+	private $type;
+	private $object;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Application $elgg   Elgg application
+	 * @param string      $name   Event name
+	 * @param string      $type   Event type
+	 * @param mixed       $object Object of the event
+	 */
+	public function __construct(Application $elgg, $name, $type, $object) {
+		$this->elgg = $elgg;
+		$this->name = $name;
+		$this->type = $type;
+		$this->object = $object;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getName() {
+		return $this->name;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getType() {
+		return $this->type;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getObject() {
+		return $this->object;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function elgg() {
+		return $this->elgg;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toLegacyArgs() {
+		return [$this->name, $this->type, $this->object];
+	}
+}

--- a/engine/classes/Elgg/HooksRegistrationService/Hook.php
+++ b/engine/classes/Elgg/HooksRegistrationService/Hook.php
@@ -1,0 +1,120 @@
+<?php
+namespace Elgg\HooksRegistrationService;
+
+use Elgg\Application;
+
+/**
+ * The object passed to invokable class name handlers
+ *
+ * @access private
+ */
+class Hook implements \Elgg\Hook {
+
+	private $elgg;
+	private $name;
+	private $type;
+	private $value;
+	private $params;
+
+	const EVENT_TYPE = 'hook';
+
+	/**
+	 * Constructor
+	 *
+	 * @param Application $elgg   Elgg application
+	 * @param string      $name   Hook name
+	 * @param string      $type   Hook type
+	 * @param mixed       $value  Hook value
+	 * @param mixed       $params Hook params
+	 */
+	public function __construct(Application $elgg, $name, $type, $value, $params) {
+		$this->elgg = $elgg;
+		$this->name = $name;
+		$this->type = $type;
+		$this->value = $value;
+		$this->params = $params;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getName() {
+		return $this->name;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getType() {
+		return $this->type;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getValue() {
+		return $this->value;
+	}
+
+	/**
+	 * Update the value
+	 *
+	 * @param mixed $value The new value
+	 * @return void
+	 * @internal
+	 */
+	public function setValue($value) {
+		$this->value = $value;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getParams() {
+		return $this->params;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getParam($key, $default = null) {
+		if (!is_array($this->params)) {
+			return $default;
+		}
+		return array_key_exists($key, $this->params) ? $this->params[$key] : $default;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getEntityParam() {
+		if (isset($this->params['entity']) && $this->params['entity'] instanceof \ElggEntity) {
+			return $this->params['entity'];
+		}
+		return null;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getUserParam() {
+		if (isset($this->params['user']) && $this->params['user'] instanceof \ElggUser) {
+			return $this->params['user'];
+		}
+		return null;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function elgg() {
+		return $this->elgg;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toLegacyArgs() {
+		return [$this->name, $this->type, $this->value, $this->params];
+	}
+}

--- a/engine/classes/Elgg/Logger.php
+++ b/engine/classes/Elgg/Logger.php
@@ -281,7 +281,6 @@ class Logger {
 	 */
 	public function setHooks(PluginHooksService $hooks) {
 		$this->hooks = $hooks;
-		$this->hooks->setLogger($this);
 	}
 }
 

--- a/engine/classes/Elgg/ObjectEvent.php
+++ b/engine/classes/Elgg/ObjectEvent.php
@@ -1,0 +1,17 @@
+<?php
+namespace Elgg;
+
+/**
+ * Models an object event passed to event handlers
+ *
+ * @since 2.0.0
+ */
+interface ObjectEvent extends Event {
+
+	/**
+	 * Get the object of the event
+	 *
+	 * @return \ElggObject
+	 */
+	public function getObject();
+}

--- a/engine/classes/Elgg/PluginHooksService.php
+++ b/engine/classes/Elgg/PluginHooksService.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elgg;
-use Elgg\Debug\Inspector;
+
+use Elgg\HooksRegistrationService\Hook;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -13,7 +14,7 @@ use Elgg\Debug\Inspector;
  * @subpackage Hooks
  * @since      1.9.0
  */
-class PluginHooksService extends \Elgg\HooksRegistrationService {
+class PluginHooksService extends HooksRegistrationService {
 
 	/**
 	 * Triggers a plugin hook
@@ -21,45 +22,52 @@ class PluginHooksService extends \Elgg\HooksRegistrationService {
 	 * @see elgg_trigger_plugin_hook
 	 * @access private
 	 */
-	public function trigger($hook, $type, $params = null, $returnvalue = null) {
-		$hooks = $this->getOrderedHandlers($hook, $type);
+	public function trigger($name, $type, $params = null, $value = null) {
 
-		foreach ($hooks as $callback) {
-			if (!is_callable($callback)) {
-				if ($this->logger) {
-					$inspector = new Inspector();
-					$this->logger->warn("handler for plugin hook [$hook, $type] is not callable: "
-							. $inspector->describeCallable($callback));
-				}
-				continue;
-			}
+		// This starts as a string, but if a handler type-hints an object we convert it on-demand inside
+		// \Elgg\HandlersService::call and keep it alive during all handler calls. We do this because
+		// creating objects for every triggering is expensive.
+		$hook = 'hook';
+		/* @var Hook|string $hook */
 
-			$exit_warning = function() use ($hook, $type, $callback) {
-				$inspector = new Inspector();
-				elgg_deprecated_notice(
-					"'$hook', '$type' plugin hook should not be used to serve a response. Instead return an "
-					. "appropriate ResponseBuilder instance from an action or page handler. Do not terminate "
-					. "code execution with exit() or die() in {$inspector->describeCallable($callback)}",
-					'2.3'
-				);
-			};
-			
-			if (in_array($hook, ['forward', 'action', 'route'])) {
+		$handlers_svc = _elgg_services()->handlers;
+
+		foreach ($this->getOrderedHandlers($name, $type) as $handler) {
+
+			$exit_warning = null;
+
+			if (in_array($name, ['forward', 'action', 'route'])) {
+				// assume the handler is going to exit the request...
+				$exit_warning = function () use ($name, $type, $handler, $handlers_svc) {
+					_elgg_services()->deprecation->sendNotice(
+						"'$name', '$type' plugin hook should not be used to serve a response. Instead return an "
+						. "appropriate ResponseBuilder instance from an action or page handler. Do not terminate "
+						. "code execution with exit() or die() in {$handlers_svc->describeCallable($handler)}",
+						'2.3'
+					);
+				};
 				_elgg_services()->events->registerHandler('shutdown', 'system', $exit_warning);
 			}
 
-			$args = array($hook, $type, $returnvalue, $params);
-			$temp_return_value = call_user_func_array($callback, $args);
-			if (!is_null($temp_return_value)) {
-				$returnvalue = $temp_return_value;
-			}
+			list($success, $return, $hook) = $handlers_svc->call($handler, $hook, [$name, $type, $value, $params]);
 
-			if (in_array($hook, ['forward', 'action', 'route'])) {
+			if ($exit_warning) {
+				// an exit did not occur, so no need for the warning...
 				_elgg_services()->events->unregisterHandler('shutdown', 'system', $exit_warning);
 			}
+
+			if (!$success) {
+				continue;
+			}
+			if ($return !== null) {
+				$value = $return;
+				if ($hook instanceof Hook) {
+					$hook->setValue($return);
+				}
+			}
 		}
-		
-		return $returnvalue;
+
+		return $value;
 	}
 
 	/**

--- a/engine/classes/Elgg/UserEvent.php
+++ b/engine/classes/Elgg/UserEvent.php
@@ -1,0 +1,17 @@
+<?php
+namespace Elgg;
+
+/**
+ * Models a user event passed to event handlers
+ *
+ * @since 2.0.0
+ */
+interface UserEvent extends Event {
+
+	/**
+	 * Get the user subject of the event
+	 *
+	 * @return \ElggUser
+	 */
+	public function getObject();
+}

--- a/engine/tests/phpunit/Elgg/HandlersServiceTest.php
+++ b/engine/tests/phpunit/Elgg/HandlersServiceTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace Elgg;
+
+require_once __DIR__ . '/../test_files/handlers/functions.php';
+require_once __DIR__ . '/../test_files/handlers/class.php';
+
+class HandlersServiceTest extends TestCase {
+
+	/**
+	 * @var HandlersService
+	 */
+	public $handlers;
+
+	/**
+	 * @var Logger
+	 */
+	public $logger;
+
+	public function setUp() {
+		$this->logger = _elgg_services()->logger;
+		$this->logger->disable();
+		$this->handlers = _elgg_services()->handlers;
+	}
+
+	public function tearDown() {
+		$this->logger->enable();
+	}
+
+	public function testCanTypeHintFunctions() {
+		$this->assertSame(null, $this->handlers->getParamTypeForCallable('test_null_1457227310'));
+		$this->assertSame('', $this->handlers->getParamTypeForCallable('test_none_1457227310'));
+		$this->assertSame('array', $this->handlers->getParamTypeForCallable('test_array_1457227310'));
+		$this->assertSame('callable', $this->handlers->getParamTypeForCallable('test_callable_1457227310'));
+		$this->assertSame('Elgg\\Hook', $this->handlers->getParamTypeForCallable('test_hook_1457227310'));
+	}
+
+	public function testCanTypeHintStaticMethods() {
+		$class = test_1457227310::class;
+
+		$this->assertSame(null, $this->handlers->getParamTypeForCallable([$class, 'test_null']));
+		$this->assertSame('', $this->handlers->getParamTypeForCallable([$class, 'test_none']));
+		$this->assertSame('array', $this->handlers->getParamTypeForCallable([$class, 'test_array']));
+		$this->assertSame('callable', $this->handlers->getParamTypeForCallable([$class, 'test_callable']));
+		$this->assertSame('Elgg\\Hook', $this->handlers->getParamTypeForCallable([$class, 'test_hook']));
+	}
+
+	public function testCanTypeHintDynamicMethods() {
+		$class = new test_1457227310();
+
+		$this->assertSame(null, $this->handlers->getParamTypeForCallable([$class, 'test_null']));
+		$this->assertSame('', $this->handlers->getParamTypeForCallable([$class, 'test_none']));
+		$this->assertSame('array', $this->handlers->getParamTypeForCallable([$class, 'test_array']));
+		$this->assertSame('callable', $this->handlers->getParamTypeForCallable([$class, 'test_callable']));
+		$this->assertSame('Elgg\\Hook', $this->handlers->getParamTypeForCallable([$class, 'test_hook']));
+	}
+
+	public function testCanTypeHintClosures() {
+		$this->assertSame(null, $this->handlers->getParamTypeForCallable(function(){}));
+		$this->assertSame('', $this->handlers->getParamTypeForCallable(function($arg){}));
+		$this->assertSame('array', $this->handlers->getParamTypeForCallable(function(array $arg){}));
+		$this->assertSame('callable', $this->handlers->getParamTypeForCallable(function(callable $arg){}));
+		$this->assertSame('Elgg\\Hook', $this->handlers->getParamTypeForCallable(function(\Elgg\Hook $arg){}));
+	}
+}

--- a/engine/tests/phpunit/Elgg/PluginHooksServiceTest.php
+++ b/engine/tests/phpunit/Elgg/PluginHooksServiceTest.php
@@ -5,29 +5,49 @@ namespace Elgg;
 class PluginHooksServiceTest extends \Elgg\TestCase {
 
 	public function testTriggerCallsRegisteredHandlers() {
-		$hooks = new \Elgg\PluginHooksService();
+		$hooks = new PluginHooksService();
 
-		$this->setExpectedException('InvalidArgumentException');
+		$this->setExpectedException(\InvalidArgumentException::class);
 
-		$hooks->registerHandler('foo', 'bar', array('\Elgg\PluginHooksServiceTest', 'throwInvalidArg'));
+		$hooks->registerHandler('foo', 'bar', [
+			PluginHooksServiceTest::class,
+			'throwInvalidArg'
+		]);
 
 		$hooks->trigger('foo', 'bar');
 	}
 
 	public function testCanPassParamsAndChangeReturnValue() {
-		$hooks = new \Elgg\PluginHooksService();
-		$hooks->registerHandler('foo', 'bar', array('\Elgg\PluginHooksServiceTest', 'changeReturn'));
+		$hooks = new PluginHooksService();
+		$hooks->registerHandler('foo', 'bar', [
+			PluginHooksServiceTest::class,
+			'changeReturn'
+		]);
 
 		$returnval = $hooks->trigger('foo', 'bar', array(
 			'testCase' => $this,
-				), 1);
+		), 1);
+
+		$this->assertEquals(2, $returnval);
+	}
+
+	public function testCanPassHookObjectAndChangeReturnValue() {
+		$hooks = new PluginHooksService();
+		$hooks->registerHandler('foo', 'bar', [
+			PluginHooksServiceTest::class,
+			'changeReturn2'
+		]);
+
+		$returnval = $hooks->trigger('foo', 'bar', array(
+			'testCase' => $this,
+		), 1);
 
 		$this->assertEquals(2, $returnval);
 	}
 
 	public function testNullReturnDoesntChangeValue() {
-		$hooks = new \Elgg\PluginHooksService();
-		$hooks->registerHandler('foo', 'bar', 'Elgg\Values::getNull');
+		$hooks = new PluginHooksService();
+		$hooks->registerHandler('foo', 'bar', [Values::class, 'getNull']);
 
 		$returnval = $hooks->trigger('foo', 'bar', array(), 1);
 
@@ -35,22 +55,57 @@ class PluginHooksServiceTest extends \Elgg\TestCase {
 	}
 
 	public function testUncallableHandlersAreLogged() {
-		$hooks = new \Elgg\PluginHooksService();
+		$hooks = new PluginHooksService();
 
-		$loggerMock = $this->getMock('\Elgg\Logger', array(), array(), '', false);
-		$hooks->setLogger($loggerMock);
-		$hooks->registerHandler('foo', 'bar', array(new \stdClass(), 'uncallableMethod'));
+		_elgg_services()->logger->disable();
 
-		$expectedMsg = 'handler for plugin hook [foo, bar] is not callable: (stdClass)->uncallableMethod';
-		$loggerMock->expects($this->once())->method('warn')->with($expectedMsg);
-
+		$hooks->registerHandler('foo', 'bar', array(
+			new \stdClass(),
+			'uncallableMethod'
+		));
 		$hooks->trigger('foo', 'bar');
+
+		$logged = _elgg_services()->logger->enable();
+
+		$this->assertSame([
+			[
+				'message' => 'Handler for hook [foo, bar] is not callable: (stdClass)->uncallableMethod',
+				'level' => 300,
+			],
+		], $logged);
+	}
+
+	public function testHookTypeHintReceivesObject() {
+		$hooks = new PluginHooksService();
+		$handler = new TestHookHandler();
+
+		$hooks->registerHandler('foo', 'bar', $handler);
+
+		$this->assertEquals(3, $hooks->trigger('foo', 'bar', array('foo' => 1), 2));
+		$this->assertCount(1, TestHookHandler::$invocations);
+		$this->assertCount(1, TestHookHandler::$invocations[0]["args"]);
+		$this->assertInstanceOf(Hook::class, TestHookHandler::$invocations[0]["args"][0]);
+
+		TestHookHandler::$invocations = [];
+	}
+
+	public static function returnTwo() {
+		return 2;
 	}
 
 	public static function changeReturn($foo, $bar, $returnval, $params) {
 		$testCase = $params['testCase'];
+		/* @var PluginHooksServiceTest $testCase */
 
 		$testCase->assertEquals(1, $returnval);
+
+		return 2;
+	}
+
+	public static function changeReturn2(\Elgg\Hook $hook) {
+		$testCase = $hook->getParam('testCase');
+
+		$testCase->assertEquals(1, $hook->getValue());
 
 		return 2;
 	}
@@ -58,5 +113,17 @@ class PluginHooksServiceTest extends \Elgg\TestCase {
 	public static function throwInvalidArg() {
 		throw new \InvalidArgumentException();
 	}
+}
 
+class TestHookHandler {
+
+	public static $invocations = [];
+
+	function __invoke(\Elgg\Hook $hook) {
+		self::$invocations[] = [
+			'this' => $this,
+			'args' => func_get_args(),
+		];
+		return $hook->getValue() + 1;
+	}
 }

--- a/engine/tests/phpunit/test_files/handlers/class.php
+++ b/engine/tests/phpunit/test_files/handlers/class.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Elgg;
+
+class test_1457227310 {
+	function test_null() {}
+	function test_none($arg) {}
+	function test_array(array $arg) {}
+	function test_callable(callable $arg) {}
+	function test_hook(Hook $arg) {}
+}

--- a/engine/tests/phpunit/test_files/handlers/functions.php
+++ b/engine/tests/phpunit/test_files/handlers/functions.php
@@ -1,0 +1,7 @@
+<?php
+
+function test_null_1457227310() {}
+function test_none_1457227310($arg) {}
+function test_array_1457227310(array $arg) {}
+function test_callable_1457227310(callable $arg) {}
+function test_hook_1457227310(\Elgg\Hook $arg) {}


### PR DESCRIPTION
Handlers can type-hint `Elgg\Hook` or `Elgg\Event` to receive a single object with various methods.

Class names can be registered as handlers. Each time the hook/event is triggered, the class is instantiated and invoked.
