### PR TITLE
feat(forms): replaces elgg_view_input, adds support for fieldsets

### DIFF
--- a/docs/guides/actions.rst
+++ b/docs/guides/actions.rst
@@ -249,13 +249,16 @@ The above example will render a dropdown select input:
       <option value="published">Published</option>
    </select>
 
-To ensure consistency in field markup, use ``elgg_view_input()``, which accepts
-all the parameters of the input being rendered, as well as ``label`` and ``help``
+To ensure consistency in field markup, use ``elgg_view_field()``, which accepts
+all the parameters of the input being rendered, as well as ``#label`` and ``#help``
 parameters (both of which are optional and accept HTML or text).
 
 .. code:: php
 
-   echo elgg_view_input('select', array(
+   echo elgg_view_field(array(
+      '#type' => 'select',
+      '#label' => elgg_echo('blog:status:label'),
+      '#help' => elgg_view_icon('help') . elgg_echo('blog:status:help'),
       'required' => true,
       'name' => 'status',
       'options_values' => array(
@@ -263,8 +266,6 @@ parameters (both of which are optional and accept HTML or text).
          'published' => elgg_echo('status:published'),
       ),
       'data-rel' => 'blog',
-      'label' => elgg_echo('blog:status:label'),
-      'help' => elgg_view_icon('help') . elgg_echo('blog:status:help'),
    ));
 
 The above will generate the following markup:

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -20,17 +20,18 @@ Deprecated APIs
  * ``ajax_forward_hook()``: No longer used as handler for `'forward','all'` hook. Ajax response is now wrapped by the ``ResponseFactory``
  * ``ajax_action_hook()``: No longer used as handler for `'action','all'` hook. Output buffering now starts before the hook is triggered in ``ActionsService``
  * ``elgg_error_page_handler()``: No longer used as a handler for `'forward',<error_code>` hooks
- * ``get_uploaded_file()`` is deprecated: Use new file uploads API instead
- * ``get_user_notification_settings()`` is deprecated: Use ``ElggUser::getNotificationSettings()``
- * ``set_user_notification_setting()`` is deprecated: Use ``ElggUser::setNotificationSetting()``
+ * ``get_uploaded_file()``: Use new file uploads API instead
+ * ``get_user_notification_settings()``: Use ``ElggUser::getNotificationSettings()``
+ * ``set_user_notification_setting()``: Use ``ElggUser::setNotificationSetting()``
  * ``pagesetup, system`` event: Use the menu or page shell hooks instead.
  * ``elgg.walled_garden`` JavaScript is deprecated: Use ``elgg/walled_garden`` AMD module instead.
- * ``elgg()->getDb()->getTableprefix()`` is deprecated: Use ``elgg_get_config('dbprefix')``.
- * Private ``update_entity_last_action()`` is deprecated: Refrain from manually updating last action timestamp.
+ * ``elgg()->getDb()->getTableprefix()``: Use ``elgg_get_config('dbprefix')``.
+ * Private ``update_entity_last_action()``: Refrain from manually updating last action timestamp.
  * Setting non-public ``access_id`` on metadata is deprecated. See below.
- * ``get_resized_image_from_existing_file()`` is deprecated: Use ``elgg_save_resized_image()``.
- * ``get_resized_image_from_uploaded_file()`` is deprecated: Use ``elgg_save_resized_image()`` in combination with upload API.
- * ``get_image_resize_parameters()`` is deprecated and will be removed.
+ * ``get_resized_image_from_existing_file()``: Use ``elgg_save_resized_image()``.
+ * ``get_resized_image_from_uploaded_file()``: Use ``elgg_save_resized_image()`` in combination with upload API.
+ * ``get_image_resize_parameters()`` will be removed.
+ * ``elgg_view_input()``: Use ``elgg_view_field()``. Apologies for the API churn.
 
 Deprecated Views
 ----------------
@@ -72,9 +73,9 @@ New API for signing URLs
 
 URLs can now be signed with a SHA-256 HMAC key and validated at any time before URL expiry. This feature can be used to tokenize action URLs in email notifications, as well as other uses outside of the Elgg installation.
 
- * `elgg_http_get_signed_url()` - signs the URL with HMAC key
- * `elgg_http_validate_signed_url()` - validates the signed URL
- * `elgg_signed_request_gatekeeper()` - gatekeeper that validates the signature of the current request
+ * ``elgg_http_get_signed_url()`` - signs the URL with HMAC key
+ * ``elgg_http_validate_signed_url()`` - validates the signed URL
+ * ``elgg_signed_request_gatekeeper()`` - gatekeeper that validates the signature of the current request
 
 Extendable form views
 ---------------------
@@ -123,6 +124,13 @@ API to alter registration and login URL
  * ``elgg_get_login_url()`` should be used to obtain site's login URL
  * ``registration_url, site`` hook can be used to alter the default registration URL
  * ``login_url, site`` hook can be used to alter the default login URL
+
+Support for fieldsets in forms
+------------------------------
+
+ * ``elgg_view_field()`` replaces ``elgg_view_input()``. It has a similar API, but accepts a single array.
+ * ``elgg_view_field()`` supports ``#type``, ``#label``, ``#help`` and ``#class``, allowing unprefixed versions to be sent to the input view ``$vars``.
+ * The new view ``input/fieldset`` can be used to render a set of fields, each rendered with ``elgg_view_field()``.
 
 From 2.1 to 2.2
 ===============

--- a/docs/tutorials/blog.rst
+++ b/docs/tutorials/blog.rst
@@ -59,32 +59,36 @@ body and tags of the my_blog post. It does not need form tag markup.
 
 .. code-block:: php
 
-    echo elgg_view_input('text', [
+    echo elgg_view_field([
+        '#type' => 'text',
+        '#label' => elgg_echo('title'),
         'name' => 'title',
-        'label' => elgg_echo('title'),
         'required' => true,
     ]);
 
-    echo elgg_view_input('longtext', [
+    echo elgg_view_field([
+        '#type' => 'longtext',
+        '#label' => elgg_echo('body'),
         'name' => 'body',
-        'label' => elgg_echo('body'),
         'required' => true,
     ]);
 
-    echo elgg_view_input('tags', [
+    echo elgg_view_field([
+        '#type' => 'tags',
+        '#label' => elgg_echo('tags'),
+        '#help' => elgg_echo('tags:help'),
         'name' => 'tags',
-        'label' => elgg_echo('tags'),
-        'help' => elgg_echo('tags:help'),
     ]);
 
-    $submit = elgg_view_input('submit', array(
+    $submit = elgg_view_field(array(
+        '#type' => 'submit',
+        '#class' => 'elgg-foot',
         'value' => elgg_echo('save'),
-        'field_class' => 'elgg-foot',
     ));
     elgg_set_form_footer($submit);
 
 
-Notice how the form is calling ``elgg_view_input()`` to render inputs. This helper
+Notice how the form is calling ``elgg_view_field()`` to render inputs. This helper
 function maintains consistency in field markup, and is used as a shortcut for
 rendering field elements, such as label, help text, and input. See :doc:`/guides/actions`.
 

--- a/engine/classes/Elgg/FormsService.php
+++ b/engine/classes/Elgg/FormsService.php
@@ -72,8 +72,8 @@ class FormsService {
 	 *
 	 * @param string $action    The name of the action. An action name does not include
 	 *                          the leading "action/". For example, "login" is an action name.
-	 * @param array  $form_vars $vars environment passed to the "input/form" view
-	 * @param array  $body_vars $vars environment passed to the "forms/$action" view
+	 * @param array  $form_vars $vars passed to the "input/form" view
+	 * @param array  $body_vars $vars passed to the "forms/<action>" view
 	 *
 	 * @return string The complete form
 	 */

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1378,53 +1378,114 @@ function elgg_get_form_footer() {
  *                           input view. Both 'label' and 'help' params accept HTML, and
  *                           will be printed unescaped within their wrapper element.
  * @return string
+ *
+ * @since 2.1
+ * @deprecated 2.3 Use elgg_view_field()
  */
 function elgg_view_input($input_type, array $vars = array()) {
 
+	elgg_deprecated_notice(__FUNCTION__ . '() is deprecated. Use elgg_view_field()', '2.3');
+
+	$vars['#type'] = $input_type;
+
+	if (isset($vars['label'])) {
+		$vars['#label'] = $vars['label'];
+		unset($vars['label']);
+	}
+	if (isset($vars['help'])) {
+		$vars['#help'] = $vars['help'];
+		unset($vars['help']);
+	}
+	if (isset($vars['field_class'])) {
+		$vars['#class'] = $vars['field_class'];
+		unset($vars['field_class']);
+	}
+
+	return elgg_view_field($vars);
+}
+
+/**
+ * Renders a form field, usually with a wrapper element, a label, help text, etc.
+ *
+ * @param array $params Field parameters and variables for the input view.
+ *                      Keys not prefixed with hash (#) are passed to the input view as $vars.
+ *                      Keys prefixed with a hash specify the field wrapper (.elgg-view-field) output.
+ *                       - #type: specifies input view. E.g. "text" uses the view "input/text".
+ *                       - #label: field label HTML
+ *                       - #help: field help HTML
+ *                       - #class: field class name
+ *                      Note: Both #label and #help are printed unescaped within their wrapper element.
+ *
+ * @return string
+ * @since 2.3
+ */
+function elgg_view_field(array $params = []) {
+
+	if (empty($params['#type'])) {
+		_elgg_services()->logger->error(__FUNCTION__ . '(): $params["#type"] is required.');
+		return '';
+	}
+
+	$input_type = $params['#type'];
 	if (!elgg_view_exists("input/$input_type")) {
 		return '';
 	}
 
-	if ($input_type == 'hidden') {
-		return elgg_view("input/$input_type", $vars);
+	$hidden_types = ['hidden', 'securitytoken'];
+	if (in_array($input_type, $hidden_types)) {
+		return elgg_view("input/$input_type", $params);
 	}
 
-	$id = elgg_extract('id', $vars);
+	$id = elgg_extract('id', $params);
 	if (!$id) {
 		$id = "elgg-field-" . base_convert(mt_rand(), 10, 36);
-		$vars['id'] = $id;
+		$params['id'] = $id;
 	}
 
-	$vars['input_type'] = $input_type;
+	// $vars passed to label, help and field wrapper views
+	$element_vars = [];
 
-	$label = elgg_view('elements/forms/label', $vars);
+	// $vars passed to input/$input_name
+	$input_vars = [];
+
+	// first pass non-hash keys into both
+	foreach ($params as $key => $value) {
+		if ($key[0] !== '#') {
+			$element_vars[$key] = $value;
+			$input_vars[$key] = $value;
+		}
+	}
+
+	// field input view needs this
+	$input_vars['input_type'] = $input_type;
+
+	// field views get more data
+	$element_vars['input_type'] = $input_type;
+	if (isset($params['#class'])) {
+		$element_vars['field_class'] = $params['#class'];
+	}
+	if (isset($params['#help'])) {
+		$element_vars['help'] = $params['#help'];
+	}
+	if (isset($params['#label'])) {
+		$element_vars['label'] = $params['#label'];
+	}
+
+	// wrap if present
+	$element_vars['label'] = elgg_view('elements/forms/label', $element_vars);
+	$element_vars['help'] = elgg_view('elements/forms/help', $element_vars);
+
 	if ($input_type == 'checkbox') {
-		$vars['label'] = $label;
-		$vars['label_tag'] = 'div';
-		$label = false;
-	} else {
-		unset($vars['label']);
+		// Single checkbox input view gets special treatment
+		// We don't want the field label to appear a checkbox without a label
+		$input_vars['label'] = $element_vars['label'];
+		$input_vars['label_tag'] = 'div';
+		unset($element_vars['label']);
 	}
 
-	$help = elgg_view('elements/forms/help', $vars);
-	unset($vars['help']);
+	$element_vars['input'] = elgg_view("elements/forms/input", $input_vars);
 
-	$required = elgg_extract('required', $vars);
-
-	$field_class = (array) elgg_extract('field_class', $vars, array());
-	unset($vars['field_class']);
-
-	$input = elgg_view("elements/forms/input", $vars);
-
-	return elgg_view('elements/forms/field', array(
-		'label' => $label,
-		'help' => $help,
-		'required' => $required,
-		'id' => $id,
-		'input' => $input,
-		'class' => $field_class,
-		'input_type' => $input_type,
-	));
+	return elgg_view('elements/forms/field', $element_vars);
 }
 
 /**
@@ -1843,6 +1904,13 @@ function elgg_views_boot() {
 		);
 		elgg_set_config('icon_sizes', $icon_sizes);
 	}
+
+	// Patches and features that were included between major releases
+	// sometimes require additional styling, but adding them to core CSS files
+	// is not always feasible, because those can be replaced by themes.
+	// @todo Remove in 3.0
+	elgg_extend_view('elgg.css', 'elements/pathces.css');
+	elgg_extend_view('admin.css', 'elements/pathces.css');
 }
 
 /**

--- a/mod/aalborg_theme/views/default/elements/forms.css.php
+++ b/mod/aalborg_theme/views/default/elements/forms.css.php
@@ -96,6 +96,24 @@ select {
 	margin: 0 auto;
 }
 
+.elgg-fieldset-has-legend {
+	border: 1px solid #dedede;
+	padding: 10px;
+}
+
+.elgg-fieldset-horizontal .elgg-field {
+    display: inline-block;
+    margin: 0 10px 0 0;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-right .elgg-field {
+    margin: 0 0 0 10px;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-center .elgg-field {
+    margin: 0 5px;
+}
+
 /* ***************************************
 	FRIENDS PICKER
 *************************************** */

--- a/mod/bookmarks/views/default/forms/bookmarks/save.php
+++ b/mod/bookmarks/views/default/forms/bookmarks/save.php
@@ -56,7 +56,8 @@ if ($guid) {
 	echo elgg_view('input/hidden', array('name' => 'guid', 'value' => $guid));
 }
 
-$footer = elgg_view_input('submit', [
+$footer = elgg_view_field([
+	'#type' => 'submit',
 	'value' => elgg_echo('save'),
 ]);
 elgg_set_form_footer($footer);

--- a/mod/developers/views/default/theme_sandbox/forms.php
+++ b/mod/developers/views/default/theme_sandbox/forms.php
@@ -4,53 +4,59 @@ $ipsum = elgg_view('developers/ipsum');
 	<fieldset>
 		<legend>Fieldset Legend</legend>
 		<?php
-		echo elgg_view_input('text', array(
+		echo elgg_view_field(array(
+			'#type' => 'text',
 			'required' => true,
 			'name' => 'f1',
 			'id' => 'f1',
 			'value' => 'input text',
-			'label' => 'Text input (.elgg-input-text):',
-			'help' => 'This is how help text looks',
+			'#label' => 'Text input (.elgg-input-text):',
+			'#help' => 'This is how help text looks',
 		));
 
-		echo elgg_view_input('password', array(
+		echo elgg_view_field(array(
+			'#type' => 'password',
 			'name' => 'f2',
 			'id' => 'f2',
 			'value' => 'password',
-			'label' => 'Password input (.elgg-input-password):',
+			'#label' => 'Password input (.elgg-input-password):',
 		));
 
-		echo elgg_view_input('radio', array(
+		echo elgg_view_field(array(
+			'#type' => 'radio',
 			'name' => 'f3',
 			'id' => 'f3',
 			'options' => array(
 				'a (.elgg-input-radio)' => 1,
 				'b (.elgg-input-radio)' => 2
 			),
-			'label' => 'Radio input (.elgg-input-radios):',
+			'#label' => 'Radio input (.elgg-input-radios):',
 		));
 
-		echo elgg_view_input('checkbox', array(
+		echo elgg_view_field(array(
+			'#type' => 'checkbox',
 			'name' => 'f4s',
 			'id' => 'f4s',
 			'value' => 1,
 			'default' => false,
 			'required' => true,
-			'label' => 'a (.elgg-input-checkbox)',
-			'help' => 'Single checkbox .elgg-input-checkbox wrapped in .elgg-input-single-checkbox',
+			'#label' => 'a (.elgg-input-checkbox)',
+			'#help' => 'Single checkbox .elgg-input-checkbox wrapped in .elgg-input-single-checkbox',
 		));
 
-		echo elgg_view_input('checkboxes', array(
+		echo elgg_view_field(array(
+			'#type' => 'checkboxes',
 			'name' => 'f4',
 			'id' => 'f4',
 			'options' => array(
 				'a (.elgg-input-checkbox)' => 1,
 				'b (.elgg-input-checkbox)' => 2
 			),
-			'label' => 'Checkboxes input (.elgg-input-checkboxes):',
+			'#label' => 'Checkboxes input (.elgg-input-checkboxes):',
 		));
 
-		echo elgg_view_input('select', array(
+		echo elgg_view_field(array(
+			'#type' => 'select',
 			'name' => 'f5',
 			'id' => 'f5',
 			'options' => array(
@@ -61,67 +67,76 @@ $ipsum = elgg_view('developers/ipsum');
 		            'disabled' => true,
 		        ],
 			),
-			'label' => 'Select input (dropdown) (.elgg-input-dropdown) with a disabled option:',
+			'#label' => 'Select input (dropdown) (.elgg-input-dropdown) with a disabled option:',
 		));
 
-		echo elgg_view_input('select', array(
+		echo elgg_view_field(array(
+			'#type' => 'select',
 			'name' => 'f51[]',
 			'id' => 'f51',
 			'options_values' => array('value 1' => 'option 1', 'value 2' => 'option 2', 'value 3' => 'option 3'),
 			'multiple' => true,
-			'label' => 'Select input (multiselect) (.elgg-input-dropdown):',
+			'#label' => 'Select input (multiselect) (.elgg-input-dropdown):',
 		));
 
-		echo elgg_view_input('access', array(
+		echo elgg_view_field(array(
+			'#type' => 'access',
 			'name' => 'f6',
 			'id' => 'f6',
 			'value' => ACCESS_PUBLIC,
-			'label' => 'Access input (.elgg-input-access):',
+			'#label' => 'Access input (.elgg-input-access):',
 		));
 
-		echo elgg_view_input('file', array(
+		echo elgg_view_field(array(
+			'#type' => 'file',
 			'name' => 'f7',
 			'id' => 'f7',
-			'label' => 'File input (.elgg-input-file):',
+			'#label' => 'File input (.elgg-input-file):',
 		));
 
-		echo elgg_view_input('url', array(
+		echo elgg_view_field(array(
+			'#type' => 'url',
 			'name' => 'f8',
 			'id' => 'f8',
 			'value' => 'http://elgg.org/',
-			'label' => 'URL input (.elgg-input-url):',
+			'#label' => 'URL input (.elgg-input-url):',
 		));
 
-		echo elgg_view_input('tags', array(
+		echo elgg_view_field(array(
+			'#type' => 'tags',
 			'name' => 'f9',
 			'id' => 'f9',
 			'value' => 'one, two, three',
-			'label' => 'Tags input (.elgg-input-tags):',
+			'#label' => 'Tags input (.elgg-input-tags):',
 		));
 
-		echo elgg_view_input('email', array(
+		echo elgg_view_field(array(
+			'#type' => 'email',
 			'name' => 'f10',
 			'id' => 'f10',
 			'value' => 'noone@elgg.org',
-			'label' => 'Email input (.elgg-input-email):',
+			'#label' => 'Email input (.elgg-input-email):',
 		));
 
-		echo elgg_view_input('autocomplete', array(
+		echo elgg_view_field(array(
+			'#type' => 'autocomplete',
 			'name' => 'f11',
 			'id' => 'f11',
 			'match_on' => array('groups', 'friends'),
-			'label' => 'Autocomplete input (.elgg-input-autocomplete):',
+			'#label' => 'Autocomplete input (.elgg-input-autocomplete):',
 		));
 
-		echo elgg_view_input('date', array(
+		echo elgg_view_field(array(
+			'#type' => 'date',
 			'name' => 'f12',
 			'id' => 'f12',
 			'value' => '2012-12-31',
-			'label' => 'Date input (.elgg-input-date):',
+			'#label' => 'Date input (.elgg-input-date):',
 		));
 
 		$year = date('Y');
-		echo elgg_view_input('date', array(
+		echo elgg_view_field(array(
+			'#type' => 'date',
 			'name' => 'f12-custom',
 			'id' => 'f12-custom',
 			'value' => "$year/02/01",
@@ -133,61 +148,106 @@ $ipsum = elgg_view('developers/ipsum');
 				'minDate' => "$year/01/15",
 				'maxDate' => "$year/02/15",
 			),
-			'label' => 'Date input (.elgg-input-date) with custom options:',
-			'help' => 'Select a date from 15 Jan to 15 Feb',
+			'#label' => 'Date input (.elgg-input-date) with custom options:',
+			'#help' => 'Select a date from 15 Jan to 15 Feb',
 		));
 
-		echo elgg_view_input('userpicker', array(
+		echo elgg_view_field(array(
+			'#type' => 'userpicker',
 			'name' => 'f13',
 			'id' => 'f13',
-			'label' => 'User picker input (.elgg-user-picker):',
+			'#label' => 'User picker input (.elgg-user-picker):',
 		));
 
-		echo elgg_view_input('userpicker', array(
+		echo elgg_view_field(array(
+			'#type' => 'userpicker',
 			'name' => 'f16',
 			'id' => 'f16',
 			'limit' => 1,
-			'label' => 'User picker input (with max 1 results) (.elgg-user-picker):',
+			'#label' => 'User picker input (with max 1 results) (.elgg-user-picker):',
 		));
 
-		echo elgg_view_input('plaintext', array(
+		echo elgg_view_field(array(
+			'#type' => 'plaintext',
 			'name' => 'f15',
 			'id' => 'f15',
 			'value' => $ipsum,
-			'label' => 'Plain textarea input (.elgg-input-plaintext):',
+			'#label' => 'Plain textarea input (.elgg-input-plaintext):',
 		));
 
-		echo elgg_view_input('longtext', array(
+		echo elgg_view_field(array(
+			'#type' => 'longtext',
 			'name' => 'f14',
 			'id' => 'f14',
 			'value' => $ipsum,
-			'label' => 'Long textarea input (.elgg-input-longtext):',
+			'#label' => 'Long textarea input (.elgg-input-longtext):',
 		));
 
-		echo elgg_view_input('longtext', array(
+		echo elgg_view_field(array(
+			'#type' => 'longtext',
 			'name' => 'f14a',
 			'id' => 'f14a',
 			'value' => $ipsum,
 			'editor' => false,
-			'label' => 'Long textarea input (.elgg-input-longtext) with a disabled editor:',
+			'#label' => 'Long textarea input (.elgg-input-longtext) with a disabled editor:',
 		));
 
-		echo elgg_view_input('longtext', array(
+		echo elgg_view_field(array(
+			'#type' => 'longtext',
 			'name' => 'f14b',
 			'id' => 'f14b',
 			'value' => $ipsum,
 			'visual' => false,
-			'label' => 'Long textarea input (.elgg-input-longtext) without a visual editor activated by default:',
+			'#label' => 'Long textarea input (.elgg-input-longtext) without a visual editor activated by default:',
 		));
 
-		echo elgg_view_input('number', array(
+		echo elgg_view_field(array(
+			'#type' => 'number',
 			'name' => 'f15',
 			'id' => 'f15',
 			'value' => 1,
 			'min' => 1,
 			'step' => 1,
-			'label' => 'Number input (.elgg-input-number) with custom options:',
-			'help' => 'Enter an integer number larger than zero',
+			'#label' => 'Number input (.elgg-input-number) with custom options:',
+			'#help' => 'Enter an integer number larger than zero',
+		));
+
+		$dt = new \DateTime(null, new \DateTimeZone('UTC'));
+		$hour_options = array();
+		$hour_options_ts = range(0, 24*60*60, 900); // step of 15 minutes
+		foreach ($hour_options_ts as $ts) {
+			$hour_options[$ts] = $dt->setTimestamp($ts)->format('g:ia');
+		}
+
+		echo elgg_view_field(array(
+			'#type' => 'fieldset',
+			'name' => 'f16',
+			'legend' => 'Fieldset with a legend',
+			'fields' => [
+				[
+					'#type' => 'text',
+					'#label' => 'Text field',
+					'required' => true,
+				],
+				[
+					'#type' => 'fieldset',
+					'#label' => 'Date and time fieldset',
+					'align' => 'horizontal',
+					'fields' => [
+						[
+							'#type' => 'date',
+							'value' => time(),
+							'timestamp' => true,
+							'#label' => 'Date',
+						],
+						[
+							'#type' => 'select',
+							'#label' => 'Time',
+							'options' => $hour_options,
+						],
+					],
+				],
+			]
 		));
 		?>
 	</fieldset>

--- a/mod/discussions/views/default/ajax/discussion/reply/edit.php
+++ b/mod/discussions/views/default/ajax/discussion/reply/edit.php
@@ -15,5 +15,8 @@ $form_vars = array(
 	'class' => ($hidden ? 'hidden ' : '') . 'mvl',
 	'id' => "edit-discussion-reply-{$guid}",
 );
-$body_vars = array('entity' => $reply);
+$body_vars = array(
+	'entity' => $reply,
+	'inline' => true,
+);
 echo elgg_view_form('discussion/reply/save', $form_vars, $body_vars);

--- a/mod/discussions/views/default/forms/discussion/save.php
+++ b/mod/discussions/views/default/forms/discussion/save.php
@@ -14,63 +14,62 @@ $guid = elgg_extract('guid', $vars, null);
 
 $fields = [
 	[
-		'type' => 'text',
+		'#type' => 'text',
 		'name' => 'title',
 		'value' => $title,
-		'label' => elgg_echo('title'),
+		'#label' => elgg_echo('title'),
 		'required' => true,
 	],
 	[
-		'type' => 'longtext',
+		'#type' => 'longtext',
 		'name' => 'description',
 		'value' => $desc,
-		'label' => elgg_echo('discussion:topic:description'),
+		'#label' => elgg_echo('discussion:topic:description'),
 		'required' => true,
 	],
 	[
-		'type' => 'tags',
+		'#type' => 'tags',
 		'name' => 'tags',
 		'value' => $tags,
-		'label' => elgg_echo('tags'),
+		'#label' => elgg_echo('tags'),
 	],
 	[
-		'type' => 'select',
+		'#type' => 'select',
 		'name' => 'status',
 		'value' => $status,
 		'options_values' => array(
 			'open' => elgg_echo('status:open'),
 			'closed' => elgg_echo('status:closed'),
 		),
-		'label' => elgg_echo('discussion:topic:status'),
+		'#label' => elgg_echo('discussion:topic:status'),
 	],
 	[
-		'type' => 'access',
+		'#type' => 'access',
 		'name' => 'access_id',
 		'value' => $access_id,
 		'entity' => get_entity($guid),
 		'entity_type' => 'object',
 		'entity_subtype' => 'discussion',
-		'label' => elgg_echo('access'),
+		'#label' => elgg_echo('access'),
 	],
 	[
-		'type' => 'hidden',
+		'#type' => 'hidden',
 		'name' => 'container_guid',
 		'value' => $container_guid,
 	],
 	[
-		'type' => 'hidden',
+		'#type' => 'hidden',
 		'name' => 'topic_guid',
 		'value' => $guid,
 	],
 ];
 
 foreach ($fields as $field) {
-	$type = elgg_extract('type', $field, 'text');
-	unset($field['type']);
-	echo elgg_view_input($type, $field);
+	echo elgg_view_field($field);
 }
 
-$footer = elgg_view_input('submit', [
+$footer = elgg_view_field([
+	'#type' => 'submit',
 	'value' => elgg_echo('save'),
 ]);
 elgg_set_form_footer($footer);

--- a/mod/file/views/default/forms/file/upload.php
+++ b/mod/file/views/default/forms/file/upload.php
@@ -33,67 +33,64 @@ $max_upload = $upload_max_filesize > $post_max_size ? $post_max_size : $upload_m
 
 $upload_limit = elgg_echo('file:upload_limit', array(elgg_format_bytes($max_upload)));
 
+$categories_field = $vars;
+$categories_field['#type'] = 'categories';
+
 $fields = [
 	[
-		'type' => 'file',
+		'#type' => 'file',
+		'#label' => $file_label,
+		'#help' => $upload_limit,
 		'name' => 'upload',
-		'label' => $file_label,
-		'help' => $upload_limit,
 		'value' => ($guid),
 		'required' => (!$guid),
 	],
 	[
-		'type' => 'text',
+		'#type' => 'text',
+		'#label' => elgg_echo('title'),
 		'name' => 'title',
 		'value' => $title,
-		'label' => elgg_echo('title'),
 	],
 	[
-		'type' => 'longtext',
+		'#type' => 'longtext',
+		'#label' => elgg_echo('description'),
 		'name' => 'description',
 		'value' => $desc,
-		'label' => elgg_echo('description'),
 	],
 	[
-		'type' => 'tags',
+		'#type' => 'tags',
+		'#label' => elgg_echo('tags'),
 		'name' => 'tags',
 		'value' => $tags,
-		'label' => elgg_echo('tags'),
 	],
+	$categories_field,
 	[
-		'type' => 'categories',
-	],
-	[
-		'type' => 'access',
+		'#type' => 'access',
+		'#label' => elgg_echo('access'),
 		'name' => 'access_id',
 		'value' => $access_id,
 		'entity' => get_entity($guid),
 		'entity_type' => 'object',
 		'entity_subtype' => 'file',
-		'label' => elgg_echo('access'),
 	],
 	[
-		'type' => 'hidden',
+		'#type' => 'hidden',
 		'name' => 'container_guid',
 		'value' => $container_guid,
 	],
 	[
-		'type' => 'hidden',
+		'#type' => 'hidden',
 		'name' => 'file_guid',
 		'value' => $guid,
 	],
 ];
 
 foreach ($fields as $field) {
-	$type = elgg_extract('type', $field, 'text');
-	unset($field['type']);
-	if ($type == 'categories') {
-		$field = $vars;
-	}
-	echo elgg_view_input($type, $field);
+	echo elgg_view_field($field);
 }
 
-$footer = elgg_view_input('submit', [
+$footer = elgg_view_field([
+	'#type' => 'submit',
 	'value' => elgg_echo('save'),
 ]);
 elgg_set_form_footer($footer);

--- a/mod/groups/views/default/forms/groups/edit.php
+++ b/mod/groups/views/default/forms/groups/edit.php
@@ -28,7 +28,8 @@ if ($entity) {
 	));
 }
 
-$footer = elgg_view_input('submit', [
+$footer = elgg_view_field([
+	'#type' => 'submit',
 	'value' => elgg_echo('save'),
 ]);
 

--- a/mod/groups/views/default/widgets/group_activity/edit.php
+++ b/mod/groups/views/default/widgets/group_activity/edit.php
@@ -15,9 +15,10 @@ foreach ($groups as $group) {
 	$mygroups[$group->guid] = $group->name;
 }
 
-echo elgg_view_input('select', [
+echo elgg_view_field([
+	'#type' => 'select',
 	'name' => 'params[group_guid]',
-	'label' => elgg_echo('groups:widget:group_activity:edit:select'),
+	'#label' => elgg_echo('groups:widget:group_activity:edit:select'),
 	'value' => $widget->group_guid,
 	'options_values' => $mygroups,
 ]);

--- a/views/default/admin.css.php
+++ b/views/default/admin.css.php
@@ -526,18 +526,30 @@ select {
 	padding: 4px;
 }
 
-.elgg-fieldset {
+.elgg-fieldset-has-legend {
 	border: 1px solid #ccc;
 	border-radius: 5px;
 	padding: 5px;
 	padding-bottom: 10px;
 	margin-bottom: 15px;
 }
-.elgg-fieldset > legend {
+.elgg-fieldset-has-legend > legend {
 	color: #333333;
 	font-size: 110%;
 	font-weight: bold;
 	padding: 0 3px;
+}
+.elgg-fieldset-horizontal .elgg-field {
+    display: inline-block;
+    margin: 0 10px 0 0;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-right .elgg-field {
+    margin: 0 0 0 10px;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-center .elgg-field {
+    margin: 0 5px;
 }
 
 .elgg-button {
@@ -1682,6 +1694,17 @@ table.mceLayout {
 }
 .center {
 	text-align: center;
+}
+.elgg-justify-center {
+	text-align: center;
+}
+
+.elgg-justify-right {
+	text-align: right;
+}
+
+.elgg-justify-left {
+	text-align: left;
 }
 .float {
 	float: left;

--- a/views/default/core/settings/account/default_access.php
+++ b/views/default/core/settings/account/default_access.php
@@ -21,10 +21,11 @@ if ($default_access === null) {
 }
 
 $title = elgg_echo('default_access:settings');
-$content = elgg_view_input('access', array(
+$content = elgg_view_field(array(
+	'#type' => 'access',
 	'name' => 'default_access',
 	'value' => $default_access,
-	'label' => elgg_echo('default_access:label'),
+	'#label' => elgg_echo('default_access:label'),
 		));
 
 echo elgg_view_module('info', $title, $content);

--- a/views/default/core/settings/account/email.php
+++ b/views/default/core/settings/account/email.php
@@ -13,10 +13,11 @@ if (!$user instanceof ElggUser) {
 }
 
 $title = elgg_echo('email:settings');
-$content = elgg_view_input('email', array(
+$content = elgg_view_field(array(
+	'#type' => 'email',
 	'name' => 'email',
 	'value' => $user->email,
-	'label' => elgg_echo('email:address:label'),
+	'#label' => elgg_echo('email:address:label'),
 ));
 
 echo elgg_view_module('info', $title, $content);

--- a/views/default/core/settings/account/language.php
+++ b/views/default/core/settings/account/language.php
@@ -13,11 +13,12 @@ if (!$user instanceof ElggUser) {
 }
 
 $title = elgg_echo('user:set:language');
-$content = elgg_view_input('select', array(
+$content = elgg_view_field(array(
+	'#type' => 'select',
 	'name' => 'language',
 	'value' => $user->language,
 	'options_values' => get_installed_translations(),
-	'label' => elgg_echo('user:language:label'),
+	'#label' => elgg_echo('user:language:label'),
 		));
 
 echo elgg_view_module('info', $title, $content);

--- a/views/default/core/settings/account/name.php
+++ b/views/default/core/settings/account/name.php
@@ -14,10 +14,11 @@ if (!$user instanceof ElggUser) {
 }
 
 $title = elgg_echo('user:name:label');
-$content .= elgg_view_input('text', array(
+$content .= elgg_view_field(array(
+	'#type' => 'text',
 	'name' => 'name',
 	'value' => $user->name,
-	'label' => elgg_echo('name'),
+	'#label' => elgg_echo('name'),
 		));
 
 echo elgg_view_module('info', $title, $content);

--- a/views/default/core/settings/account/password.php
+++ b/views/default/core/settings/account/password.php
@@ -17,20 +17,23 @@ $title = elgg_echo('user:set:password');
 // only make the admin user enter current password for changing his own password.
 $admin = '';
 if (!elgg_is_admin_logged_in() || elgg_is_admin_logged_in() && $user->guid == elgg_get_logged_in_user_guid()) {
-	$admin .= elgg_view_input('password', array(
+	$admin .= elgg_view_field(array(
+	'#type' => 'password',
 		'name' => 'current_password',
-		'label' => elgg_echo('user:current_password:label'),
+		'#label' => elgg_echo('user:current_password:label'),
 	));
 }
 
-$password = elgg_view_input('password', array(
+$password = elgg_view_field(array(
+	'#type' => 'password',
 	'name' => 'password',
-	'label' => elgg_echo('user:password:label'),
+	'#label' => elgg_echo('user:password:label'),
 		));
 
-$password2 = elgg_view_input('password', array(
+$password2 = elgg_view_field(array(
+	'#type' => 'password',
 	'name' => 'password2',
-	'label' => elgg_echo('user:password2:label')
+	'#label' => elgg_echo('user:password2:label')
 		));
 
 $content = $admin . $password . $password2;

--- a/views/default/elements/forms.css.php
+++ b/views/default/elements/forms.css.php
@@ -92,6 +92,24 @@ input[type="radio"] {
 	margin: 0 auto;
 }
 
+.elgg-fieldset-has-legend {
+	border: 1px solid #dedede;
+	padding: 10px;
+}
+
+.elgg-fieldset-horizontal .elgg-field {
+    display: inline-block;
+    margin: 0 10px 0 0;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-right .elgg-field {
+    margin: 0 0 0 10px;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-center .elgg-field {
+    margin: 0 5px;
+}
+
 /* ***************************************
 	FRIENDS PICKER
 *************************************** */

--- a/views/default/elements/helpers.css.php
+++ b/views/default/elements/helpers.css.php
@@ -25,8 +25,17 @@
 	margin: 0 auto;
 }
 
-.center {
+.center,
+.elgg-justify-center {
 	text-align: center;
+}
+
+.elgg-justify-right {
+	text-align: right;
+}
+
+.elgg-justify-left {
+	text-align: left;
 }
 
 .float {

--- a/views/default/elements/patches.css.php
+++ b/views/default/elements/patches.css.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @warning INTERNAL USE ONLY. DO NOT OVERRIDE THIS VIEW.
+ * @access private
+ *
+ * Patches and features that were included between major releases
+ * sometimes require additional styling, but adding them to core CSS files
+ * is not always feasible, because those can be replaced by themes.
+ *
+ * @note Accoring to our BC policy, user-facing changes are not allowed in
+ * minor and bugfix releases. Use this file sparsely.
+ *
+ * @todo Remove in 3.0
+ */
+?>
+
+.elgg-fieldset-has-legend {
+	border: 1px solid #dedede;
+	padding: 10px;
+}
+
+.elgg-fieldset-horizontal .elgg-field {
+    display: inline-block;
+    margin: 0 10px 0 0;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-right .elgg-field {
+    margin: 0 0 0 10px;
+}
+
+.elgg-fieldset-horizontal.elgg-justify-center .elgg-field {
+    margin: 0 5px;
+}
+
+.elgg-justify-center {
+	text-align: center;
+}
+
+.elgg-justify-right {
+	text-align: right;
+}
+
+.elgg-justify-left {
+	text-align: left;
+}

--- a/views/default/forms/admin/site/advanced/caching.php
+++ b/views/default/forms/admin/site/advanced/caching.php
@@ -60,12 +60,13 @@ $minify_css_input = elgg_view("input/checkbox", array(
 	'label_class' => $simple_cache_disabled_class,
 ));
 
-$system_cache_input = elgg_view_input('checkbox', [
-	'label' => elgg_echo('installation:systemcache:label'),
+$system_cache_input = elgg_view_field([
+	'#type' => 'checkbox',
+	'#label' => elgg_echo('installation:systemcache:label'),
 	'help' => elgg_echo('installation:systemcache:description'),
 	'name' => 'system_cache_enabled',
 	'checked' => elgg_is_system_cache_enabled(),
-	'field_class' => 'mtm',
+	'#class' => 'mtm',
 ]);
 
 $body = <<<BODY

--- a/views/default/forms/admin/site/advanced/content_access.php
+++ b/views/default/forms/admin/site/advanced/content_access.php
@@ -3,7 +3,8 @@
  * Advanced site settings, content access section.
  */
 
-$body = elgg_view_input('access', [
+$body = elgg_view_field([
+	'#type' => 'access',
 	'options_values' => [
 		ACCESS_PRIVATE => elgg_echo('PRIVATE'),
 		ACCESS_FRIENDS => elgg_echo('access:friends:label'),
@@ -11,14 +12,15 @@ $body = elgg_view_input('access', [
 		ACCESS_PUBLIC => elgg_echo('PUBLIC'),
 	],
 	'name' => 'default_access',
-	'label' => elgg_echo('installation:sitepermissions'),
-	'help' => elgg_echo('admin:site:access:warning'),
+	'#label' => elgg_echo('installation:sitepermissions'),
+	'#help' => elgg_echo('admin:site:access:warning'),
 	'value' => elgg_get_config('default_access'),
 ]);
 
-$body .= elgg_view_input('checkbox', [
-	'label' => elgg_echo('installation:allow_user_default_access:label'),
-	'help' => elgg_echo('installation:allow_user_default_access:description'),
+$body .= elgg_view_field([
+	'#type' => 'checkbox',
+	'#label' => elgg_echo('installation:allow_user_default_access:label'),
+	'#help' => elgg_echo('installation:allow_user_default_access:description'),
 	'name' => 'allow_user_default_access',
 	'checked' => (bool)elgg_get_config('allow_user_default_access'),
 ]);

--- a/views/default/forms/admin/site/advanced/debugging.php
+++ b/views/default/forms/admin/site/advanced/debugging.php
@@ -3,7 +3,8 @@
  * Advanced site settings, debugging section.
  */
 
-$body = elgg_view_input('select', [
+$body = elgg_view_field([
+	'#type' => 'select',
 	'options_values' => [
 		'0' => elgg_echo('installation:debug:none'),
 		'ERROR' => elgg_echo('installation:debug:error'),
@@ -12,8 +13,8 @@ $body = elgg_view_input('select', [
 		'INFO' => elgg_echo('installation:debug:info'),
 	],
 	'name' => 'debug',
-	'label' => elgg_echo('installation:debug:label'),
-	'help' => elgg_echo('installation:debug'),
+	'#label' => elgg_echo('installation:debug:label'),
+	'#help' => elgg_echo('installation:debug'),
 	'value' => elgg_get_config('debug'),
 ]);
 

--- a/views/default/forms/admin/site/advanced/security.php
+++ b/views/default/forms/admin/site/advanced/security.php
@@ -13,11 +13,12 @@ $body .= elgg_view_module('main', "$current_strength: $strength_text", $strength
 	'class' => ($strength != 'strong') ? 'elgg-message elgg-state-error' : 'elgg-message elgg-state-success',
 ]);
 
-$body .= elgg_view_input('checkbox', [
-	'label' => elgg_echo('admin:site:secret:regenerate'),
+$body .= elgg_view_field([
+	'#type' => 'checkbox',
+	'#label' => elgg_echo('admin:site:secret:regenerate'),
 	'value' => 1,
 	'name' => 'regenerate_site_secret',
-	'help' => elgg_echo('admin:site:secret:regenerate:help'),
+	'#help' => elgg_echo('admin:site:secret:regenerate:help'),
 ]);
 
 echo elgg_view_module('inline', elgg_echo('admin:legend:security'), $body, ['id' => 'elgg-settings-advanced-security']);

--- a/views/default/forms/admin/site/advanced/site_access.php
+++ b/views/default/forms/admin/site/advanced/site_access.php
@@ -4,17 +4,19 @@
  */
 
 // new user registration
-$body = elgg_view_input('checkbox', [
-	'label' => elgg_echo('installation:registration:label'),
-	'help' => elgg_echo('installation:registration:description'),
+$body = elgg_view_field([
+	'#type' => 'checkbox',
+	'#label' => elgg_echo('installation:registration:label'),
+	'#help' => elgg_echo('installation:registration:description'),
 	'name' => 'allow_registration',
 	'checked' => (bool)elgg_get_config('allow_registration'),
 ]);
 
 // walled garden
-$body .= elgg_view_input('checkbox', [
-	'label' => elgg_echo('installation:walled_garden:label'),
-	'help' => elgg_echo('installation:walled_garden:description'),
+$body .= elgg_view_field([
+	'#type' => 'checkbox',
+	'#label' => elgg_echo('installation:walled_garden:label'),
+	'#help' => elgg_echo('installation:walled_garden:description'),
 	'name' => 'walled_garden',
 	'checked' => (bool)elgg_get_config('walled_garden'),
 ]);

--- a/views/default/forms/admin/site/advanced/system.php
+++ b/views/default/forms/admin/site/advanced/system.php
@@ -3,26 +3,29 @@
  * Advanced site settings, system section.
  */
 
-$body = elgg_view_input('text', [
+$body = elgg_view_field([
+	'#type' => 'text',
 	'name' => 'wwwroot',
-	'label' => elgg_echo('installation:wwwroot'),
+	'#label' => elgg_echo('installation:wwwroot'),
 	'value' => elgg_get_config('wwwroot'),
 ]);
 
-$body .= elgg_view_input('text', [
+$body .= elgg_view_field([
+	'#type' => 'text',
 	'name' => 'path',
-	'label' => elgg_echo('installation:path'),
+	'#label' => elgg_echo('installation:path'),
 	'value' => elgg_get_config('path'),
 ]);
 
 $dataroot_in_settings = !empty($GLOBALS['_ELGG']->dataroot_in_settings);
-$body .= elgg_view_input('text', [
+$body .= elgg_view_field([
+	'#type' => 'text',
 	'name' => 'dataroot',
-	'label' => elgg_echo('installation:dataroot'),
+	'#label' => elgg_echo('installation:dataroot'),
 	'value' => elgg_get_config('dataroot'),
 	'readonly' => $dataroot_in_settings,
 	'class' => $dataroot_in_settings ? 'elgg-state-disabled' : '',
-	'help' => $dataroot_in_settings ? elgg_echo('admin:settings:in_settings_file') : '',
+	'#help' => $dataroot_in_settings ? elgg_echo('admin:settings:in_settings_file') : '',
 ]);
 
 echo elgg_view_module('inline', elgg_echo('admin:legend:system'), $body, ['id' => 'elgg-settings-advanced-system']);

--- a/views/default/forms/admin/site/update_basic.php
+++ b/views/default/forms/admin/site/update_basic.php
@@ -1,35 +1,40 @@
 <?php
 
-echo elgg_view_input('text', [
+echo elgg_view_field([
+	'#type' => 'text',
 	'name' => 'sitename',
-	'label' => elgg_echo('installation:sitename'),
+	'#label' => elgg_echo('installation:sitename'),
 	'value' => elgg_get_config('sitename'),
 ]);
 
-echo elgg_view_input('text', [
+echo elgg_view_field([
+	'#type' => 'text',
 	'name' => 'sitedescription',
-	'label' => elgg_echo('installation:sitedescription'),
+	'#label' => elgg_echo('installation:sitedescription'),
 	'value' => elgg_get_config('sitedescription'),
 ]);
 
-echo elgg_view_input('email', [
+echo elgg_view_field([
+	'#type' => 'email',
 	'name' => 'siteemail',
-	'label' => elgg_echo('installation:siteemail'),
+	'#label' => elgg_echo('installation:siteemail'),
 	'value' => elgg_get_site_entity()->email,
 	'class' => 'elgg-input-text',
 ]);
 
-echo elgg_view_input('number', [
+echo elgg_view_field([
+	'#type' => 'number',
 	'name' => 'default_limit',
-	'label' => elgg_echo('installation:default_limit'),
+	'#label' => elgg_echo('installation:default_limit'),
 	'value' => elgg_get_config('default_limit'),
 	'min' => 1,
 	'step' => 1,
 ]);
 
-echo elgg_view_input('select', [
+echo elgg_view_field([
+	'#type' => 'select',
 	'name' => 'language',
-	'label' => elgg_echo('installation:language'),
+	'#label' => elgg_echo('installation:language'),
 	'value' => elgg_get_config('language'),
 	'options_values' => get_installed_translations(),
 ]);

--- a/views/default/forms/login.php
+++ b/views/default/forms/login.php
@@ -5,23 +5,27 @@
  * @package Elgg
  * @subpackage Core
  */
-echo elgg_view_input('text', [
+echo elgg_view_field([
+	'#type' => 'text',
+
 	'name' => 'username',
 	'autofocus' => true,
 	'required' => true,
-	'label' => elgg_echo('loginusername'),
+	'#label' => elgg_echo('loginusername'),
 ]);
 
-echo elgg_view_input('password', [
+echo elgg_view_field([
+	'#type' => 'password',
 	'name' => 'password',
 	'required' => true,
-	'label' => elgg_echo('password'),
+	'#label' => elgg_echo('password'),
 ]);
 
 echo elgg_view('login/extend', $vars);
 
 if (isset($vars['returntoreferer'])) {
-	echo elgg_view_input('hidden', [
+	echo elgg_view_field([
+		'#type' => 'hidden',
 		'name' => 'returntoreferer',
 		'value' => 'true'
 	]);

--- a/views/default/forms/profile/edit.php
+++ b/views/default/forms/profile/edit.php
@@ -11,10 +11,11 @@
  */
 $entity = elgg_extract('entity', $vars);
 
-echo elgg_view_input('text', array(
+echo elgg_view_field(array(
+	'#type' => 'text',
 	'name' => 'name',
 	'value' => $entity->name,
-	'label' => elgg_echo('user:name:label'),
+	'#label' => elgg_echo('user:name:label'),
 	'maxlength' => 50, // hard coded in /actions/profile/edit
 ));
 
@@ -79,7 +80,8 @@ if (is_array($profile_fields) && count($profile_fields) > 0) {
 elgg_clear_sticky_form('profile:edit');
 
 echo elgg_view('input/hidden', array('name' => 'guid', 'value' => $entity->guid));
-echo elgg_view_input('submit', [
+echo elgg_view_field([
+	'#type' => 'submit',
 	'value' => elgg_echo('save'),
-	'field_class' => 'elgg-foot',
+	'#class' => 'elgg-foot',
 ]);

--- a/views/default/forms/register.php
+++ b/views/default/forms/register.php
@@ -25,59 +25,56 @@ $name = elgg_extract('name', $values, get_input('n'));
 
 $fields = [
 	[
+		'#type' => 'hidden',
 		'name' => 'friend_guid',
-		'type' => 'hidden',
 		'value' => elgg_extract('friend_guid', $vars),
 	],
 	[
+		'#type' => 'hidden',
 		'name' => 'invitecode',
-		'type' => 'hidden',
 		'value' => elgg_extract('invitecode', $vars),
 	],
 	[
+		'#type' => 'text',
+		'#label' => elgg_echo('name'),
+		'#class' => 'mtm',
 		'name' => 'name',
-		'type' => 'text',
 		'value' => $name,
 		'autofocus' => true,
 		'required' => true,
-		'label' => elgg_echo('name'),
-		'field_class' => 'mtm',
 	],
 	[
+		'#type' => 'email',
+		'#label' => elgg_echo('email'),
 		'name' => 'email',
-		'type' => 'email',
 		'value' => $email,
 		'required' => true,
-		'label' => elgg_echo('email'),
 	],
 	[
+		'#type' => 'text',
+		'#label' => elgg_echo('username'),
 		'name' => 'username',
-		'type' => 'text',
 		'value' => $username,
 		'required' => true,
-		'label' => elgg_echo('username'),
 	],
 	[
-	'name' => 'password',
-		'type' => 'password',
+		'#type' => 'password',
+		'#label' => elgg_echo('password'),
+		'name' => 'password',
 		'value' => $password,
 		'required' => true,
-		'label' => elgg_echo('password'),
-		],
+	],
 	[
+		'#type' => 'password',
+		'#label' => elgg_echo('passwordagain'),
 		'name' => 'password2',
-		'type' => 'password',
 		'value' => $password2,
 		'required' => true,
-		'label' => elgg_echo('passwordagain'),
 	],
 ];
 
 foreach ($fields as $field) {
-	$type = elgg_extract('type', $field, 'text');
-	unset($field[$type]);
-
-	echo elgg_view_input($type, $field);
+	echo elgg_view_field($field);
 }
 
 // view to extend to add more fields to the registration form
@@ -86,7 +83,8 @@ echo elgg_view('register/extend', $vars);
 // Add captcha hook
 echo elgg_view('input/captcha', $vars);
 
-$footer = elgg_view_input('submit', [
+$footer = elgg_view_field([
+	'#type' => 'submit',
 	'value' => elgg_echo('register'),
 ]);
 

--- a/views/default/forms/useradd.php
+++ b/views/default/forms/useradd.php
@@ -23,58 +23,66 @@ $email = elgg_extract('email', $values);
 $admin = elgg_extract('admin', $values);
 $autogen_password = elgg_extract('autogen_password', $values);
 
-echo elgg_view_input('text', [
+echo elgg_view_field([
+	'#type' => 'text',
 	'name' => 'name',
 	'value' => $name,
-	'label' => elgg_echo('name'),
+	'#label' => elgg_echo('name'),
 	'required' => true,
 ]);
 
-echo elgg_view_input('text', [
+echo elgg_view_field([
+	'#type' => 'text',
 	'name' => 'username',
 	'value' => $username,
-	'label' => elgg_echo('username'),
+	'#label' => elgg_echo('username'),
 	'required' => true,
 ]);
 
-echo elgg_view_input('email', [
+echo elgg_view_field([
+	'#type' => 'email',
 	'name' => 'email',
 	'value' => $email,
-	'label' => elgg_echo('email'),
+	'#label' => elgg_echo('email'),
 	'required' => true,
 ]);
 
-echo elgg_view_input('checkbox', array(
+echo elgg_view_field(array(
+	'#type' => 'checkbox',
 	'name' => 'autogen_password',
 	'value' => 1,
 	'default' => false,
-	'label' => elgg_echo('autogen_password_option'),
+	'#label' => elgg_echo('autogen_password_option'),
 	'checked' => (bool) $autogen_password,
 ));
 
-echo elgg_view_input('password', [
+echo elgg_view_field([
+	'#type' => 'password',
 	'name' => 'password',
 	'value' => $password,
-	'label' => elgg_echo('password'),
+	'#label' => elgg_echo('password'),
 	'required' => true,
 ]);
 
-echo elgg_view_input('password', [
+echo elgg_view_field([
+	'#type' => 'password',
 	'name' => 'password2',
 	'value' => $password2,
-	'label' => elgg_echo('passwordagain'),
+	'#label' => elgg_echo('passwordagain'),
 	'required' => true,
 ]);
 
-echo elgg_view_input('checkbox', array(
+echo elgg_view_field(array(
+	'#type' => 'checkbox',
 	'name' => 'admin',
 	'value' => 1,
 	'default' => false,
-	'label' => elgg_echo('admin_option'),
+	'#label' => elgg_echo('admin_option'),
 	'checked' => $admin,
 ));
 
-echo elgg_view_input('submit', [
+echo elgg_view_field([
+	'#type' => 'submit',
 	'value' => elgg_echo('register'),
-	'field_class' => 'elgg-foot',
+	'#class' => 'elgg-foot',
 ]);

--- a/views/default/input/fieldset.php
+++ b/views/default/input/fieldset.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Renders a set of fields wrapped in a <fieldset> tag
+ *
+ * @uses $vars['class']   Additional CSS classes
+ * @uses $vars['align']   Field alignment (vertical|horizontal)
+ *                        If set to horizontal, fields will be rendered
+ *                        with inline display
+ * @uses $vars['justify'] Text justification (left|right|center)
+ * @uses $vars['legend']  Optional fieldset legend
+ * @uses $vars['fields']  An array of field options
+ *                        Field options should be suitable for use in
+ *                        elgg_view_field()
+ */
+
+$vars['class'] = elgg_extract_class($vars, [
+	'elgg-fieldset',
+	'clearfix',
+]);
+
+$align = elgg_extract('align', $vars, 'vertical');
+unset($vars['align']);
+$vars['class'][] = "elgg-fieldset-$align";
+
+$justify = elgg_extract('justify', $vars, '');
+unset($vars['justify']);
+if ($justify) {
+	$vars['class'][] = "elgg-justify-$justify";
+}
+
+$legend = elgg_extract('legend', $vars);
+unset($vars['legend']);
+
+$fields = (array) elgg_extract('fields', $vars, []);
+unset($vars['fields']);
+
+$fieldset = '';
+if ($legend) {
+	$vars['class'] = 'elgg-fieldset-has-legend';
+	$fieldset .= elgg_format_element('legend', [], $legend);
+}
+
+foreach ($fields as $field) {
+	$fieldset .= elgg_view_field($field);
+}
+
+echo elgg_format_element('fieldset', $vars, $fieldset);

--- a/views/default/object/widget/edit/num_display.php
+++ b/views/default/object/widget/edit/num_display.php
@@ -19,6 +19,8 @@ $vars['name'] = "params[{$name}]";
 if (!isset($vars['label'])) {
 	$vars['label'] = elgg_echo('widget:numbertodisplay');
 }
+$vars['#label'] = $vars['label'];
+unset($vars['label']);
 
 if (!isset($vars['options'])) {
 	$vars['options'] = [5, 8, 10, 12, 15, 20];
@@ -29,5 +31,6 @@ if (!$value) {
 	$value = elgg_extract('default', $vars, $vars['options'][0]);
 }
 $vars['value'] = $value;
+$vars['#type'] = 'select';
 
-echo elgg_view_input('select', $vars);
+echo elgg_view_field($vars);

--- a/views/default/widgets/friends/edit.php
+++ b/views/default/widgets/friends/edit.php
@@ -24,9 +24,10 @@ echo elgg_view('object/widget/edit/num_display', [
 	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 15, 20, 30, 50, 100],
 ]);
 
-echo elgg_view_input('select', [
+echo elgg_view_field([
+	'#type' => 'select',
 	'name' => 'params[icon_size]',
-	'label' => elgg_echo('friends:icon_size'),
+	'#label' => elgg_echo('friends:icon_size'),
 	'value' => $widget->icon_size,
 	'options_values' => [
 		'small' => elgg_echo('friends:small'),

--- a/views/default/widgets/river_widget/edit.php
+++ b/views/default/widgets/river_widget/edit.php
@@ -11,9 +11,10 @@ if (elgg_in_context('dashboard')) {
 		$widget->content_type = 'friends';
 	}
 
-	echo elgg_view_input('select', [
+	echo elgg_view_field([
+		'#type' => 'select',
 		'name' => 'params[content_type]',
-		'label' => elgg_echo('river:widget:type'),
+		'#label' => elgg_echo('river:widget:type'),
 		'value' => $widget->content_type,
 		'options_values' => [
 			'friends' => elgg_echo('river:widgets:friends'),


### PR DESCRIPTION
Deprecates `elgg_view_input()` in favor of `elgg_view_field()`.

The "input/fieldset" views is added, which can be used to render sets of "fields" (arrays of arguments for `elgg_view_field()`).
- [x] update docs for new approach
- [x] update all uses of elgg_view_input
