### PR TITLE
fix(members): Don't rely on newest members tab set as default tab in pagehandler for members page

### DIFF
--- a/mod/members/start.php
+++ b/mod/members/start.php
@@ -107,7 +107,7 @@ function members_nav_popular($hook, $type, $returnvalue, $params) {
 function members_nav_newest($hook, $type, $returnvalue, $params) {
 	$returnvalue['newest'] = array(
 		'title' => elgg_echo('sort:newest'),
-		'url' => "members",
+		'url' => "members/newest",
 	);
 	return $returnvalue;
 }


### PR DESCRIPTION
See also discussion at https://elgg.org/discussion/view/2536482/need-example-of-hooks-usage.

If you want to make another tab than the newest member tab the default (by registering your custom pagehandler), the newest members tab won't load anymore. With this fix the full url is set also for the newest member tab in the corresponding 'members:config', 'tabs' callback function.
