### PR TITLE
chore(core): removed support for class parameter in elgg_instanceof

### DIFF
--- a/docs/guides/notifications.rst
+++ b/docs/guides/notifications.rst
@@ -286,7 +286,7 @@ Example:
 	function discussion_get_subscriptions($hook, $type, $subscriptions, $params) {
 		$reply = $params['event']->getObject();
 
-		if (!elgg_instanceof($reply, 'object', 'discussion_reply', 'ElggDiscussionReply')) {
+		if (!elgg_instanceof($reply, 'object', 'discussion_reply')) {
 			return $subscriptions;
 		}
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -243,6 +243,7 @@ Miscellaneous API changes
  * ``ElggGroup::removeObjectFromGroup`` requires passing in an ``ElggObject`` (no longer accepts a GUID)
  * ``ElggUser::$salt`` no longer exists as an attribute, nor is it used for authentication
  * ``ElggUser::$password`` no longer exists as an attribute, nor is it used for authentication
+ * ``elgg_instanceof`` no longer supports the fourth ``class`` argument
  * ``elgg_view_icon`` no longer supports ``true`` as the 2nd argument
  * ``elgg_list_entities`` no longer supports the option ``view_type_toggle``
  * ``elgg_list_registered_entities`` no longer supports the option ``view_type_toggle``

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -707,12 +707,11 @@ function elgg_list_registered_entities(array $options = array()) {
  * @param mixed  $entity  Entity
  * @param string $type    Entity type
  * @param string $subtype Entity subtype
- * @param string $class   Class name
  *
  * @return bool
  * @since 1.8.0
  */
-function elgg_instanceof($entity, $type = null, $subtype = null, $class = null) {
+function elgg_instanceof($entity, $type = null, $subtype = null) {
 	$return = ($entity instanceof \ElggEntity);
 
 	if ($type) {
@@ -722,10 +721,6 @@ function elgg_instanceof($entity, $type = null, $subtype = null, $class = null) 
 
 	if ($subtype) {
 		$return = $return && ($entity->getSubtype() == $subtype);
-	}
-
-	if ($class) {
-		$return = $return && ($entity instanceof $class);
 	}
 
 	return $return;

--- a/mod/legacy_urls/start.php
+++ b/mod/legacy_urls/start.php
@@ -28,7 +28,7 @@ function legacy_urls_init() {
  * a) Displays an error page with the new URL
  * b) Forwards to the new URL and displays an error message
  * c) Silently forwards to the new URL
- * 
+ *
  * @param string $url Relative or absolute URL
  * @return mixed
  */
@@ -63,7 +63,7 @@ function legacy_urls_redirect($url) {
 
 /**
  * Adds query parameters to URL for redirect
- * 
+ *
  * @param string $url        The URL
  * @param array  $query_vars Additional query parameters in associate array
  * @return string
@@ -81,7 +81,7 @@ function legacy_urls_prepare_url($url, array $query_vars = array()) {
 			// on multiple redirects, __elgg_uri is appended to the URL causing infinite loops #8494
 			unset($params['__elgg_uri']);
 		}
-		return elgg_http_add_url_query_elements($url, $params);		
+		return elgg_http_add_url_query_elements($url, $params);
 	} else {
 		return $url;
 	}
@@ -112,7 +112,7 @@ function legacy_urls_pg_handler($segments) {
 
 /**
  * Blog forwarder
- * 
+ *
  * 1.0-1.7.5
  * Group blogs page: /blog/group:<container_guid>/
  * Group blog view:  /blog/group:<container_guid>/read/<guid>/<title>
@@ -155,7 +155,7 @@ function legacy_urls_blog_forward($hook, $type, $result) {
 	if ($page[0] == "read") {
 		$url = "blog/view/{$page[1]}/";
 		legacy_urls_redirect(legacy_urls_prepare_url($url));
-		return false;		
+		return false;
 	}
 
 	// user usernames
@@ -230,7 +230,7 @@ function legacy_urls_bookmarks_forward($hook, $type, $result) {
 	if ($page[0] == "read") {
 		$url = "bookmarks/view/{$page[1]}/";
 		legacy_urls_redirect(legacy_urls_prepare_url($url));
-		return false;		
+		return false;
 	}
 
 	$user = get_user_by_username($page[0]);
@@ -311,7 +311,7 @@ function legacy_urls_groups_forward($hook, $type, $result) {
 
 	if (is_numeric($page[0])) {
 		$group = get_entity($page[0]);
-		if (elgg_instanceof($group, 'group', '', 'ElggGroup')) {
+		if ($group instanceof \ElggGroup) {
 			legacy_urls_redirect(legacy_urls_prepare_url($group->getURL()));
 			return false;
 		}
@@ -327,7 +327,7 @@ function legacy_urls_groups_forward($hook, $type, $result) {
 /**
  * User settings forwarder
  * /settings/plugins/
- * 
+ *
  * @param $hook   string "route"
  * @param $type   string "settings"
  * @param $result mixed  Old identifier and segments


### PR DESCRIPTION
fixes #6230

BREAKING CHANGE:
If you rely on a class check for your content, please use the PHP
instanceof type operator
