### PR TITLE
chore(project): separate i18n updates from releases

### DIFF
--- a/.scripts/languages.php
+++ b/.scripts/languages.php
@@ -1,0 +1,50 @@
+<?php
+
+if (!isset($argv[1]) || $argv[1] == '--help') {
+	echo "Usage: php .scripts/languages.php <branch>\n";
+	exit;
+}
+
+$branch = $argv[1];
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+function run_commands($commands) {
+	foreach ($commands as $command) {
+		echo "$command\n";
+		passthru($command, $return_val);
+		if ($return_val !== 0) {
+			echo "Error executing command! Interrupting!\n";
+			exit(2);
+		}
+	}
+}
+
+$new_branch = "{$branch}_i18n_" . time();
+
+$elgg_path = dirname(__DIR__);
+
+// Setup. Version checks are here so we fail early if any deps are missing
+run_commands([
+	"tx --version",
+	"git --version",
+
+	"cd $elgg_path",
+	"git checkout -B $new_branch",
+	"tx pull -af --minimum-perc=95",
+]);
+
+// Clean translations
+$cleaner = new Elgg\I18n\ReleaseCleaner();
+$cleaner->cleanInstallation(dirname(__DIR__));
+foreach ($cleaner->log as $msg) {
+	echo "ReleaseCleaner: $msg\n";
+}
+
+run_commands([
+	"git add .",
+	"git commit -am \"chore(i18n): update translations\"",
+]);
+
+echo "Please submit '$new_branch' as a pull request:\n\n";
+echo "   git push -u <fork_remote> $new_branch\n";

--- a/.scripts/release.php
+++ b/.scripts/release.php
@@ -34,10 +34,8 @@ $elgg_path = dirname(__DIR__);
 
 $branch = "release-$version";
 
-
 // Setup. Version checks are here so we fail early if any deps are missing
 run_commands([
-	"tx --version",
 	"git --version",
 	"npm --version",
 	"node --version",
@@ -45,25 +43,6 @@ run_commands([
 
 	"cd $elgg_path",
 	"git checkout -B $branch",
-]);
-
-// Update translations
-run_commands([
-	"tx pull -af --minimum-perc=95",
-]);
-
-// Clean translations
-$cleaner = new Elgg\I18n\ReleaseCleaner();
-$cleaner->cleanInstallation(dirname(__DIR__));
-foreach ($cleaner->log as $msg) {
-	echo "ReleaseCleaner: $msg\n";
-}
-
-run_commands([
-	"sphinx-build -b gettext docs docs/locale/pot",
-	"sphinx-intl build --locale-dir=docs/locale/",
-	"git add .",
-	"git commit -am \"chore(i18n): update translations\"",
 ]);
 
 // Update version in composer.json
@@ -77,6 +56,8 @@ file_put_contents($composer_path, $json);
 
 // Generate changelog
 run_commands(array(
+	"sphinx-build -b gettext docs docs/locale/pot",
+	"sphinx-intl build --locale-dir=docs/locale/",
 	"npm install && npm update",
 	"node .scripts/write-changelog.js",
 	"git add .",


### PR DESCRIPTION
Language updates are super slow and ruin the DX of cutting releases. Also, pairing them with releases puts a large amount of pressure on core devs to rubber stamp language changes without any public review.

This allows language files (code, not docs) to be updated independently of releases. The follow up to this would be to update the docs in 2.x to recommend running the language intake separately and sending in standard pull requests independently of releases.
