### PR TITLE
feat(forms): adds support for fieldsets

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -124,6 +124,13 @@ API to alter registration and login URL
  * ``registration_url, site`` hook can be used to alter the default registration URL
  * ``login_url, site`` hook can be used to alter the default login URL
 
+Support for fieldsets in forms
+------------------------------
+
+ * ``elgg_view_input()`` now supports ``#type``, ``#label``, ``#help`` and ``#class`` parameters to prevent name collision with input view ``$vars``
+ * ``elgg_view_field()`` has been added as a shortcut to ``elgg_view_input()``
+ * New ``input/fieldset`` can be used to render a set of ``fields``
+
 From 2.1 to 2.2
 ===============
 

--- a/engine/classes/Elgg/FormsService.php
+++ b/engine/classes/Elgg/FormsService.php
@@ -72,8 +72,8 @@ class FormsService {
 	 *
 	 * @param string $action    The name of the action. An action name does not include
 	 *                          the leading "action/". For example, "login" is an action name.
-	 * @param array  $form_vars $vars environment passed to the "input/form" view
-	 * @param array  $body_vars $vars environment passed to the "forms/$action" view
+	 * @param array  $form_vars $vars passed to the "input/form" view
+	 * @param array  $body_vars $vars passed to the "forms/<action>" view
 	 *
 	 * @return string The complete form
 	 */

--- a/mod/aalborg_theme/views/default/elements/forms.css.php
+++ b/mod/aalborg_theme/views/default/elements/forms.css.php
@@ -96,6 +96,24 @@ select {
 	margin: 0 auto;
 }
 
+.elgg-fieldset-has-legend {
+	border: 1px solid #dedede;
+	padding: 10px;
+}
+
+.elgg-fieldset-horizontal .elgg-field {
+    display: inline-block;
+    margin: 0 10px 0 0;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-right .elgg-field {
+    margin: 0 0 0 10px;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-center .elgg-field {
+    margin: 0 5px;
+}
+
 /* ***************************************
 	FRIENDS PICKER
 *************************************** */

--- a/mod/developers/views/default/theme_sandbox/forms.php
+++ b/mod/developers/views/default/theme_sandbox/forms.php
@@ -189,6 +189,43 @@ $ipsum = elgg_view('developers/ipsum');
 			'label' => 'Number input (.elgg-input-number) with custom options:',
 			'help' => 'Enter an integer number larger than zero',
 		));
+
+		$dt = new \DateTime(null, new \DateTimeZone('UTC'));
+		$hour_options = array();
+		$hour_options_ts = range(0, 24*60*60, 900); // step of 15 minutes
+		foreach ($hour_options_ts as $ts) {
+			$hour_options[$ts] = $dt->setTimestamp($ts)->format('g:ia');
+		}
+
+		echo elgg_view_input('fieldset', array(
+			'name' => 'f16',
+			'legend' => 'Fieldset with a legend',
+			'fields' => [
+				[
+					'#type' => 'text',
+					'label' => 'Text field',
+					'required' => true,
+				],
+				[
+					'#type' => 'fieldset',
+					'label' => 'Date and time fieldset',
+					'align' => 'horizontal',
+					'fields' => [
+						[
+							'#type' => 'date',
+							'value' => time(),
+							'timestamp' => true,
+							'label' => 'Date',
+						],
+						[
+							'#type' => 'select',
+							'label' => 'Time',
+							'options' => $hour_options,
+						],
+					],
+				],
+			]
+		));
 		?>
 	</fieldset>
 </form>

--- a/mod/discussions/views/default/ajax/discussion/reply/edit.php
+++ b/mod/discussions/views/default/ajax/discussion/reply/edit.php
@@ -15,5 +15,8 @@ $form_vars = array(
 	'class' => ($hidden ? 'hidden ' : '') . 'mvl',
 	'id' => "edit-discussion-reply-{$guid}",
 );
-$body_vars = array('entity' => $reply);
+$body_vars = array(
+	'entity' => $reply,
+	'inline' => true,
+);
 echo elgg_view_form('discussion/reply/save', $form_vars, $body_vars);

--- a/mod/discussions/views/default/forms/discussion/save.php
+++ b/mod/discussions/views/default/forms/discussion/save.php
@@ -14,60 +14,58 @@ $guid = elgg_extract('guid', $vars, null);
 
 $fields = [
 	[
-		'type' => 'text',
+		'#type' => 'text',
 		'name' => 'title',
 		'value' => $title,
-		'label' => elgg_echo('title'),
+		'#label' => elgg_echo('title'),
 		'required' => true,
 	],
 	[
-		'type' => 'longtext',
+		'#type' => 'longtext',
 		'name' => 'description',
 		'value' => $desc,
-		'label' => elgg_echo('discussion:topic:description'),
+		'#label' => elgg_echo('discussion:topic:description'),
 		'required' => true,
 	],
 	[
-		'type' => 'tags',
+		'#type' => 'tags',
 		'name' => 'tags',
 		'value' => $tags,
-		'label' => elgg_echo('tags'),
+		'#label' => elgg_echo('tags'),
 	],
 	[
-		'type' => 'select',
+		'#type' => 'select',
 		'name' => 'status',
 		'value' => $status,
 		'options_values' => array(
 			'open' => elgg_echo('status:open'),
 			'closed' => elgg_echo('status:closed'),
 		),
-		'label' => elgg_echo('discussion:topic:status'),
+		'#label' => elgg_echo('discussion:topic:status'),
 	],
 	[
-		'type' => 'access',
+		'#type' => 'access',
 		'name' => 'access_id',
 		'value' => $access_id,
 		'entity' => get_entity($guid),
 		'entity_type' => 'object',
 		'entity_subtype' => 'discussion',
-		'label' => elgg_echo('access'),
+		'#label' => elgg_echo('access'),
 	],
 	[
-		'type' => 'hidden',
+		'#type' => 'hidden',
 		'name' => 'container_guid',
 		'value' => $container_guid,
 	],
 	[
-		'type' => 'hidden',
+		'#type' => 'hidden',
 		'name' => 'topic_guid',
 		'value' => $guid,
 	],
 ];
 
 foreach ($fields as $field) {
-	$type = elgg_extract('type', $field, 'text');
-	unset($field['type']);
-	echo elgg_view_input($type, $field);
+	echo elgg_view_field($field);
 }
 
 $footer = elgg_view_input('submit', [

--- a/mod/file/views/default/forms/file/upload.php
+++ b/mod/file/views/default/forms/file/upload.php
@@ -33,64 +33,60 @@ $max_upload = $upload_max_filesize > $post_max_size ? $post_max_size : $upload_m
 
 $upload_limit = elgg_echo('file:upload_limit', array(elgg_format_bytes($max_upload)));
 
+$categories_field = $vars;
+$categories_field['#type'] = 'categories';
+
 $fields = [
 	[
-		'type' => 'file',
+		'#type' => 'file',
+		'#label' => $file_label,
+		'#help' => $upload_limit,
 		'name' => 'upload',
-		'label' => $file_label,
-		'help' => $upload_limit,
 		'value' => ($guid),
 		'required' => (!$guid),
 	],
 	[
-		'type' => 'text',
+		'#type' => 'text',
+		'#label' => elgg_echo('title'),
 		'name' => 'title',
 		'value' => $title,
-		'label' => elgg_echo('title'),
 	],
 	[
-		'type' => 'longtext',
+		'#type' => 'longtext',
+		'#label' => elgg_echo('description'),
 		'name' => 'description',
 		'value' => $desc,
-		'label' => elgg_echo('description'),
 	],
 	[
-		'type' => 'tags',
+		'#type' => 'tags',
+		'#label' => elgg_echo('tags'),
 		'name' => 'tags',
 		'value' => $tags,
-		'label' => elgg_echo('tags'),
 	],
+	$categories_field,
 	[
-		'type' => 'categories',
-	],
-	[
-		'type' => 'access',
+		'#type' => 'access',
+		'#label' => elgg_echo('access'),
 		'name' => 'access_id',
 		'value' => $access_id,
 		'entity' => get_entity($guid),
 		'entity_type' => 'object',
 		'entity_subtype' => 'file',
-		'label' => elgg_echo('access'),
 	],
 	[
-		'type' => 'hidden',
+		'#type' => 'hidden',
 		'name' => 'container_guid',
 		'value' => $container_guid,
 	],
 	[
-		'type' => 'hidden',
+		'#type' => 'hidden',
 		'name' => 'file_guid',
 		'value' => $guid,
 	],
 ];
 
 foreach ($fields as $field) {
-	$type = elgg_extract('type', $field, 'text');
-	unset($field['type']);
-	if ($type == 'categories') {
-		$field = $vars;
-	}
-	echo elgg_view_input($type, $field);
+	echo elgg_view_field($field);
 }
 
 $footer = elgg_view_input('submit', [

--- a/views/default/admin.css.php
+++ b/views/default/admin.css.php
@@ -526,18 +526,30 @@ select {
 	padding: 4px;
 }
 
-.elgg-fieldset {
+.elgg-fieldset-has-legend {
 	border: 1px solid #ccc;
 	border-radius: 5px;
 	padding: 5px;
 	padding-bottom: 10px;
 	margin-bottom: 15px;
 }
-.elgg-fieldset > legend {
+.elgg-fieldset-has-legend > legend {
 	color: #333333;
 	font-size: 110%;
 	font-weight: bold;
 	padding: 0 3px;
+}
+.elgg-fieldset-horizontal .elgg-field {
+    display: inline-block;
+    margin: 0 10px 0 0;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-right .elgg-field {
+    margin: 0 0 0 10px;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-center .elgg-field {
+    margin: 0 5px;
 }
 
 .elgg-button {
@@ -1682,6 +1694,17 @@ table.mceLayout {
 }
 .center {
 	text-align: center;
+}
+.elgg-justify-center {
+	text-align: center;
+}
+
+.elgg-justify-right {
+	text-align: right;
+}
+
+.elgg-justify-left {
+	text-align: left;
 }
 .float {
 	float: left;

--- a/views/default/elements/forms.css.php
+++ b/views/default/elements/forms.css.php
@@ -92,6 +92,24 @@ input[type="radio"] {
 	margin: 0 auto;
 }
 
+.elgg-fieldset-has-legend {
+	border: 1px solid #dedede;
+	padding: 10px;
+}
+
+.elgg-fieldset-horizontal .elgg-field {
+    display: inline-block;
+    margin: 0 10px 0 0;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-right .elgg-field {
+    margin: 0 0 0 10px;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-center .elgg-field {
+    margin: 0 5px;
+}
+
 /* ***************************************
 	FRIENDS PICKER
 *************************************** */

--- a/views/default/elements/helpers.css.php
+++ b/views/default/elements/helpers.css.php
@@ -25,8 +25,17 @@
 	margin: 0 auto;
 }
 
-.center {
+.center,
+.elgg-justify-center {
 	text-align: center;
+}
+
+.elgg-justify-right {
+	text-align: right;
+}
+
+.elgg-justify-left {
+	text-align: left;
 }
 
 .float {

--- a/views/default/elements/patches.css.php
+++ b/views/default/elements/patches.css.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @warning INTERNAL USE ONLY. DO NOT OVERRIDE THIS VIEW.
+ * @access private
+ *
+ * Patches and features that were included between major releases
+ * sometimes require additional styling, but adding them to core CSS files
+ * is not always feasible, because those can be replaced by themes.
+ *
+ * @note Accoring to our BC policy, user-facing changes are not allowed in
+ * minor and bugfix releases. Use this file sparsely.
+ *
+ * @todo Remove in 3.0
+ */
+?>
+
+.elgg-fieldset-has-legend {
+	border: 1px solid #dedede;
+	padding: 10px;
+}
+
+.elgg-fieldset-horizontal .elgg-field {
+    display: inline-block;
+    margin: 0 10px 0 0;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-right .elgg-field {
+    margin: 0 0 0 10px;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-center .elgg-field {
+    margin: 0 5px;
+}
+
+.elgg-justify-center {
+	text-align: center;
+}
+
+.elgg-justify-right {
+	text-align: right;
+}
+
+.elgg-justify-left {
+	text-align: left;
+}

--- a/views/default/forms/register.php
+++ b/views/default/forms/register.php
@@ -25,59 +25,56 @@ $name = elgg_extract('name', $values, get_input('n'));
 
 $fields = [
 	[
+		'#type' => 'hidden',
 		'name' => 'friend_guid',
-		'type' => 'hidden',
 		'value' => elgg_extract('friend_guid', $vars),
 	],
 	[
+		'#type' => 'hidden',
 		'name' => 'invitecode',
-		'type' => 'hidden',
 		'value' => elgg_extract('invitecode', $vars),
 	],
 	[
+		'#type' => 'text',
+		'#label' => elgg_echo('name'),
+		'#class' => 'mtm',
 		'name' => 'name',
-		'type' => 'text',
 		'value' => $name,
 		'autofocus' => true,
 		'required' => true,
-		'label' => elgg_echo('name'),
-		'field_class' => 'mtm',
 	],
 	[
+		'#type' => 'email',
+		'#label' => elgg_echo('email'),
 		'name' => 'email',
-		'type' => 'email',
 		'value' => $email,
 		'required' => true,
-		'label' => elgg_echo('email'),
 	],
 	[
+		'#type' => 'text',
+		'#label' => elgg_echo('username'),
 		'name' => 'username',
-		'type' => 'text',
 		'value' => $username,
 		'required' => true,
-		'label' => elgg_echo('username'),
 	],
 	[
-	'name' => 'password',
-		'type' => 'password',
+		'#type' => 'password',
+		'#label' => elgg_echo('password'),
+		'name' => 'password',
 		'value' => $password,
 		'required' => true,
-		'label' => elgg_echo('password'),
-		],
+	],
 	[
+		'#type' => 'password',
+		'#label' => elgg_echo('passwordagain'),
 		'name' => 'password2',
-		'type' => 'password',
 		'value' => $password2,
 		'required' => true,
-		'label' => elgg_echo('passwordagain'),
 	],
 ];
 
 foreach ($fields as $field) {
-	$type = elgg_extract('type', $field, 'text');
-	unset($field[$type]);
-
-	echo elgg_view_input($type, $field);
+	echo elgg_view_field($field);
 }
 
 // view to extend to add more fields to the registration form

--- a/views/default/input/fieldset.php
+++ b/views/default/input/fieldset.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Renders a set of fields wrapped in a <fieldset> tag
+ *
+ * @uses $vars['class']   Additional CSS classes
+ * @uses $vars['align']   Field alignment (vertical|horizontal)
+ *                        If set to horizontal, fields will be rendered
+ *                        with inline display
+ * @uses $vars['justify'] Text justification (left|right|center)
+ * @uses $vars['legend']  Optional fieldset legend
+ * @uses $vars['fields']  An array of field options
+ *                        Field options should be suitable for use in
+ *                        elgg_view_field()
+ */
+
+$vars['class'] = elgg_extract_class($vars, [
+	'elgg-fieldset',
+	'clearfix',
+]);
+
+$align = elgg_extract('align', $vars, 'vertical');
+unset($vars['align']);
+$vars['class'][] = "elgg-fieldset-$align";
+
+$justify = elgg_extract('justify', $vars, '');
+unset($vars['justify']);
+if ($justify) {
+	$vars['class'][] = "elgg-justify-$justify";
+}
+
+$legend = elgg_extract('legend', $vars);
+unset($vars['legend']);
+
+$fields = (array) elgg_extract('fields', $vars, []);
+unset($vars['fields']);
+
+$fieldset = '';
+if ($legend) {
+	$vars['class'] = 'elgg-fieldset-has-legend';
+	$fieldset .= elgg_format_element('legend', [], $legend);
+}
+
+foreach ($fields as $field) {
+	$fieldset .= elgg_view_field($field);
+}
+
+echo elgg_format_element('fieldset', $vars, $fieldset);


### PR DESCRIPTION
elgg_view_input() now supports "fieldset" input type, which
can be used to render sets of "fields" (associative arrays
of field params suitable for use in elgg_view_input())
