### PR TITLE
Group icons upgrades and upgrade service tests and fixes

### DIFF
--- a/actions/admin/upgrade.php
+++ b/actions/admin/upgrade.php
@@ -7,13 +7,13 @@ $guid = get_input('guid');
 
 $upgrade = get_entity($guid);
 
-if (!$upgrade instanceof \ElggUpgrade) {
-	register_error(elgg_echo('admin:upgrades:error:invalid_upgrade', array($entity->title, $guid)));
-	exit;
+try {
+	if (!$upgrade instanceof \ElggUpgrade) {
+		throw new RuntimeException(elgg_echo('admin:upgrades:error:invalid_upgrade', [$entity->title, $guid]));
+	}
+
+	$result = _elgg_services()->batchUpgrader->run($upgrade);
+	return elgg_ok_response($result);
+} catch (RuntimeException $ex) {
+	return elgg_error_response($ex->getMessage(), REFERRER, ELGG_HTTP_INTERNAL_SERVER_ERROR);
 }
-
-$upgrader = _elgg_services()->batchUpgrader;
-$upgrader->setUpgrade($upgrade);
-$result = $upgrader->run();
-
-echo json_encode($result);

--- a/docs/guides/upgrading-data.rst
+++ b/docs/guides/upgrading-data.rst
@@ -25,8 +25,8 @@ Example from ``mod/blog/elgg-plugin.php`` file:
 
 	return [
 		'upgrades' => [
-			'Blog\Upgrades\AccessLevelFix',
-			'Blog\Upgrades\DraftStatusUpgrade',
+			Blog\Upgrades\AccessLevelFix::class,
+			Blog\Upgrades\DraftStatusUpgrade::class,
 		]
 	];
 
@@ -50,13 +50,10 @@ The basic structure of the class is the following:
 	
 	namespace Blog\Upgrades;
 	
-	use Elgg\Upgrade\Batch;
-	use Elgg\Upgrade\Result;
-	
 	/**
 	 * Fixes invalid blog access values
 	 */
-	class AccessLevelFix implements BatchUpgrade {
+	class AccessLevelFix implements \Elgg\Upgrade\Batch {
 		const INCREMENT_OFFSET = true;
 		
 		const VERSION = 2016120300;
@@ -68,7 +65,7 @@ The basic structure of the class is the following:
 		 * @param int    $offset
 		 * @return Result result
 		 */
-		public function run(Result $result, $offset) {
+		public function run(\Elgg\Upgrade\Result $result, $offset) {
 		
 		}
 	}

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -359,6 +359,8 @@ Default icon image files have been moved and re-mapped as follows:
  * User icons: ``views/default/icon/user/default/$size.gif``
  * Group icons: ``views/default/icon/group/default/$size.gif`` in the groups plugin
 
+Groups icon files have been moved from ``groups/<guid><size>.jpg`` relative to group owner's directory on filestore to a location prescribed by the entity icon service. Plugins should stop accessing files on the filestore directly and use the entity icon API. Upgrade script is available via admin interface.
+
 From 2.2 to 2.3
 ===============
 

--- a/engine/classes/Elgg/BatchUpgrader.php
+++ b/engine/classes/Elgg/BatchUpgrader.php
@@ -4,7 +4,6 @@ namespace Elgg;
 
 use ElggUpgrade;
 use Elgg\Config;
-use Elgg\Timer;
 use Elgg\Upgrade\Result;
 
 /**
@@ -19,11 +18,6 @@ use Elgg\Upgrade\Result;
 class BatchUpgrader {
 
 	/**
-	 * @var $upgrade ElggUpgrade
-	 */
-	private $upgrade;
-
-	/**
 	 * @var $config Config
 	 */
 	private $config;
@@ -36,89 +30,105 @@ class BatchUpgrader {
 	public function __construct(Config $config) {
 		$this->config = $config;
 
-		// Custom limit can be defined in settings.php if necessary
+		// Custom limit can be defined in elgg-config/settings.php if necessary
 		if (empty($this->config->get('batch_run_time_in_secs'))) {
 			$this->config->set('batch_run_time_in_secs', 4);
 		}
 	}
 
 	/**
-	 * Set ElggUpgrade object
-	 *
-	 * @param ElggUpgrade $upgrade ElggEntity representing the upgrade
-	 * @return void
-	 */
-	public function setUpgrade(ElggUpgrade $upgrade) {
-		$this->upgrade = $upgrade;
-	}
-
-	/**
 	 * Run single upgrade batch
 	 *
+	 * @param ElggUpgrade $upgrade Upgrade to run
 	 * @return void
+	 * @throws \RuntimeException
 	 */
-	public function run() {
+	public function run(ElggUpgrade $upgrade) {
 		// Upgrade also disabled data, so the compatibility is
 		// preserved in case the data ever gets enabled again
-		global $ENTITY_SHOW_HIDDEN_OVERRIDE;
-		$ENTITY_SHOW_HIDDEN_OVERRIDE = true;
+		$ha = access_get_show_hidden_status();
+		access_show_hidden_entities(true);
 
-		// Defined in Elgg\Application
-		global $START_MICROTIME;
-
-		$result = new Result;
+		$started = microtime(true);
 
 		// Get the class taking care of the actual upgrading
-		$upgrade = $this->upgrade->getUpgrade();
+		$batch = $upgrade->getBatch();
+			
+		if (!$batch) {
+			throw new \RuntimeException(elgg_echo('admin:upgrades:error:invalid_batch', [$upgrade->title, $upgrade->guid]));
+		}
 
-		do {
-			$upgrade->run($result, $this->upgrade->offset);
+		$count = $batch->countItems();
+		
+		$batch_failure_count = 0;
+		$batch_success_count = 0;
+		$errors = [];
+
+		$processed = (int) $upgrade->processed;
+		$offset = (int) $upgrade->offset;
+		$has_errors = (bool) $upgrade->has_errors;
+		
+		while ($count > $processed && (microtime(true) - $started) < $this->config->get('batch_run_time_in_secs')) {
+			
+			$result = $batch->run(new Result(), $offset);
 
 			$failure_count = $result->getFailureCount();
 			$success_count = $result->getSuccessCount();
 
-			$total = $failure_count + $success_count;
+			$batch_failure_count += $failure_count;
+			$batch_success_count += $success_count;
 
-			if ($upgrade::INCREMENT_OFFSET) {
+			$total = $failure_count + $success_count;
+			
+			if ($batch::INCREMENT_OFFSET) {
 				// Offset needs to incremented by the total amount of processed
 				// items so the upgrade we won't get stuck upgrading the same
 				// items over and over.
-				$this->upgrade->offset += $total;
+				$offset += $total;
 			} else {
 				// Offset doesn't need to be incremented, so we mark only
 				// the items that caused a failure.
-				$this->upgrade->offset += $failure_count;
+				$offset += $failure_count;
 			}
 
 			if ($failure_count > 0) {
-				$this->upgrade->has_errors = true;
+				$has_errors = true;
 			}
 
-			$this->upgrade->processed += $total;
-		} while ((microtime(true) - $START_MICROTIME) < $this->config->get('batch_run_time_in_secs'));
+			$processed += $total;
 
-		if ($this->upgrade->processed >= $this->upgrade->total) {
+			$errors = array_merge($errors, $result->getErrors());
+		}
+
+		access_show_hidden_entities($ha);
+
+		$upgrade->processed = $processed;
+		$upgrade->offset = $offset;
+		$upgrade->has_errors = $has_errors;
+		
+		$completed = $processed >= $batch->countItems();
+		if ($completed) {
 			// Upgrade is finished
-			if ($this->upgrade->has_errors) {
+			if ($has_errors) {
 				// The upgrade was finished with errors. Reset offset
 				// and errors so the upgrade can start from a scratch
 				// if attempted to run again.
-				$this->upgrade->offset = 0;
-				$this->upgrade->has_errors = false;
-
-				// TODO Should $this->upgrade->count be updated again?
+				$upgrade->processed = 0;
+				$upgrade->offset = 0;
+				$upgrade->has_errors = false;
 			} else {
 				// Everything has been processed without errors
 				// so the upgrade can be marked as completed.
-				$this->upgrade->setCompleted();
+				$upgrade->setCompleted();
 			}
 		}
 
 		// Give feedback to the user interface about the current batch.
 		return array(
-			'errors' => $result->getErrors(),
-			'numErrors' => $failure_count,
-			'numSuccess' => $success_count,
+			'errors' => $errors,
+			'numErrors' => $batch_failure_count,
+			'numSuccess' => $batch_success_count,
 		);
 	}
+
 }

--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -172,10 +172,14 @@ class EntityTable {
 	/**
 	 * Adds a new row to the entity table
 	 *
-	 * @param stdClass $row Entity base information
+	 * @param stdClass $row        Entity base information
+	 * @param array    $attributes All primary and secondary table attributes
+	 *                             Used by database mock services to allow mocking
+	 *                             entities that were instantiated using new keyword
+	 *                             and calling ElggEntity::save()
 	 * @return int|false
 	 */
-	public function insertRow(stdClass $row) {
+	public function insertRow(stdClass $row, array $attributes = []) {
 
 		$sql = "INSERT INTO {$this->db->prefix}entities
 			(type, subtype, owner_guid, site_guid, container_guid,

--- a/engine/classes/Elgg/Database/PrivateSettingsTable.php
+++ b/engine/classes/Elgg/Database/PrivateSettingsTable.php
@@ -18,17 +18,25 @@ use Elgg\Cache\PluginSettingsCache;
  */
 class PrivateSettingsTable {
 
-	/** @var Database */
-	private $db;
+	/**
+	 * @var Database
+	 */
+	protected $db;
 
-	/** @var EntityTable */
-	private $entities;
+	/**
+	 * @var EntityTable
+	 */
+	protected $entities;
 
-	/** @var string Name of the database table */
-	private $table;
+	/**
+	 * @var string Name of the database table
+	 */
+	protected $table;
 
-	/** @var PluginSettingsCache cache for settings */
-	private $cache;
+	/**
+	 * @var PluginSettingsCache cache for settings
+	 */
+	protected $cache;
 
 	/**
 	 * Constructor
@@ -304,23 +312,27 @@ class PrivateSettingsTable {
 	 * @return mixed The setting value, or null if does not exist
 	 */
 	public function get($entity_guid, $name) {
+
 		$values = $this->cache->getAll($entity_guid);
 		if (isset($values[$name])) {
 			return $values[$name];
 		}
 
-		$entity_guid = (int) $entity_guid;
-		$name = $this->db->sanitizeString($name);
-
-		$entity = $this->entities->get($entity_guid);
-
-		if (!$entity instanceof \ElggEntity) {
-			return null;
+		if (!$this->entities->exists($entity_guid)) {
+			return false;
 		}
 
-		$query = "SELECT value FROM {$this->table}
-			where name = '{$name}' and entity_guid = {$entity_guid}";
-		$setting = $this->db->getDataRow($query);
+		$query = "
+			SELECT value FROM {$this->table}
+			WHERE name = :name
+			AND entity_guid = :entity_guid
+		";
+		$params = [
+			':entity_guid' => (int) $entity_guid,
+			':name' => (string) $name,
+		];
+
+		$setting = $this->db->getDataRow($query, null, $params);
 
 		if ($setting) {
 			return $setting->value;
@@ -336,27 +348,30 @@ class PrivateSettingsTable {
 	 *
 	 * @return string[] empty array if no settings
 	 */
-	function getAll($entity_guid) {
-		$entity_guid = (int) $entity_guid;
-		$entity = $this->entities->get($entity_guid);
-
-		if (!$entity instanceof \ElggEntity) {
-			return false;
+	public function getAll($entity_guid) {
+		if (!$this->entities->exists($entity_guid)) {
+			return [];
 		}
 
-		$query = "SELECT * FROM {$this->table} WHERE entity_guid = {$entity_guid}";
-		$result = $this->db->getData($query);
+		$query = "
+			SELECT * FROM {$this->table}
+			WHERE entity_guid = :entity_guid
+		";
+		$params = [
+			':entity_guid' => (int) $entity_guid,
+		];
+
+		$result = $this->db->getData($query, null, $params);
+
+		$return = [];
 
 		if ($result) {
-			$return = array();
 			foreach ($result as $r) {
 				$return[$r->name] = $r->value;
 			}
-
-			return $return;
 		}
 
-		return array();
+		return $return;
 	}
 
 	/**
@@ -371,14 +386,23 @@ class PrivateSettingsTable {
 		$this->cache->clear($entity_guid);
 		_elgg_services()->boot->invalidateCache();
 
-		$entity_guid = (int) $entity_guid;
-		$name = $this->db->sanitizeString($name);
-		$value = $this->db->sanitizeString($value);
+		if (!$this->entities->exists($entity_guid)) {
+			return false;
+		}
 
-		$result = $this->db->insertData("INSERT into {$this->table}
+		$query = "
+			INSERT into {$this->table}
 			(entity_guid, name, value) VALUES
-			($entity_guid, '$name', '$value')
-			ON DUPLICATE KEY UPDATE value='$value'");
+			(:entity_guid, :name, :value)
+			ON DUPLICATE KEY UPDATE value = :value
+		";
+		$params = [
+			':entity_guid' => (int) $entity_guid,
+			':name' => (string) $name,
+			':value' => (string) $value,
+		];
+
+		$result = $this->db->insertData($query, $params);
 
 		return $result !== false;
 	}
@@ -390,23 +414,21 @@ class PrivateSettingsTable {
 	 * @param string $name        The name of the setting
 	 * @return bool
 	 */
-	function remove($entity_guid, $name) {
+	public function remove($entity_guid, $name) {
 		$this->cache->clear($entity_guid);
 		_elgg_services()->boot->invalidateCache();
 
-		$entity_guid = (int) $entity_guid;
-
-		$entity = $this->entities->get($entity_guid);
-
-		if (!$entity instanceof \ElggEntity) {
-			return false;
-		}
-
-		$name = $this->db->sanitizeString($name);
-
-		return $this->db->deleteData("DELETE FROM {$this->table}
-			WHERE name = '{$name}'
-			AND entity_guid = {$entity_guid}");
+		$query = "
+			DELETE FROM {$this->table}
+			WHERE name = :name
+			AND entity_guid = :entity_guid
+		";
+		$params = [
+			':entity_guid' => (int) $entity_guid,
+			':name' => (string) $name,
+		];
+		
+		return $this->db->deleteData($query, $params);
 	}
 
 	/**
@@ -415,19 +437,19 @@ class PrivateSettingsTable {
 	 * @param int $entity_guid The Entity GUID
 	 * @return bool
 	 */
-	function removeAllForEntity($entity_guid) {
+	public function removeAllForEntity($entity_guid) {
 		$this->cache->clear($entity_guid);
 		_elgg_services()->boot->invalidateCache();
 
-		$entity_guid = (int) $entity_guid;
+		$query = "
+			DELETE FROM {$this->table}
+			WHERE entity_guid = :entity_guid
+		";
+		$params = [
+			':entity_guid' => (int) $entity_guid,
+		];
 
-		$entity = $this->entities->get($entity_guid);
-
-		if (!$entity instanceof \ElggEntity) {
-			return false;
-		}
-
-		return $this->db->deleteData("DELETE FROM {$this->table}
-			WHERE entity_guid = {$entity_guid}");
+		return $this->db->deleteData($query, $params);
 	}
+
 }

--- a/engine/classes/Elgg/Upgrade/Batch.php
+++ b/engine/classes/Elgg/Upgrade/Batch.php
@@ -16,9 +16,9 @@ interface Batch {
 	 *
 	 * @param Result $result Object that holds results of the batch
 	 * @param int    $offset Starting point of the batch
-	 * @return Result Instance of \Elgg\Upgrade\Result;
+	 * @return Result Instance of \Elgg\Upgrade\Result
 	 */
-	public function run(Result $result, int $offset);
+	public function run(Result $result, $offset);
 
 	/**
 	 * Gets the amount of items that need to be upgraded

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1464,7 +1464,7 @@ abstract class ElggEntity extends \ElggData implements
 			'time_created' => $time_created,
 			'time_updated' => $now,
 			'last_action' => $now,
-		]);
+		], $this->attributes);
 
 		if (!$result) {
 			throw new \IOException("Unable to save new object's base entity information!");

--- a/engine/classes/ElggUpgrade.php
+++ b/engine/classes/ElggUpgrade.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Upgrade object for upgrades that need to be tracked
  * and listed in the admin area.
@@ -6,13 +7,19 @@
  * @todo Expand for all upgrades to be \ElggUpgrade subclasses.
  */
 
+use Elgg\TimeUsing;
+use Elgg\Upgrade\Batch;
+
 /**
  * Represents an upgrade that runs outside of the upgrade.php script.
  *
  * @package Elgg.Admin
  * @access private
  */
-class ElggUpgrade extends \ElggObject {
+class ElggUpgrade extends ElggObject {
+
+	use TimeUsing;
+	
 	private $requiredProperties = array(
 		'id',
 		'title',
@@ -88,16 +95,10 @@ class ElggUpgrade extends \ElggObject {
 	/**
 	 * Return instance of the class that processes the data
 	 *
-	 * @return \Elgg\BatchUpgrade
+	 * @return Batch|false
 	 */
-	public function getUpgrade() {
-		static $upgrade;
-
-		if (!$upgrade) {
-			$upgrade = new $this->class;
-		}
-
-		return $upgrade;
+	public function getBatch() {
+		return _elgg_services()->upgradeLocator->getBatch($this->class);
 	}
 
 	/**
@@ -108,7 +109,7 @@ class ElggUpgrade extends \ElggObject {
 	 */
 	public function setCompletedTime($time = null) {
 		if (!$time) {
-			$time = time();
+			$time = $this->getCurrentTime()->getTimestamp();
 		}
 
 		return $this->completed_time = $time;
@@ -170,4 +171,5 @@ class ElggUpgrade extends \ElggObject {
 
 		return $this->getPrivateSetting($name);
 	}
+
 }

--- a/engine/tests/phpunit/Elgg/BatchUpgraderTest.php
+++ b/engine/tests/phpunit/Elgg/BatchUpgraderTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Elgg;
+
+use Elgg\Upgrade\TestBatch;
+use Elgg\Upgrade\TestNoIncrementBatch;
+use ElggUpgrade;
+
+/**
+ * @group UpgradeService
+ */
+class BatchUpgraderTest extends TestCase {
+
+	public function setUp() {
+		$this->setupMockServices();
+	}
+
+	public function testCanRunIncrementedUpgrade() {
+
+		$upgrade = new ElggUpgrade();
+		$upgrade->setClass(TestBatch::class);
+		$upgrade->setId("test_plugin:2016101900");
+		$upgrade->title = 'test_plugin:upgrade:2016101900:title';
+		$upgrade->description = 'test_plugin:upgrade:2016101900:title';
+		$upgrade->save();
+		
+		$config = _elgg_services()->config;
+		$upgrader = new BatchUpgrader($config);
+		$result = $upgrader->run($upgrade);
+
+		$expected = [
+			'errors' => [0, 25, 50, 75],
+			'numErrors' => 40,
+			'numSuccess' => 60,
+		];
+
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testCanRunIncrementedUpgradeWithInitialOffset() {
+
+		$upgrade = new ElggUpgrade();
+		$upgrade->setClass(TestBatch::class);
+		$upgrade->setId("test_plugin:2016101900");
+		$upgrade->title = 'test_plugin:upgrade:2016101900:title';
+		$upgrade->description = 'test_plugin:upgrade:2016101900:title';
+		$upgrade->save();
+		
+		$upgrade->processed = 50;
+		$upgrade->offset = 50;
+		$upgrade->has_errors = false;
+
+		$config = _elgg_services()->config;
+		$upgrader = new BatchUpgrader($config);
+		$result = $upgrader->run($upgrade);
+
+		$expected = [
+			'errors' => [50, 75],
+			'numErrors' => 20,
+			'numSuccess' => 30,
+		];
+
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testCanRunUnincrementedUpgrade() {
+
+		$upgrade = new ElggUpgrade();
+		$upgrade->setClass(TestNoIncrementBatch::class);
+		$upgrade->setId("test_plugin:2016101901");
+		$upgrade->title = 'test_plugin:upgrade:2016101901:title';
+		$upgrade->description = 'test_plugin:upgrade:2016101901:title';
+		$upgrade->save();
+		
+		$config = _elgg_services()->config;
+		$upgrader = new BatchUpgrader($config);
+		$result = $upgrader->run($upgrade);
+
+		$expected = [
+			'errors' => [0, 10, 20, 30],
+			'numErrors' => 40,
+			'numSuccess' => 60,
+		];
+
+		$this->assertEquals($expected, $result);
+	}
+
+}

--- a/engine/tests/phpunit/Elgg/Mocks/Database/EntityTable.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Database/EntityTable.php
@@ -35,10 +35,9 @@ class EntityTable extends DbEntityTable {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function insertRow(stdClass $row) {
-		$attributes = (array) $row;
+	public function insertRow(stdClass $row, array $attributes = []) {
 		$subtype = isset($row->subtype) ? $row->subtype : null;
-		$this->setup(null, $row->type, $subtype, $attributes);
+		$this->setup(null, $row->type, $subtype, array_merge($attributes, (array) $row));
 		return parent::insertRow($row);
 	}
 

--- a/engine/tests/phpunit/Elgg/Mocks/Database/PrivateSettingsTable.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Database/PrivateSettingsTable.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Elgg\Mocks\Database;
+
+use Elgg\Database\PrivateSettingsTable as DbPrivateSettingsTable;
+use stdClass;
+
+/**
+ * This is a mock database table class and is intended to simplify testing of
+ * entity APIs. Do not use this class to test the private settings table iteself
+ */
+class PrivateSettingsTable extends DbPrivateSettingsTable {
+
+	/**
+	 * @var stdClass[]
+	 */
+	public $rows = [];
+
+	/**
+	 * DB query query_specs
+	 * @var array
+	 */
+	public $query_specs = [];
+
+	/**
+	 * @var int
+	 */
+	public $iterator = 100;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function set($entity_guid, $name, $value) {
+		$entity = get_entity((int) $entity_guid);
+		if (!$entity) {
+			return false;
+		}
+
+		if (!isset($value)) {
+			return false;
+		}
+
+		$this->iterator++;
+		$id = $this->iterator;
+
+		$row = (object) [
+			'id' => $id,
+			'entity_guid' => $entity->guid,
+			'name' => (string) $name,
+			'value' => (string) $value,
+		];
+
+		$this->rows[$id] = $row;
+
+		$this->addQuerySpecs($row);
+
+		return parent::set($entity_guid, $name, $value);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getAll($entity_guid) {
+		$rows = [];
+		foreach ($this->rows as $id => $row) {
+			if ($row->entity_guid == $entity_guid) {
+				$rows[] = new ElggMetadata($row);
+			}
+		}
+		return $rows;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function removeAllForEntity($entity_guid) {
+		$deleted = false;
+		foreach ($this->rows as $id => $row) {
+			if ($row->entity_guid == $entity_guid) {
+				$this->clearQuerySpecs($this->rows[$id]);
+				$deleted = true;
+				unset($this->rows[$id]);
+			}
+		}
+		return $deleted;
+	}
+
+	/**
+	 * Clear query specs
+	 * 
+	 * @param stdClass $row Data row
+	 * @return void
+	 */
+	public function clearQuerySpecs(stdClass $row) {
+		if (!isset($this->query_specs[$row->id])) {
+			return;
+		}
+		foreach ($this->query_specs[$row->id] as $spec) {
+			$this->db->removeQuerySpec($spec);
+		}
+	}
+
+	/**
+	 * Add query query_specs for a metadata object
+	 * 
+	 * @param stdClass $row Data row
+	 * @return void
+	 */
+	public function addQuerySpecs(stdClass $row) {
+
+		$this->clearQuerySpecs($row);
+
+		// Set a new setting
+		$query = "
+			INSERT into {$this->table}
+			(entity_guid, name, value) VALUES
+			(:entity_guid, :name, :value)
+			ON DUPLICATE KEY UPDATE value = :value
+		";
+		$params = [
+			':entity_guid' => (int) $row->entity_guid,
+			':name' => (string) $row->name,
+			':value' => (string) $row->value,
+		];
+		
+		$this->query_specs[$row->id][] = $this->db->addQuerySpec([
+			'sql' => $query,
+			'params' => $params,
+			'insert_id' => $row->id,
+		]);
+
+		// Get setting by its value
+		$query = "
+			SELECT value FROM {$this->table}
+			WHERE name = :name
+			AND entity_guid = :entity_guid
+		";
+		$params = [
+			':entity_guid' => (int) $row->entity_guid,
+			':name' => (string) $row->name,
+		];
+		
+		$this->query_specs[$row->id][] = $this->db->addQuerySpec([
+			'sql' => $query,
+			'params' => $params,
+			'results' => function() use ($row) {
+				if (isset($this->rows[$row->id])) {
+					return [$this->rows[$row->id]];
+				}
+				return [];
+			},
+		]);
+
+		$query = "
+			DELETE FROM {$this->table}
+			WHERE name = :name
+			AND entity_guid = :entity_guid
+		";
+		$params = [
+			':entity_guid' => (int) $row->entity_guid,
+			':name' => (string) $row->name,
+		];
+
+		$this->query_specs[$row->id][] = $this->db->addQuerySpec([
+			'sql' => $query,
+			'params' => $params,
+			'results' => function() use ($row) {
+				if (isset($this->rows[$row->id])) {
+					unset($this->rows[$row->id]);
+					$this->clearQuerySpecs($row);
+					return [$row->id];
+				}
+				return [];
+			}
+		]);
+
+	}
+
+	/**
+	 * Iterate ID
+	 * @return int
+	 */
+	public function iterate() {
+		$this->iterator++;
+		return $this->iterator;
+	}
+
+}

--- a/engine/tests/phpunit/Elgg/Mocks/Di/MockServiceProvider.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Di/MockServiceProvider.php
@@ -9,13 +9,14 @@ use ElggUser;
 /**
  * Mocking service
  *
- * @property-read \Elgg\Mocks\Database                    $db                 Database
- * @property-read \Elgg\Mocks\Database\EntityTable        $entityTable        Entity mocks
- * @property-read \Elgg\Mocks\Database\MetadataTable      $metadataTable      Metadata mocks
- * @property-read \Elgg\Mocks\Database\Annotations        $annotations        Annotation mocks
- * @property-read \Elgg\Mocks\Database\RelationshipsTable $relationshipsTable Annotation mocks
- * @property-read \Elgg\Mocks\Database\SubtypeTable       $subtypeTable       Subtype table mock
- * @property-read \Elgg\Mocks\Database\AccessCollections  $accessCollections  ACL table mock
+ * @property-read \Elgg\Mocks\Database                      $db                 Database
+ * @property-read \Elgg\Mocks\Database\EntityTable          $entityTable        Entity mocks
+ * @property-read \Elgg\Mocks\Database\MetadataTable        $metadataTable      Metadata mocks
+ * @property-read \Elgg\Mocks\Database\Annotations          $annotations        Annotation mocks
+ * @property-read \Elgg\Mocks\Database\RelationshipsTable   $relationshipsTable Annotation mocks
+ * @property-read \Elgg\Mocks\Database\SubtypeTable         $subtypeTable       Subtype table mock
+ * @property-read \Elgg\Mocks\Database\AccessCollections    $accessCollections  ACL table mock
+ * @property-read \Elgg\Mocks\Database\PrivateSettingsTable $privateSettings    Private settings table mock
  *
  * @since 2.3
  */
@@ -79,6 +80,14 @@ class MockServiceProvider extends \Elgg\Di\DiContainer {
 				$sp->hooks,
 				$sp->session,
 				$sp->translator
+			);
+		});
+
+		$this->setFactory('privateSettings', function(MockServiceProvider $m) use ($sp) {
+			return new \Elgg\Mocks\Database\PrivateSettingsTable(
+				$m->db,
+				$m->entityTable,
+				$sp->pluginSettingsCache
 			);
 		});
 

--- a/engine/tests/phpunit/Elgg/TestCase.php
+++ b/engine/tests/phpunit/Elgg/TestCase.php
@@ -8,7 +8,6 @@ use Elgg\Database\TestingPlugins;
 use Elgg\Di\ServiceProvider;
 use Elgg\Http\Request;
 use Elgg\Mocks\Di\MockServiceProvider;
-use ElggSession;
 use PHPUnit_Framework_TestCase;
 use stdClass;
 use Zend\Mail\Transport\InMemory as InMemoryTransport;
@@ -27,7 +26,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Constructs a test case with the given name.
-	 * Boostraps testing environment
+	 * Bootstraps testing environment
 	 * 
 	 * @param string $name
 	 * @param array  $data
@@ -51,7 +50,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Boostraps test suite
+	 * Bootstraps test suite
 	 *
 	 * @global stdClass $CONFIG Global config
 	 * @global stdClass $_ELGG  Global vars
@@ -166,7 +165,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 			// Individual tests can reset service providers to get a clean global state
 			self::bootstrap();
 		}
-
+		
 		_elgg_services()->setValue('session', self::mocks()->session);
 		_elgg_services()->setValue('db', self::mocks()->db);
 		_elgg_services()->setValue('entityTable', self::mocks()->entityTable);
@@ -175,6 +174,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 		_elgg_services()->setValue('annotations', self::mocks()->annotations);
 		_elgg_services()->setValue('relationshipsTable', self::mocks()->relationshipsTable);
 		_elgg_services()->setValue('accessCollections', self::mocks()->accessCollections);
+		_elgg_services()->setValue('privateSettings', self::mocks()->privateSettings);
 		_elgg_services()->setValue('subtypeTable', self::mocks()->subtypeTable);
 		_elgg_services()->setValue('datalist', self::mocks()->datalist);
 

--- a/engine/tests/phpunit/Elgg/Upgrade/InvalidBatch.php
+++ b/engine/tests/phpunit/Elgg/Upgrade/InvalidBatch.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Elgg\Upgrade;
+
+class InvalidBatch {
+	
+}

--- a/engine/tests/phpunit/Elgg/Upgrade/LocatorTest.php
+++ b/engine/tests/phpunit/Elgg/Upgrade/LocatorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Elgg\Upgrade;
+
+/**
+ * @group UpgradeService
+ */
+class LocatorTest extends \Elgg\TestCase {
+	
+	/**
+	 * @var \ElggPlugin
+	 */
+	private $plugin;
+
+	public function setUp() {
+
+		$this->setupMockServices();
+		
+		$this->plugin = $this->getMockBuilder(\ElggPlugin::class)
+				->disableOriginalConstructor()
+				->setMethods(['getStaticConfig', 'getID'])
+				->getMock();
+
+		$this->plugin
+			->expects($this->any())
+			->method('getStaticConfig')
+			->will($this->returnCallback(function($name) {
+				if ($name == 'upgrades') {
+					return [\Elgg\Upgrade\TestBatch::class];
+				}
+			}));
+
+			$this->plugin
+			->expects($this->any())
+			->method('getID')
+			->will($this->returnValue('test_plugin'));
+	}
+
+	public function tearDown() {
+
+	}
+
+	public function testRunner() {
+		// Can be implemented once Plugins::find() is mocked
+		$this->markTestIncomplete();
+	}
+
+	public function testCanGetPluginUpgrades() {
+
+		$upgrades = _elgg_services()->upgradeLocator->getUpgrades($this->plugin);
+
+		$this->assertNotEmpty($upgrades);
+		
+		$upgrade = array_shift($upgrades);
+		/* @var $upgrade \ElggUpgrade */
+
+		$this->assertInstanceOf(\ElggUpgrade::class, $upgrade);
+		$this->assertEquals('test_plugin:2016101900', $upgrade->id);
+		$this->assertEquals("test_plugin:upgrade:2016101900:title", $upgrade->title);
+		$this->assertEquals("test_plugin:upgrade:2016101900:description", $upgrade->description);
+		
+	}
+
+	public function testCanGetExistingUpgrade() {
+		// Can be implemented once PluginsSettingsTable::getEntities() is mocked
+		$this->markTestIncomplete();
+	}
+}

--- a/engine/tests/phpunit/Elgg/Upgrade/TestBatch.php
+++ b/engine/tests/phpunit/Elgg/Upgrade/TestBatch.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Elgg\Upgrade;
+
+class TestBatch implements \Elgg\Upgrade\Batch {
+
+	const INCREMENT_OFFSET = true;
+	const VERSION = 2016101900;
+
+	public function countItems() {
+		return 100;
+	}
+
+	public function run(Result $result, $offset) {
+		$result->addError($offset);
+		$result->addSuccesses(15);
+		$result->addFailures(10);
+		return $result;
+	}
+
+}

--- a/engine/tests/phpunit/Elgg/Upgrade/TestNoIncrementBatch.php
+++ b/engine/tests/phpunit/Elgg/Upgrade/TestNoIncrementBatch.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Elgg\Upgrade;
+
+class TestNoIncrementBatch implements \Elgg\Upgrade\Batch {
+	
+	const INCREMENT_OFFSET = false;
+	const VERSION = 2016101901;
+
+	private $count = 100;
+
+	public function countItems() {
+		return $this->count;
+	}
+
+	public function run(Result $result, $offset) {
+		$result->addError($offset);
+		$result->addSuccesses(15);
+		$this->count -= 15;
+
+		$result->addFailures(10);
+		return $result;
+	}
+}

--- a/engine/tests/phpunit/ElggObjectTest.php
+++ b/engine/tests/phpunit/ElggObjectTest.php
@@ -50,9 +50,6 @@ class ElggObjectTest extends \Elgg\TestCase {
 	 */
 	public function testCanSaveNewObject() {
 
-		// We can't effectively test this without objects table mock
-		$this->markTestSkipped();
-
 		$subtype = 'test_subtype';
 		$subtype_id = add_subtype('object', $subtype);
 
@@ -71,19 +68,17 @@ class ElggObjectTest extends \Elgg\TestCase {
 		$object->setCurrentTime(); // We should be able to match timestamps
 		$now = $object->getCurrentTime()->getTimestamp();
 
-		$guid = _elgg_services()->entityTable->iterate();
-
-		$object->save();
+		$guid = $object->save();
+		$this->assertNotFalse($guid);
 
 		$object = get_entity($guid);
 
 		$this->assertEquals('object', $object->type);
 		$this->assertEquals($subtype_id, $object->subtype);
 
-		// These can't be tested for now, because we are not storing secondary attributes
-		//$this->assertEquals('Foo', $object->title);
-		//$this->assertEquals('Foo', $object->getDisplayName());
-		//$this->assertEquals('Bar', $object->description);
+		$this->assertEquals('Foo', $object->title);
+		$this->assertEquals('Foo', $object->getDisplayName());
+		$this->assertEquals('Bar', $object->description);
 
 		$this->assertEquals($user->guid, $object->getOwnerGUID());
 		$this->assertEquals($user, $object->getOwnerEntity());

--- a/engine/tests/phpunit/ElggUpgradeTest.php
+++ b/engine/tests/phpunit/ElggUpgradeTest.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group UpgradeService
+ */
 class ElggUpgradeTest extends \Elgg\TestCase {
 
 	/**
@@ -16,8 +19,14 @@ class ElggUpgradeTest extends \Elgg\TestCase {
 				->getMock();
 
 		$this->obj->_callable_egefps = array($this, 'mock_egefps');
+
+		_elgg_services()->logger->disable();
 	}
 
+	public function tearDown() {
+		_elgg_services()->logger->enable();
+	}
+	
 	public function mock_egefps($options) {
 		return array();
 	}
@@ -83,5 +92,16 @@ class ElggUpgradeTest extends \Elgg\TestCase {
 		$this->obj->description = 'Test';
 		$this->obj->title = 'Test';
 		$this->obj->save();
+	}
+
+	public function testCanInstantiateBatchRunner() {
+		$this->obj->setClass('\InvalidClass');
+		$this->assertFalse($this->obj->getBatch());
+
+		$this->obj->setClass(\Elgg\Upgrade\InvalidBatch::class);
+		$this->assertFalse($this->obj->getBatch());
+
+		$this->obj->setClass(\Elgg\Upgrade\TestBatch::class);
+		$this->assertInstanceOf(\Elgg\Upgrade\TestBatch::class, $this->obj->getBatch());
 	}
 }

--- a/languages/en.php
+++ b/languages/en.php
@@ -541,7 +541,8 @@ return array(
 	'admin:administer_utilities:maintenance' => 'Maintenance mode',
 	'admin:upgrades' => 'Upgrades',
 	'admin:upgrades:run' => 'Run upgrades now',
-	'admin:upgrades:error:invalid_upgrade' => 'The upgrade %s (%s)is not an instance of ElggUpgrade',
+	'admin:upgrades:error:invalid_upgrade' => 'The upgrade %s (%s) is not an instance of ElggUpgrade',
+	'admin:upgrades:error:invalid_batch' => 'Batch runner for the upgrade %s (%s) could not be instantiated',
 
 	'admin:settings' => 'Settings',
 	'admin:settings:basic' => 'Basic Settings',

--- a/mod/groups/classes/Elgg/Groups/Upgrades/GroupIconTransfer.php
+++ b/mod/groups/classes/Elgg/Groups/Upgrades/GroupIconTransfer.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Elgg\Groups\Upgrades;
+
+class GroupIconTransfer implements \Elgg\Upgrade\Batch {
+
+	const INCREMENT_OFFSET = true;
+
+	const VERSION = 2016101900;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function countItems() {
+		return elgg_get_entities([
+			'types' => 'group',
+			'count' => true,
+		]);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function run(\Elgg\Upgrade\Result $result, $offset) {
+
+		$groups = elgg_get_entities([
+			'types' => 'group',
+			'offset' => $offset,
+			'limit' => 10,
+		]);
+
+		foreach ($groups as $group) {
+			$result = $this->transferIcons($group, $result);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Transfer group icons to new filestore location
+	 * Before 3.0, group icons where owned by the group owner
+	 * and located in /groups/<guid><size>.jpg
+	 * relative to group owner's filestore directory
+	 * In 3.0, we are moving these to default filestore location
+	 * relative to group's filestore directory
+	 *
+	 * @param \ElggGroup           $group  Group entity
+	 * @param \Elgg\Upgrade\Result $result Upgrade result
+	 * @return \Elgg\Upgrade\Result
+	 */
+	public function transferIcons(\ElggGroup $group, \Elgg\Upgrade\Result $result) {
+
+		$sizes = elgg_get_icon_sizes('group', $group->getSubtype());
+
+		$dataroot = elgg_get_config('dataroot');
+		$dir = (new \Elgg\EntityDirLocator($group->owner_guid))->getPath();
+		$prefix = 'groups/';
+
+		foreach ($sizes as $size => $opts) {
+			$filename = "{$group->guid}{$size}.jpg";
+			$filestorename = "{$dataroot}{$dir}{$prefix}{$filename}";
+			if (!file_exists($filestorename)) {
+				// nothing to move
+				continue;
+			}
+
+			$icon = $group->getIcon($size);
+
+			// before transferring the file, we need to make sure
+			// the directory structure of the new filestore location exists
+			$icon->open('write');
+			$icon->close();
+
+			if (!rename($filestorename, $icon->getFilenameOnFilestore())) {
+				$result->addError("
+					Failed to transfer file from '$filestorename'
+					to {$icon->getFilenameOnFilestore()}
+				");
+				$error = true;
+			}
+		}
+
+		if ($error) {
+			$result->addFailures();
+		} else {
+			$result->addSuccesses();
+		}
+
+		return $result;
+	}
+
+}

--- a/mod/groups/elgg-plugin.php
+++ b/mod/groups/elgg-plugin.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+	'upgrades' => [
+		\Elgg\Groups\Upgrades\GroupIconTransfer::class,
+	],
+];

--- a/mod/groups/languages/en.php
+++ b/mod/groups/languages/en.php
@@ -210,4 +210,14 @@ or click below to view the group's join requests:
 	 * ecml
 	 */
 	'groups:ecml:groupprofile' => 'Group profiles',
+
+	/**
+	 * Upgrades
+	 */
+	'groups:upgrade:2016101900:title' => 'Transfer group icons to new location',
+	'groups:upgrade:2016101900:description' => '
+		New entity icon API stores icons in a predictable location on the filestore
+		relative to the entity\'s filestore directory. This upgrade aligns
+		will align group plugin with the requirements of the new API.
+	',
 );

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -30,7 +30,6 @@ function groups_init() {
 
 	// Register URL handlers for groups
 	elgg_register_plugin_hook_handler('entity:url', 'group', 'groups_set_url');
-	elgg_register_plugin_hook_handler('entity:icon:file', 'group', 'groups_set_icon_file');
 
 	// Register some actions
 	$action_base = __DIR__ . '/actions/groups';
@@ -353,26 +352,6 @@ function groups_set_url($hook, $type, $url, $params) {
 	$entity = $params['entity'];
 	$title = elgg_get_friendly_title($entity->name);
 	return "groups/profile/{$entity->guid}/$title";
-}
-
-/**
- * Override the default entity icon file for groups
- *
- * @param string    $hook   "entity:icon:file"
- * @param string    $type   "group"
- * @param \ElggIcon $icon   Icon file
- * @param array     $params Hook params
- * @return \ElggIcon
- */
-function groups_set_icon_file($hook, $type, $icon, $params) {
-
-	$entity = elgg_extract('entity', $params);
-	$size = elgg_extract('size', $params, 'medium');
-
-	$icon->owner_guid = $entity->owner_guid;
-	$icon->setFilename("groups/{$entity->guid}{$size}.jpg");
-
-	return $icon;
 }
 
 /**

--- a/views/default/object/elgg_upgrade.php
+++ b/views/default/object/elgg_upgrade.php
@@ -4,12 +4,19 @@
  */
 
 $entity = elgg_extract('entity', $vars);
+/* @var $entity \ElggUpgrade */
+
+$batch = $entity->getBatch();
+if (!$batch) {
+	// Something went wrong with class resolution
+	return;
+}
 
 $data = elgg_format_element(
 	'span',
 	array(
 		'class' => 'upgrade-data hidden',
-		'data-total' => $entity->total,
+		'data-total' => $batch->countItems(),
 	)
 );
 
@@ -22,7 +29,7 @@ $timer = elgg_format_element(
 $counter = elgg_format_element(
 	'span',
 	array('class' => 'upgrade-counter float-alt'),
-	"0/$entity->total"
+	"0/{$batch->countItems()}"
 );
 
 $progressbar = elgg_format_element('div', array(


### PR DESCRIPTION
**chore(upgrades): fix upgrader and add tests**
Fixes bad loop calculations in the batch upgrader, refactors some code and adds tests.

**feat(groups): transfer icon files to a new location**
BREAKING CHANGE
Group icon files have been moved from group owner directory into a new location prescribed by the entity icon service.
Plugins should stop accessing files directly and the entity icon APIs.

Fixes #4683
