### PR TITLE
WIP perf(db): DB fetch optimizations

### DIFF
--- a/engine/classes/Elgg/Cache/MetadataCache.php
+++ b/engine/classes/Elgg/Cache/MetadataCache.php
@@ -140,17 +140,11 @@ class MetadataCache {
 		// could be useful at some point in future
 		//$guids = $this->filterMetadataHeavyEntities($guids);
 
-		$db_prefix = _elgg_services()->db->getTablePrefix();
 		$options = array(
 			'guids' => $guids,
 			'limit' => 0,
 			'callback' => false,
 			'distinct' => false,
-			'joins' => array(
-				"JOIN {$db_prefix}metastrings v ON n_table.value_id = v.id",
-				"JOIN {$db_prefix}metastrings n ON n_table.name_id = n.id",
-			),
-			'selects' => array('n.string AS name', 'v.string AS value'),
 			'order_by' => 'n_table.entity_guid, n_table.time_created ASC, n_table.id ASC',
 
 			// @todo don't know why this is necessary
@@ -160,6 +154,9 @@ class MetadataCache {
 			))),
 		);
 		$data = _elgg_services()->metadataTable->getAll($options);
+
+		// query metastrings separately (SQL JOIN is slow)
+		_elgg_services()->metastringsTable->populateMetadataRows($data);
 
 		// make sure we show all entities as loaded
 		foreach ($guids as $guid) {

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -232,8 +232,9 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 
 		$this->setFactory('metastringsTable', function(ServiceProvider $c) {
 			// TODO(ewinslow): Use memcache-based Pool if available...
-			$pool = new Pool\InMemory();
-			return new \Elgg\Database\MetastringsTable($pool, $c->db);
+			$pool1 = new Pool\InMemory();
+			$pool2 = new Pool\InMemory();
+			return new \Elgg\Database\MetastringsTable($pool1, $pool2, $c->db);
 		});
 
 		$this->setFactory('mutex', function(ServiceProvider $c) {

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -38,7 +38,7 @@ function elgg_get_metastring_id($string, $case_sensitive = true) {
  * @since 2.1
  */
 function elgg_get_metastring_map(array $strings) {
-	return _elgg_services()->metastringsTable->getMap($strings);
+	return _elgg_services()->metastringsTable->getIds($strings);
 }
 
 /**


### PR DESCRIPTION
`metastrings` is a large table of text and slows queries that join it, so we fetch metadata without the join and use separate queries to fetch the strings. We internally cache short metastrings to avoid re-fetching them.
- [ ] test on some production sites with large metastring tables
