### PR TITLE
WIP fix(logrotate): crashed log table no longer takes down site

### DIFF
--- a/engine/lib/system_log.php
+++ b/engine/lib/system_log.php
@@ -239,14 +239,14 @@ function system_log($object, $event) {
 
 		// Create log if we haven't already created it
 		if (!isset($log_cache[$time][$object_id][$event])) {
-			$query = "INSERT DELAYED into {$CONFIG->dbprefix}system_log
+			$query = "INSERT INTO {$CONFIG->dbprefix}system_log
 				(object_id, object_class, object_type, object_subtype, event,
 				performed_by_guid, owner_guid, access_id, enabled, time_created, ip_address)
 			VALUES
 				('$object_id','$object_class','$object_type', '$object_subtype', '$event',
 				$performed_by, $owner_guid, $access_id, '$enabled', '$time', '$ip_address')";
 
-			insert_data($query);
+			execute_delayed_write_query($query);
 
 			$log_cache[$time][$object_id][$event] = true;
 			$cache_size += 1;

--- a/mod/logrotate/languages/en.php
+++ b/mod/logrotate/languages/en.php
@@ -4,6 +4,8 @@ return array(
 
 	'logrotate:logrotated' => "Log rotated\n",
 	'logrotate:lognotrotated' => "Error rotating log\n",
+	'logrotate:table_crashed' => "The MySQL table %s has crashed. Check the error_log and MySQL log for details.",
+	'logrotate:table_crashed:subject' => "A MySQL table has crashed on %s",
 	
 	'logrotate:delete' => 'Delete archived logs older than a',
 

--- a/mod/logrotate/tests/LogRotateTest.php
+++ b/mod/logrotate/tests/LogRotateTest.php
@@ -1,0 +1,35 @@
+<?php
+
+class LogRotateTest extends ElggCoreUnitTest {
+
+	function testCanCatchTableCrashes() {
+		$match1 = "'./server/elgg_foo'";
+		$match0 = "Table $match1 is marked as crashed";
+		$notice_id = "crash_table_" . md5($match1);
+
+		$func = function () use ($match0) {
+			throw new DatabaseException("SQLSTATE[HY000]: General error: 145 {$match0} and should be repaired");
+		};
+
+		$this->assertFalse(elgg_admin_notice_exists($notice_id));
+		$this->assertSame(null, _logrotate_handle_crashed_table($func));
+		$this->assertTrue(elgg_admin_notice_exists($notice_id));
+
+		elgg_delete_admin_notice($notice_id);
+	}
+
+	function testPassesOnOtherExceptions() {
+		$msg = "SQLSTATE[HY000]: Bad query";
+
+		$func = function () use ($msg) {
+			throw new DatabaseException($msg);
+		};
+
+		try {
+			_logrotate_handle_crashed_table($func);
+			$this->fail();
+		} catch (DatabaseException $e) {
+			$this->assertSame($msg, $e->getMessage());
+		}
+	}
+}


### PR DESCRIPTION
Upon log rotation, a crashed log table generates an admin notice and sends an email to the oldest admin account (assuming that to be one in charge of maintaining the site).

Additionally, this back-ports #9493 to 1.12.

Fixes #10146
- [ ] agree on a scope for #10146
