### PR TITLE
Adds elgg_extract_class() and fixes #10102

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -64,6 +64,12 @@ Form footer rendering can now be deferred until the form view and its extensions
  * ``elgg_set_form_footer()`` - sets form footer for deferred rendering
  * ``elgg_get_form_footer()`` - returns currently set form footer
 
+New API for extracting class names from arrays
+----------------------------------------------
+
+Similar to ``elgg_extract()``, ``elgg_extract_class()`` extracts the "class" key (if present), merges into existing class names, and always returns an array.
+
+
 From 2.1 to 2.2
 ===============
 
@@ -97,7 +103,7 @@ Added ``elgg/lightbox`` module
 New :doc:`elgg/lightbox module <javascript>` can be used to open and close the lightbox programmatically.
 
 Added ``elgg/embed`` module
-------------------------------
+---------------------------
 
 Even though rarely necessary, ``elgg/embed`` AMD module can be used to access the embed methods programmatically. The module bootstraps itself when necessary and is unlikely to require further decoration.
 

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1347,9 +1347,9 @@ function elgg_signed_request_gatekeeper() {
  *
  * Shorthand for $value = (isset($array['key'])) ? $array['key'] : 'default';
  *
- * @param string $key     The key to check.
- * @param array  $array   The array to check against.
- * @param mixed  $default Default value to return if nothing is found.
+ * @param string $key     Key to check in the source array
+ * @param array  $array   Source array
+ * @param mixed  $default Value to return if key is not found
  * @param bool   $strict  Return array key if it's set, even if empty. If false,
  *                        return $default if the array key is unset or empty.
  *
@@ -1366,6 +1366,25 @@ function elgg_extract($key, array $array, $default = null, $strict = true) {
 	} else {
 		return (isset($array[$key]) && !empty($array[$key])) ? $array[$key] : $default;
 	}
+}
+
+/**
+ * Extract class names from an array with key "class", optionally merging into a preexisting set.
+ *
+ * @param array           $array    Source array
+ * @param string|string[] $existing Existing name(s)
+ * @return string[]
+ *
+ * @since 2.3.0
+ */
+function elgg_extract_class(array $array, $existing = []) {
+	$existing = empty($existing) ? [] : (array) $existing;
+
+	$merge = (array) elgg_extract('class', $array, []);
+
+	array_splice($existing, count($existing), 0, $merge);
+
+	return array_values(array_unique($existing));
 }
 
 /**

--- a/engine/tests/phpunit/Elgg/lib/elgglib/ElggExtractClassTest.php
+++ b/engine/tests/phpunit/Elgg/lib/elgglib/ElggExtractClassTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Elgg\lib\elgglib;
+
+/**
+ * @group Elgglib
+ */
+class ElggExtractClassTest extends \Elgg\TestCase {
+
+	function testCanExtract() {
+		$this->assertSame(['b'], elgg_extract_class(['class' => 'b']));
+		$this->assertSame(['b'], elgg_extract_class(['class' => ['b']]));
+		$this->assertSame(['a', 'b'], elgg_extract_class(['class' => ['a', 'b']]));
+	}
+
+	function testCanMergeUniquely() {
+		$this->assertSame(['a', 'b'], elgg_extract_class(['class' => 'b'], 'a'));
+		$this->assertSame(['a', 'b'], elgg_extract_class(['class' => ['a', 'b']], 'a'));
+		$this->assertSame(['a', 'b', 'c', 'd'], elgg_extract_class(['class' => ['c', 'd']], ['a', 'b']));
+	}
+
+	function testDefaultIsEmptyArray() {
+		$this->assertSame([], elgg_extract_class([]));
+	}
+}

--- a/engine/tests/phpunit/Elgg/lib/elgglib/ElggExtractTest.php
+++ b/engine/tests/phpunit/Elgg/lib/elgglib/ElggExtractTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Elgg\lib\elgglib;
+
+/**
+ * @group Elgglib
+ */
+class ElggExtractTest extends \Elgg\TestCase {
+
+	function testCanExtract() {
+		$this->assertSame('b', elgg_extract('a', ['a' => 'b']));
+	}
+
+	function testUsesDefault() {
+		$this->assertSame(null, elgg_extract('f', []));
+		$this->assertSame('default', elgg_extract('a', [], 'default'));
+	}
+
+	function testStrictIgnoresEmptiness() {
+		$this->assertSame(false, elgg_extract('a', ['a' => false]));
+		$this->assertSame(null, elgg_extract('a', ['a' => false], null, false));
+	}
+
+	function testCantHandleNull() {
+		$this->assertSame('default', elgg_extract('a', ['a' => null], 'default'));
+		$this->assertSame('default', elgg_extract('a', ['a' => null], 'default', false));
+	}
+}

--- a/views/default/elements/forms/field.php
+++ b/views/default/elements/forms/field.php
@@ -17,8 +17,7 @@ if (!$input) {
 $label = elgg_extract('label', $vars, '');
 $help = elgg_extract('help', $vars, '');
 
-$field_class = (array) elgg_extract('class', $vars, array());
-$field_class[] = 'elgg-field';
+$field_class = elgg_extract_class($vars, 'elgg-field');
 if (elgg_extract('required', $vars)) {
 	$field_class[] = "elgg-field-required";
 }

--- a/views/default/input/access.php
+++ b/views/default/input/access.php
@@ -26,8 +26,7 @@ if (isset($vars['options_values'])) {
 $entity_allows_comments = elgg_extract('entity_allows_comments', $vars, true);
 unset($vars['entity_allows_comments']);
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-input-access';
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-access');
 
 // this will be passed to plugin hooks ['access:collections:write', 'user'] and ['default', 'access']
 $params = array();

--- a/views/default/input/button.php
+++ b/views/default/input/button.php
@@ -9,8 +9,7 @@
  * @uses $vars['class'] Additional CSS class
  */
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = "elgg-button";
+$vars['class'] = elgg_extract_class($vars, 'elgg-button');
 
 $defaults = ['type' => 'button'];
 

--- a/views/default/input/checkbox.php
+++ b/views/default/input/checkbox.php
@@ -21,8 +21,7 @@
  * @uses $vars['label_tag']   HTML tag that wraps concatinated label and input. Defaults to 'label'.
  */
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-input-checkbox';
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-checkbox');
 
 $defaults = array(
 	'default' => 0,

--- a/views/default/input/checkboxes.php
+++ b/views/default/input/checkboxes.php
@@ -43,7 +43,7 @@ if (empty($vars['options'])) {
 	return;
 }
 
-$list_class = (array) elgg_extract('class', $vars, []);
+$list_class = elgg_extract_class($vars);
 unset($vars['class']);
 
 $list_class[] = 'elgg-input-checkboxes';

--- a/views/default/input/date.php
+++ b/views/default/input/date.php
@@ -16,8 +16,7 @@
  * @uses $vars['timestamp'] Store as a Unix timestamp in seconds. Default = false
  * @uses $vars['datepicker_options'] An array of options to pass to the jQuery UI datepicker
  */
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-input-date';
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-date');
 
 //@todo popup_calendar deprecated in 1.8.  Remove in 2.0
 $vars['class'][] = 'popup_calendar';

--- a/views/default/input/email.php
+++ b/views/default/input/email.php
@@ -9,8 +9,7 @@
  * @uses $vars['class'] Additional CSS class
  */
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-input-email';
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-email');
 
 $defaults = array(
 	'disabled' => false,

--- a/views/default/input/file.php
+++ b/views/default/input/file.php
@@ -14,8 +14,7 @@ if (!empty($vars['value'])) {
 	echo elgg_echo('fileexists') . "<br />";
 }
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-input-file';
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-file');
 
 $defaults = array(
 	'disabled' => false,

--- a/views/default/input/form.php
+++ b/views/default/input/form.php
@@ -22,9 +22,7 @@ $defaults = array(
 
 $vars = array_merge($defaults, $vars);
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-form';
-
+$vars['class'] = elgg_extract_class($vars, 'elgg-form');
 $vars['action'] = elgg_normalize_url($vars['action']);
 $vars['method'] = strtolower($vars['method']);
 

--- a/views/default/input/location.php
+++ b/views/default/input/location.php
@@ -7,8 +7,7 @@
  * @uses $vars['class']  Additional CSS class
  */
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-input-location';
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-location');
 
 $defaults = array(
 	'disabled' => false,

--- a/views/default/input/longtext.php
+++ b/views/default/input/longtext.php
@@ -11,8 +11,7 @@
  * @uses $vars['class']    Additional CSS class
  */
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-input-longtext';
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-longtext');
 
 $defaults = array(
 	'value' => '',

--- a/views/default/input/password.php
+++ b/views/default/input/password.php
@@ -11,8 +11,7 @@
  * @uses $vars['class'] Additional CSS class
  */
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-input-password';
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-password');
 
 $defaults = array(
 	'disabled' => false,

--- a/views/default/input/plaintext.php
+++ b/views/default/input/plaintext.php
@@ -12,8 +12,7 @@
  * @uses $vars['disabled']
  */
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-input-plaintext';
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-plaintext');
 
 $defaults = array(
 	'value' => '',

--- a/views/default/input/radio.php
+++ b/views/default/input/radio.php
@@ -39,9 +39,7 @@ if (empty($options)) {
 $id = elgg_extract('id', $vars, '');
 unset($vars['id']);
 
-$list_class = (array) elgg_extract('class', $vars, []);
-$list_class[] = 'elgg-input-radios';
-$list_class[] = "elgg-{$vars['align']}";
+$list_class = elgg_extract_class($vars, ['elgg-input-radios', "elgg-{$vars['align']}"]);
 
 unset($vars['class']);
 unset($vars['align']);

--- a/views/default/input/select.php
+++ b/views/default/input/select.php
@@ -23,8 +23,7 @@
  * @uses $vars['class']          Additional CSS class
  */
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-input-dropdown';
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-dropdown');
 
 $defaults = array(
 	'disabled' => false,

--- a/views/default/input/submit.php
+++ b/views/default/input/submit.php
@@ -10,7 +10,6 @@
 
 $vars['type'] = 'submit';
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = "elgg-button-submit";
+$vars['class'] = elgg_extract_class($vars, 'elgg-button-submit');
 
 echo elgg_view('input/button', $vars);

--- a/views/default/input/tag.php
+++ b/views/default/input/tag.php
@@ -8,8 +8,7 @@
  * @uses $vars['class'] Additional CSS class
  */
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-input-tag';
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-tag');
 
 $defaults = array(
 	'value' => '',

--- a/views/default/input/tags.php
+++ b/views/default/input/tags.php
@@ -9,8 +9,7 @@
  * @uses $vars['entity']   Optional. Entity whose tags are being displayed (metadata ->tags)
  */
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-input-tags';
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-tags');
 
 $defaults = array(
 	'value' => '',

--- a/views/default/input/text.php
+++ b/views/default/input/text.php
@@ -9,8 +9,7 @@
  * @uses $vars['class'] Additional CSS class
  */
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-input-text';
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-text');
 
 $defaults = array(
 	'value' => '',

--- a/views/default/input/url.php
+++ b/views/default/input/url.php
@@ -9,8 +9,7 @@
  * @uses $vars['class'] Additional CSS class
  */
 
-$vars['class'] = (array) elgg_extract('class', $vars, []);
-$vars['class'][] = 'elgg-input-url';
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-url');
 
 $defaults = array(
 	'value' => '',

--- a/views/default/navigation/breadcrumbs.php
+++ b/views/default/navigation/breadcrumbs.php
@@ -18,29 +18,29 @@ if (isset($vars['breadcrumbs'])) {
 	$breadcrumbs = elgg_get_breadcrumbs();
 }
 
-$class = 'elgg-menu elgg-breadcrumbs';
-$additional_class = elgg_extract('class', $vars, '');
-if ($additional_class) {
-	$class = "$class $additional_class";
+if (!is_array($breadcrumbs) || !$breadcrumbs) {
+	return;
 }
 
-if (is_array($breadcrumbs) && count($breadcrumbs) > 0) {
-	echo "<ul class=\"$class\">";
-	foreach ($breadcrumbs as $breadcrumb) {
-		// We have to escape text (without double-encoding). Titles in core plugins are HTML escaped
-		// on input, but we can't guarantee that other users of this view and of elgg_push_breadcrumb()
-		// will do so.
-		if (!empty($breadcrumb['link'])) {
-			$crumb = elgg_view('output/url', array(
-				'href' => $breadcrumb['link'],
-				'text' => $breadcrumb['title'],
-				'encode_text' => true,
-				'is_trusted' => true,
-			));
-		} else {
-			$crumb = htmlspecialchars($breadcrumb['title'], ENT_QUOTES, 'UTF-8', false);
-		}
-		echo "<li>$crumb</li>";
+$attrs['class'] = elgg_extract_class($vars, ['elgg-menu', 'elgg-breadcrumbs']);
+$lis = '';
+
+foreach ($breadcrumbs as $breadcrumb) {
+	// We have to escape text (without double-encoding). Titles in core plugins are HTML escaped
+	// on input, but we can't guarantee that other users of this view and of elgg_push_breadcrumb()
+	// will do so.
+	if (!empty($breadcrumb['link'])) {
+		$crumb = elgg_view('output/url', array(
+			'href' => $breadcrumb['link'],
+			'text' => $breadcrumb['title'],
+			'encode_text' => true,
+			'is_trusted' => true,
+		));
+	} else {
+		$crumb = htmlspecialchars($breadcrumb['title'], ENT_QUOTES, 'UTF-8', false);
 	}
-	echo '</ul>';
+
+	$lis .= "<li>$crumb</li>";
 }
+
+echo elgg_format_element('ul', $attrs, $lis);

--- a/views/default/navigation/menu/elements/section.php
+++ b/views/default/navigation/menu/elements/section.php
@@ -12,7 +12,7 @@
 
 $items = elgg_extract('items', $vars, array());
 $headers = elgg_extract('show_section_headers', $vars, false);
-$class = elgg_extract('class', $vars, '');
+$attrs['class'] = elgg_extract_class($vars);
 $item_class = elgg_extract('item_class', $vars, '');
 
 if ($headers) {
@@ -21,15 +21,15 @@ if ($headers) {
 	echo '<h2>' . elgg_echo("menu:$name:header:$section") . '</h2>';
 }
 
-echo "<ul class=\"$class\">";
+$lis = '';
 
 if (is_array($items)) {
 	foreach ($items as $menu_item) {
-		echo elgg_view('navigation/menu/elements/item', array(
+		$lis .= elgg_view('navigation/menu/elements/item', array(
 			'item' => $menu_item,
 			'item_class' => $item_class,
 		));
 	}
 }
 
-echo '</ul>';
+echo elgg_format_element('ul', $attrs, $lis);

--- a/views/default/object/elements/full.php
+++ b/views/default/object/elements/full.php
@@ -15,10 +15,7 @@ if (!$entity instanceof ElggEntity) {
 	elgg_log("object/elements/full expects an ElggEntity in \$vars['entity']", 'ERROR');
 }
 
-$class = (array) elgg_extract('class', $vars, []);
-$class[] = 'elgg-listing-full';
-$class[] = 'elgg-content';
-$class[] = 'clearfix';
+$class = elgg_extract_class($vars, ['elgg-listing-full', 'elgg-content', 'clearfix']);
 unset($vars['class']);
 
 $header = elgg_view('object/elements/full/header', $vars);

--- a/views/default/object/elements/summary.php
+++ b/views/default/object/elements/summary.php
@@ -13,6 +13,7 @@
  * @uses $vars['content']   HTML for the entity content (optional)
  * @uses $vars['icon']      Object icon. If set, the listing will be wrapped with an image block
  * @uses $vars['class']     Class selector for the image block
+ * @uses $vars['image_block_vars'] Attributes for the image block wrapper
  */
 $entity = elgg_extract('entity', $vars);
 if (!$entity instanceof ElggEntity) {
@@ -44,14 +45,10 @@ $summary = $metadata . $title . $subtitle . $tags . $extensions . $content;
 
 $icon = elgg_extract('icon', $vars);
 if (isset($icon)) {
-	$params = $vars;
-	foreach (['title', 'metadata', 'subtitle', 'tags', 'content', 'icon', 'class'] as $key) {
-		unset($params[$key]);
-	}
-	$class = (array) elgg_extract('class', $vars, []);
-	$class[] = 'elgg-listing-summary';
+	$params = (array) elgg_extract('image_block_vars', $vars, []);
+	$class = elgg_extract_class($params);
+	$class = elgg_extract_class($vars, $class);
 	$params['class'] = $class;
-
 	$params['data-guid'] = $entity->guid;
 
 	echo elgg_view_image_block($icon, $summary, $params);

--- a/views/default/object/widget.php
+++ b/views/default/object/widget.php
@@ -40,17 +40,11 @@ $controls = elgg_view('object/widget/elements/controls', array(
 $content = elgg_view('object/widget/elements/content', $vars);
 
 $widget_id = "elgg-widget-$widget->guid";
-$widget_instance = preg_replace('/[^a-z0-9-]/i', '-', "elgg-widget-instance-$handler");
-if ($can_edit) {
-	$widget_class = "elgg-state-draggable $widget_instance";
-} else {
-	$widget_class = "elgg-state-fixed $widget_instance";
-}
 
-$additional_class = elgg_extract('class', $vars, '');
-if ($additional_class) {
-	$widget_class = "$widget_class $additional_class";
-}
+$widget_instance = preg_replace('/[^a-z0-9-]/i', '-', "elgg-widget-instance-$handler");
+
+$widget_class = elgg_extract_class($vars, $widget_instance);
+$widget_class[] = $can_edit ? "elgg-state-draggable" : "elgg-state-fixed";
 
 $widget_header = <<<HEADER
 	<div class="elgg-widget-handle clearfix"><h3 class="elgg-widget-title">$title</h3>

--- a/views/default/output/icon.php
+++ b/views/default/output/icon.php
@@ -58,9 +58,7 @@ $translated_icons = array(
 $convert = (bool) elgg_extract('convert', $vars, true);
 unset($vars['convert']);
 
-$class = (array) elgg_extract("class", $vars);
-$class[] = "elgg-icon";
-$class[] = "fa";
+$class = elgg_extract_class($vars, ["elgg-icon", "fa"]);
 
 foreach ($class as $index => $c) {
 	if (preg_match_all('/^elgg-icon-(.+)-hover$/i', $c)) {

--- a/views/default/output/longtext.php
+++ b/views/default/output/longtext.php
@@ -11,13 +11,7 @@
  * @uses $vars['class']
  */
 
-$class = 'elgg-output';
-$additional_class = elgg_extract('class', $vars, '');
-if ($additional_class) {
-	$vars['class'] = "$class $additional_class";
-} else {
-	$vars['class'] = $class;
-}
+$vars['class'] = elgg_extract_class($vars, 'elgg-output');
 
 $parse_urls = elgg_extract('parse_urls', $vars, true);
 unset($vars['parse_urls']);
@@ -33,6 +27,4 @@ $text = filter_tags($text);
 
 $text = elgg_autop($text);
 
-$attributes = elgg_format_attributes($vars);
-
-echo "<div $attributes>$text</div>";
+echo elgg_format_element('div', $vars, $text);

--- a/views/default/page/components/image_block.php
+++ b/views/default/page/components/image_block.php
@@ -28,9 +28,7 @@ unset($vars['image']);
 $alt_image = elgg_extract('image_alt', $vars, '');
 unset($vars['image_alt']);
 
-$class = (array) elgg_extract('class', $vars, []);
-$class[] = 'elgg-image-block';
-$class[] = 'clearfix';
+$class = elgg_extract_class($vars, ['elgg-image-block', 'clearfix']);
 unset($vars['class']);
 
 $body = elgg_format_element('div', [

--- a/views/default/page/components/module.php
+++ b/views/default/page/components/module.php
@@ -20,10 +20,9 @@ $show_inner = elgg_extract('show_inner', $vars, false);
 
 $attrs = [
 	'id' => elgg_extract('id', $vars),
-	'class' => (array) elgg_extract('class', $vars, []),
+	'class' => elgg_extract_class($vars, 'elgg-module'),
 ];
 
-$attrs['class'][] = 'elgg-module';
 if ($type) {
 	$attrs['class'][] = "elgg-module-$type";
 }

--- a/views/default/page/elements/comments.php
+++ b/views/default/page/elements/comments.php
@@ -21,9 +21,8 @@ if (!$limit) {
 
 $attr = [
 	'id' => elgg_extract('id', $vars, 'comments'),
-	'class' => (array) elgg_extract('class', $vars, []),
+	'class' => elgg_extract_class($vars, 'elgg-comments'),
 ];
-$attr['class'][] = 'elgg-comments';
 
 // work around for deprecation code in elgg_view()
 unset($vars['internalid']);

--- a/views/default/page/elements/title.php
+++ b/views/default/page/elements/title.php
@@ -11,10 +11,6 @@ if (!is_string($title) || $title === '') {
 	return;
 }
 
-$attributes = [];
-$class = elgg_extract('class', $vars);
-if (!empty($class)) {
-	$attributes['class'] = $class;
-}
+$attributes['class'] = elgg_extract_class($vars);
 
 echo elgg_format_element('h2', $attributes, $title);


### PR DESCRIPTION
**chore(views): list $vars no longer pollute the image block wrapper**

In #9944 `elgg_view_image_block()` started rendering arbitrary $vars as attributes. The problem is that `object/elements/summary` also passed all $vars into it from the list view. This limits the $params passed in from `object/elements/summary`.

Fixes #10102

**feature(views): adds function for extracting $vars['class'] more cleanly**

This cleans up the pattern of creating an array of classnames by extracting `$vars['class']` and optionally merging other classnames.

Adds missing tests for `elgg_extract()`.
