### PR TITLE
fix(http): Use Symfony to parse PATH_INFO

### DIFF
--- a/docs/admin/upgrading.rst
+++ b/docs/admin/upgrading.rst
@@ -40,6 +40,21 @@ Basic instructions
 From 2.3 to 3.0
 ===============
 
+Update ``.htaccess``
+--------------------
+
+Find the line:
+
+.. code::
+
+	RewriteRule ^(.*)$ index.php?__elgg_uri=$1 [QSA,L]
+
+And replace it with:
+
+.. code::
+
+	RewriteRule ^(.*)$ index.php [QSA,L]
+
 Removed / changed language keys
 -------------------------------
 

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -20,7 +20,6 @@ use Elgg\Filesystem\Directory;
  */
 class Application {
 
-	const GET_PATH_KEY = '__elgg_uri';
 	const REWRITE_TEST_TOKEN = '__testing_rewrite';
 	const REWRITE_TEST_OUTPUT = 'success';
 
@@ -383,7 +382,7 @@ class Application {
 	 * @return bool False if Elgg wants the PHP CLI server to handle the request
 	 */
 	public function run() {
-		$path = $this->setupPath();
+		$path = $this->services->request->getPathInfo();
 
 		// allow testing from the upgrade page before the site is upgraded.
 		if (isset($_GET[self::REWRITE_TEST_TOKEN])) {
@@ -554,8 +553,7 @@ class Application {
 				// note: translation may not be available until after upgrade
 				$msg = elgg_echo("installation:htaccess:needs_upgrade");
 				if ($msg === "installation:htaccess:needs_upgrade") {
-					$msg = "You must update your .htaccess file so that the path is injected "
-						. "into the GET parameter __elgg_uri (you can use install/config/htaccess.dist as a guide).";
+					$msg = "You must update your .htaccess file (use install/config/htaccess.dist as a guide).";
 				}
 				echo $msg;
 				exit;
@@ -573,26 +571,6 @@ class Application {
 		}
 
 		forward($forward_url);
-	}
-
-	/**
-	 * Get the request URI and store it in $_GET['__elgg_uri']
-	 *
-	 * @return string e.g. "cache/123..."
-	 */
-	private function setupPath() {
-		if (!isset($_GET[self::GET_PATH_KEY]) || is_array($_GET[self::GET_PATH_KEY])) {
-			if (php_sapi_name() === 'cli-server') {
-				$_GET[self::GET_PATH_KEY] = (string) parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
-			} else {
-				$_GET[self::GET_PATH_KEY] = '/';
-			}
-		}
-
-		// normalize
-		$_GET[self::GET_PATH_KEY] = '/' . trim($_GET[self::GET_PATH_KEY], '/');
-
-		return $_GET[self::GET_PATH_KEY];
 	}
 
 	/**

--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -19,7 +19,7 @@ class Request extends SymfonyRequest {
 	 * @return string[]
 	 */
 	public function getUrlSegments($raw = false) {
-		$path = trim($this->query->get(Application::GET_PATH_KEY), '/');
+		$path = trim($this->getPathInfo(), '/');
 		if (!$raw) {
 			$path = htmlspecialchars($path, ENT_QUOTES, 'UTF-8');
 		}
@@ -38,9 +38,11 @@ class Request extends SymfonyRequest {
 	 * @return Request
 	 */
 	public function setUrlSegments(array $segments) {
-		$query = $this->query->all();
-		$query[Application::GET_PATH_KEY] = '/' . implode('/', $segments);
-		return $this->duplicate($query);
+		$base_path = trim($this->getBasePath(), '/');
+		$server = $this->server->all();
+		$server['REQUEST_URI'] = "$base_path/" . implode('/', $segments);
+
+		return $this->duplicate(null, null, null, null, null, $server);
 	}
 
 	/**

--- a/engine/tests/phpunit/Elgg/Application/ServeFileHandlerTest.php
+++ b/engine/tests/phpunit/Elgg/Application/ServeFileHandlerTest.php
@@ -43,8 +43,7 @@ class ServeFileHandlerTest extends \Elgg\TestCase {
 		$site_url = elgg_get_site_url();
 		$url = $file->getURL();
 		$path = substr($url, strlen($site_url));
-		$path_key = \Elgg\Application::GET_PATH_KEY;
-		$request = \Elgg\Http\Request::create("?$path_key=$path");
+		$request = \Elgg\Http\Request::create("/$path");
 
 		$cookie_name = _elgg_services()->config->getCookieConfig()['session']['name'];
 		$session_id = _elgg_services()->session->getId();

--- a/engine/tests/phpunit/Elgg/EntityIconServiceTest.php
+++ b/engine/tests/phpunit/Elgg/EntityIconServiceTest.php
@@ -52,8 +52,7 @@ class EntityIconServiceTest extends \Elgg\TestCase {
 		_elgg_filestore_init(); // we will need simpletype hook to work
 
 		$this->hooks = new \Elgg\PluginHooksService();
-		$path_key = \Elgg\Application::GET_PATH_KEY;
-		$this->request = \Elgg\Http\Request::create("?$path_key=action/upload");
+		$this->request = \Elgg\Http\Request::create("/action/upload");
 		$this->logger = new \Elgg\Logger($this->hooks, $this->config(), new \Elgg\Context());
 
 		$this->setupMockServices(false);
@@ -879,8 +878,7 @@ class EntityIconServiceTest extends \Elgg\TestCase {
 	 */
 	public function testServeIconSends400ForMalformattedRequest() {
 
-		$path_key = \Elgg\Application::GET_PATH_KEY;
-		$this->request = \Elgg\Http\Request::create("?$path_key=serve-icon/x/large");
+		$this->request = \Elgg\Http\Request::create("/serve-icon/x/large");
 
 		$service = $this->createService();
 		$service->setCurrentTime();
@@ -897,8 +895,7 @@ class EntityIconServiceTest extends \Elgg\TestCase {
 	 */
 	public function testServeIconSends404ForNonExistentGuid() {
 
-		$path_key = \Elgg\Application::GET_PATH_KEY;
-		$this->request = \Elgg\Http\Request::create("?$path_key=serve-icon/55/small");
+		$this->request = \Elgg\Http\Request::create("/serve-icon/55/small");
 
 		$service = $this->createService();
 		$service->setCurrentTime();
@@ -919,8 +916,7 @@ class EntityIconServiceTest extends \Elgg\TestCase {
 		$file->owner_guid = 1;
 		$file->setFilename('600x300.jpg');
 
-		$path_key = \Elgg\Application::GET_PATH_KEY;
-		$this->request = \Elgg\Http\Request::create("?$path_key=serve-icon/{$this->entity->guid}/small");
+		$this->request = \Elgg\Http\Request::create("/serve-icon/{$this->entity->guid}/small");
 
 		$service = $this->createService();
 		$service->setCurrentTime();

--- a/engine/tests/phpunit/Elgg/Http/RequestTest.php
+++ b/engine/tests/phpunit/Elgg/Http/RequestTest.php
@@ -5,23 +5,17 @@ namespace Elgg\Http;
 class RequestTest extends \Elgg\TestCase {
 
 	public function testCanDetectElggPath() {
-		$req = new Request([
-			'__elgg_uri' => '/foo/bar/',
-		]);
+		$req = Request::create("/foo/bar/");
 		$this->assertEquals(['foo', 'bar'], $req->getUrlSegments());
 	}
 
 	public function testUrlSegmentsAutoHtmlEscaped() {
-		$req = new Request([
-			'__elgg_uri' => '/fo<script>alert("/ba&r/',
-		]);
+		$req = Request::create('/fo<script>alert("/ba&r/');
 		$this->assertEquals(['fo&lt;script&gt;alert(&quot;', 'ba&amp;r'], $req->getUrlSegments());
 	}
 
 	public function testCanAccessRawUrlSegments() {
-		$req = new Request([
-			'__elgg_uri' => '/fo<script>alert("/ba&r/',
-		]);
+		$req = Request::create('/fo<script>alert("/ba&r/');
 		$this->assertEquals(['fo<script>alert("', 'ba&r'], $req->getUrlSegments(true));
 	}
 

--- a/engine/tests/phpunit/Elgg/Http/ResponseFactoryTest.php
+++ b/engine/tests/phpunit/Elgg/Http/ResponseFactoryTest.php
@@ -106,8 +106,7 @@ class ResponseFactoryTest extends \Elgg\TestCase {
 	public function createRequest($uri = '', $method = 'POST', $parameters = [], $xhr = false) {
 		$site_url = elgg_get_site_url();
 		$path = substr(elgg_normalize_url($uri), strlen($site_url));
-		$path_key = Application::GET_PATH_KEY;
-		$request = Request::create("?$path_key=$path", $method, $parameters);
+		$request = Request::create("/$path", $method, $parameters);
 
 		$cookie_name = $this->config->getCookieConfig()['session']['name'];
 		$session_id = $this->session->getId();

--- a/engine/tests/phpunit/Elgg/RouterTest.php
+++ b/engine/tests/phpunit/Elgg/RouterTest.php
@@ -129,7 +129,7 @@ class RouterTest extends \Elgg\TestCase {
 
 		$this->assertTrue($registered);
 
-		$path = "hello/1/\xE2\x82\xAC"; // euro sign
+		$path = "hello/1/%E2%82%AC"; // euro sign
 
 		ob_start();
 		$handled = $this->router->route($this->prepareHttpRequest($path));

--- a/engine/tests/phpunit/Elgg/TestCase.php
+++ b/engine/tests/phpunit/Elgg/TestCase.php
@@ -214,8 +214,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function prepareHttpRequest($uri = '', $method = 'GET', $parameters = [], $ajax = 0, $add_csrf_tokens = false) {
 		$site_url = elgg_get_site_url();
-		$path = substr(elgg_normalize_url($uri), strlen($site_url));
-		$path_key = Application::GET_PATH_KEY;
+		$path = '/' . ltrim(substr(elgg_normalize_url($uri), strlen($site_url)), '/');
 
 		if ($add_csrf_tokens) {
 			$ts = time();
@@ -223,7 +222,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 			$parameters['__elgg_token'] = _elgg_services()->actions->generateActionToken($ts);
 		}
 
-		$request = Request::create("?$path_key=" . urlencode($path), $method, $parameters);
+		$request = Request::create($path, $method, $parameters);
 
 		$cookie_name = _elgg_services()->config->getCookieConfig()['session']['name'];
 		$session_id = _elgg_services()->session->getId();

--- a/install/config/htaccess.dist
+++ b/install/config/htaccess.dist
@@ -133,6 +133,6 @@ RewriteRule (^\.|/\.) - [F]
 # Everything else that isn't a file gets routed through Elgg
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule ^(.*)$ index.php?__elgg_uri=$1 [QSA,L]
+RewriteRule ^(.*)$ index.php [QSA,L]
 
 </IfModule>

--- a/install/config/nginx.dist
+++ b/install/config/nginx.dist
@@ -80,6 +80,5 @@ server {
 		include /etc/nginx/fastcgi_params;
 		fastcgi_param SCRIPT_FILENAME $document_root/index.php;
 		fastcgi_param SCRIPT_NAME     /index.php;
-		fastcgi_param QUERY_STRING    __elgg_uri=$uri&$args;
 	}
 }

--- a/languages/en.php
+++ b/languages/en.php
@@ -1236,7 +1236,7 @@ Once you have logged in, we highly recommend that you change your password.
 	'installation:minify_js:label' => "Compress JavaScript (recommended)",
 	'installation:minify_css:label' => "Compress CSS (recommended)",
 
-	'installation:htaccess:needs_upgrade' => "You must update your .htaccess file so that the path is injected into the GET parameter __elgg_uri (you can use install/config/htaccess.dist as a guide).",
+	'installation:htaccess:needs_upgrade' => "You must update your .htaccess file (use install/config/htaccess.dist as a guide).",
 	'installation:htaccess:localhost:connectionfailed' => "Elgg cannot connect to itself to test rewrite rules properly. Check that curl is working and there are no IP restrictions preventing localhost connections.",
 
 	'installation:systemcache:description' => "The system cache decreases the loading time of Elgg by caching data to files.",

--- a/mod/legacy_urls/start.php
+++ b/mod/legacy_urls/start.php
@@ -77,10 +77,6 @@ function legacy_urls_prepare_url($url, array $query_vars = []) {
 	}
 	$params = array_merge($params, $query_vars);
 	if ($params) {
-		if (!empty($params['__elgg_uri'])) {
-			// on multiple redirects, __elgg_uri is appended to the URL causing infinite loops #8494
-			unset($params['__elgg_uri']);
-		}
 		return elgg_http_add_url_query_elements($url, $params);
 	} else {
 		return $url;


### PR DESCRIPTION
Instead of having Apache rewrite the path into a query string argument, we use Symfony's battle-tested `Request::getPathInfo`.

Fixes #10608

- [x] rebase and rework once #10681 is in