### PR TITLE
fix(notifications): no notifications about private content

### DIFF
--- a/engine/classes/Elgg/Notifications/SubscriptionsService.php
+++ b/engine/classes/Elgg/Notifications/SubscriptionsService.php
@@ -20,7 +20,7 @@ class SubscriptionsService {
 	const RELATIONSHIP_PREFIX = 'notify';
 
 	/**
-	 *  @var array Array of strings. Delivery names as registered with 
+	 *  @var array Array of strings. Delivery names as registered with
 	 *             elgg_register_notification_method()
 	 */
 	public $methods;
@@ -64,7 +64,8 @@ class SubscriptionsService {
 			return $subscriptions;
 		}
 		
-		if ($object instanceof \ElggEntity) {
+		// get subscribers only for \ElggEntity if it isn't private
+		if (($object instanceof \ElggEntity) && ($object->access_id !== ACCESS_PRIVATE)) {
 			$prefixLength = strlen(self::RELATIONSHIP_PREFIX);
 			$records = $this->getSubscriptionRecords($object->getContainerGUID());
 			foreach ($records as $record) {
@@ -109,9 +110,9 @@ class SubscriptionsService {
 
 	/**
 	 * Subscribe a user to notifications about a target entity
-	 * 
+	 *
 	 * This method will return false if the subscription already exists.
-	 * 
+	 *
 	 * @param int    $userGuid   The GUID of the user to subscribe to notifications
 	 * @param string $method     The delivery method of the notifications
 	 * @param int    $targetGuid The entity to receive notifications about
@@ -127,7 +128,7 @@ class SubscriptionsService {
 
 	/**
 	 * Unsubscribe a user to notifications about a target entity
-	 * 
+	 *
 	 * @param int    $userGuid   The GUID of the user to unsubscribe to notifications
 	 * @param string $method     The delivery method of the notifications to stop
 	 * @param int    $targetGuid The entity to stop receiving notifications about
@@ -169,7 +170,7 @@ class SubscriptionsService {
 
 	/**
 	 * Get the relationship names for notifications
-	 * 
+	 *
 	 * @return array
 	 */
 	protected function getMethodRelationships() {

--- a/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/Notifications/SubscriptionsServiceTest.php
@@ -8,15 +8,16 @@ namespace Elgg\Notifications;
 class SubscriptionsServiceTest extends \Elgg\TestCase {
 
 	public function setUp() {
+		
+		$this->setupMockServices();
+		
 		$this->containerGuid = 42;
 
 		// mock \ElggObject that has a container guid
-		$object = $this->getMock(
-				'\ElggObject', array('getContainerGUID'), array(), '', false);
-		$object->expects($this->any())
-				->method('getContainerGUID')
-				->will($this->returnValue($this->containerGuid));
-
+		$object = $this->mocks()->getObject([
+			'container_guid' => $this->containerGuid,
+		]);
+		
 		// mock event that holds the mock object
 		$this->event = $this->getMock(
 				'\Elgg\Notifications\Event', array('getObject'), array(), '', false);
@@ -31,9 +32,7 @@ class SubscriptionsServiceTest extends \Elgg\TestCase {
 		$this->db->expects($this->any())
 				->method('sanitizeString')
 				->will($this->returnArgument(0));
-
-		// Event class has dependency on elgg_get_logged_in_user_guid()
-		_elgg_services()->setValue('session', \ElggSession::getMock());
+		
 	}
 
 	public function testGetSubscriptionsWithNoMethodsRegistered() {


### PR DESCRIPTION
Admins could receive a notification about content which was created with
access private. Now the events still get processed like normal, but the
default subscribers won't be filled. If you still wish to send out a
notification about private content than the subscribers need to be added
using the hook 'get' 'subscribers'.

fixes: #9789