### PR TITLE
chore(widgets): remove collapse menu item

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -470,10 +470,14 @@ All menu items are now identified with with ``data-menu-item`` attribute, sectio
 
  * ``access`` menu item has been removed. Access information is now rendered in the entity byline.
  
- ``user_hover`` menu:
+``user_hover`` menu:
  
  * All items use the ``icon`` parameter.
  * The layout of the dropdown has been changed. If you have modified the look and feel of this dropdown, you might need to update your HTML/CSS.
+
+``widget`` menu:
+
+ * ``collapse`` menu item has been removed and CSS updated accordingly
 
 Entity icons
 ------------

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -614,16 +614,6 @@ function _elgg_widget_menu_setup($hook, $type, $return, $params) {
 	/* @var \ElggWidget $widget */
 	$show_edit = elgg_extract('show_edit', $params, true);
 
-	$collapse = [
-		'name' => 'collapse',
-		'text' => ' ',
-		'href' => "#elgg-widget-content-$widget->guid",
-		'link_class' => 'elgg-widget-collapse-button',
-		'rel' => 'toggle',
-		'priority' => 1,
-	];
-	$return[] = \ElggMenuItem::factory($collapse);
-
 	if ($widget->canEdit()) {
 		$delete = [
 			'name' => 'delete',

--- a/views/default/admin.css.php
+++ b/views/default/admin.css.php
@@ -1012,22 +1012,13 @@ echo elgg_view('elements/misc/checkbox_switch.css');
 /* ***************************************
 	WIDGET MENU
 *************************************** */
+.elgg-menu-widget-container {
+	float: right;
+	margin-right: 15px;
+}
 .elgg-menu-widget > li {
-	position: absolute;
-	top: 4px;
 	display: inline-block;
-	width: 18px;
-	height: 18px;
-	padding: 2px 2px 0 0;
-}
-.elgg-menu-widget > .elgg-menu-item-collapse {
-	left: 5px;
-}
-.elgg-menu-widget > .elgg-menu-item-delete {
-	right: 5px;
-}
-.elgg-menu-widget > .elgg-menu-item-settings {
-	right: 25px;
+	margin-left: 10px;
 }
 
 /* ***************************************

--- a/views/default/elements/navigation.css.php
+++ b/views/default/elements/navigation.css.php
@@ -616,21 +616,13 @@
 /* ***************************************
 	WIDGET MENU
 *************************************** */
+.elgg-menu-widget-container {
+	float: right;
+	margin-right: 15px;
+}
 .elgg-menu-widget > li {
-	position: absolute;
-	top: 8px;
 	display: inline-block;
-	width: 18px;
-	height: 18px;
-}
-.elgg-menu-widget > .elgg-menu-item-collapse {
-	left: 10px;
-}
-.elgg-menu-widget > .elgg-menu-item-delete {
-	right: 10px;
-}
-.elgg-menu-widget > .elgg-menu-item-settings {
-	right: 32px;
+	margin-left: 10px;
 }
 
 @media (max-width: 820px) {

--- a/views/default/elements/widgets.css
+++ b/views/default/elements/widgets.css
@@ -42,25 +42,11 @@
 }
 .elgg-module-widget > .elgg-head h3 {
 	float: left;
-	padding: 0 45px 0 30px;
+	padding: 0 45px 0 20px;
 	color: #666;
 }
 .elgg-module-widget.elgg-state-draggable .elgg-widget-handle {
 	cursor: move;
-}
-a.elgg-widget-collapse-button {
-	color: #C5C5C5;
-}
-a.elgg-widget-collapse-button:hover,
-a.elgg-widget-collapsed:hover {
-	color: #9D9D9D;
-	text-decoration: none;
-}
-a.elgg-widget-collapse-button:before {
-	content: "\25BC";
-}
-a.elgg-widget-collapsed:before {
-	content: "\25BA";
 }
 .elgg-module-widget > .elgg-body {
 	background-color: #FFF;


### PR DESCRIPTION
(this was broken out of #10405)

BREAKING CHANGE
The collapse widget menu item has been removed.
