### PR TITLE
chore(tests): metadata table no longer calls time

### DIFF
--- a/engine/classes/Elgg/Database/MetadataTable.php
+++ b/engine/classes/Elgg/Database/MetadataTable.php
@@ -19,6 +19,9 @@ use Elgg\Cache\MetadataCache as Cache;
  * @since      1.10.0
  */
 class MetadataTable {
+
+	use \Elgg\TimeUsing;
+	
 	/** @var array */
 	protected $independents = array();
 	
@@ -116,7 +119,7 @@ class MetadataTable {
 		$entity_guid = (int)$entity_guid;
 		// name and value are encoded in add_metastring()
 		$value_type = detect_extender_valuetype($value, $this->db->sanitizeString(trim($value_type)));
-		$time = time();
+		$time = $this->getCurrentTime()->getTimestamp();
 		$owner_guid = (int)$owner_guid;
 		$allow_multiple = (boolean)$allow_multiple;
 	

--- a/engine/tests/phpunit/Elgg/Mocks/Database/MetadataTable.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Database/MetadataTable.php
@@ -67,7 +67,7 @@ class MetadataTable extends DbMetadataTabe {
 			'owner_guid' => $entity->owner_guid,
 			'name' => $name,
 			'value' => $value,
-			'time_created' => time(),
+			'time_created' => $this->getCurrentTime()->getTimestamp(),
 			'access_id' => (int) $access_id,
 			'value_type' => detect_extender_valuetype($value, $this->db->sanitizeString(trim($value_type))),
 		];

--- a/engine/tests/phpunit/ElggMetadataTest.php
+++ b/engine/tests/phpunit/ElggMetadataTest.php
@@ -11,6 +11,7 @@ class ElggMetadataTest extends TestCase {
 		$this->setupTestingServices();
 		$this->setupMockServices();
 		_elgg_services()->db->clearQuerySpecs();
+		_elgg_services()->metadataTable->setCurrentTime();
 	}
 
 	public function testExtenderConstructor() {
@@ -97,7 +98,7 @@ class ElggMetadataTest extends TestCase {
 		$metadata->entity_guid = $object->guid;
 		$metadata->name = 'foo';
 		$metadata->value = 'bar';
-		$metadata->time_created = time();
+		$metadata->time_created = _elgg_services()->metadataTable->getCurrentTime()->getTimestamp();
 
 		$id = _elgg_services()->metadataTable->iterate();
 


### PR DESCRIPTION
Replaces time() with TimeUsing trait to prevent tests from breaking arbitrarily
