### PR TITLE
chore(js): user hover menus no longer have a "caret" hover indicator

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -417,6 +417,7 @@ Notable changes in plugins:
  * ``.elgg-icon`` no longer has a global ``font-size``, ``line-height`` or ``color``: these values will be inherited from parent items
  * Support for ``.elgg-icon-hover`` has been dropped
  * Admin theme now reuses icon classes from ``elements/icons.css``
+ * User "hover" icons are no longer covered with a "caret" icon.
 
 Comment notifications
 ---------------------

--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -122,17 +122,9 @@ elgg.ui.initHoverMenu = function(parent) {
 		parent = document;
 	}
 
-	// avatar image menu link
-	$(parent).on('mouseover', ".elgg-avatar", function() {
-		$(this).children(".elgg-icon-hover-menu").show();
-	})
-	.on('mouseout', '.elgg-avatar', function() {
-		$(this).children(".elgg-icon-hover-menu").hide();
-	});
-
-
 	// avatar contextual menu
-	$(document).on('click', ".elgg-avatar > .elgg-icon-hover-menu", function(e) {
+	$(document).on('click', ".elgg-avatar > a", function(e) {
+		e.preventDefault();
 
 		var $icon = $(this);
 

--- a/views/default/icon/user/default.php
+++ b/views/default/icon/user/default.php
@@ -78,7 +78,6 @@ if ($show_menu) {
 		'username' => $username,
 		'name' => $name,
 	];
-	echo elgg_view_icon('hover-menu');
 	echo elgg_view('navigation/menu/user_hover/placeholder', ['entity' => $user]);
 }
 


### PR DESCRIPTION
The anchor now opens the menu, and the user can use context-click to open the profile.

Fixes #6906

BREAKING CHANGE:
User icons no longer include a `hover-menu` icon that's displayed on mouseover. The click event is bound to the surrounding anchor.
