### PR TITLE
fix(entity): fix discussion_reply with logic check

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1526,7 +1526,7 @@ abstract class ElggEntity extends \ElggData implements
 
 			// If different owner than logged in, verify can write to container.
 
-			if ($user_guid != $owner_guid && !$owner->canWriteToContainer(0, $type, $subtype)) {
+			if ($user_guid != $owner_guid && !$owner->canWriteToContainer(0)) {
 				_elgg_services()->logger->error("User $user_guid tried to create a ($type, $subtype) with owner"
 					. " $owner_guid, but the user wasn't permitted to write to the owner's container.");
 				return false;


### PR DESCRIPTION
An issue where if you'd like to save a object with subtype `discussion_reply`, the object isn't being saved. This because the type and subtype passed to the `canWriteToContainer`-method are `object` and `discussion_reply`, but the container checking is an `ElggUser`, which doesn't match the required logic_check in the discussions [start.php](https://github.com/Elgg/Elgg/blob/2836fe14d22a96e255cbed551ae368326a1454e7/mod/discussions/start.php#L453-L460).
