### PR TITLE
Some changes to group saving logic

### DIFF
--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -126,19 +126,6 @@ if (!$is_new_group && $new_owner_guid && $new_owner_guid != $old_owner_guid) {
 			// container if it the group is not contained by the original owner.
 			$group->container_guid = $new_owner_guid;
 		}
-
-		$metadata = elgg_get_metadata(array(
-			'guid' => $group_guid,
-			'limit' => false,
-		));
-		if ($metadata) {
-			foreach ($metadata as $md) {
-				if ($md->owner_guid == $old_owner_guid) {
-					$md->owner_guid = $new_owner_guid;
-					$md->save();
-				}
-			}
-		}
 	}
 }
 

--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -44,20 +44,32 @@ if ($name !== null) {
 
 $user = elgg_get_logged_in_user_entity();
 
-$group_guid = (int)get_input('group_guid');
-$is_new_group = $group_guid == 0;
+$group_guid = (int) get_input('group_guid');
 
-if ($is_new_group
-		&& (elgg_get_plugin_setting('limited_groups', 'groups') == 'yes')
-		&& !$user->isAdmin()) {
-	register_error(elgg_echo("groups:cantcreate"));
-	forward(REFERER);
-}
-
-$group = $group_guid ? get_entity($group_guid) : new ElggGroup();
-if (elgg_instanceof($group, "group") && !$group->canEdit()) {
-	register_error(elgg_echo("groups:cantedit"));
-	forward(REFERER);
+if ($group_guid) {
+	$is_new_group = false;
+	$group = get_entity($group_guid);
+	if (!$group instanceof ElggGroup || !$group->canEdit()) {
+		$error = elgg_echo('groups:cantedit');
+		return elgg_error_response($error);
+	}
+} else {
+	if (elgg_get_plugin_setting('limited_groups', 'groups') == 'yes' && !$user->isAdmin()) {
+		$error = elgg_echo('groups:cantcreate');
+		return elgg_error_response($error);
+	}
+	
+	$container_guid = get_input('container_guid', $user->guid);
+	$container = get_entity($container_guid);
+	
+	if (!$container || !$container->canWriteToContainer($user->guid, 'group')) {
+		$error = elgg_echo('groups:cantcreate');
+		return elgg_error_response($error);
+	}
+	
+	$is_new_group = true;
+	$group = new ElggGroup();
+	$group->container_guid = $container->guid;
 }
 
 // Assume we can edit or this is a new group
@@ -75,8 +87,7 @@ foreach ($input as $shortname => $value) {
 
 // Validate create
 if (!$group->name) {
-	register_error(elgg_echo("groups:notitle"));
-	forward(REFERER);
+	return elgg_error_response(elgg_echo('groups:notitle'));
 }
 
 // Set group tool options (only pass along saved entities)
@@ -132,8 +143,7 @@ if (!$is_new_group && $new_owner_guid && $new_owner_guid != $old_owner_guid) {
 if ($is_new_group) {
 	// if new group, we need to save so group acl gets set in event handler
 	if (!$group->save()) {
-		register_error(elgg_echo("groups:save_error"));
-		forward(REFERER);
+		return elgg_error_response(elgg_echo('groups:save_error'));
 	}
 }
 
@@ -161,8 +171,7 @@ if (elgg_get_plugin_setting('hidden_groups', 'groups') == 'yes') {
 }
 
 if (!$group->save()) {
-	register_error(elgg_echo("groups:save_error"));
-	forward(REFERER);
+	return elgg_error_response(elgg_echo('groups:save_error'));
 }
 
 // group saved so clear sticky form
@@ -185,6 +194,7 @@ if ($is_new_group) {
 
 $group->saveIconFromUploadedFile('icon');
 
-system_message(elgg_echo("groups:saved"));
-
-forward($group->getUrl());
+$data = [
+	'entity' => $group,
+];
+return elgg_ok_response($data, elgg_echo('groups:saved'), $group->getURL());

--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -62,20 +62,6 @@ if (elgg_instanceof($group, "group") && !$group->canEdit()) {
 
 // Assume we can edit or this is a new group
 foreach ($input as $shortname => $value) {
-	// update access collection name if group name changes
-	if (!$is_new_group && $shortname == 'name' && $value != $group->name) {
-		$group_name = html_entity_decode($value, ENT_QUOTES, 'UTF-8');
-		$ac_name = sanitize_string(elgg_echo('groups:group') . ": " . $group_name);
-		$acl = get_access_collection($group->group_acl);
-		if ($acl) {
-			// @todo Elgg api does not support updating access collection name
-			$db_prefix = elgg_get_config('dbprefix');
-			$query = "UPDATE {$db_prefix}access_collections SET name = '$ac_name'
-				WHERE id = $group->group_acl";
-			update_data($query);
-		}
-	}
-
 	if ($value === '' && !in_array($shortname, ['name', 'description'])) {
 		// The group profile displays all profile fields that have a value.
 		// We don't want to display fields with empty string value, so we

--- a/mod/groups/classes/Elgg/Groups/Upgrades/GroupIconTransfer.php
+++ b/mod/groups/classes/Elgg/Groups/Upgrades/GroupIconTransfer.php
@@ -38,7 +38,11 @@ class GroupIconTransfer implements \Elgg\Upgrade\Batch {
 		// Check whether there are icons that are still saved under the
 		// group's owner instead of the group itself.
 		foreach ($sizes as $size => $opts) {
-			$filename = "{$group->guid}{$size}.jpg";
+			if ($size == 'original') {
+				$filename = "{$group->guid}.jpg";
+			} else {
+				$filename = "{$group->guid}{$size}.jpg";
+			}
 			$filestorename = "{$dataroot}{$dir}{$prefix}{$filename}";
 			if (file_exists($filestorename)) {
 				// A group icon was found meaning that the upgrade is needed.
@@ -98,7 +102,11 @@ class GroupIconTransfer implements \Elgg\Upgrade\Batch {
 		$prefix = 'groups/';
 
 		foreach ($sizes as $size => $opts) {
-			$filename = "{$group->guid}{$size}.jpg";
+			if ($size == 'original') {
+				$filename = "{$group->guid}.jpg";
+			} else {
+				$filename = "{$group->guid}{$size}.jpg";
+			}
 			$filestorename = "{$dataroot}{$dir}{$prefix}{$filename}";
 			if (!file_exists($filestorename)) {
 				// nothing to move

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -505,6 +505,20 @@ function groups_update_event_listener($event, $type, $group) {
 		$filehandler->owner_guid = $previous_owner_guid;
 		$filehandler->setFilename("groups/$group->guid.jpg");
 		$filehandler->transfer($group->owner_guid);
+
+		// Update owned metadata
+		$metadata = elgg_get_metadata([
+			'guid' => $group->guid,
+			'metadata_owner_guids' => $previous_owner_guid,
+			'limit' => 0,
+		]);
+
+		if ($metadata) {
+			foreach ($metadata as $md) {
+				$md->owner_guid = $group->owner_guid;
+				$md->save();
+			}
+		}
 	}
 
 	if (!empty($original_attributes['name'])) {

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -30,6 +30,7 @@ function groups_init() {
 
 	// Register URL handlers for groups
 	elgg_register_plugin_hook_handler('entity:url', 'group', 'groups_set_url');
+	elgg_register_plugin_hook_handler('entity:icon:sizes', 'group', 'groups_set_icon_sizes');
 
 	// add group activity tool option
 	if (elgg_get_plugin_setting('allow_activity', 'groups') === 'yes') {
@@ -72,7 +73,6 @@ function groups_init() {
 	// Register a handler for create groups
 	elgg_register_event_handler('create', 'group', 'groups_create_event_listener');
 	elgg_register_event_handler('update:after', 'group', 'groups_update_event_listener');
-	elgg_register_event_handler('delete', 'group', 'groups_delete_event_listener', 999);
 
 	elgg_register_event_handler('join', 'group', 'groups_user_join_event_listener');
 	elgg_register_event_handler('leave', 'group', 'groups_user_leave_event_listener');
@@ -502,38 +502,6 @@ function groups_update_event_listener($event, $type, $group) {
 
 	$previous_owner_guid = $original_attributes['owner_guid'];
 
-	// In addition to standard icons, groups plugin stores a copy of the original upload
-	$filehandler = new ElggFile();
-	$filehandler->owner_guid = $previous_owner_guid;
-	$filehandler->setFilename("groups/$group->guid.jpg");
-	$filehandler->transfer($group->owner_guid);
-}
-
-/**
- * Remove groups icons on delete
- *
- * This operation is performed in an event listener to ensure that icons
- * are removed when group is deleted outside of groups/delete action flow.
- *
- * Registered with a hight priority to make sure that other handlers to not prevent
- * the deletion.
- *
- * @param string    $event "delete"
- * @param string    $type  "group"
- * @param ElggGroup $group Group entity
- * @return void
- */
-function groups_delete_event_listener($event, $type, $group) {
-
-	/* @var $group \ElggGroup */
-
-	// In addition to standard icons, groups plugin stores a copy of the original upload
-	$filehandler = new ElggFile();
-	$filehandler->owner_guid = $group->owner_guid;
-	$filehandler->setFilename("groups/$group->guid.jpg");
-	$filehandler->delete();
-
-	$group->deleteIcon();
 }
 
 /**
@@ -1027,4 +995,20 @@ function groups_setup_filter_tabs($hook, $type, $return, $params) {
 	]);
 	
 	return $return;
+}
+
+/**
+ * Add 'original' to group icon sizes
+ *
+ * @elgg_plugin_hook entity:icon:sizes group
+ * 
+ * @param \Elgg\Hook $hook Hook
+ * @return array
+ */
+function groups_set_icon_sizes(\Elgg\Hook $hook) {
+
+	$sizes = $hook->getValue();
+	$sizes['original'] = [];
+
+	return $sizes;
 }

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -496,17 +496,27 @@ function groups_update_event_listener($event, $type, $group) {
 	/* @var $group \ElggGroup */
 
 	$original_attributes = $group->getOriginalAttributes();
-	if (empty($original_attributes['owner_guid'])) {
-		return;
+
+	if (!empty($original_attributes['owner_guid'])) {
+		$previous_owner_guid = $original_attributes['owner_guid'];
+
+		// In addition to standard icons, groups plugin stores a copy of the original upload
+		$filehandler = new ElggFile();
+		$filehandler->owner_guid = $previous_owner_guid;
+		$filehandler->setFilename("groups/$group->guid.jpg");
+		$filehandler->transfer($group->owner_guid);
 	}
 
-	$previous_owner_guid = $original_attributes['owner_guid'];
-
-	// In addition to standard icons, groups plugin stores a copy of the original upload
-	$filehandler = new ElggFile();
-	$filehandler->owner_guid = $previous_owner_guid;
-	$filehandler->setFilename("groups/$group->guid.jpg");
-	$filehandler->transfer($group->owner_guid);
+	if (!empty($original_attributes['name'])) {
+		// update access collection name if group name changes
+		$group_name = html_entity_decode($group->name, ENT_QUOTES, 'UTF-8');
+		$ac_name = elgg_echo('groups:group') . ": " . $group_name;
+		$acl = get_access_collection($group->group_acl);
+		if ($acl) {
+			$acl->name = $ac_name;
+			$acl->save();
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
**feat(groups): group ACL name is now always in sync with the group name**

Group name changes that take place outside of the groups/edit
action are now correctly reflected in access collections table

**feat(groups): group metadata ownership in now in sync with group ownership**

Group metadata ownerships is now correctly updated if group
owner changes outside of the groups/edit action

**feat(groups): validate container permissions when creating a new group**

Makes it easier to supply a container_guid for a new group without having to
replace an entire action.
Makes sure the user can write a new group to container, thus making it
easier to implement more granular controls over who can create new groups