### PR TITLE
chore(forms): No spinner arrows in number input field on Firefox

### DIFF
--- a/install/css/install.css
+++ b/install/css/install.css
@@ -226,6 +226,10 @@ input[type="submit"]:focus {
 	border: 4px solid #0054a7;
 }
 
+input[type="number"] {
+	-moz-appearance: textfield;
+}
+
 select {
 	display: block;
 	padding: .5em;

--- a/mod/aalborg_theme/views/default/elements/forms.css.php
+++ b/mod/aalborg_theme/views/default/elements/forms.css.php
@@ -75,6 +75,9 @@ input[type="radio"] {
 	border: none;
 	width: auto;
 }
+input[type="number"] {
+	-moz-appearance: textfield;
+}
 .elgg-input-checkbox + label,
 .elgg-input-checkbox + .elgg-field-label {
 	display: inline-block;

--- a/mod/aalborg_theme/views/default/maintenance.css.php
+++ b/mod/aalborg_theme/views/default/maintenance.css.php
@@ -173,6 +173,9 @@ input[type="radio"] {
 	border: none;
 	width: auto;
 }
+input[type="number"] {
+	-moz-appearance: textfield;
+}
 .elgg-input-checkboxes.elgg-horizontal li,
 .elgg-input-radios.elgg-horizontal li {
 	display: inline;

--- a/views/default/admin.css.php
+++ b/views/default/admin.css.php
@@ -521,6 +521,10 @@ input[type="radio"] {
 	margin: 0 3px 0 0;
 }
 
+input[type="number"] {
+	-moz-appearance: textfield;
+}
+
 select {
 	max-width: 100%;
 	padding: 4px;

--- a/views/default/elements/forms.css.php
+++ b/views/default/elements/forms.css.php
@@ -77,6 +77,9 @@ input[type="radio"] {
 	border-radius:0;
 	width:auto;
 }
+input[type="number"] {
+	-moz-appearance: textfield;
+}
 .elgg-input-checkbox + label,
 .elgg-input-checkbox + .elgg-field-label {
 	display: inline-block;

--- a/views/default/maintenance.css.php
+++ b/views/default/maintenance.css.php
@@ -175,6 +175,9 @@ input[type="radio"] {
 	border: none;
 	width: auto;
 }
+input[type="number"] {
+	-moz-appearance: textfield;
+}
 .elgg-input-checkboxes.elgg-horizontal li,
 .elgg-input-radios.elgg-horizontal li {
 	display: inline;


### PR DESCRIPTION
Fixes #10288
