### PR TITLE
feat(js): add support for inline popup modules

### DIFF
--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -583,6 +583,8 @@ Open popup modules will always contain the following data that can be accessed v
  * ``trigger`` - jQuery element used to trigger the popup module to open
  * ``position`` - An object defining popup module position that was passed to ``$.position()``
 
+By default, ``target`` element will be appended to ``$('body')`` thus altering DOM hierarchy. If you need to preserve the DOM position of the popup module, you can add ``.elgg-popup-inline`` class to your trigger.
+
 Module ``elgg/widgets``
 -----------------------
 

--- a/views/default/elgg/popup.js
+++ b/views/default/elgg/popup.js
@@ -122,13 +122,13 @@ define('elgg/popup', ['elgg', 'jquery', 'jquery-ui'], function (elgg, $) {
 			$target.data('trigger', $trigger); // used to remove elgg-state-active class when popup is closed
 			$target.data('position', position); // used to reposition the popup module on window manipulations
 
-			// @todo: in 3.0, do not append to 'body' and use fixed positioning with z-indexes instead
-			// @todo: use css transitions instead of $.fadeOut() to avoid collisions
-			// (with fading the DOM element is considered visible until animation is complete)
-			$target.appendTo('body')
-					.fadeIn()
-					.addClass('elgg-state-active elgg-state-popped')
-					.position(position);
+			if (!$trigger.is('.elgg-popup-inline')) {
+				$target.appendTo('body');
+			}
+			
+			$target.fadeIn()
+				   .addClass('elgg-state-active elgg-state-popped')
+				   .position(position);
 
 			$trigger.addClass('elgg-state-active');
 


### PR DESCRIPTION
Popup modules can now be popped preserving their DOM position by
adding .elgg-popup-inline to the trigger element classes

Cherry picked from #10419
