### PR TITLE
chore(db): in private DB API, table prefix is available via property

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -23,6 +23,7 @@ Deprecated APIs
  * ``get_uploaded_file()`` is deprecated: Use new file uploads API instead
  * ``pagesetup, system`` event: Use the menu or page shell hooks instead.
  * ``elgg.walled_garden`` JavaScript is deprecated: Use ``elgg/walled_garden`` AMD module instead.
+ * ``elgg()->getDb()->getTableprefix()`` is deprecated: Use ``elgg_get_config('dbprefix')``.
 
 Deprecated Views
 ----------------

--- a/engine/classes/Elgg/Application/CacheHandler.php
+++ b/engine/classes/Elgg/Application/CacheHandler.php
@@ -223,7 +223,7 @@ class CacheHandler {
 		try {
 			$rows = $db->getData("
 				SELECT `name`, `value`
-				FROM {$db->getTablePrefix()}datalists
+				FROM {$db->prefix}datalists
 				WHERE `name` IN ('dataroot', 'simplecache_enabled')
 			");
 			if (!$rows) {

--- a/engine/classes/Elgg/Application/Database.php
+++ b/engine/classes/Elgg/Application/Database.php
@@ -16,6 +16,8 @@ use Elgg\Logger;
  *       no longer extend \Elgg\Database.
  *
  * @see \Elgg\Application::getDb for more details.
+ *
+ * @property-read string $prefix Elgg table prefix (read only)
  */
 class Database extends ElggDb {
 
@@ -73,9 +75,13 @@ class Database extends ElggDb {
 
 	/**
 	 * {@inheritdoc}
+	 * @deprecated 2.3 Read the "prefix" property
 	 */
 	public function getTablePrefix() {
-		return $this->db->getTablePrefix();
+		if (function_exists('elgg_deprecated_notice')) {
+			elgg_deprecated_notice(__METHOD__ . ' is deprecated. Read the "prefix" property', '2.3');
+		}
+		return $this->db->prefix;
 	}
 
 	/**
@@ -90,6 +96,31 @@ class Database extends ElggDb {
 	 */
 	public function sanitizeString($value) {
 		return $this->db->sanitizeString($value);
+	}
+
+	/**
+	 * Handle magic property reads
+	 *
+	 * @param string $name Property name
+	 * @return mixed
+	 */
+	public function __get($name) {
+		if ($name === 'prefix') {
+			return $this->db->prefix;
+		}
+
+		throw new \RuntimeException("Cannot read property '$name'");
+	}
+
+	/**
+	 * Handle magic property writes
+	 *
+	 * @param string $name  Property name
+	 * @param mixed  $value Value
+	 * @return void
+	 */
+	public function __set($name, $value) {
+		throw new \RuntimeException("Cannot write property '$name'");
 	}
 
 	/**

--- a/engine/classes/Elgg/BootData.php
+++ b/engine/classes/Elgg/BootData.php
@@ -61,7 +61,7 @@ class BootData {
 		// do not store site key in cache. The others we've already fetched.
 		$rows = $db->getData("
 			SELECT *
-			FROM {$db->getTablePrefix()}datalists
+			FROM {$db->prefix}datalists
 			WHERE `name` NOT IN ('__site_secret__', 'default_site', 'dataroot')
 		");
 		$this->datalist_cache = new InMemory();
@@ -72,7 +72,7 @@ class BootData {
 		// get subtypes
 		$rows = $db->getData("
 			SELECT *
-			FROM {$db->getTablePrefix()}entity_subtypes
+			FROM {$db->prefix}entity_subtypes
 		");
 		foreach ($rows as $row) {
 			$this->subtype_data[$row->id] = $row;
@@ -87,7 +87,7 @@ class BootData {
 		// get config
 		$rows = $db->getData("
 			SELECT *
-			FROM {$db->getTablePrefix()}config
+			FROM {$db->prefix}config
 			WHERE site_guid = {$config->site_guid}
 		");
 		foreach ($rows as $row) {
@@ -112,7 +112,7 @@ class BootData {
 		$set = implode(',', $guids);
 		$sql = "
 			SELECT entity_guid
-			FROM {$db->getTablePrefix()}private_settings
+			FROM {$db->prefix}private_settings
 			WHERE entity_guid IN ($set)
 			  AND name NOT LIKE 'plugin:user_setting:%'
 			  AND name NOT LIKE 'elgg:internal:%'
@@ -129,7 +129,7 @@ class BootData {
 		$set = implode(',', $guids);
 		$rows = $db->getData("
 			SELECT entity_guid, `name`, `value`
-			FROM {$db->getTablePrefix()}private_settings
+			FROM {$db->prefix}private_settings
 			WHERE entity_guid IN ($set)
 			  AND name NOT LIKE 'plugin:user_setting:%'
 			  AND name NOT LIKE 'elgg:internal:%'

--- a/engine/classes/Elgg/BootService.php
+++ b/engine/classes/Elgg/BootService.php
@@ -60,7 +60,7 @@ class BootService {
 		// we need this stuff before cache
 		$rows = $db->getData("
 			SELECT *
-			FROM {$db->getTablePrefix()}datalists
+			FROM {$db->prefix}datalists
 			WHERE `name` IN ('__site_secret__', 'default_site', 'dataroot')
 		");
 		$datalists = [];

--- a/engine/classes/Elgg/Cache/MetadataCache.php
+++ b/engine/classes/Elgg/Cache/MetadataCache.php
@@ -140,7 +140,7 @@ class MetadataCache {
 		// could be useful at some point in future
 		//$guids = $this->filterMetadataHeavyEntities($guids);
 
-		$db_prefix = _elgg_services()->db->getTablePrefix();
+		$db_prefix = _elgg_services()->db->prefix;
 		$options = array(
 			'guids' => $guids,
 			'limit' => 0,

--- a/engine/classes/Elgg/Database/AccessCollections.php
+++ b/engine/classes/Elgg/Database/AccessCollections.php
@@ -196,7 +196,7 @@ class AccessCollections {
 			// The following can only return sensible data for a known user.
 			if ($user_guid) {
 				$db = $this->db;
-				$prefix = $db->getTablePrefix();
+				$prefix = $db->prefix;
 
 				$access_array[] = ACCESS_LOGGED_IN;
 
@@ -320,7 +320,7 @@ class AccessCollections {
 			'ands' => array()
 		);
 
-		$prefix = $this->db->getTablePrefix();
+		$prefix = $this->db->prefix;
 
 		if ($options['ignore_access']) {
 			$clauses['ors']['ignore_access'] = '1 = 1';
@@ -397,7 +397,7 @@ class AccessCollections {
 		elgg_set_ignore_access($ia);
 
 		$db = $this->db;
-		$prefix = $db->getTablePrefix();
+		$prefix = $db->prefix;
 
 		$query = "SELECT guid from {$prefix}entities e WHERE e.guid = {$entity->guid}";
 		// Add access controls
@@ -555,7 +555,7 @@ class AccessCollections {
 		}
 
 		$db = $this->db;
-		$prefix = $db->getTablePrefix();
+		$prefix = $db->prefix;
 
 		$name = $db->sanitizeString($name);
 
@@ -636,7 +636,7 @@ class AccessCollections {
 		}
 
 		$db = $this->db;
-		$prefix = $db->getTablePrefix();
+		$prefix = $db->prefix;
 
 		// Deleting membership doesn't affect result of deleting ACL.
 		$q = "DELETE FROM {$prefix}access_collection_membership
@@ -667,7 +667,7 @@ class AccessCollections {
 		$collection_id = (int) $collection_id;
 
 		$db = $this->db;
-		$prefix = $db->getTablePrefix();
+		$prefix = $db->prefix;
 
 		$query = "SELECT * FROM {$prefix}access_collections WHERE id = {$collection_id}";
 		$get_collection = $db->getDataRow($query);
@@ -707,7 +707,7 @@ class AccessCollections {
 		}
 
 		$db = $this->db;
-		$prefix = $db->getTablePrefix();
+		$prefix = $db->prefix;
 
 		// if someone tries to insert the same data twice, we do a no-op on duplicate key
 		$q = "INSERT INTO {$prefix}access_collection_membership
@@ -749,7 +749,7 @@ class AccessCollections {
 		}
 
 		$db = $this->db;
-		$prefix = $db->getTablePrefix();
+		$prefix = $db->prefix;
 
 		$q = "DELETE FROM {$prefix}access_collection_membership
 			WHERE access_collection_id = {$collection_id}
@@ -775,7 +775,7 @@ class AccessCollections {
 		}
 
 		$db = $this->db;
-		$prefix = $db->getTablePrefix();
+		$prefix = $db->prefix;
 
 		$query = "SELECT * FROM {$prefix}access_collections
 				WHERE owner_guid = {$owner_guid}
@@ -799,7 +799,7 @@ class AccessCollections {
 		$collection_id = (int) $collection_id;
 
 		$db = $this->db;
-		$prefix = $db->getTablePrefix();
+		$prefix = $db->prefix;
 
 		if (!$guids_only) {
 			$query = "SELECT e.* FROM {$prefix}access_collection_membership m"
@@ -839,7 +839,7 @@ class AccessCollections {
 		}
 
 		$db = $this->db;
-		$prefix = $db->getTablePrefix();
+		$prefix = $db->prefix;
 
 		$query = "SELECT ac.* FROM {$prefix}access_collections ac
 				JOIN {$prefix}access_collection_membership m ON ac.id = m.access_collection_id

--- a/engine/classes/Elgg/Database/Annotations.php
+++ b/engine/classes/Elgg/Database/Annotations.php
@@ -110,7 +110,7 @@ class Annotations {
 		$entity = get_entity($entity_guid);
 	
 		if ($this->events->trigger('annotate', $entity->type, $entity)) {
-			$result = $this->db->insertData("INSERT INTO {$this->db->getTablePrefix()}annotations
+			$result = $this->db->insertData("INSERT INTO {$this->db->prefix}annotations
 				(entity_guid, name_id, value_id, value_type, owner_guid, time_created, access_id) VALUES
 				($entity_guid, $name_id, $value_id, '$value_type', $owner_guid, $time, $access_id)");
 	
@@ -174,7 +174,7 @@ class Annotations {
 			return false;
 		}
 	
-		$result = $this->db->updateData("UPDATE {$this->db->getTablePrefix()}annotations
+		$result = $this->db->updateData("UPDATE {$this->db->prefix}annotations
 			SET name_id = $name_id, value_id = $value_id, value_type = '$value_type',
 			access_id = $access_id, owner_guid = $owner_guid
 			WHERE id = $annotation_id");
@@ -427,7 +427,7 @@ class Annotations {
 			return elgg_get_entities_from_annotations($options);
 		}
 		
-		$db_prefix = $this->db->getTablePrefix();
+		$db_prefix = $this->db->prefix;
 		$defaults = array(
 			'calculation' => 'sum',
 			'order_by' => 'annotation_calculation desc'
@@ -476,8 +476,8 @@ class Annotations {
 		$owner_guid = sanitize_int($owner_guid);
 		$annotation_type = sanitize_string($annotation_type);
 	
-		$sql = "SELECT a.id FROM {$this->db->getTablePrefix()}annotations a" .
-				" JOIN {$this->db->getTablePrefix()}metastrings m ON a.name_id = m.id" .
+		$sql = "SELECT a.id FROM {$this->db->prefix}annotations a" .
+				" JOIN {$this->db->prefix}metastrings m ON a.name_id = m.id" .
 				" WHERE a.owner_guid = $owner_guid AND a.entity_guid = $entity_guid" .
 				" AND m.string = '$annotation_type'";
 	

--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -61,7 +61,7 @@ class EntityTable {
 			'table_alias' => '',
 		]);
 
-		$sql = "SELECT * FROM {$this->db->getTablePrefix()}entities
+		$sql = "SELECT * FROM {$this->db->prefix}entities
 			WHERE guid = :guid AND $access";
 
 		$params = [
@@ -79,7 +79,7 @@ class EntityTable {
 	 */
 	public function insertRow(\stdClass $row) {
 
-		$sql = "INSERT INTO {$this->db->getTablePrefix()}entities
+		$sql = "INSERT INTO {$this->db->prefix}entities
 			(type, subtype, owner_guid, site_guid, container_guid,
 				access_id, time_created, time_updated, last_action)
 			VALUES
@@ -108,7 +108,7 @@ class EntityTable {
 	 */
 	public function updateRow($guid, \stdClass $row) {
 		$sql = "
-			UPDATE {$this->db->getTablePrefix()}entities
+			UPDATE {$this->db->prefix}entities
 			SET owner_guid = :owner_guid,
 			    access_id = :access_id,
 				container_guid = :container_guid,
@@ -252,7 +252,7 @@ class EntityTable {
 	 */
 	public function exists($guid) {
 
-		$query = "SELECT 1 FROM {$this->db->getTablePrefix()}entities 
+		$query = "SELECT 1 FROM {$this->db->prefix}entities
 			WHERE guid = :guid";
 		
 		$result = $this->db->getDataRow($query, false, [
@@ -482,11 +482,11 @@ class EntityTable {
 
 		if (!$options['count']) {
 			$distinct = $options['distinct'] ? "DISTINCT" : "";
-			$query = "SELECT $distinct e.*{$selects} FROM {$this->db->getTablePrefix()}entities e ";
+			$query = "SELECT $distinct e.*{$selects} FROM {$this->db->prefix}entities e ";
 		} else {
 			// note: when DISTINCT unneeded, it's slightly faster to compute COUNT(*) than GUIDs
 			$count_expr = $options['distinct'] ? "DISTINCT e.guid" : "*";
-			$query = "SELECT COUNT($count_expr) as total FROM {$this->db->getTablePrefix()}entities e ";
+			$query = "SELECT COUNT($count_expr) as total FROM {$this->db->prefix}entities e ";
 		}
 
 		// add joins
@@ -626,7 +626,7 @@ class EntityTable {
 		}
 
 		// join the secondary table
-		$options['joins'][] = "JOIN {$this->db->getTablePrefix()}{$type}s_entity st ON (e.guid = st.guid)";
+		$options['joins'][] = "JOIN {$this->db->prefix}{$type}s_entity st ON (e.guid = st.guid)";
 
 		return $options;
 	}
@@ -1085,7 +1085,7 @@ class EntityTable {
 		}
 
 
-		$type_table = "{$this->db->getTablePrefix()}{$type}s_entity";
+		$type_table = "{$this->db->prefix}{$type}s_entity";
 
 		$return = array(
 			'joins' => array(),
@@ -1244,7 +1244,7 @@ class EntityTable {
 		$where[] = _elgg_get_access_where_sql(array('table_alias' => ''));
 
 		$sql = "SELECT DISTINCT EXTRACT(YEAR_MONTH FROM FROM_UNIXTIME(time_created)) AS yearmonth
-			FROM {$this->db->getTablePrefix()}entities where ";
+			FROM {$this->db->prefix}entities where ";
 
 		foreach ($where as $w) {
 			$sql .= " $w and ";
@@ -1284,7 +1284,7 @@ class EntityTable {
 
 		if ($guid) {
 			//now add to the river updated table
-			$query = "UPDATE {$this->db->getTablePrefix()}entities SET last_action = {$posted} WHERE guid = {$guid}";
+			$query = "UPDATE {$this->db->prefix}entities SET last_action = {$posted} WHERE guid = {$guid}";
 			$result = $this->db->updateData($query);
 			if ($result) {
 				return true;

--- a/engine/classes/Elgg/Database/MetadataTable.php
+++ b/engine/classes/Elgg/Database/MetadataTable.php
@@ -66,7 +66,7 @@ class MetadataTable {
 		$this->events = $events;
 		$this->metastringsTable = $metastringsTable;
 		$this->session = $session;
-		$this->table = $this->db->getTablePrefix() . "metadata";
+		$this->table = $this->db->prefix . "metadata";
 	}
 
 	/**
@@ -570,7 +570,7 @@ class MetadataTable {
 		);
 	
 		// will always want to join these tables if pulling metastrings.
-		$return['joins'][] = "JOIN {$this->db->getTablePrefix()}{$n_table} n_table on
+		$return['joins'][] = "JOIN {$this->db->prefix}{$n_table} n_table on
 			{$e_table}.guid = n_table.entity_guid";
 	
 		$wheres = array();
@@ -716,7 +716,7 @@ class MetadataTable {
 				$name = $this->db->sanitizeString($pair['name']);
 	
 				// @todo The multiple joins are only needed when the operator is AND
-				$return['joins'][] = "JOIN {$this->db->getTablePrefix()}{$n_table} n_table{$i}
+				$return['joins'][] = "JOIN {$this->db->prefix}{$n_table} n_table{$i}
 					on {$e_table}.guid = n_table{$i}.entity_guid";
 				$return['joins'][] = "JOIN {$this->metastringsTable->getTableName()} msn{$i}
 					on n_table{$i}.name_id = msn{$i}.id";
@@ -763,7 +763,7 @@ class MetadataTable {
 					} else {
 						$direction = 'ASC';
 					}
-					$return['joins'][] = "JOIN {$this->db->getTablePrefix()}{$n_table} n_table{$i}
+					$return['joins'][] = "JOIN {$this->db->prefix}{$n_table} n_table{$i}
 						on {$e_table}.guid = n_table{$i}.entity_guid";
 					$return['joins'][] = "JOIN {$this->metastringsTable->getTableName()} msn{$i}
 						on n_table{$i}.name_id = msn{$i}.id";

--- a/engine/classes/Elgg/Database/MetastringsTable.php
+++ b/engine/classes/Elgg/Database/MetastringsTable.php
@@ -173,7 +173,7 @@ class MetastringsTable {
 	 * @return string
 	 */
 	public function getTableName() {
-		return $this->db->getTablePrefix() . "metastrings";
+		return $this->db->prefix . "metastrings";
 	}
 
 }

--- a/engine/classes/Elgg/Database/Mutex.php
+++ b/engine/classes/Elgg/Database/Mutex.php
@@ -45,7 +45,7 @@ class Mutex {
 
 		if (!$this->isLocked($namespace)) {
 			// Lock it
-			$this->db->insertData("CREATE TABLE {$this->db->getTablePrefix()}{$namespace}_lock (id INT)");
+			$this->db->insertData("CREATE TABLE {$this->db->prefix}{$namespace}_lock (id INT)");
 			$this->logger->info("Locked mutex for $namespace");
 			return true;
 		}
@@ -63,7 +63,7 @@ class Mutex {
 	public function unlock($namespace) {
 		$this->assertNamespace($namespace);
 
-		$this->db->deleteData("DROP TABLE {$this->db->getTablePrefix()}{$namespace}_lock");
+		$this->db->deleteData("DROP TABLE {$this->db->prefix}{$namespace}_lock");
 		$this->logger->notice("Mutex unlocked for $namespace.");
 	}
 
@@ -76,7 +76,7 @@ class Mutex {
 	public function isLocked($namespace) {
 		$this->assertNamespace($namespace);
 
-		return (bool) count($this->db->getData("SHOW TABLES LIKE '{$this->db->getTablePrefix()}{$namespace}_lock'"));
+		return (bool) count($this->db->getData("SHOW TABLES LIKE '{$this->db->prefix}{$namespace}_lock'"));
 	}
 
 	/**

--- a/engine/classes/Elgg/Database/PrivateSettingsTable.php
+++ b/engine/classes/Elgg/Database/PrivateSettingsTable.php
@@ -41,7 +41,7 @@ class PrivateSettingsTable {
 		$this->db = $db;
 		$this->entities = $entities;
 		$this->cache = $cache;
-		$this->table = $this->db->getTablePrefix() . 'private_settings';
+		$this->table = $this->db->prefix . 'private_settings';
 	}
 
 	/**

--- a/engine/classes/Elgg/Database/RelationshipsTable.php
+++ b/engine/classes/Elgg/Database/RelationshipsTable.php
@@ -77,7 +77,7 @@ class RelationshipsTable {
 	 * @access private
 	 */
 	public function getRow($id) {
-		$sql = "SELECT * FROM {$this->db->getTablePrefix()}entity_relationships WHERE id = :id";
+		$sql = "SELECT * FROM {$this->db->prefix}entity_relationships WHERE id = :id";
 		$params = [
 			':id' => (int) $id,
 		];
@@ -101,7 +101,7 @@ class RelationshipsTable {
 			return false;
 		}
 
-		$sql = "DELETE FROM {$this->db->getTablePrefix()}entity_relationships WHERE id = :id";
+		$sql = "DELETE FROM {$this->db->prefix}entity_relationships WHERE id = :id";
 		$params = [
 			':id' => $id,
 		];
@@ -134,7 +134,7 @@ class RelationshipsTable {
 		}
 
 		$sql = "
-			INSERT INTO {$this->db->getTablePrefix()}entity_relationships
+			INSERT INTO {$this->db->prefix}entity_relationships
 			       (guid_one, relationship, guid_two, time_created)
 			VALUES (:guid1, :relationship, :guid2, :time)
 				ON DUPLICATE KEY UPDATE time_created = :time
@@ -175,7 +175,7 @@ class RelationshipsTable {
 	 */
 	public function check($guid_one, $relationship, $guid_two) {
 		$query = "
-			SELECT * FROM {$this->db->getTablePrefix()}entity_relationships
+			SELECT * FROM {$this->db->prefix}entity_relationships
 			WHERE guid_one = :guid1
 			  AND relationship = :relationship
 			  AND guid_two = :guid2
@@ -238,9 +238,9 @@ class RelationshipsTable {
 
 		if (!empty($type)) {
 			if (!$inverse_relationship) {
-				$join = "JOIN {$this->db->getTablePrefix()}entities e ON e.guid = er.guid_two";
+				$join = "JOIN {$this->db->prefix}entities e ON e.guid = er.guid_two";
 			} else {
-				$join = "JOIN {$this->db->getTablePrefix()}entities e ON e.guid = er.guid_one";
+				$join = "JOIN {$this->db->prefix}entities e ON e.guid = er.guid_one";
 				$where .= " AND ";
 			}
 			$where .= " AND e.type = :type";
@@ -252,7 +252,7 @@ class RelationshipsTable {
 		$guid_col = $inverse_relationship ? "guid_two" : "guid_one";
 
 		$this->db->deleteData("
-			DELETE er FROM {$this->db->getTablePrefix()}entity_relationships AS er
+			DELETE er FROM {$this->db->prefix}entity_relationships AS er
 			$join
 			WHERE $guid_col = $guid
 			$where
@@ -275,7 +275,7 @@ class RelationshipsTable {
 
 		$where = ($inverse_relationship ? "guid_two = :guid" : "guid_one = :guid");
 
-		$query = "SELECT * from {$this->db->getTablePrefix()}entity_relationships WHERE {$where}";
+		$query = "SELECT * from {$this->db->prefix}entity_relationships WHERE {$where}";
 
 		return $this->db->getData($query, [$this, 'rowToElggRelationship'], $params);
 	}
@@ -409,9 +409,9 @@ class RelationshipsTable {
 		$group_by = '';
 
 		if ($inverse_relationship) {
-			$joins[] = "JOIN {$this->db->getTablePrefix()}entity_relationships r on r.guid_one = $column";
+			$joins[] = "JOIN {$this->db->prefix}entity_relationships r on r.guid_one = $column";
 		} else {
-			$joins[] = "JOIN {$this->db->getTablePrefix()}entity_relationships r on r.guid_two = $column";
+			$joins[] = "JOIN {$this->db->prefix}entity_relationships r on r.guid_two = $column";
 		}
 
 		if ($relationship) {

--- a/engine/classes/Elgg/Database/SubtypeTable.php
+++ b/engine/classes/Elgg/Database/SubtypeTable.php
@@ -180,7 +180,7 @@ class SubtypeTable {
 	
 		if (!$id) {
 			$sql = "
-				INSERT INTO {$this->db->getTablePrefix()}entity_subtypes
+				INSERT INTO {$this->db->prefix}entity_subtypes
 					(type,  subtype,  class) VALUES
 					(:type, :subtype, :class)
 			";
@@ -213,7 +213,7 @@ class SubtypeTable {
 	 */
 	public function remove($type, $subtype) {
 		$sql = "
-			DELETE FROM {$this->db->getTablePrefix()}entity_subtypes
+			DELETE FROM {$this->db->prefix}entity_subtypes
 			WHERE type = :type AND subtype = :subtype
 		";
 		$params = [
@@ -245,7 +245,7 @@ class SubtypeTable {
 		}
 	
 		$sql = "
-			UPDATE {$this->db->getTablePrefix()}entity_subtypes
+			UPDATE {$this->db->prefix}entity_subtypes
 			SET type = :type, subtype = :subtype, class = :class
 			WHERE id = :id
 		";
@@ -286,7 +286,7 @@ class SubtypeTable {
 		if ($this->cache === null) {
 			$rows = $this->db->getData("
 				SELECT *
-				FROM {$this->db->getTablePrefix()}entity_subtypes
+				FROM {$this->db->prefix}entity_subtypes
 			");
 
 			$this->cache = [];

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -156,7 +156,7 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setFactory('datalist', function(ServiceProvider $c) {
 			// TODO(ewinslow): Add back memcached support
 			$db = $c->db;
-			$dbprefix = $db->getTablePrefix();
+			$dbprefix = $db->prefix;
 			$pool = new Pool\InMemory();
 			return new \Elgg\Database\Datalist($pool, $db, $c->logger, "{$dbprefix}datalists");
 		});

--- a/engine/classes/Elgg/Http/DatabaseSessionHandler.php
+++ b/engine/classes/Elgg/Http/DatabaseSessionHandler.php
@@ -36,7 +36,7 @@ class DatabaseSessionHandler implements \SessionHandlerInterface {
 	public function read($session_id) {
 		
 		$id = sanitize_string($session_id);
-		$query = "SELECT * FROM {$this->db->getTablePrefix()}users_sessions WHERE session='$id'";
+		$query = "SELECT * FROM {$this->db->prefix}users_sessions WHERE session='$id'";
 		$result = $this->db->getDataRow($query);
 		if ($result) {
 			return (string) $result->data;
@@ -53,7 +53,7 @@ class DatabaseSessionHandler implements \SessionHandlerInterface {
 		$time = time();
 		$sess_data_sanitised = sanitize_string($session_data);
 
-		$query = "INSERT INTO {$this->db->getTablePrefix()}users_sessions
+		$query = "INSERT INTO {$this->db->prefix}users_sessions
 			(session, ts, data) VALUES
 			('$id', '$time', '$sess_data_sanitised')
 			ON DUPLICATE KEY UPDATE ts = '$time', data = '$sess_data_sanitised'";
@@ -78,7 +78,7 @@ class DatabaseSessionHandler implements \SessionHandlerInterface {
 	public function destroy($session_id) {
 		
 		$id = sanitize_string($session_id);
-		$query = "DELETE FROM {$this->db->getTablePrefix()}users_sessions WHERE session='$id'";
+		$query = "DELETE FROM {$this->db->prefix}users_sessions WHERE session='$id'";
 		return (bool) $this->db->deleteData($query);
 	}
 
@@ -88,7 +88,7 @@ class DatabaseSessionHandler implements \SessionHandlerInterface {
 	public function gc($max_lifetime) {
 		
 		$life = time() - $max_lifetime;
-		$query = "DELETE FROM {$this->db->getTablePrefix()}users_sessions WHERE ts < '$life'";
+		$query = "DELETE FROM {$this->db->prefix}users_sessions WHERE ts < '$life'";
 		return (bool) $this->db->deleteData($query);
 	}
 }

--- a/engine/classes/Elgg/Notifications/SubscriptionsService.php
+++ b/engine/classes/Elgg/Notifications/SubscriptionsService.php
@@ -155,7 +155,7 @@ class SubscriptionsService {
 		array_walk($rels, array($this->db, 'sanitizeString'));
 		$methods_string = "'" . implode("','", $rels) . "'";
 
-		$db_prefix = $this->db->getTablePrefix();
+		$db_prefix = $this->db->prefix;
 		$query = "SELECT guid_one AS guid, GROUP_CONCAT(relationship SEPARATOR ',') AS methods
 			FROM {$db_prefix}entity_relationships
 			WHERE guid_two = $container_guid AND

--- a/engine/classes/Elgg/PersistentLoginService.php
+++ b/engine/classes/Elgg/PersistentLoginService.php
@@ -48,7 +48,7 @@ class PersistentLoginService {
 		$this->cookie_config = $cookie_config;
 		$this->cookie_token = $cookie_token;
 
-		$prefix = $this->db->getTablePrefix();
+		$prefix = $this->db->prefix;
 		$this->table = "{$prefix}users_remember_me_cookies";
 		$this->time = is_numeric($time) ? (int)$time : time();
 	}

--- a/engine/classes/Elgg/Queue/DatabaseQueue.php
+++ b/engine/classes/Elgg/Queue/DatabaseQueue.php
@@ -39,7 +39,7 @@ class DatabaseQueue implements \Elgg\Queue\Queue {
 	 * {@inheritdoc}
 	 */
 	public function enqueue($item) {
-		$prefix = $this->db->getTablePrefix();
+		$prefix = $this->db->prefix;
 		$name = $this->db->sanitizeString($this->name);
 		$blob = $this->db->sanitizeString(serialize($item));
 		$time = time();
@@ -53,7 +53,7 @@ class DatabaseQueue implements \Elgg\Queue\Queue {
 	 * {@inheritdoc}
 	 */
 	public function dequeue() {
-		$prefix = $this->db->getTablePrefix();
+		$prefix = $this->db->prefix;
 		$name = $this->db->sanitizeString($this->name);
 		$worker_id = $this->db->sanitizeString($this->workerId);
 
@@ -82,7 +82,7 @@ class DatabaseQueue implements \Elgg\Queue\Queue {
 	 * {@inheritdoc}
 	 */
 	public function clear() {
-		$prefix = $this->db->getTablePrefix();
+		$prefix = $this->db->prefix;
 		$name = $this->db->sanitizeString($this->name);
 
 		$this->db->deleteData("DELETE FROM {$prefix}queue WHERE name = '$name'");
@@ -92,7 +92,7 @@ class DatabaseQueue implements \Elgg\Queue\Queue {
 	 * {@inheritdoc}
 	 */
 	public function size() {
-		$prefix = $this->db->getTablePrefix();
+		$prefix = $this->db->prefix;
 		$name = $this->db->sanitizeString($this->name);
 
 		$result = $this->db->getDataRow("SELECT COUNT(id) AS total FROM {$prefix}queue WHERE name = '$name'");

--- a/engine/classes/ElggRiverItem.php
+++ b/engine/classes/ElggRiverItem.php
@@ -175,7 +175,7 @@ class ElggRiverItem {
 		}
 
 		$db = _elgg_services()->db;
-		$prefix = $db->getTablePrefix();
+		$prefix = $db->prefix;
 		_elgg_services()->db->deleteData("DELETE FROM {$prefix}river WHERE id = ?", [$this->id]);
 
 		$events->triggerAfter('delete', 'river', $this);

--- a/engine/tests/ElggCoreMetadataAPITest.php
+++ b/engine/tests/ElggCoreMetadataAPITest.php
@@ -221,7 +221,7 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 		$obj->test_md = [1, 2, 3];
 
 		$time = time();
-		$prefix = _elgg_services()->db->getTablePrefix();
+		$prefix = _elgg_services()->db->prefix;
 
 		// reverse the times
 		$mds = elgg_get_metadata([

--- a/engine/tests/ElggDataFunctionsTest.php
+++ b/engine/tests/ElggDataFunctionsTest.php
@@ -10,7 +10,7 @@ class ElggDataFunctionsTest extends \ElggCoreUnitTest {
 	private $user;
 
 	public function setUp() {
-		$this->prefix = _elgg_services()->db->getTablePrefix();
+		$this->prefix = _elgg_services()->db->prefix;
 
 		$users = elgg_get_entities([
 			'type' => 'user',

--- a/engine/tests/phpunit/Elgg/Mocks/Database/EntityTable.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Database/EntityTable.php
@@ -193,7 +193,7 @@ class EntityTable extends DbEntityTable {
 			}
 		}
 
-		$dbprefix = $this->db->getTablePrefix();
+		$dbprefix = $this->db->prefix;
 
 		$access = _elgg_get_access_where_sql([
 			'table_alias' => '',

--- a/engine/tests/phpunit/Elgg/Mocks/Database/RelationshipsTable.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Database/RelationshipsTable.php
@@ -74,7 +74,7 @@ class RelationshipsTable extends DbRelationshipsTable {
 
 		// Insert a new relationship
 		$sql = "
-			INSERT INTO {$this->db->getTablePrefix()}entity_relationships
+			INSERT INTO {$this->db->prefix}entity_relationships
 			       (guid_one, relationship, guid_two, time_created)
 			VALUES (:guid1, :relationship, :guid2, :time)
 				ON DUPLICATE KEY UPDATE time_created = :time
@@ -106,7 +106,7 @@ class RelationshipsTable extends DbRelationshipsTable {
 	public function addQuerySpecs(\stdClass $row) {
 
 		// Get relationship by its ID
-		$sql = "SELECT * FROM {$this->db->getTablePrefix()}entity_relationships WHERE id = :id";
+		$sql = "SELECT * FROM {$this->db->prefix}entity_relationships WHERE id = :id";
 		$params = [
 			':id' => (int) $row->id,
 		];
@@ -119,7 +119,7 @@ class RelationshipsTable extends DbRelationshipsTable {
 		]);
 
 		// Delete relationship by its ID
-		$sql = "DELETE FROM {$this->db->getTablePrefix()}entity_relationships WHERE id = :id";
+		$sql = "DELETE FROM {$this->db->prefix}entity_relationships WHERE id = :id";
 		$params = [
 			':id' => $row->id,
 		];
@@ -132,7 +132,7 @@ class RelationshipsTable extends DbRelationshipsTable {
 
 		// Check relationship between two GUIDs
 		$sql = "
-			SELECT * FROM {$this->db->getTablePrefix()}entity_relationships
+			SELECT * FROM {$this->db->prefix}entity_relationships
 			WHERE guid_one = :guid1
 			  AND relationship = :relationship
 			  AND guid_two = :guid2

--- a/engine/tests/phpunit/Elgg/Mocks/Di/MockServiceProvider.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Di/MockServiceProvider.php
@@ -68,7 +68,7 @@ class MockServiceProvider extends \Elgg\Di\DiContainer {
 
 		$this->setFactory('datalist', function(MockServiceProvider $m) use ($sp) {
 			$db = $m->db;
-			$dbprefix = $db->getTablePrefix();
+			$dbprefix = $db->prefix;
 			$pool = new \Elgg\Cache\Pool\InMemory();
 			return new \Elgg\Mocks\Database\Datalist($pool, $db, $sp->logger, "{$dbprefix}datalists");
 		});

--- a/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
@@ -20,10 +20,10 @@ class SubscriptionsServiceTest extends \Elgg\TestCase {
 		$this->event->expects($this->any())
 				->method('getObject')
 				->will($this->returnValue($object));
-		$this->db = $this->getMock('\Elgg\Database', array('getData', 'getTablePrefix', 'sanitizeString'), array(), '', false
+		$this->db = $this->getMock('\Elgg\Database', array('getData', 'prefix', 'sanitizeString'), array(), '', false
 		);
 		$this->db->expects($this->any())
-				->method('getTablePrefix')
+				->method('prefix')
 				->will($this->returnValue('elgg_'));
 		$this->db->expects($this->any())
 				->method('sanitizeString')
@@ -52,7 +52,7 @@ class SubscriptionsServiceTest extends \Elgg\TestCase {
 	public function testQueryGenerationForRetrievingSubscriptionRelationships() {
 		$methods = array('apples', 'bananas');
 		$query = "SELECT guid_one AS guid, GROUP_CONCAT(relationship SEPARATOR ',') AS methods
-			FROM elgg_entity_relationships
+			FROM {$this->db->prefix}entity_relationships
 			WHERE guid_two = $this->containerGuid AND
 					relationship IN ('notifyapples','notifybananas') GROUP BY guid_one";
 		$this->db->expects($this->once())

--- a/engine/tests/phpunit/ElggEntityTest.php
+++ b/engine/tests/phpunit/ElggEntityTest.php
@@ -98,7 +98,7 @@ class ElggEntityTest extends \Elgg\TestCase {
 	 * @expectedException InvalidParameterException
 	 */
 	public function testSaveWithoutType() {
-		$db = $this->getMock('\Elgg\Database', array('getData', 'getTablePrefix', 'sanitizeString'), array(), '', false
+		$db = $this->getMock('\Elgg\Database', array('getData', 'sanitizeString'), array(), '', false
 		);
 		$db->expects($this->any())
 				->method('sanitizeString')


### PR DESCRIPTION
`$db->getTablePrefix()` is now `$db->prefix`. Considering typical usage this yields cleaner code.

Deprecates `elgg()->getDb()->getTablePrefix()`. This is public API, but probably not in common use. Better to guide devs towards the usage `elgg_get_config('dbprefix')` which is compatible with more Elgg versions.
