### PR TITLE
fix(entities): classnames for entity subtypes can be up to 255 chars

### DIFF
--- a/engine/lib/upgrades/2016090100-2.2.0-wider_subtype_class-40b951c36343280b.php
+++ b/engine/lib/upgrades/2016090100-2.2.0-wider_subtype_class-40b951c36343280b.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Elgg 2.2.0 upgrade 2016090100
+ * wider_subtype_class
+ *
+ * Widen entity_subtypes.class to 255 chars.
+ */
+
+$db = _elgg_services()->db;
+$db->updateData("
+	ALTER TABLE {$db->prefix}entity_subtypes
+	MODIFY `class` VARCHAR(255) NOT NULL DEFAULT '';
+");

--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -107,7 +107,7 @@ CREATE TABLE `prefix_entity_subtypes` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `type` enum('object','user','group','site') NOT NULL,
   `subtype` varchar(50) NOT NULL,
-  `class` varchar(50) NOT NULL DEFAULT '',
+  `class` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   UNIQUE KEY `type` (`type`,`subtype`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2015062900;
+$version = 2016090100;
 
 $composerJson = file_get_contents(dirname(__FILE__) . "/composer.json");
 if ($composerJson === false) {


### PR DESCRIPTION
Fixes #6802
