### PR TITLE
chore(entities): entity gatekeeper hook now receives forward flag

### DIFF
--- a/engine/lib/pagehandler.php
+++ b/engine/lib/pagehandler.php
@@ -214,6 +214,7 @@ function elgg_entity_gatekeeper($guid, $type = null, $subtype = null, $forward =
 	$hook_type = "{$entity->getType()}:{$entity->getSubtype()}";
 	$hook_params = [
 		'entity' => $entity,
+		'forward' => $forward,
 	];
 	if (!elgg_trigger_plugin_hook('gatekeeper', $hook_type, $hook_params, true)) {
 		if ($forward) {


### PR DESCRIPTION
Gatekeeper hook handlers should be aware of the forward flag to
correctly redirect if forward is enabled
