### PR TITLE
fix(views): input/select view can select options more reliably

### DIFF
--- a/views/default/input/select.php
+++ b/views/default/input/select.php
@@ -82,17 +82,23 @@ if ($options_values) {
 	if (is_array($options)) {
 		foreach ($options as $option) {
 
-			$option_attrs = ['selected' => in_array((string)$option, $value)];
-
 			if (is_array($option)) {
 				$text = elgg_extract('text', $option, '');
 				unset($option['text']);
+
 				if (!$text) {
 					elgg_log('No text defined for input/select option', 'ERROR');
 				}
 
+				$option_attrs = [
+					'selected' => in_array((string)$text, $value),
+				];
 				$option_attrs = array_merge($option_attrs, $option);
 			} else {
+				$option_attrs = [
+					'selected' => in_array((string)$option, $value),
+				];
+
 				$text = $option;
 			}
 


### PR DESCRIPTION
If `$vars['options']` is given as an array and an element `$option` is also an array, we no longer emit a notice and properly set the `selected` attribute based on `$option['text']`.

Fixes #10154
