### PR TITLE
chore(composer): fixes deprecated type hint for post-package-update script

### DIFF
--- a/engine/classes/Elgg/Composer/PostUpdate.php
+++ b/engine/classes/Elgg/Composer/PostUpdate.php
@@ -1,7 +1,7 @@
 <?php
 namespace Elgg\Composer;
 
-use Composer\Script\Event;
+use Composer\Script\PackageEvent;
 
 /**
  * A composer command handler to run after post-package-update event


### PR DESCRIPTION
Fixes the deprecation Notice:

> The callback accepts a Composer\Script\Event but post-package-update events use a Composer\Script\PackageEvent instance. Please adjust your type hint accordingly, see https://getcomposer.org/doc/articles/scripts.md#event-classes
