### PR TITLE
fix(output): attribute formatter now skips arrays with non-scalar values

### DIFF
--- a/engine/tests/phpunit/Elgg/lib/output/FormatAttributesTest.php
+++ b/engine/tests/phpunit/Elgg/lib/output/FormatAttributesTest.php
@@ -1,6 +1,10 @@
 <?php
+
 namespace Elgg\lib\output;
 
+/**
+ * @group Output
+ */
 class FormatAttributesTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGeneralUsage() {
@@ -10,9 +14,22 @@ class FormatAttributesTest extends \PHPUnit_Framework_TestCase {
 			'c' => true,
 			'd' => null, // ignored
 			'e' => ['&', '&amp;', '<', '&lt;'],
-			'f' => (object)['foo' => 'bar'], // ignored
+			'f' => (object) ['foo' => 'bar'], // ignored
+			'g' => [
+				'bar',
+				true,
+				1.5,
+				2
+			],
+			'h' => [
+				'foo',
+				[],
+			],
+			'i' => [
+				new \ElggObject(),
+			],
 		];
-		$expected = 'a="Hello &amp; &amp; &lt; &lt;" c="c" e="&amp; &amp; &lt; &lt;"';
+		$expected = 'a="Hello &amp; &amp; &lt; &lt;" c="c" e="&amp; &amp; &lt; &lt;" g="bar 1 1.5 2"';
 
 		$this->assertEquals($expected, elgg_format_attributes($attrs));
 	}
@@ -36,4 +53,5 @@ class FormatAttributesTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals($expected, elgg_format_attributes($attrs));
 	}
+
 }


### PR DESCRIPTION
Fixes #10010
