### PR TITLE
Improvements to tabs and popup components

### DIFF
--- a/js/lib/elgglib.js
+++ b/js/lib/elgglib.js
@@ -599,3 +599,24 @@ elgg.is_in_object_array = function(object, parent, value) {
 
 	return typeof(object[parent]) != 'undefined' && $.inArray(value, object[parent]) >= 0;
 };
+
+/**
+ * Builds a new jQuery DOM element from an array of attributes
+ *
+ * @param {object} element Element attributes
+ *                         Optional #tag_name that defies the tag name (default: div)
+ *                         Optional #text     that defines the html content of the new element (default: '')
+ * @returns {jQuery}
+ */
+elgg.format_element = function(element) {
+	var tag_name = element['#tag_name'] || 'div';
+	var text = element['#text'] || ''
+	
+	delete element['#tag_name'];
+	delete element['#text'];
+
+	return $('<' + tag_name + '>')
+			.addClass('hidden')
+			.attr(element)
+			.html(text);
+}

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -27,7 +27,7 @@ function developers_init() {
 	elgg_register_action('developers/entity_explorer_delete', "$action_base/entity_explorer_delete.php", 'admin');
 
 	elgg_register_ajax_view('forms/developers/ajax_demo');
-	elgg_register_ajax_view('theme_sandbox/components/tabs/ajax_demo');
+	elgg_register_ajax_view('theme_sandbox/components/tabs/ajax');
 }
 
 function developers_process_settings() {

--- a/mod/developers/views/default/theme_sandbox/javascript/popup.php
+++ b/mod/developers/views/default/theme_sandbox/javascript/popup.php
@@ -2,32 +2,34 @@
 
 $ipsum = elgg_view('developers/ipsum');
 
-$link = elgg_view('output/url', array(
-	'text' => 'Popup content',
-	'href' => "#elgg-popup-test",
-	'rel' => 'popup',
-		));
+echo elgg_view_field([
+	'#type' => 'fieldset',
+	'align' => 'horizontal',
+	'fields' => [
+		[
+			'#type' => 'anchor',
+			'text' => 'Popup content',
+			'href' => "#elgg-popup-test",
+			'rel' => 'popup',
+		],
+		[
+			'#type' => 'button',
+			'class' => 'elgg-button elgg-button-submit mll',
+			'rel' => 'popup',
+			'data-href' => "#elgg-popup-test2",
+			'data-position' => json_encode(array(
+				'my' => 'left top',
+				'at' => 'left bottom',
+			)),
+			'value' => 'Load content in a popup',
+		]
+	],
+]);
 
-echo $link;
 echo elgg_view_module('popup', 'Popup Test', $ipsum, array(
 	'id' => 'elgg-popup-test',
 	'class' => 'hidden theme-sandbox-content-thin',
 ));
-
-
-$button = elgg_format_element(array(
-	'#tag_name' => 'button',
-	'class' => 'elgg-button elgg-button-submit mll',
-	'rel' => 'popup',
-	'data-href' => "#elgg-popup-test2",
-	'data-position' => json_encode(array(
-		'my' => 'left top',
-		'at' => 'left bottom',
-	)),
-	'#text' => 'Load content in a popup',
-));
-
-echo $button;
 
 echo elgg_format_element(array(
 	'#tag_name' => 'div',

--- a/mod/developers/views/default/theme_sandbox/javascript/popup.php
+++ b/mod/developers/views/default/theme_sandbox/javascript/popup.php
@@ -14,7 +14,7 @@ echo elgg_view_field([
 		],
 		[
 			'#type' => 'button',
-			'class' => 'elgg-button elgg-button-submit mll',
+			'class' => 'elgg-button elgg-button-submit',
 			'rel' => 'popup',
 			'data-href' => "#elgg-popup-test2",
 			'data-position' => json_encode(array(
@@ -22,6 +22,24 @@ echo elgg_view_field([
 				'at' => 'left bottom',
 			)),
 			'value' => 'Load content in a popup',
+		],
+		[
+			'#type' => 'button',
+			'class' => 'elgg-button elgg-button-submit',
+			'rel' => 'popup',
+			'data-ajax-href' => 'ajax/view/theme_sandbox/components/tabs/ajax',
+			'data-ajax-reload' => true,
+			'data-ajax-query' => json_encode([
+				'content' => 'Hello, world',
+			]),
+			'data-ajax-target' => json_encode([
+				'class' => 'theme-sandbox-content-thin elgg-module-popup',
+			]),
+			'data-position' => json_encode(array(
+				'my' => 'left top',
+				'at' => 'left bottom',
+			)),
+			'value' => 'Create new ajax popup',
 		]
 	],
 ]);

--- a/views/default/elgg/popup.js
+++ b/views/default/elgg/popup.js
@@ -5,7 +5,9 @@
  * @module elgg/popup
  * @since 2.2
  */
-define('elgg/popup', ['elgg', 'jquery', 'jquery-ui'], function (elgg, $) {
+define('elgg/popup', ['elgg', 'jquery', 'elgg/Ajax', 'jquery-ui'], function (elgg, $, Ajax) {
+
+	var ajax = new Ajax(false);
 
 	var popup = {
 		/**
@@ -73,17 +75,30 @@ define('elgg/popup', ['elgg', 'jquery', 'jquery-ui'], function (elgg, $) {
 				return;
 			}
 
+			var href, targetSelector;
+
 			if (typeof $target === 'undefined') {
-				var href = $trigger.attr('href') || $trigger.data('href') || '';
-				var targetSelector = elgg.getSelectorFromUrlFragment(href);
-				$target = $(targetSelector);
+				href = $trigger.attr('href') || $trigger.data('href') || $trigger.data('ajaxHref') || '';
+				targetSelector = elgg.getSelectorFromUrlFragment(href);
+				if (targetSelector) {
+					$target = $(targetSelector);
+				} else {
+					$target = elgg.format_element($trigger.data('ajaxTarget') || {});
+					$target.uniqueId().addClass('hidden').appendTo('body');
+					targetSelector = '#' + $target.attr('id');
+				}
 			} else {
 				$target.uniqueId();
-				var targetSelector = '#' + $target.attr('id');
+				targetSelector = '#' + $target.attr('id');
+				href = targetSelector;
 			}
 
 			if (!$target.length) {
 				return;
+			}
+
+			if (!$trigger.data('ajaxReload')) {
+				$trigger.attr('href', href);
 			}
 
 			// emit a hook to allow plugins to position and control popups
@@ -116,7 +131,7 @@ define('elgg/popup', ['elgg', 'jquery', 'jquery-ui'], function (elgg, $) {
 				popup.close($target);
 				return;
 			}
-			
+
 			popup.close(); // close any open popup modules
 
 			$target.data('trigger', $trigger); // used to remove elgg-state-active class when popup is closed
@@ -125,14 +140,35 @@ define('elgg/popup', ['elgg', 'jquery', 'jquery-ui'], function (elgg, $) {
 			if (!$trigger.is('.elgg-popup-inline')) {
 				$target.appendTo('body');
 			}
-			
+
 			$target.fadeIn()
-				   .addClass('elgg-state-active elgg-state-popped')
-				   .position(position);
+					.addClass('elgg-state-active elgg-state-popped')
+					.position(position);
 
 			$trigger.addClass('elgg-state-active');
 
-			$target.trigger('open');
+			var loadFunc = elgg.nullFunction;
+			if (href.indexOf('#') !== 0) {
+				var data = $trigger.data('ajaxQuery') || {};
+				loadFunc = ajax.path(href, {
+					data: data,
+					beforeSend: function () {
+						$target.addClass('elgg-ajax-loader');
+					}
+				}).done(function (output, statusText, jqXHR) {
+					$target.data('loaded', true);
+					$target.removeClass('elgg-ajax-loader');
+					if (jqXHR.AjaxData.status === -1) {
+						$target.html(elgg.echo('ajax:error'));
+					} else {
+						$target.html(output);
+					}
+				});
+			}
+
+			$.when(loadFunc).done(function () {
+				$target.trigger('open');
+			});
 		},
 		/**
 		 * Hides a set of $targets. If not defined, closes all visible popup modules.
@@ -153,15 +189,21 @@ define('elgg/popup', ['elgg', 'jquery', 'jquery-ui'], function (elgg, $) {
 					return;
 				}
 
-				var $trigger = $target.data('trigger');
-				if ($trigger.length) {
-					$trigger.removeClass('elgg-state-active');
-				}
+				$.when($target.fadeOut('fast')).done(function () {
+					$target.removeClass('elgg-state-active elgg-state-popped');
 
-				// @todo: use css transitions instead of $.fadeOut()
-				$target.fadeOut().removeClass('elgg-state-active elgg-state-popped');
+					var $trigger = $target.data('trigger');
+					if ($trigger.length) {
+						$trigger.removeClass('elgg-state-active');
+						if ($trigger.data('ajaxReload')) {
+							$target.remove();
+						}
+					}
 
-				$target.trigger('close');
+					console.log($target.trigger('close'));
+
+					
+				});
 			});
 		}
 	};

--- a/views/default/input/anchor.php
+++ b/views/default/input/anchor.php
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * Shortcut that allows using anchors with elgg_view_field()
+ */
+echo elgg_view('output/url', $vars);

--- a/views/default/page/components/tabs.js
+++ b/views/default/page/components/tabs.js
@@ -18,13 +18,13 @@ define(function (require) {
 
 		var $target = $tab.data('target');
 		if (!$target || !$target.length) {
-			return;
+			return false;
 		}
 
 		$target.siblings().addClass('hidden').removeClass('elgg-state-active');
 		$target.removeClass('hidden').addClass('elgg-state-active');
 
-		$tab.trigger('open');
+		return true;
 	}
 
 	$(document).on('click', '.elgg-tabs-component .elgg-tabs > li > a', function (e) {
@@ -49,7 +49,7 @@ define(function (require) {
 		} else {
 			// Load an ajax tab
 			if (!$target || !$target.length) {
-				var $target = $('<div>').addClass('elgg-content hidden');
+				$target = elgg.format_element($link.data('ajaxTarget') || {});
 				$content.append($target);
 				$tab.data('target', $target);
 			}
@@ -58,6 +58,7 @@ define(function (require) {
 				loadFunc = ajax.path(href, {
 					data: $link.data('ajaxQuery') || {},
 					beforeSend: function () {
+						$target.html('');
 						changeTab($tab);
 						$target.addClass('elgg-ajax-loader');
 					}
@@ -73,8 +74,10 @@ define(function (require) {
 			}
 		}
 
-		$.when(loadFunc).done(function() {
-			changeTab($tab);
+		$.when(loadFunc).done(function () {
+			if (changeTab($tab)) {
+				$tab.trigger('open');
+			}
 		});
 	});
 

--- a/views/default/page/components/tabs.php
+++ b/views/default/page/components/tabs.php
@@ -16,7 +16,7 @@
  *                        click via 'data-ajax-reload' parameter; by default,
  *                        all tabs will be reloading on subsequent clicks.
  *                        You can pass additional data to the ajax view via
- *                        data-ajax-query attribute (json encoded string).
+ *                        'data-ajax-query' attribute (json encoded string).
  *                        You can also set the data-ajax-href parameter of the tab,
  *                        which will override the href parameter, in case you want
  *                        to ensure the tab is clickable even before the JS is bootstrapped.
@@ -26,7 +26,7 @@
  *                           ['text' => 'Tab 2', 'href' => '/static', 'data-ajax-reload' => false],
  *                           ['text' => 'Tab 3', 'href' => '/static', 'data-ajax-reload' => false, 'data-ajax-query' => json_encode($data)],
  *                           ['text' => 'Tab 3', 'href' => '/page', 'data-ajax-href' => '/ajax/page'],
- *                           ['text' => 'Tab 4', 'href' => 'Tab content'],
+ *                           ['text' => 'Tab 4', 'content' => 'Tab content'],
  *                        ]
  *                        </code>
  */

--- a/views/default/page/components/tabs.php
+++ b/views/default/page/components/tabs.php
@@ -20,6 +20,9 @@
  *                        You can also set the data-ajax-href parameter of the tab,
  *                        which will override the href parameter, in case you want
  *                        to ensure the tab is clickable even before the JS is bootstrapped.
+ *                        Wrapper for the content loaded via ajax can be defined
+ *                        via 'data-ajax-target' parameter, which access a json
+ *                        encoded string of options similar to elgg_format_element()
  *                        <code>
  *                        [
  *                           ['text' => 'Tab 1', 'href' => '/dynamic', 'data-ajax-reload' => true],
@@ -61,31 +64,36 @@ foreach ($tabs as $index => $tab) {
 		$content .= elgg_format_element('div', [
 			'class' => $class,
 			'id' => "{$id}-{$index}",
-		], $tab['content']);
+				], $tab['content']);
 		unset($tab['content']);
 
 		$tab['href'] = "#{$id}-{$index}";
 	} else {
+		if (!isset($tab['data-ajax-target'])) {
+			$tab['data-ajax-target'] = json_encode([
+				'#tag_name' => 'div',
+				'class' => 'elgg-content',
+			]);
+		}
 		if (!isset($tab['data-ajax-reload'])) {
 			$tab['data-ajax-reload'] = true;
 		}
 	}
-	
+
 	$tabs[$index] = $tab;
 }
 
 $tabs = elgg_view('navigation/tabs', [
 	'tabs' => $tabs,
-]);
+		]);
 
 $content = elgg_format_element('div', [
 	'class' => 'elgg-tabs-content',
-], $content);
+		], $content);
 
 $module = elgg_extract('module', $vars, 'tabs');
 unset($vars['module']);
 echo elgg_view_module($module, $tabs, $content, $vars);
-
 ?>
 <script>
 	require(['page/components/tabs']);


### PR DESCRIPTION
**feat(forms): anchors can now be rendered as form field type**
Adds input/anchor to allow anchors to be rendered as forms fields

**chore(js): tabs component now uses deferred object**

**feat(js): add elgg.format_element**
Adds elgg.format_element() to easily build new DOM elements.
Allows tabs component to specify the target element to load ajax data into

**feat(js): teach popup module to load ajax content**
- [ ] Update popup docs
