### PR TITLE
chore(forms): apply checkbox exceptions earlier when rendering fields

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1459,6 +1459,14 @@ function elgg_view_field(array $params = []) {
 	// field input view needs this
 	$input_vars['input_type'] = $input_type;
 
+	if ($input_type == 'checkbox') {
+		// Single checkbox input view gets special treatment
+		// We don't want the field label to appear a checkbox without a label
+		$input_vars['label'] = $element_vars['label'];
+		$input_vars['label_tag'] = 'div';
+		unset($element_vars['label']);
+	}
+
 	// field views get more data
 	$element_vars['input_type'] = $input_type;
 	if (isset($params['#class'])) {
@@ -1470,18 +1478,10 @@ function elgg_view_field(array $params = []) {
 	if (isset($params['#label'])) {
 		$element_vars['label'] = $params['#label'];
 	}
-
+	
 	// wrap if present
 	$element_vars['label'] = elgg_view('elements/forms/label', $element_vars);
 	$element_vars['help'] = elgg_view('elements/forms/help', $element_vars);
-
-	if ($input_type == 'checkbox') {
-		// Single checkbox input view gets special treatment
-		// We don't want the field label to appear a checkbox without a label
-		$input_vars['label'] = $element_vars['label'];
-		$input_vars['label_tag'] = 'div';
-		unset($element_vars['label']);
-	}
 
 	$element_vars['input'] = elgg_view("elements/forms/input", $input_vars);
 


### PR DESCRIPTION
Normalize checkbox options earler to correctly build the checkbox field markup
