### PR TITLE
WIP feature(http): adds API for streaming messages to clients

### DIFF
--- a/channel-messages.php
+++ b/channel-messages.php
@@ -1,0 +1,9 @@
+<?php
+
+$autoload_path = __DIR__ . '/vendor/autoload.php';
+$autoload_available = include_once($autoload_path);
+if (!$autoload_available) {
+	die("Couldn't include '$autoload_path'. Did you run `composer install`?");
+}
+
+(new \Elgg\Channels\PollServer())->serve($_POST, $_COOKIE, __DIR__);

--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -585,6 +585,14 @@ Other
 	"container_guid" (int) are provided. An empty entity value generally means the form is to
 	create a new object.
 
+**elgg_channels:send, <channel_name>**
+	Filters the data array sent the to clients by ``elgg()->channels->sendMessage()``. Handlers
+	should return ``false`` if you send the message to the client by another method.
+
+**elgg_channels:setupClient, <channel_name>**
+	Triggered by ``elgg()->channels->setupClient()``. Return ``false`` if you setup the client
+	connection by another method.
+
 **entity:icon:sizes, <entity_type>**
 	Triggered by ``elgg_get_icon_sizes()`` and sets entity type/subtype specific icon sizes.
 	``entity_subtype`` will be passed with the ``$params`` array to the callback.

--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -793,6 +793,9 @@ Available hooks
 **insert, editor**
     This hook is triggered by the embed plugin and can be used to filter content before it is inserted into the textarea. This hook can also be used by WYSIWYG editors to insert content using their own API (in this case the handler should return ``false``). See ckeditor plugin for an example.
 
+**channels:message, <channel_name>**
+    This hook receives Message objects from the PHP API ``elgg()->channels->sendMessage()``. The type is the channel name.
+
 Third-party assets
 ==================
 

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -15,6 +15,7 @@ use Elgg\Filesystem\Directory;
  *
  * @since 2.0.0
  *
+ * @property-read \Elgg\Channels\Api $channels
  * @property-read \Elgg\Menu\Service $menus
  * @property-read \Elgg\Views\TableColumn\ColumnFactory $table_columns
  */
@@ -44,6 +45,7 @@ class Application {
 	 */
 	private static $public_services = [
 		//'config' => true,
+		'channels' => true,
 		'menus' => true,
 		'table_columns' => true,
 	];

--- a/engine/classes/Elgg/Channels/Api.php
+++ b/engine/classes/Elgg/Channels/Api.php
@@ -1,0 +1,225 @@
+<?php
+namespace Elgg\Channels;
+
+use Elgg\Database;
+use Elgg\Database\Datalist;
+use ElggCrypto;
+use Elgg\PluginHooksService;
+
+class Api {
+
+	/**
+	 * @var string
+	 */
+	protected $hmac_key;
+
+	/**
+	 * @var string
+	 */
+	protected $session_id;
+
+	/**
+	 * @var Database
+	 */
+	protected $db;
+
+	/**
+	 * @var PluginHooksService
+	 */
+	protected $hooks;
+
+	/**
+	 * @var int[]
+	 */
+	protected $channel_id_cache = [];
+
+	/**
+	 * @var array (channels are keys)
+	 */
+	protected $client_channels = [];
+
+	/**
+	 * Constructor
+	 *
+	 * @param string             $hmac_key   HMAC key
+	 * @param string             $session_id Session ID
+	 * @param PluginHooksService $hooks      Hooks service
+	 * @param Database           $db         Database
+	 * @access private
+	 * @internal
+	 */
+	public function __construct($hmac_key, $session_id, PluginHooksService $hooks, Database $db) {
+		$this->hmac_key = $hmac_key;
+		$this->session_id = $session_id;
+		$this->hooks = $hooks;
+		$this->db = $db;
+	}
+
+	/**
+	 * Send a message to a push channel, auto-creates the channel if necessary
+	 *
+	 * @param string $channel Channel name
+	 * @param array  $data    JSON-serializable data (not false)
+	 *
+	 * @return void
+	 */
+	public function sendMessage($channel, array $data) {
+		$channel = trim($channel);
+
+		$params = [
+			'channel' => $channel,
+			'original_data' => $data,
+		];
+		$data = $this->hooks->trigger('elgg_channels:send', $channel, $params, $data);
+		if ($data === false) {
+			return;
+		}
+
+		$channel_id = $this->getChannelId($channel);
+		$json = json_encode($data, JSON_UNESCAPED_SLASHES);
+
+		$this->db->insertData("
+			INSERT INTO {$this->db->prefix}channel_messages
+			(channel_id, data, time_created) VALUES
+			(:channel_id, :data, :time_created)
+		", [
+			':channel_id' => $channel_id,
+			':data' => $json,
+			':time_created' => time(),
+		]);
+	}
+
+	/**
+	 * Prepare the client for requesting new messages on this channel
+	 *
+	 * @param string $channel Channel name
+	 *
+	 * @return void
+	 */
+	public function setupClient($channel) {
+		$channel = trim($channel);
+
+		$params = [
+			'channel' => $channel,
+		];
+		if (!$this->hooks->trigger('elgg_channels:setupClient', $channel, $params, true)) {
+			return;
+		}
+
+		if (!$this->session_id) {
+			// can't authenticate
+			return;
+		}
+
+		if (!$this->client_channels) {
+			// register for hook
+			$this->hooks->registerHandler('elgg.data', 'page', [$this, 'populateElggData']);
+			elgg_require_js('elgg/channels');
+		}
+
+		$channel = trim($channel);
+		$this->getChannelId($channel);
+		$this->client_channels[$channel] = true;
+	}
+
+	/**
+	 * Get the key to use for HMAC in authenticating connections
+	 *
+	 * @return string
+	 */
+	public function getHmacKey() {
+		return $this->hmac_key;
+	}
+
+	/**
+	 * Get a channel ID
+	 *
+	 * @param string $name Channel name
+	 *
+	 * @return int
+	 */
+	protected function getChannelId($name) {
+		$name = trim($name);
+
+		if (empty($this->channel_id_cache[$name])) {
+			$row = $this->db->getDataRow("
+				SELECT id
+				FROM {$this->db->prefix}channels
+				WHERE name = :name
+			", null, [':name' => $name]);
+
+			if (!$row) {
+				$id = $this->db->insertData("
+					INSERT INTO {$this->db->prefix}channels
+					(name) VALUES (:name)
+				", [':name' => $name]);
+
+				$row = (object)[
+					'id' => $id,
+				];
+			}
+
+			$this->channel_id_cache[$name] = (int)$row->id;
+		}
+
+		return $this->channel_id_cache[$name];
+	}
+
+	/**
+	 * Send channel data to the client
+	 *
+	 * @param string $hook   "elgg.data"
+	 * @param string $type   "page"
+	 * @param array  $value  Value
+	 * @param array  $params Hook params
+	 *
+	 * @return array
+	 * @access private
+	 * @internal
+	 */
+	public function populateElggData($hook, $type, $value, $params) {
+		foreach (array_keys($this->client_channels) as $channel) {
+			$id = $this->getChannelId($channel);
+
+			// TODO can do this in 1 query
+			$row = $this->db->getDataRow("
+				SELECT id
+				FROM {$this->db->prefix}channel_messages
+				WHERE channel_id = :channel_id
+				ORDER BY id DESC
+				LIMIT 1
+			", null, [':channel_id' => $id]);
+
+			$last_message_id = $row ? (int)$row->id : 0;
+
+			$value['elgg_channels']['channels'][] = [
+				'name' => $channel,
+				'id' => $id,
+				'mac' => hash_hmac('sha256', "$id,{$this->session_id}", $this->hmac_key),
+				'last_message_id' => $last_message_id,
+			];
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Get/Populate the HMAC key
+	 *
+	 * @param Datalist   $datalist Datalist service
+	 * @param ElggCrypto $crypto   Crypto service
+	 *
+	 * @return string
+	 * @access private
+	 * @internal
+	 */
+	public static function initHmacKey(Datalist $datalist, ElggCrypto $crypto) {
+		$name = 'channels_hmac_key';
+		$key = $datalist->get($name);
+		if (!$key) {
+			$key = $crypto->getRandomString(40);
+			$datalist->set($name, $key);
+		}
+		return $key;
+	}
+}

--- a/engine/classes/Elgg/Channels/PollServer.php
+++ b/engine/classes/Elgg/Channels/PollServer.php
@@ -1,0 +1,101 @@
+<?php
+namespace Elgg\Channels;
+
+use Elgg\Database\PdoFactory;
+
+class PollServer {
+	const MAX_CHANNELS_PER_REQUEST = 50;
+
+	/**
+	 * Handle a push API request
+	 *
+	 * @param array  $post      $_POST array
+	 * @param array  $cookie    $_COOKIE array
+	 * @param string $root_path Path to Elgg installation
+	 *
+	 * @return void
+	 */
+	public function serve(array $post, array $cookie, $root_path) {
+
+		list ($pdo, $prefix) = (new PdoFactory())->fromRootPath($root_path, 'read');
+		/* @var \PDO $pdo */
+
+		$pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+		if (empty($cookie['Elgg']) || !is_string($cookie['Elgg'])) {
+			die('Session cookie missing/invalid');
+		}
+
+		if (empty($post['channels'])
+				|| !is_array($post['channels'])
+				|| count($post['channels']) > self::MAX_CHANNELS_PER_REQUEST) {
+			die('Invalid request');
+		}
+
+		$channels = [];
+		foreach ($post['channels'] as $channel) {
+			if (!is_string($channel)) {
+				die('Invalid request');
+			}
+			$parts = explode(',', $channel);
+			if (count($parts) !== 3) {
+				die('Invalid request');
+			}
+			$channels[] = [
+				'id' => (int)$parts[0],
+				'given_mac' => $parts[1],
+				'last_message_id' => (int)$parts[2],
+			];
+		}
+
+		$sql = "
+			SELECT d.value
+			FROM {$prefix}datalists d
+			WHERE d.name = 'channels_hmac_key'
+		";
+		$row = $pdo->query($sql, \PDO::FETCH_ASSOC)->fetch();
+		if ($row) {
+			$hmac_key = $row['value'];
+		} else {
+			die('No HMAC key set');
+		}
+
+		$wheres = [];
+		foreach ($channels as $channel) {
+			$wheres[] = "(m.channel_id = {$channel['id']} && m.id > {$channel['last_message_id']})";
+		}
+		$where = implode(' OR ', $wheres);
+		$sql = "
+			SELECT m.id, m.data, m.channel_id
+			FROM {$prefix}channel_messages m
+			WHERE $where
+			ORDER BY m.id
+		";
+		$stmt = $pdo->query($sql, \PDO::FETCH_ASSOC);
+		$data = [];
+		foreach ($stmt as $row) {
+			$data[$row['channel_id']][] = $row;
+		}
+
+		// assemble JSON by hand to avoid overhead of JSON-decoding MySQL rows and re-encoding
+		$channel_objs = array_map(function ($channel) use ($data, $hmac_key, $cookie) {
+			// validate MAC
+			$mac = hash_hmac('sha256', "{$channel['id']},{$cookie['Elgg']}", $hmac_key);
+			if ($mac !== $channel['given_mac']) {
+				die('Invalid MAC');
+			}
+
+			$messages = [];
+			if (!empty($data[$channel['id']])) {
+				$messages = array_map(function ($row) {
+					return "[{$row['id']}, {$row['data']}]";
+				}, $data[$channel['id']]);
+			}
+
+			return "{\"id\":{$channel['id']},\"messages\":[" . implode(',', $messages) . "]}";
+		}, $channels);
+
+		header('Content-Type: application/json;charset=utf-8');
+		echo "[" .implode(',', $channel_objs) . "]";
+	}
+}

--- a/engine/classes/Elgg/Database/Config.php
+++ b/engine/classes/Elgg/Database/Config.php
@@ -83,18 +83,13 @@ class Config {
 	 * @return array
 	 */
 	public function getConnectionConfig($type = self::READ_WRITE) {
-		$config = array();
 		switch ($type) {
 			case self::READ:
 			case self::WRITE:
-				$config = $this->getParticularConnectionConfig($type);
-				break;
+				return $this->getParticularConnectionConfig($type);
 			default:
-				$config = $this->getGeneralConnectionConfig();
-				break;
+				return $this->getGeneralConnectionConfig();
 		}
-
-		return $config;
 	}
 
 	/**

--- a/engine/classes/Elgg/Database/PdoFactory.php
+++ b/engine/classes/Elgg/Database/PdoFactory.php
@@ -1,0 +1,52 @@
+<?php
+namespace Elgg\Database;
+
+use Elgg\Database\Config as DbConfig;
+
+/**
+ * Builds a PDO object from Elgg's settings
+ */
+class PdoFactory {
+
+	/**
+	 * Build a PDO by loading the settings.php file.
+	 *
+	 * <code>
+	 * list ($pdo, $prefix) = $factory->fromRootPath('/var/www/elgg');
+	 * </code>
+	 *
+	 * @param string $root_path Root path of Elgg installation
+	 * @param string $type      "readwrite", "read", or "write"
+	 *
+	 * @return [\PDO $pdo, string $dbprefix]
+	 */
+	public function fromRootPath($root_path, $type = DbConfig::READ_WRITE) {
+		global $CONFIG;
+
+		// may already be loaded
+		if (!isset($CONFIG->dbprefix)) {
+			if (file_exists("$root_path/elgg-config/settings.php")) {
+				require "$root_path/elgg-config/settings.php";
+			} elseif (file_exists("$root_path/engine/settings.php")) {
+				require "$root_path/engine/settings.php";
+			} else {
+				throw new \RuntimeException('Cannot locate settings.php');
+			}
+		}
+
+		$db_config = new DbConfig($CONFIG);
+		if ($db_config->isDatabaseSplit()) {
+			$arr = $db_config->getConnectionConfig(DbConfig::READ);
+		} else {
+			$arr = $db_config->getConnectionConfig(DbConfig::READ_WRITE);
+		}
+
+		$pdo = new \PDO(
+			"mysql:host={$arr['host']};dbname={$arr['database']};charset=utf8",
+			$arr['user'],
+			$arr['password']
+		);
+
+		return [$pdo, $CONFIG->dbprefix];
+	}
+}

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -22,6 +22,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\Database\Annotations               $annotations
  * @property-read \ElggAutoP                               $autoP
  * @property-read \Elgg\BootService                        $boot
+ * @property-read \Elgg\Channels\Api                       $channels
  * @property-read \Elgg\ClassLoader                        $classLoader
  * @property-read \Elgg\AutoloadManager                    $autoloadManager
  * @property-read \ElggCrypto                              $crypto
@@ -145,6 +146,11 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 				$boot->setTimer($c->timer);
 			}
 			return $boot;
+		});
+
+		$this->setFactory('channels', function(ServiceProvider $c) {
+			$hmac_key = \Elgg\Channels\Api::initHmacKey($c->datalist, $c->crypto);
+			return new \Elgg\Channels\Api($hmac_key, $c->session->getId(), $c->hooks, $c->db);
 		});
 
 		$this->setValue('config', $config);

--- a/engine/lib/upgrades/2016091900-2.2.0-push_api-ed5c5677705b87fb.php
+++ b/engine/lib/upgrades/2016091900-2.2.0-push_api-ed5c5677705b87fb.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Elgg 2.2.0 upgrade 2016091900
+ * push_api
+ *
+ * Create tables for Push API channels
+ */
+
+// upgrade code here.
+$db = _elgg_services()->db;
+
+$db->updateData("
+	CREATE TABLE IF NOT EXISTS {$db->prefix}channels (
+	  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+	  `name` varchar(255) NOT NULL,
+	  `retire_if_unused` tinyint(1) NOT NULL DEFAULT 0,
+	  PRIMARY KEY (`id`),
+	  UNIQUE KEY `name` (`name`)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+");
+
+$db->updateData("
+	CREATE TABLE IF NOT EXISTS {$db->prefix}channel_messages (
+	  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+	  `channel_id` bigint(20) unsigned NOT NULL,
+	  `data` TEXT NOT NULL,
+	  `time_created` int(11) NOT NULL,
+	  PRIMARY KEY (`id`),
+	  KEY `channel_id` (`channel_id`)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+");

--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -50,6 +50,25 @@ CREATE TABLE `prefix_api_users` (
   UNIQUE KEY `api_key` (`api_key`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
+-- push API channels
+CREATE TABLE `prefix_channels` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `retire_if_unused` tinyint(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- push API messages
+CREATE TABLE `prefix_channel_messages` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `channel_id` bigint(20) unsigned NOT NULL,
+  `data` TEXT NOT NULL,
+  `time_created` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `channel_id` (`channel_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 -- site specific configuration
 CREATE TABLE `prefix_config` (
   `name` varchar(255) NOT NULL,

--- a/mod/likes/actions/likes/add.php
+++ b/mod/likes/actions/likes/add.php
@@ -38,6 +38,21 @@ if (!$annotation_id) {
 	forward(REFERER);
 }
 
+// TODO REMOVE ME
+// This sends a message to the likes channel for this entity
+	$owner = $entity->getOwnerEntity();
+	/* @var ElggUser $owner */
+
+	elgg()->channels->sendMessage("{$entity->guid}-likes", [
+		'id' => $annotation_id,
+		'owner' => [
+			'guid' => $owner->guid,
+			'username' => $owner->username,
+			'name' => $owner->name,
+			'icon' => $owner->getIconURL(['size' => 'tiny']),
+		],
+	]);
+
 // notify if poster wasn't owner
 if ($entity->owner_guid != $user->guid) {
 	$owner = $entity->getOwnerEntity();

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2016090100;
+$version = 2016091900;
 
 $composerJson = file_get_contents(dirname(__FILE__) . "/composer.json");
 if ($composerJson === false) {

--- a/views/default/elgg/channels.js
+++ b/views/default/elgg/channels.js
@@ -1,0 +1,141 @@
+/**
+ * By default, this delivers messages from `elgg()->channels->sendMessage()` to the
+ * client-side plugin hook ["channels:message", "<channel_name>"]
+ */
+define(function (require) {
+	var elgg = require('elgg');
+	var	$ = require('jquery');
+
+	var URL = elgg.get_site_url() + 'channel-messages.php',
+
+		delay = 10000,
+		// when we receive a change, we decrease delay to minDelay and slowly increase it to targetDelay
+		targetDelay = 60000,
+		minDelay = 3000,
+		waiting = false,
+		stopped = true,
+
+		/**
+		 * @type {Channel[]}
+		 */
+		channels = {};
+
+	function Channel(id, name, mac, last_message_id) {
+		this.id = id;
+		this.name = name;
+		this.last_message_id = last_message_id;
+
+		this.getRequestString = function () {
+			return id + ',' + mac + ',' + this.last_message_id;
+		};
+	}
+
+	function start() {
+		if (stopped) {
+			stopped = false;
+			scheduleNextRequest();
+		}
+	}
+
+	function throttleUp() {
+		delay = minDelay;
+	}
+
+	function scheduleNextRequest() {
+		setTimeout(makeRequest, delay);
+
+		var delta = (targetDelay - delay);
+		delay += delta * .1;
+	}
+
+	///**
+	// * Set the maximum expected delay (in ms) between polling requests
+	// *
+	// * @param {Number} suggestedDelay (ms)
+	// */
+	//function suggestDelay(suggestedDelay) {
+	//	suggestedDelay = Math.max(minDelay, suggestedDelay);
+	//	targetDelay = Math.min(targetDelay, suggestedDelay);
+	//}
+
+	function makeRequest() {
+		if (waiting) {
+			setTimeout(makeRequest, 1000);
+			return;
+		}
+
+		var data = {channels:[]};
+		$.each(channels, function (i, channel) {
+			data.channels.push(channel.getRequestString());
+		});
+
+		waiting = true;
+		$.ajax({
+			url: URL,
+			data: data,
+			method: 'POST',
+			dataType: 'json'
+		}).done(function (data) {
+			waiting = false;
+			var has_new_messages = false;
+
+			$.each(data, function (i, obj) {
+				if (!channels['id' + obj.id]) {
+					return;
+				}
+
+				var channel = channels['id' + obj.id];
+				$.each(obj.messages, function (i, msg) {
+					if (msg[0] > channel.last_message_id) {
+						var message = new Message(channel.name, msg[1]);
+						elgg.trigger_hook('channels:message', channel.name, null, message);
+						channel.last_message_id = msg[0];
+						has_new_messages = true;
+					}
+				});
+			});
+
+			if (has_new_messages) {
+				throttleUp();
+			}
+
+			if (!stopped) {
+				scheduleNextRequest();
+			}
+		});
+	}
+
+	/**
+	 * A message from a channel
+	 *
+	 * @param {String} channel
+	 * @param {*} data
+	 * @constructor
+	 */
+	function Message(channel, data) {
+		/**
+		 * @type {String} Channel name
+		 */
+		this.channel = channel;
+
+		/**
+		 * @type {*} Message data
+		 */
+		this.data = data;
+	}
+
+	if (elgg.data.elgg_channels) {
+		// page has called setupChannel()
+		$.each(elgg.data.elgg_channels.channels, function (i, obj) {
+			channels["id" + obj.id] = new Channel(obj.id, obj.name, obj.mac, obj.last_message_id);
+		});
+
+		start();
+	}
+
+	elgg.register_hook_handler('channels:message', 'all', function (h, t, p, v) {
+		console.log('New message:', v);
+	});
+
+	return {};
+});

--- a/views/default/page/elements/comments.php
+++ b/views/default/page/elements/comments.php
@@ -12,6 +12,13 @@
  * in this view
  */
 
+$entity = $vars['entity'];
+/* @var ElggEntity $entity */
+
+// TODO REMOVE ME
+// This sends the client data it needs to request later messages
+	elgg()->channels->setupClient("{$entity->guid}-likes");
+
 $show_add_form = elgg_extract('show_add_form', $vars, true);
 $full_view = elgg_extract('full_view', $vars, true);
 $limit = elgg_extract('limit', $vars, get_input('limit', 0));
@@ -30,7 +37,7 @@ unset($vars['internalid']);
 $content = elgg_list_entities(array(
 	'type' => 'object',
 	'subtype' => 'comment',
-	'container_guid' => $vars['entity']->guid,
+	'container_guid' => $entity->guid,
 	'reverse_order_by' => true,
 	'full_view' => true,
 	'limit' => $limit,


### PR DESCRIPTION
Work toward #10200.
- [x] plugin API
- [x] server implementation for polling
- [x] JS polling implementation
- [ ] WS implementations

Set up the client for receiving messages
`elgg()->channels->setupClient("{$guid}-likes");`

Send a message to listening clients
`elgg()->channels->sendMessage("{$guid}-likes", $like_data);`

Receive messages on client

``` js
elgg.register_hook_handler('elgg/channels:message', 'all', function (h, t, p, v) {
    console.log('New message:', v);
});
```

Hooks allow a plugin to take over message sending.

Fixes #10200
