### PR TITLE
docs(install): warn composer users they have to "install" twice

### DIFF
--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -78,6 +78,7 @@ With Composer (recommended if comfortable with CLI):
     composer global require "fxp/composer-asset-plugin:~1.1.4"
     composer create-project elgg/starter-project:dev-master .
     composer install
+    composer install # 2nd call is currently required
 
 From pre-packaged zip (recommended if not comfortable with CLI):
 


### PR DESCRIPTION
Until https://github.com/Elgg/starter-project/issues/37 is resolved end users must call `composer install` twice for plugins to be properly symlinked into the top /mod directory.
