### PR TITLE
feature(forms): makes form views extendable by deferring footer rendering

### DIFF
--- a/docs/guides/actions.rst
+++ b/docs/guides/actions.rst
@@ -198,7 +198,10 @@ Put the content of your form in your plugin’s ``forms/example`` view:
 
    // /mod/example/views/default/forms/example.php
    echo elgg_view('input/text', array('name' => 'example'));
-   echo elgg_view('input/submit');
+
+   // defer form footer rendering
+   // this will allow other plugins to extend forms/example view
+   elgg_set_form_footer(elgg_view('input/submit'));
 
 Now when you call ``elgg_view_form('example')``, Elgg will produce:
 
@@ -210,7 +213,9 @@ Now when you call ``elgg_view_form('example')``, Elgg will produce:
        <input type="hidden" name="__elgg_token" value="...">
  
        <input type="text" class="elgg-input-text" name="example">
-       <input type="submit" class="elgg-button elgg-button-submit" value="Submit">
+       <div class="elgg-foot elgg-form-footer">
+           <input type="submit" class="elgg-button elgg-button-submit" value="Submit">
+       </div>
      </fieldset>
    </form>
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -56,6 +56,13 @@ URLs can now be signed with a SHA-256 HMAC key and validated at any time before 
  * `elgg_http_validate_signed_url()` - validates the signed URL
  * `elgg_signed_request_gatekeeper()` - gatekeeper that validates the signature of the current request
 
+Extendable form views
+---------------------
+
+Form footer rendering can now be deferred until the form view and its extensions have finished rendering. This allows plugins to collaborate on form views without breaking the markup logic.
+
+ * ``elgg_set_form_footer()`` - sets form footer for deferred rendering
+ * ``elgg_get_form_footer()`` - returns currently set form footer
 
 From 2.1 to 2.2
 ===============

--- a/docs/tutorials/blog.rst
+++ b/docs/tutorials/blog.rst
@@ -51,55 +51,49 @@ See :doc:`Plugins</guides/plugins>` for more information
 about the manifest file.
 
 Create the form for creating a new blog post
-================================================
+============================================
 
 Create a file at ``/mod/my_blog/views/default/forms/my_blog/save.php``
-that contains the form body.
-The form should have input fields for the title, body and tags
-of the my_blog post. It does not need form tag markup.
+that contains the form body. The form should have input fields for the title,
+body and tags of the my_blog post. It does not need form tag markup.
 
 .. code-block:: php
 
-    <?php
-
-    // creates a field where you can write the blog post's title
     echo elgg_view_input('text', [
         'name' => 'title',
-        'label' => 'Title of your post',
+        'label' => elgg_echo('title'),
         'required' => true,
     ]);
 
-    // creates a field where you can write the blog post's content
     echo elgg_view_input('longtext', [
         'name' => 'body',
-        'label' => 'Content of your post',
+        'label' => elgg_echo('body'),
         'required' => true,
     ]);
 
-    // creates a field where you can write the blog post's tags
     echo elgg_view_input('tags', [
         'name' => 'tags',
-        'label' => 'Tags of your post',
+        'label' => elgg_echo('tags'),
+        'help' => elgg_echo('tags:help'),
     ]);
 
-    // creates a save button
-    echo elgg_view_input('submit', array(
-        'value' => 'Save your post',
+    $submit = elgg_view_input('submit', array(
+        'value' => elgg_echo('save'),
         'field_class' => 'elgg-foot',
     ));
+    elgg_set_form_footer($submit);
 
-The input fields are rendered by calling ``elgg_view_input``.
-This helper function maintains consistency in field markup,
-and is used as a shortcut for rendering field elements like label,
-help text, input and so on. See :doc:`/guides/actions` for more information.
-The name field is used to identify the data in the saving phase.
+
+Notice how the form is calling ``elgg_view_input()`` to render inputs. This helper
+function maintains consistency in field markup, and is used as a shortcut for
+rendering field elements, such as label, help text, and input. See :doc:`/guides/actions`.
 
 You can see a complete list of input views in the
-``/views/default/input/`` directory.
+``/vendor/elgg/elgg/views/default/input/`` directory.
 
-It is recommended that you make your plugin translatable by using
-``elgg_echo(textkey)`` whenever there is a string of text that will
-be shown to the user. Read more at :doc:`Internationalization</guides/i18n>`.
+It is recommended that you make your plugin translatable by using ``elgg_echo()``
+whenever there is a string of text that will be shown to the user. Read more at
+:doc:`Internationalization</guides/i18n>`.
 
 Create a page for composing the blogs
 =====================================

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -37,6 +37,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\EventsService                      $events
  * @property-read \Elgg\Assets\ExternalFiles               $externalFiles
  * @property-read \ElggFileCache                           $fileCache
+ * @property-read \Elgg\FormsService                       $forms
  * @property-read \Elgg\PluginHooksService                 $hooks
  * @property-read \Elgg\EntityIconService                  $iconService
  * @property-read \Elgg\Http\Input                         $input
@@ -214,6 +215,10 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 
 		$this->setFactory('fileCache', function(ServiceProvider $c) {
 			return new \ElggFileCache($c->config->getCachePath() . 'system_cache/');
+		});
+
+		$this->setFactory('forms', function(ServiceProvider $c) {
+			return new \Elgg\FormsService($c->views, $c->logger);
 		});
 
 		$this->setFactory('hooks', function(ServiceProvider $c) {

--- a/engine/classes/Elgg/FormsService.php
+++ b/engine/classes/Elgg/FormsService.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Elgg;
+
+/**
+ * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ *
+ * Use the elgg_* versions instead.
+ *
+ * @access private
+ * @since 2.3
+ */
+class FormsService {
+
+	/**
+	 * @var ViewsService
+	 */
+	private $views;
+
+	/**
+	 * @var Logger
+	 */
+	private $logger;
+
+	/**
+	 * @var bool
+	 */
+	private $rendering;
+
+	/**
+	 * @var string
+	 */
+	private $footer = '';
+
+	/**
+	 * Constructor
+	 *
+	 * @param ViewsService $views  Views service
+	 * @param Logger       $logger Logger service
+	 */
+	public function __construct(ViewsService $views, Logger $logger) {
+		$this->views = $views;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Convenience function for generating a form from a view in a standard location.
+	 *
+	 * This function assumes that the body of the form is located at "forms/$action" and
+	 * sets the action by default to "action/$action".  Automatically wraps the forms/$action
+	 * view with a <form> tag and inserts the anti-csrf security tokens.
+	 *
+	 * @tip This automatically appends elgg-form-action-name to the form's class. It replaces any
+	 * slashes with dashes (blog/save becomes elgg-form-blog-save)
+	 *
+	 * @example
+	 * <code>echo elgg_view_form('login');</code>
+	 *
+	 * This would assume a "login" form body to be at "forms/login" and would set the action
+	 * of the form to "http://yoursite.com/action/login".
+	 *
+	 * If elgg_view('forms/login') is:
+	 * <input type="text" name="username" />
+	 * <input type="password" name="password" />
+	 *
+	 * Then elgg_view_form('login') generates:
+	 * <form action="http://yoursite.com/action/login" method="post">
+	 *     ...security tokens...
+	 *     <input type="text" name="username" />
+	 *     <input type="password" name="password" />
+	 * </form>
+	 *
+	 * @param string $action    The name of the action. An action name does not include
+	 *                          the leading "action/". For example, "login" is an action name.
+	 * @param array  $form_vars $vars environment passed to the "input/form" view
+	 * @param array  $body_vars $vars environment passed to the "forms/$action" view
+	 *
+	 * @return string The complete form
+	 */
+	public function render($action, $form_vars = array(), $body_vars = array()) {
+
+		$defaults = array(
+			'action' => elgg_normalize_url("action/$action"),
+		);
+
+		// append elgg-form class to any class options set
+		$form_vars['class'] = (array) elgg_extract('class', $form_vars, []);
+		$form_vars['class'][] = 'elgg-form-' . preg_replace('/[^a-z0-9]/i', '-', $action);
+
+		$form_vars = array_merge($defaults, $form_vars);
+
+		$form_vars['action_name'] = $action;
+		
+		if (!isset($form_vars['body'])) {
+			$this->rendering = true;
+			$this->footer = '';
+
+			// Render form body
+			$body = $this->views->renderView("forms/$action", $body_vars);
+
+			if (!empty($body)) {
+				// Grab the footer if one was set during form rendering
+				$body .= $this->views->renderView('elements/forms/footer', [
+					'footer' => $this->getFooter(),
+					'action_name' => $action,
+				]);
+			}
+			
+			$this->rendering = false;
+
+			$form_vars['body'] = $body;
+		}
+
+		return elgg_view('input/form', $form_vars);
+	}
+
+	/**
+	 * Sets form footer and defers its rendering until the form view and extensions have been rendered.
+	 * Deferring footer rendering allows plugins to extend the form view while maintaining
+	 * logical DOM structure.
+	 * Footer will be rendered using 'elements/forms/footer' view after form body has finished rendering
+	 *
+	 * @param string $footer Footer
+	 * @return bool
+	 */
+	public function setFooter($footer = '') {
+
+		if (!$this->rendering) {
+			$this->logger->error('Form footer can only be set and retrieved during form rendering, '
+					. 'anywhere in elgg_view_form() call stack (e.g. form view, extending views, or view hooks)');
+			return false;
+		}
+
+		$this->footer = $footer;
+		return true;
+	}
+
+	/**
+	 * Returns currently set footer, or false if not in the form rendering stack
+	 * @return string|false
+	 */
+	public function getFooter() {
+		if (!$this->rendering) {
+			$this->logger->error('Form footer can only be set and retrieved during form rendering, '
+					. 'anywhere in elgg_view_form() call stack (e.g. form view, extending views, or view hooks)');
+			return false;
+		}
+
+		return $this->footer;
+	}
+
+}

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1306,21 +1306,28 @@ function elgg_view_river_item($item, array $vars = array()) {
  * @return string The complete form
  */
 function elgg_view_form($action, $form_vars = array(), $body_vars = array()) {
-	global $CONFIG;
+	return _elgg_services()->forms->render($action, $form_vars, $body_vars);
+}
 
-	$defaults = array(
-		'action' => $CONFIG->wwwroot . "action/$action",
-		'body' => elgg_view("forms/$action", $body_vars)
-	);
+/**
+ * Sets form footer and defers its rendering until the form view and extensions have been rendered.
+ * Deferring footer rendering allows plugins to extend the form view while maintaining
+ * logical DOM structure.
+ * Footer will be rendered using 'elements/forms/footer' view after form body has finished rendering
+ *
+ * @param string $footer Footer
+ * @return bool
+ */
+function elgg_set_form_footer($footer = '') {
+	return _elgg_services()->forms->setFooter($footer);
+}
 
-	// append elgg-form class to any class options set
-	$form_vars['class'] = (array) elgg_extract('class', $form_vars, []);
-	$form_vars['class'][] = 'elgg-form-' . preg_replace('/[^a-z0-9]/i', '-', $action);
-	
-	$form_vars = array_merge($defaults, $form_vars);
-	$form_vars['action_name'] = $action;
-
-	return elgg_view('input/form', $form_vars);
+/**
+ * Returns currently set footer, or false if not in the form rendering stack
+ * @return string|false
+ */
+function elgg_get_form_footer() {
+	return _elgg_services()->forms->getFooter();
 }
 
 /**

--- a/engine/tests/phpunit/Elgg/FormsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/FormsServiceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Elgg;
+
+/**
+ * @group FormsService
+ */
+class FormsServiceTest extends \PHPUnit_Framework_TestCase {
+
+	public function setUp() {
+		$views_dir = dirname(dirname(__FILE__)) . "/test_files/views";
+
+		_elgg_services()->views->autoregisterViews('', "$views_dir/default", 'default');
+	}
+
+	public function testCanRenderForm() {
+
+		$expected = elgg_view('forms/foo/bar.html');
+		$actual = elgg_view_form('foo/bar', [
+			'class' => 'foo-bar',
+		], [
+			'baz2' => 'bar2',
+		]);
+
+		$this->assertNotEmpty($expected);
+		$this->assertNotEmpty($actual);
+		$normalize = function ($html) {
+			return preg_replace('~>\s+~', ">", $html);
+		};
+		$this->assertEquals($normalize($expected), $normalize($actual));
+	}
+
+	public function testCanNotSetFooterOutsideFormView() {
+		_elgg_services()->logger->disable();
+
+		$this->assertFalse(_elgg_services()->forms->setFooter('footer'));
+		$logs = _elgg_services()->logger->enable();
+		$expected = [
+			[
+				'message' => 'Form footer can only be set and retrieved during form rendering, anywhere in elgg_view_form() call stack (e.g. form view, extending views, or view hooks)',
+				'level' => Logger::ERROR,
+			],
+		];
+		$this->assertEquals($expected, $logs);
+	}
+
+	public function testCanNotGetFooterOutsideFormView() {
+		_elgg_services()->logger->disable();
+		$this->assertFalse(_elgg_services()->forms->getFooter());
+
+		$expected = [
+			[
+				'message' => 'Form footer can only be set and retrieved during form rendering, anywhere in elgg_view_form() call stack (e.g. form view, extending views, or view hooks)',
+				'level' => Logger::ERROR,
+			]
+		];
+		$logs = _elgg_services()->logger->enable();
+		$this->assertEquals($expected, $logs);
+	}
+}

--- a/engine/tests/phpunit/Elgg/RouterTest.php
+++ b/engine/tests/phpunit/Elgg/RouterTest.php
@@ -1443,7 +1443,7 @@ class RouterTest extends \Elgg\TestCase {
 			'value' => elgg_view_form('query_view', [], $vars),
 			'_elgg_msgs' => (object) [],
 			'_elgg_deps' => [],
-		]);
+				], ELGG_JSON_ENCODING);
 
 		$this->assertEquals($output, $response->getContent());
 	}
@@ -1480,7 +1480,7 @@ class RouterTest extends \Elgg\TestCase {
 
 		$output = json_encode([
 			'error' => 'good bye',
-		]);
+				], ELGG_JSON_ENCODING);
 
 		$this->assertEquals($output, $response->getContent());
 	}

--- a/engine/tests/phpunit/test_files/views/default/elements/forms/footer.php
+++ b/engine/tests/phpunit/test_files/views/default/elements/forms/footer.php
@@ -1,0 +1,3 @@
+<?php
+
+echo $vars['footer'];

--- a/engine/tests/phpunit/test_files/views/default/forms/foo/bar.html
+++ b/engine/tests/phpunit/test_files/views/default/forms/foo/bar.html
@@ -1,0 +1,5 @@
+<form class="foo-bar elgg-form-foo-bar" action="http://localhost/action/foo/bar">
+	<input type="text" name="baz" />
+	<span>bar2</span><input type="text" name="baz3" />
+	<input type="submit" value="Save" />
+</form>

--- a/engine/tests/phpunit/test_files/views/default/forms/foo/bar.php
+++ b/engine/tests/phpunit/test_files/views/default/forms/foo/bar.php
@@ -1,0 +1,10 @@
+<input type="text" name="baz" />
+<?php
+
+echo elgg_format_element('span', [], $vars['baz2']);
+
+elgg_set_form_footer('<input type="submit" value="Save" />');
+
+?>
+
+<input type="text" name="baz3" />

--- a/engine/tests/phpunit/test_files/views/default/input/form.php
+++ b/engine/tests/phpunit/test_files/views/default/input/form.php
@@ -1,0 +1,10 @@
+<?php
+
+$class = elgg_extract('class', $vars);
+$action = elgg_extract('action', $vars);
+$body = elgg_extract('body', $vars);
+
+echo elgg_format_element('form', [
+	'class' => $class,
+	'action' => $action,
+		], $body);

--- a/mod/blog/views/default/forms/blog/save.php
+++ b/mod/blog/views/default/forms/blog/save.php
@@ -156,15 +156,16 @@ $categories_input
 	$status_input
 </div>
 
-<div class="elgg-foot">
-	<div class="elgg-subtext mbm">
-	$save_status <span class="blog-save-status-time">$saved</span>
-	</div>
-
-	$guid_input
-	$container_guid_input
-
-	$action_buttons
-</div>
+$guid_input
+$container_guid_input
 
 ___HTML;
+
+$footer = <<<___HTML
+<div class="elgg-subtext mbm">
+	$save_status <span class="blog-save-status-time">$saved</span>
+</div>
+$action_buttons
+___HTML;
+
+elgg_set_form_footer($footer);

--- a/mod/bookmarks/views/default/forms/bookmarks/save.php
+++ b/mod/bookmarks/views/default/forms/bookmarks/save.php
@@ -49,7 +49,6 @@ if ($categories) {
 		'entity_subtype' => 'bookmarks',
 	)); ?>
 </div>
-<div class="elgg-foot">
 <?php
 
 echo elgg_view('input/hidden', array('name' => 'container_guid', 'value' => $container_guid));
@@ -58,7 +57,8 @@ if ($guid) {
 	echo elgg_view('input/hidden', array('name' => 'guid', 'value' => $guid));
 }
 
-echo elgg_view('input/submit', array('value' => elgg_echo("save")));
+$footer = elgg_view_input('submit', [
+	'value' => elgg_echo('save'),
+]);
+elgg_set_form_footer($footer);
 
-?>
-</div>

--- a/mod/discussions/views/default/forms/discussion/reply/save.php
+++ b/mod/discussions/views/default/forms/discussion/reply/save.php
@@ -72,11 +72,14 @@ echo <<<FORM
 		<label>$reply_label</label>
 		$description_input
 	</div>
-	<div class="foot">
-		$reply_guid_input
-		$topic_guid_input
-		$submit_input $cancel_button
-	</div>
+	$reply_guid_input
+	$topic_guid_input
 FORM;
+
+	$footer = elgg_format_element('div', [
+		'class' => 'foot',
+			], $submit_input . ' ' . $cancel_button);
+
+	elgg_set_form_footer($footer);
 }
 

--- a/mod/discussions/views/default/forms/discussion/save.php
+++ b/mod/discussions/views/default/forms/discussion/save.php
@@ -62,11 +62,6 @@ $fields = [
 		'name' => 'topic_guid',
 		'value' => $guid,
 	],
-	[
-		'type' => 'submit',
-		'value' => elgg_echo('save'),
-		'field_class' => 'elgg-foot',
-	]
 ];
 
 foreach ($fields as $field) {
@@ -74,3 +69,8 @@ foreach ($fields as $field) {
 	unset($field['type']);
 	echo elgg_view_input($type, $field);
 }
+
+$footer = elgg_view_input('submit', [
+	'value' => elgg_echo('save'),
+]);
+elgg_set_form_footer($footer);

--- a/mod/file/views/default/forms/file/upload.php
+++ b/mod/file/views/default/forms/file/upload.php
@@ -82,11 +82,6 @@ $fields = [
 		'name' => 'file_guid',
 		'value' => $guid,
 	],
-	[
-		'type' => 'submit',
-		'value' => $submit_label,
-		'field_class' => 'elgg-foot',
-	]
 ];
 
 foreach ($fields as $field) {
@@ -97,3 +92,8 @@ foreach ($fields as $field) {
 	}
 	echo elgg_view_input($type, $field);
 }
+
+$footer = elgg_view_input('submit', [
+	'value' => elgg_echo('save'),
+]);
+elgg_set_form_footer($footer);

--- a/mod/groups/views/default/forms/groups/edit.php
+++ b/mod/groups/views/default/forms/groups/edit.php
@@ -21,10 +21,6 @@ echo elgg_view("groups/edit/access", $vars);
 echo elgg_view("groups/edit/tools", $vars);
 
 // display the save button and some additional form data
-?>
-<div class="elgg-foot">
-<?php
-
 if ($entity) {
 	echo elgg_view("input/hidden", array(
 		"name" => "group_guid",
@@ -32,11 +28,13 @@ if ($entity) {
 	));
 }
 
-echo elgg_view("input/submit", array("value" => elgg_echo("save")));
+$footer = elgg_view_input('submit', [
+	'value' => elgg_echo('save'),
+]);
 
 if ($entity) {
 	$delete_url = "action/groups/delete?guid=" . $entity->getGUID();
-	echo elgg_view("output/url", array(
+	$footer .= elgg_view("output/url", array(
 		"text" => elgg_echo("groups:delete"),
 		"href" => $delete_url,
 		"confirm" => elgg_echo("groups:deletewarning"),
@@ -44,6 +42,6 @@ if ($entity) {
 	));
 }
 
+elgg_set_form_footer($footer);
+
 elgg_pop_context();
-?>
-</div>

--- a/views/default/elements/forms/footer.php
+++ b/views/default/elements/forms/footer.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Wrap form footer
+ * @uses $vars['footer']      Form footer
+ * @uses $vars['action_name'] Action name
+ */
+$footer = elgg_extract('footer', $vars);
+if (empty($footer)) {
+	return;
+}
+
+echo elgg_format_element('div', [
+	'class' => 'elgg-foot elgg-form-footer',
+		], $footer);


### PR DESCRIPTION
This makes form views extendable by allowing deferring of form footer (controls) rendering until after the form body view and its extensions have been rendered.

(replaces #9939)
- [x] exception in blog form
