### PR TITLE
fix(ckeditor): ensure basepath is set before CKeditor is loaded

### DIFF
--- a/mod/ckeditor/start.php
+++ b/mod/ckeditor/start.php
@@ -15,6 +15,7 @@ function ckeditor_init() {
 	elgg_extend_view('elgg/wysiwyg.css', 'elements/typography.css', 100);
 
 	elgg_define_js('ckeditor', array(
+		'deps' => ['elgg/ckeditor/set-basepath'],
 		'exports' => 'CKEDITOR',
 	));
 	elgg_define_js('jquery.ckeditor', array(

--- a/mod/ckeditor/views/default/elgg/ckeditor/set-basepath.js
+++ b/mod/ckeditor/views/default/elgg/ckeditor/set-basepath.js
@@ -1,7 +1,8 @@
 /**
  * This view extends elgg.js and sets ckeditor basepath before jquery.ckeditor is loaded
  */
-require(['elgg'], function(elgg) {
+define('elgg/ckeditor/set-basepath', function (require) {
+	var elgg = require('elgg');
 	// This global variable must be set before the editor script loading.
 	CKEDITOR_BASEPATH = elgg.get_simplecache_url('ckeditor/');
 });


### PR DESCRIPTION
This converts `set-basepath.js` to a real module and makes sure it's run before `ckeditor.js` is loaded. Previously we wrongly assumed ckeditor would always be loaded after elgg.js ran all `require()` scripts.

Fixes #10304

(I'm not sure this is fully BC, but see no other way to fix it.)
