### PR TITLE
docs(events): prefered use of the shutdown event vs shutdown function

### DIFF
--- a/docs/guides/events-list.rst
+++ b/docs/guides/events-list.rst
@@ -32,6 +32,9 @@ System events
     might not be shown until after the process is completed. This means that any long-running
     processes will still delay the page load.
 
+.. note:: This event is prefered above using ``register_shutdown_function`` as you may not have access
+    to all the Elgg services (eg. database) in the shutdown function but you will in the event.
+
 **regenerate_site_secret:before, system**
     Return false to cancel regenerating the site secret. You should also provide a message
     to the user.

--- a/docs/guides/guidelines.rst
+++ b/docs/guides/guidelines.rst
@@ -121,3 +121,4 @@ These points are good ideas, but are not yet in the official guidelines. Followi
 - Update functions deprecated in 1.8.
    - Many registration functions simply added an ``elgg_`` prefix for consistency
    - See ``/engine/lib/deprecated-1.8.php`` for the full list. You can also set the debug level to warning to get visual reminders of deprecated functions
+- Don't use ``register_shutdown_function`` as you may not have access to certain Elgg parts anymore (eg database). Instead use the ``shutdown`` ``system`` event


### PR DESCRIPTION
fixes #7619
