### PR TITLE
fix(notifications): only prefetch subscribers for ElggEntities

### DIFF
--- a/engine/classes/Elgg/Notifications/SubscriptionsService.php
+++ b/engine/classes/Elgg/Notifications/SubscriptionsService.php
@@ -61,12 +61,14 @@ class SubscriptionsService {
 		if (!$object) {
 			return $subscriptions;
 		}
-
-		$prefixLength = strlen(self::RELATIONSHIP_PREFIX);
-		$records = $this->getSubscriptionRecords($object->getContainerGUID());
-		foreach ($records as $record) {
-			$deliveryMethods = explode(',', $record->methods);
-			$subscriptions[$record->guid] = substr_replace($deliveryMethods, '', 0, $prefixLength);
+		
+		if ($object instanceof \ElggEntity) {
+			$prefixLength = strlen(self::RELATIONSHIP_PREFIX);
+			$records = $this->getSubscriptionRecords($object->getContainerGUID());
+			foreach ($records as $record) {
+				$deliveryMethods = explode(',', $record->methods);
+				$subscriptions[$record->guid] = substr_replace($deliveryMethods, '', 0, $prefixLength);
+			}
 		}
 
 		$params = array('event' => $event);


### PR DESCRIPTION
The subscription service can only prefetch the subscribers for
ElggEntities. It tried for all ElggData objects and this caused PHP
crashed

fixes #9780
