### PR TITLE
fix(core): outgoing email should have a message-id header

### DIFF
--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -226,6 +226,36 @@ function _elgg_send_email_notification($hook, $type, $result, $params) {
 }
 
 /**
+ * Adds default Message-ID header to all e-mails
+ *
+ * @param string $hook        Equals to 'email'
+ * @param string $type        Equals to 'system'
+ * @param array  $returnvalue Array containing fields: 'to', 'from', 'subject', 'body', 'headers', 'params'
+ * @param array  $params      The same value as $returnvalue
+ * 
+ * @see https://tools.ietf.org/html/rfc5322#section-3.6.4
+ * 
+ * @return array
+ * 
+ * @access private
+ */
+function _elgg_notifications_smtp_default_message_id_header($hook, $type, $returnvalue, $params) {
+	
+	if (!is_array($returnvalue) || !is_array($returnvalue['params'])) {
+		// another hook handler returned a non-array, let's not override it
+		return;
+	}
+	
+	$hostname = parse_url(elgg_get_site_url(), PHP_URL_HOST);
+	$url_path = parse_url(elgg_get_site_url(), PHP_URL_PATH);
+	
+	$mt = microtime(true);
+	
+	$returnvalue['headers']['Message-ID'] = "<{$url_path}.default.{$mt}@{$hostname}>";
+	
+	return $returnvalue;
+}
+/**
  * Adds default thread SMTP headers to group messages correctly.
  * Note that it won't be sufficient for some email clients. Ie. Gmail is looking at message subject anyway.
  *
@@ -292,6 +322,7 @@ function _elgg_notifications_init() {
 	// add email notifications
 	elgg_register_notification_method('email');
 	elgg_register_plugin_hook_handler('send', 'notification:email', '_elgg_send_email_notification');
+	elgg_register_plugin_hook_handler('email', 'system', '_elgg_notifications_smtp_default_message_id_header', 1);
 	elgg_register_plugin_hook_handler('email', 'system', '_elgg_notifications_smtp_thread_headers');
 
 	// add ability to set personal notification method


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc5322#section-3.6.4 all
emails should have a message-id header

fixes: #10043
