### PR TITLE
fix(files): mitigate issues with special chars in file names

### DIFF
--- a/engine/classes/Elgg/Application/ServeFileHandler.php
+++ b/engine/classes/Elgg/Application/ServeFileHandler.php
@@ -51,7 +51,7 @@ class ServeFileHandler {
 		$response = new Response();
 		$response->prepare($request);
 
-		$path = implode('/', $request->getUrlSegments());
+		$path = implode('/', $request->getUrlSegments(true));
 		if (!preg_match('~serve-file/e(\d+)/l(\d+)/d([ia])/c([01])/([a-zA-Z0-9\-_]+)/(.*)$~', $path, $m)) {
 			return $response->setStatusCode(400)->setContent('Malformatted request URL');
 		}
@@ -77,6 +77,11 @@ class ServeFileHandler {
 		$hmac = $this->crypto->getHmac($hmac_data);
 		if (!$hmac->matchesToken($mac)) {
 			return $response->setStatusCode(403)->setContent('HMAC mistmatch');
+		}
+
+		// Path may have been encoded to avoid problems with special chars in URLs
+		if (0 === strpos($path_from_dataroot, ':')) {
+			$path_from_dataroot = base64_decode(substr($path_from_dataroot, 1));
 		}
 
 		$dataroot = $this->config->getDataPath();

--- a/engine/classes/Elgg/FileService/File.php
+++ b/engine/classes/Elgg/FileService/File.php
@@ -106,6 +106,12 @@ class File {
 			return false;
 		}
 
+		if (preg_match('~[^\w\./ ]~', $relative_path)) {
+			// Filenames may contain special characters that result in malformatted URLs
+			// and/or HMAC mismatches. We want to avoid that by encoding the path.
+			$relative_path = ':' . base64_encode($relative_path);
+		}
+		
 		$data = array(
 			'expires' => isset($this->expires) ? $this->expires : 0,
 			'last_updated' => filemtime($this->file->getFilenameOnFilestore()),

--- a/engine/tests/phpunit/Elgg/Application/ServeFileHandlerTest.php
+++ b/engine/tests/phpunit/Elgg/Application/ServeFileHandlerTest.php
@@ -24,7 +24,11 @@ class ServeFileHandlerTest extends \Elgg\TestCase {
 
 		$file = new \ElggFile();
 		$file->owner_guid = 1;
-		$file->setFilename("foobar.txt");
+
+		// Using special characters to test against files that have been
+		// uploaded prior to implementation of filename sanitization
+		// See #10608
+		$file->setFilename("foo'baž.txt");
 
 		$this->file = $file;
 	}

--- a/engine/tests/phpunit/test_files/dataroot/1/1/foo'baž.txt
+++ b/engine/tests/phpunit/test_files/dataroot/1/1/foo'baž.txt
@@ -1,0 +1,1 @@
+File with a crazy filename for testing.


### PR DESCRIPTION
Relative paths to files that contain special characters in the name
will now be encoded with base64 to avoid malformatted URLs and
HMAC mismatches resulting from unescaped characters.
URLs generated prior to this change will continue working.

Refs #10608