### PR TITLE
fix(composer): composer post-update script no longer crashes

### DIFF
--- a/engine/classes/Elgg/Composer/PostUpdate.php
+++ b/engine/classes/Elgg/Composer/PostUpdate.php
@@ -10,11 +10,11 @@ class PostUpdate {
 	/**
 	 * Todo
 	 *
-	 * @param Event $event The Composer event (install/upgrade)
+	 * @param PackageEvent $event The Composer event (install/upgrade)
 	 *
 	 * @return void
 	 */
-	public static function execute(Event $event) {
+	public static function execute(PackageEvent $event) {
 
 	}
 }


### PR DESCRIPTION
The `use` statement had been updated, but not the type-hint. This blocked updating Elgg in the `www.elgg.org` repo, forcing use of `--no-scripts`.
