### PR TITLE
feat(views): input/password only populates value if explicitely set

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -81,6 +81,11 @@ Removed classes/interfaces
  * ``Exportable`` and its methods ``export`` and ``getExportableValues``: Use ``toObject``
  * ``Importable`` and its method ``import``.
 
+Form and field related changes
+------------------------------
+
+* ``input/password``: by default this field will no longer show a value passed to it, this can be overridden by passing the view var ``always_empty`` and set it to false
+
 Inheritance changes
 -------------------
 

--- a/views/default/input/password.php
+++ b/views/default/input/password.php
@@ -9,18 +9,25 @@
  * @uses $vars['value'] The current value, if any
  * @uses $vars['name']  The name of the input field
  * @uses $vars['class'] Additional CSS class
+ * @uses $vars['always_empty'] If for some reason you want to set a value to a password field, set this field to false. Best practice is to not populate password fields.
  */
 
 $vars['class'] = elgg_extract_class($vars, 'elgg-input-password');
 
 $defaults = array(
 	'disabled' => false,
-	'value' => '',
 	'autocapitalize' => 'off',
 	'autocorrect' => 'off',
 	'type' => 'password'
 );
 
 $vars = array_merge($defaults, $vars);
+
+$always_empty = elgg_extract('always_empty', $vars, true);
+unset($vars['always_empty']);
+
+if ($always_empty) {
+	unset($vars['value']);
+}
 
 echo elgg_format_element('input', $vars);


### PR DESCRIPTION
fixes #9895

BREAKING CHANGE:
This change applies the best practice to not populate password fields.
If you really need to set the value of a password field, you need to set
$vars['always_empty'] to false.
