### PR TITLE
fix(core): Check existence of cache symlink without usage of readlink()

### DIFF
--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -235,7 +235,7 @@ function elgg_flush_caches() {
 function _elgg_is_cache_symlinked() {
 	$link = elgg_get_root_path() . 'cache/';
 	$target = elgg_get_cache_path() . 'views_simplecache/';
-	return is_dir($link) && realpath($target) == realpath(readlink($link));
+	return is_dir($link) && realpath($target) == realpath($link);
 }
 
 /**


### PR DESCRIPTION
This is a backport from the 2.3 branch.

It's not only a matter of readlink() not being necessary. At least on my server the readlink() call produces an "Invalid argument" warning resulting in the check for existence of the cache symlink to fail even if the symlink is correctly set up.