### PR TITLE
feature(views): friendlytime now turns into date notation after 30 days

### DIFF
--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -391,11 +391,21 @@ function elgg_get_friendly_time($time, $current_time = null) {
 	$minute = 60;
 	$hour = $minute * 60;
 	$day = $hour * 24;
+	$month = $day * 30;
+	$year = $day * 365;
 
 	if ($diff < $minute) {
-		return elgg_echo("friendlytime:justnow");
+		return elgg_echo('friendlytime:justnow');
 	}
 	
+	if ($diff > $year) {
+		return trim(elgg_echo('date:month:' . date('m', $time), [''])) . ' ' . date('Y', $time);
+	}
+	
+	if ($diff > $month) {
+		return elgg_echo('date:month:' . date('m', $time), [date('d', $time)]);
+	}
+		
 	if ($diff < $hour) {
 		$granularity = ':minutes';
 		$diff = round($diff / $minute);


### PR DESCRIPTION
fixes #9897

< 30 days = x days ago:
< 365 days = 'Month DD'
> 365 days = 'Month YYYY'

![friendliertime](https://cloud.githubusercontent.com/assets/861833/18786998/1272b2e0-81a1-11e6-8cb8-e37bcebe92b7.png)
