### PR TITLE
chore(metadata): removes access_id from metadata

### DIFF
--- a/docs/design/database.rst
+++ b/docs/design/database.rst
@@ -386,14 +386,14 @@ Under the hood, metadata is stored as an instance of the
 practice (although if you're interested, see the ``ElggMetadata`` class
 reference). What you need to know is:
 
--  Metadata has an owner and access ID (see note below), both of which may be different
-   to the owner of the entity it's attached to
+-  Metadata has an owner, which may be different to the owner of the entity
+   it's attached to
 -  You can potentially have multiple items of each type of metadata
    attached to a single entity
 -  Like annotations, values are stored as strings unless the value given is a PHP integer (``is_int($value)`` is true),
    or unless the ``$value_type`` is manually specified as ``integer`` (see below).
 
-.. note:: Metadata's ``access_id`` value will be ignored in Elgg 3.0 and all metadata values will be available in all contexts.
+.. note:: As of Elgg 3.0, metadata no longer have ``access_id``.
 
 The simple case
 ---------------
@@ -422,7 +422,6 @@ Or to add a couple of tags to an object:
 When adding metadata like this:
 
 -  The owner is set to the currently logged-in user
--  Access permissions are inherited from the entity (see note below)
 -  Reassigning a piece of metadata will overwrite the old value
 
 This is suitable for most purposes. Be careful to note which attributes
@@ -433,7 +432,7 @@ built in attributes. As an example, if you changed the access id of an
 ElggObject, you need to save it or the change isn't pushed to the
 database.
 
-.. note:: Metadata's ``access_id`` value will be ignored in Elgg 3.0 and all metadata values will be available in all contexts.
+.. note:: As of Elgg 3.0, metadata's ``access_id`` property is ignored.
 
 Reading metadata
 ~~~~~~~~~~~~~~~~
@@ -484,7 +483,7 @@ defined as follows:
             $value,                 // The metadata value
             $value_type,            // Currently either 'text' or 'integer'
             $owner_guid,            // The owner of the metadata
-            $access_id = 0,         // The access restriction
+            $ignored = null,        // Provide null here
             $allow_multiple = false // Do we have more than one value?
             )
 
@@ -493,9 +492,7 @@ the example of a date of birth attached to a user):
 
 .. code:: php
 
-    create_metadata($user_guid, 'dob', $dob_timestamp, 'integer', $_SESSION['guid'], $access_id);
-
-.. note:: ``$access_id`` will be ignored in Elgg 3.0 and all metadata values will be available in all contexts. Always set it to ``ACCESS_PUBLIC`` for compatibility with Elgg 3.0.
+    create_metadata($user_guid, 'dob', $dob_timestamp, 'integer', $_SESSION['guid']);
 
 For multiple values, you will need to iterate through and call
 ``create_metadata`` on each one. The following piece of code comes from
@@ -507,7 +504,7 @@ the profile save action:
     foreach ($value as $interval) {
         $i++;
         $multiple = ($i != 1);
-        create_metadata($user->guid, $shortname, $interval, 'text', $user->guid, $access_id, $multiple);
+        create_metadata($user->guid, $shortname, $interval, 'text', $user->guid, null, $multiple);
     }
 
 Note that the *allow multiple* setting is set to *false* in the first

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -170,7 +170,15 @@ Metastrings in the database have been denormalized for performance purposes. We 
 metadata and annotation tables. You need to update your custom queries to reflect these changes. Also the ``msv`` and ``msn`` table aliases are no longer available.
 It is best practice not to rely on the table aliases used in core queries. If you need to use custom clauses you should do your own joins.
 
+
 From the "users_entity" table, the ``password`` and ``hash`` columns have been removed.
+
+Metadata no longer are access-controlled
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Metadata is available in all contexts. If your plugin created metadata with restricted access, those restrictions will not be honored. You should use annotations or entities instead, which do provide access control.
+
+Do not read or write to the ``access_id`` property on ElggMetadata objects.
 
 Multi Site Changes
 ------------------

--- a/engine/classes/Elgg/Cache/MetadataCache.php
+++ b/engine/classes/Elgg/Cache/MetadataCache.php
@@ -41,7 +41,7 @@ class MetadataCache {
 	 * @access private For testing only
 	 */
 	public function inject($entity_guid, array $values) {
-		$this->values[$this->getAccessKey()][$entity_guid] = $values;
+		$this->values[$entity_guid] = $values;
 	}
 
 	/**
@@ -58,11 +58,9 @@ class MetadataCache {
 	 * @return array|string|int|null null = value does not exist
 	 */
 	public function getSingle($entity_guid, $name) {
-		$access_key = $this->getAccessKey();
-
-		if (isset($this->values[$access_key][$entity_guid])
-				&& array_key_exists($name, $this->values[$access_key][$entity_guid])) {
-			return $this->values[$access_key][$entity_guid][$name];
+		if (isset($this->values[$entity_guid])
+				&& array_key_exists($name, $this->values[$entity_guid])) {
+			return $this->values[$entity_guid][$name];
 		} else {
 			return null;
 		}
@@ -75,9 +73,7 @@ class MetadataCache {
 	 * @return void
 	 */
 	public function clear($entity_guid) {
-		foreach (array_keys($this->values) as $access_key) {
-			unset($this->values[$access_key][$entity_guid]);
-		}
+		unset($this->values[$entity_guid]);
 	}
 
 	/**
@@ -87,12 +83,7 @@ class MetadataCache {
 	 * @return bool
 	 */
 	public function isLoaded($entity_guid) {
-		$access_key = $this->getAccessKey();
-
-		if (empty($this->values[$access_key])) {
-			return false;
-		}
-		return array_key_exists($entity_guid, $this->values[$access_key]);
+		return array_key_exists($entity_guid, $this->values);
 	}
 
 	/**
@@ -136,8 +127,6 @@ class MetadataCache {
 			return;
 		}
 
-		$access_key = $this->getAccessKey();
-
 		if (!is_array($guids)) {
 			$guids = [$guids];
 		}
@@ -153,18 +142,12 @@ class MetadataCache {
 			'callback' => false,
 			'distinct' => false,
 			'order_by' => 'n_table.entity_guid, n_table.time_created ASC, n_table.id ASC',
-
-			// @todo don't know why this is necessary
-			'wheres' => [_elgg_get_access_where_sql([
-				'table_alias' => 'n_table',
-				'guid_column' => 'entity_guid',
-			])],
 		];
 		$data = _elgg_services()->metadataTable->getAll($options);
 
 		// make sure we show all entities as loaded
 		foreach ($guids as $guid) {
-			$this->values[$access_key][$guid] = null;
+			$this->values[$guid] = null;
 		}
 
 		// build up metadata for each entity, save when GUID changes (or data ends)
@@ -177,7 +160,7 @@ class MetadataCache {
 			$guid = $row->entity_guid;
 			if ($guid !== $last_guid) {
 				if ($last_guid) {
-					$this->values[$access_key][$last_guid] = $metadata;
+					$this->values[$last_guid] = $metadata;
 				}
 				$metadata = [];
 			}
@@ -188,7 +171,7 @@ class MetadataCache {
 				$metadata[$name] = $value;
 			}
 			if (($i == $last_row_idx)) {
-				$this->values[$access_key][$guid] = $metadata;
+				$this->values[$guid] = $metadata;
 			}
 			$last_guid = $guid;
 		}
@@ -222,17 +205,5 @@ class MetadataCache {
 			}
 		}
 		return $guids;
-	}
-
-	/**
-	 * Get a key to represent the access ability of the system. This is used to shard the cache array.
-	 *
-	 * @return string E.g. "ignored" or "123"
-	 */
-	protected function getAccessKey() {
-		if ($this->session->getIgnoreAccess()) {
-			return "ignored";
-		}
-		return (string) $this->session->getLoggedInUserGuid();
 	}
 }

--- a/engine/classes/Elgg/Database/UsersTable.php
+++ b/engine/classes/Elgg/Database/UsersTable.php
@@ -122,7 +122,7 @@ class UsersTable {
 			return false;
 		}
 
-		create_metadata($user_guid, 'ban_reason', $reason, '', 0, ACCESS_PUBLIC);
+		$user->ban_reason = $reason;
 
 		_elgg_invalidate_cache_for_entity($user_guid);
 		_elgg_invalidate_memcache_for_entity($user_guid);
@@ -177,7 +177,7 @@ class UsersTable {
 			return false;
 		}
 
-		create_metadata($user_guid, 'ban_reason', '', '', 0, ACCESS_PUBLIC);
+		$user->deleteMetadata('ban_reason');
 
 		_elgg_invalidate_cache_for_entity($user_guid);
 		_elgg_invalidate_memcache_for_entity($user_guid);
@@ -486,8 +486,9 @@ class UsersTable {
 		if (!$user) {
 			return false;
 		}
-		$result1 = create_metadata($user->guid, 'validated', $status, '', 0, ACCESS_PUBLIC, false);
-		$result2 = create_metadata($user->guid, 'validated_method', $method, '', 0, ACCESS_PUBLIC, false);
+
+		$result1 = create_metadata($user->guid, 'validated', (int) $status);
+		$result2 = create_metadata($user->guid, 'validated_method', $method);
 		if ($result1 && $result2) {
 			if ((bool) $status) {
 				elgg_trigger_after_event('validate', 'user', $user);
@@ -602,5 +603,4 @@ class UsersTable {
 			$user->storeInPersistedCache(_elgg_get_memcache('new_entity_cache'));
 		});
 	}
-
 }

--- a/engine/classes/ElggExtender.php
+++ b/engine/classes/ElggExtender.php
@@ -51,11 +51,9 @@ abstract class ElggExtender extends \ElggData {
 	 * @return void
 	 */
 	public function __set($name, $value) {
-		if ($name === 'access_id' && $this instanceof ElggMetadata && $value != ACCESS_PUBLIC) {
-			elgg_deprecated_notice('Setting ->access_id to a value other than ACCESS_PUBLIC is deprecated. '
-				. 'All metadata will be public in 3.0.', '2.3');
+		if ($name === 'access_id' && $this instanceof ElggMetadata) {
+			$value = ACCESS_PUBLIC;
 		}
-
 		$this->attributes[$name] = $value;
 		if ($name == 'value') {
 			$this->attributes['value_type'] = self::detectValueType($value);
@@ -96,6 +94,10 @@ abstract class ElggExtender extends \ElggData {
 						throw new \UnexpectedValueException($msg);
 						break;
 				}
+			}
+
+			if ($name === 'access_id' && $this instanceof ElggMetadata) {
+				return ACCESS_PUBLIC;
 			}
 
 			return $this->attributes[$name];

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -1636,8 +1636,8 @@ class ElggInstaller {
 		elgg_set_ignore_access(false);
 
 		// add validation data to satisfy user validation plugins
-		create_metadata($guid, 'validated', true, '', 0, ACCESS_PUBLIC);
-		create_metadata($guid, 'validated_method', 'admin_user', '', 0, ACCESS_PUBLIC);
+		$user->validated = 1;
+		$user->validated_method = 'admin_user';
 
 		if ($login) {
 			$handler = new Elgg\Http\DatabaseSessionHandler(_elgg_services()->db);

--- a/engine/classes/ElggMetadata.php
+++ b/engine/classes/ElggMetadata.php
@@ -45,6 +45,8 @@ class ElggMetadata extends \ElggExtender {
 				$this->attributes[$key] = $value;
 			}
 		}
+
+		$this->attributes['access_id'] = ACCESS_PUBLIC;
 	}
 
 	/**
@@ -72,11 +74,11 @@ class ElggMetadata extends \ElggExtender {
 	public function save() {
 		if ($this->id > 0) {
 			return update_metadata($this->id, $this->name, $this->value,
-				$this->value_type, $this->owner_guid, $this->access_id);
+				$this->value_type, $this->owner_guid);
 		} else {
 			// using create_metadata() for deprecation notices in 2.x
 			$this->id = create_metadata($this->entity_guid, $this->name, $this->value,
-				$this->value_type, $this->owner_guid, $this->access_id);
+				$this->value_type, $this->owner_guid);
 
 			if (!$this->id) {
 				throw new \IOException("Unable to save new " . get_class());

--- a/engine/lib/metadata.php
+++ b/engine/lib/metadata.php
@@ -57,24 +57,15 @@ function elgg_delete_metadata_by_id($id) {
  * @param string $value          Value of the metadata
  * @param string $value_type     'text', 'integer', or '' for automatic detection
  * @param int    $owner_guid     GUID of entity that owns the metadata. Default is logged in user.
- * @param int    $access_id      Access level of the metadata (deprecated). Default in 2.x is ACCESS_PRIVATE, but
- *                               use ACCESS_PUBLIC for compatibility with Elgg 3.0
+ * @param null   $ignored        This argument is not used
  * @param bool   $allow_multiple Allow multiple values for one key. Default is false
  *
  * @return int|false id of metadata or false if failure
  */
 function create_metadata($entity_guid, $name, $value, $value_type = '', $owner_guid = 0,
-		$access_id = null, $allow_multiple = false) {
-
-	if ($access_id === null) {
-		$access_id = ACCESS_PRIVATE;
-	} elseif ($access_id != ACCESS_PUBLIC) {
-		elgg_deprecated_notice('Setting $access_id to a value other than ACCESS_PUBLIC is deprecated. '
-			. 'All metadata will be public in 3.0.', '2.3');
-	}
-
+		$ignored = null, $allow_multiple = false) {
 	return _elgg_services()->metadataTable->create($entity_guid, $name, $value,
-		$value_type, $owner_guid, $access_id, $allow_multiple);
+		$value_type, $owner_guid, null, $allow_multiple);
 }
 
 /**
@@ -85,19 +76,12 @@ function create_metadata($entity_guid, $name, $value, $value_type = '', $owner_g
  * @param string $value      Metadata value
  * @param string $value_type Value type
  * @param int    $owner_guid Owner guid
- * @param int    $access_id  Access level of the metadata (deprecated). Use ACCESS_PUBLIC for compatibility
- *                           with Elgg 3.0
  *
  * @return bool
  */
-function update_metadata($id, $name, $value, $value_type, $owner_guid, $access_id) {
-	if ($access_id != ACCESS_PUBLIC) {
-		elgg_deprecated_notice('Setting $access_id to a value other than ACCESS_PUBLIC is deprecated. '
-			. 'All metadata will be public in 3.0.', '2.3');
-	}
-
+function update_metadata($id, $name, $value, $value_type, $owner_guid) {
 	return _elgg_services()->metadataTable->update($id, $name, $value,
-		$value_type, $owner_guid, $access_id);
+		$value_type, $owner_guid);
 }
 
 /**
@@ -111,24 +95,16 @@ function update_metadata($id, $name, $value, $value_type, $owner_guid, $access_i
  * @param array  $name_and_values Associative array - a value can be a string, number, bool
  * @param string $value_type      'text', 'integer', or '' for automatic detection
  * @param int    $owner_guid      GUID of entity that owns the metadata
- * @param int    $access_id       Access level of the metadata (deprecated). Default in 2.x is ACCESS_PRIVATE, but
- *                                use ACCESS_PUBLIC for compatibility with Elgg 3.0
+ * @param null   $ignored         This argument is not used
  * @param bool   $allow_multiple  Allow multiple values for one key. Default is false
  *
  * @return bool
  */
 function create_metadata_from_array($entity_guid, array $name_and_values, $value_type, $owner_guid,
-		$access_id = null, $allow_multiple = false) {
-
-	if ($access_id === null) {
-		$access_id = ACCESS_PRIVATE;
-	} elseif ($access_id != ACCESS_PUBLIC) {
-		elgg_deprecated_notice('Setting $access_id to a value other than ACCESS_PUBLIC is deprecated. '
-			. 'All metadata will be public in 3.0.', '2.3');
-	}
+		$ignored = null, $allow_multiple = false) {
 
 	return _elgg_services()->metadataTable->createFromArray($entity_guid, $name_and_values,
-		$value_type, $owner_guid, $access_id, $allow_multiple);
+		$value_type, $owner_guid, null, $allow_multiple);
 }
 
 /**
@@ -379,20 +355,6 @@ function is_metadata_independent($type, $subtype) {
 }
 
 /**
- * When an entity is updated, resets the access ID on all of its child metadata
- *
- * @param string     $event       The name of the event
- * @param string     $object_type The type of object
- * @param \ElggEntity $object      The entity itself
- *
- * @return true
- * @access private Set as private in 1.9.0
- */
-function metadata_update($event, $object_type, $object) {
-	return _elgg_services()->metadataTable->handleUpdate($event, $object_type, $object);
-}
-
-/**
  * Invalidate the metadata cache based on options passed to various *_metadata functions
  *
  * @param string $action  Action performed on metadata. "delete", "disable", or "enable"
@@ -424,8 +386,5 @@ function _elgg_metadata_test($hook, $type, $value, $params) {
 }
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
-	/** Call a function whenever an entity is updated **/
-	$events->registerHandler('update', 'all', 'metadata_update', 600);
-
 	$hooks->registerHandler('unit_test', 'system', '_elgg_metadata_test');
 };

--- a/engine/tests/ElggCoreMetadataAPITest.php
+++ b/engine/tests/ElggCoreMetadataAPITest.php
@@ -8,6 +8,11 @@
 class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 
 	/**
+	 * @var ElggObject
+	 */
+	protected $object;
+
+	/**
 	 * Called before each test method.
 	 */
 	public function setUp() {
@@ -54,8 +59,8 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 		$this->object->save();
 
 		$guid = $this->object->getGUID();
-		create_metadata($guid, 'tested', 'tested1', 'text', 0, ACCESS_PUBLIC, true);
-		create_metadata($guid, 'tested', 'tested2', 'text', 0, ACCESS_PUBLIC, true);
+		create_metadata($guid, 'tested', 'tested1', 'text', 0, null, true);
+		create_metadata($guid, 'tested', 'tested2', 'text', 0, null, true);
 
 		$count = (int)elgg_get_metadata(array(
 			'metadata_names' => array('tested'),

--- a/engine/tests/ElggCoreMetadataCacheTest.php
+++ b/engine/tests/ElggCoreMetadataCacheTest.php
@@ -102,46 +102,6 @@ class ElggCoreMetadataCacheTest extends \ElggCoreUnitTest {
 		$this->assertFalse($cache->isLoaded(2));
 	}
 
-	public function testCacheIsSegregatedByAccessState() {
-		$session = ElggSession::getMock();
-		$cache = new MetadataCache($session);
-		$cache->inject(1, ['foo' => 'bar']);
-
-		$session->setIgnoreAccess();
-		$this->assertFalse($cache->isLoaded(1));
-
-		$session->setIgnoreAccess(false);
-		$this->assertTrue($cache->isLoaded(1));
-
-		$user = elgg_get_entities(['type' => 'user', 'limit' => 1]);
-		$user = $user[0];
-		$cache->inject(1, ['foo' => 'bar']);
-
-		$session->setLoggedInUser($user);
-		$this->assertFalse($cache->isLoaded(1));
-	}
-
-	public function testClearActsOnAllAccessStates() {
-		$session = ElggSession::getMock();
-		$cache = new MetadataCache($session);
-
-		$session->setIgnoreAccess(false);
-		$cache->inject(1, ['foo' => 'bar']);
-
-		$session->setIgnoreAccess(true);
-		$cache->clear(1);
-		$session->setIgnoreAccess(false);
-		$this->assertFalse($cache->isLoaded(1));
-
-		$session->setIgnoreAccess(true);
-		$cache->inject(1, ['foo' => 'bar']);
-
-		$session->setIgnoreAccess(false);
-		$cache->clear(1);
-		$session->setIgnoreAccess(true);
-		$this->assertFalse($cache->isLoaded(1));
-	}
-
 	public function testMetadataReadsFillsCache() {
 		// test that reads fill cache
 		$this->obj1->setMetadata($this->name, [1, 2]);
@@ -170,7 +130,7 @@ class ElggCoreMetadataCacheTest extends \ElggCoreUnitTest {
 		// setMetadata
 		$this->cache->inject($this->guid1, ['foo' => 'bar']);
 		$this->obj1->setMetadata($this->name, $this->value);
-		$this->assertFalse($this->cache->isLoaded($this->obj1));
+		$this->assertFalse($this->cache->isLoaded($this->guid1));
 
 		// deleteMetadata
 		$this->cache->inject($this->guid1, ['foo' => 'bar']);

--- a/engine/tests/phpunit/Elgg/Mocks/Database/MetadataTable.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Database/MetadataTable.php
@@ -30,7 +30,7 @@ class MetadataTable extends DbMetadataTabe {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function create($entity_guid, $name, $value, $value_type = '', $owner_guid = 0, $access_id = ACCESS_PRIVATE, $allow_multiple = false) {
+	public function create($entity_guid, $name, $value, $value_type = '', $owner_guid = 0, $ignore = null, $allow_multiple = false) {
 		$entity = get_entity((int) $entity_guid);
 		if (!$entity) {
 			return false;
@@ -45,8 +45,6 @@ class MetadataTable extends DbMetadataTabe {
 			$owner_guid = $this->session->getLoggedInUserGuid();
 		}
 
-		$access_id = (int) $access_id;
-
 		$this->iterator++;
 		$id = $this->iterator;
 
@@ -60,7 +58,7 @@ class MetadataTable extends DbMetadataTabe {
 			'name' => $name,
 			'value' => $value,
 			'time_created' => $this->getCurrentTime()->getTimestamp(),
-			'access_id' => (int) $access_id,
+			'access_id' => ACCESS_PUBLIC,
 			'value_type' => \ElggExtender::detectValueType($value, trim($value_type)),
 		];
 
@@ -68,13 +66,13 @@ class MetadataTable extends DbMetadataTabe {
 
 		$this->addQuerySpecs($row);
 
-		return parent::create($entity_guid, $name, $value, $value_type, $owner_guid, $access_id, $allow_multiple);
+		return parent::create($entity_guid, $name, $value, $value_type, $owner_guid, null, $allow_multiple);
 	}
 
 	/**
 	 * {@inheritdoc}
 	 */
-	public function update($id, $name, $value, $value_type, $owner_guid, $access_id) {
+	public function update($id, $name, $value, $value_type, $owner_guid) {
 		if (!isset($this->rows[$id])) {
 			return false;
 		}
@@ -83,13 +81,13 @@ class MetadataTable extends DbMetadataTabe {
 		$row->value = $value;
 		$row->value_type = \ElggExtender::detectValueType($value, trim($value_type));
 		$row->owner_guid = $owner_guid;
-		$row->access_id = $access_id;
+		$row->access_id = ACCESS_PUBLIC;
 
 		$this->rows[$id] = $row;
 
 		$this->addQuerySpecs($row);
 
-		return parent::update($id, $name, $value, $value_type, $owner_guid, $access_id);
+		return parent::update($id, $name, $value, $value_type, $owner_guid);
 	}
 
 	/**
@@ -151,18 +149,14 @@ class MetadataTable extends DbMetadataTabe {
 
 		// Return this metadata object when _elgg_get_metastring_based_objects() is called
 		$e_access_sql = _elgg_get_access_where_sql(array('table_alias' => 'e'));
-		$md_access_sql = _elgg_get_access_where_sql(array(
-			'table_alias' => 'n_table',
-			'guid_column' => 'entity_guid',
-		));
-
+		
 		$dbprefix = elgg_get_config('dbprefix');
 		$sql = "SELECT DISTINCT  n_table.*
 			FROM {$dbprefix}metadata n_table
 				JOIN {$dbprefix}entities e ON n_table.entity_guid = e.guid
-				WHERE  (n_table.id IN ({$row->id}) AND $md_access_sql) AND $e_access_sql
+				WHERE  (n_table.id IN ({$row->id})) AND $e_access_sql
 				ORDER BY n_table.time_created ASC, n_table.id ASC, n_table.id";
-
+		
 		$this->query_specs[$row->id][] = $this->db->addQuerySpec([
 			'sql' => $sql,
 			'results' => function() use ($row) {
@@ -186,7 +180,7 @@ class MetadataTable extends DbMetadataTabe {
 				':value_type' => $row->value_type,
 				':owner_guid' => $row->owner_guid,
 				':time_created' => $row->time_created,
-				':access_id' => $row->access_id,
+				':access_id' => ACCESS_PUBLIC,
 			],
 			'insert_id' => $row->id,
 		]);
@@ -206,7 +200,7 @@ class MetadataTable extends DbMetadataTabe {
 				':value' => $row->value,
 				':value_type' => $row->value_type,
 				':owner_guid' => $row->owner_guid,
-				':access_id' => $row->access_id,
+				':access_id' => ACCESS_PUBLIC,
 				':id' => $row->id,
 			],
 			'results' => function() use ($row) {

--- a/engine/tests/phpunit/Elgg/Notifications/NotificationsServiceTestCase.php
+++ b/engine/tests/phpunit/Elgg/Notifications/NotificationsServiceTestCase.php
@@ -147,7 +147,7 @@ abstract class NotificationsServiceTestCase extends TestCase {
 		
 		$user = $this->actor;
 
-		$metadata_id = create_metadata($object->guid, 'test_metadata_name', 'test_metadata_value', 'text', $this->actor->guid, ACCESS_PUBLIC);
+		$metadata_id = create_metadata($object->guid, 'test_metadata_name', 'test_metadata_value', 'text', $this->actor->guid);
 		$metadata = elgg_get_metadata_from_id($metadata_id);
 
 		$annotation_id = $object->annotate('test_annotation_name', 'test_annotation_value', 'text', $this->actor->guid, ACCESS_PUBLIC);
@@ -693,7 +693,7 @@ abstract class NotificationsServiceTestCase extends TestCase {
 		$to1 = $this->mocks()->getUser();
 
 		$to2 = $this->mocks()->getUser();
-		create_metadata($to2->guid, 'notification:method:test_method', true, '', $to2->guid, ACCESS_PUBLIC);
+		create_metadata($to2->guid, 'notification:method:test_method', true, '', $to2->guid);
 
 		$to3 = $this->mocks()->getUser();
 
@@ -772,7 +772,7 @@ abstract class NotificationsServiceTestCase extends TestCase {
 		$to1 = $this->mocks()->getUser();
 
 		$to2 = $this->mocks()->getUser();
-		create_metadata($to2->guid, 'notification:method:test_method', true, '', $to2->guid, ACCESS_PUBLIC);
+		create_metadata($to2->guid, 'notification:method:test_method', true, '', $to2->guid);
 		
 		$to3 = $this->mocks()->getUser();
 
@@ -847,7 +847,7 @@ abstract class NotificationsServiceTestCase extends TestCase {
 		$to1 = $this->mocks()->getUser();
 
 		$to2 = $this->mocks()->getUser();
-		create_metadata($to2->guid, 'notification:method:test_method', true, '', $to2->guid, ACCESS_PUBLIC);
+		create_metadata($to2->guid, 'notification:method:test_method', true, '', $to2->guid);
 
 		$subject = 'Test message';
 		$body = 'Lorem ipsum';
@@ -899,10 +899,10 @@ abstract class NotificationsServiceTestCase extends TestCase {
 
 		$from = $this->mocks()->getUser();
 		$to1 = $this->mocks()->getUser();
-		create_metadata($to1->guid, 'notification:method:test_method', true, '', $to1->guid, ACCESS_PUBLIC);
+		create_metadata($to1->guid, 'notification:method:test_method', true, '', $to1->guid);
 
 		$to2 = $this->mocks()->getUser();
-		create_metadata($to2->guid, 'notification:method:test_method', true, '', $to2->guid, ACCESS_PUBLIC);
+		create_metadata($to2->guid, 'notification:method:test_method', true, '', $to2->guid);
 
 		$subject = 'Test message';
 		$body = 'Lorem ipsum';

--- a/engine/tests/phpunit/ElggMetadataTest.php
+++ b/engine/tests/phpunit/ElggMetadataTest.php
@@ -3,6 +3,12 @@
 use Elgg\TestCase;
 
 /**
+ * Metadata operations are mocked in \Elgg\Mocks\Database\MetadataTable table
+ * Any changes to the SQL queries in the metadata table/API should be reflected there
+ * For elgg_get_metadata_from_id() to work with the mocks, the SQL query must be
+ * an exact match, so any new commas, brackets and clauses need to be reflected in the
+ * mock class.
+ * 
  * @group ElggMetadata
  */
 class ElggMetadataTest extends TestCase {
@@ -22,6 +28,8 @@ class ElggMetadataTest extends TestCase {
 		$id = create_metadata($object->guid, 'foo', 'bar', '', $owner->guid);
 		$metadata = elgg_get_metadata_from_id($id);
 
+		$this->assertInstanceOf(\ElggMetadata::class, $metadata);
+		
 		$this->assertEquals('metadata', $metadata->getType());
 		$this->assertEquals('foo', $metadata->getSubtype());
 		$this->assertInstanceOf(stdClass::class, $metadata->toObject());
@@ -50,6 +58,8 @@ class ElggMetadataTest extends TestCase {
 		$id = create_metadata($object->guid, 'foo', 'bar', '', $owner->guid);
 		$metadata = elgg_get_metadata_from_id($id);
 
+		$this->assertInstanceOf(\ElggMetadata::class, $metadata);
+		
 		_elgg_services()->hooks->backup();
 
 		_elgg_services()->hooks->registerHandler('extender:url', 'metadata', function($hook, $type, $return, $params) use ($metadata) {
@@ -76,8 +86,10 @@ class ElggMetadataTest extends TestCase {
 		$id = create_metadata($object->guid, 'foo', 'bar', '', $owner->guid);
 		$metadata = elgg_get_metadata_from_id($id);
 
+		$this->assertInstanceOf(\ElggMetadata::class, $metadata);
+		
 		// Default access level is private
-		$this->assertEquals(ACCESS_PRIVATE, $metadata->access_id);
+		$this->assertEquals(ACCESS_PUBLIC, $metadata->access_id);
 		
 		$this->assertTrue($metadata->canEdit($owner->guid));
 		$this->assertFalse($metadata->canEdit($other->guid));
@@ -97,7 +109,7 @@ class ElggMetadataTest extends TestCase {
 		$metadata->name = 'foo';
 		$metadata->value = 'bar';
 		$metadata->time_created = _elgg_services()->metadataTable->getCurrentTime()->getTimestamp();
-
+		
 		$id = _elgg_services()->metadataTable->iterator + 1;
 
 		// Insert
@@ -137,6 +149,8 @@ class ElggMetadataTest extends TestCase {
 		$id = create_metadata($object->guid, 'foo', 'bar', '', $owner->guid);
 		$metadata = elgg_get_metadata_from_id($id);
 
+		$this->assertInstanceOf(\ElggMetadata::class, $metadata);
+		
 		$dbprefix = elgg_get_config('dbprefix');
 		_elgg_services()->db->addQuerySpec([
 			'sql' => "DELETE FROM {$dbprefix}metadata WHERE id = :id",
@@ -164,6 +178,8 @@ class ElggMetadataTest extends TestCase {
 		$id = create_metadata($object->guid, 'foo', 'bar', '', $owner->guid);
 		$metadata = elgg_get_metadata_from_id($id);
 
+		$this->assertInstanceOf(\ElggMetadata::class, $metadata);
+		
 		$this->assertTrue($metadata->disable());
 
 		$this->assertEquals('no', $metadata->enabled);

--- a/mod/profile/classes/ElggPlugin/Profile/AnnotationMigration.php
+++ b/mod/profile/classes/ElggPlugin/Profile/AnnotationMigration.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace ElggPlugin\Profile;
+
+use Elgg\Upgrade\Batch;
+use Elgg\Upgrade\Result;
+
+/**
+ * Copy all profile field metadata to annotations, with each name prefixed with "profile:"
+ */
+class AnnotationMigration implements Batch {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getVersion() {
+		return 2017040700;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function shouldBeSkipped() {
+		return false;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function needsIncrementOffset() {
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function countItems() {
+		return count($this->getFieldNames());
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function run(Result $result, $offset) {
+		$name = $this->getFieldNames()[$offset];
+
+		$db = elgg()->getDb();
+		$sql = "
+			INSERT INTO {$db->prefix}annotations
+				  (entity_guid, `name`,    `value`, value_type, owner_guid, access_id, time_created, enabled)
+			SELECT entity_guid, :new_name, `value`, value_type, owner_guid, access_id, time_created, enabled
+			FROM {$db->prefix}metadata
+			WHERE `name` = :old_name
+			AND entity_guid IN (
+				SELECT guid FROM {$db->prefix}users_entity
+			)
+		";
+		try {
+			$db->updateData($sql, false, [
+				':old_name' => $name,
+				':new_name' => "profile:$name",
+			]);
+			$result->addSuccesses(1);
+
+		} catch (\DatabaseException $e) {
+			$result->addError("Profile field '$name' could not be migrated: " . $e->getMessage());
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Get the profile field names
+	 *
+	 * @return string[]
+	 */
+	private function getFieldNames() {
+		return array_keys(elgg_get_config('profile_fields'));
+	}
+}

--- a/mod/profile/elgg-plugin.php
+++ b/mod/profile/elgg-plugin.php
@@ -1,0 +1,9 @@
+<?php
+
+use ElggPlugin\Profile\AnnotationMigration;
+
+return [
+	'upgrades' => [
+		AnnotationMigration::class,
+	],
+];

--- a/mod/profile/languages/en.php
+++ b/mod/profile/languages/en.php
@@ -1,6 +1,8 @@
 <?php
+
 return [
 	'profile' => 'Profile',
 	'profile:notfound' => 'Sorry. We could not find the requested profile.',
-
+	'profile:upgrade:2017040700:title' => 'Migrate schema of profile fields',
+	'profile:upgrade:2017040700:description' => '<p>This migration converts profile fields from metadata to annotations with each name prefixed with "profile:". <strong>Note:</strong> If you have "inactive" profile fields you want migrated, re-create those fields and re-load this page to make sure they get migrated.</p>',
 ];

--- a/views/default/forms/profile/edit.php
+++ b/views/default/forms/profile/edit.php
@@ -10,6 +10,7 @@
  * @uses vars['entity']
  */
 $entity = elgg_extract('entity', $vars);
+/* @var ElggUser $entity */
 
 echo elgg_view_field([
 	'#type' => 'text',
@@ -24,28 +25,23 @@ $sticky_values = elgg_get_sticky_values('profile:edit');
 $profile_fields = elgg_get_config('profile_fields');
 if (is_array($profile_fields) && count($profile_fields) > 0) {
 	foreach ($profile_fields as $shortname => $valtype) {
-		$metadata = elgg_get_metadata([
-			'guid' => $entity->guid,
-			'metadata_name' => $shortname,
-			'limit' => false
+
+		$annotations = $entity->getAnnotations([
+			'annotation_names' => "profile:$shortname",
+			'limit' => false,
 		]);
-		if ($metadata) {
-			if (is_array($metadata)) {
-				$value = '';
-				foreach ($metadata as $md) {
-					if (!empty($value)) {
-						$value .= ', ';
-					}
-					$value .= $md->value;
-					$access_id = $md->access_id;
+		$access_id = ACCESS_DEFAULT;
+		if ($annotations) {
+			$value = '';
+			foreach ($annotations as $annotation) {
+				if (!empty($value)) {
+					$value .= ', ';
 				}
-			} else {
-				$value = $metadata->value;
-				$access_id = $metadata->access_id;
+				$value .= $annotation->value;
+				$access_id = $annotation->access_id;
 			}
 		} else {
 			$value = '';
-			$access_id = ACCESS_DEFAULT;
 		}
 
 		// sticky form values take precedence over saved ones


### PR DESCRIPTION
Elgg now ignores the access_id fields of metadata, hence all metadata set previously are now visible to queries in all contexts, including logged out.

Methods to set metadata no longer accept `$access_id` arguments, or values given are ignored. ElggMetadata objects always return ACCESS_PUBLIC when the "access_id" property is read.

User profile field data is now stored in annotations, but a copy is maintained in metadata for better BC with older plugins. A field with the name "example" will be stored in annotation(s) with name "profile:example". At the time of upgrade, active profile fields will be migrated to annotation storage, but inactive profile field data will be left as inert metadata only.

Fixes #9050

BREAKING CHANGE:
Plugins can no longer rely on Elgg to "hide" metadata in queries. All metadata is assumed to be public. Plugins that read user profile fields in metadata will see all fields every time, and plugins that write user profile fields in metadata will have no effect. These plugins should instead access fields via annotations; see the profile edit actions and forms for reference.

- [x] get #10879 in
- [x] async upgrade that requires the "profile" plugin be enabled and any fields you want migrated must be active.
- [x] Steve tested upgrade