### PR TITLE
perf(metadata): convert metastring joins to subqueries

### DIFF
--- a/engine/classes/Elgg/Database/Annotations.php
+++ b/engine/classes/Elgg/Database/Annotations.php
@@ -371,7 +371,7 @@ class Annotations {
 		if ($time_wheres) {
 			$options['wheres'][] = $time_wheres;
 		}
-	
+
 		return elgg_get_entities_from_metadata($options);
 	}
 	

--- a/engine/classes/Elgg/Database/MetadataTable.php
+++ b/engine/classes/Elgg/Database/MetadataTable.php
@@ -552,7 +552,7 @@ class MetadataTable {
 			if (!is_array($names)) {
 				$names = array($names);
 			}
-	
+
 			$sanitised_names = array();
 			foreach ($names as $name) {
 				// normalise to 0.
@@ -563,8 +563,10 @@ class MetadataTable {
 			}
 	
 			if ($names_str = implode(',', $sanitised_names)) {
-				$return['joins'][] = "JOIN {$this->metastringsTable->getTableName()} msn on n_table.name_id = msn.id";
-				$names_where = "(msn.string IN ($names_str))";
+				$names_where = "(n_table.name_id IN (
+					SELECT id FROM {$this->db->getTablePrefix()}metastrings
+					WHERE string IN ($names_str)
+				))";
 			}
 		}
 	
@@ -585,8 +587,10 @@ class MetadataTable {
 			}
 	
 			if ($values_str = implode(',', $sanitised_values)) {
-				$return['joins'][] = "JOIN {$this->metastringsTable->getTableName()} msv on n_table.value_id = msv.id";
-				$values_where = "({$binary}msv.string IN ($values_str))";
+				$values_where = "(n_table.value_id IN (
+					SELECT id FROM {$this->db->getTablePrefix()}metastrings
+					WHERE $binary string IN ($values_str)
+				))";
 			}
 		}
 	

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -400,8 +400,10 @@ function _elgg_get_metastring_sql($table, $names = null, $values = null,
 		}
 
 		if ($names_str = implode(',', $sanitised_names)) {
-			$return['joins'][] = "JOIN {$db_prefix}metastrings msn on $table.name_id = msn.id";
-			$names_where = "(msn.string IN ($names_str))";
+			$names_where = "($table.name_id IN (
+				SELECT id FROM {$db_prefix}metastrings
+				WHERE string IN ($names_str)
+			))";
 		}
 	}
 
@@ -422,8 +424,10 @@ function _elgg_get_metastring_sql($table, $names = null, $values = null,
 		}
 
 		if ($values_str = implode(',', $sanitised_values)) {
-			$return['joins'][] = "JOIN {$db_prefix}metastrings msv on $table.value_id = msv.id";
-			$values_where = "({$binary}msv.string IN ($values_str))";
+			$values_where = "($table.value_id IN (
+				SELECT id FROM {$db_prefix}metastrings
+				WHERE $binary string IN ($values_str)
+			))";
 		}
 	}
 
@@ -731,6 +735,16 @@ function _elgg_entities_get_metastrings_options($type, $options) {
 			} else {
 				$options['order_by'] = "$order_by_metadata, e.time_created DESC";
 			}
+		}
+	}
+
+	// a user may expect the n_table to be present and reference it in a join, but this will
+	// fail if the n_table is joined *after*. So here we find the n_table join and place it first.
+	foreach ($options['joins'] as $k => $join) {
+		if (preg_match("~$n_table n_table\\b~", $join)) {
+			unset($options['joins'][$k]);
+			array_unshift($options['joins'], $join);
+			break;
 		}
 	}
 

--- a/engine/tests/ElggCoreGetEntitiesFromAnnotationsTest.php
+++ b/engine/tests/ElggCoreGetEntitiesFromAnnotationsTest.php
@@ -330,6 +330,7 @@ class ElggCoreGetEntitiesFromAnnotationsTest extends \ElggCoreGetEntitiesBaseTes
 			}
 		}
 
+		$prefix = _elgg_services()->db->getTablePrefix();
 		$options = array(
 			'type' => 'object',
 			'subtypes' => $subtypes,
@@ -337,6 +338,9 @@ class ElggCoreGetEntitiesFromAnnotationsTest extends \ElggCoreGetEntitiesBaseTes
 			'annotation_name' => $name,
 			'annotation_values' => array_unique(call_user_func_array('array_merge', $values)),
 			'calculation' => 'sum',
+			'joins' => array(
+				"JOIN {$prefix}metastrings msv ON (n_table.value_id = msv.id)",
+			),
 			'wheres' => array(
 				"CAST(msv.string as SIGNED) > 0"
 			)

--- a/engine/tests/ElggCoreMetadataAPITest.php
+++ b/engine/tests/ElggCoreMetadataAPITest.php
@@ -132,7 +132,7 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 
 		$result = _elgg_get_entity_metadata_where_sql('e', 'metadata', array('test'), array(false));
 		$where = preg_replace( '/\s+/', ' ', $result['wheres'][0]);
-		$this->assertTrue(strpos($where, "msn.string IN ('test')) AND ( BINARY msv.string IN ('0')"));
+		$this->assertTrue(strpos($where, "WHERE BINARY string IN ('0')"));
 	}
 
 	// Make sure metadata with multiple values is correctly deleted when re-written


### PR DESCRIPTION
Replaced with #10040.

Metadata-related queries that currently join the metastrings table now in some case use subqueries to match the metastring IDs. If these tables are large this should speed up these queries.

BREAKING CHANGE:
Entity queries based on annotations and metadata previously automatically added `msn` and/or `mvn` joins internally. If your query must reference the metastrings table, it must specify its own joins in `$options`.
- [x] move to master
