### PR TITLE
chore(messageboard): fix parse error in widget content

### DIFF
--- a/mod/messageboard/views/default/widgets/messageboard/content.php
+++ b/mod/messageboard/views/default/widgets/messageboard/content.php
@@ -28,7 +28,7 @@ $more_link = elgg_view('output/url', [
 	'href' => $url,
 	'text' => elgg_echo('messageboard:viewall'),
 	'is_trusted' => true,
-));
+]);
 
 echo "<div class=\"elgg-widget-more\">$more_link</div>";
 


### PR DESCRIPTION
Was introduced in a merge conflict resolution.
