### PR TITLE
fix(core): elgg_get_page_owner_entity will return ElggEntity

### DIFF
--- a/docs/guides/page-owner.rst
+++ b/docs/guides/page-owner.rst
@@ -2,7 +2,12 @@ Page ownership
 ==============
 
 One recurring task of any plugin will be to determine the page ownership in order to decide which actions are allowed or not. Elgg has a number of functions related to page ownership and also offers plugin developers flexibility by letting the plugin handle page ownership requests as well.
-Determining the owner of a page can be determined with ``elgg_get_page_owner_guid()``, which will return the GUID of the owner. Alternatively, ``elgg_get_page_owner_entity()`` will retrieve the whole page owner entity. If the page already knows who the page owner is, but the system doesn't, the it be can set by passing the GUID to ``elgg_set_page_owner_guid($guid)``.
+Determining the owner of a page can be determined with ``elgg_get_page_owner_guid()``, which will return the GUID of the owner. Alternatively, ``elgg_get_page_owner_entity()`` will retrieve the whole page owner entity.
+If the page already knows who the page owner is, but the system doesn't, the page can set the page owner by passing the GUID to ``elgg_set_page_owner_guid($guid)``.
+
+.. note::
+
+	The page owner entity can be any ``ElggEntity``. If you wish to only apply some setting in case of a user or a group make sure you check that you have the correct entity. 
 
 Custom page owner handlers
 --------------------------

--- a/engine/lib/pageowner.php
+++ b/engine/lib/pageowner.php
@@ -44,7 +44,7 @@ function elgg_get_page_owner_guid($guid = 0) {
 /**
  * Gets the owner entity for the current page.
  *
- * @return \ElggUser|\ElggGroup|false The current page owner or false if none.
+ * @return \ElggEntity|false The current page owner or false if none.
  *
  * @since 1.8.0
  */
@@ -54,12 +54,7 @@ function elgg_get_page_owner_entity() {
 		return false;
 	}
 
-	$owner = get_entity($guid);
-	if ($owner instanceof ElggUser || $owner instanceof ElggGroup) {
-		return $owner;
-	}
-
-	return false;
+	return get_entity($guid);
 }
 
 /**


### PR DESCRIPTION
The user still needs to have access to the entity, but the entity isn't
limited to users or groups

fixes #10361
