### PR TITLE
feature(plugins): adds static config file for plugins

### DIFF
--- a/docs/guides/plugins.rst
+++ b/docs/guides/plugins.rst
@@ -10,6 +10,30 @@ start.php
 The start.php file bootstraps plugin by registering event listeners and plugin
 hooks.
 
+elgg-plugin.php
+===============
+
+This optional file is read by Elgg to configure various services, and must return an array if present.
+It should not be included by plugins and is not guaranteed to run at any particular time. Besides magic
+constants like ``__DIR__``, its return value should not change.
+
+Syntax
+------
+
+Here's a trivial example configuring view locations via the ``views`` key:
+
+.. code:: php
+
+	<?php
+
+	return [
+		'views' => [
+			'default' => [
+				'file/icon/' => __DIR__ . '/graphics/icons',
+			],
+		],
+	];
+
 activate.php, deactivate.php
 ============================
 
@@ -79,7 +103,7 @@ In addition to the require elements above, the follow elements are available to 
 
 .. seealso::
 
-   :doc:`plugins/dependencies`
+	:doc:`plugins/dependencies`
 
 Simple Example
 --------------
@@ -149,7 +173,7 @@ Related
 =======
 
 .. toctree::
-   :maxdepth: 1
-   
-   plugins/plugin-skeleton
-   plugins/dependencies
+	:maxdepth: 1
+
+	plugins/plugin-skeleton
+	plugins/dependencies

--- a/docs/guides/plugins/plugin-skeleton.rst
+++ b/docs/guides/plugins/plugin-skeleton.rst
@@ -56,6 +56,7 @@ The following files for plugin ``example`` would go in ``/mod/example/``
                     edit.php
     activate.php
     deactivate.php
+    elgg-plugin.php
     CHANGES.txt
     COPYRIGHT.txt
     INSTALL.txt
@@ -140,7 +141,7 @@ Included third-party libraries of any kind *should* be included in the ``vendors
 Views
 -----
 
-In order to override core views, a plugin's views **must** be placed in a ``views/``. This directory has special meaning to Elgg as views defined here automatically override Elgg core's version of those views. For more info, see :doc:`/guides/views`.
+In order to override core views, a plugin's views can be placed in ``views/``, or an ``elgg-plugin.php`` config file can be used for more detailed file/path mapping. See :doc:`/guides/views`.
 
 Javascript and CSS will live in the views system. See :doc:`/guides/javascript`.
 

--- a/docs/guides/views.rst
+++ b/docs/guides/views.rst
@@ -143,22 +143,25 @@ Views and third-party assets
 ============================
 
 The best way to serve third-party assets is through views. However, instead of manually copy/pasting
-the assets into the right location in ``/views/*``, you can use a ``views.php`` file in your plugin's
-directory to map the assets into the views system.
+the assets into the right location in ``/views/*``, you can map the assets into the views system via
+the ``"views"`` key in your plugin's ``elgg-plugin.php`` config file.
 
-A views file must return a 2 dimensional array. The first level maps a viewtype to a list of view
+The views value must be a 2 dimensional array. The first level maps a viewtype to a list of view
 mappings. The secondary lists map view names to file paths, either absolute or relative to the Elgg root directory.
 
 If you check your assets into source control, point to them like this:
 
 .. code-block:: php
 
-    <?php // mod/example/views.php
+    <?php // mod/example/elgg-plugin.php
     return [
-        // viewtype
-        'default' => [
-            // view => /path/from/filesystem/root
-            'js/jquery-ui.js' => __DIR__ . '/bower_components/jquery-ui/jquery-ui.min.js',
+        // view mappings
+        'views' => [
+            // viewtype
+            'default' => [
+                // view => /path/from/filesystem/root
+                'js/jquery-ui.js' => __DIR__ . '/bower_components/jquery-ui/jquery-ui.min.js',
+            ],
         ],
     ];
 
@@ -167,16 +170,17 @@ paths by leaving off the leading slash:
 
 .. code-block:: php
 
-    <?php // mod/example/views.php
+    <?php // mod/example/elgg-plugin.php
     return [
-        // viewtype
-        'default' => [
-            // view => path/from/install/root
-            'js/jquery-ui.js' => 'vendor/bower-asset/jquery-ui/jquery-ui.min.js',
+        'views' => [
+            'default' => [
+                // view => path/from/install/root
+                'js/jquery-ui.js' => 'vendor/bower-asset/jquery-ui/jquery-ui.min.js',
+            ],
         ],
     ];
     
-Elgg core uses this feature extensively. See ``/engine/views.php``.
+Elgg core uses this feature extensively, though the value is returned directly from ``/engine/views.php``.
 
 .. note::
 
@@ -187,15 +191,17 @@ Elgg core uses this feature extensively. See ``/engine/views.php``.
 Specifying additional views directories
 ---------------------------------------
 
-In your ``views.php`` file you can also specify directories to be scanned for views. Just provide
+In ``elgg-plugin.php`` you can also specify directories to be scanned for views. Just provide
 a view name prefix ending with ``/`` and a directory path (like above).
 
 .. code-block:: php
 
-    <?php // mod/file/views.php
+    <?php // mod/file/elgg-plugin.php
     return [
-        'default' => [
-            'file/icon/' => __DIR__ . '/graphics/icons',
+        'views' => [
+            'default' => [
+                'file/icon/' => __DIR__ . '/graphics/icons',
+            ],
         ],
     ];
 
@@ -210,12 +216,14 @@ Multiple paths can share the same prefix, just give an array of paths:
 
 .. code-block:: php
 
-    <?php // mod/file/views.php
+    <?php // mod/file/elgg-plugin.php
     return [
-        'default' => [
-            'file/icon/' => [
-                __DIR__ . '/graphics/icons',
-                __DIR__ . '/more_icons', // processed 2nd (may override)
+        'views' => [
+            'default' => [
+                'file/icon/' => [
+                    __DIR__ . '/graphics/icons',
+                    __DIR__ . '/more_icons', // processed 2nd (may override)
+                ],
             ],
         ],
     ];

--- a/engine/classes/Elgg/ActionsService.php
+++ b/engine/classes/Elgg/ActionsService.php
@@ -159,7 +159,6 @@ class ActionsService {
 		}
 
 		ob_start();
-		$ob_started = true;
 		
 		// To quietly cancel the file, return a falsey value in the "action" hook.
 		if (!_elgg_services()->hooks->trigger('action', $action, null, true)) {
@@ -172,23 +171,13 @@ class ActionsService {
 			return $forward('actionnotfound', ELGG_HTTP_NOT_IMPLEMENTED);
 		}
 
-		$result = self::includeFile($file);
+		$result = Includer::includeFile($file);
 		if ($result instanceof ResponseBuilder) {
 			ob_end_clean();
 			return $result;
 		}
 
 		return $forward('', ELGG_HTTP_OK);
-	}
-
-	/**
-	 * Include an action file with isolated scope
-	 *
-	 * @param string $file File to be interpreted by PHP
-	 * @return mixed
-	 */
-	protected static function includeFile($file) {
-		return include $file;
 	}
 	
 	/**

--- a/engine/classes/Elgg/Includer.php
+++ b/engine/classes/Elgg/Includer.php
@@ -1,0 +1,30 @@
+<?php
+namespace Elgg;
+
+/**
+ * Allow executing scripts without $this context or local vars
+ *
+ * @access private
+ */
+final class Includer {
+
+	/**
+	 * Include a file with as little context as possible
+	 *
+	 * @param string $file File to include
+	 * @return mixed
+	 */
+	static public function includeFile($file) {
+		return (include $file);
+	}
+
+	/**
+	 * Require a file with as little context as possible
+	 *
+	 * @param string $file File to require
+	 * @return mixed
+	 */
+	static public function requireFile($file) {
+		return (require $file);
+	}
+}

--- a/engine/classes/Elgg/UpgradeService.php
+++ b/engine/classes/Elgg/UpgradeService.php
@@ -138,7 +138,7 @@ class UpgradeService {
 			if ($quiet) {
 				// hide include errors as well as any exceptions that might happen
 				try {
-					if (!@self::includeCode("$upgrade_path/$upgrade")) {
+					if (!@Includer::includeFile("$upgrade_path/$upgrade")) {
 						$success = false;
 						$this->logger->error("Could not include $upgrade_path/$upgrade");
 					}
@@ -147,7 +147,7 @@ class UpgradeService {
 					$this->logger->error($e->getMessage());
 				}
 			} else {
-				if (!self::includeCode("$upgrade_path/$upgrade")) {
+				if (!Includer::includeFile("$upgrade_path/$upgrade")) {
 					$success = false;
 					$this->logger->error("Could not include $upgrade_path/$upgrade");
 				}
@@ -168,16 +168,6 @@ class UpgradeService {
 		}
 
 		return true;
-	}
-
-	/**
-	 * PHP include a file with a very limited scope
-	 *
-	 * @param string $file File path to include
-	 * @return mixed
-	 */
-	protected static function includeCode($file) {
-		return include $file;
 	}
 
 	/**

--- a/engine/classes/Elgg/ViewsService.php
+++ b/engine/classes/Elgg/ViewsService.php
@@ -365,7 +365,10 @@ class ViewsService {
 
 		if (pathinfo($file, PATHINFO_EXTENSION) === 'php') {
 			ob_start();
+
+			// don't isolate, scripts use the local $vars
 			include $file;
+
 			return ob_get_clean();
 		}
 

--- a/engine/classes/ElggPluginPackage.php
+++ b/engine/classes/ElggPluginPackage.php
@@ -18,6 +18,8 @@
  */
 class ElggPluginPackage {
 
+	const STATIC_CONFIG_FILENAME = 'elgg-plugin.php';
+
 	/**
 	 * The required files in the package
 	 *
@@ -195,7 +197,32 @@ class ElggPluginPackage {
 			return false;
 		}
 
+		if (!$this->hasReadableConfigFile()) {
+			return false;
+		}
+
 		return true;
+	}
+
+	/**
+	 * Check that, if the plugin has a static config file, it is readable. We wait to read the contents
+	 * because we don't want to risk crashing the whole plugins page.
+	 *
+	 * @return bool
+	 */
+	private function hasReadableConfigFile() {
+		$file = "{$this->path}/" . self::STATIC_CONFIG_FILENAME;
+		if (!is_file($file)) {
+			return true;
+		}
+
+		if (is_readable($file)) {
+			return true;
+		}
+
+		$this->errorMsg =
+			_elgg_services()->translator->translate('ElggPluginPackage:InvalidPlugin:UnreadableConfig');
+		return false;
 	}
 
 	/**

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -880,7 +880,10 @@ function _elgg_php_exception_handler($exception) {
 		// value should be a system path to a file to include
 		if (!empty($CONFIG->exception_include) && is_file($CONFIG->exception_include)) {
 			ob_start();
+
+			// don't isolate, these scripts may use the local $exception var.
 			include $CONFIG->exception_include;
+
 			$exception_output = ob_get_clean();
 			
 			// if content is returned from the custom handler we will output

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -48,6 +48,7 @@
 
 use Elgg\Menu\Menu;
 use Elgg\Menu\UnpreparedMenu;
+use Elgg\Includer;
 
 /**
  * The viewtype override.
@@ -1710,7 +1711,7 @@ function elgg_views_boot() {
 		// Core view definitions in /engine/views.php
 		$file = dirname(__DIR__) . '/views.php';
 		if (is_file($file)) {
-			$spec = (include $file);
+			$spec = Includer::includeFile($file);
 			if (is_array($spec)) {
 				_elgg_services()->views->mergeViewsSpec($spec);
 			}

--- a/languages/en.php
+++ b/languages/en.php
@@ -59,7 +59,9 @@ return array(
 	'ElggPluginPackage:InvalidPlugin:InvalidDependency' => 'Its manifest contains an invalid dependency type "%s".',
 	'ElggPluginPackage:InvalidPlugin:InvalidProvides' => 'Its manifest contains an invalid provides type "%s".',
 	'ElggPluginPackage:InvalidPlugin:CircularDep' => 'There is an invalid %s dependency "%s" in plugin %s.  Plugins cannot conflict with or require something they provide!',
+	'ElggPluginPackage:InvalidPlugin:UnreadableConfig' => 'Plugin file "elgg-plugin.php" file is present but unreadble.',
 	'ElggPlugin:Exception:CannotIncludeFile' => 'Cannot include %s for plugin %s (guid: %s) at %s.',
+	'ElggPlugin:Exception:IncludeFileThrew' => 'Threw exception including %s for plugin %s (guid: %s) at %s.',
 	'ElggPlugin:Exception:CannotRegisterViews' => 'Cannot open views dir for plugin %s (guid: %s) at %s.',
 	'ElggPlugin:Exception:NoID' => 'No ID for plugin guid %s!',
 	'PluginException:NoPluginName' => "The plugin name could not be found",
@@ -67,6 +69,8 @@ return array(
 	'PluginException:NoAvailableParser' => 'Cannot find a parser for manifest API version %s in plugin %s.',
 	'PluginException:ParserErrorMissingRequiredAttribute' => "Missing required '%s' attribute in manifest for plugin %s.",
 	'ElggPlugin:InvalidAndDeactivated' => '%s is an invalid plugin and has been deactivated.',
+	'ElggPlugin:activate:BadConfigFormat' => 'Plugin file "elgg-plugin.php" did not return a serializable array.',
+	'ElggPlugin:activate:ConfigSentOutput' => 'Plugin file "elgg-plugin.php" sent output.',
 
 	'ElggPlugin:Dependencies:Requires' => 'Requires',
 	'ElggPlugin:Dependencies:Suggests' => 'Suggests',


### PR DESCRIPTION
This opens the door to configuring Elgg declaratively instead of via "register" functions. Initially only the `views` key is available.

For BC, the plugin `views.php` file is still read, but plugins should migrate to `elgg-plugin.php`.

Fixes #5947
