### PR TITLE
fix(discussions): removes site "Discussions" menu item added in 2.2.0

### DIFF
--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -12,11 +12,6 @@ function discussion_init() {
 
 	elgg_register_library('elgg:discussion', __DIR__ . '/lib/discussion.php');
 
-	elgg_register_menu_item('site', [
-		'name' => 'discussion',
-		'text' => elgg_echo('discussion'),
-		'href' => 'discussion/all',
-	]);
 	elgg_register_page_handler('discussion', 'discussion_page_handler');
 
 	elgg_register_plugin_hook_handler('entity:url', 'object', 'discussion_set_topic_url');


### PR DESCRIPTION
Either sites already added this via a plugin in 2.1 or they didn't want it.

Fixes #9731
