### PR TITLE
feat(users): unifies login and registration URL generation

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -103,6 +103,16 @@ System hooks
 **elgg.data, page**
    Filters uncached, page-specific configuration data to pass to the client. :ref:`More info <guides/javascript#config>`
 
+**registration_url, site**
+   Filters site's registration URL. Can be used by plugins to attach invitation codes, referrer codes etc. to the registration URL.
+   ``$params`` array contains an array of query elements added to the registration URL by the invoking script.
+   The hook must return an absolute URL to the registration page.
+
+**login_url, site**
+   Filters site's login URL.
+   ``$params`` array contains an array of query elements added to the login URL by the invoking script.
+   The hook must return an absolute URL of the login page.
+
 User hooks
 ==========
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -96,6 +96,14 @@ Each column is an ``Elgg\Views\TableColumn`` object, usually created via methods
 Plugins can provide or alter these factory methods (see ``Elgg\Views\TableColumn\ColumnFactory``).
 See the view ``admin/users/newest`` for a usage example.
 
+API to alter registration and login URL
+---------------------------------------
+
+ * ``elgg_get_registration_url()`` should be used to obtain site's registration URL
+ * ``elgg_get_login_url()`` should be used to obtain site's login URL
+ * ``registration_url, site`` hook can be used to alter the default registration URL
+ * ``login_url, site`` hook can be used to alter the default login URL
+
 From 2.1 to 2.2
 ===============
 

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -574,7 +574,7 @@ function _elgg_login_menu_setup($hook, $type, $return, $params) {
 	if (elgg_get_config('allow_registration')) {
 		$return[] = \ElggMenuItem::factory(array(
 			'name' => 'register',
-			'href' => 'register',
+			'href' => elgg_get_registration_url(),
 			'text' => elgg_echo('register'),
 			'link_class' => 'registration_link',
 		));

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -399,6 +399,37 @@ function elgg_user_account_page_handler($page_elements, $handler) {
 }
 
 /**
+ * Returns site's registration URL
+ * Triggers a 'registration_url', 'site' plugin hook that can be used by
+ * plugins to alter the default registration URL and append query elements, such as
+ * an invitation code and inviting user's guid
+ *
+ * @param array  $query    An array of query elements
+ * @param string $fragment Fragment identifier
+ * @return string
+ */
+function elgg_get_registration_url(array $query = [], $fragment = '') {
+	$url = elgg_normalize_url('register');
+	$url = elgg_http_add_url_query_elements($url, $query) . $fragment;
+	return elgg_trigger_plugin_hook('registration_url', 'site', $query, $url);
+}
+
+/**
+ * Returns site's login URL
+ * Triggers a 'login_url', 'site' plugin hook that can be used by
+ * plugins to alter the default login URL
+ *
+ * @param array  $query    An array of query elements
+ * @param string $fragment Fragment identifier (e.g. #login-dropdown-box)
+ * @return string
+ */
+function elgg_get_login_url(array $query = [], $fragment = '') {
+	$url = elgg_normalize_url('login');
+	$url = elgg_http_add_url_query_elements($url, $query) . $fragment;
+	return elgg_trigger_plugin_hook('login_url', 'site', $query, $url);
+}
+
+/**
  * Sets the last action time of the given user to right now.
  *
  * @param int $user_guid The user GUID

--- a/mod/invitefriends/actions/invite.php
+++ b/mod/invitefriends/actions/invite.php
@@ -54,10 +54,11 @@ foreach ($emails as $email) {
 		continue;
 	}
 
-	$link = elgg_get_site_url() . 'register?' . http_build_query(array(
+	$link = elgg_get_registration_url(array(
 		'friend_guid' => $current_user->guid,
 		'invitecode' => generate_invite_code($current_user->username),
 	));
+	
 	$message = elgg_echo('invitefriends:email', array(
 		$site->name,
 		$current_user->name,

--- a/views/default/core/account/login_dropdown.php
+++ b/views/default/core/account/login_dropdown.php
@@ -12,7 +12,7 @@ $body = elgg_view_form('login', array(), array('returntoreferer' => TRUE));
 <div id="login-dropdown">
 	<?php 
 		echo elgg_view('output/url', array(
-			'href' => 'login#login-dropdown-box',
+			'href' => elgg_get_login_url([], '#login-dropdown-box'),
 			'rel' => 'popup',
 			'class' => 'elgg-button elgg-button-dropdown',
 			'text' => elgg_echo('login'),


### PR DESCRIPTION
Adds elgg_get_registraiton_url() and elgg_get_login_url() in order to
provide a consistent way to retrieve and filter login and registration
endpoints.

Fixes #9896
