### PR TITLE
chore(cache): do not use http requests to test if cache is symlinked

### DIFF
--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -227,17 +227,15 @@ function elgg_flush_caches() {
 }
 
 /**
- * Checks if /cache has been symlinked to views simplecache directory,
- * and if HTTP requests to /cache are are successful
+ * Checks if /cache directory has been symlinked to views simplecache directory
+ * 
  * @return bool
  * @access private
  */
 function _elgg_is_cache_symlinked() {
-	if (!is_dir(elgg_get_root_path() . 'cache/')) {
-		return false;
-	}
-	$headers = get_headers(elgg_get_simplecache_url('elgg.js'));
-	return substr($headers[0], 9, 3) == 200;
+	$link = elgg_get_root_path() . 'cache/';
+	$target = elgg_get_cache_path() . 'views_simplecache/';
+	return is_dir($link) && realpath($target) == realpath(readlink($link));
 }
 
 /**

--- a/languages/en.php
+++ b/languages/en.php
@@ -1114,6 +1114,7 @@ Once you have logged in, we highly recommend that you change your password.
 	'installation:cache_symlink:description' => "The symbolic link to the simple cache directory allows the server to serve static views bypassing the engine, which considerably improves performance and reduces the server load",
 	'installation:cache_symlink:label' => "Use symbolic link to simple cache directory (recommended)",
 	'installation:cache_symlink:warning' => "Symbolic link has been established. If, for some reason, you want to remove the link, delete the symbolic link directory from your server",
+	'installation:cache_symlink:paths' => 'Correctly configured symbolink link must link <i>%s</i> to <i>%s</i>',
 	'installation:cache_symlink:error' => "Due to your server configuration the symbolic link can not be established automatically. Please refer to the documentation and establish the symbolic link manually.",
 
 	'installation:minify:description' => "The simple cache can also improve performance by compressing JavaScript and CSS files. (Requires that simple cache is enabled.)",

--- a/views/default/forms/admin/site/advanced/caching.php
+++ b/views/default/forms/admin/site/advanced/caching.php
@@ -41,6 +41,10 @@ $symlink_input .= elgg_view("input/checkbox", $params);
 if ($cache_symlinked) {
 	$symlink_warning .= elgg_format_element('span', ['class' => 'elgg-text-help'], elgg_echo('installation:cache_symlink:warning'));
 }
+$symlink_source = elgg_get_root_path() . 'cache/';
+$symlink_target = elgg_get_cache_path() . 'views_simplecache/';
+$symlink_paths_help = elgg_echo('installation:cache_symlink:paths', [$symlink_source, $symlink_target]);
+$symlink_warning .= elgg_format_element('span', ['class' => 'elgg-text-help'], $symlink_paths_help);
 
 // minify
 $minify_js_input = elgg_view("input/checkbox", array(


### PR DESCRIPTION
No longer tries to read HTTP headers of a simple cache view, instead
compares paths of the symlinked cache directory and its expected target.

Fixes #10236
