### PR TITLE
feat(forms): buttons are now rendered with a <button> tag

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -87,7 +87,8 @@ Removed classes/interfaces
 Form and field related changes
 ------------------------------
 
-* ``input/password``: by default this field will no longer show a value passed to it, this can be overridden by passing the view var ``always_empty`` and set it to false
+ * ``input/password``: by default this field will no longer show a value passed to it, this can be overridden by passing the view var ``always_empty`` and set it to false
+ * ``input/submit``, ``input/reset`` and ``input/button`` are now rendered with a ``<button>`` instead of the ``<input>`` tag. These input view also accept ``text`` and ``icon`` parameters.
 
 
 Removed libraries

--- a/mod/developers/views/default/theme_sandbox/forms.php
+++ b/mod/developers/views/default/theme_sandbox/forms.php
@@ -60,12 +60,12 @@ $ipsum = elgg_view('developers/ipsum');
 			'name' => 'f5',
 			'id' => 'f5',
 			'options' => array(
-				'option 1', 
+				'option 1',
 				'option 2',
-				[
-		            'text' => 'disabled',
-		            'disabled' => true,
-		        ],
+					[
+					'text' => 'disabled',
+					'disabled' => true,
+				],
 			),
 			'#label' => 'Select input (dropdown) (.elgg-input-dropdown) with a disabled option:',
 		));
@@ -214,7 +214,7 @@ $ipsum = elgg_view('developers/ipsum');
 
 		$dt = new \DateTime(null, new \DateTimeZone('UTC'));
 		$hour_options = array();
-		$hour_options_ts = range(0, 24*60*60, 900); // step of 15 minutes
+		$hour_options_ts = range(0, 24 * 60 * 60, 900); // step of 15 minutes
 		foreach ($hour_options_ts as $ts) {
 			$hour_options[$ts] = $dt->setTimestamp($ts)->format('g:ia');
 		}
@@ -224,26 +224,52 @@ $ipsum = elgg_view('developers/ipsum');
 			'name' => 'f16',
 			'legend' => 'Fieldset with a legend',
 			'fields' => [
-				[
+					[
 					'#type' => 'text',
 					'#label' => 'Text field',
 					'required' => true,
 				],
-				[
+					[
 					'#type' => 'fieldset',
 					'#label' => 'Date and time fieldset',
 					'align' => 'horizontal',
 					'fields' => [
-						[
+							[
 							'#type' => 'date',
 							'value' => time(),
 							'timestamp' => true,
 							'#label' => 'Date',
 						],
-						[
+							[
 							'#type' => 'select',
 							'#label' => 'Time',
 							'options' => $hour_options,
+						],
+					],
+				],
+				[
+					'#type' => 'fieldset',
+					'#label' => 'Nested fieldset',
+					'#help' => 'Fieldset with horizontal alignment of fields',
+					'align' => 'horizontal',
+					'fields' => [
+						[
+							'#type' => 'button',
+							'type' => 'submit',
+							'text' => 'Save',
+							'icon' => 'save',
+						],
+							[
+							'#type' => 'button',
+							'text' => 'Download',
+							'icon' => 'download',
+							'class' => 'elgg-button-action',
+						],
+							[
+							'#type' => 'button',
+							'type' => 'reset',
+							'text' => 'Cancel',
+							'icon' => 'remove',
 						],
 					],
 				],

--- a/views/default/elements/buttons.css.php
+++ b/views/default/elements/buttons.css.php
@@ -97,3 +97,7 @@
 	margin: 15px 0;
 	border-radius: 5px;
 }
+
+.elgg-button-icon + .elgg-button-label {
+	margin-left: 10px;
+}

--- a/views/default/input/button.php
+++ b/views/default/input/button.php
@@ -1,34 +1,41 @@
 <?php
-/**
- * Create a input button
- *
- * @package Elgg
- * @subpackage Core
- *
- * @uses $vars['src']   Src of an image
- * @uses $vars['class'] Additional CSS class
- */
 
+/**
+ * Renders a <button>
+ *
+ * @uses $vars['type']  Button type (submit|reset|image)
+ * @uses $vars['class'] Additional CSS class
+ * @uses $vars['text']  Text to include between <button> tags
+ * @uses $vars['icon']  Optional icon name
+ */
 $vars['class'] = elgg_extract_class($vars, 'elgg-button');
 
-$defaults = ['type' => 'button'];
+$type = elgg_extract('type', $vars, 'button', false);
 
-$vars = array_merge($defaults, $vars);
+$text = elgg_extract('text', $vars);
+unset($vars['text']);
 
-switch ($vars['type']) {
-	case 'button':
-	case 'reset':
+$text = elgg_format_element('span', [
+	'class' => 'elgg-button-label',
+], $text);
+
+$icon = elgg_extract('icon', $vars, '');
+unset($vars['icon']);
+
+if ($icon && !preg_match('/^</', $icon)) {
+	$icon = elgg_view_icon($icon, [
+		'class' => 'elgg-button-icon',
+	]);
+}
+
+switch ($type) {
 	case 'submit':
-	case 'image':
+		$vars['class'][] = 'elgg-button-submit';
 		break;
-	default:
-		$vars['type'] = 'button';
+
+	case 'reset':
+		$vars['class'][] = 'elgg-button-cancel';
 		break;
 }
 
-// blank src if trying to access an offsite image. @todo why?
-if (isset($vars['src']) && strpos($vars['src'], elgg_get_site_url()) === false) {
-	$vars['src'] = "";
-}
-
-echo elgg_format_element('input', $vars);
+echo elgg_format_element('button', $vars, $icon . $text);

--- a/views/default/input/reset.php
+++ b/views/default/input/reset.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Create a reset input button
+ * Renders a <button type="reset">
  *
- * @package Elgg
- * @subpackage Core
- * 
- * @uses $vars['class'] CSS class that replaces elgg-button-cancel
+ * @uses $vars['text'] Text of the button
  */
 
 $vars['type'] = 'reset';
-$vars['class'] = elgg_extract('class', $vars, 'elgg-button-cancel');
+
+if (!isset($vars['text'])) {
+	$vars['text'] = elgg_echo('reset');
+}
 
 echo elgg_view('input/button', $vars);

--- a/views/default/input/submit.php
+++ b/views/default/input/submit.php
@@ -1,15 +1,17 @@
 <?php
 /**
- * Create a submit input button
+ * Renders a <button type="submit">
  *
- * @package Elgg
- * @subpackage Core
- *
- * @uses $vars['class'] Additional CSS class
+ * See input/button view for a full list of options
+ * 
+ * @uses $vars['text'] Text of the button
  */
 
 $vars['type'] = 'submit';
 
-$vars['class'] = elgg_extract_class($vars, 'elgg-button-submit');
+if (!isset($vars['text']) && isset($vars['value'])) {
+	// Keeping this to ease the transition to 3.0
+	$vars['text'] = $vars['value'];
+}
 
 echo elgg_view('input/button', $vars);


### PR DESCRIPTION
(extracted from #10405)

BREAKING CHANGE
input/submit, input/reset and input/button now render a <button> tag
with nested <span> elements containing icon and label. Plugins should
update their uses of these input views.
