### PR TITLE
fix(boot): boot cache now respects system cache setting

### DIFF
--- a/engine/classes/Elgg/BootService.php
+++ b/engine/classes/Elgg/BootService.php
@@ -141,7 +141,9 @@ class BootService {
 
 		// finish boot sequence
 		_elgg_session_boot();
-		_elgg_services()->systemCache->loadAll();
+		if ($CONFIG->system_cache_enabled) {
+			_elgg_services()->systemCache->loadAll();
+		}
 		_elgg_services()->translator->loadTranslations();
 
 		// we always need site->email and user->icontime, so load them together


### PR DESCRIPTION
(wrong branch)

When system cache is off, the boot sequence was still trying to load it. This caused no problem as the cache was always empty, but it's a waste of cycles and could be a source of bugs in the future.
