### PR TITLE
feat(images): adds a new image manipulation service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "bower-asset/jquery-colorbox": "^1.5.14",
         "FortAwesome/Font-Awesome": "^4.3",
         "michelf/php-markdown": "^1.5.0",
-        "league/flysystem-memory": "^1.0"
+        "league/flysystem-memory": "^1.0",
+        "imagine/imagine": "^0.6.3"
     },
     "scripts": {
         "pre-install-cmd": "php .scripts/check_global_requirements.php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "060acc9e20dd6c0b6817196bfeb21aa8",
-    "content-hash": "9e70d1557007eef66cbe25b50224b11c",
+    "hash": "160f0f336ebb0ea36e102dc57b085e78",
+    "content-hash": "c74d8e1b48a39f7aa5d30b95e0436e5e",
     "packages": [
         {
             "name": "bower-asset/jquery",
@@ -890,6 +890,63 @@
                 "icon"
             ],
             "time": "2016-05-13 15:42:25"
+        },
+        {
+            "name": "imagine/imagine",
+            "version": "v0.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/avalanche123/Imagine.git",
+                "reference": "149041d2a1b517107bfe270ca2b1a17aa341715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/avalanche123/Imagine/zipball/149041d2a1b517107bfe270ca2b1a17aa341715d",
+                "reference": "149041d2a1b517107bfe270ca2b1a17aa341715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "sami/sami": "dev-master"
+            },
+            "suggest": {
+                "ext-gd": "to use the GD implementation",
+                "ext-gmagick": "to use the Gmagick implementation",
+                "ext-imagick": "to use the Imagick implementation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-develop": "0.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Imagine": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bulat Shakirzyanov",
+                    "email": "mallluhuct@gmail.com",
+                    "homepage": "http://avalanche123.com"
+                }
+            ],
+            "description": "Image processing for PHP 5.3",
+            "homepage": "http://imagine.readthedocs.org/",
+            "keywords": [
+                "drawing",
+                "graphics",
+                "image manipulation",
+                "image processing"
+            ],
+            "time": "2015-09-19 16:54:05"
         },
         {
             "name": "ircmaxell/password-compat",

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -28,6 +28,9 @@ Deprecated APIs
  * ``elgg()->getDb()->getTableprefix()`` is deprecated: Use ``elgg_get_config('dbprefix')``.
  * Private ``update_entity_last_action()`` is deprecated: Refrain from manually updating last action timestamp.
  * Setting non-public ``access_id`` on metadata is deprecated. See below.
+ * ``get_resized_image_from_existing_file()`` is deprecated: Use ``elgg_save_resized_image()``.
+ * ``get_resized_image_from_uploaded_file()`` is deprecated: Use ``elgg_save_resized_image()`` in combination with upload API.
+ * ``get_image_resize_parameters()`` is deprecated and will be removed.
 
 Deprecated Views
 ----------------
@@ -51,6 +54,13 @@ New API for working with file uploads
 
  * ``elgg_get_uploaded_files()`` - returns an array of Symfony uploaded file objects
  * ``ElggFile::acceptUploadedFile()`` - moves an uploaded file to Elgg's filestore
+
+New API for manipulating images
+-------------------------------
+
+New image manipulation service implements a more efficient approach to cropping and resizing images.
+
+ * ``elgg_save_resized_image()`` - crops and resizes an image to preferred dimensions
 
 New API for events
 ------------------

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -41,6 +41,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\PluginHooksService                 $hooks
  * @property-read \Elgg\EntityIconService                  $iconService
  * @property-read \Elgg\Http\Input                         $input
+ * @property-read \Elgg\ImageService                       $imageService
  * @property-read \Elgg\Logger                             $logger
  * @property-read Mailer                                   $mailer
  * @property-read \Elgg\Menu\Service                       $menus
@@ -231,6 +232,11 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		});
 
 		$this->setClassName('input', \Elgg\Http\Input::class);
+
+		$this->setFactory('imageService', function(ServiceProvider $c) {
+			$imagine = new \Imagine\Gd\Imagine();
+			return new \Elgg\ImageService($imagine, $c->config);
+		});
 
 		$this->setFactory('logger', function(ServiceProvider $c) {
 			return $this->resolveLoggerDependencies('logger');

--- a/engine/classes/Elgg/ImageService.php
+++ b/engine/classes/Elgg/ImageService.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Elgg;
+
+use Exception;
+use Imagine\Image\Box;
+use Imagine\Image\ImagineInterface;
+use Imagine\Image\Point;
+
+/**
+ * Image manipulation service
+ *
+ * @since 2.3
+ * @access private
+ */
+class ImageService {
+
+	const JPEG_QUALITY = 75;
+
+	/**
+	 * @var ImagineInterface
+	 */
+	private $imagine;
+
+	/**
+	 * @var Config
+	 */
+	private $config;
+
+	/**
+	 * Constructor
+	 *
+	 * @param ImagineInterface $imagine Imagine interface
+	 * @param Config           $config  Elgg config
+	 */
+	public function __construct(ImagineInterface $imagine, Config $config) {
+		$this->imagine = $imagine;
+		$this->config = $config;
+	}
+
+	/**
+	 * Crop and resize an image
+	 *
+	 * @param string $source      Path to source image
+	 * @param string $destination Path to destination
+	 *                            If not set, will modify the source image
+	 * @param array  $params      An array of cropping/resizing parameters
+	 *                             - INT 'w' represents the width of the new image
+	 *                               With upscaling disabled, this is the maximum width
+	 *                               of the new image (in case the source image is
+	 *                               smaller than the expected width)
+	 *                             - INT 'h' represents the height of the new image
+	 *                               With upscaling disabled, this is the maximum height
+	 *                             - INT 'x1', 'y1', 'x2', 'y2' represent optional cropping
+	 *                               coordinates. The source image will first be cropped
+	 *                               to these coordinates, and then resized to match
+	 *                               width/height parameters
+	 *                             - BOOL 'square' - square images will fill the
+	 *                               bounding box (width x height). In Imagine's terms,
+	 *                               this equates to OUTBOUND mode
+	 *                             - BOOL 'upscale' - if enabled, smaller images
+	 *                               will be upscaled to fit the bounding box.
+	 * @return bool
+	 */
+	public function resize($source, $destination = null, array $params = []) {
+
+		if (!isset($destination)) {
+			$destination = $source;
+		}
+
+		try {
+			$image = $this->imagine->open($source);
+
+			$width = $image->getSize()->getWidth();
+			$height = $image->getSize()->getHeight();
+
+			$params = $this->normalizeResizeParameters($width, $height, $params);
+
+			$max_width = elgg_extract('w', $params);
+			$max_height = elgg_extract('h', $params);
+
+			$x1 = (int) elgg_extract('x1', $params, 0);
+			$y1 = (int) elgg_extract('y1', $params, 0);
+			$x2 = (int) elgg_extract('x2', $params, 0);
+			$y2 = (int) elgg_extract('y2', $params, 0);
+
+			if ($x2 > $x1 && $y2 > $y1) {
+				$crop_start = new Point($x1, $y1);
+				$crop_size = new Box($x2 - $x1, $y2 - $y1);
+				$image->crop($crop_start, $crop_size);
+			}
+
+			$target_size = new Box($max_width, $max_height);
+			$thumbnail = $image->resize($target_size);
+
+			$thumbnail->save($destination, [
+				'jpeg_quality' => elgg_extract('jpeg_quality', $params, self::JPEG_QUALITY),
+			]);
+
+			unset($image);
+			unset($thumbnail);
+		} catch (Exception $ex) {
+			_elgg_services()->logger->error($ex->getMessage());
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Calculate the parameters for resizing an image
+	 *
+	 * @param int   $width  Natural width of the image
+	 * @param int   $height Natural height of the image
+	 * @param array $params Resize parameters
+	 *                      - 'w' maximum width of the resized image
+	 *                      - 'h' maximum height of the resized image
+	 *                      - 'upscale' allow upscaling
+	 *                      - 'square' constrain to a square
+	 *                      - 'x1', 'y1', 'x2', 'y2' cropping coordinates
+	 *
+	 * @return array
+	 * @throws \LogicException
+	 */
+	public function normalizeResizeParameters($width, $height, array $params = []) {
+
+		$max_width = (int) elgg_extract('w', $params, 100, false);
+		$max_height = (int) elgg_extract('h', $params, 100, false);
+		if (!$max_height || !$max_width) {
+			throw new \LogicException("Resize width and height parameters are required");
+		}
+
+		$square = elgg_extract('square', $params, false);
+		$upscale = elgg_extract('upscale', $params, false);
+
+		$x1 = (int) elgg_extract('x1', $params, 0);
+		$y1 = (int) elgg_extract('y1', $params, 0);
+		$x2 = (int) elgg_extract('x2', $params, 0);
+		$y2 = (int) elgg_extract('y2', $params, 0);
+
+		$cropping_mode = $x1 || $y1 || $x2 || $y2;
+
+		if ($cropping_mode) {
+			$crop_width = $x2 - $x1;
+			$crop_height = $y2 - $y1;
+			if ($crop_width <= 0 || $crop_height <= 0 || $crop_width > $width || $crop_height > $height) {
+				throw new \LogicException("Coordinates [$x1, $y1], [$x2, $y2] are invalid for image cropping");
+			}
+		} else {
+			// everything selected if no crop parameters
+			$crop_width = $width;
+			$crop_height = $height;
+		}
+
+		// determine cropping offsets
+		if ($square) {
+			// asking for a square image back
+			// detect case where someone is passing crop parameters that are not for a square
+			if ($cropping_mode == true && $crop_width != $crop_height) {
+				throw new \LogicException("Coordinates [$x1, $y1], [$x2, $y2] are invalid for a squared image cropping");
+			}
+
+			// size of the new square image
+			$max_width = $max_height = min($max_width, $max_height);
+
+			// find largest square that fits within the selected region
+			$crop_width = $crop_height = min($crop_width, $crop_height);
+
+			if (!$cropping_mode) {
+				// place square region in the center
+				$x1 = floor(($width - $crop_width) / 2);
+				$y1 = floor(($height - $crop_height) / 2);
+			}
+		} else {
+			// maintain aspect ratio of original image/crop
+			if ($crop_height / $max_height > $crop_width / $max_width) {
+				$max_width = floor($max_height * $crop_width / $crop_height);
+			} else {
+				$max_height = floor($max_width * $crop_height / $crop_width);
+			}
+		}
+
+		if (!$upscale && ($crop_height < $max_height || $crop_width < $max_width)) {
+			// we cannot upscale and selected area is too small so we decrease size of returned image
+			$max_height = $crop_height;
+			$max_width = $crop_width;
+		}
+
+		return [
+			'w' => $max_width,
+			'h' => $max_height,
+			'x1' => $x1,
+			'y1' => $y1,
+			'x2' => $x1 + $crop_width,
+			'y2' => $y1 + $crop_height,
+			'square' => $square,
+			'upscale' => $upscale,
+		];
+	}
+
+}

--- a/engine/lib/filestore.php
+++ b/engine/lib/filestore.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Elgg filestore.
  * This file contains functions for saving and retrieving data from files.
@@ -6,7 +7,6 @@
  * @package Elgg.Core
  * @subpackage DataModel.FileStorage
  */
-
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
@@ -54,6 +54,35 @@ function get_uploaded_file($input_name) {
 }
 
 /**
+ * Crops and resizes an image
+ *
+ * @param string $source      Path to source image
+ * @param string $destination Path to destination
+ *                            If not set, will modify the source image
+ * @param array  $params      An array of cropping/resizing parameters
+ *                             - INT 'w' represents the width of the new image
+ *                               With upscaling disabled, this is the maximum width
+ *                               of the new image (in case the source image is
+ *                               smaller than the expected width)
+ *                             - INT 'h' represents the height of the new image
+ *                               With upscaling disabled, this is the maximum height
+ *                             - INT 'x1', 'y1', 'x2', 'y2' represent optional cropping
+ *                               coordinates. The source image will first be cropped
+ *                               to these coordinates, and then resized to match
+ *                               width/height parameters
+ *                             - BOOL 'square' - square images will fill the
+ *                               bounding box (width x height). In Imagine's terms,
+ *                               this equates to OUTBOUND mode
+ *                             - BOOL 'upscale' - if enabled, smaller images
+ *                               will be upscaled to fit the bounding box.
+ * @return bool
+ * @since 2.3
+ */
+function elgg_save_resized_image($source, $destination = null, array $params = array()) {
+	return _elgg_services()->imageService->resize($source, $destination, $params);
+}
+
+/**
  * Gets the jpeg contents of the resized version of an uploaded image
  * (Returns false if the uploaded file was not an image)
  *
@@ -66,14 +95,18 @@ function get_uploaded_file($input_name) {
  * @param bool   $upscale    Resize images smaller than $maxwidth x $maxheight?
  *
  * @return false|mixed The contents of the resized image, or false on failure
+ * @deprecated 2.3
  */
 function get_resized_image_from_uploaded_file($input_name, $maxwidth, $maxheight,
-$square = false, $upscale = false) {
+		$square = false, $upscale = false) {
+
+	elgg_deprecated_notice(__FUNCTION__ . ' has been deprecated. Use elgg_save_resized_image()', '2.3');
+
 	$files = _elgg_services()->request->files;
 	if (!$files->has($input_name)) {
 		return false;
 	}
-	
+
 	$file = $files->get($input_name);
 	if (empty($file)) {
 		// a file input was provided but no file uploaded
@@ -83,8 +116,7 @@ $square = false, $upscale = false) {
 		return false;
 	}
 
-	return get_resized_image_from_existing_file($file->getPathname(), $maxwidth,
-		$maxheight, $square, 0, 0, 0, 0, $upscale);
+	return get_resized_image_from_existing_file($file->getPathname(), $maxwidth, $maxheight, $square, 0, 0, 0, 0, $upscale);
 }
 
 /**
@@ -106,216 +138,86 @@ $square = false, $upscale = false) {
  * @param bool   $upscale    Resize images smaller than $maxwidth x $maxheight?
  *
  * @return false|mixed The contents of the resized image, or false on failure
+ * @deprecated 2.3
  */
-function get_resized_image_from_existing_file($input_name, $maxwidth, $maxheight, $square = false,
-$x1 = 0, $y1 = 0, $x2 = 0, $y2 = 0, $upscale = false) {
+function get_resized_image_from_existing_file($input_name, $maxwidth, $maxheight,
+			$square = false, $x1 = 0, $y1 = 0, $x2 = 0, $y2 = 0, $upscale = false) {
 
-	// Get the size information from the image
-	$imgsizearray = getimagesize($input_name);
-	if ($imgsizearray == false) {
+	elgg_deprecated_notice(__FUNCTION__ . ' has been deprecated. Use elgg_save_resized_image()', '2.3');
+
+	if (!is_readable($input_name)) {
 		return false;
 	}
 
-	$width = $imgsizearray[0];
-	$height = $imgsizearray[1];
+	// we will write resized image to a temporary file and then delete it
+	$tmp_filename = time() . pathinfo($input_name, PATHINFO_BASENAME);
+	$tmp = new ElggFile();
+	$tmp->setFilename("tmp/$tmp_filename");
+	$tmp->open('write');
+	$tmp->close();
 
-	$accepted_formats = array(
-		'image/jpeg' => 'jpeg',
-		'image/pjpeg' => 'jpeg',
-		'image/png' => 'png',
-		'image/x-png' => 'png',
-		'image/gif' => 'gif'
-	);
-
-	// make sure the function is available
-	$load_function = "imagecreatefrom" . $accepted_formats[$imgsizearray['mime']];
-	if (!is_callable($load_function)) {
-		return false;
-	}
-
-	// get the parameters for resizing the image
-	$options = array(
-		'maxwidth' => $maxwidth,
-		'maxheight' => $maxheight,
-		'square' => $square,
-		'upscale' => $upscale,
+	$params = [
+		'w' => $maxwidth,
+		'h' => $maxheight,
 		'x1' => $x1,
 		'y1' => $y1,
 		'x2' => $x2,
 		'y2' => $y2,
-	);
-	$params = get_image_resize_parameters($width, $height, $options);
-	if ($params == false) {
-		return false;
+		'square' => $square,
+		'upscale' => $upscale,
+	];
+
+	$destination = $tmp->getFilenameOnFilestore();
+	$image_bytes = false;
+	if (elgg_save_resized_image($input_name, $destination, $params)) {
+		$tmp->open('read');
+		$image_bytes = $tmp->grabFile();
+		$tmp->close();
 	}
 
-	// load original image
-	$original_image = call_user_func($load_function, $input_name);
-	if (!$original_image) {
-		return false;
-	}
+	$tmp->delete();
 
-	// allocate the new image
-	$new_image = imagecreatetruecolor($params['newwidth'], $params['newheight']);
-	if (!$new_image) {
-		return false;
-	}
-
-	// color transparencies white (default is black)
-	imagefilledrectangle(
-		$new_image, 0, 0, $params['newwidth'], $params['newheight'],
-		imagecolorallocate($new_image, 255, 255, 255)
-	);
-
-	$rtn_code = imagecopyresampled(	$new_image,
-									$original_image,
-									0,
-									0,
-									$params['xoffset'],
-									$params['yoffset'],
-									$params['newwidth'],
-									$params['newheight'],
-									$params['selectionwidth'],
-									$params['selectionheight']);
-	if (!$rtn_code) {
-		return false;
-	}
-
-	// grab a compressed jpeg version of the image
-	ob_start();
-	imagejpeg($new_image, null, 90);
-	$jpeg = ob_get_clean();
-
-	imagedestroy($new_image);
-	imagedestroy($original_image);
-
-	return $jpeg;
+	return $image_bytes;
 }
 
 /**
  * Calculate the parameters for resizing an image
  *
- * @param int   $width   Width of the original image
- * @param int   $height  Height of the original image
- * @param array $options See $defaults for the options
+ * @param int   $width  Natural width of the image
+ * @param int   $height Natural height of the image
+ * @param array $params Resize parameters
+ *                      - 'maxwidth' maximum width of the resized image
+ *                      - 'maxheight' maximum height of the resized image
+ *                      - 'upscale' allow upscaling
+ *                      - 'square' constrain to a square
+ *                      - 'x1', 'y1', 'x2', 'y2' cropping coordinates
  *
- * @return array or false
+ * @return array|false
  * @since 1.7.2
+ * @deprecated 2.3
  */
-function get_image_resize_parameters($width, $height, $options) {
+function get_image_resize_parameters($width, $height, array $params = []) {
 
-	$defaults = array(
-		'maxwidth' => 100,
-		'maxheight' => 100,
+	elgg_deprecated_notice(__FUNCTION__ . ' has been deprecated and will be removed from public API', '2.3');
 
-		'square' => false,
-		'upscale' => false,
-
-		'x1' => 0,
-		'y1' => 0,
-		'x2' => 0,
-		'y2' => 0,
-	);
-
-	$options = array_merge($defaults, $options);
-
-	// Avoiding extract() because it hurts static analysis
-	$maxwidth = $options['maxwidth'];
-	$maxheight = $options['maxheight'];
-	$square = $options['square'];
-	$upscale = $options['upscale'];
-	$x1 = $options['x1'];
-	$y1 = $options['y1'];
-	$x2 = $options['x2'];
-	$y2 = $options['y2'];
-
-	// crop image first?
-	$crop = true;
-	if ($x1 == 0 && $y1 == 0 && $x2 == 0 && $y2 == 0) {
-		$crop = false;
+	try {
+		$params['w'] = elgg_extract('maxwidth', $params);
+		$params['h'] = elgg_extract('maxheight', $params);
+		unset($params['maxwidth']);
+		unset($params['maxheight']);
+		$params = _elgg_services()->imageService->normalizeResizeParameters($width, $height, $params);
+		return [
+			'newwidth' => $params['w'],
+			'newheight' => $params['h'],
+			'selectionwidth' => $params['x2'] - $params['x1'],
+			'selectionheight' => $params['y2'] - $params['y1'],
+			'xoffset' => $params['x1'],
+			'yoffset' => $params['y1'],
+		];
+	} catch (\LogicException $ex) {
+		elgg_log($ex->getMessage(), 'ERROR');
+		return false;
 	}
-
-	// how large a section of the image has been selected
-	if ($crop) {
-		$selection_width = $x2 - $x1;
-		$selection_height = $y2 - $y1;
-	} else {
-		// everything selected if no crop parameters
-		$selection_width = $width;
-		$selection_height = $height;
-	}
-
-	// determine cropping offsets
-	if ($square) {
-		// asking for a square image back
-
-		// detect case where someone is passing crop parameters that are not for a square
-		if ($crop == true && $selection_width != $selection_height) {
-			return false;
-		}
-
-		// size of the new square image
-		$new_width = $new_height = min($maxwidth, $maxheight);
-
-		// find largest square that fits within the selected region
-		$selection_width = $selection_height = min($selection_width, $selection_height);
-
-		// set offsets for crop
-		if ($crop) {
-			$widthoffset = $x1;
-			$heightoffset = $y1;
-			$width = $x2 - $x1;
-			$height = $width;
-		} else {
-			// place square region in the center
-			$widthoffset = floor(($width - $selection_width) / 2);
-			$heightoffset = floor(($height - $selection_height) / 2);
-		}
-	} else {
-		// non-square new image
-		$new_width = $maxwidth;
-		$new_height = $maxheight;
-
-		// maintain aspect ratio of original image/crop
-		if (($selection_height / (float)$new_height) > ($selection_width / (float)$new_width)) {
-			$new_width = floor($new_height * $selection_width / (float)$selection_height);
-		} else {
-			$new_height = floor($new_width * $selection_height / (float)$selection_width);
-		}
-
-		// by default, use entire image
-		$widthoffset = 0;
-		$heightoffset = 0;
-
-		if ($crop) {
-			$widthoffset = $x1;
-			$heightoffset = $y1;
-		}
-	}
-
-	if (!$upscale && ($selection_height < $new_height || $selection_width < $new_width)) {
-		// we cannot upscale and selected area is too small so we decrease size of returned image
-		if ($square) {
-			$new_height = $selection_height;
-			$new_width = $selection_width;
-		} else {
-			if ($selection_height < $new_height && $selection_width < $new_width) {
-				$new_height = $selection_height;
-				$new_width = $selection_width;
-			}
-		}
-	}
-
-	$params = array(
-		'newwidth' => $new_width,
-		'newheight' => $new_height,
-		'selectionwidth' => $selection_width,
-		'selectionheight' => $selection_height,
-		'xoffset' => $widthoffset,
-		'yoffset' => $heightoffset,
-	);
-
-	return $params;
 }
 
 /**
@@ -415,7 +317,6 @@ function _elgg_clear_entity_files($entity) {
 	}
 }
 
-
 /// Variable holding the default datastore
 $DEFAULT_FILE_STORE = null;
 
@@ -484,7 +385,7 @@ function _elgg_filestore_init() {
 
 	// Fix MIME type detection for Microsoft zipped formats
 	elgg_register_plugin_hook_handler('mime_type', 'file', '_elgg_filestore_detect_mimetype');
-	
+
 	// Parse category of file from MIME type
 	elgg_register_plugin_hook_handler('simple_type', 'file', '_elgg_filestore_parse_simpletype');
 
@@ -497,7 +398,7 @@ function _elgg_filestore_init() {
 	// Touch entity icons if entity access id has changed
 	elgg_register_event_handler('update:after', 'object', '_elgg_filestore_touch_icons');
 	elgg_register_event_handler('update:after', 'group', '_elgg_filestore_touch_icons');
-	
+
 	// Move entity icons if entity owner has changed
 	elgg_register_event_handler('update:after', 'object', '_elgg_filestore_move_icons');
 	elgg_register_event_handler('update:after', 'group', '_elgg_filestore_move_icons');
@@ -573,7 +474,6 @@ function _elgg_filestore_test($hook, $type, $value) {
 	$value[] = "{$CONFIG->path}engine/tests/ElggCoreFilestoreTest.php";
 	return $value;
 }
-
 
 /**
  * Returns file's download URL
@@ -720,19 +620,19 @@ function _elgg_filestore_move_icons($event, $type, $entity) {
 			// there is no icon to move
 			continue;
 		}
-		
+
 		if ($new_icon->exists()) {
 			// there is already a new icon
 			// just removing the old one
 			$old_icon->delete();
 			elgg_log("Entity $entity->guid has been transferred to a new owner but an icon was left behind under {$old_icon->getFilenameOnFilestore()}. "
-				. "Old icon has been deleted", 'NOTICE');
+			. "Old icon has been deleted", 'NOTICE');
 			continue;
 		}
 
 		$old_icon->transfer($new_icon->owner_guid, $new_icon->getFilename());
 		elgg_log("Entity $entity->guid has been transferred to a new owner. "
-				. "Icon was moved from {$old_icon->getFilenameOnFilestore()} to {$new_icon->getFilenameOnFilestore()}.", 'NOTICE');
+		. "Icon was moved from {$old_icon->getFilenameOnFilestore()} to {$new_icon->getFilenameOnFilestore()}.", 'NOTICE');
 	}
 }
 


### PR DESCRIPTION
Adds a basic image manipulation service based on Imagine (temporarily supporting only GD interface).
Entity icons are now cropped via the new image service
