### PR TITLE
Comment and reply permissions overrides

### DIFF
--- a/engine/classes/Elgg/UserCapabilities.php
+++ b/engine/classes/Elgg/UserCapabilities.php
@@ -284,10 +284,10 @@ class UserCapabilities {
 	 *
 	 * @param ElggEntity $entity    Object entity
 	 * @param int        $user_guid User guid (default is logged in user)
-	 *
+	 * @param bool       $default   Default permission
 	 * @return bool
 	 */
-	public function canComment(ElggEntity $entity, $user_guid = 0) {
+	public function canComment(ElggEntity $entity, $user_guid = 0, $default = null) {
 		try {
 			$user = $this->entities->getUserForPermissionsCheck($user_guid);
 		} catch (UserFetchFailureException $e) {
@@ -300,7 +300,7 @@ class UserCapabilities {
 			'entity' => $entity,
 			'user' => $user
 		];
-		return $this->hooks->trigger('permissions_check:comment', $entity->getType(), $params, null);
+		return $this->hooks->trigger('permissions_check:comment', $entity->getType(), $params, $default);
 	}
 
 	/**

--- a/engine/classes/ElggComment.php
+++ b/engine/classes/ElggComment.php
@@ -25,12 +25,16 @@ class ElggComment extends \ElggObject {
 	 *
 	 * @see \ElggEntity::canComment()
 	 *
-	 * @param int $user_guid User guid (default is logged in user)
-	 * @return bool False
+	 * @param int  $user_guid User guid (default is logged in user)
+	 * @param bool $default   Default permission
+	 * @return bool
 	 * @since 1.9.0
 	 */
-	public function canComment($user_guid = 0) {
-		return false;
+	public function canComment($user_guid = 0, $default = null) {
+		if (!isset($default)) {
+			$default = false;
+		}
+		return parent::canComment($user_guid, $default);
 	}
 
 	/**

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1065,12 +1065,12 @@ abstract class ElggEntity extends \ElggData implements
 	 * @tip Can be overridden by registering for the permissions_check:comment,
 	 * <entity type> plugin hook.
 	 *
-	 * @param int $user_guid User guid (default is logged in user)
-	 *
+	 * @param int  $user_guid User guid (default is logged in user)
+	 * @param bool $default   Default permission
 	 * @return bool
 	 */
-	public function canComment($user_guid = 0) {
-		return _elgg_services()->userCapabilities->canComment($this, $user_guid);
+	public function canComment($user_guid = 0, $default = null) {
+		return _elgg_services()->userCapabilities->canComment($this, $user_guid, $default);
 	}
 
 	/**

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -605,12 +605,13 @@ class ElggGroup extends \ElggEntity
 	 *
 	 * @see \ElggEntity::canComment()
 	 *
-	 * @param int $user_guid User guid (default is logged in user)
+	 * @param int  $user_guid User guid (default is logged in user)
+	 * @param bool $default   Default permission
 	 * @return bool
 	 * @since 1.8.0
 	 */
-	public function canComment($user_guid = 0) {
-		$result = parent::canComment($user_guid);
+	public function canComment($user_guid = 0, $default = null) {
+		$result = parent::canComment($user_guid, $default);
 		if ($result !== null) {
 			return $result;
 		}

--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -210,12 +210,13 @@ class ElggObject extends \ElggEntity {
 	 *
 	 * @see \ElggEntity::canComment()
 	 *
-	 * @param int $user_guid User guid (default is logged in user)
+	 * @param int  $user_guid User guid (default is logged in user)
+	 * @param bool $default   Default permission
 	 * @return bool
 	 * @since 1.8.0
 	 */
-	public function canComment($user_guid = 0) {
-		$result = parent::canComment($user_guid);
+	public function canComment($user_guid = 0, $default = null) {
+		$result = parent::canComment($user_guid, $default);
 		if ($result !== null) {
 			return $result;
 		}

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -645,12 +645,13 @@ class ElggUser extends \ElggEntity
 	 *
 	 * @see \ElggEntity::canComment()
 	 *
-	 * @param int $user_guid User guid (default is logged in user)
+	 * @param int  $user_guid User guid (default is logged in user)
+	 * @param bool $default   Default permission
 	 * @return bool
 	 * @since 1.8.0
 	 */
-	public function canComment($user_guid = 0) {
-		$result = parent::canComment($user_guid);
+	public function canComment($user_guid = 0, $default = null) {
+		$result = parent::canComment($user_guid, $default);
 		if ($result !== null) {
 			return $result;
 		}

--- a/engine/tests/phpunit/Elgg/UserCapabilitiesTest.php
+++ b/engine/tests/phpunit/Elgg/UserCapabilitiesTest.php
@@ -417,6 +417,15 @@ class UserCapabilitiesTest extends \Elgg\TestCase {
 		$this->assertTrue($object->canComment($viewer->guid));
 		$this->assertFalse($group->canComment($viewer->guid));
 		$this->assertNull($entity->canComment($viewer->guid));
+
+		// can pass default value
+		$this->assertTrue($object->canComment($viewer->guid, true));
+		$this->assertFalse($object->canComment($viewer->guid, false));
+
+		// can't comment on comment
+		$comment = new \ElggComment();
+		$comment->owner_guid = $owner->guid;
+		$this->assertFalse($comment->canComment($owner->guid));
 	}
 
 	/**

--- a/mod/discussions/activate.php
+++ b/mod/discussions/activate.php
@@ -1,10 +1,21 @@
 <?php
-/**
- * Register the ElggDiscussionReply class for the object/discussion_reply subtype
- */
 
-if (get_subtype_id('object', 'discussion_reply')) {
-	update_subtype('object', 'discussion_reply', 'ElggDiscussionReply');
-} else {
-	add_subtype('object', 'discussion_reply', 'ElggDiscussionReply');
+// Update subtype classes
+
+$subtypes = [
+	ElggDiscussion::SUBTYPE => ElggDiscussion::class,
+	ElggDiscussionReply::SUBTYPE => ElggDiscussionReply::class,
+];
+
+foreach ($subtypes as $subtype => $class_name) {
+	if (!get_subtype_id('object', $subtype)) {
+		add_subtype('object', $subtype, $class_name);
+		continue;
+	}
+	// We want to make sure we respect class declarations set by other plugins,
+	// in case the plugin was deactivated accidentally
+	$old_class_name = get_subtype_class('object', $subtype);
+	if (!$old_class_name || $old_class_name == ElggObject::class) {
+		update_subtype('object', $subtype, $class_name);
+	}
 }

--- a/mod/discussions/classes/ElggDiscussion.php
+++ b/mod/discussions/classes/ElggDiscussion.php
@@ -14,4 +14,15 @@ class ElggDiscussion extends ElggObject {
 		
 		$this->attributes['subtype'] = self::SUBTYPE;
 	}
+
+	/**
+	 * Override commenting permissions
+	 *
+	 * @param int  $user_guid User guid
+	 * @param bool $default   Default permission
+	 * @return boolean
+	 */
+	public function canComment($user_guid = 0, $default = null) {
+		return false;
+	}
 }

--- a/mod/discussions/classes/ElggDiscussion.php
+++ b/mod/discussions/classes/ElggDiscussion.php
@@ -1,12 +1,10 @@
 <?php
 /**
- * Class for discussion reply
- *
- * We extend ElggComment to get the future thread support.
+ * Discussion topic class
  */
-class ElggDiscussionReply extends ElggComment {
+class ElggDiscussion extends ElggObject {
 
-	const SUBTYPE = 'discussion_reply';
+	const SUBTYPE = 'discussion';
 
 	/**
 	 * {@inheritdoc}

--- a/mod/discussions/classes/ElggDiscussion.php
+++ b/mod/discussions/classes/ElggDiscussion.php
@@ -25,4 +25,14 @@ class ElggDiscussion extends ElggObject {
 	public function canComment($user_guid = 0, $default = null) {
 		return false;
 	}
+
+	/**
+	 * Shortcut method to check permissions
+	 *
+	 * @param int $user_guid GUID of the user to leave a reply
+	 * @return bool
+	 */
+	public function canReply($user_guid = 0) {
+		return $this->canWriteToContainer($user_guid, 'object', ElggDiscussionReply::SUBTYPE);
+	}
 }

--- a/mod/discussions/deactivate.php
+++ b/mod/discussions/deactivate.php
@@ -1,6 +1,15 @@
 <?php
-/**
- * Deregister the ElggDiscussionReply class
- */
 
-update_subtype('object', 'discussion_reply');
+$subtypes = [
+	ElggDiscussion::SUBTYPE => ElggDiscussion::class,
+	ElggDiscussionReply::SUBTYPE => ElggDiscussionReply::class,
+];
+
+foreach ($subtypes as $subtype => $class_name) {
+	$old_class_name = get_subtype_class('object', $subtype);
+	if ($old_class_name  == $class_name) {
+		// Plugin classes will no longer be loaded once the plugin is deactivated,
+		// so we need to make sure objects are no longer instantiated using them
+		update_subtype('object', $subtype);
+	}
+}

--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -4,6 +4,7 @@
  */
 
 elgg_register_event_handler('init', 'system', 'discussion_init');
+elgg_register_event_handler('upgrade', 'system', 'discussion_upgrade');
 
 /**
  * Initialize the discussion component
@@ -660,4 +661,16 @@ function discussion_prepare_form_vars($topic = NULL) {
 	elgg_clear_sticky_form('topic');
 
 	return $values;
+}
+
+/**
+ * Run upgrade scripts
+ * @return void
+ */
+function discussion_upgrade() {
+
+	$class = get_subtype_class('object', ElggDiscussion::SUBTYPE);
+	if (!$class || $class == ElggObject::class) {
+		update_subtype('object', ElggDiscussion::SUBTYPE, ElggDiscussion::class);
+	}
 }


### PR DESCRIPTION
feat(discussions): discussion topics now have their own class

feat(comments): entities can now inherit canComment permissions
Extending classes can now explicitly pass default canComment permissions value to the parent class

feat(discussions): adds a shortcut ElggDiscussion::canReply method
