### PR TITLE
chore(js): ligthbox is working again on all pages

### DIFF
--- a/mod/developers/views/default/elgg/dev/gear.js
+++ b/mod/developers/views/default/elgg/dev/gear.js
@@ -6,7 +6,6 @@ define(function (require) {
 	var elgg = require('elgg');
 	var spinner = require('elgg/spinner');
 	var gear_html = require('text!elgg/dev/gear.html');
-	require('elgg/lightbox');
 
 	$(gear_html)
 		.appendTo('body')

--- a/mod/developers/views/default/theme_sandbox/javascript/lightbox.js
+++ b/mod/developers/views/default/theme_sandbox/javascript/lightbox.js
@@ -1,9 +1,12 @@
 define(function(require) {
+	require('elgg/ready');
+	
 	var lightbox = require('elgg/lightbox');
 	var opts = {
 		photo: true,
 		width: 600
 	};
+	
 	lightbox.bind('[rel="lightbox-gallery"]', opts, false);
 	
 	$(document).on('click', '#elgg-lightbox-test-resize', function(event) {

--- a/views/default/elgg.js.php
+++ b/views/default/elgg.js.php
@@ -96,4 +96,4 @@ if (!window._require_queue) {
 
 elgg.trigger_hook('boot', 'system');
 
-require(['elgg/init', 'elgg/ready']);
+require(['elgg/init', 'elgg/ready', 'elgg/lightbox']);


### PR DESCRIPTION
Deprecated function cleanup resulted in lightbox loading being removed
from runtime
