### PR TITLE
fix(css): apply hidden class to menu items

### DIFF
--- a/views/default/elements/helpers.css.php
+++ b/views/default/elements/helpers.css.php
@@ -16,7 +16,8 @@
 
 <?php /* Need .elgg-page to be able to override .elgg-menu-hz > li {display:inline-block} and such */ ?>
 .hidden,
-.elgg-page .hidden {
+.elgg-page .hidden,
+.elgg-menu > li.hidden {
 	display: none;
 }
 


### PR DESCRIPTION
Help themes that use inline display for menu items by setting
a more specific selector for .hidden class
