### PR TITLE
feat(menus): elgg_view_menu() now accepts an array of menu items

### DIFF
--- a/engine/classes/Elgg/Menu/Service.php
+++ b/engine/classes/Elgg/Menu/Service.php
@@ -57,9 +57,13 @@ class Service {
 	 */
 	public function getUnpreparedMenu($name, array $params = []) {
 		$menus = $this->config->getVolatile('menus');
-		$items = [];
+
+		$items = $this->prepareMenuItems(elgg_extract('items', $params, []));
+		unset($params['items']);
+		
 		if ($menus && isset($menus[$name])) {
-			$items = elgg_extract($name, $menus, []);
+			$registered_items = elgg_extract($name, $menus, []);
+			$items = array_merge($items, $registered_items);
 		}
 
 		$params['name'] = $name;
@@ -131,4 +135,30 @@ class Service {
 
 		return new UnpreparedMenu($params, $all_items);
 	}
+
+	/**
+	 * Prepare menu items
+	 *
+	 * @param array $items An array of ElggMenuItem instances or menu item factory options
+	 * @return ElggMenuItem[]
+	 */
+	public function prepareMenuItems(array $items = []) {
+		$prepared_items = [];
+		
+		foreach ($items as $item) {
+			if (is_array($item)) {
+				$options = $item;
+				$item = \ElggMenuItem::factory($options);
+			}
+
+			if (!$item instanceof \ElggMenuItem) {
+				continue;
+			}
+			
+			$prepared_items[] = $item;
+		}
+
+		return $prepared_items;
+	}
+
 }

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -739,6 +739,8 @@ function elgg_view_layout($layout_name, $vars = array()) {
  * @param array                      $vars An associative array of display options for the menu.
  *
  *                          Options include:
+ *                              items => an array of unprepared menu items
+ *                                       as ElggMenuItem or menu item factory options
  *                              sort_by => string or php callback
  *                                  string options: 'name', 'priority', 'title' (default),
  *                                  'register' (registration order) or a


### PR DESCRIPTION
elgg_view_menu() now accepts an array of default menu items to add to the
unprepared menu bypassing menu registers. This is useful for rendering
multiple instances of the same menu on the page, e.g. filter
