### PR TITLE
chore(test): Moves more tests to PHPUnit

### DIFF
--- a/engine/classes/Elgg/Database/TestingPlugins.php
+++ b/engine/classes/Elgg/Database/TestingPlugins.php
@@ -1,0 +1,21 @@
+<?php
+namespace Elgg\Database;
+
+/**
+ * Testing version of Plugins, finds no plugins
+ *
+ * @access private
+ */
+class TestingPlugins extends Plugins {
+
+	/**
+	 * Returns no plugins
+	 *
+	 * @param string $status    The status of the plugins. active, inactive, or all.
+	 * @param mixed  $site_guid Optional site guid
+	 * @return \ElggPlugin[]
+	 */
+	function find($status = 'active', $site_guid = null) {
+		return [];
+	}
+}

--- a/engine/tests/ElggCoreHelpersTest.php
+++ b/engine/tests/ElggCoreHelpersTest.php
@@ -9,33 +9,11 @@
 class ElggCoreHelpersTest extends \ElggCoreUnitTest {
 
 	/**
-	 * Called before each test object.
-	 */
-	public function __construct() {
-		parent::__construct();
-	}
-
-	/**
-	 * Called before each test method.
-	 */
-	public function setUp() {
-
-	}
-
-	/**
 	 * Called after each test method.
 	 */
 	public function tearDown() {
 		unset($GLOBALS['_ELGG']->externals);
 		unset($GLOBALS['_ELGG']->externals_map);
-	}
-
-	/**
-	 * Called after each test object.
-	 */
-	public function __destruct() {
-		// all __destruct() code should go above here
-		parent::__destruct();
 	}
 
 	/**
@@ -98,126 +76,6 @@ class ElggCoreHelpersTest extends \ElggCoreUnitTest {
 
 		foreach ($conversions as $input => $output) {
 			$this->assertIdentical($output, elgg_normalize_url($input));
-		}
-	}
-
-	/**
-	 * Test elgg_http_url_is_identical()
-	 */
-	public function testHttpUrlIsIdentical() {
-		$tests = array(
-			'http://example.com' => 'http://example.com',
-			'https://example.com' => 'https://example.com',
-			'http://example-time.com' => 'http://example-time.com',
-
-			'//example.com' => '//example.com',
-			'ftp://example.com/file' => 'ftp://example.com/file',
-			'mailto:brett@elgg.org' => 'mailto:brett@elgg.org',
-			'javascript:alert("test")' => 'javascript:alert("test")',
-			'app://endpoint' => 'app://endpoint',
-
-			'example.com' => 'http://example.com',
-			'example.com/subpage' => 'http://example.com/subpage',
-
-			'page/handler' =>                	elgg_get_site_url() . 'page/handler',
-			'page/handler?p=v&p2=v2' =>      	elgg_get_site_url() . 'page/handler?p=v&p2=v2',
-			'mod/plugin/file.php' =>            elgg_get_site_url() . 'mod/plugin/file.php',
-			'mod/plugin/file.php?p=v&p2=v2' =>  elgg_get_site_url() . 'mod/plugin/file.php?p=v&p2=v2',
-            'search?foo.bar' =>                 elgg_get_site_url() . 'search?foo.bar',
-			'rootfile.php' =>                   elgg_get_site_url() . 'rootfile.php',
-			'rootfile.php?p=v&p2=v2' =>         elgg_get_site_url() . 'rootfile.php?p=v&p2=v2',
-
-			'/page/handler' =>               	elgg_get_site_url() . 'page/handler',
-			'/page/handler?p=v&p2=v2' =>     	elgg_get_site_url() . 'page/handler?p=v&p2=v2',
-			'/mod/plugin/file.php' =>           elgg_get_site_url() . 'mod/plugin/file.php',
-			'/mod/plugin/file.php?p=v&p2=v2' => elgg_get_site_url() . 'mod/plugin/file.php?p=v&p2=v2',
-			'/rootfile.php' =>                  elgg_get_site_url() . 'rootfile.php',
-			'/rootfile.php?p=v&p2=v2' =>        elgg_get_site_url() . 'rootfile.php?p=v&p2=v2',
-		);
-
-		foreach ($tests as $input => $output) {
-			$this->assertTrue(elgg_http_url_is_identical($output, $input), "Failed to determine URLs as identical for: '$output' and '$input'");
-			$this->assertTrue(elgg_http_url_is_identical($input, $output), "Failed to determine URLs as identical for: '$input' and '$output'");
-		}
-	}
-
-	/**
-	 * Test elgg_http_url_is_identical() for $ignore_params parameter handling
-	 */
-	public function testHttpUrlIsIdenticalIgnoreParamsHandling() {
-		$tests = array(
-			array('page/handler', elgg_get_site_url() . 'page/handler', array('p', 'p2'), true),
-			array('page/handler?p=v&p2=q2', elgg_get_site_url() . 'page/handler?p=q&p2=v2', array('p', 'p2'), true),
-			array('/rootfile.php', elgg_get_site_url() . 'rootfile.php?param=23', array('param'), true),
-			array('/rootfile.php?p=v&p2=v2', elgg_get_site_url() . 'rootfile.php?p=v&p2=q', array('p', 'p2'), true),
-			array('mod/plugin/file.php?other_param=123', elgg_get_site_url() . 'mod/plugin/file.php', array('q', 'p2'), false),
-			array('/rootfile.php', elgg_get_site_url() . 'rootfile.php?param=23', array(), false),
-		);
-
-		foreach ($tests as $test) {
-			list($url1, $url2, $ignore_params, $result) = $test;
-			$this->assertIdentical(elgg_http_url_is_identical($url1, $url2, $ignore_params), $result, "Failed to determine URLs as "
-				. ($result ? 'identical' : 'different') . " for: '$url1', '$url2' and ignore params set to " . print_r($ignore_params, true));
-			$this->assertIdentical(elgg_http_url_is_identical($url2, $url1, $ignore_params), $result, "Failed to determine URLs as "
-				. ($result ? 'identical' : 'different') . " for: '$url2', '$url1' and ignore params set to " . print_r($ignore_params, true));
-		}
-	}
-
-	/**
-	 * Test elgg_format_element()
-	 */
-	public function testElggFormatElement() {
-		$tests = array(
-			'<span>a & b</span>' => array(
-				'tag_name' => 'span',
-				'text' => 'a & b',
-				'_msg' => 'Basic formatting, span recognized as non-void element',
-			),
-			'<span>a &amp; &amp; b</span>' => array(
-				'tag_name' => 'span',
-				'text' => 'a & &amp; b',
-				'opts' => array('encode_text' => true),
-				'_msg' => 'HTML escaping, does not double encode',
-			),
-			'<span>a &amp;times; b</span>' => array(
-				'tag_name' => 'span',
-				'text' => 'a &times; b',
-				'opts' => array('encode_text' => true, 'double_encode' => true),
-				'_msg' => 'HTML escaping double encodes',
-			),
-			'<IMG src="a &amp; b">' => array(
-				'tag_name' => 'IMG',
-				'attrs' => array('src' => 'a & b'),
-				'text' => 'should not appear',
-				'_msg' => 'IMG recognized as void element, text ignored',
-			),
-			'<foo />' => array(
-				'tag_name' => 'foo',
-				'opts' => array('is_void' => true, 'is_xml' => true),
-				'_msg' => 'XML syntax for self-closing elements',
-			),
-		);
-		foreach ($tests as $expected => $vars) {
-			$tag_name = $vars['tag_name'];
-			$text = isset($vars['text']) ? $vars['text'] : null;
-			$opts = isset($vars['opts']) ? $vars['opts'] : array();
-			$attrs = isset($vars['attrs']) ? $vars['attrs'] : array();
-			$message = isset($vars['_msg']) ? $vars['_msg'] : null;
-			unset($vars['tag_name'], $vars['text'], $vars['_msg']);
-
-			$this->assertEqual(elgg_format_element($tag_name, $attrs, $text, $opts), $expected, $message);
-
-			$attrs['#tag_name'] = $tag_name;
-			$attrs['#text'] = $text;
-			$attrs['#options'] = $opts;
-			$this->assertEqual(elgg_format_element($attrs), $expected, $message);
-		}
-
-		try {
-			elgg_format_element(array());
-			$this->fail('Failed to throw exception');
-		} catch (InvalidArgumentException $e) {
-			$this->pass();
 		}
 	}
 
@@ -317,8 +175,6 @@ class ElggCoreHelpersTest extends \ElggCoreUnitTest {
 	 * Test elgg_load_js()
 	 */
 	public function testElggLoadJS() {
-		global $CONFIG;
-
 		// load before register
 		elgg_load_js('key');
 		$result = elgg_register_js('key', 'http://test1.com', 'footer');
@@ -332,8 +188,6 @@ class ElggCoreHelpersTest extends \ElggCoreUnitTest {
 	 * Test elgg_get_loaded_js()
 	 */
 	public function testElggGetJS() {
-		global $CONFIG;
-
 		$base = trim(elgg_get_site_url(), "/");
 
 		$urls = array(
@@ -355,26 +209,5 @@ class ElggCoreHelpersTest extends \ElggCoreUnitTest {
 
 		$js_urls = elgg_get_loaded_js('footer');
 		$this->assertIdentical(array(), $js_urls);
-	}
-	
-	/**
-	 * Test elgg_get_friendly_time()
-	 */
-	public function testElggGetFriendlyTime() {
-
-		$current_time = time();
-		$offsets = array(
-			'0' => elgg_echo('friendlytime:justnow'),
-			'-120' => elgg_echo('friendlytime:minutes', array('2')),
-			'-60' => elgg_echo('friendlytime:minutes:singular'),
-			'-10800' => elgg_echo('friendlytime:hours', array('3')),
-			'-86400' => elgg_echo('friendlytime:days:singular'),
-			'120' => elgg_echo('friendlytime:future:minutes', array('2')),
-			'86400' => elgg_echo('friendlytime:future:days:singular'),
-		);
-		
-		foreach ($offsets as $num_seconds => $friendlytime) {
-			$this->assertIdentical(elgg_get_friendly_time($current_time + $num_seconds, $current_time), $friendlytime);
-		}
 	}
 }

--- a/engine/tests/phpunit/Elgg/ActionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ActionsServiceTest.php
@@ -344,7 +344,7 @@ class ActionsServiceTest extends \Elgg\TestCase {
 
 		$this->assertInstanceOf(ErrorResponse::class, $result);
 		$this->assertEquals(ELGG_HTTP_NOT_IMPLEMENTED, $result->getStatusCode());
-		$this->assertEquals(elgg_echo('actionundefined'), $result->getContent());
+		$this->assertEquals(elgg_echo('actionundefined', ['unregistered']), $result->getContent());
 		$this->assertEquals('referrer', $result->getForwardURL());
 	}
 
@@ -358,7 +358,7 @@ class ActionsServiceTest extends \Elgg\TestCase {
 
 		$this->assertInstanceOf(ErrorResponse::class, $result);
 		$this->assertEquals(ELGG_HTTP_FORBIDDEN, $result->getStatusCode());
-		$this->assertEquals(elgg_echo('actionloggedout'), $result->getContent());
+		$this->assertEquals(elgg_echo('actionloggedout', ['output3']), $result->getContent());
 		$this->assertEquals('referrer', $result->getForwardURL());
 	}
 
@@ -385,7 +385,7 @@ class ActionsServiceTest extends \Elgg\TestCase {
 
 		$this->assertInstanceOf(ErrorResponse::class, $result);
 		$this->assertEquals(ELGG_HTTP_NOT_IMPLEMENTED, $result->getStatusCode());
-		$this->assertEquals(elgg_echo('actionnotfound'), $result->getContent());
+		$this->assertEquals(elgg_echo('actionnotfound', ['no_file']), $result->getContent());
 		$this->assertEquals('referrer', $result->getForwardURL());
 	}
 
@@ -417,7 +417,7 @@ class ActionsServiceTest extends \Elgg\TestCase {
 
 		$this->assertInstanceOf(ErrorResponse::class, $result);
 		$this->assertEquals(ELGG_HTTP_NOT_IMPLEMENTED, $result->getStatusCode());
-		$this->assertEquals(elgg_echo('actionnotfound'), $result->getContent());
+		$this->assertEquals(elgg_echo('actionnotfound', ['no_file']), $result->getContent());
 		$this->assertEquals('referrer', $result->getForwardURL());
 	}
 

--- a/engine/tests/phpunit/Elgg/TestCase.php
+++ b/engine/tests/phpunit/Elgg/TestCase.php
@@ -4,6 +4,7 @@ namespace Elgg;
 
 use Elgg\Di\ServiceProvider;
 use Elgg\Http\Request;
+use Elgg\Cache\Pool\InMemory;
 use stdClass;
 use Zend\Mail\Transport\InMemory as InMemoryTransport;
 
@@ -37,6 +38,11 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 
 		$config = new Config((object) self::getTestingConfigArray());
 		$sp = new ServiceProvider($config);
+
+		$sp->setFactory('plugins', function(ServiceProvider $c) {
+			$pool = new InMemory();
+			return new \Elgg\Database\TestingPlugins($pool, $c->pluginSettingsCache);
+		});
 
 		$sp->setValue('mailer', new InMemoryTransport());
 

--- a/engine/tests/phpunit/ElggCoreUrlHelpersTest.php
+++ b/engine/tests/phpunit/ElggCoreUrlHelpersTest.php
@@ -8,9 +8,15 @@ class ElggCoreUrlHelpersTest extends \Elgg\TestCase {
 
 	/**
 	 * Test if elgg_http_add_url_query_elements() preserves original url when no params are passed
+	 *
+	 * @dataProvider providerElggHttpAddURLQueryElementsPreserveURL
 	 */
-	public function testElggHttpAddURLQueryElementsPreserveURL() {
-		$tests = array(
+	public function testElggHttpAddURLQueryElementsPreserveURL($input, $params, $output) {
+		$this->assertEquals($output, elgg_http_add_url_query_elements($input, $params));
+	}
+
+	function providerElggHttpAddURLQueryElementsPreserveURL() {
+		return[
 			array('', array(), '?'),
 			array('/', array(), '/'),
 			array('/path', array(), '/path'),
@@ -30,19 +36,20 @@ class ElggCoreUrlHelpersTest extends \Elgg\TestCase {
 			array('app://endpoint/path', array(), 'app://endpoint/path'),
 			array('https://example.com?foo=123&bar=abc', array(), 'https://example.com?foo=123&bar=abc'),
 			array('https://example.com/path?foo=123&bar=abc', array(), 'https://example.com/path?foo=123&bar=abc'),
-		);
-
-		foreach ($tests as $test) {
-			list($input, $params, $output) = $test;
-			$this->assertEquals($output, elgg_http_add_url_query_elements($input, $params));
-		}
+		];
 	}
 
 	/**
 	 * Test elgg_http_add_url_query_elements() addition of parameters
+	 *
+	 * @dataProvider providerElggHttpAddURLQueryElementsAddElements
 	 */
-	public function testElggHttpAddURLQueryElementsAddElements() {
-		$tests = array(
+	public function testElggHttpAddURLQueryElementsAddElements($input, $params, $output) {
+		$this->assertEquals($output, elgg_http_add_url_query_elements($input, $params));
+	}
+
+	function providerElggHttpAddURLQueryElementsAddElements() {
+		return [
 			array('', array('foo' => 'bar'), '?foo=bar'),
 			array('/', array('foo' => 'bar'), '/?foo=bar'),
 			array('/path', array('foo' => 'bar'), '/path?foo=bar'),
@@ -63,19 +70,23 @@ class ElggCoreUrlHelpersTest extends \Elgg\TestCase {
 			array('https://example.com/path?foo=123&bar=abc', array('foo' => 'bar'), 'https://example.com/path?foo=bar&bar=abc'),
 			array('https://example.com?foo=123&bar=abc', array('foo2' => 'bar2', '123' => 456), 'https://example.com?foo=123&bar=abc&foo2=bar2&123=456'),
 			array('https://example.com/path?foo=123&bar=abc', array('foo' => 'bar'), 'https://example.com/path?foo=bar&bar=abc'),
-		);
-
-		foreach ($tests as $test) {
-			list($input, $params, $output) = $test;
-			$this->assertEquals($output, elgg_http_add_url_query_elements($input, $params));
-		}
+		];
 	}
 
 	/**
 	 * Test elgg_http_add_url_query_elements() removal of parameters
+	 *
+	 * @dataProvider providerElggHttpAddURLQueryElementsRemoveElements
 	 */
-	public function testElggHttpAddURLQueryElementsRemoveElements() {
-		$tests = array(
+	public function testElggHttpAddURLQueryElementsRemoveElements($input, $params, $output) {
+		$this->assertEquals($output, elgg_http_add_url_query_elements($input, $params));
+		if ($params === array('foo' => null)) {
+			$this->assertEquals($output, elgg_http_remove_url_query_element($input, 'foo'));
+		}
+	}
+
+	function providerElggHttpAddURLQueryElementsRemoveElements() {
+		return [
 			array('?foo=bar', array('foo' => ''), '?foo='),
 			array('?foo=bar', array('foo' => 0), '?foo=0'),
 			array('?foo=bar', array('foo' => false), '?foo=0'),
@@ -102,15 +113,73 @@ class ElggCoreUrlHelpersTest extends \Elgg\TestCase {
 			array('https://example.com/path?bar=abc&foo=123', array('foo' => null, 'foo2' => 'bar'), 'https://example.com/path?bar=abc&foo2=bar'),
 			array('https://example.com?foo=123&bar=abc', array('foo' => null, 'foo2' => 'bar2', '123' => 456), 'https://example.com?bar=abc&foo2=bar2&123=456'),
 			array('https://example.com/path?foo=123&bar=abc', array('foo2' => 'bar', 'foo' => null), 'https://example.com/path?bar=abc&foo2=bar'),
-		);
-
-		foreach ($tests as $test) {
-			list($input, $params, $output) = $test;
-			$this->assertEquals($output, elgg_http_add_url_query_elements($input, $params));
-			if ($params === array('foo' => null)) {
-				$this->assertEquals($output, elgg_http_remove_url_query_element($input, 'foo'));
-			}
-		}
+		];
 	}
 
+
+	/**
+	 * @dataProvider providerHttpUrlIsIdentical
+	 */
+	public function testHttpUrlIsIdentical($input, $output) {
+		$this->assertTrue(elgg_http_url_is_identical($output, $input), "Failed to determine URLs as identical for: '$output' and '$input'");
+		$this->assertTrue(elgg_http_url_is_identical($input, $output), "Failed to determine URLs as identical for: '$input' and '$output'");
+	}
+
+	function providerHttpUrlIsIdentical() {
+		$data = [
+			'http://example.com' => 'http://example.com',
+			'https://example.com' => 'https://example.com',
+			'http://example-time.com' => 'http://example-time.com',
+
+			'//example.com' => '//example.com',
+			'ftp://example.com/file' => 'ftp://example.com/file',
+			'mailto:brett@elgg.org' => 'mailto:brett@elgg.org',
+			'javascript:alert("test")' => 'javascript:alert("test")',
+			'app://endpoint' => 'app://endpoint',
+
+			'example.com' => 'http://example.com',
+			'example.com/subpage' => 'http://example.com/subpage',
+
+			'page/handler' =>                	elgg_get_site_url() . 'page/handler',
+			'page/handler?p=v&p2=v2' =>      	elgg_get_site_url() . 'page/handler?p=v&p2=v2',
+			'mod/plugin/file.php' =>            elgg_get_site_url() . 'mod/plugin/file.php',
+			'mod/plugin/file.php?p=v&p2=v2' =>  elgg_get_site_url() . 'mod/plugin/file.php?p=v&p2=v2',
+			'search?foo.bar' =>                 elgg_get_site_url() . 'search?foo.bar',
+			'rootfile.php' =>                   elgg_get_site_url() . 'rootfile.php',
+			'rootfile.php?p=v&p2=v2' =>         elgg_get_site_url() . 'rootfile.php?p=v&p2=v2',
+
+			'/page/handler' =>               	elgg_get_site_url() . 'page/handler',
+			'/page/handler?p=v&p2=v2' =>     	elgg_get_site_url() . 'page/handler?p=v&p2=v2',
+			'/mod/plugin/file.php' =>           elgg_get_site_url() . 'mod/plugin/file.php',
+			'/mod/plugin/file.php?p=v&p2=v2' => elgg_get_site_url() . 'mod/plugin/file.php?p=v&p2=v2',
+			'/rootfile.php' =>                  elgg_get_site_url() . 'rootfile.php',
+			'/rootfile.php?p=v&p2=v2' =>        elgg_get_site_url() . 'rootfile.php?p=v&p2=v2',
+		];
+		$ret = [];
+		foreach ($data as $in => $out) {
+			$ret[] = [$in, $out];
+		}
+		return $ret;
+	}
+
+	/**
+	 * @dataProvider providerHttpUrlIsIdenticalIgnoreParamsHandling
+	 */
+	public function testHttpUrlIsIdenticalIgnoreParamsHandling($url1, $url2, $ignore_params, $result) {
+		$this->assertSame(elgg_http_url_is_identical($url1, $url2, $ignore_params), $result, "Failed to determine URLs as "
+			. ($result ? 'identical' : 'different') . " for: '$url1', '$url2' and ignore params set to " . print_r($ignore_params, true));
+		$this->assertSame(elgg_http_url_is_identical($url2, $url1, $ignore_params), $result, "Failed to determine URLs as "
+			. ($result ? 'identical' : 'different') . " for: '$url2', '$url1' and ignore params set to " . print_r($ignore_params, true));
+	}
+
+	function providerHttpUrlIsIdenticalIgnoreParamsHandling() {
+		return [
+			array('page/handler', elgg_get_site_url() . 'page/handler', array('p', 'p2'), true),
+			array('page/handler?p=v&p2=q2', elgg_get_site_url() . 'page/handler?p=q&p2=v2', array('p', 'p2'), true),
+			array('/rootfile.php', elgg_get_site_url() . 'rootfile.php?param=23', array('param'), true),
+			array('/rootfile.php?p=v&p2=v2', elgg_get_site_url() . 'rootfile.php?p=v&p2=q', array('p', 'p2'), true),
+			array('mod/plugin/file.php?other_param=123', elgg_get_site_url() . 'mod/plugin/file.php', array('q', 'p2'), false),
+			array('/rootfile.php', elgg_get_site_url() . 'rootfile.php?param=23', array(), false),
+		];
+	}
 }

--- a/engine/tests/phpunit/ElggViewHelpersTest.php
+++ b/engine/tests/phpunit/ElggViewHelpersTest.php
@@ -23,4 +23,87 @@ class ElggViewHelpersTest extends \Elgg\TestCase {
 		// more complete: https://github.com/mrclay/minify/blob/master/tests/MinifyCSSUriRewriterTest.php
 	}
 
+	/**
+	 * @dataProvider providerElggFormatElement
+	 */
+	public function testElggFormatElement($expected, $vars) {
+		$tag_name = $vars['tag_name'];
+		$text = isset($vars['text']) ? $vars['text'] : null;
+		$opts = isset($vars['opts']) ? $vars['opts'] : array();
+		$attrs = isset($vars['attrs']) ? $vars['attrs'] : array();
+		$message = isset($vars['_msg']) ? $vars['_msg'] : null;
+		unset($vars['tag_name'], $vars['text'], $vars['_msg']);
+
+		$this->assertSame(elgg_format_element($tag_name, $attrs, $text, $opts), $expected, $message);
+
+		$attrs['#tag_name'] = $tag_name;
+		$attrs['#text'] = $text;
+		$attrs['#options'] = $opts;
+		$this->assertSame(elgg_format_element($attrs), $expected, $message);
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testElggFormatElementThrows() {
+		elgg_format_element(array());
+	}
+
+	function providerElggFormatElement() {
+		$data = [
+			'<span>a & b</span>' => array(
+				'tag_name' => 'span',
+				'text' => 'a & b',
+				'_msg' => 'Basic formatting, span recognized as non-void element',
+			),
+			'<span>a &amp; &amp; b</span>' => array(
+				'tag_name' => 'span',
+				'text' => 'a & &amp; b',
+				'opts' => array('encode_text' => true),
+				'_msg' => 'HTML escaping, does not double encode',
+			),
+			'<span>a &amp;times; b</span>' => array(
+				'tag_name' => 'span',
+				'text' => 'a &times; b',
+				'opts' => array('encode_text' => true, 'double_encode' => true),
+				'_msg' => 'HTML escaping double encodes',
+			),
+			'<IMG src="a &amp; b">' => array(
+				'tag_name' => 'IMG',
+				'attrs' => array('src' => 'a & b'),
+				'text' => 'should not appear',
+				'_msg' => 'IMG recognized as void element, text ignored',
+			),
+			'<foo />' => array(
+				'tag_name' => 'foo',
+				'opts' => array('is_void' => true, 'is_xml' => true),
+				'_msg' => 'XML syntax for self-closing elements',
+			),
+		];
+		$ret = [];
+		foreach ($data as $one => $two) {
+			$ret[] = [$one, $two];
+		}
+		return $ret;
+	}
+
+	/**
+	 * @dataProvider providerElggGetFriendlyTime
+	 */
+	public function testElggGetFriendlyTime($num_seconds, $friendlytime) {
+		$current_time = time();
+		$this->assertSame(elgg_get_friendly_time($current_time + $num_seconds, $current_time), $friendlytime);
+	}
+
+	function providerElggGetFriendlyTime() {
+		return [
+			['0', elgg_echo('friendlytime:justnow')],
+			['-120', elgg_echo('friendlytime:minutes', array('2'))],
+			['-60', elgg_echo('friendlytime:minutes:singular')],
+			['-10800', elgg_echo('friendlytime:hours', array('3'))],
+			['-86400', elgg_echo('friendlytime:days:singular')],
+			['120', elgg_echo('friendlytime:future:minutes', array('2'))],
+			['86400', elgg_echo('friendlytime:future:days:singular')],
+		];
+	}
 }


### PR DESCRIPTION
PHPUnit no longer tries to load plugin translations, allowing `elgg_echo()` to be used without error.
