### PR TITLE
feat(output): inline rendering of tags

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -99,6 +99,7 @@ Form and field related changes
  * ``input/password``: by default this field will no longer show a value passed to it, this can be overridden by passing the view var ``always_empty`` and set it to false
  * ``output/url`` now sets ``.elgg-anchor`` class on anchor elements and accepts ``icon`` parameter. If no ``text`` is set, the ``href`` parameter used as a label will be restricted to 100 characters.
  * ``output/url`` now supports a ``badge`` parameter, which can be used where a counter, a badge, or similar is required as a postfix (mainly in menu items that have counters).
+ * ``output/tags`` no longer uses ``<ul>`` tags with floats and instead it relies on inherently inline elements such as ``<span>`` and ``<a>``
 
 Removed libraries
 -----------------

--- a/views/default/admin.css.php
+++ b/views/default/admin.css.php
@@ -458,6 +458,8 @@ a.elgg-maintenance-mode-warning {
 	display: inline-block;
 }
 
+<?= elgg_view('elements/components/tags.css', $vars) ?>
+
 /* ***************************************
 	FORMS AND INPUT
 *************************************** */

--- a/views/default/elements/components.css.php
+++ b/views/default/elements/components.css.php
@@ -341,22 +341,7 @@
 	height: auto;
 }
 
-/* ***************************************
-	Tags
-*************************************** */
-.elgg-tags {
-	font-size: 85%;
-}
-.elgg-tags > li {
-	float:left;
-	margin-right: 5px;
-}
-.elgg-tags li.elgg-tag:after {
-	content: ",";
-}
-.elgg-tags li.elgg-tag:last-child:after {
-	content: "";
-}
+<?= elgg_view('elements/components/tags.css', $vars) ?>
 
 @media (max-width: 820px) {
 	.elgg-river-item input[type=text] {

--- a/views/default/elements/components/tags.css
+++ b/views/default/elements/components/tags.css
@@ -1,0 +1,18 @@
+/* ***************************************
+	Tags
+*************************************** */
+.elgg-tags {
+    font-size: 85%;
+    color: #AAA;
+    line-height: normal;
+    vertical-align: middle;
+}
+
+.elgg-tags > .elgg-icon {
+    margin-right: 5px;
+}
+
+.elgg-tags > .elgg-tag:not(:last-child):after {
+	content: ",";
+	margin-right: 3px;
+}

--- a/views/default/output/tags.php
+++ b/views/default/output/tags.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Elgg tags
  * Tags can be a single string (for one tag) or an array of strings. Accepts all output/tag options
@@ -7,9 +8,10 @@
  * @uses $vars['entity']     Optional. Entity whose tags are being displayed (metadata ->tags)
  * @uses $vars['list_class'] Optional. Additional classes to be passed to <ul> element
  * @uses $vars['item_class'] Optional. Additional classes to be passed to <li> elements
+ * @uses $vars['icon']       Optional. Icon name to be used (default: tag)
+ *                           Set to false to not render an icon
  * @uses $vars['icon_class'] Optional. Additional classes to be passed to tags icon image
  */
-
 if (isset($vars['entity'])) {
 	$vars['tags'] = $vars['entity']->tags;
 	unset($vars['entity']);
@@ -44,19 +46,30 @@ if (isset($vars['item_class'])) {
 	unset($vars['item_class']);
 }
 
+$icon_name = elgg_extract('icon', $vars, 'tag');
+unset($vars['icon']);
+
 $icon_class = elgg_extract('icon_class', $vars);
 unset($vars['icon_class']);
 
-$list_items = ''; 
+if ($icon_name === false) {
+	$icon = '';
+} else {
+	$icon = elgg_view_icon($icon_name, $icon_class);
+}
+
+$list_items = $icon;
 
 $params = $vars;
-foreach($tags as $tag) {
+foreach ($tags as $tag) {
 	if (is_string($tag) && strlen($tag) > 0) {
 		$params['value'] = $tag;
-
-		$list_items .= "<li class=\"$item_class\">";
-		$list_items .= elgg_view('output/tag', $params);
-		$list_items .= '</li>';
+		$tag_view = elgg_view('output/tag', $params);
+		$list_items .= elgg_format_element([
+			'#tag_name' => 'span',
+			'#text' => $tag_view,
+			'class' => $item_class,
+		]);
 	}
 }
 
@@ -64,15 +77,8 @@ if (empty($list_items)) {
 	return;
 }
 
-$icon = elgg_view_icon('tag', $icon_class);
-
-$list = <<<___HTML
-	<div class="clearfix">
-		<ul class="$list_class">
-			<li>$icon</li>
-			$list_items
-		</ul>
-	</div>
-___HTML;
-
-echo $list;
+echo elgg_format_element([
+	'#tag_name' => 'div',
+	'#text' => $list_items,
+	'class' => $list_class,
+]);


### PR DESCRIPTION
BREAKING CHANGE
output/tags no longer uses `<ul>` and `<li>` with floats to render tags.
Instead we now use inline `<span>` and `<a>` tags.
Adds an option to specify the icon name with view vars.
