### PR TITLE
fix(access): updates no longer mistakenly blocked in some scenarios

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1592,12 +1592,6 @@ abstract class ElggEntity extends \ElggData implements
 
 		_elgg_services()->boot->invalidateCache($this->guid);
 
-		if (!has_access_to_entity($this)) {
-			// Why worry about this case? If access control was off when the user fetched $this, but
-			// was turned back on again. Better to just bail than to turn access control off again.
-			return false;
-		}
-
 		if (!$this->canEdit()) {
 			return false;
 		}

--- a/engine/classes/ElggSession.php
+++ b/engine/classes/ElggSession.php
@@ -209,7 +209,7 @@ class ElggSession implements \ArrayAccess {
 	/**
 	 * Gets the logged in user
 	 * 
-	 * @return \ElggUser
+	 * @return \ElggUser|null
 	 * @since 1.9
 	 */
 	public function getLoggedInUser() {

--- a/engine/tests/ElggCoreMetadataAPITest.php
+++ b/engine/tests/ElggCoreMetadataAPITest.php
@@ -161,8 +161,7 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 
 		// need to fake different logins.
 		// good times without mocking.
-		$original_user = elgg_get_logged_in_user_entity();
-		$_SESSION['user'] = $u1;
+		$original_user = $this->replaceSession($u1);
 		
 		elgg_set_ignore_access(false);
 
@@ -182,7 +181,7 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 		}
 
 		// add md w/ same name as a different user
-		$_SESSION['user'] = $u2;
+		$this->replaceSession($u2);
 		$md_values2 = array(
 			'four',
 			'five',
@@ -202,7 +201,7 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 			$this->assertEqual('test', $md->name);
 		}
 
-		$_SESSION['user'] = $original_user;
+		$this->replaceSession($original_user);
 
 		$obj->delete();
 		$u1->delete();

--- a/engine/tests/ElggCoreUnitTest.php
+++ b/engine/tests/ElggCoreUnitTest.php
@@ -48,6 +48,23 @@ abstract class ElggCoreUnitTest extends UnitTestCase {
 		return $this->assert(new IdenticalEntityExpectation($first), $second, $message);
 	}
 
+	/**
+	 * Replace the current user session
+	 *
+	 * @param ElggUser $user New user to login as (null to log out)
+	 * @return ElggUser|null Removed session user (or null)
+	 */
+	public function replaceSession(ElggUser $user = null) {
+		$session = elgg_get_session();
+		$old = $session->getLoggedInUser();
+		if ($user) {
+			$session->setLoggedInUser($user);
+		} else {
+			$session->removeLoggedInUser();
+		}
+		return $old;
+	}
+
 }
 
 /**

--- a/engine/tests/ElggObjectTest.php
+++ b/engine/tests/ElggObjectTest.php
@@ -201,14 +201,13 @@ class ElggCoreObjectTest extends \ElggCoreUnitTest {
 		$guid2 = $e2->getGUID();
 
 		// fake being logged out
-		$user = $_SESSION['user'];
-		unset($_SESSION['user']);
+		$old_user = $this->replaceSession();
 		$ia = elgg_set_ignore_access(true);
 
 		$this->assertTrue($e1->disable(null, true));
 
 		// "log in" original user
-		$_SESSION['user'] = $user;
+		$this->replaceSession($old_user);
 		elgg_set_ignore_access($ia);
 
 		$this->assertFalse(get_entity($guid1));

--- a/engine/tests/ElggUserTest.php
+++ b/engine/tests/ElggUserTest.php
@@ -98,7 +98,7 @@ class ElggCoreUserTest extends \ElggCoreUnitTest {
 	public function testElggUserConstructorByDbRow() {
 		$row = $this->fetchUser(elgg_get_logged_in_user_guid());
 		$user = new \ElggUser($row);
-		$this->assertIdenticalEntities($user, $_SESSION['user']);
+		$this->assertIdenticalEntities($user, elgg_get_logged_in_user_entity());
 	}
 
 	public function testElggUserSave() {


### PR DESCRIPTION
In order to fix `canEdit()` in 1.9, `update()` needed to load a fresh copy of entity from the DB to check the persisted attributes. In that fix, https://github.com/Elgg/Elgg/commit/66eb9e6d14252314769867cd45aed7557a29532a, a corner case was checked out of my paranoia that a dev would load an invisible entity with access control on, but try to delete it with access off.

I now believe this check was unnecessary (we never did similar checks for `delete()`). When the original `canEdit()` attributes issue was resolved in #9434, I should've made this change.

(replaces #10098)
