### PR TITLE
fix(web_services): create_api_user() and create_user_token() work again

### DIFF
--- a/engine/classes/ElggCrypto.php
+++ b/engine/classes/ElggCrypto.php
@@ -25,15 +25,15 @@ class ElggCrypto {
 	/**
 	 * @var SiteSecret
 	 */
-	private $siteSecret;
+	private $site_secret;
 
 	/**
 	 * Constructor
 	 *
-	 * @param SiteSecret $siteSecret Secret service
+	 * @param SiteSecret $site_secret Secret service
 	 */
-	public function __construct(SiteSecret $siteSecret) {
-		$this->siteSecret = $siteSecret;
+	public function __construct(SiteSecret $site_secret = null) {
+		$this->site_secret = $site_secret;
 	}
 
 	/**
@@ -185,7 +185,7 @@ class ElggCrypto {
 	 */
 	public function getHmac($data, $algo = 'sha256', $key = '') {
 		if (!$key) {
-			$key = $this->siteSecret->get(true);
+			$key = $this->site_secret->get(true);
 		}
 		return new Elgg\Security\Hmac($key, [$this, 'areEqual'], $data, $algo);
 	}

--- a/mod/web_services/lib/api_user.php
+++ b/mod/web_services/lib/api_user.php
@@ -21,9 +21,8 @@ function create_api_user($site_guid) {
 
 	$site_guid = (int)$site_guid;
 
-	$crypto = new ElggCrypto();
-	$public = $crypto->getRandomString(40, ElggCrypto::CHARS_HEX);
-	$secret = $crypto->getRandomString(40, ElggCrypto::CHARS_HEX);
+	$public = _elgg_services()->crypto->getRandomString(40, ElggCrypto::CHARS_HEX);
+	$secret = _elgg_services()->crypto->getRandomString(40, ElggCrypto::CHARS_HEX);
 
 	$insert = insert_data("INSERT into {$CONFIG->dbprefix}api_users
 		(site_guid, api_key, secret) values

--- a/mod/web_services/lib/tokens.php
+++ b/mod/web_services/lib/tokens.php
@@ -18,8 +18,7 @@ function create_user_token($username, $expire = 60) {
 	$user = get_user_by_username($username);
 	$time = time() + 60 * $expire;
 
-	$crypto = new ElggCrypto();
-	$token = $crypto->getRandomString(32, ElggCrypto::CHARS_HEX);
+	$token = _elgg_services()->crypto->getRandomString(32, ElggCrypto::CHARS_HEX);
 
 	if (!$user) {
 		return false;


### PR DESCRIPTION
These uses of the `ElggCrypto` constructor had not been properly updated when the `SiteSecret` dependency was added.

(replaces #10100)
