### PR TITLE
feat(developers): explorer entity information in developer tools

### DIFF
--- a/mod/developers/actions/developers/entity_explorer_delete.php
+++ b/mod/developers/actions/developers/entity_explorer_delete.php
@@ -1,0 +1,38 @@
+<?php
+
+$guid = (int) get_input('guid');
+$type = get_input('type');
+$key = get_input('key');
+
+$show_hidden = access_show_hidden_entities(true);
+
+$entity = get_entity($guid);
+if (empty($entity) || empty($type) || $key === null) {
+	access_show_hidden_entities($show_hidden);
+	return elgg_error_response(elgg_echo('error:missing_data'));
+}
+
+if (!$entity->canEdit()) {
+	access_show_hidden_entities($show_hidden);
+	return elgg_error_response(elgg_echo('action:unauthorized'));
+}
+
+switch ($type) {
+	case 'entity':
+		if (!($entity instanceof ElggSite)) {
+			$entity->delete();
+		}
+		break;
+	case 'metadata':
+		unset($entity->$key);
+		break;
+	case 'relationship':
+		get_relationship($key)->delete();
+		break;
+	case 'private_setting':
+		$entity->removePrivateSetting($key);
+		break;
+}
+
+access_show_hidden_entities($show_hidden);
+forward(REFERER);

--- a/mod/developers/languages/en.php
+++ b/mod/developers/languages/en.php
@@ -6,6 +6,7 @@ return array(
 	'admin:develop_tools:inspect' => 'Inspect',
 	'admin:inspect' => 'Inspect',
 	'admin:develop_tools:unit_tests' => 'Unit Tests',
+	'admin:develop_tools:entity_explorer' => 'Entity Explorer',
 	'admin:developers' => 'Developers',
 	'admin:developers:settings' => 'Settings',
 
@@ -39,6 +40,16 @@ return array(
 	'developers:debug:warning' => 'Warning',
 	'developers:debug:notice' => 'Notice',
 	'developers:debug:info' => 'Info',
+	
+	// entity explorer
+	'developers:entity_explorer:help' => 'View information about entities and perform some basic actions on them.',
+	'developers:entity_explorer:guid:label' => 'Enter the guid of the entity to inspect',
+	'developers:entity_explorer:info' => 'Entity Information',
+	'developers:entity_explorer:info:attributes' => 'Attributes',
+	'developers:entity_explorer:info:metadata' => 'Metadata',
+	'developers:entity_explorer:info:relationships' => 'Relationships',
+	'developers:entity_explorer:info:private_settings' => 'Private Settings',
+	'developers:entity_explorer:delete_entity' => 'Remove this entity',
 	
 	// inspection
 	'developers:inspect:help' => 'Inspect configuration of the Elgg framework.',

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -24,6 +24,7 @@ function developers_init() {
 	$action_base = __DIR__ . '/actions/developers';
 	elgg_register_action('developers/settings', "$action_base/settings.php", 'admin');
 	elgg_register_action('developers/ajax_demo', "$action_base/ajax_demo.php", 'admin');
+	elgg_register_action('developers/entity_explorer_delete', "$action_base/entity_explorer_delete.php", 'admin');
 
 	elgg_register_ajax_view('forms/developers/ajax_demo');
 }
@@ -85,6 +86,7 @@ function developers_setup_menu() {
 		elgg_register_admin_menu_item('develop', 'inspect');
 		elgg_register_admin_menu_item('develop', 'sandbox', 'develop_tools');
 		elgg_register_admin_menu_item('develop', 'unit_tests', 'develop_tools');
+		elgg_register_admin_menu_item('develop', 'entity_explorer', 'develop_tools');
 
 		elgg_register_menu_item('page', array(
 			'name' => 'dev_settings',

--- a/mod/developers/views/default/admin/develop_tools/entity_explorer.php
+++ b/mod/developers/views/default/admin/develop_tools/entity_explorer.php
@@ -1,0 +1,42 @@
+<?php
+
+echo '<p>' . elgg_echo('developers:entity_explorer:help') . '</p>';
+
+echo elgg_view_form('developers/entity_explorer', [
+	'action' => 'admin/develop_tools/entity_explorer',
+	'method' => 'GET',
+	'disable_security' => true,
+]);
+
+$guid = get_input('guid');
+if ($guid === null) {
+	return;
+}
+
+$show_hidden = access_show_hidden_entities(true);
+$entity = get_entity($guid);
+if (!$entity) {
+	echo elgg_echo('notfound');
+	return;
+}
+
+// Entity Information
+echo elgg_view('admin/develop_tools/entity_explorer/attributes', ['entity' => $entity]);
+
+// Metadata Information
+echo elgg_view('admin/develop_tools/entity_explorer/metadata', ['entity' => $entity]);
+
+// Relationship Information
+echo elgg_view('admin/develop_tools/entity_explorer/relationships', ['entity' => $entity]);
+
+// Private Settings Information
+echo elgg_view('admin/develop_tools/entity_explorer/private_settings', ['entity' => $entity]);
+
+access_show_hidden_entities($show_hidden);
+
+echo elgg_view('output/url', [
+	'text' => elgg_echo('developers:entity_explorer:delete_entity'),
+	'href' => 'action/developers/entity_explorer_delete?guid=' . $entity->guid . '&type=entity&key=' . $entity->guid,
+	'confirm' => true,
+	'class' => 'elgg-button elgg-button-submit',
+]);

--- a/mod/developers/views/default/admin/develop_tools/entity_explorer/attributes.php
+++ b/mod/developers/views/default/admin/develop_tools/entity_explorer/attributes.php
@@ -1,0 +1,31 @@
+<?php
+$entity = elgg_extract('entity', $vars);
+
+$entity_rows = ['type', 'subtype', 'owner_guid', 'site_guid', 'container_guid', 'access_id', 'time_created', 'time_updated', 'last_action', 'enabled'];
+
+if ($entity instanceof ElggUser) {
+	$entity_rows = array_merge($entity_rows, ['name', 'username', 'email', 'language', 'banned', 'admin', 'last_action', 'prev_last_action', 'last_login', 'prev_last_login']);
+}
+
+if ($entity instanceof ElggGroup) {
+	$entity_rows = array_merge($entity_rows, ['name', 'description']);
+}
+
+if ($entity instanceof ElggSite) {
+	$entity_rows = array_merge($entity_rows, ['name', 'description', 'url']);
+}
+
+$entity_info = '<table class="elgg-table">';
+
+foreach ($entity_rows as $entity_row) {
+	
+	$value = elgg_view('output/text', ['value' => $entity->$entity_row]);
+	
+	$entity_info .= '<tr>';
+	$entity_info .= '<td>' . $entity_row . '</td><td>' . $value . '</td>';
+	$entity_info .= '</tr>';
+}
+
+$entity_info .= '</table>';
+	
+echo elgg_view_module('inline', elgg_echo('developers:entity_explorer:info:attributes'), $entity_info);

--- a/mod/developers/views/default/admin/develop_tools/entity_explorer/metadata.php
+++ b/mod/developers/views/default/admin/develop_tools/entity_explorer/metadata.php
@@ -1,0 +1,39 @@
+<?php
+
+$entity = elgg_extract('entity', $vars);
+
+$entity_metadata = elgg_get_metadata(['guid' => $entity->guid, 'limit' => false]);
+
+if (empty($entity_metadata)) {
+	$metadata_info = elgg_echo('notfound');
+} else {
+	$md_columns = ['id', 'name_id', 'name', 'value_id', 'value', 'value_type', 'access_id', 'time_created', 'enabled'];
+	
+	$metadata_info = '<table class="elgg-table">';
+	$metadata_info .= '<tr>';
+	foreach ($md_columns as $md_col) {
+		$metadata_info .= '<th>' . $md_col . '</th>';
+	}
+	$metadata_info .= '<th>&nbsp;</th>';
+	$metadata_info .= '</tr>';
+	
+	foreach ($entity_metadata as $md) {
+		$metadata_info .= '<tr>';
+		foreach ($md_columns as $md_col) {
+			$value = elgg_view('output/text', ['value' => $md->$md_col]);
+			$metadata_info .= '<td>' . $value . '</td>';
+		}
+		$metadata_info .= '<td>' . elgg_view('output/url', [
+			'text' => elgg_view_icon('remove'),
+			'href' => elgg_http_add_url_query_elements('action/developers/entity_explorer_delete', [
+				'guid' => $entity->guid,
+				'type' => 'metadata',
+				'key' => $md->name,
+			]),
+			'confirm' => true,
+		]) . '</td>';
+		$metadata_info .= '</tr>';
+	}
+	$metadata_info .= '</table>';
+}
+echo elgg_view_module('inline', elgg_echo('developers:entity_explorer:info:metadata'), $metadata_info);

--- a/mod/developers/views/default/admin/develop_tools/entity_explorer/private_settings.php
+++ b/mod/developers/views/default/admin/develop_tools/entity_explorer/private_settings.php
@@ -1,0 +1,34 @@
+<?php
+
+$entity = elgg_extract('entity', $vars);
+
+$private_settings = get_all_private_settings($entity->guid);
+if (empty($private_settings)) {
+	$private_settings_info = elgg_echo('notfound');
+} else {
+	$private_settings_info = '<table class="elgg-table">';
+	$private_settings_info .= '<tr>';
+	$private_settings_info .= '<th>key</th><th>value</th><th>&nbsp;</th>';
+	$private_settings_info .= '</tr>';
+	
+	foreach ($private_settings as $key => $value) {
+		
+		$key_val = elgg_view('output/text', ['value' => $key]);
+		$value = elgg_view('output/text', ['value' => $value]);
+		
+		$private_settings_info .= '<tr>';
+		$private_settings_info .= "<td>$key_val</td><td>$value</td>";
+		$private_settings_info .= '<td>' . elgg_view('output/url', [
+			'text' => elgg_view_icon('remove'),
+			'href' => elgg_http_add_url_query_elements('action/developers/entity_explorer_delete', [
+				'guid' => $entity->guid,
+				'type' => 'private_setting',
+				'key' => $key,
+			]),
+			'confirm' => true,
+		]) . '</td>';
+		$private_settings_info .= '</tr>';
+	}
+	$private_settings_info .= '</table>';
+}
+echo elgg_view_module('inline', elgg_echo('developers:entity_explorer:info:private_settings'), $private_settings_info);

--- a/mod/developers/views/default/admin/develop_tools/entity_explorer/relationships.php
+++ b/mod/developers/views/default/admin/develop_tools/entity_explorer/relationships.php
@@ -1,0 +1,38 @@
+<?php
+
+$entity = elgg_extract('entity', $vars);
+
+$entity_relationships = get_entity_relationships($entity->guid);
+
+if (empty($entity_relationships)) {
+	$relationship_info = elgg_echo('notfound');
+} else {
+	$relationship_columns = ['id', 'time_created', 'guid_one', 'relationship', 'guid_two'];
+
+	$relationship_info = '<table class="elgg-table">';
+	$relationship_info .= '<tr>';
+	foreach ($relationship_columns as $relationship_col) {
+		$relationship_info .= '<th>' . $relationship_col . '</th>';
+	}
+	$relationship_info .= '<th>&nbsp;</th>';
+	$relationship_info .= '</tr>';
+	
+	foreach ($entity_relationships as $relationship) {
+		$relationship_info .= '<tr>';
+		foreach ($relationship_columns as $relationship_col) {
+			$relationship_info .= '<td>' . $relationship->$relationship_col . '</td>';
+		}
+		$relationship_info .= '<td>' . elgg_view('output/url', [
+			'text' => elgg_view_icon('remove'),
+			'href' => elgg_http_add_url_query_elements('action/developers/entity_explorer_delete', [
+				'guid' => $entity->guid,
+				'type' => 'relationship',
+				'key' => $relationship->id,
+			]),
+			'confirm' => true,
+		]) . '</td>';
+		$relationship_info .= '</tr>';
+	}
+	$relationship_info .= '</table>';
+}
+echo elgg_view_module('inline', elgg_echo('developers:entity_explorer:info:relationships'), $relationship_info);

--- a/mod/developers/views/default/forms/developers/entity_explorer.php
+++ b/mod/developers/views/default/forms/developers/entity_explorer.php
@@ -1,0 +1,14 @@
+<?php
+
+echo elgg_view_input('text', [
+	'name' => 'guid',
+	'value' => get_input('guid'),
+	'required' => true,
+	'label' => elgg_echo('developers:entity_explorer:guid:label'),
+]);
+
+$footer = elgg_view('input/submit', [
+	'value' => elgg_echo('submit'),
+]);
+
+elgg_set_form_footer($footer);


### PR DESCRIPTION
With the developer tools you can now lookup attributes, metadata,
relationships and private settings of entities. You can also remove
individual metadata, relationships or private settings for an entity or
remove an entity completely.

fixes #9384 

![entity_explorer](https://cloud.githubusercontent.com/assets/861833/18989963/3f757872-870f-11e6-9d9d-abb33b106291.png)
