### PR TITLE
fix(notifications): incorrect use statement no longer throws

### DIFF
--- a/engine/classes/Elgg/Notifications/InstantNotificationEvent.php
+++ b/engine/classes/Elgg/Notifications/InstantNotificationEvent.php
@@ -4,6 +4,7 @@ namespace Elgg\Notifications;
 
 use ElggData;
 use ElggEntity;
+use stdClass;
 
 /**
  * Instant notification event


### PR DESCRIPTION
Corrects the use statement which results in an exception in PHP 7.