### PR TITLE
fix(core): parse_url no longer does a double parse

### DIFF
--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -27,8 +27,12 @@ function parse_urls($text) {
 	// By default htmlawed rewrites tags to this format.
 	// if PHP supported conditional negative lookbehinds we could use this:
 	// $r = preg_replace_callback('/(?<!=)(?<![ ])?(?<!["\'])((ht|f)tps?:\/\/[^\s\r\n\t<>"\'\!\(\),]+)/i',
-	$r = preg_replace_callback('/(?<![=\/"\'])((ht|f)tps?:\/\/[^\s\r\n\t<>"\']+)/i',
+	$r = preg_replace_callback('/<a(?:\s[^>]*)?>[\W\w]*?<\/a>|((?:https?|ftp):\/\/[^\s\r\n\t<>"]+)/i',
 	function($matches) {
+		if (!isset($matches[1])) {
+			return $matches[0];
+		}
+		
 		$url = $matches[1];
 		$punc = '';
 		$last = substr($url, -1, 1);

--- a/engine/tests/ElggCoreRegressionBugsTest.php
+++ b/engine/tests/ElggCoreRegressionBugsTest.php
@@ -224,6 +224,9 @@ class ElggCoreRegressionBugsTest extends \ElggCoreUnitTest {
 			'already anchor <a href="http://twitter.com/">twitter</a> test' =>
 				'already anchor <a href="http://twitter.com/">twitter</a> test',
 
+			'already anchor with link text <a href="http://twitter.com/">http://twitter.com</a> test' =>
+				'already anchor with link text <a href="http://twitter.com/">http://twitter.com</a> test',
+
 			'ssl https://example.org/ test' =>
 				'ssl <a href="https://example.org/" rel="nofollow">https:/<wbr />/<wbr />example.org/<wbr /></a> test',
 			'ftp ftp://example.org/ test' =>


### PR DESCRIPTION
fixes #8490 and fixes #6695
