### PR TITLE
fix(i18n): validate the translation key

### DIFF
--- a/engine/classes/Elgg/I18n/Translator.php
+++ b/engine/classes/Elgg/I18n/Translator.php
@@ -40,7 +40,14 @@ class Translator {
 	public function translate($message_key, $args = [], $language = "") {
 		// TODO find a way to cache getLanguage() and get rid of this
 		static $CURRENT_LANGUAGE;
-
+		
+		if (!is_string($message_key) || strlen($message_key) < 1) {
+			_elgg_services()->logger->warn(
+				'$message_key needs to be a string in ' . __METHOD__ . '(), ' . gettype($message_key) . ' provided'
+			);
+			return '';
+		}
+		
 		// old param order is deprecated
 		if (!is_array($args)) {
 			elgg_deprecated_notice(


### PR DESCRIPTION
If the translation key isn't a string this caused PHP warnings, so now
let the user know that the function was called incorrectly.

fixes #9673
