### PR TITLE
fix(relationships): ElggRelationship::save returns the ID

### DIFF
--- a/engine/classes/Elgg/Database/RelationshipsTable.php
+++ b/engine/classes/Elgg/Database/RelationshipsTable.php
@@ -88,13 +88,12 @@ class RelationshipsTable {
 	 * @param int    $guid_one     GUID of the subject entity of the relationship
 	 * @param string $relationship Type of the relationship
 	 * @param int    $guid_two     GUID of the target entity of the relationship
+	 * @param bool   $return_id    Return the ID instead of bool?
 	 *
-	 * @return bool
+	 * @return bool|int
 	 * @throws \InvalidArgumentException
 	 */
-	function add($guid_one, $relationship, $guid_two) {
-		
-	
+	function add($guid_one, $relationship, $guid_two, $return_id = false) {
 		if (strlen($relationship) > \ElggRelationship::RELATIONSHIP_LIMIT) {
 			$msg = "relationship name cannot be longer than " . \ElggRelationship::RELATIONSHIP_LIMIT;
 			throw new \InvalidArgumentException($msg);
@@ -122,7 +121,7 @@ class RelationshipsTable {
 	
 			$result = _elgg_services()->events->trigger('create', 'relationship', $obj);
 			if ($result && $result_old) {
-				return true;
+				return $return_id ? $id : true;
 			} else {
 				delete_relationship($obj->id);
 			}

--- a/engine/classes/ElggRelationship.php
+++ b/engine/classes/ElggRelationship.php
@@ -47,6 +47,8 @@ class ElggRelationship extends \ElggData implements
 		foreach ((array)$row as $key => $value) {
 			$this->attributes[$key] = $value;
 		}
+
+		$this->attributes['id'] = (int)$this->attributes['id'];
 	}
 
 	/**
@@ -127,7 +129,12 @@ class ElggRelationship extends \ElggData implements
 			delete_relationship($this->id);
 		}
 
-		$this->id = add_entity_relationship($this->guid_one, $this->relationship, $this->guid_two);
+		$this->id = _elgg_services()->relationshipsTable->add(
+			$this->guid_one,
+			$this->relationship,
+			$this->guid_two,
+			true
+		);
 		if (!$this->id) {
 			throw new \IOException("Unable to save new " . get_class());
 		}

--- a/engine/tests/ElggRelationshipTest.php
+++ b/engine/tests/ElggRelationshipTest.php
@@ -19,7 +19,7 @@ class ElggRelationshipTest extends ElggCoreUnitTest {
 	 */
 	public function setUp() {
 		$this->original_events = _elgg_services()->events;
-		_elgg_services()->events = new Elgg\EventsService();
+		_elgg_services()->setValue('events', new Elgg\EventsService());
 
 		$this->entity1 = new ElggObject();
 		$this->entity1->subtype = 'elgg_relationship_test';
@@ -54,7 +54,7 @@ class ElggRelationshipTest extends ElggCoreUnitTest {
 		}
 		remove_subtype('object', 'elgg_relationship_test');
 
-		_elgg_services()->events = $this->original_events;
+		_elgg_services()->setValue('events', $this->original_events);
 	}
 	
 	/**
@@ -110,10 +110,13 @@ class ElggRelationshipTest extends ElggCoreUnitTest {
 		$this->assertTrue(add_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
 		$r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid);
 		$this->assertIsA($r, 'ElggRelationship');
+		$old_id = $r->id;
 		
 		// note - string because that's how it's returned when getting a new object
 		$r->guid_two = (string) $this->entity3->guid;
-		$this->assertTrue($r->save());
+		$new_id = $r->save();
+		$this->assertIsA($new_id, 'int');
+		$this->assertNotEqual($new_id, $old_id);
 		
 		$test_r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity3->guid);
 		$this->assertIsA($test_r, 'ElggRelationship');


### PR DESCRIPTION
This fix also makes sure a relationship object that's saved twice doesn't result in a `delete_relationship(true)` call.

Fixes #10373
