### PR TITLE
fix(forms): fieldset with a legend no longer overrides the class

### DIFF
--- a/views/default/input/fieldset.php
+++ b/views/default/input/fieldset.php
@@ -37,7 +37,7 @@ unset($vars['fields']);
 
 $fieldset = '';
 if ($legend) {
-	$vars['class'] = 'elgg-fieldset-has-legend';
+	$vars['class'][] = 'elgg-fieldset-has-legend';
 	$fieldset .= elgg_format_element('legend', [], $legend);
 }
 


### PR DESCRIPTION
Preserve fieldset class values when adding elgg-fieldset-has-legend class.