### PR TITLE
fix(router): current_page_url() now respects route:rewrite hook values

### DIFF
--- a/engine/lib/input.php
+++ b/engine/lib/input.php
@@ -73,8 +73,8 @@ function current_page_url() {
 
 	$page = trim($page, "/");
 
-	$page .= _elgg_services()->request->getRequestUri();
-
+	$page .= implode('/', _elgg_services()->request->getUrlSegments());
+	
 	return $page;
 }
 


### PR DESCRIPTION
When routes are rewritten with route:rewrite hook they should be
considered the current page URL segments
