### PR TITLE
Email formatting changes

### DIFF
--- a/engine/classes/Elgg/Mail/Address.php
+++ b/engine/classes/Elgg/Mail/Address.php
@@ -3,26 +3,41 @@ namespace Elgg\Mail;
 
 /**
  * TODO(ewinslow): Contribute something like this back to Zend project.
- * 
+ *
  * @access private
  */
 class Address {
 	/**
 	 * Parses strings like "Evan <evan@elgg.org>" into name/email objects.
-	 * 
+	 *
 	 * This is not very sophisticated and only used to provide a light BC effort.
-	 * 
+	 *
 	 * @param string $contact e.g. "Evan <evan@elgg.org>"
-	 * 
+	 *
 	 * @return \Zend\Mail\Address
 	 */
 	public static function fromString($contact) {
 		$containsName = preg_match('/<(.*)>/', $contact, $matches) == 1;
 		if ($containsName) {
 			$name = trim(substr($contact, 0, strpos($contact, '<')));
-			return new \Zend\Mail\Address($matches[1], $name); 
+			return new \Zend\Mail\Address($matches[1], $name);
 		} else {
 			return new \Zend\Mail\Address(trim($contact));
 		}
+	}
+	
+	/**
+	 * Format an email address and name into a formatted email address
+	 *
+	 * eg "Some name <someone@example.com>"
+	 *
+	 * @param string $email the email address
+	 * @param string $name  the name
+	 *
+	 * @return string
+	 */
+	public static function getFormattedEmailAddress($email, $name = null) {
+		$mail = new \Zend\Mail\Address($email, $name);
+		return $mail->toString();
 	}
 }

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -335,4 +335,21 @@ class ElggSite extends \ElggEntity {
 		// non-public page
 		return false;
 	}
+	
+	/**
+	 * Get the email address for the site
+	 *
+	 * This can be set in the basic site settings or fallback to noreply@domain
+	 *
+	 * @return string
+	 * @since 3.0.0
+	 */
+	public function getEmailAddress() {
+		$email = $this->email;
+		if (empty($email)) {
+			$email = "noreply@{$this->getDomain()}";
+		}
+		
+		return $email;
+	}
 }

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -235,15 +235,17 @@ function _elgg_send_email_notification($hook, $type, $result, $params) {
 		return false;
 	}
 
-	$to = $recipient->email;
+	$recipient_address = new \Zend\Mail\Address($recipient->email, $recipient->getDisplayName());
+	$to = $recipient_address->toString();
 
-	$site = elgg_get_site_entity();
 	// If there's an email address, use it - but only if it's not from a user.
 	if (!($sender instanceof \ElggUser) && $sender->email) {
-		$from = $sender->email;
+		$from = Address::getFormattedEmailAddress($sender->email, $sender->getDisplayName());
 	} else {
 		// get the site email address
-		$from = $site->getEmailAddress();
+		$site = elgg_get_site_entity();
+		
+		$from = Address::getFormattedEmailAddress($site->getEmailAddress(), $site->getDisplayName());
 	}
 
 	return elgg_send_email($from, $to, $message->subject, $message->body, $params);

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -102,7 +102,7 @@ function elgg_register_notification_method($name) {
  *		'sms' => 'sms',
  *	]
  * </code>
- * 
+ *
  * @return array
  * @since 2.3
  */
@@ -241,11 +241,9 @@ function _elgg_send_email_notification($hook, $type, $result, $params) {
 	// If there's an email address, use it - but only if it's not from a user.
 	if (!($sender instanceof \ElggUser) && $sender->email) {
 		$from = $sender->email;
-	} else if ($site->email) {
-		$from = $site->email;
 	} else {
-		// If all else fails, use the domain of the site.
-		$from = 'noreply@' . $site->getDomain();
+		// get the site email address
+		$from = $site->getEmailAddress();
 	}
 
 	return elgg_send_email($from, $to, $message->subject, $message->body, $params);
@@ -258,11 +256,11 @@ function _elgg_send_email_notification($hook, $type, $result, $params) {
  * @param string $type        Equals to 'system'
  * @param array  $returnvalue Array containing fields: 'to', 'from', 'subject', 'body', 'headers', 'params'
  * @param array  $params      The same value as $returnvalue
- * 
+ *
  * @see https://tools.ietf.org/html/rfc5322#section-3.6.4
- * 
+ *
  * @return array
- * 
+ *
  * @access private
  */
 function _elgg_notifications_smtp_default_message_id_header($hook, $type, $returnvalue, $params) {

--- a/engine/tests/phpunit/ElggSiteTest.php
+++ b/engine/tests/phpunit/ElggSiteTest.php
@@ -11,4 +11,20 @@ class ElggSiteTest extends \Elgg\TestCase {
 		$this->assertNotNull(new \ElggSite());
 	}
 
+	public function testGetNoreplyEmailAddress() {
+		
+		$site = new \ElggSite();
+		$site->url = 'https://example.com/';
+		
+		$this->assertEquals('noreply@example.com', $site->getEmailAddress());
+	}
+	
+	public function testGetEmailAddress() {
+		
+		$site = new \ElggSite();
+		$site->url = 'https://example.com/';
+		$site->email = 'someemail@example.com';
+		
+		$this->assertEquals('someemail@example.com', $site->getEmailAddress());
+	}
 }

--- a/mod/invitefriends/actions/invitefriends/invite.php
+++ b/mod/invitefriends/actions/invitefriends/invite.php
@@ -13,6 +13,8 @@ if (!elgg_get_config('allow_registration')) {
 }
 
 $site = elgg_get_site_entity();
+// create the from address
+$from = \Elgg\Mail\Address::getFormattedEmailAddress($site->getEmailAddress(), $site->getDisplayName());
 
 $emails = get_input('emails');
 $emailmessage = get_input('emailmessage');
@@ -65,9 +67,6 @@ foreach ($emails as $email) {
 	));
 
 	$subject = elgg_echo('invitefriends:subject', array($site->getDisplayName()));
-
-	// create the from address
-	$from = $site->getEmailAddress();
 
 	elgg_send_email($from, $email, $subject, $message);
 	$sent_total++;

--- a/mod/invitefriends/actions/invitefriends/invite.php
+++ b/mod/invitefriends/actions/invitefriends/invite.php
@@ -67,11 +67,7 @@ foreach ($emails as $email) {
 	$subject = elgg_echo('invitefriends:subject', array($site->getDisplayName()));
 
 	// create the from address
-	if ($site->email) {
-		$from = $site->email;
-	} else {
-		$from = 'noreply@' . $site->getDomain();
-	}
+	$from = $site->getEmailAddress();
 
 	elgg_send_email($from, $email, $subject, $message);
 	$sent_total++;


### PR DESCRIPTION
- unified the site email address fallback to a class function (no more boilerplate) + tests
- the formatting of recipient and sender changed to `Someone <someone@example.com>` instead of just `someone@example.com`