### PR TITLE
feat(groups): added generic ElggGroup functions for tool availability

### DIFF
--- a/docs/appendix/upgrade-notes/2.x-to-3.0.rst
+++ b/docs/appendix/upgrade-notes/2.x-to-3.0.rst
@@ -115,6 +115,7 @@ All the functions in ``engine/lib/deprecated-1.10.php`` were removed. See https:
  * ``get_user_entity_as_row``
  * ``garbagecollector_orphaned_metastrings``
  * ``groups_access_collection_override``
+ * ``groups_get_group_tool_options``: Use ``elgg_get_group_tool_options``
  * ``groups_join_group``: Use ``ElggGroup::join``
  * ``groups_setup_sidebar_menus``
  * ``groups_set_icon_url``

--- a/docs/guides/authentication.rst
+++ b/docs/guides/authentication.rst
@@ -42,6 +42,8 @@ The returned object is an ``ElggUser`` so you can use all the methods and proper
 of that class to access information about the user. If the user is not logged in,
 this will return ``null``, so be sure to check for that first.
 
+.. _authentication-gatekeepers:
+
 Gatekeepers
 -----------
 

--- a/docs/guides/group-tools.rst
+++ b/docs/guides/group-tools.rst
@@ -1,0 +1,33 @@
+Group Tools
+===========
+
+In Elgg groups have a feature where you can enable or disable different tools for a group. These tools are provided by other plugins like blog or file.
+
+Plugins need to tell Elgg that these tools exist. This can be done by using the ``add_group_tool_option`` function.
+If an existing tool option needs to be removed you can use ``remove_group_tool_option``.
+
+On a group edit form you can turn the tools on or off for the specific group. You can also do so programmatically as shown in the code example below. 
+
+.. code-block:: php
+	
+	$group = get_entity($group_guid);
+	
+	// enables the file tool for the group
+	$group->enableTool('file');
+	
+	// disables the file tool for the group
+	$group->disableTool('file');
+
+If you want to allow a certain feature in a group only if the group tool option is enabled, you can check this using ``\ElggGroup::isToolEnabled($tool_option)``.
+
+It is also a possibility to use a gatekeeper function to prevent access to a group page based on an enabled tool.
+
+.. code-block:: php
+
+	elgg_group_tool_gatekeeper('file', $group);
+
+.. seealso::
+
+	Read more about gatekeepers here: :ref:`authentication-gatekeepers`
+
+If you need the configured group tool options for a specific group you can use the ``elgg_get_group_tool_options($group)`` function.

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -17,6 +17,7 @@ Customize Elgg's behavior with plugins.
    database
    file-system
    actions
+   group-tools
    helpers
    i18n
    javascript

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * A group entity, used as a container for other entities.
  *
@@ -215,6 +214,92 @@ class ElggGroup extends \ElggEntity {
 	 * @since 1.8.0
 	 */
 	public function canComment($user_guid = 0, $default = null) {
+		return false;
+	}
+	
+	/**
+	 * Checks if a tool option is enabled
+	 *
+	 * @param string $option The option to check
+	 * @return bool
+	 * @since 3.0.0
+	 */
+	public function isToolEnabled($option) {
+		if (empty($option)) {
+			return false;
+		}
+		
+		$setting = $this->{"{$option}_enable"};
+		if ($setting === 'no') {
+			return false;
+		}
+		
+		$tool_config = $this->getToolConfig($option);
+		if (!$tool_config) {
+			return false;
+		}
+		
+		if ($setting !== null) {
+			return (bool) ($setting == 'yes');
+		}
+		
+		// check default setting
+		return (bool) $tool_config->default_on;
+	}
+	
+	/**
+	 * Enables a tool option
+	 *
+	 * @param string $option The option to enable
+	 * @return bool
+	 * @since 3.0.0
+	 */
+	public function enableTool($option) {
+		if (!$this->getToolConfig($option)) {
+			return false;
+		}
+		
+		$this->{"{$option}_enable"} = 'yes';
+		return true;
+	}
+	
+	/**
+	 * Disables a tool option
+	 *
+	 * @param string $option The option to disable
+	 * @return bool
+	 * @since 3.0.0
+	 */
+	public function disableTool($option) {
+		if (!$this->getToolConfig($option)) {
+			return false;
+		}
+		
+		$this->{"{$option}_enable"} = 'no';
+		return true;
+	}
+	
+	/**
+	 * Returns the registered tool configuration
+	 *
+	 * @param string $option The tool option to get the config for
+	 * @return stdClass|false Returns the config object or false if it does not exists
+	 */
+	protected function getToolConfig($option) {
+		if (empty($option)) {
+			return false;
+		}
+		
+		$group_tool_options = (array) elgg_get_group_tool_options($this);
+		
+		foreach ($group_tool_options as $config) {
+			if ($config->name !== $option) {
+				continue;
+			}
+			
+			return $config;
+		}
+		
 		return false;
 	}
 }

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGroupToolTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGroupToolTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Elgg\Integration;
+
+use ElggGroup;
+use Elgg\IntegrationTestCase;
+
+/**
+ * Elgg Test \ElggGroup
+ *
+ * @group IntegrationTests
+ * @subpackage Test
+ */
+class ElggCoreGroupToolTest extends IntegrationTestCase {
+	/**
+	 * @var ElggGroup
+	 */
+	protected $group;
+
+	/**
+	 * @var \ElggUser
+	 */
+	protected $user;
+
+	public function up() {
+		$this->group = $this->createGroup();
+	}
+
+	public function down() {
+		$this->group->delete();
+	}
+	
+	public function testToolRegistration() {
+		add_group_tool_option('test_option', 'test_label');
+		
+		$this->assertArrayHasKey('test_option', elgg_get_group_tool_options());
+		
+		remove_group_tool_option('test_option');
+		
+		$this->assertArrayNotHasKey('test_option', elgg_get_group_tool_options());
+	}
+	
+	public function testCanSaveGroupToolAvailability() {
+		$this->assertNull($this->group->test_option_enable);
+		$this->assertFalse($this->group->enableTool('test_option'));
+		$this->assertFalse($this->group->disableTool('test_option'));
+		
+		add_group_tool_option('test_option', 'test_label');
+		
+		$this->assertTrue($this->group->enableTool('test_option'));
+		$this->assertEquals('yes', $this->group->test_option_enable);
+		
+		$this->assertTrue($this->group->disableTool('test_option'));
+		$this->assertEquals('no', $this->group->test_option_enable);
+	}
+	
+	public function testCanCheckGroupToolAvailability() {
+		$this->assertFalse($this->group->isToolEnabled(''));
+		$this->assertFalse($this->group->isToolEnabled('test_option'));
+		
+		add_group_tool_option('test_option', 'test_label');
+		$this->assertTrue($this->group->isToolEnabled('test_option'));
+		
+		$this->assertTrue($this->group->disableTool('test_option'));
+		$this->assertFalse($this->group->isToolEnabled('test_option'));
+		
+		$this->assertTrue($this->group->enableTool('test_option'));
+		$this->assertTrue($this->group->isToolEnabled('test_option'));
+	}
+}

--- a/languages/en.php
+++ b/languages/en.php
@@ -231,6 +231,7 @@ return array(
 
 	'group' => "Group",
 	'item:group' => "Groups",
+	'groups:tool_gatekeeper' => "The requested functionality is currently not enabled in this group",
 
 /**
  * Users

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -176,7 +176,7 @@ function blog_owner_block_menu($hook, $type, $return, $params) {
 			'href' => "blog/owner/{$entity->username}",
 		]);
 	} elseif ($entity instanceof ElggGroup) {
-		if ($entity->blog_enable != 'no') {
+		if ($entity->isToolEnabled('blog')) {
 			$return[] = ElggMenuItem::factory([
 				'name' => 'blog',
 				'text' => elgg_echo('blog:group'),

--- a/mod/blog/views/default/blog/group_module.php
+++ b/mod/blog/views/default/blog/group_module.php
@@ -3,10 +3,13 @@
  * Group blog module
  */
 
-$group = elgg_get_page_owner_entity();
+$group = elgg_extract('entity', $vars);
+if (!($group instanceof \ElggGroup)) {
+	return;
+}
 
-if ($group->blog_enable == "no") {
-	return true;
+if (!$group->isToolEnabled('blog')) {
+	return;
 }
 
 $all_link = elgg_view('output/url', [

--- a/mod/bookmarks/start.php
+++ b/mod/bookmarks/start.php
@@ -154,7 +154,7 @@ function bookmark_set_url($hook, $type, $url, $params) {
  * @return ElggMenuItem[]
  */
 function bookmarks_owner_block_menu($hook, $type, $return, $params) {
-	
+
 	$entity = elgg_extract('entity', $params);
 	
 	if ($entity instanceof ElggUser) {
@@ -162,13 +162,13 @@ function bookmarks_owner_block_menu($hook, $type, $return, $params) {
 		$item = new ElggMenuItem('bookmarks', elgg_echo('bookmarks'), $url);
 		$return[] = $item;
 	} elseif ($entity instanceof ElggGroup) {
-		if ($entity->bookmarks_enable != 'no') {
+		if ($entity->isToolEnabled('bookmarks')) {
 			$url = "bookmarks/group/{$entity->guid}/all";
 			$item = new ElggMenuItem('bookmarks', elgg_echo('bookmarks:group'), $url);
 			$return[] = $item;
 		}
 	}
-
+	
 	return $return;
 }
 

--- a/mod/bookmarks/views/default/bookmarks/group_module.php
+++ b/mod/bookmarks/views/default/bookmarks/group_module.php
@@ -5,10 +5,13 @@
  * @package Bookmarks
  */
 
-$group = elgg_get_page_owner_entity();
+$group = elgg_extract('entity', $vars);
+if (!($group instanceof \ElggGroup)) {
+	return;
+}
 
-if ($group->bookmarks_enable == "no") {
-	return true;
+if (!$group->isToolEnabled('bookmarks')) {
+	return;
 }
 
 $all_link = elgg_view('output/url', [

--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -260,7 +260,7 @@ function discussion_owner_block_menu($hook, $type, $return, $params) {
 		return;
 	}
 	
-	if ($entity->forum_enable === 'no') {
+	if (!$entity->isToolEnabled('forum')) {
 		return;
 	}
 	

--- a/mod/discussions/views/default/discussion/group_module.php
+++ b/mod/discussions/views/default/discussion/group_module.php
@@ -5,11 +5,14 @@
  * @uses $vars['entity']
  */
 
-if ($vars['entity']->forum_enable == 'no') {
-	return true;
+$group = elgg_extract('entity', $vars);
+if (!($group instanceof \ElggGroup)) {
+	return;
 }
 
-$group = $vars['entity'];
+if (!$group->isToolEnabled('forum')) {
+	return;
+}
 
 $all_link = elgg_view('output/url', [
 	'href' => "discussion/owner/$group->guid",

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -215,20 +215,20 @@ function file_prepare_notification($hook, $type, $notification, $params) {
  * @return ElggMenuItem[]
  */
 function file_owner_block_menu($hook, $type, $return, $params) {
-	
+
 	$entity = elgg_extract('entity', $params);
 	if ($entity instanceof ElggUser) {
 		$url = "file/owner/{$entity->username}";
 		$item = new ElggMenuItem('file', elgg_echo('file'), $url);
 		$return[] = $item;
 	} elseif ($entity instanceof ElggGroup) {
-		if ($entity->file_enable != "no") {
+		if ($entity->isToolEnabled('file')) {
 			$url = "file/group/{$entity->guid}/all";
 			$item = new ElggMenuItem('file', elgg_echo('file:group'), $url);
 			$return[] = $item;
 		}
 	}
-
+	
 	return $return;
 }
 

--- a/mod/file/views/default/file/group_module.php
+++ b/mod/file/views/default/file/group_module.php
@@ -3,10 +3,13 @@
  * Group file module
  */
 
-$group = elgg_get_page_owner_entity();
+$group = elgg_extract('entity', $vars);
+if (!($group instanceof \ElggGroup)) {
+	return;
+}
 
-if ($group->file_enable == "no") {
-	return true;
+if (!$group->isToolEnabled('file')) {
+	return;
 }
 
 $all_link = elgg_view('output/url', [

--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -92,19 +92,20 @@ if (!$group->name) {
 
 // Set group tool options (only pass along saved entities)
 $tool_entity = !$is_new_group ? $group : null;
-$tool_options = groups_get_group_tool_options($tool_entity);
+$tool_options = elgg_get_group_tool_options($tool_entity);
 if ($tool_options) {
 	foreach ($tool_options as $group_option) {
 		$option_toggle_name = $group_option->name . "_enable";
-		$option_default = $group_option->default_on ? 'yes' : 'no';
 		$value = get_input($option_toggle_name);
-
-		// if already has option set, don't change if no submission
-		if ($group->$option_toggle_name && $value === null) {
+		if ($value === null) {
 			continue;
 		}
-
-		$group->$option_toggle_name = $value ? $value : $option_default;
+		
+		if ($value === 'yes') {
+			$group->enableTool($group_option->name);
+		} else {
+			$group->disableTool($group_option->name);
+		}
 	}
 }
 

--- a/mod/groups/lib/groups.php
+++ b/mod/groups/lib/groups.php
@@ -50,14 +50,6 @@ function groups_prepare_form_vars($group = null) {
 		}
 	}
 
-	// handle tool options
-	$entity = ($group instanceof \ElggGroup) ? $group : null;
-	$tools = groups_get_group_tool_options($entity);
-	foreach ($tools as $group_option) {
-		$option_name = $group_option->name . "_enable";
-		$values[$option_name] = $group_option->default_on ? 'yes' : 'no';
-	}
-
 	// get current group settings
 	if ($group) {
 		foreach (array_keys($values) as $field) {
@@ -79,7 +71,20 @@ function groups_prepare_form_vars($group = null) {
 
 		$values['entity'] = $group;
 	}
-
+	
+	// handle tool options
+	$entity = ($group instanceof \ElggGroup) ? $group : null;
+	$tools = elgg_get_group_tool_options($entity);
+	foreach ($tools as $group_option) {
+		$option_name = $group_option->name . "_enable";
+		
+		$enabled = $group_option->default_on;
+		if ($entity) {
+			$enabled = $entity->isToolEnabled($group_option->name);
+		}
+		$values[$option_name] = $enabled ? 'yes' : 'no';
+	}
+	
 	// get any sticky form settings
 	if (elgg_is_sticky_form('groups')) {
 		$sticky_values = elgg_get_sticky_values('groups');
@@ -91,23 +96,4 @@ function groups_prepare_form_vars($group = null) {
 	elgg_clear_sticky_form('groups');
 
 	return $values;
-}
-
-/**
- * Function to return available group tool options
- *
- * @param \ElggGroup $group optional group
- *
- * @return array
- */
-function groups_get_group_tool_options(\ElggGroup $group = null) {
-	
-	$tool_options = elgg_get_config('group_tool_options');
-	
-	$hook_params = [
-		'group_tool_options' => $tool_options,
-		'entity' => $group,
-	];
-		
-	return (array) elgg_trigger_plugin_hook('tool_options', 'group', $hook_params, $tool_options);
 }

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -351,7 +351,7 @@ function groups_activity_owner_block_menu($hook, $type, $return, $params) {
 		return;
 	}
 	
-	if ($entity->activity_enable === "no") {
+	if (!$entity->isToolEnabled('activity')) {
 		return;
 	}
 	

--- a/mod/groups/views/default/groups/edit/tools.php
+++ b/mod/groups/views/default/groups/edit/tools.php
@@ -8,7 +8,7 @@
  * @package ElggGroups
  */
 
-$tools = groups_get_group_tool_options(elgg_extract('entity', $vars));
+$tools = elgg_get_group_tool_options(elgg_extract('entity', $vars));
 if (empty($tools)) {
 	return;
 }

--- a/mod/groups/views/default/groups/profile/activity_module.php
+++ b/mod/groups/views/default/groups/profile/activity_module.php
@@ -12,7 +12,7 @@ if (!($group instanceof \ElggGroup)) {
 	return;
 }
 
-if ($group->activity_enable == 'no') {
+if (!$group->isToolEnabled('activity')) {
 	return;
 }
 

--- a/mod/groups/views/default/resources/groups/activity.php
+++ b/mod/groups/views/default/resources/groups/activity.php
@@ -9,10 +9,11 @@ elgg_group_gatekeeper();
 
 $group = get_entity($guid);
 
-if (elgg_get_plugin_setting('allow_activity', 'groups') === 'no'
-		|| $group->activity_enable !== 'yes') {
+if (elgg_get_plugin_setting('allow_activity', 'groups') === 'no') {
 	forward($group->getURL(), '404');
 }
+
+elgg_group_tool_gatekeeper('activity');
 
 $title = elgg_echo('groups:activity');
 

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -213,7 +213,7 @@ function pages_owner_block_menu($hook, $type, $return, $params) {
 		$item = new ElggMenuItem('pages', elgg_echo('pages'), $url);
 		$return[] = $item;
 	} elseif ($entity instanceof ElggGroup) {
-		if ($entity->pages_enable != "no") {
+		if ($entity->isToolEnabled('pages')) {
 			$url = "pages/group/{$entity->guid}/all";
 			$item = new ElggMenuItem('pages', elgg_echo('pages:group'), $url);
 			$return[] = $item;

--- a/mod/pages/views/default/pages/group_module.php
+++ b/mod/pages/views/default/pages/group_module.php
@@ -3,8 +3,12 @@
  * Group pages
  */
 
-$group = elgg_get_page_owner_entity();
-if (!$group instanceof ElggGroup || $group->pages_enable === 'no') {
+$group = elgg_extract('entity', $vars);
+if (!($group instanceof \ElggGroup)) {
+	return;
+}
+
+if (!$group->isToolEnabled('pages')) {
 	return;
 }
 


### PR DESCRIPTION
BREAKING CHANGE:
The groups specific function 'groups_get_group_tool_options' has been
replaced with the generic 'elgg_get_group_tool_options' function.

- [x] write something about this feature in docs
- [x] add test for new class functions