### PR TITLE
Adds multiple editor configs

### DIFF
--- a/mod/bookmarks/views/default/forms/bookmarks/save.php
+++ b/mod/bookmarks/views/default/forms/bookmarks/save.php
@@ -13,26 +13,27 @@ $fields = [
 		'#label' => elgg_echo('title'),
 		'#type' => 'text',
 		'name' => 'title',
-		'value' => elgg_extract('title', $vars),		
+		'value' => elgg_extract('title', $vars),
 	],
 	[
 		'#label' => elgg_echo('bookmarks:address'),
 		'#type' => 'text',
 		'name' => 'address',
-		'value' => elgg_extract('address', $vars),		
+		'value' => elgg_extract('address', $vars),
 	],
 	[
 		'#label' => elgg_echo('description'),
 		'#type' => 'longtext',
 		'name' => 'description',
-		'value' => elgg_extract('description', $vars),		
+		'value' => elgg_extract('description', $vars),
+		'editor_type' => 'simple',
 	],
 	[
 		'#label' => elgg_echo('tags'),
 		'#type' => 'tags',
 		'name' => 'tags',
 		'id' => 'blog_tags',
-		'value' => elgg_extract('tags', $vars),		
+		'value' => elgg_extract('tags', $vars),
 	],
 	$categories_vars,
 	[
@@ -42,17 +43,17 @@ $fields = [
 		'value' => elgg_extract('access_id', $vars, ACCESS_DEFAULT),
 		'entity' => get_entity(elgg_extract('guid', $vars)),
 		'entity_type' => 'object',
-		'entity_subtype' => 'bookmarks',	
+		'entity_subtype' => 'bookmarks',
 	],
 	[
 		'#type' => 'hidden',
 		'name' => 'container_guid',
-		'value' => elgg_extract('container_guid', $vars),		
+		'value' => elgg_extract('container_guid', $vars),
 	],
 	[
 		'#type' => 'hidden',
 		'name' => 'guid',
-		'value' => elgg_extract('guid', $vars),		
+		'value' => elgg_extract('guid', $vars),
 	],
 ];
 

--- a/mod/ckeditor/start.php
+++ b/mod/ckeditor/start.php
@@ -29,6 +29,7 @@ function ckeditor_init() {
 	elgg_extend_view('input/longtext', 'ckeditor/init');
 
 	elgg_register_plugin_hook_handler('register', 'menu:longtext', 'ckeditor_longtext_menu');
+	elgg_register_plugin_hook_handler('view_vars', 'input/longtext', 'ckeditor_longtext_id');
 }
 
 function ckeditor_longtext_menu($hook, $type, $items, $vars) {
@@ -44,6 +45,20 @@ function ckeditor_longtext_menu($hook, $type, $items, $vars) {
 		'href' => "#{$id}",
 		'text' => elgg_echo('ckeditor:html'),
 	));
+
+	return $items;
+}
+
+function ckeditor_longtext_id($hook, $type, $items, $vars) {
+
+	$id = elgg_extract('id', $items);
+	if ($id !== null) {
+		return;
+	}
+	
+	// input/longtext view vars need to contain an id for editors to be initialized
+	// random id generator is the same as in input/longtext
+	$items['id'] = 'elgg-input-' . base_convert(mt_rand(), 10, 36);
 
 	return $items;
 }

--- a/mod/ckeditor/views/default/ckeditor/init.php
+++ b/mod/ckeditor/views/default/ckeditor/init.php
@@ -1,15 +1,31 @@
 <?php
 /**
  * Initialize the CKEditor script
- * 
+ *
  * Doing this inline enables the editor to initialize textareas loaded through ajax
  */
+
+// someone does not want the editor enabled for this field
 if (!elgg_extract('editor', $vars, true)) {
 	return;
 }
+
+$id = elgg_extract('id', $vars);
+if (!$id) {
+	return;
+}
+
+$editor_type = elgg_extract('editor_type', $vars); // eg simple
+
+// editor_type
+$config = 'elgg/ckeditor/config';
+if ($editor_type && elgg_view_exists("elgg/ckeditor/config/{$editor_type}.js")) {
+	$config = "elgg/ckeditor/config/{$editor_type}";
+}
+
 ?>
 <script>
 	require(['elgg/ckeditor'], function (elggCKEditor) {
-		elggCKEditor.bind('.elgg-input-longtext');
+		elggCKEditor.bind('#<?php echo $id; ?>', '<?php echo $config; ?>');
 	});
 </script>

--- a/mod/ckeditor/views/default/elgg/ckeditor.js
+++ b/mod/ckeditor/views/default/elgg/ckeditor.js
@@ -13,42 +13,53 @@
 define(function (require) {
 	var elgg = require('elgg');
 	require('elgg/init');
+
 	var $ = require('jquery');
 	require('jquery.ckeditor');
+
 	var CKEDITOR = require('ckeditor');
-	var config = require('elgg/ckeditor/config');
 
 	var elggCKEditor = {
-		bind: function (selector) {
-			elggCKEditor.registerHandlers();
-			CKEDITOR = elgg.trigger_hook('prepare', 'ckeditor', null, CKEDITOR);
-			selector = selector || '.elgg-input-longtext';
-			if ($(selector).length === 0) {
-				return;
+		bind: function (selector, editor_config) {
+			var default_config = 'elgg/ckeditor/config';			
+			
+			if (typeof editor_config === undefined) {
+				editor_config = default_config;
 			}
-			$(selector).not('[data-cke-init]')
-					.attr('data-cke-init', true)
-					.each(function () {
-						var opts = $(this).data('editorOpts') || {};
 
-						if (opts.disabled) {
-							// Editor has been disabled
-							return;
-						}
-						delete opts.disabled;
-
-						var visual = opts.state !== 'html';
-						delete opts.state;
-
-						var config = $.extend({}, elggCKEditor.config, opts);
-						$(this).data('elggCKEeditorConfig', config);
-
-						if (!visual) {
-							elggCKEditor.init(this, visual);
-						} else {
-							$(this).ckeditor(elggCKEditor.init, config);
-						}
-					});
+			require([editor_config], function(config) {
+				elggCKEditor.config = config;
+				
+				elggCKEditor.registerHandlers();
+				CKEDITOR = elgg.trigger_hook('prepare', 'ckeditor', null, CKEDITOR);
+				selector = selector || '.elgg-input-longtext';
+				if ($(selector).length === 0) {
+					return;
+				}
+				$(selector).not('[data-cke-init]')
+						.attr('data-cke-init', true)
+						.each(function () {
+							var opts = $(this).data('editorOpts') || {};
+	
+							if (opts.disabled) {
+								// Editor has been disabled
+								return;
+							}
+							delete opts.disabled;
+	
+							var visual = opts.state !== 'html';
+							delete opts.state;
+	
+							var config = $.extend({}, elggCKEditor.config, opts);
+							$(this).data('elggCKEeditorConfig', config);
+	
+							if (!visual) {
+								elggCKEditor.init(this, visual);
+							} else {
+								$(this).ckeditor(elggCKEditor.init, config);
+							}
+						});
+			});
 		},
 
 		/**
@@ -205,17 +216,7 @@ define(function (require) {
 				}
 			});
 		},
-
-		/**
-		 * CKEditor configuration
-		 *
-		 * You can find configuration information here:
-		 * http://docs.ckeditor.com/#!/api/CKEDITOR.config
-		 */
-		config: config
 	};
-
-	elggCKEditor.bind('.elgg-input-longtext');
 
 	$(document).on('click', '.ckeditor-toggle-editor', elggCKEditor.toggleEditor);
 

--- a/mod/ckeditor/views/default/elgg/ckeditor/config/simple.js
+++ b/mod/ckeditor/views/default/elgg/ckeditor/config/simple.js
@@ -3,12 +3,12 @@ define(function(require) {
 	var elgg = require('elgg');
 	var $ = require('jquery');
 
-	return elgg.trigger_hook('config', 'ckeditor', {'editor': 'default'}, {
-		toolbar: [['Bold', 'Italic', 'Underline', 'Strike', 'RemoveFormat'], ['NumberedList', 'BulletedList', 'Undo', 'Redo', 'Link', 'Unlink', 'Image', 'Blockquote', 'Paste', 'PasteFromWord', 'Maximize']],
+	return elgg.trigger_hook('config', 'ckeditor', {'editor': 'simple'}, {
+		toolbar: [['Bold', 'Italic', 'Underline', 'Strike', 'RemoveFormat']],
 		removeButtons: 'Subscript,Superscript', // To have Underline back
 		allowedContent: true,
 		baseHref: elgg.get_site_url(),
-		removePlugins: 'liststyle,contextmenu,tabletools',
+		removePlugins: 'liststyle,contextmenu,tabletools,elementspath',
 		extraPlugins: 'blockimagepaste,autogrow',
 		defaultLanguage: 'en',
 		language: elgg.get_language(),

--- a/mod/developers/views/default/theme_sandbox/forms.php
+++ b/mod/developers/views/default/theme_sandbox/forms.php
@@ -235,6 +235,15 @@ $ipsum = elgg_view('developers/ipsum');
 		));
 
 		echo elgg_view_field(array(
+			'#type' => 'longtext',
+			'name' => 'f14c',
+			'id' => 'f14c',
+			'value' => $ipsum,
+			'editor_type' => 'simple',
+			'#label' => 'Long textarea input (.elgg-input-longtext) with the editor_type configured as "simple":',
+		));
+
+		echo elgg_view_field(array(
 			'#type' => 'number',
 			'name' => 'f15',
 			'id' => 'f15',

--- a/mod/discussions/views/default/forms/discussion/reply/save.php
+++ b/mod/discussions/views/default/forms/discussion/reply/save.php
@@ -39,6 +39,7 @@ echo elgg_view_field([
 	'name' => 'description',
 	'value' => $value,
 	'visual' => !$inline,
+	'editor_type' => 'simple',
 ]);
 
 $buttons = [

--- a/mod/discussions/views/default/forms/discussion/save.php
+++ b/mod/discussions/views/default/forms/discussion/save.php
@@ -26,6 +26,7 @@ $fields = [
 		'value' => $desc,
 		'#label' => elgg_echo('discussion:topic:description'),
 		'required' => true,
+		'editor_type' => 'simple',
 	],
 	[
 		'#type' => 'tags',

--- a/mod/file/views/default/forms/file/upload.php
+++ b/mod/file/views/default/forms/file/upload.php
@@ -5,7 +5,7 @@
  *
  * @package ElggFile
  */
-// once elgg_view stops throwing all sorts of junk into $vars, we can use 
+// once elgg_view stops throwing all sorts of junk into $vars, we can use
 $title = elgg_extract('title', $vars, '');
 $desc = elgg_extract('description', $vars, '');
 $tags = elgg_extract('tags', $vars, '');
@@ -56,6 +56,7 @@ $fields = [
 		'#label' => elgg_echo('description'),
 		'name' => 'description',
 		'value' => $desc,
+		'editor_type' => 'simple',
 	],
 	[
 		'#type' => 'tags',

--- a/mod/messages/views/default/forms/messages/process.php
+++ b/mod/messages/views/default/forms/messages/process.php
@@ -4,41 +4,42 @@
  *
  * Provides form body for mass deleting messages
  *
- * @uses $vars['list'] List of messages
- * 
+ * @uses $vars['list']   List of messages
+ * @uses $vars['folder'] The folder currently looking at
+ *
  */
 
-$messages = $vars['list'];
-if (!$messages) {
+$list = elgg_extract('list', $vars);
+if (!$list) {
 	echo elgg_echo('messages:nomessages');
 	return true;
 }
 
-echo '<div class="messages-container">';
-echo $messages;
-echo '</div>';
+echo "<div class='messages-container'>{$list}</div>";
 
-echo '<div class="elgg-foot messages-buttonbank">';
-
-echo elgg_view('input/submit', array(
+$footer = '<div class="messages-buttonbank">';
+$footer .= elgg_view('input/submit', [
+	'#type' => 'submit',
 	'value' => elgg_echo('delete'),
 	'name' => 'delete',
 	'class' => 'elgg-button-delete',
 	'title' => elgg_echo('deleteconfirm:plural'),
-	'data-confirm' => elgg_echo('deleteconfirm:plural')
-));
+	'data-confirm' => elgg_echo('deleteconfirm:plural'),
+]);
 
-if ($vars['folder'] == "inbox") {
-	echo elgg_view('input/submit', array(
+if (elgg_extract('folder', $vars) == 'inbox') {
+	$footer .= elgg_view('input/submit', [
 		'value' => elgg_echo('messages:markread'),
 		'name' => 'read',
-	));
+	]);
 }
 
-echo elgg_view('input/button', array(
+$footer .= elgg_view('input/button', [
 	'value' => elgg_echo('messages:toggle'),
 	'class' => 'elgg-button elgg-button-cancel',
 	'id' => 'messages-toggle',
-));
+]);
 
-echo '</div>';
+$footer .= '</div>';
+
+elgg_set_form_footer($footer);

--- a/mod/messages/views/default/forms/messages/process.php
+++ b/mod/messages/views/default/forms/messages/process.php
@@ -17,29 +17,35 @@ if (!$list) {
 
 echo "<div class='messages-container'>{$list}</div>";
 
-$footer = '<div class="messages-buttonbank">';
-$footer .= elgg_view('input/submit', [
+$buttons = [];
+$buttons[] = [
 	'#type' => 'submit',
 	'value' => elgg_echo('delete'),
 	'name' => 'delete',
 	'class' => 'elgg-button-delete',
 	'title' => elgg_echo('deleteconfirm:plural'),
 	'data-confirm' => elgg_echo('deleteconfirm:plural'),
-]);
+];
 
 if (elgg_extract('folder', $vars) == 'inbox') {
-	$footer .= elgg_view('input/submit', [
+	$buttons[] = [
+		'#type' => 'submit',
 		'value' => elgg_echo('messages:markread'),
 		'name' => 'read',
-	]);
+	];
 }
 
-$footer .= elgg_view('input/button', [
+$buttons[] = [
+	'#type' => 'button',
 	'value' => elgg_echo('messages:toggle'),
-	'class' => 'elgg-button elgg-button-cancel',
+	'class' => 'elgg-button-cancel',
 	'id' => 'messages-toggle',
-]);
+];
 
-$footer .= '</div>';
+$footer = elgg_view('input/fieldset', [
+	'align' => 'horizontal',
+	'justify' => 'right',
+	'fields' => $buttons,
+]);
 
 elgg_set_form_footer($footer);

--- a/mod/messages/views/default/forms/messages/reply.php
+++ b/mod/messages/views/default/forms/messages/reply.php
@@ -5,39 +5,50 @@
  * @uses $vars['message']
  */
 
+$message = elgg_extract('message', $vars);
+if (empty($message)) {
+	return;
+}
+
 // fix for RE: RE: RE: that builds on replies
 $reply_title = $vars['message']->title;
 if (strncmp($reply_title, "RE:", 3) != 0) {
 	$reply_title = "RE: " . $reply_title;
 }
 
-echo elgg_view('input/hidden', array(
-	'name' => 'recipients[]',
-	'value' => $vars['message']->fromId,
-));
-
-echo elgg_view('input/hidden', array(
-	'name' => 'original_guid',
-	'value' => $vars['message']->guid,
-));
-?>
-
-<div>
-	<label><?php echo elgg_echo("messages:title"); ?>: <br /></label>
-	<?php echo elgg_view('input/text', array(
+$fields = [
+	[
+		'#type' => 'hidden',
+		'name' => 'recipients[]',
+		'value' => $message->fromId,
+	],
+	[
+		'#type' => 'hidden',
+		'name' => 'original_guid',
+		'value' => $message->guid,
+	],
+	[
+		'#type' => 'text',
+		'#label' => elgg_echo('messages:title'),
 		'name' => 'subject',
 		'value' => $reply_title,
-	));
-	?>
-</div>
-<div>
-	<label><?php echo elgg_echo("messages:message"); ?>:</label>
-	<?php echo elgg_view("input/longtext", array(
+		'required' => true,
+	],
+	[
+		'#type' => 'longtext',
+		'#label' => elgg_echo('messages:message'),
 		'name' => 'body',
-		'value' => '',
-	));
-	?>
-</div>
-<div class="elgg-foot">
-	<?php echo elgg_view('input/submit', array('value' => elgg_echo('send'))); ?>
-</div>
+		'required' => true,
+	],
+	
+];
+foreach ($fields as $field) {
+	echo elgg_view_field($field);
+}
+
+$footer = elgg_view_field([
+	'#type' => 'submit',
+	'value' => elgg_echo('send'),
+]);
+
+elgg_set_form_footer($footer);

--- a/mod/messages/views/default/forms/messages/reply.php
+++ b/mod/messages/views/default/forms/messages/reply.php
@@ -39,6 +39,7 @@ $fields = [
 		'#label' => elgg_echo('messages:message'),
 		'name' => 'body',
 		'required' => true,
+		'editor_type' => 'simple',
 	],
 	
 ];

--- a/mod/messages/views/default/forms/messages/send.php
+++ b/mod/messages/views/default/forms/messages/send.php
@@ -3,7 +3,7 @@
  * Compose message form
  *
  * @package ElggMessages
- * @uses $vars['$recipient_username']
+ * @uses $vars['recipients']
  * @uses $vars['subject']
  * @uses $vars['body']
  */
@@ -12,35 +12,39 @@ $recipients = elgg_extract('recipients', $vars);
 $subject = elgg_extract('subject', $vars, '');
 $body = elgg_extract('body', $vars, '');
 
-$recipient_autocomplete = elgg_view('input/userpicker', array(
-	'name' => 'recipients',
-	'values' => $recipients,
-	'limit' => 1,
-));
-
-?>
-<div>
-	<label><?php echo elgg_echo("email:to"); ?>: </label>
-	<?php echo $recipient_autocomplete; ?>
-	<span class="elgg-text-help"><?php echo elgg_echo("messages:to:help"); ?></span>
-	
-</div>
-<div>
-	<label><?php echo elgg_echo("messages:title"); ?>: <br /></label>
-	<?php echo elgg_view('input/text', array(
+$fields = [
+	[
+		'#type' => 'userpicker',
+		'#label' => elgg_echo('email:to'),
+		'#help' => elgg_echo('messages:to:help'),
+		'name' => 'recipients',
+		'values' => $recipients,
+		'limit' => 1,
+		'required' => true,
+	],
+	[
+		'#type' => 'text',
+		'#label' => elgg_echo('messages:title'),
 		'name' => 'subject',
 		'value' => $subject,
-	));
-	?>
-</div>
-<div>
-	<label><?php echo elgg_echo("messages:message"); ?>:</label>
-	<?php echo elgg_view("input/longtext", array(
+		'required' => true,
+	],
+	[
+		'#type' => 'longtext',
+		'#label' => elgg_echo('messages:message'),
 		'name' => 'body',
 		'value' => $body,
-	));
-	?>
-</div>
-<div class="elgg-foot">
-	<?php echo elgg_view('input/submit', array('value' => elgg_echo('send'))); ?>
-</div>
+		'required' => true,
+	],
+	
+];
+foreach ($fields as $field) {
+	echo elgg_view_field($field);
+}
+
+$footer = elgg_view_field([
+	'#type' => 'submit',
+	'value' => elgg_echo('send'),
+]);
+
+elgg_set_form_footer($footer);

--- a/mod/messages/views/default/forms/messages/send.php
+++ b/mod/messages/views/default/forms/messages/send.php
@@ -35,8 +35,8 @@ $fields = [
 		'name' => 'body',
 		'value' => $body,
 		'required' => true,
+		'editor_type' => 'simple',
 	],
-	
 ];
 foreach ($fields as $field) {
 	echo elgg_view_field($field);

--- a/mod/messages/views/default/messages/css.php
+++ b/mod/messages/views/default/messages/css.php
@@ -12,12 +12,6 @@
 .message.unread a {
 	color: #D40005;
 }
-.messages-buttonbank {
-	text-align: right;
-}
-.messages-buttonbank input {
-	margin-left: 10px;
-}
 
 /*** message metadata ***/
 .messages-owner {

--- a/views/default/forms/comment/save.php
+++ b/views/default/forms/comment/save.php
@@ -66,7 +66,8 @@ if ($inline) {
 	$comment_input = elgg_view('input/longtext', array(
 		'name' => 'generic_comment',
 		'value' => $comment_text,
-		'required' => true
+		'required' => true,
+		'editor_type' => 'simple',
 	));
 
 	echo <<<FORM

--- a/views/default/input/button.php
+++ b/views/default/input/button.php
@@ -17,6 +17,7 @@ if (!isset($vars['text']) && isset($vars['value'])) {
 }
 
 $type = elgg_extract('type', $vars, 'button', false);
+$vars['type'] = $type;
 
 $text = elgg_extract('text', $vars);
 unset($vars['text']);

--- a/views/default/input/button.php
+++ b/views/default/input/button.php
@@ -8,7 +8,13 @@
  * @uses $vars['text']  Text to include between <button> tags
  * @uses $vars['icon']  Optional icon name
  */
+
 $vars['class'] = elgg_extract_class($vars, 'elgg-button');
+
+if (!isset($vars['text']) && isset($vars['value'])) {
+	// Keeping this to ease the transition to 3.0
+	$vars['text'] = $vars['value'];
+}
 
 $type = elgg_extract('type', $vars, 'button', false);
 

--- a/views/default/input/longtext.php
+++ b/views/default/input/longtext.php
@@ -9,12 +9,14 @@
  * @uses $vars['value']    The current value, if any - will be html encoded
  * @uses $vars['disabled'] Is the input field disabled?
  * @uses $vars['class']    Additional CSS class
- * @uses $vars['editor']   Enable WYSIWYG support
- *                         Requires a plugin that implements a WYWIWYG library
- *                         (e.g. bundled ckeditor plugin)
  * @uses $vars['visual']   Activate WYSIWYG editor immediately
  *                         If disabled, will display a plaintext input with
  *                         a link to activate the visual editor
+
+ * @uses $vars['editor']         Enable WYSIWYG support
+ *                               Requires a plugin that implements a WYWIWYG library
+ *                               (e.g. bundled ckeditor plugin)
+ * @uses $vars['editor_type']    The type of editor eg. 'simple'. It determines the style of the editor (if supported).
  * @uses $vars['editor_options'] Additional options to pass to the editor
  */
 
@@ -33,8 +35,9 @@ $editor_opts = (array) elgg_extract('editor_options', $vars, []);
 $editor_opts['disabled'] = !elgg_extract('editor', $vars, true);
 $editor_opts['state'] = elgg_extract('visual', $vars, true) ? 'visual' : 'html';
 
-unset($vars['editor_options']);
 unset($vars['editor']);
+unset($vars['editor_options']);
+unset($vars['editor_type']);
 unset($vars['visual']);
 
 $vars['data-editor-opts'] = json_encode($editor_opts);

--- a/views/default/input/reset.php
+++ b/views/default/input/reset.php
@@ -7,8 +7,4 @@
 
 $vars['type'] = 'reset';
 
-if (!isset($vars['text'])) {
-	$vars['text'] = elgg_echo('reset');
-}
-
 echo elgg_view('input/button', $vars);

--- a/views/default/input/submit.php
+++ b/views/default/input/submit.php
@@ -3,15 +3,10 @@
  * Renders a <button type="submit">
  *
  * See input/button view for a full list of options
- * 
+ *
  * @uses $vars['text'] Text of the button
  */
 
 $vars['type'] = 'submit';
-
-if (!isset($vars['text']) && isset($vars['value'])) {
-	// Keeping this to ease the transition to 3.0
-	$vars['text'] = $vars['value'];
-}
 
 echo elgg_view('input/button', $vars);


### PR DESCRIPTION
feat(forms): input/longtext now support editor variations

fixes #9391

A few longtext inputs have been changed to use a simpler editor config.

- [x] add theme_sandbox input/longtext with a variation