### PR TITLE
Drop member of site

### DIFF
--- a/docs/design/database.rst
+++ b/docs/design/database.rst
@@ -686,13 +686,13 @@ and/or related entities. A few are listed below:
 - ``elgg_get_entities_from_relationship()`` : fetch entities in relationships in a
   variety of ways
 
-E.g. retrieving users who joined your site in January 2014.
+E.g. retrieving users who joined your group in January 2014.
 
 .. code:: php
 
     $entities = elgg_get_entities_from_relationship(array(
-        'relationship' => 'member_of_site',
-        'relationship_guid' => elgg_get_site_entity()->guid,
+        'relationship' => 'member',
+        'relationship_guid' => $group->guid,
         'inverse_relationship' => true,
 
         'relationship_created_time_lower' => 1388534400, // January 1st 2014

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -143,7 +143,12 @@ The storage engine for the database tables has been changed from MyISAM to InnoD
 Multi Site Changes
 ------------------
 
-Related to the removal of the multisite concept in Elgg, there is no longer a need for entities having a 'member_of_site' relationship with the Site Entity.
+Pre 3.0 Elgg has some (partial) support for having multiple sites in the same database. This Multi Site concept has been completely removed in 3.0.
+Entities no longer have the site_guid attribute. This means there is no longer the ability to have entities on different sites.
+If you currently have multiple sites in your database, upgrading Elgg to 3.0 will fail. 
+You need to separate the different sites into separate databases/tables.
+
+Related to the removal of the Multi Site concept in Elgg, there is no longer a need for entities having a 'member_of_site' relationship with the Site Entity.
 All functions related to adding/removing this relationship has been removed. All existing relationships will be removed as part of this upgrade. 
 
 Search changes

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -76,6 +76,9 @@ All the functions in ``engine/lib/deprecated-1.10.php`` were removed. See https:
  * ``run_function_once``: Use ``Elgg\Upgrade\Batch`` interface
  * ``system_messages``
  * ``notifications_plugin_pagesetup``
+ * ``ElggEntity::addToSite``
+ * ``ElggEntity::getSites``
+ * ``ElggEntity::removeFromSite``
  * ``ElggFile::setFilestore``: ElggFile objects can no longer use custom filestores.
  * ``ElggFile::size``: Use ``getSize``
  * ``ElggDiskFilestore::makeFileMatrix``: Use ``Elgg\EntityDirLocator``
@@ -90,14 +93,17 @@ All the functions in ``engine/lib/deprecated-1.10.php`` were removed. See https:
  * ``ElggMenuItem::setWeight``: Use ``setPriority``
  * ``ElggRiverItem::getPostedTime``: Use ``getTimePosted``
  * ``ElggSession`` has removed all deprecated methods
- * ``ElggSite::addObject``: Use ``addEntity``
- * ``ElggSite::addUser``: Use ``addEntity``
+ * ``ElggSite::addEntity``
+ * ``ElggSite::addObject``
+ * ``ElggSite::addUser``
+ * ``ElggSite::getEntities``: Use ``elgg_get_entities_from_relationship()``
  * ``ElggSite::getExportableValues``: Use ``toObject``
- * ``ElggSite::getMembers``: Use ``getEntities``
- * ``ElggSite::getObjects``: Use ``getEntities``
+ * ``ElggSite::getMembers``: Use ``elgg_get_entities_from_relationship()``
+ * ``ElggSite::getObjects``: Use ``elgg_get_entities_from_relationship()``
  * ``ElggSite::listMembers``: Use ``elgg_list_entities_from_relationship()``
- * ``ElggSite::removeObject``: Use ``removeEntity``
- * ``ElggSite::removeUser``: Use ``removeEntity``
+ * ``ElggSite::removeEntity``
+ * ``ElggSite::removeObject``
+ * ``ElggSite::removeUser``
  * ``ElggUser::countObjects``: Use ``elgg_get_entities()``
  * ``Logger::getClassName``: Use ``get_class()``
  * ``Elgg\Application\Database::getTablePrefix``: Read the ``prefix`` property
@@ -133,6 +139,12 @@ Schema changes
 --------------
  
 The storage engine for the database tables has been changed from MyISAM to InnoDB. You maybe need to optimize your database settings for this change.
+
+Multi Site Changes
+------------------
+
+Related to the removal of the multisite concept in Elgg, there is no longer a need for entities having a 'member_of_site' relationship with the Site Entity.
+All functions related to adding/removing this relationship has been removed. All existing relationships will be removed as part of this upgrade. 
 
 Search changes
 --------------

--- a/engine/classes/Elgg/EventsService.php
+++ b/engine/classes/Elgg/EventsService.php
@@ -39,7 +39,7 @@ class EventsService extends \Elgg\HooksRegistrationService {
 	 * {@inheritdoc}
 	 */
 	public function registerHandler($name, $type, $callback, $priority = 500) {
-		if (in_array($type, ['member', 'friend', 'member_of_site', 'attached'])
+		if (in_array($type, ['member', 'friend', 'attached'])
 				&& in_array($name, ['create', 'update', 'delete'])) {
 			$this->logger->error("'$name, $type' event is no longer triggered. Update your event registration "
 				. "to use '$name, relationship'");

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1272,63 +1272,6 @@ abstract class ElggEntity extends \ElggData implements
 	}
 
 	/**
-	 * Add this entity to a site
-	 *
-	 * This creates a 'member_of_site' relationship.
-	 *
-	 * @param \ElggSite $site The site to add this entity to
-	 *
-	 * @return bool
-	 * @todo add \ElggSite type hint once we have removed addToSite() from \ElggUser
-	 * and \ElggObject
-	 */
-	public function addToSite($site) {
-		if (!elgg_instanceof($site, 'site')) {
-			return false;
-		}
-
-		return $site->addEntity($this);
-	}
-
-	/**
-	 * Remove this entity from a site
-	 *
-	 * This deletes the 'member_of_site' relationship.
-	 *
-	 * @param \ElggSite $site The site to remove this entity from
-	 *
-	 * @return bool
-	 * @todo add \ElggSite type hint once we have removed addToSite() from \ElggUser
-	 */
-	public function removeFromSite($site) {
-		if (!elgg_instanceof($site, 'site')) {
-			return false;
-		}
-
-		return $site->removeEntity($this);
-	}
-
-	/**
-	 * Gets the sites this entity is a member of
-	 *
-	 * Site membership is determined by relationship.
-	 *
-	 * @param array $options Options array for elgg_get_entities_from_relationship()
-	 *                       Parameters set automatically by this method:
-	 *                       'relationship', 'relationship_guid', 'inverse_relationship'
-	 *
-	 * @return array
-	 * @todo add type hint when \ElggUser and \ElggObject have been updates
-	 */
-	public function getSites($options = array()) {
-		$options['relationship'] = 'member_of_site';
-		$options['relationship_guid'] = $this->guid;
-		$options['inverse_relationship'] = false;
-
-		return elgg_get_entities_from_relationship($options);
-	}
-
-	/**
 	 * Tests to see whether the object has been persisted.
 	 *
 	 * @return bool

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -211,56 +211,6 @@ class ElggSite extends \ElggEntity {
 	}
 
 	/**
-	 * Adds an entity to the site.
-	 *
-	 * This adds a 'member_of_site' relationship between between the entity and
-	 * the site.
-	 *
-	 * @param \ElggEntity $entity User, group, or object entity
-	 *
-	 * @return bool
-	 */
-	public function addEntity(\ElggEntity $entity) {
-		if (elgg_instanceof($entity, 'site')) {
-			return false;
-		}
-		return add_entity_relationship($entity->guid, "member_of_site", $this->guid);
-	}
-
-	/**
-	 * Removes an entity from this site
-	 *
-	 * @param \ElggEntity $entity User, group, or object entity
-	 *
-	 * @return bool
-	 */
-	public function removeEntity($entity) {
-		if (elgg_instanceof($entity, 'site')) {
-			return false;
-		}
-		return remove_entity_relationship($entity->guid, "member_of_site", $this->guid);
-	}
-
-	/**
-	 * Get an array of entities that belong to the site.
-	 *
-	 * This only returns entities that have been explicitly added to the
-	 * site through addEntity().
-	 *
-	 * @param array $options Options array for elgg_get_entities_from_relationship()
-	 *                       Parameters set automatically by this method:
-	 *                       'relationship', 'relationship_guid', 'inverse_relationship'
-	 * @return array
-	 */
-	public function getEntities(array $options = array()) {
-		$options['relationship'] = 'member_of_site';
-		$options['relationship_guid'] = $this->guid;
-		$options['inverse_relationship'] = true;
-
-		return elgg_get_entities_from_relationship($options);
-	}
-
-	/**
 	 * {@inheritdoc}
 	 */
 	protected function prepareObject($object) {

--- a/engine/lib/upgrades/2016110400-3.0.0-remove_member_of_site-eefe9f305fa83188.php
+++ b/engine/lib/upgrades/2016110400-3.0.0-remove_member_of_site-eefe9f305fa83188.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Elgg 3.0.0 upgrade 2016110400
+ * remove_member_of_site
+ *
+ * Removes all member_of_site relationships in the relationships table
+ */
+
+$dbprefix = elgg_get_config('dbprefix');
+
+delete_data("DELETE FROM {$dbprefix}entity_relationships
+	WHERE relationship = 'member_of_site'");

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -452,20 +452,6 @@ function set_last_login($user_guid) {
 }
 
 /**
- * Creates a relationship between this site and the user.
- *
- * @param string   $event       create
- * @param string   $object_type user
- * @param \ElggUser $object      User object
- *
- * @return void
- * @access private
- */
-function user_create_hook_add_site_relationship($event, $object_type, $object) {
-	add_entity_relationship($object->getGUID(), 'member_of_site', elgg_get_site_entity()->guid);
-}
-
-/**
  * Set user avatar URL
  * Replaces user avatar URL with a public URL when walled garden is disabled
  *
@@ -991,8 +977,6 @@ function users_init() {
 	elgg_register_entity_type('user', '');
 
 	elgg_register_plugin_hook_handler('register', 'menu:entity', 'elgg_users_setup_entity_menu', 501);
-
-	elgg_register_event_handler('create', 'user', 'user_create_hook_add_site_relationship');
 
 	elgg_register_plugin_hook_handler('entity:icon:file', 'user', '_elgg_user_set_icon_file');
 	

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2016102600;
+$version = 2016110400;
 
 $composerJson = file_get_contents(dirname(__FILE__) . "/composer.json");
 if ($composerJson === false) {


### PR DESCRIPTION
chore(relationships): no longer use the 'member_of_site' relationship

BREAKING CHANGE:
Because of the removal of the multisite concept in entities, this
relationship makes no sense.

Fixes #10473