### PR TITLE
chore(http): forwards default to HTTP redirects unless code given

### DIFF
--- a/engine/classes/Elgg/Http/ResponseFactory.php
+++ b/engine/classes/Elgg/Http/ResponseFactory.php
@@ -407,25 +407,25 @@ class ResponseFactory {
 		$forward_url = elgg_normalize_url($forward_url);
 
 		switch ($status_code) {
-			case 'walled_garden';
-			case 'csrf' :
+			case 'walled_garden':
 			case 'admin' :
 			case 'login' :
-				$status_code = ELGG_HTTP_FORBIDDEN;
+				$status_code = ELGG_HTTP_SEE_OTHER;
 				break;
 			case 'system' :
+			case 'csrf' :
 				$status_code = ELGG_HTTP_OK;
 				break;
 			default :
 				$status_code = (int) $status_code;
 				if (!$status_code || $status_code < 100 || $status_code > 599) {
-					$status_code = ELGG_HTTP_OK;
+					$status_code = ELGG_HTTP_SEE_OTHER;
 				}
 				break;
 		}
 
 		if ($this->isXhr()) {
-			if ($status_code < 100 || ($status_code > 299 && $status_code < 400) || $status_code > 599) {
+			if ($status_code < 100 || ($status_code >= 300 && $status_code <= 399) || $status_code > 599) {
 				// We only want to preserve OK and error codes
 				// Redirect responses should be converted to OK responses as this is an XHR request
 				$status_code = ELGG_HTTP_OK;
@@ -448,7 +448,7 @@ class ResponseFactory {
 		if ($this->isAction()) {
 			// actions should always redirect on non xhr-calls
 			if (!is_int($status_code) || $status_code < 300 || $status_code > 399) {
-				$status_code = ELGG_HTTP_FOUND;
+				$status_code = ELGG_HTTP_SEE_OTHER;
 			}
 		}
 

--- a/engine/tests/phpunit/Elgg/ActionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ActionsServiceTest.php
@@ -359,7 +359,7 @@ class ActionsServiceTest extends \Elgg\TestCase {
 
 		$response = _elgg_services()->responseFactory->getSentResponse();
 		$this->assertInstanceOf(RedirectResponse::class, $response);
-		$this->assertEquals(ELGG_HTTP_FOUND, $response->getStatusCode());
+		$this->assertEquals(ELGG_HTTP_SEE_OTHER, $response->getStatusCode());
 	}
 
 	public function testCanNotExecuteUnregisteredAction() {

--- a/views/default/resources/error.php
+++ b/views/default/resources/error.php
@@ -1,7 +1,7 @@
 <?php
 
 $type = elgg_extract('type', $vars);
-$params = elgg_extract('params', $vars);
+$params = elgg_extract('params', $vars, []);
 
 if (elgg_view_exists("errors/$type")) {
 	$title = elgg_echo("error:$type:title");


### PR DESCRIPTION
We again send redirect HTTP status codes for all forward() calls by default except for certain cases.

Error pages no longer rendering views with `null` for `$vars`.

Fixes #10369
