### PR TITLE
fix(http): elgg/Ajax error responses with 200 status use Ajax wrapper

### DIFF
--- a/engine/classes/Elgg/Http/ResponseFactory.php
+++ b/engine/classes/Elgg/Http/ResponseFactory.php
@@ -240,6 +240,10 @@ class ResponseFactory {
 			return $this->redirect($redirect_url, $status_code);
 		}
 
+		if ($this->ajax->isReady() && $response->isSuccessful()) {
+			return $this->respondFromContent($content, $status_code, $headers);
+		}
+
 		if ($response->isClientError() || $response->isServerError() || $response instanceof ErrorResponse) {
 			return $this->respondWithError($content, $status_code, $headers);
 		}

--- a/engine/tests/phpunit/Elgg/ActionsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ActionsServiceTest.php
@@ -930,7 +930,11 @@ class ActionsServiceTest extends \Elgg\TestCase {
 		$this->assertContains('application/json', $response->headers->get('Content-Type'));
 		//$this->assertContains('charset=utf-8', strtolower($response->headers->get('Content-Type')));
 		$output = json_encode([
-			'error' => 'error'
+			'value' => 'error',
+			'_elgg_msgs' => [
+				'error' => ['error'],
+			],
+			'_elgg_deps' => [],
 		]);
 
 		$this->assertEquals($output, $response->getContent());


### PR DESCRIPTION
For requests made with elgg/Ajax, a standard error response (HTTP 200)
will now use the standard Ajax service response format.