### PR TITLE
feat(core): elgg_require_js has extra parameter to allow inline require

### DIFF
--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -225,12 +225,17 @@ function elgg_load_js($name) {
 /**
  * Request that Elgg load an AMD module onto the page.
  *
- * @param string $name The AMD module name.
+ * @param string $name   The AMD module name.
+ * @param bool   $inline If true the module will be echoed inline if in XHR
  * @return void
  * @since 1.9.0
  */
-function elgg_require_js($name) {
-	_elgg_services()->amdConfig->addDependency($name);
+function elgg_require_js($name, $inline = false) {
+	if ($inline && elgg_is_xhr()) {
+		echo elgg_format_element('script', [], "require(['{$name}'])");
+	} else {
+		_elgg_services()->amdConfig->addDependency($name);
+	}
 }
 
 /**

--- a/views/default/page/components/tabs.php
+++ b/views/default/page/components/tabs.php
@@ -86,8 +86,4 @@ $module = elgg_extract('module', $vars, 'tabs');
 unset($vars['module']);
 echo elgg_view_module($module, $tabs, $content, $vars);
 
-?>
-<script>
-	require(['page/components/tabs']);
-</script>
-
+elgg_require_js('page/components/tabs', true);

--- a/views/default/page/layouts/widgets/add_button.php
+++ b/views/default/page/layouts/widgets/add_button.php
@@ -25,7 +25,6 @@ echo elgg_view_menu('title:widgets', [
 				'maxWidth' => '900px',
 				'maxHeight' => '90%',
 			]),
-			'deps' => 'resources/widgets/add_panel',
 		],
 	],
 	'class' => 'elgg-menu-hz',

--- a/views/default/resources/widgets/add_panel.php
+++ b/views/default/resources/widgets/add_panel.php
@@ -7,6 +7,8 @@
  * @uses $vars['owner_guid']  Container limit widgets for
  */
 
+elgg_require_js('resources/widgets/add_panel', true);
+
 $context = elgg_extract('context', $vars);
 $exact = elgg_extract('exact_match', $vars);
 $owner_guid = (int) elgg_extract('owner_guid', $vars);


### PR DESCRIPTION
Ref #7784

This removes the need for stuff like this in views:
```php
?>
<script>
    require(['js/to/require']);
</script>
<?php
```