### PR TITLE
feat(entities): get_entity() can now fetch entities with ignored access

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -40,6 +40,11 @@ Deprecated Views
  * ``resources/pages/world``: Use the ``resources/pages/all`` view instead.
  * ``walled_garden.js``: Use the ``elgg/walled_garden`` module instead.
 
+Notable API changes
+-------------------
+
+ * `get_entity()` now accepts a second argument that allows to fetch an entity with ignored access (bypassing access control system)
+
 New API for page and action handling
 ------------------------------------
 

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -195,14 +195,23 @@ function entity_row_to_elggstar($row) {
 }
 
 /**
- * Loads and returns an entity object from a guid.
+ * Loads and returns an entity object from its GUID
  *
- * @param int $guid The GUID of the entity
- *
- * @return \ElggEntity The correct Elgg or custom object based upon entity type and subtype
+ * @param int  $guid          GUID of the entity
+ * @param bool $ignore_access Fetch with ignored access
+ * @return \ElggEntity
  */
-function get_entity($guid) {
-	return _elgg_services()->entityTable->get($guid);
+function get_entity($guid, $ignore_access = false) {
+	$ia = elgg_get_ignore_access();
+	if ($ignore_access) {
+		$ia = elgg_set_ignore_access(true);
+	}
+
+	$entity = _elgg_services()->entityTable->get($guid);
+
+	elgg_set_ignore_access($ia);
+
+	return $entity;
 }
 
 /**

--- a/engine/tests/ElggCoreGetEntitiesTest.php
+++ b/engine/tests/ElggCoreGetEntitiesTest.php
@@ -634,14 +634,14 @@ class ElggCoreGetEntitiesTest extends \ElggCoreGetEntitiesBaseTest {
 		);
 
 		// grab ourself again to fill out attributes.
-		$e = get_entity($e->getGUID());
+		$e = get_entity($e->guid);
 
 		$entities = elgg_get_entities($options);
 
 		$this->assertEqual(count($entities), 1);
 
 		foreach ($entities as $entity) {
-			$this->assertIdentical($e->getGUID(), $entity->getGUID());
+			$this->assertIdentical($e->guid, $entity->guid);
 		}
 
 		$e->delete();
@@ -662,14 +662,14 @@ class ElggCoreGetEntitiesTest extends \ElggCoreGetEntitiesBaseTest {
 		);
 
 		// grab ourself again to fill out attributes.
-		$e = get_entity($e->getGUID());
+		$e = get_entity($e->guid);
 
 		$entities = elgg_get_entities($options);
 
 		$this->assertEqual(count($entities), 1);
 
 		foreach ($entities as $entity) {
-			$this->assertIdentical($e->getGUID(), $entity->getGUID());
+			$this->assertIdentical($e->guid, $entity->guid);
 		}
 
 		$e->delete();
@@ -697,7 +697,7 @@ class ElggCoreGetEntitiesTest extends \ElggCoreGetEntitiesBaseTest {
 		);
 
 		// grab ourself again to fill out attributes.
-		$e = get_entity($e->getGUID());
+		$e = get_entity($e->guid);
 
 		$entities = elgg_get_entities($options);
 
@@ -998,5 +998,37 @@ class ElggCoreGetEntitiesTest extends \ElggCoreGetEntitiesBaseTest {
 		$options['distinct'] = false;
 		$users = elgg_get_entities($options);
 		$this->assertTrue(count($users) > 1);
+	}
+
+	public function testCanGetEntityWithIgnoredAccess() {
+
+		$user = _elgg_services()->session->getLoggedInUser();
+		$logged_in_user = $user;
+		
+		if (!$user) {
+			$user = new \ElggUser();
+			$user->save();
+			_elgg_services()->session->setLoggedInUser($user);
+		}
+
+		$object = new \ElggObject();
+		$object->access_id = ACCESS_PRIVATE;
+		$object->save();
+
+		$this->assertEqual($object->guid, get_entity($object->guid)->guid);
+		$this->assertEqual($object->guid, get_entity($object->guid, true)->guid);
+
+		_elgg_services()->session->removeLoggedInUser();
+
+		$this->assertFalse(get_entity($object->guid));
+		$this->assertEqual($object->guid, get_entity($object->guid, true)->guid);
+
+		if ($logged_in_user) {
+			_elgg_services()->session->setLoggedInUser($logged_in_user);
+		} else {
+			$user->delete();
+		}
+
+		$object->delete();
 	}
 }

--- a/mod/groups/actions/groups/membership/join.php
+++ b/mod/groups/actions/groups/membership/join.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Join a group
  *
@@ -9,74 +10,88 @@
  *
  * @package ElggGroups
  */
-
-global $CONFIG;
-
 $user_guid = get_input('user_guid', elgg_get_logged_in_user_guid());
 $group_guid = get_input('group_guid');
 
-$user = get_user($user_guid);
+$user = get_entity($user_guid, true);
+$group = get_entity($group_guid, true);
 
-// access bypass for getting invisible group
-$ia = elgg_set_ignore_access(true);
-$group = get_entity($group_guid);
-elgg_set_ignore_access($ia);
-
-if ($user && ($group instanceof ElggGroup)) {
-
-	// join or request
-	$join = false;
-	if ($group->isPublicMembership() || $group->canEdit($user->guid)) {
-		// anyone can join public groups and admins can join any group
-		$join = true;
-	} else {
-		if (check_entity_relationship($group->guid, 'invited', $user->guid)) {
-			// user has invite to closed group
-			$join = true;
-		}
-	}
-
-	if ($join) {
-		if (groups_join_group($group, $user)) {
-			system_message(elgg_echo("groups:joined"));
-			forward($group->getURL());
-		} else {
-			register_error(elgg_echo("groups:cantjoin"));
-		}
-	} else {
-		add_entity_relationship($user->guid, 'membership_request', $group->guid);
-
-		$owner = $group->getOwnerEntity();
-
-		$url = "{$CONFIG->url}groups/requests/$group->guid";
-
-		$subject = elgg_echo('groups:request:subject', array(
-			$user->name,
-			$group->name,
-		), $owner->language);
-
-		$body = elgg_echo('groups:request:body', array(
-			$group->getOwnerEntity()->name,
-			$user->name,
-			$group->name,
-			$user->getURL(),
-			$url,
-		), $owner->language);
-
-		$params = [
-			'action' => 'membership_request',
-			'object' => $group,
-		];
-		
-		// Notify group owner
-		if (notify_user($owner->guid, $user->getGUID(), $subject, $body, $params)) {
-			system_message(elgg_echo("groups:joinrequestmade"));
-		} else {
-			register_error(elgg_echo("groups:joinrequestnotmade"));
-		}
-	}
-} else {
+if (!$user instanceof ElggUser || !$group instanceof ElggGroup) {
 	register_error(elgg_echo("groups:cantjoin"));
+	forward(REFERRER);
 }
 
-forward(REFERER);
+$can_join = function() use ($user, $group) {
+	if ($group->isPublicMembership()) {
+		// any user is allowed to join a public groups
+		return true;
+	}
+	if ($group->canEdit($user->guid)) {
+		// anyone with edit permissions (site admins) join any group
+		return true;
+	}
+	if (check_entity_relationship($group->guid, 'invited', $user->guid)) {
+		// user has a pending group invitation
+		return true;
+	}
+	return false;
+};
+
+if ($can_join()) {
+	// attempt to join a group
+	if (groups_join_group($group, $user)) {
+		system_message(elgg_echo("groups:joined"));
+		forward($group->getURL());
+	}
+	register_error(elgg_echo("groups:cantjoin"));
+	forward(REFERRER);
+}
+
+if (check_entity_relationship($user->guid, 'membership_request', $group->guid)) {
+	register_error(elgg_echo("groups:requestexists"));
+	forward(REFERER);
+}
+
+// create a membership request if the group is closed
+// or there is no pending invitation
+$requested = add_entity_relationship($user->guid, 'membership_request', $group->guid);
+
+if (!$requested) {
+	register_error(elgg_echo("groups:joinrequestnotmade"));
+	forward(REFERRER);
+}
+
+system_message(elgg_echo("groups:joinrequestmade"));
+
+// @todo: in 3.0, move this to a 'create', 'relationship' event listener
+$notify_owner = function() use ($user, $group) {
+	$owner = get_entity($group->owner_guid, true);
+
+	if (!$owner) {
+		return false;
+	}
+
+	$url = elgg_normalize_url("groups/requests/$group->guid");
+
+	$subject = elgg_echo('groups:request:subject', array(
+		$user->name,
+		$group->name,
+	), $owner->language);
+
+	$body = elgg_echo('groups:request:body', array(
+		$group->getOwnerEntity()->name,
+		$user->name,
+		$group->name,
+		$user->getURL(),
+		$url,
+	), $owner->language);
+
+	$params = [
+		'action' => 'membership_request',
+		'object' => $group,
+	];
+	
+	return notify_user($owner->guid, $user->getGUID(), $subject, $body, $params);
+};
+
+$notify_owner();

--- a/mod/groups/languages/en.php
+++ b/mod/groups/languages/en.php
@@ -134,6 +134,7 @@ return array(
 	'groups:joinrequestmade' => 'Requested to join group',
 	'groups:joined' => 'Successfully joined group!',
 	'groups:left' => 'Successfully left group',
+	'groups:requestexists' => 'You have already requested to join this group',
 	'groups:notowner' => 'Sorry, you are not the owner of this group.',
 	'groups:notmember' => 'Sorry, you are not a member of this group.',
 	'groups:alreadymember' => 'You are already a member of this group!',


### PR DESCRIPTION
`get_entity()` now accepts a second argument which allows fetching entities with ignored access. This reduces the boilerplate with `elgg_set_ignored_access()` as well as eliminates risk of plugins not
restoring the previous access bypass setting.

Also refactors the groups/join action for improved readability, adds a check to ensure that membership request does not exist before trying to create a new one.

Fixes #8901
