### PR TITLE
fix(icons): cropping mode is now determined by actual cropping coords

### DIFF
--- a/engine/classes/Elgg/EntityIconService.php
+++ b/engine/classes/Elgg/EntityIconService.php
@@ -202,7 +202,7 @@ class EntityIconService {
 			return false;
 		}
 
-		$cropping_mode = $x1 || $y1 || $x2 || $y2;
+		$cropping_mode = ($x2 > $x1) && ($y2 > $y1);
 		if (!$cropping_mode) {
 			$this->deleteIcon($entity, $type);
 		}
@@ -254,11 +254,12 @@ class EntityIconService {
 			$square = (bool) elgg_extract('square', $opts);
 			$upscale = (bool) elgg_extract('upscale', $opts);
 
-			if ($type === 'icon' && $cropping_mode && $square === false && $size !== 'large') {
-				// In cropping mode, we want to preserve non-square images the way they are.
-				// For BC, we need to crop the large icon into a square if cropping coordinates are provided.
-				// There is a problem with cropping large icons however. See #9663 and EntityIconServiceTest::testIconDimensionsAfterResize
-				continue;
+			if ($type === 'icon' && $cropping_mode) {
+				// Do not crop out non-square icons if cropping coordinates are a square
+				$cropping_ratio = ($x2 - $x1) / ($y2 - $y1);
+				if ($cropping_ratio == 1 && $square === false) {
+					continue;
+				}
 			}
 
 			$icon = $this->getIcon($entity, $size, $type);


### PR DESCRIPTION
No longer exempts icons from cropping based on size name, instead determines
whether cropping coordinates correspond to the square setting of the icon
