### PR TITLE
fix(likes): check for a valid entity in menu setup

### DIFF
--- a/mod/likes/start.php
+++ b/mod/likes/start.php
@@ -93,8 +93,10 @@ function likes_entity_menu_setup($hook, $type, $return, $params) {
 		return $return;
 	}
 
-	$entity = $params['entity'];
-	/* @var ElggEntity $entity */
+	$entity = elgg_extract('entity', $params);
+	if (!($entity instanceof \ElggEntity)) {
+		return $return;
+	}
 
 	$type = $entity->type;
 	$subtype = $entity->getSubtype();


### PR DESCRIPTION
It was assumed a valid entity was provided in the menu hook, this is not
always the case. So now it's validated

fixes: #9371
