### PR TITLE
feat(views): added elgg_parse_emails to output/longtext

### DIFF
--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -45,6 +45,28 @@ function parse_urls($text) {
 }
 
 /**
+ * Takes a string and turns any email addresses into formatted links
+ *
+ * @param string $text The input string
+ *
+ * @return string The output string with formatted links
+ *
+ * @since 3.0
+ */
+function elgg_parse_emails($text) {
+	$search  = '/<a(?:\s[^>]*)?>[\W\w]*?<\/a>|([a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})(?:\s|$|<)/';
+
+	return preg_replace_callback($search, function($email) {
+		if (!isset($email[1])) {
+			return $email[0];
+		}
+		$after = substr($email[0], strlen($email[1]));
+		
+		return "<a href=\"mailto:{$email[1]}\" rel=\"nofollow\">$email[1]</a>" . $after;
+	}, $text);
+}
+
+/**
  * Create paragraphs from text with line spacing
  *
  * @param string $string The string

--- a/engine/tests/ElggCoreRegressionBugsTest.php
+++ b/engine/tests/ElggCoreRegressionBugsTest.php
@@ -247,6 +247,37 @@ class ElggCoreRegressionBugsTest extends \ElggCoreUnitTest {
 	}
 
 	/**
+	 * Test #10398 -- elgg_parse_emails()
+	 * https://github.com/Elgg/Elgg/pull/10398
+	 */
+	public function test_elgg_parse_emails() {
+
+		$cases = array(
+			'no.email.here' =>
+				'no.email.here',
+			'simple email mail@test.com test' =>
+				'simple email <a href="mailto:mail@test.com" rel="nofollow">mail@test.com</a> test',
+			'simple paragraph <p>mail@test.com</p>' =>
+				'simple paragraph <p><a href="mailto:mail@test.com" rel="nofollow">mail@test.com</a></p>',
+			'multiple matches mail@test.com test mail@test.com test' =>
+				'multiple matches <a href="mailto:mail@test.com" rel="nofollow">mail@test.com</a> test <a href="mailto:mail@test.com" rel="nofollow">mail@test.com</a> test',
+			'invalid email 1 @invalid.com test' =>
+				'invalid email 1 @invalid.com test',
+			'invalid email 2 mail@invalid. test' =>
+				'invalid email 2 mail@invalid. test',
+			'no double parsing <a href="mailto:mail@test.com" rel="nofollow">mail@test.com</a> test' =>
+				'no double parsing <a href="mailto:mail@test.com" rel="nofollow">mail@test.com</a> test',
+			'no double parsing 2 <a href="#">mail@test.com</a> test' =>
+				'no double parsing 2 <a href="#">mail@test.com</a> test',
+			'no double parsing 3 <a href="#">with a lot of text - mail@test.com - around it</a> test' =>
+				'no double parsing 3 <a href="#">with a lot of text - mail@test.com - around it</a> test',
+		);
+		foreach ($cases as $input => $output) {
+			$this->assertEqual($output, elgg_parse_emails($input));
+		}
+	}
+
+	/**
 	 * Ensure additional select columns do not end up in entity attributes.
 	 *
 	 * https://github.com/Elgg/Elgg/issues/5538

--- a/views/default/output/longtext.php
+++ b/views/default/output/longtext.php
@@ -5,6 +5,7 @@
  * @uses $vars['value'] HTML to display
  * @uses $vars['class']
  * @uses $vars['parse_urls'] Turn urls into links? Default is true.
+ * @uses $vars['parse_emails'] Turn email addresses into mailto links? Default is true.
  * @uses $vars['sanitize'] Sanitize HTML? (highly recommended) Default is true.
  * @uses $vars['autop'] Convert line breaks to paragraphs? Default is true.
  */
@@ -13,6 +14,9 @@ $vars['class'] = elgg_extract_class($vars, 'elgg-output');
 
 $parse_urls = elgg_extract('parse_urls', $vars, true);
 unset($vars['parse_urls']);
+
+$parse_emails = elgg_extract('parse_emails', $vars, true);
+unset($vars['parse_emails']);
 
 $sanitize = elgg_extract('sanitize', $vars, true);
 unset($vars['sanitize']);
@@ -25,6 +29,10 @@ unset($vars['value']);
 
 if ($parse_urls) {
 	$text = parse_urls($text);
+}
+
+if ($parse_emails) {
+	$text = elgg_parse_emails($text);
 }
 
 if ($sanitize) {


### PR DESCRIPTION
This makes emails in text clickable mailto links.

Fixes #7052

i am no regex wonder... so this is the best i could steal from someone else...

tests here https://regex101.com/r/lbTbwE/3
- [x] add tests
