### PR TITLE
fix(groups): multiple membership requests don't trigger messages

### DIFF
--- a/mod/groups/actions/groups/membership/join.php
+++ b/mod/groups/actions/groups/membership/join.php
@@ -43,6 +43,8 @@ if ($user && ($group instanceof ElggGroup)) {
 		} else {
 			register_error(elgg_echo("groups:cantjoin"));
 		}
+	} elseif (check_entity_relationship($user->guid, 'membership_request', $group->guid)) {
+		register_error(elgg_echo("groups:joinrequest:exists"));
 	} else {
 		add_entity_relationship($user->guid, 'membership_request', $group->guid);
 

--- a/mod/groups/languages/en.php
+++ b/mod/groups/languages/en.php
@@ -132,6 +132,7 @@ return array(
 	'groups:addedtogroup' => 'Successfully added the user to the group',
 	'groups:joinrequestnotmade' => 'Could not request to join group',
 	'groups:joinrequestmade' => 'Requested to join group',
+	'groups:joinrequest:exists' => 'You already requested membership for this group',
 	'groups:joined' => 'Successfully joined group!',
 	'groups:left' => 'Successfully left group',
 	'groups:notowner' => 'Sorry, you are not the owner of this group.',


### PR DESCRIPTION
When a user clicked on the 'request membership' button for closed
groups, each requests was handled as a new request. The group admin got
a notification about each new request.
Now the user gets a notification that a request was already made.

fixes: #8901
