### PR TITLE
chore(tests): actions service no longer calls time()

### DIFF
--- a/engine/classes/Elgg/ActionsService.php
+++ b/engine/classes/Elgg/ActionsService.php
@@ -17,6 +17,8 @@ use ElggSession;
  * @since      1.9.0
  */
 class ActionsService {
+
+	use \Elgg\TimeUsing;
 	
 	/**
 	 * @var Config
@@ -306,7 +308,7 @@ class ActionsService {
 	 */
 	protected function validateTokenTimestamp($ts) {
 		$timeout = $this->getActionTokenTimeout();
-		$now = time();
+		$now = $this->getCurrentTime()->getTimestamp();
 		return ($timeout == 0 || ($ts > $now - $timeout) && ($ts < $now + $timeout));
 	}
 
@@ -479,7 +481,7 @@ class ActionsService {
 			}
 		}
 
-		$ts = time();
+		$ts = $this->getCurrentTime()->getTimestamp();
 		$token = $this->generateActionToken($ts);
 		$data = array(
 			'token' => array(


### PR DESCRIPTION
Replaces calls to time() with TimeUsing trait to prevent tests
from breaking due to time discrepancies.

Fixes #10110
