### PR TITLE
feature(pages): UI improvements

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -143,6 +143,11 @@ If handlers were registered with the same priority, these are called in the orde
 To emulate prior behavior, Elgg core handlers registered with the ``all`` keyword have been raised in
 priority. Some of these handlers will most likely be called in a different order.
 
+Pages changes
+-------------
+
+ * The editor's icon is shown instead of the ``pages/*`` icon views.
+ * When viewing a page/revision, we no longer duplicate the title beneath the page heading.
 
 From 2.2 to 2.3
 ===============

--- a/mod/pages/views/default/object/page_top.php
+++ b/mod/pages/views/default/object/page_top.php
@@ -41,9 +41,10 @@ if ($revision) {
 	}
 }
 
-$page_icon = elgg_view('pages/icon', array('annotation' => $annotation, 'size' => 'small'));
-
 $editor = get_entity($annotation->owner_guid);
+
+$page_icon = elgg_view_entity_icon($editor, 'tiny');
+
 $editor_link = elgg_view('output/url', array(
 	'href' => "pages/owner/$editor->username",
 	'text' => $editor->name,
@@ -55,7 +56,7 @@ $editor_text = elgg_echo('pages:strapline', array($date, $editor_link));
 $categories = elgg_view('output/categories', $vars);
 
 $comments_count = $page->countComments();
-//only display if there are commments
+// only display if there are comments
 if ($comments_count != 0 && !$revision) {
 	$text = elgg_echo("comments") . " ($comments_count)";
 	$comments_link = elgg_view('output/url', array(
@@ -97,6 +98,7 @@ if ($full) {
 		'entity' => $page,
 		'metadata' => $metadata,
 		'subtitle' => $subtitle,
+		'title' => false,
 	);
 	$params = $params + $vars;
 	$summary = elgg_view('object/elements/summary', $params);


### PR DESCRIPTION
Fixes #8723

BREAKING CHANGES:
On pages, the editor's icon is shown instead of the `pages/*` icon views.
When viewing a page/revision, we no longer duplicate the title beneath the page heading.
