### PR TITLE
docs(license): clarifies dual licensing in LICENSE.txt

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,14 +1,15 @@
 The follow individuals, companies, or entities have contributed significant 
 code to the Elgg project and share the copyright. (In alphabetical order.)
 
-Organizations:
-The MITRE Corportation (jricher@mitre.org)
-Curverider Ltd (info@elgg.com)
-
-Individuals:
 Steve Clay (steve@mrclay.org)
 Cash Costello (cash.costello@gmail.com)
 Brett Profitt (brett.profitt@gmail.com)
 Dave Tosh (davidgtosh@gmail.com)
 Ben Werdmuller (ben@benwerd.com)
 Evan Winslow (evan.b.winslow@gmail.com)
+
+Organizations:
+The MITRE Corportation (jricher@mitre.org)
+Curverider Ltd (info@elgg.com)
+
+When adding to this list, update the list of copyright owners in LICENSE.txt.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,48 @@
+Bundled plugins (the contents of the "/mod" directory) are available
+only under the GPLv2 license.
+
+The remainder of the project is available under either MIT or GPLv2.
+
+Both licenses can be found below.
+
+More info: http://learn.elgg.org/en/latest/intro/license.html
+
+------------------------------------------------------------------------
+
+The MIT License (MIT)
+Copyright (c) 2016 The following parties:
+
+	Steve Clay (steve@mrclay.org)
+	Cash Costello (cash.costello@gmail.com)
+	Brett Profitt (brett.profitt@gmail.com)
+	Dave Tosh (davidgtosh@gmail.com)
+	Ben Werdmuller (ben@benwerd.com)
+	Evan Winslow (evan.b.winslow@gmail.com)
+
+	The MITRE Corportation (jricher@mitre.org)
+	Curverider Ltd (info@elgg.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------
+
 		    GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 


### PR DESCRIPTION
The goal here is a portable LICENSE.txt file that includes both licenses and lists copyright holders.
