### PR TITLE
fix(profile): use correct default access for profile fields

### DIFF
--- a/actions/profile/edit.php
+++ b/actions/profile/edit.php
@@ -82,6 +82,10 @@ if ($name) {
 
 // go through custom fields
 if (sizeof($input) > 0) {
+	
+	// fetch default access level for the user for use in fallback cases
+	$user_default_access = get_default_access($owner);
+	
 	foreach ($input as $shortname => $value) {
 		$options = array(
 			'guid' => $owner->guid,
@@ -98,7 +102,7 @@ if (sizeof($input) > 0) {
 				$access_id = (int) $accesslevel[$shortname];
 			} else {
 				// this should never be executed since the access level should always be set
-				$access_id = ACCESS_DEFAULT;
+				$access_id = $user_default_access;
 			}
 			if (is_array($value)) {
 				$i = 0;


### PR DESCRIPTION
In exceptional use cases the access level of a profile field could be
set to an unsupported access level

fixes #9982
