### PR TITLE
chore(ckeditor): assume that default editor state is visual

### DIFF
--- a/mod/ckeditor/views/default/elgg/ckeditor.js
+++ b/mod/ckeditor/views/default/elgg/ckeditor.js
@@ -163,7 +163,7 @@ define(function (require) {
 				$(textarea).data('toggler', $toggler);
 			}
 
-			if (!visual) {
+			if (visual === false) {
 				$toggler.html(elgg.echo('ckeditor:visual'));
 			}
 


### PR DESCRIPTION
Now assumes that all editors are visual by default.

Fixes #10528