### PR TITLE
chore(river): core can use elgg_delete_river for 2.x w/o notices

### DIFF
--- a/actions/avatar/crop.php
+++ b/actions/avatar/crop.php
@@ -32,7 +32,7 @@ if (!$owner->saveIconFromElggFile($owner->getIcon('master'), 'icon', $coords)) {
 
 system_message(elgg_echo('avatar:crop:success'));
 $view = 'river/user/default/profileiconupdate';
-elgg_delete_river(array('subject_guid' => $owner->guid, 'view' => $view));
+_elgg_delete_river(array('subject_guid' => $owner->guid, 'view' => $view));
 elgg_create_river_item(array(
 	'view' => $view,
 	'action_type' => 'update',

--- a/actions/avatar/upload.php
+++ b/actions/avatar/upload.php
@@ -26,7 +26,7 @@ if (elgg_trigger_event('profileiconupdate', $owner->type, $owner)) {
 	system_message(elgg_echo("avatar:upload:success"));
 
 	$view = 'river/user/default/profileiconupdate';
-	elgg_delete_river(array('subject_guid' => $owner->guid, 'view' => $view));
+	_elgg_delete_river(array('subject_guid' => $owner->guid, 'view' => $view));
 	elgg_create_river_item(array(
 		'view' => $view,
 		'action_type' => 'update',

--- a/engine/classes/ElggAnnotation.php
+++ b/engine/classes/ElggAnnotation.php
@@ -88,7 +88,7 @@ class ElggAnnotation extends \ElggExtender {
 	public function delete() {
 		$result = _elgg_delete_metastring_based_object_by_id($this->id, 'annotation');
 		if ($result) {
-			elgg_delete_river(array('annotation_id' => $this->id));
+			_elgg_delete_river(array('annotation_id' => $this->id));
 		}
 
 		return $result;

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -2003,9 +2003,9 @@ abstract class ElggEntity extends \ElggData implements
 		access_show_hidden_entities($entity_disable_override);
 		elgg_set_ignore_access($ia);
 
-		elgg_delete_river(array('subject_guid' => $guid));
-		elgg_delete_river(array('object_guid' => $guid));
-		elgg_delete_river(array('target_guid' => $guid));
+		_elgg_delete_river(array('subject_guid' => $guid));
+		_elgg_delete_river(array('object_guid' => $guid));
+		_elgg_delete_river(array('target_guid' => $guid));
 		remove_all_private_settings($guid);
 
 		$res = $this->getDatabase()->deleteData("

--- a/engine/lib/deprecated-2.1.php
+++ b/engine/lib/deprecated-2.1.php
@@ -65,6 +65,19 @@ function system_messages($message = null, $register = "success", $count = false)
 }
 
 /**
+ * Alias of elgg_delete_river() that doesn't raise notices
+ *
+ * @param array $options Options for elgg_delete_river()
+ * @return bool
+ * @internal Will be removed with elgg_delete_river()
+ * @access private
+ */
+function _elgg_delete_river(array $options = []) {
+	$options['__bypass_notice'] = true;
+	return elgg_delete_river($options);
+}
+
+/**
  * Delete river items
  *
  * @warning Does not fire permission hooks or delete, river events.
@@ -93,7 +106,10 @@ function system_messages($message = null, $register = "success", $count = false)
 function elgg_delete_river(array $options = array()) {
 	global $CONFIG;
 
-	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use elgg_get_river() and call delete() on the returned item(s)', '2.3');
+	// allow core to use this in 2.x w/o warnings
+	if (empty($options['__bypass_notice'])) {
+		elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use elgg_get_river() and call delete() on the returned item(s)', '2.3');
+	}
 
 	$defaults = array(
 		'ids'                  => ELGG_ENTITIES_ANY_VALUE,

--- a/engine/tests/ElggCoreRiverAPITest.php
+++ b/engine/tests/ElggCoreRiverAPITest.php
@@ -18,13 +18,13 @@ class ElggCoreRiverAPITest extends \ElggCoreUnitTest {
 
 		$id = elgg_create_river_item($params);
 		$this->assertTrue(is_int($id));
-		$this->assertTrue(elgg_delete_river(array('id' => $id)));
+		$this->assertTrue(_elgg_delete_river(array('id' => $id)));
 
 		$params['return_item'] = true;
 		$item = elgg_create_river_item($params);
 
 		$this->assertIsA($item, ElggRiveritem::class);
-		$this->assertTrue(elgg_delete_river(array('id' => $item->id)));
+		$this->assertTrue(_elgg_delete_river(array('id' => $item->id)));
 	}
 
 	public function testRiverCreationEmitsHookAndEvent() {
@@ -187,7 +187,7 @@ class ElggCoreRiverAPITest extends \ElggCoreUnitTest {
 		elgg_register_event_handler('delete:before', 'river', $handler);
 		elgg_register_event_handler('delete:after', 'river', $handler);
 
-		elgg_delete_river(['id' => $id]);
+		_elgg_delete_river(['id' => $id]);
 
 		elgg_unregister_plugin_hook_handler('permissions_check:delete', 'river', $handler);
 		elgg_unregister_event_handler('delete:before', 'river', $handler);

--- a/mod/blog/actions/blog/save.php
+++ b/mod/blog/actions/blog/save.php
@@ -164,7 +164,7 @@ if (!$error) {
 				$blog->save();
 			}
 		} elseif ($old_status == 'published' && $status == 'draft') {
-			elgg_delete_river(array(
+			_elgg_delete_river(array(
 				'object_guid' => $blog->guid,
 				'action_type' => 'create',
 			));


### PR DESCRIPTION
Fixes #10115

(For 3.0 we need to decide how/whether to migrate these usages.)
