### PR TITLE
feature(views): more flexible output/longtext view

### DIFF
--- a/views/default/output/longtext.php
+++ b/views/default/output/longtext.php
@@ -1,20 +1,24 @@
 <?php
 /**
- * Elgg display long text
- * Displays a large amount of text, with new lines converted to line breaks
+ * Displays HTML, with new lines converted to line breaks
  *
- * @package Elgg
- * @subpackage Core
- *
- * @uses $vars['value'] The text to display
- * @uses $vars['parse_urls'] Whether to turn urls into links. Default is true.
+ * @uses $vars['value'] HTML to display
  * @uses $vars['class']
+ * @uses $vars['parse_urls'] Turn urls into links? Default is true.
+ * @uses $vars['sanitize'] Sanitize HTML? (highly recommended) Default is true.
+ * @uses $vars['autop'] Convert line breaks to paragraphs? Default is true.
  */
 
 $vars['class'] = elgg_extract_class($vars, 'elgg-output');
 
 $parse_urls = elgg_extract('parse_urls', $vars, true);
 unset($vars['parse_urls']);
+
+$sanitize = elgg_extract('sanitize', $vars, true);
+unset($vars['sanitize']);
+
+$autop = elgg_extract('autop', $vars, true);
+unset($vars['autop']);
 
 $text = $vars['value'];
 unset($vars['value']);
@@ -23,8 +27,12 @@ if ($parse_urls) {
 	$text = parse_urls($text);
 }
 
-$text = filter_tags($text);
+if ($sanitize) {
+	$text = filter_tags($text);
+}
 
-$text = elgg_autop($text);
+if ($autop) {
+	$text = elgg_autop($text);
+}
 
 echo elgg_format_element('div', $vars, $text);


### PR DESCRIPTION
Allows disabling HTML sanitization and/or autop via $vars or the `view_vars` hook.
