### PR TITLE
feature(api): allow convenience methods to return ElggBatch as a result

### DIFF
--- a/engine/classes/Elgg/BatchResult.php
+++ b/engine/classes/Elgg/BatchResult.php
@@ -1,0 +1,9 @@
+<?php
+namespace Elgg;
+
+/**
+ * Specifies a countable iterator, usually of result rows from a DB
+ *
+ * @since 2.3
+ */
+interface BatchResult extends \Countable, \Iterator {}

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -305,7 +305,17 @@ function elgg_enable_entity($guid, $recursive = true) {
  *				Avoid setting this option without a full understanding of the underlying
  *				SQL query Elgg creates.
  *
- * @return mixed If count, int. If not count, array. false on errors.
+ *  batch => bool (false) If set to true, an Elgg\BatchResult object will be returned instead of an array.
+ *           Since 2.3
+ *
+ *  batch_inc_offset => bool (true) If "batch" is used, this tells the batch to increment the offset
+ *                      on each fetch. This must be set to false if you delete the batched results.
+ *
+ *  batch_size => int (25) If "batch" is used, this is the number of entities/rows to pull in before
+ *                requesting more.
+ *
+ * @return \ElggEntity[]|int|mixed If count, int. Otherwise an array or an Elgg\BatchResult. false on errors.
+ *
  * @since 1.7.0
  * @see elgg_get_entities_from_metadata()
  * @see elgg_get_entities_from_relationship()

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -140,12 +140,26 @@ function _elgg_get_metastring_based_objects($options) {
 		'distinct' => true,
 		'preload_owners' => false,
 		'callback' => $callback,
+
+		'batch' => false,
+		'batch_inc_offset' => true,
+		'batch_size' => 25,
 	);
 
 	// @todo Ignore site_guid right now because of #2910
 	$options['site_guid'] = ELGG_ENTITIES_ANY_VALUE;
 
 	$options = array_merge($defaults, $options);
+
+	if ($options['batch'] && !$options['count']) {
+		$batch_size = $options['batch_size'];
+		$batch_inc_offset = $options['batch_inc_offset'];
+
+		// clean batch keys from $options.
+		unset($options['batch'], $options['batch_size'], $options['batch_inc_offset']);
+
+		return new \ElggBatch('_elgg_get_metastring_based_objects', $options, null, $batch_size, $batch_inc_offset);
+	}
 
 	// can't use helper function with type_subtype_pair because
 	// it's already an array...just need to merge it

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -181,7 +181,17 @@ function elgg_create_river_item(array $options = array()) {
  *                                   option without a full understanding of the
  *                                   underlying SQL query Elgg creates. (true)
  *
- * @return ElggRiverItem[]|int
+ *   batch                => BOOL    If set to true, an Elgg\BatchResult object will be returned
+ *                                   instead of an array. (false) Since 2.3.
+ *
+ *   batch_inc_offset     => BOOL    If "batch" is used, this tells the batch to increment the offset
+ *                                   on each fetch. This must be set to false if you delete the batched
+ *                                   results. (true)
+ *
+ *   batch_size           => INT     If "batch" is used, this is the number of entities/rows to pull
+ *                                   in before requesting more. (25)
+ *
+ * @return \ElggRiverItem[]|\Elgg\BatchResult|array|int
  * @since 1.8.0
  */
 function elgg_get_river(array $options = array()) {
@@ -212,6 +222,10 @@ function elgg_get_river(array $options = array()) {
 		'count'                => false,
 		'distinct'             => true,
 
+		'batch'                => false,
+		'batch_inc_offset'     => true,
+		'batch_size'           => 25,
+
 		'order_by'             => 'rv.posted desc',
 		'group_by'             => ELGG_ENTITIES_ANY_VALUE,
 
@@ -220,6 +234,16 @@ function elgg_get_river(array $options = array()) {
 	);
 
 	$options = array_merge($defaults, $options);
+
+	if ($options['batch'] && !$options['count']) {
+		$batch_size = $options['batch_size'];
+		$batch_inc_offset = $options['batch_inc_offset'];
+
+		// clean batch keys from $options.
+		unset($options['batch'], $options['batch_size'], $options['batch_inc_offset']);
+
+		return new \ElggBatch('elgg_get_river', $options, null, $batch_size, $batch_inc_offset);
+	}
 
 	$singulars = array('id', 'subject_guid', 'object_guid', 'target_guid', 'annotation_id', 'action_type', 'type', 'subtype');
 	$options = _elgg_normalize_plural_options_array($options, $singulars);

--- a/engine/tests/ElggBatchTest.php
+++ b/engine/tests/ElggBatchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Elgg\BatchResult;
+
 /**
  * test \ElggBatch
  *
@@ -165,6 +167,44 @@ class ElggBatchTest extends \ElggCoreUnitTest {
 		}
 		delete_data("DELETE FROM {$db_prefix}entities WHERE guid IN (" . implode(',', $guids) . ")");
 		delete_data("DELETE FROM {$db_prefix}objects_entity WHERE guid IN (" . implode(',', $guids) . ")");
+	}
+
+	public function testBatchCanCount() {
+		$getter = function ($options) {
+			if ($options['count']) {
+				return 20;
+			}
+			return false;
+		};
+		$options = [];
+
+		$count1 = count(new ElggBatch($getter, $options));
+		$count2 = $getter($options + ['count' => true]);
+
+		$this->assertEqual($count1, $count2);
+	}
+
+	public function testCanGetBatchFromAnEntityGetter() {
+		$options = [
+			'type' => 'plugin',
+			'limit' => 5,
+			'callback' => function ($row) {
+				return $row->guid;
+			},
+		];
+		$guids1 = elgg_get_entities($options);
+
+		$batch = elgg_get_entities($options + ['batch' => true]);
+
+		$this->assertIsA($batch, BatchResult::class);
+		/* @var ElggBatch $batch */
+
+		$guids2 = [];
+		foreach ($batch as $val) {
+			$guids2[] = $val;
+		}
+
+		$this->assertEqual($guids1, $guids2);
 	}
 
 	public static function elgg_batch_callback_test($options, $reset = false) {


### PR DESCRIPTION
Allows developers to pass a flag in the options to return an ElggBatch from convenience methods when they need to iterate through large sets. This also makes batches implement Countable and our new Elgg\BatchResult for more flexible type-hinting.

Fixes #6676

(replaces #7723)
