### PR TITLE
fix(river): ensure unique comment form id

### DIFF
--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -430,7 +430,7 @@ function _elgg_river_menu_setup($hook, $type, $return, $params) {
 			if ($object->canComment()) {
 				$options = array(
 					'name' => 'comment',
-					'href' => "#comments-add-$object->guid",
+					'href' => "#comments-add-{$object->guid}-{$item->id}",
 					'text' => elgg_view_icon('speech-bubble'),
 					'title' => elgg_echo('comment:this'),
 					'rel' => 'toggle',

--- a/views/default/river/elements/responses.php
+++ b/views/default/river/elements/responses.php
@@ -54,6 +54,6 @@ if ($comment_count) {
 }
 
 // inline comment form
-$form_vars = array('id' => "comments-add-{$object->getGUID()}", 'class' => 'hidden');
+$form_vars = array('id' => "comments-add-{$object->guid}-{$item->id}", 'class' => 'hidden');
 $body_vars = array('entity' => $object, 'inline' => true);
 echo elgg_view_form('comment/save', $form_vars, $body_vars);


### PR DESCRIPTION
rel="toggle" fails to work with multiple river entries rendering
a comment form with the same id (due to multiple entries with the
same object entity). This adds river item id to the id attribute.
