### PR TITLE
chore(views): remove unused river comment forms

### DIFF
--- a/views/default/river/elements/responses.php
+++ b/views/default/river/elements/responses.php
@@ -53,6 +53,10 @@ if ($comment_count) {
 	}
 }
 
+if (!$object->canComment()) {
+	return;
+}
+
 // inline comment form
 $form_vars = array('id' => "comments-add-{$object->getGUID()}", 'class' => 'hidden');
 $body_vars = array('entity' => $object, 'inline' => true);


### PR DESCRIPTION
When `$entity->canComment()` is false, the comment icon is not shown in the entity menu, so rendering the hidden form (which can't be opened) is pointless.
