### PR TITLE
fix(mysql): adds MySQL 5.7 compatibility

### DIFF
--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -154,6 +154,10 @@ class Database {
 
 		// Set DB for UTF8
 		mysql_query("SET NAMES utf8", $this->dbLinks[$dblinkname]);
+
+		// https://github.com/Elgg/Elgg/issues/8121
+		$sub_query = "SELECT REPLACE(@@SESSION.sql_mode, 'ONLY_FULL_GROUP_BY', '')";
+		mysql_query("SET SESSION sql_mode=($sub_query);", $this->dbLinks[$dblinkname]);
 	}
 
 	/**


### PR DESCRIPTION
Removes `ONLY_FULL_GROUP_BY` from MySQL's session `sql_mode`, as it's incompatible with our queries.

Fixes #8121
