### PR TITLE
feat(js): adds animate.css for integration with JS events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "michelf/php-markdown": "^1.5.0",
         "league/flysystem-memory": "^1.0",
         "htmlawed/htmlawed": "^1.1.22",
-        "imagine/imagine": "^0.6.3"
+        "imagine/imagine": "^0.6.3",
+        "bower-asset/animate-css": "^3.5.2"
     },
     "scripts": {
         "pre-install-cmd": "php .scripts/check_global_requirements.php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2b37efbdd8395123e155c1bb89b01e56",
-    "content-hash": "39e4c1634b130ddec5e628d7e353a570",
+    "hash": "d58c204088fd2a2def67523252d2b565",
+    "content-hash": "75e8e67279cc63b649f70e4031341f68",
     "packages": [
+        {
+            "name": "bower-asset/animate-css",
+            "version": "3.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/daneden/animate.css.git",
+                "reference": "dac3dab7b59cb6072b5d0fe23eae3805e370a58c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/daneden/animate.css/zipball/dac3dab7b59cb6072b5d0fe23eae3805e370a58c",
+                "reference": "dac3dab7b59cb6072b5d0fe23eae3805e370a58c",
+                "shasum": ""
+            },
+            "type": "bower-asset-library",
+            "extra": {
+                "bower-asset-main": "./animate.css",
+                "bower-asset-ignore": [
+                    ".*",
+                    "*.yml",
+                    "Gemfile",
+                    "Gemfile.lock",
+                    "*.md"
+                ]
+            }
+        },
         {
             "name": "bower-asset/jquery",
             "version": "2.2.4",

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -125,6 +125,7 @@ Removed JavaScript APIs
  * ``elgg.ui.river``
  * ``elgg.ui.initDatePicker``: Use the ``input/date`` module
  * ``elgg.ui.likesPopupHandler``
+ * ``elgg.ui.toggles``
  * ``elgg.embed``: Use the ``elgg/embed`` module
  * ``embed/custom_insert_js``: Use the ``embed, editor`` JS hook
  * ``elgg/ckeditor/insert.js``
@@ -275,6 +276,13 @@ Notable changes in plugins:
 
  * search plugin no longer extends ``page/elements/header`` and instead extends ``page/elements/sidebar``
  * topbar menu items might now have a new parent item or be found in a different section
+
+Element toggling
+----------------
+
+``elgg.ui.toggles`` has been removed and is now handled by ``elgg/toggle`` AMD module.
+
+``data-toggle-slide`` attribute of the ``[rel="toggle"]`` is no longer respected: instead use ``data-animation`` with a json encoded array of open and close animation classes.
 
 From 2.2 to 2.3
 ===============

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -510,6 +510,10 @@ function _elgg_river_menu_setup($hook, $type, $return, $params) {
 					'title' => elgg_echo('comment:this'),
 					'rel' => 'toggle',
 					'priority' => 50,
+					'data-animation' => json_encode([
+						'open' => 'slideInDown',
+						'close' => 'slideOutUp',
+					]),
 				);
 				$return[] = \ElggMenuItem::factory($options);
 			}

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1883,6 +1883,9 @@ function elgg_views_boot() {
 	elgg_register_css('lightbox', elgg_get_simplecache_url('lightbox/elgg-colorbox-theme/colorbox.css'));
 	elgg_load_css('lightbox');
 
+	elgg_register_css('animate', elgg_get_simplecache_url('animate.css'));
+	elgg_load_css('animate');
+
 	// just provides warning to use elgg/autocomplete AMD
 	elgg_register_js('elgg.autocomplete', elgg_normalize_url('js/lib/ui.autocomplete.js'));
 

--- a/engine/views.php
+++ b/engine/views.php
@@ -23,6 +23,9 @@ return [
 		"font-awesome/css/font-awesome.css" => "vendor/fortawesome/font-awesome/css/font-awesome.min.css",
 		"font-awesome/fonts/" => "vendor/fortawesome/font-awesome/fonts",
 
+		// Animate.css
+		"animate.css" => "vendor/bower-asset/animate-css/animate.min.css",
+
 		/**
 		 * __DIR__ should be utilized when referring to assets that are checked in to version control.
 		 */

--- a/js/lib/ui.js
+++ b/js/lib/ui.js
@@ -18,7 +18,9 @@ elgg.ui.init = function () {
 	$('.elgg-system-messages li').animate({opacity: 0.9}, 6000);
 	$('.elgg-system-messages li.elgg-state-success').fadeOut('slow');
 
-	$(document).on('click', '[rel=toggle]', elgg.ui.toggles);
+	require(['elgg/toggle'], function(toggle) {
+		toggle.bind($('[rel="toggle"]'));
+	});
 
 	require(['elgg/popup'], function(popup) {
 		popup.bind($('[rel="popup"]'));
@@ -43,48 +45,6 @@ elgg.ui.init = function () {
 	$(elementId).addClass('elgg-state-highlight');
 
 	elgg.ui.registerTogglableMenuItems('add-friend', 'remove-friend');
-};
-
-/**
- * Toggles an element based on clicking a separate element
- *
- * Use rel="toggle" on the toggler element
- * Set the href to target the item you want to toggle (<a rel="toggle" href="#id-of-target">)
- * or use data-toggle-selector="your_jquery_selector" to have an advanced selection method
- *
- * By default elements perform a slideToggle.
- * If you want a normal toggle (hide/show) you can add data-toggle-slide="0" on the elements to prevent a slide.
- *
- * @param {Object} event
- * @return void
- */
-elgg.ui.toggles = function(event) {
-	event.preventDefault();
-	var $this = $(this),
-		selector = $this.data().toggleSelector;
-
-	if (!selector) {
-		// @todo we can switch to elgg.getSelectorFromUrlFragment() in 1.x if
-		// we also extend it to support href=".some-class"
-		selector = $this.attr('href');
-	}
-
-	var $elements = $(selector);
-
-	$this.toggleClass('elgg-state-active');
-
-	$elements.each(function(index, elem) {
-		var $elem = $(elem);
-		if ($elem.data().toggleSlide != false) {
-			$elem.slideToggle('medium');
-		} else {
-			$elem.toggle();
-		}
-	});
-
-	$this.trigger('elgg_ui_toggle', [{
-		$toggled_elements: $elements
-	}]);
 };
 
 /**

--- a/mod/developers/views/default/theme_sandbox/javascript/toggle.php
+++ b/mod/developers/views/default/theme_sandbox/javascript/toggle.php
@@ -3,13 +3,25 @@
 $ipsum = elgg_view('developers/ipsum');
 
 $link = elgg_view('output/url', array(
-	'text' => 'Toggle content',
+	'text' => 'Toggle without animation',
 	'href' => "#elgg-toggle-test",
 	'rel' => 'toggle',
 ));
 
-echo $link;
-echo elgg_view_module('featured', 'Toggle Test', $ipsum, array(
+$link2 = elgg_view('output/url', array(
+	'text' => 'Toggle with animation',
+	'href' => "#elgg-toggle-test",
+	'rel' => 'toggle',
+	'class' => 'mlm',
+	'data-animation' => json_encode([
+		'open' => 'slideInDown',
+		'close' => 'slideOutUp',
+	]),
+));
+
+echo elgg_format_element('div', [], $link . $link2);
+
+echo elgg_view_module('featured', 'Toggled module', $ipsum, array(
 	'id' => 'elgg-toggle-test',
 	'class' => 'hidden theme-sandbox-content-thin mtm',
 ));

--- a/views/default/elgg.js.php
+++ b/views/default/elgg.js.php
@@ -19,6 +19,7 @@ echo elgg_view('sprintf.js');
 // We use named AMD modules and inline them here in order to save HTTP requests,
 // as these modules will be required on each page
 echo elgg_view('elgg/popup.js');
+echo elgg_view('elgg/toggle.js');
 
 $elggDir = \Elgg\Application::elggDir();
 $files = array(

--- a/views/default/elgg/animate.js
+++ b/views/default/elgg/animate.js
@@ -1,0 +1,12 @@
+define(function (require) {
+	require('jquery');
+	return function ($elem, animation, callback) {
+		var event = 'webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend';
+		$elem.addClass('animated ' + animation).one(event, function () {
+			$elem.removeClass('animated ' + animation);
+			if (typeof callback === 'function') {
+				callback.call(null, $elem);
+			}
+		});
+	};
+});

--- a/views/default/elgg/toggle.js
+++ b/views/default/elgg/toggle.js
@@ -1,0 +1,80 @@
+/**
+ * We use a named AMD module that is inlined in elgg.js, as this module is
+ * loaded on each page request and we do not want to issue an additional HTTP request
+ *
+ * @module elgg/toggle
+ * @since 3.0
+ */
+define('elgg/toggle', ['elgg', 'jquery', 'elgg/animate'], function (elgg, $, animate) {
+	
+	var toggler = {
+
+		/**
+		 * Shortcut to bind a click event on a set of $triggers.
+		 *
+		 * Set the href to target the item you want to toggle (<a rel="toggle" href="#id-of-target">)
+		 * or use data-toggle-selector="your_jquery_selector" to have an advanced selection method
+		 *
+		 * You can define open and close animations by specifying data-animation attribute on the toggle.
+		 *
+		 * Plugins can listen to 'elgg_ui_toggle' jQuery event on the trigger to attach additional
+		 * behaviour to toggled items after they have been hidden/shown.
+		 * 
+		 * @param {jQuery} $triggers A set of triggers to bind
+		 * @return void
+		 */
+		bind: function ($triggers) {
+			$triggers.off('click.toggle')
+					.on('click.toggle', function (e) {
+						if (e.isDefaultPrevented()) {
+							return;
+						}
+						e.preventDefault();
+						e.stopPropagation();
+						toggler.toggle($(this));
+					});
+		},
+
+		/**
+		 * Toggles an element bound to a single $trigger
+		 *
+		 * @param {jQuery} $trigger A trigger element
+		 * @return void
+		 */
+		toggle: function ($trigger) {
+			var href = $trigger.prop('href'),
+				selector = $trigger.data('toggleSelector');
+
+			if (!selector) {
+				selector = elgg.getSelectorFromUrlFragment(href);
+			}
+
+			var animation = $trigger.data('animation') || {};
+			
+			var $elements = $(selector);
+
+			if ($trigger.is('.elgg-state-active')) {
+				$trigger.removeClass('elgg-state-active');
+				if (animation.close) {
+					animate($elements, animation.close, function($elements) {
+						$elements.addClass('hidden').removeClass('elgg-state-toggled');
+					});
+				} else {
+					$elements.addClass('hidden').removeClass('elgg-state-toggled');
+				}
+			} else {
+				$trigger.addClass('elgg-state-active');
+				$elements.removeClass('hidden').addClass('elgg-state-toggled');
+				if (animation.open) {
+					animate($elements, animation.open);
+				}
+			}
+			
+			$trigger.trigger('elgg_ui_toggle', [{
+				$toggled_elements: $elements
+			}]);
+		}
+	};
+
+	return toggler;
+});


### PR DESCRIPTION
Adds animate.css as a vendor dependency. Rewrites toggle module to support
custom animations.

BREAKING CHANGE
data-toggle-slide attribute of the toggle trigger is no longer supported.
Use data-animation with a json encoded array of open/close animation
classes

Refs #9459, #10421
