### PR TITLE
HTTP Response Transport

### DIFF
--- a/docs/guides/events-list.rst
+++ b/docs/guides/events-list.rst
@@ -65,6 +65,12 @@ System events
 **cache:flush, system**
     Reset internal and external caches, by default including system_cache, simplecache, and memcache. One might use it to reset others such as APC, OPCache, or WinCache.
 
+**send:before, http_response**
+    Triggered before an HTTP response is sent. Handlers will receive an instance of `\Symfony\Component\HttpFoundation\Response` that is to be sent to the requester. Handlers can terminate the event and prevent the response from being sent by returning `false`.
+
+**send:after, http_response**
+    Triggered after an HTTP response is sent. Handlers will receive an instance of `\Symfony\Component\HttpFoundation\Response` that was sent to the requester.
+
 User events
 ===========
 

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -292,7 +292,12 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setFactory('request', [\Elgg\Http\Request::class, 'createFromGlobals']);
 
 		$this->setFactory('responseFactory', function(ServiceProvider $c) {
-			return new \Elgg\Http\ResponseFactory($c->request, $c->hooks, $c->ajax);
+			if (PHP_SAPI === 'cli') {
+				$transport = new \Elgg\Http\OutputBufferTransport();
+			} else {
+				$transport = new \Elgg\Http\HttpProtocolTransport();
+			}
+			return new \Elgg\Http\ResponseFactory($c->request, $c->hooks, $c->ajax, $transport);
 		});
 
 		$this->setFactory('router', function(ServiceProvider $c) {

--- a/engine/classes/Elgg/Http/HttpProtocolTransport.php
+++ b/engine/classes/Elgg/Http/HttpProtocolTransport.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Elgg\Http;
+
+use Elgg\Http\ResponseTransport;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Transport for sending responses to HTTP clients via HTTP protocol
+ *
+ * @since 2.3
+ * @access private
+ */
+class HttpProtocolTransport implements ResponseTransport {
+	
+	/**
+	 * {@inheritdoc}
+	 */
+	public function send(Response $response) {
+		return $response->send();
+	}
+
+}

--- a/engine/classes/Elgg/Http/OutputBufferTransport.php
+++ b/engine/classes/Elgg/Http/OutputBufferTransport.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Elgg\Http;
+
+use Elgg\Http\ResponseTransport;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Transport for sending responses to non-HTTP clients, e.g. CLI applications, via output buffer
+ *
+ * @since 2.3
+ * @access private
+ */
+class OutputBufferTransport implements ResponseTransport {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function send(Response $response) {
+		echo $response->getContent();
+		return true;
+	}
+
+}

--- a/engine/classes/Elgg/Http/ResponseFactory.php
+++ b/engine/classes/Elgg/Http/ResponseFactory.php
@@ -144,7 +144,15 @@ class ResponseFactory {
 						. (string) $this->response_sent);
 			}
 		} else {
-			$response->send();
+			if (!elgg_trigger_before_event('send', 'http_response', $response)) {
+				return false;
+			}
+
+			if (!$response->send()) {
+				return false;
+			}
+
+			elgg_trigger_after_event('send', 'http_response', $response);
 			$this->response_sent = $response;
 		}
 

--- a/engine/classes/Elgg/Http/ResponseFactory.php
+++ b/engine/classes/Elgg/Http/ResponseFactory.php
@@ -35,6 +35,11 @@ class ResponseFactory {
 	private $hooks;
 
 	/**
+	 * @var ResponseTransport
+	 */
+	private $transport;
+
+	/**
 	 * @var Response|bool
 	 */
 	private $response_sent = false;
@@ -47,14 +52,16 @@ class ResponseFactory {
 	/**
 	 * Constructor
 	 * 
-	 * @param Request            $request HTTP request
-	 * @param PluginHooksService $hooks   Plugin hooks service
-	 * @param AjaxService        $ajax    AJAX service
+	 * @param Request            $request   HTTP request
+	 * @param PluginHooksService $hooks     Plugin hooks service
+	 * @param AjaxService        $ajax      AJAX service
+	 * @param ResponseTransport  $transport Response transport
 	 */
-	public function __construct(Request $request, PluginHooksService $hooks, AjaxService $ajax) {
+	public function __construct(Request $request, PluginHooksService $hooks, AjaxService $ajax, ResponseTransport $transport) {
 		$this->request = $request;
 		$this->hooks = $hooks;
 		$this->ajax = $ajax;
+		$this->transport = $transport;
 		$this->headers = new ResponseHeaderBag();
 	}
 
@@ -148,7 +155,7 @@ class ResponseFactory {
 				return false;
 			}
 
-			if (!$response->send()) {
+			if (!$this->transport->send($response)) {
 				return false;
 			}
 

--- a/engine/classes/Elgg/Http/ResponseTransport.php
+++ b/engine/classes/Elgg/Http/ResponseTransport.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Elgg\Http;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * HTTP response transport interface
+ *
+ * @since 2.3
+ * @access private
+ */
+interface ResponseTransport {
+
+	/**
+	 * Sends HTTP response to the requester
+	 * 
+	 * @param Response $response Symfony Response
+	 * @return bool
+	 */
+	public function send(Response $response);
+
+}

--- a/engine/tests/phpunit/Elgg/Http/ResponseFactoryTest.php
+++ b/engine/tests/phpunit/Elgg/Http/ResponseFactoryTest.php
@@ -10,7 +10,6 @@ use Elgg\PluginHooksService;
 use Elgg\SystemMessagesService;
 use ElggSession;
 use InvalidArgumentException;
-use SecurityException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -98,7 +97,8 @@ class ResponseFactoryTest extends \Elgg\TestCase {
 		_elgg_services()->setValue('system_messages', $this->system_messages);
 		_elgg_services()->setValue('ajax', $this->ajax);
 
-		$this->response_factory = new ResponseFactory($this->request, $this->hooks, $this->ajax);
+		$transport = new \Elgg\Http\OutputBufferTransport();
+		$this->response_factory = new ResponseFactory($this->request, $this->hooks, $this->ajax, $transport);
 		_elgg_services()->setValue('responseFactory', $this->response_factory);
 		return $this->response_factory;
 	}


### PR DESCRIPTION
**feat(http): now triggers before and after events for HTTP responses**

Plugins can now terminate the sending of the HTTP response using the `"send:before","http_response"` event. 
Plugins can now listen to sent HTTP responses using `"send:after","http_response"` event.

**feat(http): no longer sends HTTP headers to CLI requests**

Adds `\Elgg\Http\TransportInterface` implemented by concrete `\Elgg\Http\HttpProtocolTransport`
and`\Elgg\Http\OutputBufferTransport`. Transport interface is now injected into `\Elgg\Http\ResponseFactory` based on `PHP_SAPI` value
