### PR TITLE
fix(css): elgg-body elements no longer clip form and positioned elements

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -500,6 +500,15 @@ Friends collections
 
 Friends collections UI has been moved to its own plugins - ``friends_collections``.
 
+Layout of ``.elgg-body`` elements
+---------------------------------
+
+In 3.0, these elements by default no longer stretch to fill available space in a block
+context. They still clear floats and allow breaking words to wrap text.
+
+Core modules and layouts that relied on space-filling have been reworked for Flexbox and
+we encourage devs to do the same, rather than use the problematic ``overflow: hidden``.
+
 From 2.2 to 2.3
 ===============
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1278,6 +1278,9 @@ function elgg_view_comments($entity, $add_comment = true, array $vars = []) {
  * Fixed width media on the side (image, icon, flash, etc.).
  * Descriptive content filling the rest of the column.
  *
+ * @note Use the $vars "image_alt" key to set an image on the right. If you do, you may pass
+ *       in an empty string for $image to have only the right image.
+ *
  * This is a shortcut for {@elgg_view page/components/image_block}.
  *
  * @param string $image The icon and other information

--- a/mod/developers/views/default/page/layouts/theme_sandbox.php
+++ b/mod/developers/views/default/page/layouts/theme_sandbox.php
@@ -17,11 +17,11 @@ echo <<<HTML
 	<div class="theme-sandbox-sidebar">
 		$sidebar
 	</div>
-	<div class="theme-sandbox-main elgg-body">
+	<div class="theme-sandbox-main">
 		<div class="elgg-head clearfix">
 			$title
 		</div>
-		<div class="theme-sandbox-content elgg-body">
+		<div class="theme-sandbox-content">
 			$content
 		</div>
 	</div>

--- a/mod/developers/views/default/theme_sandbox.css
+++ b/mod/developers/views/default/theme_sandbox.css
@@ -8,14 +8,19 @@
 	text-align: center;
 }
 
+.theme-sandbox-layout {
+	display: flex;
+	align-items: flex-start;
+}
+
 .theme-sandbox-main {
 	padding: 20px 20px;
 	min-height: 360px;
 	position: relative;
+	flex: 1
 }
 
 .theme-sandbox-sidebar {
-	float: left;
 	padding: 20px 20px;
 	margin-right: 10px;
 	position: relative;

--- a/mod/developers/views/default/theme_sandbox/components/image_block.php
+++ b/mod/developers/views/default/theme_sandbox/components/image_block.php
@@ -1,9 +1,11 @@
 <?php
 $ipsum = elgg_view('developers/ipsum');
+$ipsum = "$ipsum $ipsum $ipsum $ipsum $ipsum $ipsum $ipsum";
 
 $user = new ElggUser();
 $image = elgg_view_entity_icon($user, 'small');
-echo elgg_view_image_block($image, "$ipsum $ipsum $ipsum $ipsum $ipsum $ipsum $ipsum", [
+
+echo elgg_view_image_block($image, $ipsum, [
 	'class' => 'theme-sandbox-image-block',
 	'data-type' => 'user',
 ]);

--- a/mod/developers/views/default/theme_sandbox/components/image_block_alt.php
+++ b/mod/developers/views/default/theme_sandbox/components/image_block_alt.php
@@ -1,11 +1,12 @@
 <?php
 $ipsum = elgg_view('developers/ipsum');
+$ipsum = "$ipsum $ipsum $ipsum $ipsum $ipsum $ipsum $ipsum";
 
 $user = new ElggUser();
 $image = elgg_view_entity_icon($user, 'small');
-$image_alt = elgg_view_icon('user-plus');
-echo elgg_view_image_block($image, "$ipsum $ipsum $ipsum $ipsum $ipsum $ipsum $ipsum", [
+
+echo elgg_view_image_block("", $ipsum, [
 	'class' => 'theme-sandbox-image-block',
 	'data-type' => 'user',
-	'image_alt' => $image_alt,
+	'image_alt' => $image,
 ]);

--- a/mod/groups/views/default/groups/css.php
+++ b/mod/groups/views/default/groups/css.php
@@ -6,6 +6,7 @@
  */
 
 ?>
+/*<style>*/
 .groups-profile > .elgg-image {
 	margin-right: 20px;
 }
@@ -58,9 +59,14 @@
 }
 
 @media (max-width: 600px) {
+	.groups-profile {
+		display: block;
+	}
 	.groups-profile-fields {
-		float: left;
-		padding-left: 0;
+		padding-top: 20px;
+	}
+	.profile > .elgg-inner {
+		display: block;
 	}
 
 	#groups-tools > li {

--- a/mod/groups/views/default/groups/profile/summary.php
+++ b/mod/groups/views/default/groups/profile/summary.php
@@ -22,7 +22,7 @@ if (!$owner) {
 }
 
 ?>
-<div class="groups-profile clearfix elgg-image-block">
+<div class="groups-profile elgg-image-block">
 	<div class="elgg-image">
 		<div class="groups-profile-icon">
 			<?php

--- a/mod/profile/views/default/profile/css.php
+++ b/mod/profile/views/default/profile/css.php
@@ -13,18 +13,21 @@
 	float: left;
 	margin-bottom: 15px;
 }
-.profile .elgg-inner {
+.profile > .elgg-inner {
 	border: 1px solid #ebebeb;
 	border-radius: 3px;
+	margin: 0 5px;
+	display: flex;
+	align-items: flex-start;
 }
 #profile-details {
 	padding: 15px;
+	flex: 1;
 }
 
 /*** ownerblock ***/
 #profile-owner-block {
 	width: 200px;
-	float: left;
 	border-right: 1px solid #ebebeb;
 	padding: 15px;
 }

--- a/views/default/elements/components.css.php
+++ b/views/default/elements/components.css.php
@@ -11,14 +11,21 @@
 *************************************** */
 .elgg-image-block {
 	padding: 10px 0;
+	display: flex;
+	align-items: flex-start;
+}
+.elgg-image-block:after {
+	display: none;
 }
 .elgg-image-block .elgg-image {
-	float: left;
 	margin-right: 8px;
 }
 .elgg-image-block .elgg-image-alt {
-	float: right;
 	margin-left: 8px;
+	order: 1;
+}
+.elgg-image-block > .elgg-body {
+	flex: 1;
 }
 
 /* ***************************************
@@ -293,11 +300,6 @@
 .elgg-river-comments .elgg-state-highlight {
 	animation: comment-highlight 5s;
 }
-/* Chrome, Safari, Opera */
-@-webkit-keyframes comment-highlight {
-	from {background: #dff2ff;}
-	to {background: white;}
-}
 /* Standard syntax */
 @keyframes comment-highlight {
 	from {background: #dff2ff;}
@@ -342,9 +344,7 @@
 	border: 1px solid #DCDCDC;
 	padding: 3px;
 	background-color: #FFF;
-
 	box-sizing: border-box;
-
 	max-width: 100%;
 	height: auto;
 }

--- a/views/default/elements/core.css.php
+++ b/views/default/elements/core.css.php
@@ -18,6 +18,7 @@
 
 /* Clearfix */
 .clearfix:after,
+.elgg-body:after,
 .elgg-grid:after,
 .elgg-layout:after,
 .elgg-inner:after,
@@ -35,8 +36,13 @@
 	visibility: hidden;	
 }
 
+/* Simple block that clears floats and breaks words to wrap */
+.elgg-body {
+	display: block;
+	word-wrap: break-word;
+}
+
 /* Fluid width container that does not wrap floats */
-.elgg-body,
 .elgg-col-last {
 	display: block;
 	width: auto;
@@ -46,11 +52,11 @@
 
 <?php
 /**
- * elgg-body fills the space available to it.
+ * elgg-col-last fills the space available to it. (elgg-body no longer does this)
  * It uses hidden text to expand itself. The combination of auto width, overflow
  * hidden, and the hidden text creates this effect.
  *
- * This allows us to float fixed width divs to either side of an .elgg-body div
+ * This allows us to float fixed width divs to either side of an .elgg-col-last div
  * without having to specify the body div's width.
  *
  * @todo check what happens with long <pre> tags or large images
@@ -59,7 +65,6 @@
 
 //@todo isn't this only needed if we use display:table-cell?
 ?>
-.elgg-body:after,
 .elgg-col-last:after {
 	display: block;
 	visibility: hidden;

--- a/views/default/elements/layout.css.php
+++ b/views/default/elements/layout.css.php
@@ -88,6 +88,7 @@
 }
 
 .elgg-layout-header {
+	padding-bottom: 5px;
 	border-bottom: 1px solid #EBEBEB;
 	margin-bottom: 10px;
 	width: 100%;
@@ -109,6 +110,28 @@
 	order: 2;
 }
 
+.elgg-layout-one-sidebar,
+.elgg-layout-two-sidebar {
+	display: flex;
+	align-items: flex-start;
+}
+.elgg-layout-one-sidebar > .elgg-body,
+.elgg-layout-two-sidebar > .elgg-body {
+	flex: 1;
+}
+.elgg-layout-one-sidebar > .elgg-sidebar {
+	float: none;
+	order: 1;
+}
+.elgg-layout-two-sidebar > .elgg-sidebar {
+	float: none;
+	order: 2;
+}
+.elgg-layout-two-sidebar > .elgg-sidebar-alt {
+	float: none;
+	order: 0;
+}
+
 .elgg-layout-widgets > .elgg-widgets {
 	float: right;
 }
@@ -117,7 +140,7 @@
 	padding: 32px 0 20px 30px;
 	float: right;
 	width: 21.212121%;
-	margin: 0;
+	margin: 0 0 0 30px;
 	border-left: 1px solid #EBEBEB;
 }
 .elgg-sidebar-alt {
@@ -132,14 +155,6 @@
 	position: relative;
 	min-height: 360px;
 	padding: 12px 0 10px 0;
-}
-.elgg-layout-one-sidebar .elgg-main {
-	float: left;
-	width: 72.525252%;
-}
-.elgg-layout-two-sidebar .elgg-main {
-	float: left;
-	width: 50.101010%;
 }
 
 /***** PAGE FOOTER ******/
@@ -170,6 +185,10 @@
         padding: 12px 20px 10px;
 		box-sizing: border-box;
     }
+	.elgg-layout-one-sidebar,
+	.elgg-layout-two-sidebar {
+		display: block;
+	}
     .elgg-layout-one-sidebar .elgg-main,
 	.elgg-layout-two-sidebar .elgg-main {
         width: 100%;
@@ -180,8 +199,8 @@
 		border-bottom: 1px solid #DCDCDC;
 		background-color: #FAFAFA;
 		width: 100%;
-		float: left;
 		padding: 27px 20px 20px;
+		margin: 0;
 		box-shadow: 0 3px 6px rgba(0, 0, 0, 0.05) inset;
 		box-sizing: border-box;
 	}

--- a/views/default/elements/modules.css.php
+++ b/views/default/elements/modules.css.php
@@ -4,7 +4,7 @@
 	Modules
 *************************************** */
 .elgg-module {
-	overflow: hidden;
+	display: block;
 	margin-bottom: 20px;
 }
 

--- a/views/default/lightbox/elgg-colorbox-theme/colorbox.css
+++ b/views/default/lightbox/elgg-colorbox-theme/colorbox.css
@@ -51,8 +51,6 @@
 
 #cboxLoadedContent > *:not(.cboxPhoto) {
 	padding: 15px;
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
 }
 
@@ -103,8 +101,6 @@
 #colorbox,
 #cboxContent,
 #cboxLoadedContent {
-	-moz-box-sizing: content-box;
-	-webkit-box-sizing: content-box;
 	box-sizing: content-box;
 }
 


### PR DESCRIPTION
(replaces #9288)

Space-filling layouts like `.elgg-image-block` have been reworked to use flexbox. `.elgg-body` elements generally no longer use `overflow: hidden` to fill space by default, and so no longer clip absolutely-positioned descendant elements or the left edges of form elements.

Some apparently needless uses of `overflow: hidden` have been removed as well as vendor prefixed properties no longer needed.

The one/two sidebar and theme_sandbox layouts were converted to flexbox. A use of the "alt" image block layout is included in theme_sandbox.

Fixes #5197

BREAKING CHANGE:
`.elgg-body` elements by default no longer stretch to fill available space in a block context. They still clear floats and allow breaking words to wrap text.

Elements matching `.elgg-module`, `.elgg-head`, and `.elgg-menu-hover` no longer hide overflowing content. and those matching `.elgg-image`, `#profile-owner-block`, and `elgg-sidebar` (inside layouts) no longer float, but are now positioned with flexbox.
