### PR TITLE
chore(tests): PHPUnit can now run multiple test suites with varying config

### DIFF
--- a/.scripts/is_memcached_enabled.php
+++ b/.scripts/is_memcached_enabled.php
@@ -1,0 +1,20 @@
+<?php
+
+if (php_sapi_name() !== "cli") {
+	die('CLI only');
+}
+
+if (!class_exists('Memcache')) {
+	fwrite(STDOUT, 'PHP memcache module not installed');
+	exit(1);
+}
+
+$memcached = new Memcache;
+if (!$memcached->connect('127.0.0.1', 11211)) {
+	fwrite(STDOUT, 'Failed to connect to memcache server');
+	exit(2);
+}
+
+$memcached->close();
+fwrite(STDOUT, 'Successfully connected to memcache server');
+exit(0);

--- a/.scripts/travis/elgg-config/core.php
+++ b/.scripts/travis/elgg-config/core.php
@@ -1,0 +1,7 @@
+<?php
+
+global $CONFIG;
+
+if (!isset($CONFIG)) {
+	$CONFIG = new \stdClass;
+}

--- a/.scripts/travis/elgg-config/core_memcached.php
+++ b/.scripts/travis/elgg-config/core_memcached.php
@@ -1,0 +1,14 @@
+<?php
+
+global $CONFIG;
+
+if (!isset($CONFIG)) {
+	$CONFIG = new \stdClass;
+}
+
+// Memcached configuration for Travis
+$CONFIG->memcache = true;
+$CONFIG->memcache_servers = [
+	['127.0.0.1', 11211],
+];
+$CONFIG->memcache_namespace_prefix = 'elgg_';

--- a/.scripts/travis/elgg-config/simpletest.php
+++ b/.scripts/travis/elgg-config/simpletest.php
@@ -1,0 +1,11 @@
+<?php
+
+global $CONFIG;
+
+if (!isset($CONFIG)) {
+	$CONFIG = new \stdClass;
+}
+
+$CONFIG->debug = 'NOTICE';
+
+

--- a/.scripts/travis/elgg-config/simpletest_memcached.php
+++ b/.scripts/travis/elgg-config/simpletest_memcached.php
@@ -1,0 +1,18 @@
+<?php
+
+global $CONFIG;
+
+if (!isset($CONFIG)) {
+	$CONFIG = new \stdClass;
+}
+
+$CONFIG->debug = 'NOTICE';
+
+// Memcached configuration for Travis
+$CONFIG->memcache = true;
+$CONFIG->memcache_servers = [
+	['127.0.0.1', 11211],
+];
+$CONFIG->memcache_namespace_prefix = 'elgg_';
+
+

--- a/.scripts/travis/memcached.ini
+++ b/.scripts/travis/memcached.ini
@@ -1,0 +1,2 @@
+extension = "memcache.so"
+extension = "memcached.so"

--- a/.scripts/travis/phpunit-memcached.xml
+++ b/.scripts/travis/phpunit-memcached.xml
@@ -1,8 +1,8 @@
-<phpunit bootstrap="./vendor/autoload.php">
+<phpunit bootstrap="../../vendor/autoload.php">
 	<testsuites>
-		<testsuite name="core">
-			<directory>./engine/tests/phpunit/</directory>
-			<directory>./engine/classes/</directory>
+		<testsuite name="core_memcached">
+			<directory>../../engine/tests/phpunit/</directory>
+			<directory>../../engine/classes/</directory>
 		</testsuite>
 	</testsuites>
 	<filter>
@@ -18,11 +18,8 @@
 	<listeners>
 		<listener class="\Elgg\TestListener">
 			<arguments>
-				<string>./engine/tests/phpunit/elgg-config/</string>
+				<string>./.scripts/travis/elgg-config/</string>
 			</arguments>
 		</listener>
 	</listeners>
-	<php>
-		<const name="PHPUNIT_ELGG_TESTING_APPLICATION" value="true"/>
-	</php>
 </phpunit>

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: hhvm
+
   include:
     # Lint checks for PHP code and composer.json
     - php: 5.6
@@ -66,6 +67,22 @@ matrix:
        - sphinx-intl build --locale-dir=docs/locale/
        - sphinx-build -b html -D language=es -n docs docs/_build/html
 
+    # Memcached enabled
+    - php: 5.6
+      services:
+       - memcached
+       - mysql
+      env: VARIA=true
+      before_install:
+        - phpenv config-rm xdebug.ini
+        - phpenv config-add ./.scripts/travis/memcached.ini
+      install:
+       - composer travis:install-with-mysql
+      script:
+       - php -f ./.scripts/is_memcached_enabled.php
+       - ./vendor/bin/phpunit --configuration ./.scripts/travis/phpunit-memcached.xml
+       - php ./engine/tests/suite.php --config ./.scripts/travis/elgg-config/simpletest_memcached.php
+
     # End to end tests
     - php: 5.6
       env: E2E=true
@@ -80,19 +97,19 @@ matrix:
        - ./vendor/bin/phpunit
        - php -f ./engine/tests/suite.php
 
-services: 
- - mysql
+services:
+  - mysql
 
 before_install:
- - phpenv config-rm xdebug.ini
- - composer config -g github-oauth.github.com ${GITHUB_TOKEN}
-  
+  - phpenv config-rm xdebug.ini
+  - composer config -g github-oauth.github.com ${GITHUB_TOKEN}
+
 install: composer travis:install-with-mysql
 
 script:
- - ./vendor/bin/phpunit
- - php -f ./engine/tests/suite.php
- 
+  - ./vendor/bin/phpunit
+  - php -f ./engine/tests/suite.php
+
 notifications:
   email:
     secure: exC/ws07lLOj3Y43C89jiaKpyB8Yt7DPGSCShV4R3Wkw/hVVzjxt1BinPxzsyL5DC7APUMcTHGOhDB2oCE4ynDE6o6L9bH79fc+V8IYAiNaEIGL0AOuHdnRdGN9GMrr2jv78cZ5MctuUTkeYLaoOEyDGHmkMhqa6SufIDAY8b58=

--- a/engine/classes/Elgg/Ajax/Service.php
+++ b/engine/classes/Elgg/Ajax/Service.php
@@ -206,7 +206,7 @@ class Service {
 		if ($ttl > 0) {
 			// Required to remove headers set by PHP session
 			if (!isset($allow_removing_headers)) {
-				$allow_removing_headers = !defined('PHPUNIT_ELGG_TESTING_APPLICATION');
+				$allow_removing_headers = !elgg()->isTestingApplication();
 			}
 
 			if ($allow_removing_headers) {

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -35,6 +35,11 @@ class Application {
 	private $engine_dir;
 
 	/**
+	 * @var bool
+	 */
+	private static $testing_app;
+
+	/**
 	 * Property names of the service provider to be exposed via __get()
 	 *
 	 * E.g. the presence of `'foo' => true` in the list would allow _elgg_services()->foo to
@@ -237,7 +242,7 @@ class Application {
 
 		$config = $this->services->config;
 
-		if (defined('PHPUNIT_ELGG_TESTING_APPLICATION')) {
+		if ($this->isTestingApplication()) {
 			throw new \RuntimeException('Unit tests should not call ' . __METHOD__);
 		}
 
@@ -597,5 +602,23 @@ class Application {
 
 		$this->services->setValue('request', $new);
 		_elgg_set_initial_context($new);
+	}
+
+	/**
+	 * Flag this application as running for testing (PHPUnit)
+	 * 
+	 * @param bool $testing Is testing application
+	 * @return void
+	 */
+	public static function setTestingApplication($testing = true) {
+		self::$testing_app = $testing;
+	}
+
+	/**
+	 * Checks if the application is running in PHPUnit
+	 * @return bool
+	 */
+	public static function isTestingApplication() {
+		return (bool) self::$testing_app;
 	}
 }

--- a/engine/classes/Elgg/BootService.php
+++ b/engine/classes/Elgg/BootService.php
@@ -233,7 +233,7 @@ class BootService {
 	 * @return \Stash\Interfaces\ItemInterface
 	 */
 	private function getStashItem(\stdClass $CONFIG, $site_guid) {
-		if (!empty($CONFIG->memcache)) {
+		if (!empty($CONFIG->memcache) && class_exists('Memcache')) {
 			$options = [];
 			if (!empty($CONFIG->memcache_servers)) {
 				$options['servers'] = $CONFIG->memcache_servers;

--- a/engine/tests/phpunit/Elgg/TestCase.php
+++ b/engine/tests/phpunit/Elgg/TestCase.php
@@ -79,6 +79,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 		$sp->config->getCookieConfig();
 
 		$app = new Application($sp);
+		Application::setTestingApplication(true);
 		Application::$_instance = $app;
 
 		// loadCore bails on repeated calls, so we need to manually inject this to make
@@ -96,7 +97,13 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 	 * @return array
 	 */
 	public static function getTestingConfigArray() {
-		return [
+		global $CONFIG;
+
+		if (!isset($CONFIG)) {
+			$CONFIG = new \stdClass;
+		}
+		
+		$conf = [
 			'Config_file' => false,
 			'dbprefix' => 'elgg_t_i_',
 			'boot_complete' => false,
@@ -128,6 +135,14 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 				'site',
 			],
 		];
+
+		foreach ($conf as $key => $val) {
+			if (!isset($CONFIG->$key)) {
+				$CONFIG->$key = $val;
+			}
+		}
+
+		return (array) $CONFIG;
 	}
 
 	/**

--- a/engine/tests/phpunit/Elgg/TestCase.php
+++ b/engine/tests/phpunit/Elgg/TestCase.php
@@ -27,7 +27,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Constructs a test case with the given name.
-	 * Boostraps testing environment
+	 * Bootstraps testing environment
 	 * 
 	 * @param string $name
 	 * @param array  $data
@@ -51,7 +51,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Boostraps test suite
+	 * Bootstraps test suite
 	 *
 	 * @global stdClass $CONFIG Global config
 	 * @global stdClass $_ELGG  Global vars
@@ -88,6 +88,10 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 		_elgg_services($sp);
 
 		_elgg_filestore_boot();
+
+		// Invalidate memcache
+		_elgg_get_memcache('new_entity_cache')->clear();
+		_elgg_get_memcache('metastrings_memcache')->clear();
 
 		self::$_mocks = null; // reset mocking service
 	}

--- a/engine/tests/phpunit/Elgg/TestListener.php
+++ b/engine/tests/phpunit/Elgg/TestListener.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Elgg;
+
+use PHPUnit_Framework_BaseTestListener;
+use PHPUnit_Framework_TestSuite;
+
+class TestListener extends PHPUnit_Framework_BaseTestListener {
+
+	/**
+	 * @var string
+	 */
+	private $config_dir;
+	
+	/**
+	 * Constructor
+	 * 
+	 * @param string $config_dir Directory containing suite-speicific config files
+	 */
+	public function __construct($config_dir) {
+		$this->config_dir = $config_dir;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function startTestSuite(PHPUnit_Framework_TestSuite $suite) {
+
+		// reset config before each suite
+		global $CONFIG;
+		unset($CONFIG);
+
+		$name = $suite->getName();
+		$dir = rtrim($this->config_dir, '/');
+
+		if (file_exists("$dir/$name.php")) {
+			require_once "$dir/$name.php";
+		}
+	}
+
+}

--- a/engine/tests/phpunit/elgg-config/core.php
+++ b/engine/tests/phpunit/elgg-config/core.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * Configuration specific to a "core" test suite
+ */
+
+global $CONFIG;
+

--- a/engine/tests/suite.php
+++ b/engine/tests/suite.php
@@ -24,13 +24,22 @@ $plugins = array(
 if (!TextReporter::inCli()) {
 	elgg_admin_gatekeeper();
 } else {
+
+	$cli_opts = getopt('', [
+		'config::', // path to config file
+	]);
+
+	if (!empty($cli_opts['config']) && file_exists($cli_opts['config'])) {
+		// File with custom config options for the suite
+		require_once $cli_opts['config'];
+		echo "Loaded custom configuration for the suite.\n";
+	}
+
 	$admin = array_shift(elgg_get_admins(array('limit' => 1)));
 	if (!login($admin)) {
 		echo "Failed to login as administrator.";
 		exit(1);
 	}
-
-	global $CONFIG;
 	
 	// activate plugins that are not activated on install
 	foreach ($plugins as $key => $id) {
@@ -42,6 +51,7 @@ if (!TextReporter::inCli()) {
 		$plugin->activate();
 	}
 
+	global $CONFIG;
 	$CONFIG->debug = 'NOTICE';
 }
 


### PR DESCRIPTION
Implements test listeners that load configuration files specific to individual test suites.
Simpletest CLI runner now accepts --config option pointing to a file containing additional $CONFIG options.
Adds memcached enabled jobs to Travis. 

Fixes #10096
