### PR TITLE
fix(core): _elgg_send_email_notification respects other email handlers

### DIFF
--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -195,6 +195,12 @@ function _elgg_notifications_cron() {
  * @access private
  */
 function _elgg_send_email_notification($hook, $type, $result, $params) {
+	
+	if ($result === true) {
+		// assume someone else already sent the message
+		return;
+	}
+	
 	/* @var \Elgg\Notifications\Notification $message */
 	$message = $params['notification'];
 


### PR DESCRIPTION
If some other email handler already successfully sent the email don't
try to sent it again.

fixes: #8300
