### PR TITLE
Innodb migrate

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -114,6 +114,7 @@ Removed global vars
  * ``$ENTITY_CACHE``
  * ``$SESSION``: Use the API provided by ``elgg_get_session()``
  * ``$CONFIG->site_id``: Use ``elgg_get_config('site_guid')`` or ``elgg_get_site_entity()->guid``
+ * ``$CONFIG->search_info``
 
 Removed classes/interfaces
 --------------------------
@@ -127,6 +128,20 @@ Removed classes/interfaces
  * ``ImportException``
  * ``ODD`` and all classes beginning with ``ODD*``.
  * ``XmlElement``
+ 
+Schema changes
+--------------
+ 
+The storage engine for the database tables has been changed from MyISAM to InnoDB. You maybe need to optimize your database settings for this change.
+
+Search changes
+--------------
+
+The FULLTEXT indices have been removed on various tables. The search plugin will now always use a like query when performing a search.
+
+ * ``search_get_where_sql`` no longer supports the argument ``use_fulltext``
+ * ``search_get_ft_min_max`` function is removed
+ * ``$CONFIG->search_info`` is no longer provided
 
 Form and field related changes
 ------------------------------

--- a/engine/lib/upgrades/2016102600-3.0.0-db-engine-to-innodb-d636305e6aa305a5.php
+++ b/engine/lib/upgrades/2016102600-3.0.0-db-engine-to-innodb-d636305e6aa305a5.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Elgg 3.0.0 upgrade 2016102600
+ * db-engine-to-innodb
+ *
+ * Converts table engine to innodb
+ */
+
+set_time_limit(0);
+
+$db = _elgg_services()->db;
+
+// drop full text indexes
+$db->updateData("ALTER TABLE {$db->prefix}groups_entity DROP KEY `name_2`");
+$db->updateData("ALTER TABLE {$db->prefix}objects_entity DROP KEY `title`");
+$db->updateData("ALTER TABLE {$db->prefix}sites_entity DROP KEY `name`");
+$db->updateData("ALTER TABLE {$db->prefix}users_entity DROP KEY `name`, DROP KEY `name_2`");
+
+// update engine
+$tables = [
+	'access_collection_membership',
+	'access_collections',
+	'annotations',
+	'api_users',
+	'config',
+	'datalists',
+	'entities',
+	'entity_relationships',
+	'entity_subtypes',
+	'groups_entity',
+	'metadata',
+	'metastrings',
+	'objects_entity',
+	'private_settings',
+	'queue',
+	'river',
+	'sites_entity',
+	'system_log',
+	'users_entity',
+	'users_remember_me_cookies',
+	'users_sessions',
+];
+
+foreach ($tables as $table) {
+	$db->updateData("ALTER TABLE {$db->prefix}{$table} ENGINE=InnoDB");
+}

--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -7,7 +7,7 @@ CREATE TABLE `prefix_access_collection_membership` (
   `user_guid` bigint(20) unsigned NOT NULL,
   `access_collection_id` int(11) NOT NULL,
   PRIMARY KEY (`user_guid`,`access_collection_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- define an access collection
 CREATE TABLE `prefix_access_collections` (
@@ -16,7 +16,7 @@ CREATE TABLE `prefix_access_collections` (
   `owner_guid` bigint(20) unsigned NOT NULL,
   PRIMARY KEY (`id`),
   KEY `owner_guid` (`owner_guid`)
-) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
 
 -- store an annotation on an entity
 CREATE TABLE `prefix_annotations` (
@@ -35,7 +35,7 @@ CREATE TABLE `prefix_annotations` (
   KEY `value_id` (`value_id`),
   KEY `owner_guid` (`owner_guid`),
   KEY `access_id` (`access_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- api keys for old web services
 CREATE TABLE `prefix_api_users` (
@@ -45,21 +45,21 @@ CREATE TABLE `prefix_api_users` (
   `active` int(1) DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `api_key` (`api_key`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- site specific configuration
 CREATE TABLE `prefix_config` (
   `name` varchar(255) NOT NULL,
   `value` text NOT NULL,
   PRIMARY KEY (`name`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- application specific configuration
 CREATE TABLE `prefix_datalists` (
   `name` varchar(255) NOT NULL,
   `value` text NOT NULL,
   PRIMARY KEY (`name`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- primary entity table
 CREATE TABLE `prefix_entities` (
@@ -81,7 +81,7 @@ CREATE TABLE `prefix_entities` (
   KEY `access_id` (`access_id`),
   KEY `time_created` (`time_created`),
   KEY `time_updated` (`time_updated`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- relationships between entities
 CREATE TABLE `prefix_entity_relationships` (
@@ -94,7 +94,7 @@ CREATE TABLE `prefix_entity_relationships` (
   UNIQUE KEY `guid_one` (`guid_one`,`relationship`,`guid_two`),
   KEY `relationship` (`relationship`),
   KEY `guid_two` (`guid_two`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- entity type/subtype pairs
 CREATE TABLE `prefix_entity_subtypes` (
@@ -104,7 +104,7 @@ CREATE TABLE `prefix_entity_subtypes` (
   `class` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   UNIQUE KEY `type` (`type`,`subtype`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- cache lookups of latitude and longitude for place names
 CREATE TABLE `prefix_geocode_cache` (
@@ -123,9 +123,8 @@ CREATE TABLE `prefix_groups_entity` (
   `description` text NOT NULL,
   PRIMARY KEY (`guid`),
   KEY `name` (`name`(50)),
-  KEY `description` (`description`(50)),
-  FULLTEXT KEY `name_2` (`name`,`description`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+  KEY `description` (`description`(50))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- cache for hmac signatures for old web services
 CREATE TABLE `prefix_hmac_cache` (
@@ -152,7 +151,7 @@ CREATE TABLE `prefix_metadata` (
   KEY `value_id` (`value_id`),
   KEY `owner_guid` (`owner_guid`),
   KEY `access_id` (`access_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- string normalization table for metadata and annotations
 CREATE TABLE `prefix_metastrings` (
@@ -160,16 +159,15 @@ CREATE TABLE `prefix_metastrings` (
   `string` text NOT NULL,
   PRIMARY KEY (`id`),
   KEY `string` (`string`(50))
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- secondary table for object entities
 CREATE TABLE `prefix_objects_entity` (
   `guid` bigint(20) unsigned NOT NULL,
   `title` text NOT NULL,
   `description` text NOT NULL,
-  PRIMARY KEY (`guid`),
-  FULLTEXT KEY `title` (`title`,`description`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+  PRIMARY KEY (`guid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- settings for an entity
 CREATE TABLE `prefix_private_settings` (
@@ -181,7 +179,7 @@ CREATE TABLE `prefix_private_settings` (
   UNIQUE KEY `entity_guid` (`entity_guid`,`name`),
   KEY `name` (`name`),
   KEY `value` (`value`(50))
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- queue for asynchronous operations
 CREATE TABLE `prefix_queue` (
@@ -193,7 +191,7 @@ CREATE TABLE `prefix_queue` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `retrieve` (`timestamp`,`worker`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- activity stream
 CREATE TABLE `prefix_river` (
@@ -218,7 +216,7 @@ CREATE TABLE `prefix_river` (
   KEY `target_guid` (`target_guid`),
   KEY `annotation_id` (`annotation_id`),
   KEY `posted` (`posted`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- secondary table for site entities
 CREATE TABLE `prefix_sites_entity` (
@@ -227,9 +225,8 @@ CREATE TABLE `prefix_sites_entity` (
   `description` text NOT NULL,
   `url` varchar(255) NOT NULL,
   PRIMARY KEY (`guid`),
-  UNIQUE KEY `url` (`url`),
-  FULLTEXT KEY `name` (`name`,`description`,`url`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+  UNIQUE KEY `url` (`url`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- log activity for the admin
 CREATE TABLE `prefix_system_log` (
@@ -255,7 +252,7 @@ CREATE TABLE `prefix_system_log` (
   KEY `access_id` (`access_id`),
   KEY `time_created` (`time_created`),
   KEY `river_key` (`object_type`,`object_subtype`,`event`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- session table for old web services
 CREATE TABLE `prefix_users_apisessions` (
@@ -291,10 +288,8 @@ CREATE TABLE `prefix_users_entity` (
   KEY `email` (`email`(50)),
   KEY `last_action` (`last_action`),
   KEY `last_login` (`last_login`),
-  KEY `admin` (`admin`),
-  FULLTEXT KEY `name` (`name`),
-  FULLTEXT KEY `name_2` (`name`,`username`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+  KEY `admin` (`admin`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- user remember me cookies
 CREATE TABLE `prefix_users_remember_me_cookies` (
@@ -303,7 +298,7 @@ CREATE TABLE `prefix_users_remember_me_cookies` (
   `timestamp` int(11) unsigned NOT NULL,
   PRIMARY KEY (`code`),
   KEY `timestamp` (`timestamp`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- user sessions
 CREATE TABLE `prefix_users_sessions` (
@@ -312,4 +307,4 @@ CREATE TABLE `prefix_users_sessions` (
   `data` mediumblob,
   PRIMARY KEY (`session`),
   KEY `ts` (`ts`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/languages/en.php
+++ b/languages/en.php
@@ -800,7 +800,8 @@ To go to the site, click here:
 	'admin:statistics:label:admins'=>"Admins",
 	'admin:statistics:label:version' => "Elgg version",
 	'admin:statistics:label:version:release' => "Release",
-	'admin:statistics:label:version:version' => "Version",
+	'admin:statistics:label:version:version' => "Database Version",
+	'admin:statistics:label:version:code' => "Code Version",
 
 	'admin:server:label:php' => 'PHP',
 	'admin:server:label:web_server' => 'Web Server',

--- a/mod/search/search_hooks.php
+++ b/mod/search/search_hooks.php
@@ -117,7 +117,7 @@ function search_groups_hook($hook, $type, $value, $params) {
  * Get users that match the search parameters.
  *
  * Searches on username, display name, and profile fields
- * 
+ *
  * @param string $hook   Hook name
  * @param string $type   Hook type
  * @param array  $value  Empty array
@@ -138,7 +138,7 @@ function search_users_hook($hook, $type, $value, $params) {
 		
 	// username and display name
 	$fields = array('username', 'name');
-	$where = search_get_where_sql('ue', $fields, $params, FALSE);
+	$where = search_get_where_sql('ue', $fields, $params);
 
 	// profile fields
 	$profile_fields = array_keys(elgg_get_config('profile_fields'));
@@ -162,8 +162,6 @@ function search_users_hook($hook, $type, $value, $params) {
 		));
 	
 		$params['joins'] = array_merge($clauses['joins'], $params['joins']);
-		// no fulltext index, can't disable fulltext search in this function.
-		// $md_where .= " AND " . search_get_where_sql('msv', array('string'), $params, FALSE);
 		$md_where = "(({$clauses['wheres'][0]}) AND msv.string LIKE '%$query%')";
 		
 		$params['wheres'][] = "(($where) OR ($md_where))";

--- a/mod/search/views/default/search/list.php
+++ b/mod/search/views/default/search/list.php
@@ -59,9 +59,8 @@ $type_str = NULL;
 
 if (array_key_exists('type', $vars['params']) && array_key_exists('subtype', $vars['params'])) {
 	$type_str_tmp = "item:{$vars['params']['type']}:{$vars['params']['subtype']}";
-	$type_str_echoed = elgg_echo($type_str_tmp);
-	if ($type_str_echoed != $type_str_tmp) {
-		$type_str = $type_str_echoed;
+	if (elgg_language_key_exists($type_str_tmp)) {
+		$type_str = elgg_echo($type_str_tmp);
 	}
 }
 
@@ -74,11 +73,9 @@ if (!$type_str) {
 }
 
 // allow overrides for titles
-$search_type_str = elgg_echo("search_types:{$vars['params']['search_type']}");
-if (array_key_exists('search_type', $vars['params'])
-	&& $search_type_str != "search_types:{$vars['params']['search_type']}") {
-
-	$type_str = $search_type_str;
+$search_type = elgg_extract('search_type', $vars['params']);
+if ($search_type && elgg_language_key_exists("search_types:{$search_type}")) {
+	$type_str = elgg_echo("search_types:{$search_type}");
 }
 
 if ($show_more) {

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2016102500;
+$version = 2016102600;
 
 $composerJson = file_get_contents(dirname(__FILE__) . "/composer.json");
 if ($composerJson === false) {

--- a/views/default/admin/statistics/overview/basic.php
+++ b/views/default/admin/statistics/overview/basic.php
@@ -4,13 +4,20 @@ $users_stats = get_number_users();
 $total_users = get_number_users(true);
 
 // Get version information
-$version = elgg_get_version();
+$code_version = elgg_get_version();
 $release = elgg_get_version(true);
+
+$db_version = elgg_get_config('version', null);
+
+$version_info = elgg_echo('admin:statistics:label:version:release') . ' - ' . $release . ', ';
+$version_info .= elgg_echo('admin:statistics:label:version:version') . ' - ' . $db_version . ', ';
+$version_info .= elgg_echo('admin:statistics:label:version:code') . ' - ' . $code_version;
+
 ?>
 <table class="elgg-table-alt">
 	<tr>
 		<td><b><?php echo elgg_echo('admin:statistics:label:version'); ?> :</b></td>
-		<td><?php echo elgg_echo('admin:statistics:label:version:release'); ?> - <?php echo $release; ?>, <?php echo elgg_echo('admin:statistics:label:version:version'); ?> - <?php echo $version; ?></td>
+		<td><?php echo $version_info; ?></td>
 	</tr>
 	<tr>
 		<td><b><?php echo elgg_echo('admin:statistics:label:numusers'); ?> :</b></td>


### PR DESCRIPTION
chore(db): changed db storage engine to InnoDB

fixes #4993

BREAKING CHANGE:
To be able to still provide support for MySQL 5.5 combined with InnoDB
the FULLTEXT indices have been dropped. This effects how search works
internally.

Mysql info about transferring from MyISAM to InnoDB: http://dev.mysql.com/doc/refman/5.7/en/converting-tables-to-innodb.html
