### PR TITLE
fix(docs): Fixed link to 'our supporters page'

### DIFF
--- a/docs/contribute/money.rst
+++ b/docs/contribute/money.rst
@@ -13,7 +13,7 @@ For only $50 per year for individuals or $150 per year for organizations,
 you can get listed as a supporter on `our supporters page`_.
 Elgg supporters are listed there unless they request not to be.
 
-.. _our supporters page: http://elgg.org/supporters.php
+.. _our supporters page: http://elgg.org/supporter.php
 
 Supporters are able to put this official logo on their site if they wish:
 


### PR DESCRIPTION
The link to the supporters page was supporters.php.
That was showing a page not found error.
The current file is supporter.php.
