### PR TITLE
feat(views): add attachments and responses to full object listing

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -409,6 +409,15 @@ Comment notifications
  * The language keys related to comment notifications have changed. Check the ``generic_comment:notification:owner:`` language keys
  * The action for creating a comment (``action/comment/save``) was changed. If your plugin overruled this action you should have a look at it in order to prevent double notifications 
 
+Object listing views
+--------------------
+
+ * ``object/elements/full/body`` now wraps the full listing body in a ``.elgg-listing-full-body`` wrapper
+ * ``object/elements/full`` now supports ``attachments`` and ``responses`` which are rendered after listing body
+ * In core plugins, resource views no longer render comments/replies - instead they pass a ``show_responses`` flag to the entity view, which renders the responses and passes them to the full listing view. Third party plugins will need to update their uses of ``object/<subtype>`` and ``resources/<handler>/view`` views.
+ * Full discussion view is now rendered using ``object/elements/full`` view
+ * ``object/file`` now passes image (specialcontent) view as an ``attachment`` to the full listing view
+
 Menu changes
 ------------
 

--- a/mod/blog/views/default/object/blog.php
+++ b/mod/blog/views/default/object/blog.php
@@ -70,11 +70,20 @@ if ($full) {
 	$params = $params + $vars;
 	$summary = elgg_view('object/elements/summary', $params);
 
+	$responses = '';
+	if (elgg_extract('show_responses', $vars, false)) {
+		// check to see if we should allow comments
+		if ($blog->comments_on != 'Off' && $blog->status == 'published') {
+			$responses = elgg_view_comments($blog);
+		}
+	}
+
 	echo elgg_view('object/elements/full', array(
 		'entity' => $blog,
 		'summary' => $summary,
 		'icon' => $owner_icon,
 		'body' => $body,
+		'responses' => $responses,
 	));
 
 } else {

--- a/mod/blog/views/default/resources/blog/view.php
+++ b/mod/blog/views/default/resources/blog/view.php
@@ -27,12 +27,10 @@ if (elgg_instanceof($container, 'group')) {
 
 elgg_push_breadcrumb($blog->title);
 
-$params['content'] = elgg_view_entity($blog, array('full_view' => true));
-
-// check to see if we should allow comments
-if ($blog->comments_on != 'Off' && $blog->status == 'published') {
-	$params['content'] .= elgg_view_comments($blog);
-}
+$params['content'] = elgg_view_entity($blog, [
+	'full_view' => true,
+	'show_responses' => true,
+]);
 
 $params['sidebar'] = elgg_view('blog/sidebar', array('page' => $page_type));
 

--- a/mod/bookmarks/views/default/object/bookmarks.php
+++ b/mod/bookmarks/views/default/object/bookmarks.php
@@ -66,11 +66,16 @@ if ($full && !elgg_in_context('gallery')) {
 </div>
 HTML;
 
+	$responses = '';
+	if (elgg_extract('show_responses', $vars, false)) {
+		$responses = elgg_view_comments($bookmark);
+	}
 	echo elgg_view('object/elements/full', array(
 		'entity' => $bookmark,
 		'icon' => $owner_icon,
 		'summary' => $summary,
 		'body' => $body,
+		'responses' => $responses,
 	));
 
 } elseif (elgg_in_context('gallery')) {

--- a/mod/bookmarks/views/default/resources/bookmarks/view.php
+++ b/mod/bookmarks/views/default/resources/bookmarks/view.php
@@ -27,8 +27,10 @@ $title = $bookmark->title;
 
 elgg_push_breadcrumb($title);
 
-$content = elgg_view_entity($bookmark, array('full_view' => true));
-$content .= elgg_view_comments($bookmark);
+$content = elgg_view_entity($bookmark, [
+	'full_view' => true,
+	'show_responses' => true,
+]);
 
 $body = elgg_view_layout('content', array(
 	'content' => $content,

--- a/mod/discussions/views/default/object/discussion.php
+++ b/mod/discussions/views/default/object/discussion.php
@@ -25,8 +25,6 @@ $poster_icon = elgg_view_entity_icon($poster, 'tiny');
 
 $by_line = elgg_view('page/elements/by_line', $vars);
 
-$tags = elgg_view('output/tags', array('tags' => $topic->tags));
-
 $replies_link = '';
 $reply_text = '';
 
@@ -84,24 +82,38 @@ if ($full) {
 
 	$params = array(
 		'entity' => $topic,
+		'title' => false,
 		'metadata' => $metadata,
 		'subtitle' => $subtitle,
-		'tags' => $tags,
 	);
-	$params = $params + $vars;
-	$list_body = elgg_view('object/elements/summary', $params);
 
-	$info = elgg_view_image_block($poster_icon, $list_body);
+	$params = $params + $vars;
+	$summary = elgg_view('object/elements/summary', $params);
 
 	$body = elgg_view('output/longtext', array(
 		'value' => $topic->description,
 		'class' => 'clearfix',
 	));
 
-	echo <<<HTML
-$info
-$body
-HTML;
+	$responses = '';
+	if (elgg_extract('show_responses', $vars)) {
+		$params = array(
+			'topic' => $topic,
+			'show_add_form' => $topic->canWriteToContainer(0, 'object', 'discussion_reply'),
+		);
+		$responses = elgg_view('discussion/replies', $params);
+		if ($topic->status == 'closed') {
+			$responses .= elgg_view('discussion/closed');
+		}
+	}
+
+	echo elgg_view('object/elements/full', array(
+		'entity' => $topic,
+		'icon' => $poster_icon,
+		'summary' => $summary,
+		'body' => $body,
+		'responses' => $responses,
+	));
 
 } else {
 	// brief view

--- a/mod/discussions/views/default/resources/discussion/view.php
+++ b/mod/discussions/views/default/resources/discussion/view.php
@@ -25,16 +25,10 @@ if ($container instanceof ElggGroup) {
 elgg_push_breadcrumb($container->getDisplayName(), $owner_url);
 elgg_push_breadcrumb($topic->title);
 
-$params = array(
-	'topic' => $topic,
-	'show_add_form' => $topic->canWriteToContainer(0, 'object', 'discussion_reply'),
-);
-
-$content = elgg_view_entity($topic, array('full_view' => true));
-$content .= elgg_view('discussion/replies', $params);
-if ($topic->status == 'closed') {
-	$content .= elgg_view('discussion/closed');
-}
+$content = elgg_view_entity($topic, [
+	'full_view' => true,
+	'show_responses' => true,
+]);
 
 $params = array(
 	'content' => $content,

--- a/mod/file/views/default/object/file.php
+++ b/mod/file/views/default/object/file.php
@@ -63,16 +63,22 @@ if ($full && !elgg_in_context('gallery')) {
 	$params = $params + $vars;
 	$summary = elgg_view('object/elements/summary', $params);
 
-	$text = elgg_view('output/longtext', array('value' => $file->description));
-	$body = "$text $extra";
+	$body = elgg_view('output/longtext', array('value' => $file->description));
 
 	$file_icon = elgg_view_entity_icon($file, 'small', array('href' => false));
+
+	$responses = '';
+	if (elgg_extract('show_responses', $vars, false)) {
+		$responses = elgg_view_comments($file);
+	}
 
 	echo elgg_view('object/elements/full', array(
 		'entity' => $file,
 		'icon' => $file_icon,
 		'summary' => $summary,
 		'body' => $body,
+		'attachments' => $extra,
+		'responses' => $responses,
 	));
 
 } elseif (elgg_in_context('gallery')) {

--- a/mod/file/views/default/resources/file/view.php
+++ b/mod/file/views/default/resources/file/view.php
@@ -28,8 +28,10 @@ $title = $file->title;
 
 elgg_push_breadcrumb($title);
 
-$content = elgg_view_entity($file, array('full_view' => true));
-$content .= elgg_view_comments($file);
+$content = elgg_view_entity($file, [
+	'full_view' => true,
+	'show_responses' => true,
+]);
 
 elgg_register_menu_item('title', array(
 	'name' => 'download',

--- a/mod/pages/views/default/object/page_top.php
+++ b/mod/pages/views/default/object/page_top.php
@@ -99,14 +99,21 @@ if ($full) {
 		'title' => false,
 		'subtitle' => $subtitle,
 	);
+
 	$params = $params + $vars;
 	$summary = elgg_view('object/elements/summary', $params);
+
+	$responses = '';
+	if (elgg_extract('show_responses', $vars, false)) {
+		$responses = elgg_view_comments($page);
+	}
 
 	echo elgg_view('object/elements/full', array(
 		'entity' => $page,
 		'icon' => $page_icon,
 		'summary' => $summary,
 		'body' => $body,
+		'responses' => $responses,
 	));
 
 } else {

--- a/mod/pages/views/default/resources/pages/view.php
+++ b/mod/pages/views/default/resources/pages/view.php
@@ -33,8 +33,10 @@ if (elgg_instanceof($container, 'group')) {
 pages_prepare_parent_breadcrumbs($page);
 elgg_push_breadcrumb($title);
 
-$content = elgg_view_entity($page, array('full_view' => true));
-$content .= elgg_view_comments($page);
+$content = elgg_view_entity($page, [
+	'full_view' => true,
+	'show_responses' => true,
+]);
 
 // can add subpage if can edit this page and write to container (such as a group)
 if ($page->canEdit() && $container->canWriteToContainer(0, 'object', 'page')) {

--- a/views/default/object/elements/full.php
+++ b/views/default/object/elements/full.php
@@ -7,8 +7,11 @@
  * @uses $vars['icon']          HTML for the content icon
  * @uses $vars['summary']       HTML for the content summary
  * @uses $vars['body']          HTML for the content body
+ * @uses $vars['attachments']   HTML for the attachments
+ * @uses $vars['responses']     HTML for the responses
  * @uses $vars['class']         Optional additional class for the content wrapper
  * @uses $vars['header_params'] Vars to pass to the header image block wrapper
+ * @uses $vars['body_params']   Attributes to pass to the body wrapper
  */
 $entity = elgg_extract('entity', $vars);
 if (!$entity instanceof ElggEntity) {
@@ -20,10 +23,12 @@ unset($vars['class']);
 
 $header = elgg_view('object/elements/full/header', $vars);
 $body = elgg_view('object/elements/full/body', $vars);
+$attachments = elgg_view('object/elements/full/attachments', $vars);
+$responses = elgg_view('object/elements/full/responses', $vars);
 
 echo elgg_format_element('div', [
 	'class' => $class,
 	'data-guid' => $entity->guid,
-		], $header . $body);
+		], $header . $body . $attachments . $responses);
 
 

--- a/views/default/object/elements/full/attachments.php
+++ b/views/default/object/elements/full/attachments.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Outputs attachments
+ *
+ * @uses $vars['attachments'] Attachments HTML
+ */
+
+$attachments = elgg_extract('attachments', $vars);
+if (!$attachments) {
+	return;
+}
+
+echo elgg_format_element('div', [
+	'class' => 'elgg-listing-full-attachments',
+], $attachments);

--- a/views/default/object/elements/full/body.php
+++ b/views/default/object/elements/full/body.php
@@ -2,7 +2,9 @@
 
 /**
  * Outputs object full view
- * @uses $vars['body'] Body
+ *
+ * @uses $vars['body']        Body HTML
+ * @uses $vars['body_params'] Vars used as attributes of the body wrapper
  */
 
 $body = elgg_extract('body', $vars);
@@ -10,4 +12,7 @@ if (!$body) {
 	return;
 }
 
-echo $body;
+$body_params = elgg_extract('body_params', $vars, []);
+$body_params['class'] = elgg_extract_class($body_params, 'elgg-listing-full-body');
+
+echo elgg_format_element('div', $body_params, $body);

--- a/views/default/object/elements/full/header.php
+++ b/views/default/object/elements/full/header.php
@@ -12,8 +12,6 @@ $icon = elgg_extract('icon', $vars);
 $summary = elgg_extract('summary', $vars);
 
 $header_params = (array) elgg_extract('header_params', $vars, []);
-$class = (array) elgg_extract('class', $header_params, []);
-$class[] = 'elgg-listing-full-header';
-$header_params['class'] = implode(' ', $class);
+$header_params['class'] = elgg_extract_class($header_params, 'elgg-listing-full-header');
 
 echo elgg_view_image_block($icon, $summary, $header_params);

--- a/views/default/object/elements/full/responses.php
+++ b/views/default/object/elements/full/responses.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Outputs responses
+ *
+ * @uses $vars['responses'] Responses HTML
+ */
+
+$responses = elgg_extract('responses', $vars);
+if (!$responses) {
+	return;
+}
+
+echo elgg_format_element('div', [
+	'class' => 'elgg-listing-full-responses',
+], $responses);


### PR DESCRIPTION
BREAKING CHANGE
In core plugins, resource views now longer render comments and replies:
instead they pass a show_responses flag to the entity view, which
renders the responses and passes them to the listing view.
Full discussion view now uses full listing view
Full file view now passes file preview as an attachment to the listing view
