### PR TITLE
feat(comments): offloaded comment creation notification

### DIFF
--- a/actions/comment/save.php
+++ b/actions/comment/save.php
@@ -65,28 +65,6 @@ if ($comment_guid) {
 		forward(REFERER);
 	}
 
-	// Notify if poster wasn't owner
-	if ($entity->owner_guid != $user->guid) {
-		$owner = $entity->getOwnerEntity();
-
-		notify_user($owner->guid,
-			$user->guid,
-			elgg_echo('generic_comment:email:subject', array(), $owner->language),
-			elgg_echo('generic_comment:email:body', array(
-				$entity->title,
-				$user->name,
-				$comment_text,
-				$comment->getURL(),
-				$user->name,
-				$user->getURL()
-			), $owner->language),
-			array(
-				'object' => $comment,
-				'action' => 'create',
-			)
-		);
-	}
-
 	// Add to river
 	elgg_create_river_item(array(
 		'view' => 'river/object/comment/create',

--- a/docs/admin/upgrading.rst
+++ b/docs/admin/upgrading.rst
@@ -37,6 +37,15 @@ Basic instructions
    Any modifications should have been written within plugins, so that they are not lost on overwriting.
    If this is not the case, take care to maintain your modifications. 
 
+From 2.3 to 3.0
+===============
+
+Removed / changed language keys
+-------------------------------
+
+ * The language keys related to comment notifications have changed. Check the ``generic_comment:notification:owner:`` language keys
+
+
 From 2.2 to 2.3
 ===============
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -200,6 +200,7 @@ Miscellaneous API changes
  * ``$CONFIG`` is no longer available as a local variable inside plugin ``start.php`` files.
  * ``elgg_get_config('siteemail')`` is no longer available. Use ``elgg_get_site_entity()->email``.
  * The URL endpoints ``js/`` and ``css/`` are no longer supported. Use ``elgg_get_simplecache_url()``.
+ * The generic comment save action no longer sends the notification directly, this has been offloaded to the notification system.
 
 JavaScript hook calling order may change
 ----------------------------------------
@@ -277,6 +278,12 @@ Notable changes in plugins:
 
  * search plugin no longer extends ``page/elements/header`` and instead extends ``page/elements/sidebar``
  * topbar menu items might now have a new parent item or be found in a different section
+
+Comment notifications
+---------------------
+
+ * The language keys related to comment notifications have changed. Check the ``generic_comment:notification:owner:`` language keys
+ * The action for creating a comment (``action/comment/save``) was changed. If your plugin overruled this action you should have a look at it in order to prevent double notifications 
 
 From 2.2 to 2.3
 ===============

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -80,7 +80,7 @@ function elgg_unregister_notification_event($object_type, $object_subtype) {
 
 /**
  * Register a delivery method for notifications
- * 
+ *
  * Register for the 'send', 'notification:[method name]' plugin hook to handle
  * sending a notification. A notification object is in the params array for the
  * hook with the key 'notification'. See \Elgg\Notifications\Notification.
@@ -206,7 +206,7 @@ function _elgg_notifications_cron() {
 
 /**
  * Send an email notification
- * 
+ *
  * @param string $hook   Hook name
  * @param string $type   Hook type
  * @param bool   $result Has anyone sent a message yet?

--- a/languages/en.php
+++ b/languages/en.php
@@ -1298,22 +1298,29 @@ If you requested this, click on the link below. Otherwise ignore this email.
 	'generic_comment:on' => '%s on %s',
 	'generic_comments:latest:posted' => 'posted a',
 
-	'generic_comment:email:subject' => 'You have a new comment!',
-	'generic_comment:email:body' => "You have a new comment on your item \"%s\" from %s. It reads:
-
+	'generic_comment:notification:owner:subject' => 'You have a new comment!',
+	'generic_comment:notification:owner:summary' => 'You have a new comment!',
+	'generic_comment:notification:owner:body' => "You have a new comment on your item \"%s\" from %s. It reads:
 
 %s
 
-
 To reply or view the original item, click here:
-
 %s
 
 To view %s's profile, click here:
+%s",
+	
+	'generic_comment:notification:user:subject' => 'A new comment on: %s',
+	'generic_comment:notification:user:summary' => 'A new comment on: %s',
+	'generic_comment:notification:user:body' => "A new comment was made on \"%s\" by %s. It reads:
 
 %s
 
-Please do not reply to this email.",
+To reply or view the original item, click here:
+%s
+
+To view %s's profile, click here:
+%s",
 
 /**
  * Entities


### PR DESCRIPTION
Also have two different messages. One for the owner being commented on.
One for all the other interesed users.

fixes #9436
