### PR TITLE
fix(forms): Don't show spinner arrows in number input fields on Firefox

### DIFF
--- a/install/css/install.css
+++ b/install/css/install.css
@@ -191,6 +191,10 @@ input[type="url"] {
 	width: 100%;
 }
 
+input[type="number"] {
+	-moz-appearance: textfield;
+}
+
 input[type="password"]:focus,
 input[type="text"]:focus,
 input[type="number"]:focus,

--- a/mod/aalborg_theme/views/default/elements/forms.css.php
+++ b/mod/aalborg_theme/views/default/elements/forms.css.php
@@ -67,7 +67,9 @@ textarea:focus {
 .elgg-input-access {
 	margin: 5px 0 0 0;
 }
-
+input[type="number"] {
+	-moz-appearance: textfield;
+}
 input[type="checkbox"],
 input[type="radio"] {
 	margin: 0 3px 0 0;

--- a/views/default/admin.css.php
+++ b/views/default/admin.css.php
@@ -521,6 +521,10 @@ input[type="radio"] {
 	margin: 0 3px 0 0;
 }
 
+input[type="number"] {
+	-moz-appearance: textfield;
+}
+
 select {
 	max-width: 100%;
 	padding: 4px;

--- a/views/default/elements/forms.css.php
+++ b/views/default/elements/forms.css.php
@@ -77,6 +77,11 @@ input[type="radio"] {
 	border-radius:0;
 	width:auto;
 }
+
+input[type="number"] {
+	-moz-appearance: textfield;
+}
+
 .elgg-input-checkbox + label,
 .elgg-input-checkbox + .elgg-field-label {
 	display: inline-block;

--- a/views/default/maintenance.css.php
+++ b/views/default/maintenance.css.php
@@ -175,6 +175,9 @@ input[type="radio"] {
 	border: none;
 	width: auto;
 }
+input[type="number"] {
+	-moz-appearance: textfield;
+}
 .elgg-input-checkboxes.elgg-horizontal li,
 .elgg-input-radios.elgg-horizontal li {
 	display: inline;


### PR DESCRIPTION
Fixes https://github.com/Elgg/Elgg/issues/10288.
