### PR TITLE
feature(cache): function caching and system cache improvements

### DIFF
--- a/engine/classes/Elgg/AutoloadManager.php
+++ b/engine/classes/Elgg/AutoloadManager.php
@@ -1,5 +1,8 @@
 <?php
 namespace Elgg;
+
+use \Elgg\Cache\SystemFileCache;
+
 /**
  * Manages core autoloading and caching of class maps
  *
@@ -10,7 +13,7 @@ namespace Elgg;
  */
 class AutoloadManager {
 
-	const FILENAME = 'autoload_data.php';
+	const FILENAME = 'autoload_data';
 	const KEY_CLASSES = 'classes';
 	const KEY_SCANNED_DIRS = 'scannedDirs';
 
@@ -30,7 +33,7 @@ class AutoloadManager {
 	protected $altered = false;
 
 	/**
-	 * @var \ElggCache
+	 * @var SystemFileCache
 	 */
 	protected $storage = null;
 
@@ -118,7 +121,7 @@ class AutoloadManager {
 			if ($this->altered || $map->getAltered()) {
 				$spec[self::KEY_CLASSES] = $map->getMap();
 				$spec[self::KEY_SCANNED_DIRS] = $this->scannedDirs;
-				$this->storage->save(self::FILENAME, serialize($spec));
+				$this->storage->save(self::FILENAME, $spec);
 			}
 		}
 		return $this;
@@ -152,12 +155,9 @@ class AutoloadManager {
 	 */
 	protected function getSpec() {
 		if ($this->storage) {
-			$serialization = $this->storage->load(self::FILENAME);
-			if ($serialization) {
-				$spec = unserialize($serialization);
-				if (isset($spec[self::KEY_CLASSES])) {
-					return $spec;
-				}
+			$spec = $this->storage->load(self::FILENAME);
+			if ($spec && isset($spec[self::KEY_CLASSES])) {
+				return $spec;
 			}
 		}
 		return false;
@@ -187,10 +187,10 @@ class AutoloadManager {
 	/**
 	 * Set the cache storage object
 	 * 
-	 * @param \ElggCache $storage Cache object
+	 * @param SystemFileCache $storage Cache object
 	 * @return void
 	 */
-	public function setStorage(\ElggCache $storage) {
+	public function setStorage(SystemFileCache $storage) {
 		$this->storage = $storage;
 	}
 

--- a/engine/classes/Elgg/Cache/SystemFileCache.php
+++ b/engine/classes/Elgg/Cache/SystemFileCache.php
@@ -1,0 +1,116 @@
+<?php
+namespace Elgg\Cache;
+
+use ElggFileCache;
+
+/**
+ * File cache customized for system cache.
+ *
+ * - Does not save/load when disabled
+ * - Can store arbitrary data
+ *
+ * @since 2.3
+ */
+class SystemFileCache extends ElggFileCache {
+
+	const PREFIX_STRING = '_0_';
+	const PREFIX_SERIALIZED = '_1_';
+
+	/**
+	 * @var bool
+	 */
+	protected $enabled = true;
+
+	/**
+	 * Set whether the cache is enabled
+	 *
+	 * @param bool $enabled
+	 * @internal For use by SystemCache only
+	 * @access private
+	 */
+	public function setEnabled($enabled) {
+		$this->enabled = (bool)$enabled;
+	}
+
+	/**
+	 * Save data in cache
+	 *
+	 * @param string $key  Cache key
+	 * @param mixed  $data Cache data (don't store the value `false` directly)
+	 *
+	 * @return bool
+	 */
+	public function save($key, $data) {
+		if (!$this->enabled) {
+			return true;
+		}
+
+		if (is_string($data)) {
+			$data = self::PREFIX_STRING . $data;
+		} else {
+			$data = self::PREFIX_SERIALIZED . serialize($data);
+		}
+
+		return parent::save($key, $data);
+	}
+
+	/**
+	 * Load cached data
+	 *
+	 * @param string $key      Cache key
+	 * @param int    $ignored1 Unused
+	 * @param null   $ignored2 Unused
+	 *
+	 * @return mixed False if not cached
+	 */
+	public function load($key, $ignored1 = 0, $ignored2 = null) {
+		if (!$this->enabled) {
+			return false;
+		}
+
+		$data = parent::load($key);
+		if (!$data) {
+			return false;
+		}
+
+		if (0 === strpos($data, self::PREFIX_STRING)) {
+			return substr($data, strlen(self::PREFIX_STRING));
+		}
+
+		if (0 === strpos($data, self::PREFIX_SERIALIZED)) {
+			$data = substr($data, strlen(self::PREFIX_SERIALIZED));
+			return unserialize($data);
+		}
+
+		return false;
+	}
+
+	/**
+	 * Cache the output of an expensive function, if the system cache is enabled
+	 *
+	 * @param string   $key  Cache key
+	 * @param callable $func Function that requires no arguments. The result must be serializable.
+	 * @param int      $ttl  TTL for result (seconds). 0 for no expiration
+	 *
+	 * @return mixed
+	 */
+	public function cacheCall($key, callable $func, $ttl = 0) {
+		if (!$this->enabled) {
+			return call_user_func($func);
+		}
+
+		$cached = $this->load($key);
+		if (is_array($cached) && isset($cached['time'])) {
+			if (!$ttl || (time() < $cached['time'] + $ttl)) {
+				return $cached['data'];
+			}
+		}
+
+		$return = call_user_func($func);
+		$this->save($key, [
+			'time' => time(),
+			'data' => $return,
+		]);
+		return $return;
+	}
+}

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -36,7 +36,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\Database\EntityTable               $entityTable
  * @property-read \Elgg\EventsService                      $events
  * @property-read \Elgg\Assets\ExternalFiles               $externalFiles
- * @property-read \ElggFileCache                           $fileCache
+ * @property-read \Elgg\Cache\SystemFileCache              $fileCache
  * @property-read \Elgg\FormsService                       $forms
  * @property-read \Elgg\PluginHooksService                 $hooks
  * @property-read \Elgg\EntityIconService                  $iconService
@@ -216,7 +216,7 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		});
 
 		$this->setFactory('fileCache', function(ServiceProvider $c) {
-			return new \ElggFileCache($c->config->getCachePath() . 'system_cache/');
+			return new \Elgg\Cache\SystemFileCache($c->config->getCachePath() . 'system_cache/');
 		});
 
 		$this->setFactory('forms', function(ServiceProvider $c) {

--- a/engine/classes/Elgg/I18n/Translator.php
+++ b/engine/classes/Elgg/I18n/Translator.php
@@ -205,8 +205,8 @@ class Translator {
 
 			foreach ($languages as $language) {
 				$data = elgg_load_system_cache("$language.lang");
-				if ($data) {
-					$this->addTranslation($language, unserialize($data));
+				if (is_array($data)) {
+					$this->addTranslation($language, $data);
 				} else {
 					$loaded = false;
 				}
@@ -387,8 +387,8 @@ class Translator {
 				if (preg_match('/(([a-z]{2,3})(_[a-z]{2})?)\.lang$/', $filename, $matches)) {
 					$language = $matches[1];
 					$data = elgg_load_system_cache("$language.lang");
-					if ($data) {
-						$this->addTranslation($language, unserialize($data));
+					if (is_array($data)) {
+						$this->addTranslation($language, $data);
 					}
 				}
 			}

--- a/engine/classes/Elgg/ViewsService.php
+++ b/engine/classes/Elgg/ViewsService.php
@@ -629,7 +629,7 @@ class ViewsService {
 		if ($this->cache) {
 			$data = $this->cache->load('view_overrides');
 			if ($data) {
-				$overrides = unserialize($data);
+				$overrides = $data;
 			}
 		}
 
@@ -650,11 +650,9 @@ class ViewsService {
 	 */
 	public function configureFromCache(SystemCache $cache) {
 		$data = $cache->load('view_locations');
-		if (!is_string($data)) {
+		if (!$data) {
 			return false;
 		}
-		// format changed, check version
-		$data = unserialize($data);
 		if (empty($data['version']) || $data['version'] !== '2.0') {
 			return false;
 		}
@@ -672,13 +670,13 @@ class ViewsService {
 	 * @access private
 	 */
 	public function cacheConfiguration(SystemCache $cache) {
-		$cache->save('view_locations', serialize([
+		$cache->save('view_locations', [
 			'version' => '2.0',
 			'locations' => $this->locations,
-		]));
+		]);
 
 		// this is saved just for the inspector and is not loaded in loadAll()
-		$cache->save('view_overrides', serialize($this->overrides));
+		$cache->save('view_overrides', $this->overrides);
 	}
 
 	/**

--- a/engine/classes/ElggFileCache.php
+++ b/engine/classes/ElggFileCache.php
@@ -32,18 +32,10 @@ class ElggFileCache extends \ElggCache {
 	 * @param string $filename Filename to save as
 	 * @param string $rw       Write mode
 	 *
-	 * @return mixed
+	 * @return resource|false
 	 */
 	protected function createFile($filename, $rw = "rb") {
-		// Create a filename matrix
-		$matrix = "";
-		$depth = strlen($filename);
-		if ($depth > 5) {
-			$depth = 5;
-		}
-
-		// Create full path
-		$path = $this->getVariable("cache_path") . $matrix;
+		$path = $this->getVariable("cache_path");
 		if (!is_dir($path)) {
 			mkdir($path, 0700, true);
 		}
@@ -113,7 +105,7 @@ class ElggFileCache extends \ElggCache {
 	 * @param int    $offset Offset
 	 * @param int    $limit  Limit
 	 *
-	 * @return string
+	 * @return string|false
 	 */
 	public function load($key, $offset = 0, $limit = null) {
 		$f = $this->createFile($this->sanitizeFilename($key));

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -15,7 +15,7 @@
  * @todo Can this be done in a cleaner way?
  * @todo Swap to memcache etc?
  *
- * @return \ElggFileCache
+ * @return \Elgg\Cache\SystemFileCache
  */
 function elgg_get_system_cache() {
 	return _elgg_services()->fileCache;
@@ -31,10 +31,10 @@ function elgg_reset_system_cache() {
 }
 
 /**
- * Saves a system cache.
+ * Saves data to system cache (if enabled)
  *
  * @param string $type The type or identifier of the cache
- * @param string $data The data to be saved
+ * @param mixed  $data The data to be saved
  * @return bool
  */
 function elgg_save_system_cache($type, $data) {
@@ -42,13 +42,13 @@ function elgg_save_system_cache($type, $data) {
 }
 
 /**
- * Retrieve the contents of a system cache.
+ * Loads data from system cache (if enabled)
  *
- * @param string $type The type of cache to load
- * @return string
+ * @param string $key Cache key
+ * @return mixed False if missing
  */
-function elgg_load_system_cache($type) {
-	return _elgg_services()->systemCache->load($type);
+function elgg_load_system_cache($key) {
+	return _elgg_services()->systemCache->load($key);
 }
 
 /**


### PR DESCRIPTION
- System cache now uses a subclass of `ElggFileCache` and it's returned by
  `elgg_get_system_cache()`.
- No longer loads/saves when the system cache is disabled
- Can store arbitrary data, auto-serialized
- Has method `cacheCall` for caching operations with a TTL
- Removed unused "depth" logic from `ElggFileCache`

``` php
$function = function () {
    return elgg_view('expensive_home_page_content');
};
$key = 'home_content';
$ttl = 60 * 5;

$content = elgg_get_system_cache()->cacheCall($key, $function, $ttl);`
```
- [ ] docs (move code sample there)
- [ ] tests
