### PR TITLE
chore(groups): removed magic group->username for pagehandling

### DIFF
--- a/docs/design/database.rst
+++ b/docs/design/database.rst
@@ -228,15 +228,6 @@ your new element (defaulting to the current user's container):
     $container = get_entity($container_guid);
     forward($container->getURL());
 
-Usernames and page ownership
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Groups have a simulated username of the form *group:\ GUID*, which you
-can get the value of by checking ``$group->username``. If you pass this
-username to a page on the URL line as part of the ``username`` variable
-(i.e., ``/yourpage?username=group:nnn``), Elgg will automatically
-register that group as being the owner of the page (unless overridden).
-
 Juggling users and groups
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -253,6 +253,8 @@ Miscellaneous API changes
  * ``Application::getDb()`` no longer returns an instance of ``Elgg\Database``, but rather a ``Elgg\Application\Database``
  * ``$CONFIG`` is no longer available as a local variable inside plugin ``start.php`` files.
  * ``elgg_get_config('siteemail')`` is no longer available. Use ``elgg_get_site_entity()->email``.
+ * Group entities do no longer have the magic ``username`` attribute.
+ * Pagehandling will no longer detect ``group:<guid>`` in the URL
  * The CRON interval ``reboot`` is removed.
  * The URL endpoints ``js/`` and ``css/`` are no longer supported. Use ``elgg_get_simplecache_url()``.
  * The generic comment save action no longer sends the notification directly, this has been offloaded to the notification system.

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -103,23 +103,6 @@ class ElggGroup extends \ElggEntity {
 	}
 
 	/**
-	 * Wrapper around \ElggEntity::__get()
-	 *
-	 * @see \ElggEntity::__get()
-	 *
-	 * @param string $name Name
-	 * @return mixed
-	 * @todo deprecate appending group to username. Was a hack used for creating
-	 * URLs for group content. We stopped using the hack in 1.8.
-	 */
-	public function __get($name) {
-		if ($name == 'username') {
-			return 'group:' . $this->getGUID();
-		}
-		return parent::__get($name);
-	}
-
-	/**
 	 * Get an array of group members.
 	 *
 	 * @param array $options Options array. See elgg_get_entities_from_relationships

--- a/engine/lib/pageowner.php
+++ b/engine/lib/pageowner.php
@@ -107,21 +107,9 @@ function default_page_owner_handler($hook, $entity_type, $returnvalue, $params) 
 	$ia = elgg_set_ignore_access(true);
 
 	$username = get_input("username");
-	if ($username) {
-		// @todo using a username of group:<guid> is deprecated
-		if (substr_count($username, 'group:')) {
-			preg_match('/group\:([0-9]+)/i', $username, $matches);
-			$guid = $matches[1];
-			if ($entity = get_entity($guid)) {
-				elgg_set_ignore_access($ia);
-				return $entity->getGUID();
-			}
-		}
-
-		if ($user = get_user_by_username($username)) {
-			elgg_set_ignore_access($ia);
-			return $user->getGUID();
-		}
+	if ($user = get_user_by_username($username)) {
+		elgg_set_ignore_access($ia);
+		return $user->getGUID();
 	}
 
 	$owner = get_input("owner_guid");


### PR DESCRIPTION
BREAKING CHANGE:
If you were relying on group entities attribute 'username' you need to
update your code, as this attribute will no longer be magically returned
as 'group:<group_guid>'.