### PR TITLE
chore(core): removed typehint as this is handled

### DIFF
--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1254,7 +1254,7 @@ function elgg_http_url_is_identical($url1, $url2, $ignore_params = array('offset
  * @return mixed
  * @since 1.8.0
  */
-function elgg_extract($key, array $array, $default = null, $strict = true) {
+function elgg_extract($key, $array, $default = null, $strict = true) {
 	if (!is_array($array)) {
 		return $default;
 	}


### PR DESCRIPTION
Having the typehint causes PHP warnings and the function handles it
internaly that it's not an array
