### PR TITLE
chore(core): removed `system, pagesetup` event

### DIFF
--- a/docs/appendix/faqs/development.rst
+++ b/docs/appendix/faqs/development.rst
@@ -149,10 +149,11 @@ There are 5 :doc:`Elgg events </design/events>` that are triggered on every page
 1. boot, system
 2. plugins_boot, system
 3. init, system
-4. pagesetup, system (deprecated)
+4. ready, system
 5. shutdown, system
 
-The *boot*, *system* event is triggered before the plugins get loaded. There does not appear to be any difference between the timing of the next two events: *plugins_boot*, *system* and *init*, *system* so plugins tend to use *init*, *system*. This event is triggered in ``Elgg\Application::bootCore``. The *pagesetup*, *system* event is thrown the first time ``elgg_view()`` is called. Some pages like the default ``index.php`` do not call ``elgg_view()`` so it is not triggered for them. The *shutdown*, *system* event is triggered after the page has been sent to the requester and is handled through the PHP function ``register_shutdown_function()``.
+
+The *boot*, *system* event is triggered before the plugins get loaded. There does not appear to be any difference between the timing of the next two events: *plugins_boot*, *system* and *init*, *system* so plugins tend to use *init*, *system*. This event is triggered in ``Elgg\Application::bootCore``. The *ready*, *system* event is triggered after all plugins are fully loaded and the engine is ready to serve pages. The *shutdown*, *system* event is triggered after the page has been sent to the requester and is handled through the PHP function ``register_shutdown_function()``.
 
 There are :doc:`other events </guides/events-list>` that are triggered by the Elgg core but they happen occasionally (such as when a user logs in).
 

--- a/docs/guides/events-list.rst
+++ b/docs/guides/events-list.rst
@@ -21,10 +21,6 @@ System events
 	Triggered after the ``init, system`` event. All plugins are fully loaded and the engine is ready
 	to serve pages.
 
-**pagesetup, system** (deprecated in 2.3)
-    Called just before the first content is produced. Is triggered by ``elgg_view()``.
-    Use the menu or page shell hooks instead.
-
 **shutdown, system**
     Triggered after the page has been sent to the user. Expensive operations could be done here
     and not make the user wait.

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -45,9 +45,13 @@ Removed functions/methods
 
 All the functions in ``engine/lib/deprecated-1.9.php`` were removed. See https://github.com/Elgg/Elgg/blob/2.0/engine/lib/deprecated-1.9.php for these functions. Each ``@deprecated`` declaration includes instructions on what to use instead.
 
+ * ``_elgg_manage_pagesetup``
+ * ``developers_setup_menu``
  * ``get_default_filestore``
+ * ``groups_setup_sidebar_menus``
  * ``set_default_filestore``
  * ``generate_user_password``: Use ``ElggUser::setPassword``
+ * ``notifications_plugin_pagesetup``
  * ``ElggFile::setFilestore``: ElggFile objects can no longer use custom filestores.
  * ``ElggFile::size``: Use ``getSize``
  * ``ElggDiskFilestore::makeFileMatrix``: Use ``Elgg\EntityDirLocator``
@@ -137,9 +141,10 @@ Removed JavaScript APIs
 Removed hooks/events
 --------------------
 
+ * Event **delete, annotations**: Use **delete, annotation**
+ * Event **pagesetup, system**: Use the menu or page shell hooks instead.
  * Hook **index, system**: Override the ``resources/index`` view
  * Hook **object:notifications, <type>**: Use the hook **send:before, notifications**
- * Event **delete, annotations**: Use **delete, annotation**
  * Hook **output:before, layout**: Use **view_vars, page/layout/<layout_name>**
  * Hook **output:after, layout**: Use **view, page/layout/<layout_name>**
 

--- a/engine/classes/Elgg/Application/CacheHandler.php
+++ b/engine/classes/Elgg/Application/CacheHandler.php
@@ -383,14 +383,6 @@ class CacheHandler {
 		// disable error reporting so we don't cache problems
 		$this->config->set('debug', null);
 
-		// @todo elgg_view() checks if the page set is done (isset($GLOBALS['_ELGG']->pagesetupdone)) and
-		// triggers an event if it's not. Calling elgg_view() here breaks submenus
-		// (at least) because the page setup hook is called before any
-		// contexts can be correctly set (since this is called before page_handler()).
-		// To avoid this, lie about $CONFIG->pagehandlerdone to force
-		// the trigger correctly when the first view is actually being output.
-		$GLOBALS['_ELGG']->pagesetupdone = true;
-
 		return elgg_view($view, $vars);
 	}
 

--- a/engine/classes/Elgg/EventsService.php
+++ b/engine/classes/Elgg/EventsService.php
@@ -6,7 +6,7 @@ use Elgg\Debug\Inspector;
  * Service for Events
  *
  * @access private
- * 
+ *
  * @package    Elgg.Core
  * @subpackage Hooks
  * @since      1.9.0
@@ -45,31 +45,12 @@ class EventsService extends \Elgg\HooksRegistrationService {
 				. "to use '$name, relationship'");
 		}
 
-		if ($name === 'pagesetup' && $type === 'system') {
-			static $ignore = [
-				'users_pagesetup' => true,
-				'profile_pagesetup' => true,
-				'_elgg_friends_page_setup' => true,
-				'_elgg_setup_collections_menu' => true,
-				'_elgg_user_settings_menu_setup' => true,
-				'developers_setup_menu' => true,
-				'groups_setup_sidebar_menus' => true,
-				'notifications_plugin_pagesetup' => true,
-				'_elgg_admin_pagesetup' => true,
-				'login_as_add_topbar_link' => true,
-			];
-			if (!is_string($callback) || !isset($ignore[$callback])) {
-				$msg = "Event [pagesetup, system] is deprecated. Use menu or page shell hooks.";
-				elgg_deprecated_notice($msg, '2.3', 2);
-			}
-		}
-
 		return parent::registerHandler($name, $type, $callback, $priority);
 	}
 
 	/**
 	 * Triggers an Elgg event.
-	 * 
+	 *
 	 * @see elgg_trigger_event
 	 * @see elgg_trigger_after_event
 	 * @access private

--- a/engine/classes/Elgg/Logger.php
+++ b/engine/classes/Elgg/Logger.php
@@ -211,7 +211,6 @@ class Logger {
 	 */
 	protected function process($data, $display, $level) {
 		
-
 		// plugin can return false to stop the default logging method
 		$params = array(
 			'level' => $level,
@@ -222,13 +221,6 @@ class Logger {
 
 		if (!$this->hooks->trigger('debug', 'log', $params, true)) {
 			return;
-		}
-
-		// Do not want to write to screen before page creation has started.
-		// This is not fool-proof but probably fixes 95% of the cases when logging
-		// results in data sent to the browser before the page is begun.
-		if (!isset($GLOBALS['_ELGG']->pagesetupdone)) {
-			$display = false;
 		}
 
 		// Do not want to write to JS or CSS pages

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -883,9 +883,7 @@ function _elgg_php_exception_handler($exception) {
 	header("Cache-Control: no-cache, must-revalidate", true);
 	header('Expires: Fri, 05 Feb 1982 00:00:00 -0500', true);
 
-	// we don't want the 'pagesetup', 'system' event to fire
 	global $CONFIG;
-	$GLOBALS['_ELGG']->pagesetupdone = true;
 
 	try {
 		// allow custom scripts to trigger on exception

--- a/engine/lib/pagehandler.php
+++ b/engine/lib/pagehandler.php
@@ -65,7 +65,7 @@ function elgg_gatekeeper() {
 
 /**
  * Alias of elgg_gatekeeper()
- * 
+ *
  * Used at the top of a page to mark it as logged in users only.
  *
  * @return void
@@ -242,7 +242,7 @@ function elgg_ajax_gatekeeper() {
 
 /**
  * Front page handler
- * 
+ *
  * @return bool
  */
 function elgg_front_page_handler() {
@@ -266,9 +266,8 @@ function elgg_front_page_handler() {
 function elgg_error_page_handler($hook, $type, $result, $params) {
 	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Error pages are drawn by resource views without "forward" hook.', '2.3');
 	
-	// This draws an error page, and sometimes there's another 40* forward() call made during that
-	// process (usually due to the pagesetup event). We want to allow the 2nd call to pass through,
-	// but draw the appropriate page for the first call.
+	// This draws an error page, and sometimes there's another 40* forward() call made during that process.
+	// We want to allow the 2nd call to pass through, but draw the appropriate page for the first call.
 	
 	static $vars;
 	if ($vars === null) {

--- a/engine/lib/pageowner.php
+++ b/engine/lib/pageowner.php
@@ -174,7 +174,7 @@ function default_page_owner_handler($hook, $entity_type, $returnvalue, $params) 
  * output could be different for those two contexts ('blog' vs 'widget').
  *
  * Pages that pass through the page handling system set the context to the
- * first string after the root url. Example: http://example.org/elgg/bookmarks/ 
+ * first string after the root url. Example: http://example.org/elgg/bookmarks/
  * results in the initial context being set to 'bookmarks'.
  *
  * The context is a stack so that for a widget on a profile, the context stack

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -749,7 +749,7 @@ function elgg_view_layout($layout_name, $vars = array()) {
 /**
  * Normalizes deprecated content layout $vars for use in default layout
  * Helper function to assist plugins transitioning to 3.0
- * 
+ *
  * @param array $vars Vars
  * @return array
  * @access private
@@ -1942,48 +1942,6 @@ function elgg_views_boot() {
 }
 
 /**
- * Handle triggering the pagesetup event at the right time
- *
- * Trigger the system "pagesetup" event just before the 1st view rendering, or the 2nd if the 1st
- * view starts with "resources/".
- *
- * We delay the pagesetup event if the first view is a resource view in order to allow plugins to
- * move all page-specific logic like context setting into a resource view with more confidence
- * that that state will be available in their pagesetup event handlers. See the commit message for
- * more BG info.
- *
- * @param string $hook   "view_vars"
- * @param string $view   View name
- * @param array  $value  View arguments
- * @param array  $params Hook params
- * @return void
- */
-function _elgg_manage_pagesetup($hook, $view, $value, $params) {
-	global $CONFIG;
-
-	static $allow_delay_pagesetup = true;
-
-	if (isset($GLOBALS['_ELGG']->pagesetupdone) || empty($CONFIG->boot_complete)) {
-		return;
-	}
-
-	// only first rendering gets an opportunity to delay
-	$allow_delay = $allow_delay_pagesetup;
-	$allow_delay_pagesetup = false;
-
-	if ($allow_delay && (0 === strpos($view, 'resources/'))) {
-		return;
-	}
-
-	$GLOBALS['_ELGG']->pagesetupdone = true;
-
-	// don't call this anymore
-	_elgg_services()->hooks->unregisterHandler('view_vars', 'all', '_elgg_manage_pagesetup');
-
-	_elgg_services()->events->trigger('pagesetup', 'system');
-}
-
-/**
  * Get the site data to be merged into "elgg" in elgg.js.
  *
  * Unlike _elgg_get_js_page_data(), the keys returned are literal expressions.
@@ -2088,5 +2046,4 @@ function _elgg_view_under_viewtype($view, $vars, $viewtype) {
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
 	$events->registerHandler('boot', 'system', 'elgg_views_boot');
-	$hooks->registerHandler('view_vars', 'all', '_elgg_manage_pagesetup', 1000);
 };

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -9,8 +9,9 @@ developers_process_settings();
 elgg_register_event_handler('init', 'system', 'developers_init');
 
 function developers_init() {
-	elgg_register_event_handler('pagesetup', 'system', 'developers_setup_menu');
 
+	elgg_register_plugin_hook_handler('register', 'menu:page', '_developers_page_menu');
+		
 	elgg_extend_view('admin.css', 'developers/css');
 	elgg_extend_view('elgg.css', 'developers/css');
 
@@ -81,33 +82,70 @@ function developers_process_settings() {
 	}
 }
 
-function developers_setup_menu() {
-	if (elgg_in_context('admin') && elgg_is_admin_logged_in()) {
-		elgg_register_admin_menu_item('develop', 'inspect');
-		elgg_register_admin_menu_item('develop', 'sandbox', 'develop_tools');
-		elgg_register_admin_menu_item('develop', 'unit_tests', 'develop_tools');
-
-		elgg_register_menu_item('page', array(
-			'name' => 'dev_settings',
-			'href' => 'admin/developers/settings',
-			'text' => elgg_echo('settings'),
-			'context' => 'admin',
-			'priority' => 10,
-			'section' => 'develop'
-		));
-		
-		$inspect_options = developers_get_inspect_options();
-		foreach ($inspect_options as $key => $value) {
-			elgg_register_menu_item('page', array(
-				'name' => 'dev_inspect_' . elgg_get_friendly_title($key),
-				'href' => "admin/develop_tools/inspect?inspect_type={$key}",
-				'text' => $value,
-				'context' => 'admin',
-				'section' => 'develop',
-				'parent_name' => 'inspect'
-			));
-		}
+/**
+ * Register menu items for the page menu
+ *
+ * @param string $hook
+ * @param string $type
+ * @param array  $return
+ * @param array  $params
+ * @return array
+ *
+ * @access private
+ *
+ * @since 3.0
+ */
+function _developers_page_menu($hook, $type, $return, $params) {
+	if (!elgg_in_context('admin') || !elgg_is_admin_logged_in()) {
+		return;
 	}
+	
+	$return[] = \ElggMenuItem::factory([
+		'name' => 'dev_settings',
+		'href' => 'admin/developers/settings',
+		'text' => elgg_echo('settings'),
+		'priority' => 10,
+		'section' => 'develop',
+	]);
+	
+	$return[] = \ElggMenuItem::factory([
+		'name' => 'inspect',
+		'text' => elgg_echo('admin:inspect'),
+		'section' => 'develop',
+	]);
+	
+	$inspect_options = developers_get_inspect_options();
+	foreach ($inspect_options as $key => $value) {
+		$return[] = \ElggMenuItem::factory([
+			'name' => 'dev_inspect_' . elgg_get_friendly_title($key),
+			'href' => "admin/develop_tools/inspect?inspect_type={$key}",
+			'text' => $value,
+			'section' => 'develop',
+			'parent_name' => 'inspect',
+		]);
+	}
+	
+	$return[] = \ElggMenuItem::factory([
+		'name' => 'develop_tools',
+		'text' => elgg_echo('admin:develop_tools'),
+		'section' => 'develop',
+	]);
+	
+	$return[] = \ElggMenuItem::factory([
+		'name' => 'develop_tools:sandbox',
+		'text' => elgg_echo('admin:develop_tools:sandbox'),
+		'parent_name' => 'develop_tools',
+		'section' => 'develop',
+	]);
+	
+	$return[] = \ElggMenuItem::factory([
+		'name' => 'develop_tools:unit_tests',
+		'text' => elgg_echo('admin:develop_tools:unit_tests'),
+		'parent_name' => 'develop_tools',
+		'section' => 'develop',
+	]);
+	
+	return $return;
 }
 
 /**

--- a/mod/developers/views/default/developers/gear_popup.php
+++ b/mod/developers/views/default/developers/gear_popup.php
@@ -6,9 +6,6 @@ _elgg_admin_add_plugin_settings_menu();
 elgg_push_context('admin');
 elgg_push_context('developers_gear');
 
-// requires "admin" in context
-developers_setup_menu();
-
 // requires "admin" and "developers_gear" in context
 $menu = elgg_view_menu('page', [
 	'sort_by' => 'priority',

--- a/mod/groups/views/default/resources/groups/profile.php
+++ b/mod/groups/views/default/resources/groups/profile.php
@@ -8,6 +8,8 @@ elgg_entity_gatekeeper($guid, 'group');
 
 $group = get_entity($guid);
 
+elgg_push_context('group_profile');
+
 elgg_push_breadcrumb($group->name);
 
 groups_register_profile_buttons($group);

--- a/mod/profile/start.php
+++ b/mod/profile/start.php
@@ -37,7 +37,7 @@ function profile_init() {
 	// allow admins to set default widgets for users on profiles
 	elgg_register_plugin_hook_handler('get_list', 'default_widgets', 'profile_default_widgets_hook');
 	
-	elgg_register_event_handler('pagesetup', 'system', 'profile_pagesetup', 50);
+	elgg_register_plugin_hook_handler('register', 'menu:topbar', '_profile_topbar_menu');
 }
 
 /**
@@ -130,18 +130,26 @@ function profile_default_widgets_hook($hook, $type, $return) {
 }
 
 /**
- * Sets up user-related menu items
+ * Register menu items for the topbar menu
  *
- * @return void
+ * @param string $hook
+ * @param string $type
+ * @param array  $return
+ * @param array  $params
+ * @return array
+ *
  * @access private
+ *
+ * @since 3.0
  */
-function profile_pagesetup() {
+function _profile_topbar_menu($hook, $type, $return, $params) {
+	
 	$viewer = elgg_get_logged_in_user_entity();
 	if (!$viewer) {
 		 return;
 	}
-	
-	elgg_register_menu_item('topbar', array(
+
+	$return[] = \ElggMenuItem::factory([
 		'name' => 'profile',
 		'href' => $viewer->getURL(),
 		'text' => elgg_view('output/img', array(
@@ -153,5 +161,7 @@ function profile_pagesetup() {
 		'priority' => 100,
 		'link_class' => 'elgg-topbar-avatar',
 		'item_class' => 'elgg-avatar elgg-avatar-topbar',
-	));
+	]);
+	
+	return $return;
 }

--- a/views/default/page/admin.php
+++ b/views/default/page/admin.php
@@ -10,6 +10,8 @@
  * @uses $vars['sysmessages'] A 2d array of various message registers, passed from system_messages()
  */
 
+elgg_load_css('elgg.admin');
+
 // render content before head so that JavaScript and CSS can be loaded. See #4032
 $header = elgg_view('admin/header', $vars);
 


### PR DESCRIPTION
All previously registered events have been moved to new locations..
mostly menu register hooks.

BREAKING CHANGE:
You can no longer use the `system, pagesetup` event

fixes #9733
- [x] document the removed functions
- [x] check usage of removed functions
