### PR TITLE
WIP Adds entity type registration service

### DIFF
--- a/docs/guides/database.rst
+++ b/docs/guides/database.rst
@@ -290,14 +290,15 @@ Elgg aware of the new mapping. Following is an example class extension:
 
     function committee_init() {
         
-        register_entity_type('group', 'committee');
-        
         // Tell Elgg that group subtype "committee" should be loaded using the Committee class
         // If you ever change the name of the class, use update_subtype() to change it
-        add_subtype('group', 'committee', 'Committee');
+        elgg_register_entity_type('group', 'committee', Committee::class, [
+            'search' => true,
+            'tools' => ['tool1', 'tool2'], // Can be accessed via Committee::getVolatileData("config:tools")
+        ]);
     }
 
-    register_elgg_event_handler('init', 'system', 'committee_init');
+    elgg_register_event_handler('init', 'system', 'committee_init');
     
 Now if you invoke ``get_entity()`` with the GUID of a committee object,
 you'll get back an object of type Committee.

--- a/engine/classes/Elgg/BootService.php
+++ b/engine/classes/Elgg/BootService.php
@@ -53,6 +53,7 @@ class BootService {
 		$CONFIG->pluginspath = "{$local_path}mod/";
 		$CONFIG->entity_types = ['group', 'object', 'site', 'user'];
 		$CONFIG->language = 'en';
+		$CONFIG->registered_entities = [];
 
 		// set cookie values for session and remember me
 		_elgg_services()->config->getCookieConfig();

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -34,6 +34,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\Cache\EntityCache                  $entityCache
  * @property-read \Elgg\EntityPreloader                    $entityPreloader
  * @property-read \Elgg\Database\EntityTable               $entityTable
+ * @property-read \Elgg\EntityTypeRegister                 $entityTypes
  * @property-read \Elgg\EventsService                      $events
  * @property-read \Elgg\Assets\ExternalFiles               $externalFiles
  * @property-read \ElggFileCache                           $fileCache
@@ -186,6 +187,10 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		});
 
 		$this->setClassName('entityTable', \Elgg\Database\EntityTable::class);
+
+		$this->setFactory('entityTypes', function(ServiceProvider $c) {
+			return new \Elgg\EntityTypeRegister($c->config, $c->subtypeTable);
+		});
 
 		$this->setFactory('events', function(ServiceProvider $c) {
 			return $this->resolveLoggerDependencies('events');

--- a/engine/classes/Elgg/EntityTypeRegister.php
+++ b/engine/classes/Elgg/EntityTypeRegister.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace Elgg;
+
+use Elgg\Database\SubtypeTable;
+
+/**
+ * Entity type/subtype registration service
+ *
+ * @since 2.3
+ * @access private
+ */
+class EntityTypeRegister {
+
+	const NO_SUBTYPE = '__BLANK__';
+
+	/**
+	 * @var array
+	 */
+	private $register = [];
+
+	/**
+	 * @var Config
+	 */
+	private $config;
+
+	/**
+	 * @var SubtypeTable
+	 */
+	private $subtype_table;
+
+	/**
+	 * Constructor
+	 * 
+	 * @param Config       $config        Config
+	 * @param SubtypeTable $subtype_table Subtype table
+	 */
+	public function __construct(Config $config, SubtypeTable $subtype_table) {
+		$this->config = $config;
+		$this->subtype_table = $subtype_table;
+	}
+
+	/**
+	 * Returns configured entity types
+	 * @return array
+	 */
+	public function getTypes() {
+		return $this->config->get('entity_types');
+	}
+
+	/**
+	 * Returns object contructor class name
+	 * 
+	 * @param string $type    Entity type
+	 * @param string $subtype Entity subtype
+	 * @return string|false
+	 */
+	public function getConstructor($type, $subtype = null) {
+
+		$type = strtolower($type);
+		if ($subtype) {
+			$constructor = $this->subtype_table->getClass($type, $subtype);
+			if ($constructor) {
+				return $constructor;
+			}
+		}
+
+		switch ($type) {
+			case 'object' :
+				return \ElggObject::class;
+			case 'user' :
+				return \ElggUser::class;
+			case 'group' :
+				return \ElggGroup::class;
+			case 'site' :
+				return \ElggSite::class;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Registers an entity type and subtype
+	 *
+	 * @param string $type        Entity type
+	 *                            "object"|"group"|"user"|"site"
+	 * @param string $subtype     Entity subtype
+	 * @param string $constructor Object constructor class name
+	 *                            Class name associated with the entity of this type and subtype
+	 *                            Will automatically update subtype, if set value does not match
+	 *                            the one in the database
+	 *                            @see update_subtype()
+	 *                            @see add_subtype()
+	 * @param array  $contexts    Context configuration
+	 *                            Specifies in which contexts entities of this type and subtype
+	 *                            should be considered public-facing, as well as additional options
+	 *                            for the given context
+	 *                            <code>
+	 *                               array(
+	 *                                  'search' => true,
+	 *                                  'likes' => [
+	 *                                     'is_likable' => true,
+	 *                                  ],
+	 *                                  'edit' => [
+	 *                                      'fields' => []
+	 *                                  ],
+	 *                               )
+	 *                            </code>
+	 * @return bool
+	 */
+	public function add($type, $subtype = null, $constructor = null, array $contexts = []) {
+
+		$type = strtolower($type);
+		if (!in_array($type, (array) $this->getTypes())) {
+			_elgg_services()->logger->error("$type is not a valid entity type");
+			return false;
+		}
+
+		if (!array_key_exists($type, $this->register)) {
+			$this->register[$type] = [];
+		}
+
+		$class = $this->getConstructor($type, $subtype);
+		if ($subtype) {
+			if (!isset($constructor)) {
+				$constructor = $class;
+			}
+			if ($class !== $constructor) {
+				if (!$this->subtype_table->update($type, $subtype, $constructor)) {
+					$this->subtype_table->add($type, $subtype, $constructor);
+				}
+			}
+
+			unset($this->register[$type][self::NO_SUBTYPE]);
+
+			if (!empty($this->register[$type][$subtype]['contexts'])) {
+				$contexts = array_merge($this->register[$type][$subtype]['contexts'], $contexts);
+			}
+
+			$this->register[$type][$subtype] = [
+				'constructor' => $constructor,
+				'contexts' => (array) $contexts,
+			];
+		} else {
+			$this->register[$type][self::NO_SUBTYPE] = [
+				'constructor' => $constructor,
+				'contexts' => (array) $contexts,
+			];
+		}
+
+		return true;
+	}
+
+	/**
+	 * Unregisters an entity type and subtype
+	 *
+	 * @warning With a blank subtype, it unregisters that entity type including
+	 * all subtypes. If that's the intention, this function must be called after
+	 * all subtypes have been registered.
+	 *
+	 * @param string $type    Entity type
+	 *                        "object"|"group"|"user"|"site"
+	 * @param string $subtype Entity subtype
+	 *                        Leave empty, to unregister both type and all subtypes
+	 * @param string $context Context(s)
+	 *                        If set, will only unregister entity type from specific context(s)
+	 *                        <code>['search', 'likes']</code>
+	 * @return bool
+	 */
+	public function remove($type, $subtype = null, $context = null) {
+
+		$type = strtolower($type);
+		if (!in_array($type, (array) $this->getTypes())) {
+			_elgg_services()->logger->error("$type is not a valid entity type");
+			return false;
+		}
+
+		if (empty($this->register[$type])) {
+			return false;
+		}
+
+		if (!$subtype) {
+			$subtype = self::NO_SUBTYPE;
+		}
+
+		$contexts = (array) $context;
+		foreach ($this->register[$type] as $subtype => $options) {
+			if (empty($contexts)) {
+				$this->subtype_table->remove($type, $subtype);
+				unset($this->register[$type][$subtype]);
+				continue;
+			}
+			foreach ($contexts as $context) {
+				unset($this->register[$type][$subtype]['contexts'][$context]);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns registered entity types and subtypes
+	 * <code>
+	 * [
+	 *     'object' => [
+	 *        'subtype1',
+	 *     ],
+	 *     'user' => [],
+	 * ]
+	 * </code>
+	 *
+	 * @param mixed  $type    Entity type(s)
+	 *                        "object"|"group"|"user"|"site"
+	 *                        Leave empty for all
+	 * @param string $context Context(s)
+	 *                        If set, will return subtypes that are registered for ALL contexts
+	 *                        <code>['search', 'likes']</code>
+	 * @return array
+	 */
+	public function getSubtypes($type = null, $context = null) {
+
+		if ($type) {
+			$types = [strtolower($type)];
+		} else {
+			$types = array_keys($this->register);
+		}
+
+		$register = [];
+		foreach ($this->register as $type => $subtypes) {
+			if (!in_array($type, $types)) {
+				continue;
+			}
+
+			foreach ($subtypes as $subtype => $options) {
+				if (!$this->inContext($context, $type, $subtype)) {
+					continue;
+				}
+				if ($subtype == self::NO_SUBTYPE) {
+					$register[$type] = [];
+					continue;
+				}
+				$register[$type][] = $subtype;
+			}
+		}
+
+		return $register;
+	}
+
+	/**
+	 * Check if entity type is considered public in a given context(s)
+	 *
+	 * @param mixed  $context Context(s)
+	 *                        If multiple contexts are provided, will check if entity type is
+	 *                        is registered for ALL contexts
+	 * @param string $type    Entity type
+	 *                        "object"|"group"|"user"|"site"
+	 * @param string $subtype Entity subtype
+	 * @return bool
+	 */
+	public function inContext($context, $type, $subtype = null) {
+		if (!$subtype) {
+			$subtype = self::NO_SUBTYPE;
+		}
+		if (!isset($this->register[$type][$subtype])) {
+			return false;
+		}
+		$contexts = (array) $context;
+		foreach ($contexts as $context) {
+			if (empty($this->register[$type][$subtype]['contexts'][$context])) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Returns context config for the entity type
+	 * 
+	 * @param string $type    Entity type
+	 * @param string $subtype Entity subtype
+	 * @return mixed
+	 */
+	public function getContextConfig($type, $subtype = null) {
+		$type = strtolower($type);
+		if (!$subtype) {
+			$subtype = self::NO_SUBTYPE;
+		}
+		if (!isset($this->register[$type][$subtype]['contexts'])) {
+			return false;
+		}
+		return $this->register[$type][$subtype]['contexts'];
+	}
+}

--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -85,6 +85,13 @@ class ElggObject extends \ElggEntity {
 				throw new \InvalidParameterException("Unrecognized value passed to constuctor.");
 			}
 		}
+
+		$config = _elgg_services()->entityTypes->getContextConfig($this->type, $this->getSubtype());
+		if ($config) {
+			foreach ($config as $key => $val) {
+				$this->setVolatileData("config:$key", $val);
+			}
+		}
 	}
 
 	/**

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -100,6 +100,10 @@ function elgg_get_config($name, $site_guid = 0) {
 	} else if ($name == 'icon_sizes') {
 		$msg = 'The config value "icon_sizes" is deprecated. Use elgg_get_icon_sizes()';
 		elgg_deprecated_notice($msg, '2.2');
+	} else if ($name == 'registered_entities') {
+		$msg = 'The config value "registered_entities" is deprecated. Use get_registered_entity_types()';
+		elgg_deprecated_notice($msg, '2.2');
+		return get_registered_entity_types();
 	}
 
 	return _elgg_services()->config->get($name, $site_guid);

--- a/engine/tests/phpunit/Elgg/TestCase.php
+++ b/engine/tests/phpunit/Elgg/TestCase.php
@@ -92,6 +92,8 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 				'large' => array('w' => 200, 'h' => 200, 'square' => false, 'upscale' => false),
 				'master' => array('w' => 550, 'h' => 550, 'square' => false, 'upscale' => false),
 			),
+			'entity_types' => ['object', 'group', 'user', 'site'],
+			'registered_entities' => [],
 		];
 	}
 

--- a/engine/tests/phpunit/Elgg/lib/entities/EntityTypeRegistrationTest.php
+++ b/engine/tests/phpunit/Elgg/lib/entities/EntityTypeRegistrationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Elgg\lib\entities;
+
+/**
+ * @group Entities
+ */
+class EntityTypeRegistrationTest extends \Elgg\TestCase {
+
+	public function setUp() {
+		$mocks = new \Elgg\Tests\EntityMocks($this);
+		unset(_elgg_services()->entityTypes); // previous state is floating over
+		_elgg_services()->setValue('subtypeTable', $mocks->getSubtypeTableMock());
+	}
+
+	/**
+	 * @dataProvider typeSubtypePairsProvider
+	 */
+	public function testCanRegisterEntityType($type, $subtype = null) {
+
+		$this->assertFalse(is_registered_entity_type($type, $subtype));
+
+		$this->assertTrue(elgg_register_entity_type($type, $subtype));
+
+		$this->assertTrue(is_registered_entity_type($type, $subtype));
+
+		if ($subtype) {
+			$this->assertTrue(in_array($subtype, get_registered_entity_types($type)));
+		} else {
+			$this->assertTrue(array_key_exists($type, get_registered_entity_types()));
+		}
+
+		$this->assertTrue(elgg_unregister_entity_type($type, $subtype));
+
+		$this->assertFalse(is_registered_entity_type($type, $subtype));
+
+	}
+
+	public function typeSubtypePairsProvider() {
+		return [
+			['object', null],
+			['group', null],
+			['user', null],
+			['object', 'test_object_subtype'],
+			['group', 'test_group_subtype'],
+			['user', 'test_user_subtype'],
+		];
+	}
+
+}

--- a/mod/blog/activate.php
+++ b/mod/blog/activate.php
@@ -1,10 +1,1 @@
 <?php
-/**
- * Register the ElggBlog class for the object/blog subtype
- */
-
-if (get_subtype_id('object', 'blog')) {
-	update_subtype('object', 'blog', 'ElggBlog');
-} else {
-	add_subtype('object', 'blog', 'ElggBlog');
-}

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -19,6 +19,13 @@ elgg_register_event_handler('init', 'system', 'blog_init');
  */
 function blog_init() {
 
+	$class = get_subtype_class('object', 'blog');
+	if (!$class) {
+		// For BC, check if other plugins have modified the class
+		$class = \ElggBlog::class;
+	}
+	elgg_register_entity_type('object', 'blog', $class);
+	
 	elgg_register_library('elgg:blog', __DIR__ . '/lib/blog.php');
 
 	// add a site navigation item
@@ -46,9 +53,6 @@ function blog_init() {
 	// pingbacks
 	//elgg_register_event_handler('create', 'object', 'blog_incoming_ping');
 	//elgg_register_plugin_hook_handler('pingback:object:subtypes', 'object', 'blog_pingback_subtypes');
-
-	// Register for search.
-	elgg_register_entity_type('object', 'blog');
 
 	// Add group option
 	add_group_tool_option('blog', elgg_echo('blog:enableblog'), true);

--- a/views/default/core/river/filter.php
+++ b/views/default/core/river/filter.php
@@ -8,7 +8,9 @@
 // create selection array
 $options = array();
 $options['type=all'] = elgg_echo('river:select', array(elgg_echo('all')));
-$registered_entities = elgg_get_config('registered_entities');
+
+// @todo: merge with entity types registered for 'river' context
+$registered_entities = get_registered_entity_types();
 
 if (!empty($registered_entities)) {
 	foreach ($registered_entities as $type => $subtypes) {


### PR DESCRIPTION
Adds a more versatile entity type registration service that can be
used to register entity types for specific contexts, as well as
to dynamically define entity subtype class
