### PR TITLE
chore(db): removes getTablePrefix() from DB classes

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -52,6 +52,7 @@ All the functions in ``engine/lib/deprecated-1.9.php`` were removed. See https:/
  * ``ElggSite::removeUser``: Use ``removeEntity``
  * ``ElggUser::countObjects``: Use ``elgg_get_entities()``
  * ``Logger::getClassName``: Use ``get_class()``
+ * ``Elgg\Application\Database::getTablePrefix``: Read the ``prefix`` property
 
 Removed global vars
 -------------------

--- a/engine/classes/Elgg/Application/Database.php
+++ b/engine/classes/Elgg/Application/Database.php
@@ -68,17 +68,6 @@ class Database {
 
 	/**
 	 * {@inheritdoc}
-	 * @deprecated 2.3 Read the "prefix" property
-	 */
-	public function getTablePrefix() {
-		if (function_exists('elgg_deprecated_notice')) {
-			elgg_deprecated_notice(__METHOD__ . ' is deprecated. Read the "prefix" property', '2.3');
-		}
-		return $this->db->prefix;
-	}
-
-	/**
-	 * {@inheritdoc}
 	 */
 	public function sanitizeInt($value, $signed = true) {
 		return $this->db->sanitizeInt($value, $signed);
@@ -98,11 +87,7 @@ class Database {
 	 * @return mixed
 	 */
 	public function __get($name) {
-		if ($name === 'prefix') {
-			return $this->db->prefix;
-		}
-
-		throw new \RuntimeException("Cannot read property '$name'");
+		return $this->db->{$name};
 	}
 
 	/**
@@ -113,6 +98,6 @@ class Database {
 	 * @return void
 	 */
 	public function __set($name, $value) {
-		throw new \RuntimeException("Cannot write property '$name'");
+		$this->db->{$name} = $value;
 	}
 }

--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -650,21 +650,6 @@ class Database {
 	}
 
 	/**
-	 * Get the value of the "prefix" property
-	 *
-	 * @see Database::$prefix
-	 *
-	 * @return string
-	 * @deprecated 2.3 Read the "prefix" property
-	 */
-	public function getTablePrefix() {
-		if (function_exists('elgg_deprecated_notice')) {
-			elgg_deprecated_notice(__METHOD__ . ' is deprecated. Read the "prefix" property', '2.3');
-		}
-		return $this->table_prefix;
-	}
-
-	/**
 	 * Sanitizes an integer value for use in a query
 	 *
 	 * @param int  $value  Value to sanitize


### PR DESCRIPTION
BREAKING CHANGE:
In `elgg()->getDb()` (the public DB API), method `getTablePrefix()` is no longer available. Read the `prefix` property instead.
