### PR TITLE
fix(likes): notification subject too long

### DIFF
--- a/mod/likes/actions/likes/add.php
+++ b/mod/likes/actions/likes/add.php
@@ -46,11 +46,21 @@ if ($entity->owner_guid != $user->guid) {
 
 	$title_str = $entity->getDisplayName();
 	if (!$title_str) {
-		$title_str = elgg_get_excerpt($entity->description);
+		$title_str = elgg_get_excerpt($entity->description, 80);
 	}
 
 	$site = elgg_get_site_entity();
 
+	// summary for site_notifications
+	$summary = elgg_echo('likes:notifications:subject', array(
+			$user->name,
+			$title_str
+		),
+		$owner->language
+	);
+	
+	// prevent long subjects in mail
+	$title_str = elgg_get_excerpt($title_str, 80);
 	$subject = elgg_echo('likes:notifications:subject', array(
 			$user->name,
 			$title_str
@@ -77,6 +87,7 @@ if ($entity->owner_guid != $user->guid) {
 		array(
 			'action' => 'create',
 			'object' => $annotation,
+			'summary' => $summary,
 		)
 	);
 }


### PR DESCRIPTION
In some use cases the subject of the notification could be very long
(eg. comments)

fixes: #8906
