### PR TITLE
chore(events): removes the deprecated login, user event

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -144,6 +144,7 @@ Removed JavaScript APIs
 Removed hooks/events
 --------------------
 
+ * Event **login, user**: Use **login:before** or **login:after**. Note the user is not logged in during the **login:before** event.
  * Event **delete, annotations**: Use **delete, annotation**
  * Event **pagesetup, system**: Use the menu or page shell hooks instead.
  * Hook **index, system**: Override the ``resources/index`` view

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -314,14 +314,6 @@ function login(\ElggUser $user, $persistent = false) {
 	// use elgg_get_logged_in_user_entity().
 	$session->setLoggedInUser($user);
 
-	// deprecate event
-	$message = "The 'login' event was deprecated. Register for 'login:before' or 'login:after'";
-	$version = "1.9";
-	if (!elgg_trigger_deprecated_event('login', 'user', $user, $message, $version)) {
-		$session->removeLoggedInUser();
-		throw new \LoginException(elgg_echo('LoginException:Unknown'));
-	}
-
 	// if remember me checked, set cookie with token and store hash(token) for user
 	if ($persistent) {
 		_elgg_services()->persistentLogin->makeLoginPersistent($user);


### PR DESCRIPTION
Fixes #6074

BREAKING CHANGE:
The event `login, user` is removed.
