### PR TITLE
feat(ckeditor): better control over ckeditor initialization and behavior

### DIFF
--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -674,8 +674,22 @@ Note that WYSIWYG will be automatically attached to all instances of ``.elgg-inp
 
 .. code:: js
 
-   require(['elgg/ckeditor'], function (editor) {
-       editor.bind('.my-text-area');
+   require(['elgg/ckeditor'], function (elggCKEditor) {
+      elggCKEditor.bind('#my-text-area');
+
+      // Toggle CKEditor
+      elggCKEditor.toggle('#my-text-area');
+
+      // Focus on CKEditor input
+      elggCKEditor.focus('#my-text-area');
+      // or
+      $('#my-text-area').trigger('focus');
+
+      // Reset CKEditor input
+      elggCKEditor.reset('#my-text-area');
+      // or
+      $('#my-text-area').trigger('reset');
+
    });
 
 Traditional scripts

--- a/mod/ckeditor/views/default/ckeditor/init.php
+++ b/mod/ckeditor/views/default/ckeditor/init.php
@@ -4,6 +4,9 @@
  * 
  * Doing this inline enables the editor to initialize textareas loaded through ajax
  */
+if (!elgg_extract('editor', $vars, true)) {
+	return;
+}
 ?>
 <script>
 	require(['elgg/ckeditor'], function (elggCKEditor) {

--- a/mod/ckeditor/views/default/elgg/ckeditor.js
+++ b/mod/ckeditor/views/default/elgg/ckeditor.js
@@ -17,10 +17,6 @@ define(function (require) {
 	var config = require('elgg/ckeditor/config');
 
 	var elggCKEditor = {
-		/**
-		 * A flag that indicates whether handlers were registered
-		 */
-		ready: false,
 		bind: function (selector) {
 			elggCKEditor.registerHandlers();
 			CKEDITOR = elgg.trigger_hook('prepare', 'ckeditor', null, CKEDITOR);
@@ -28,19 +24,35 @@ define(function (require) {
 			if ($(selector).length === 0) {
 				return;
 			}
-			$(selector)
-					.not('[data-cke-init]')
+			$(selector).not('[data-cke-init]')
 					.attr('data-cke-init', true)
-					.ckeditor(elggCKEditor.init, elggCKEditor.config);
+					.each(function () {
+						var opts = $(this).data('editorOpts') || {};
+
+						if (opts.disabled) {
+							// Editor has been disabled
+							return;
+						}
+						delete opts.disabled;
+
+						var visual = opts.state !== 'html';
+						delete opts.state;
+
+						var config = $.extend({}, elggCKEditor.config, opts);
+						$(this).data('elggCKEeditorConfig', config);
+
+						if (!visual) {
+							elggCKEditor.init(this, visual);
+						} else {
+							$(this).ckeditor(elggCKEditor.init, config);
+						}
+					});
 		},
 		/**
 		 * Register event and hook handlers
 		 * @return void
 		 */
 		registerHandlers: function () {
-			if (elggCKEditor.ready) {
-				return;
-			}
 			elgg.register_hook_handler('prepare', 'ckeditor', function (hook, type, params, CKEDITOR) {
 				CKEDITOR.plugins.addExternal('blockimagepaste', elgg.get_simplecache_url('elgg/ckeditor/blockimagepaste.js'), '');
 				CKEDITOR.on('instanceReady', elggCKEditor.fixImageAttributes);
@@ -59,10 +71,11 @@ define(function (require) {
 					}
 				}
 			});
-			elggCKEditor.ready = true;
+			elggCKEditor.registerHandlers = elgg.nullFunction;
 		},
 		/**
 		 * Toggles the CKEditor
+		 * Callback function for toggler click event
 		 *
 		 * @param {Object} event
 		 * @return void
@@ -70,23 +83,92 @@ define(function (require) {
 		toggleEditor: function (event) {
 			event.preventDefault();
 			var target = $(this).attr('href');
-			if (!$(target).data('ckeditorInstance')) {
-				$(target).ckeditor(elggCKEditor.init, elggCKEditor.config);
-				$(this).html(elgg.echo('ckeditor:html'));
-			} else {
-				$(target).ckeditorGet().destroy();
-				$(this).html(elgg.echo('ckeditor:visual'));
+			elggCKEditor.toggle($(target)[0]);
+		},
+		/**
+		 * Toggles the CKEditor
+		 *
+		 * @param {Object} textarea DOM element
+		 * @returns {void}
+		 */
+		toggle: function (textarea) {
+			$(textarea).each(function() {
+				if (!$(this).data('ckeditorInstance')) {
+					$(this).ckeditor(elggCKEditor.init, $(this).data('elggCKEeditorConfig'));
+					$(this).data('toggler').html(elgg.echo('ckeditor:html'));
+				} else {
+					$(this).ckeditorGet().destroy();
+					$(this).data('toggler').html(elgg.echo('ckeditor:visual'));
+				}
+			});
+		},
+		/**
+		 * Resets the CKEditor
+		 * Callback function for the reset event
+		 *
+		 * @param {Object} event
+		 * @return void
+		 */
+		resetEditor: function (event) {
+			event.preventDefault();
+			elggCKEditor.reset(this);
+		},
+		/**
+		 * Resets the CKEditor
+		 *
+		 * @param {Object} textarea DOM element
+		 * @returns {void}
+		 */
+		reset: function (textarea) {
+			$(textarea).each(function() {
+				if ($(textarea).data('ckeditorInstance')) {
+					$(textarea).ckeditorGet().setData('');
+				}
+			});
+		},
+		/**
+		 * Focuses the CKEditor
+		 * Callback function for the focus event
+		 *
+		 * @param {Object} event
+		 * @return void
+		 */
+		focusEditor: function (event) {
+			event.preventDefault();
+			elggCKEditor.focus(this);
+		},
+		/**
+		 * Focuses the CKEditor
+		 *
+		 * @param {Object} textarea DOM element
+		 * @returns {void}
+		 */
+		focus: function (textarea) {
+			if ($(textarea).first().data('ckeditorInstance')) {
+				$(textarea).ckeditorGet().focus();
 			}
 		},
 		/**
 		 * Initializes the ckeditor module
 		 *
-		 * @param {Object} textarea DOM element passed by ckeditor on init
+		 * @param {Object}  textarea DOM element passed by ckeditor on init
+		 * @param {Boolean} visual
 		 * @return void
 		 */
-		init: function (textarea) {
+		init: function (textarea, visual) {
+			var $toggler = $(textarea).data('toggler');
+
+			if (!$toggler) {
+				$toggler = $('.ckeditor-toggle-editor[href="#' + textarea.id + '"]');
+				$(textarea).data('toggler', $toggler);
+			}
+
+			if (!visual) {
+				$toggler.html(elgg.echo('ckeditor:visual'));
+			}
+
 			// show the toggle-editor link which is hidden by default, so it will only show up if the editor is correctly loaded
-			$('.ckeditor-toggle-editor[href="#' + textarea.id + '"]').show();
+			$toggler.show();
 		},
 		/**
 		 * CKEditor has decided using width and height as attributes on images isn't
@@ -129,6 +211,10 @@ define(function (require) {
 	elggCKEditor.bind('.elgg-input-longtext');
 
 	$(document).on('click', '.ckeditor-toggle-editor', elggCKEditor.toggleEditor);
+
+	$(document).on('reset', '[data-cke-init]', elggCKEditor.resetEditor);
+
+	$(document).on('focus', '[data-cke-init]', elggCKEditor.focusEditor);
 
 	return elggCKEditor;
 });

--- a/mod/developers/views/default/theme_sandbox/forms.php
+++ b/mod/developers/views/default/theme_sandbox/forms.php
@@ -164,6 +164,22 @@ $ipsum = elgg_view('developers/ipsum');
 			'label' => 'Long textarea input (.elgg-input-longtext):',
 		));
 
+		echo elgg_view_input('longtext', array(
+			'name' => 'f14a',
+			'id' => 'f14a',
+			'value' => $ipsum,
+			'editor' => false,
+			'label' => 'Long textarea input (.elgg-input-longtext) with a disabled editor:',
+		));
+
+		echo elgg_view_input('longtext', array(
+			'name' => 'f14b',
+			'id' => 'f14b',
+			'value' => $ipsum,
+			'visual' => false,
+			'label' => 'Long textarea input (.elgg-input-longtext) without a visual editor activated by default:',
+		));
+
 		echo elgg_view_input('number', array(
 			'name' => 'f15',
 			'id' => 'f15',

--- a/views/default/input/longtext.php
+++ b/views/default/input/longtext.php
@@ -9,6 +9,13 @@
  * @uses $vars['value']    The current value, if any - will be html encoded
  * @uses $vars['disabled'] Is the input field disabled?
  * @uses $vars['class']    Additional CSS class
+ * @uses $vars['editor']   Enable WYSIWYG support
+ *                         Requires a plugin that implements a WYWIWYG library
+ *                         (e.g. bundled ckeditor plugin)
+ * @uses $vars['visual']   Activate WYSIWYG editor immediately
+ *                         If disabled, will display a plaintext input with
+ *                         a link to activate the visual editor
+ * @uses $vars['editor_options'] Additional options to pass to the editor
  */
 
 $vars['class'] = elgg_extract_class($vars, 'elgg-input-longtext');
@@ -21,6 +28,16 @@ $defaults = array(
 );
 
 $vars = array_merge($defaults, $vars);
+
+$editor_opts = (array) elgg_extract('editor_options', $vars, []);
+$editor_opts['disabled'] = !elgg_extract('editor', $vars, true);
+$editor_opts['state'] = elgg_extract('visual', $vars, true) ? 'visual' : 'html';
+
+unset($vars['editor_options']);
+unset($vars['editor']);
+unset($vars['visual']);
+
+$vars['data-editor-opts'] = json_encode($editor_opts);
 
 $value = htmlspecialchars($vars['value'], ENT_QUOTES, 'UTF-8');
 unset($vars['value']);


### PR DESCRIPTION
Individual longtext inputs can now be configured independently.
Adds an option to disalbe an editor for a longtext input.
Adds an option to bind an editor but not activate it until toggled by the user
Adds jQuery events that can be triggered on the original textarea to focus or reset the CKEditor instance.
Adds elgg/ckeditor#reset and elgg/ckeditor#focus to reset/focus programmatically

Fixes #9391
