### PR TITLE
feat(comments): entities can now inherit canComment permissions

### DIFF
--- a/engine/classes/Elgg/UserCapabilities.php
+++ b/engine/classes/Elgg/UserCapabilities.php
@@ -315,10 +315,10 @@ class UserCapabilities {
 	 *
 	 * @param ElggEntity $entity    Object entity
 	 * @param int        $user_guid User guid (default is logged in user)
-	 *
+	 * @param bool       $default   Default permission
 	 * @return bool
 	 */
-	public function canComment(ElggEntity $entity, $user_guid = 0) {
+	public function canComment(ElggEntity $entity, $user_guid = 0, $default = null) {
 		try {
 			$user = $this->entities->getUserForPermissionsCheck($user_guid);
 		} catch (UserFetchFailureException $e) {
@@ -331,7 +331,7 @@ class UserCapabilities {
 			'entity' => $entity,
 			'user' => $user
 		];
-		return $this->hooks->trigger('permissions_check:comment', $entity->getType(), $params, null);
+		return $this->hooks->trigger('permissions_check:comment', $entity->getType(), $params, $default);
 	}
 
 	/**

--- a/engine/classes/ElggComment.php
+++ b/engine/classes/ElggComment.php
@@ -25,12 +25,16 @@ class ElggComment extends \ElggObject {
 	 *
 	 * @see \ElggEntity::canComment()
 	 *
-	 * @param int $user_guid User guid (default is logged in user)
-	 * @return bool False
+	 * @param int  $user_guid User guid (default is logged in user)
+	 * @param bool $default   Default permission
+	 * @return bool
 	 * @since 1.9.0
 	 */
-	public function canComment($user_guid = 0) {
-		return false;
+	public function canComment($user_guid = 0, $default = null) {
+		if (!isset($default)) {
+			$default = false;
+		}
+		return parent::canComment($user_guid, $default);
 	}
 
 	/**

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1084,12 +1084,12 @@ abstract class ElggEntity extends \ElggData implements
 	 * @tip Can be overridden by registering for the permissions_check:comment,
 	 * <entity type> plugin hook.
 	 *
-	 * @param int $user_guid User guid (default is logged in user)
-	 *
+	 * @param int  $user_guid User guid (default is logged in user)
+	 * @param bool $default   Default permission
 	 * @return bool
 	 */
-	public function canComment($user_guid = 0) {
-		return _elgg_services()->userCapabilities->canComment($this, $user_guid);
+	public function canComment($user_guid = 0, $default = null) {
+		return _elgg_services()->userCapabilities->canComment($this, $user_guid, $default);
 	}
 
 	/**

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -605,12 +605,13 @@ class ElggGroup extends \ElggEntity
 	 *
 	 * @see \ElggEntity::canComment()
 	 *
-	 * @param int $user_guid User guid (default is logged in user)
+	 * @param int  $user_guid User guid (default is logged in user)
+	 * @param bool $default   Default permission
 	 * @return bool
 	 * @since 1.8.0
 	 */
-	public function canComment($user_guid = 0) {
-		$result = parent::canComment($user_guid);
+	public function canComment($user_guid = 0, $default = null) {
+		$result = parent::canComment($user_guid, $default);
 		if ($result !== null) {
 			return $result;
 		}

--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -220,12 +220,13 @@ class ElggObject extends \ElggEntity {
 	 *
 	 * @see \ElggEntity::canComment()
 	 *
-	 * @param int $user_guid User guid (default is logged in user)
+	 * @param int  $user_guid User guid (default is logged in user)
+	 * @param bool $default   Default permission
 	 * @return bool
 	 * @since 1.8.0
 	 */
-	public function canComment($user_guid = 0) {
-		$result = parent::canComment($user_guid);
+	public function canComment($user_guid = 0, $default = null) {
+		$result = parent::canComment($user_guid, $default);
 		if ($result !== null) {
 			return $result;
 		}

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -640,12 +640,13 @@ class ElggUser extends \ElggEntity
 	 *
 	 * @see \ElggEntity::canComment()
 	 *
-	 * @param int $user_guid User guid (default is logged in user)
+	 * @param int  $user_guid User guid (default is logged in user)
+	 * @param bool $default   Default permission
 	 * @return bool
 	 * @since 1.8.0
 	 */
-	public function canComment($user_guid = 0) {
-		$result = parent::canComment($user_guid);
+	public function canComment($user_guid = 0, $default = null) {
+		$result = parent::canComment($user_guid, $default);
 		if ($result !== null) {
 			return $result;
 		}

--- a/engine/tests/phpunit/Elgg/UserCapabilitiesTest.php
+++ b/engine/tests/phpunit/Elgg/UserCapabilitiesTest.php
@@ -399,6 +399,15 @@ class UserCapabilitiesTest extends TestCase {
 		$this->assertTrue($object->canComment($viewer->guid));
 		$this->assertFalse($group->canComment($viewer->guid));
 		$this->assertNull($entity->canComment($viewer->guid));
+
+		// can pass default value
+		$this->assertTrue($object->canComment($viewer->guid, true));
+		$this->assertFalse($object->canComment($viewer->guid, false));
+
+		// can't comment on comment
+		$comment = new \ElggComment();
+		$comment->owner_guid = $owner->guid;
+		$this->assertFalse($comment->canComment($owner->guid));
 	}
 
 	/**


### PR DESCRIPTION
Extending classes can now explicitly pass default canComment permissions
value to the parent class
