### PR TITLE
chore(db): align all GUID columns to be of the same type

### DIFF
--- a/actions/admin/upgrades/upgrade_database_guid_columns.php
+++ b/actions/admin/upgrades/upgrade_database_guid_columns.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Convert all the GUID columns in the database to be of the same type/size
+ */
+
+// if upgrade has run correctly, mark it done
+if (get_input('upgrade_completed')) {
+	// set the upgrade as completed
+	$factory = new ElggUpgrade();
+	$upgrade = $factory->getUpgradeFromPath('admin/upgrades/database_guid_columns');
+	if ($upgrade instanceof ElggUpgrade) {
+		$upgrade->setCompleted();
+	}
+
+	return true;
+}
+
+// for large databases this could take a while
+set_time_limit(0);
+
+// prepare
+$dbprefix = elgg_get_config('dbprefix');
+
+// Access collection membership
+update_data("ALTER TABLE {$dbprefix}access_collection_membership MODIFY COLUMN user_guid bigint(20) unsigned NOT NULL");
+
+// Config
+update_data("ALTER TABLE {$dbprefix}config MODIFY COLUMN site_guid bigint(20) unsigned NOT NULL");
+
+// Private settings
+update_data("ALTER TABLE {$dbprefix}private_settings MODIFY COLUMN entity_guid bigint(20) unsigned NOT NULL");
+
+// River
+update_data("ALTER TABLE {$dbprefix}river MODIFY COLUMN subject_guid bigint(20) unsigned NOT NULL");
+update_data("ALTER TABLE {$dbprefix}river MODIFY COLUMN object_guid bigint(20) unsigned NOT NULL");
+update_data("ALTER TABLE {$dbprefix}river MODIFY COLUMN target_guid bigint(20) unsigned NOT NULL");
+
+// System log
+update_data("ALTER TABLE {$dbprefix}system_log MODIFY COLUMN performed_by_guid bigint(20) unsigned NOT NULL");
+update_data("ALTER TABLE {$dbprefix}system_log MODIFY COLUMN owner_guid bigint(20) unsigned NOT NULL");
+
+// Give some feedback for the UI
+echo json_encode(array(
+	'numSuccess' => 8,
+	'numErrors' => 0,
+));

--- a/docs/admin/upgrading.rst
+++ b/docs/admin/upgrading.rst
@@ -44,6 +44,7 @@ From 2.2 to 2.3
  * Some core files now sniff if	``PHPUNIT_ELGG_TESTING_APPLICATION`` constant is set to determine whether Elgg is being bootstrapped for PHPUnit tests. ``phpunit.xml`` configuration needs to updated to include this constant definition.
  * PHPUnit bootstrap no longer sets global ``$CONFIG``. Tests should use ``_elgg_services()->config`` instead.
  * Core and tests no longer use private global values in ``$_ELGG->view_path`` and ``$_ELGG->allowed_ajax_views``
+ * The database GUID columns need to be aligned. In the admin section an upgrade is available to handle this. Please make sure you have a backup available
 
 Deprecations in 2.x
 ===================

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -230,6 +230,7 @@ function _elgg_admin_init() {
 	elgg_register_action('admin/upgrades/upgrade_datadirs', '', 'admin');
 	elgg_register_action('admin/upgrades/upgrade_discussion_replies', '', 'admin');
 	elgg_register_action('admin/upgrades/upgrade_comments_access', '', 'admin');
+	elgg_register_action('admin/upgrades/upgrade_database_guid_columns', '', 'admin');
 	elgg_register_action('admin/site/regenerate_secret', '', 'admin');
 
 	elgg_register_action('admin/menu/save', '', 'admin');

--- a/engine/lib/upgrades/2016092300-2.2.0-database-guid-columns-5a57ba1bfdd8d925.php
+++ b/engine/lib/upgrades/2016092300-2.2.0-database-guid-columns-5a57ba1bfdd8d925.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Elgg 2.2.0 upgrade 2016092300
+ * database-guid-columns
+ *
+ * Align all GUID columns to be of the same type/size
+ */
+
+$ia = elgg_set_ignore_access(true);
+
+$upgrade = new ElggUpgrade();
+$path = 'admin/upgrades/database_guid_columns';
+if (!$upgrade->getUpgradeFromPath($path)) {
+	$upgrade->setPath($path);
+	$upgrade->title = 'Align the GUID columns in the database';
+	$upgrade->description = 'Not all the columns in the database that store GUIDs are of the same size.
+			This can cause problems on very large databases. Before you run this upgrade make sure you have a backup of your database.';
+	
+	$upgrade->save();
+}
+
+elgg_set_ignore_access($ia);

--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -4,7 +4,7 @@
 
 -- record membership in an access collection
 CREATE TABLE `prefix_access_collection_membership` (
-  `user_guid` int(11) NOT NULL,
+  `user_guid` bigint(20) unsigned NOT NULL,
   `access_collection_id` int(11) NOT NULL,
   PRIMARY KEY (`user_guid`,`access_collection_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
@@ -54,7 +54,7 @@ CREATE TABLE `prefix_api_users` (
 CREATE TABLE `prefix_config` (
   `name` varchar(255) NOT NULL,
   `value` text NOT NULL,
-  `site_guid` int(11) NOT NULL,
+  `site_guid` bigint(20) unsigned NOT NULL,
   PRIMARY KEY (`name`,`site_guid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
@@ -180,7 +180,7 @@ CREATE TABLE `prefix_objects_entity` (
 -- settings for an entity
 CREATE TABLE `prefix_private_settings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `entity_guid` int(11) NOT NULL,
+  `entity_guid` bigint(20) unsigned NOT NULL,
   `name` varchar(128) NOT NULL,
   `value` text NOT NULL,
   PRIMARY KEY (`id`),
@@ -209,9 +209,9 @@ CREATE TABLE `prefix_river` (
   `action_type` varchar(32) NOT NULL,
   `access_id` int(11) NOT NULL,
   `view` text NOT NULL,
-  `subject_guid` int(11) NOT NULL,
-  `object_guid` int(11) NOT NULL,
-  `target_guid` int(11) NOT NULL,
+  `subject_guid` bigint(20) unsigned NOT NULL,
+  `object_guid` bigint(20) unsigned NOT NULL,
+  `target_guid` bigint(20) unsigned NOT NULL,
   `annotation_id` int(11) NOT NULL,
   `posted` int(11) NOT NULL,
   `enabled` enum('yes','no') NOT NULL DEFAULT 'yes',
@@ -245,8 +245,8 @@ CREATE TABLE `prefix_system_log` (
   `object_type` varchar(50) NOT NULL,
   `object_subtype` varchar(50) NOT NULL,
   `event` varchar(50) NOT NULL,
-  `performed_by_guid` int(11) NOT NULL,
-  `owner_guid` int(11) NOT NULL,
+  `performed_by_guid` bigint(20) unsigned NOT NULL,
+  `owner_guid` bigint(20) unsigned NOT NULL,
   `access_id` int(11) NOT NULL,
   `enabled` enum('yes','no') NOT NULL DEFAULT 'yes',
   `time_created` int(11) NOT NULL,

--- a/languages/en.php
+++ b/languages/en.php
@@ -1211,6 +1211,9 @@ Once you have logged in, we highly recommend that you change your password.
 	'admin:upgrades:discussion_replies' => 'Discussion reply upgrade',
 	'discussion:upgrade:replies:create_failed' => 'Failed to convert discussion reply id %s to an entity.',
 
+	// Strings specific for the database guid columns reply upgrade
+	'admin:upgrades:database_guid_columns' => 'Align database GUID columns',
+	
 /**
  * Welcome
  */

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2016090100;
+$version = 2016092300;
 
 $composerJson = file_get_contents(dirname(__FILE__) . "/composer.json");
 if ($composerJson === false) {

--- a/views/default/admin/upgrades/database_guid_columns.php
+++ b/views/default/admin/upgrades/database_guid_columns.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Align all GUID columns to be of the same type/size
+ */
+
+$factory = new ElggUpgrade();
+$upgrade = $factory->getUpgradeFromPath('admin/upgrades/database_guid_columns');
+
+if ($upgrade->isCompleted()) {
+	$count = 0;
+} else {
+	$count = 8;
+}
+
+echo elgg_view('admin/upgrades/view', [
+	'count' => $count,
+	'action' => 'action/admin/upgrades/upgrade_database_guid_columns',
+]);


### PR DESCRIPTION
Not all GUID columns were of the same datatype, this could cause
problems in (very) large databases

fixes #1430
