### PR TITLE
fix(entity): honor ignore access on update entity

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1596,7 +1596,7 @@ abstract class ElggEntity extends \ElggData implements
 		
 		_elgg_services()->boot->invalidateCache($this->guid);
 
-		if (!has_access_to_entity($this)) {
+		if (!elgg_get_ignore_access() && !has_access_to_entity($this)) {
 			// Why worry about this case? If access control was off when the user fetched $this, but
 			// was turned back on again. Better to just bail than to turn access control off again.
 			return false;


### PR DESCRIPTION
The ignore access setting is being ignored when updating the entity. So an user which doesn't have access to an entity, can't update it EVEN when ignore access is set to true. This because `has_access_to_entity` also ignores the ignore access setting.
