### PR TITLE
chore(plugins): plugins page properly updates on ajax (de)activate

### DIFF
--- a/actions/admin/plugins/activate.php
+++ b/actions/admin/plugins/activate.php
@@ -57,10 +57,7 @@ if (count($activated_guids) === 1) {
 	$plugin = get_entity($plugin_guids[0]);
 	$id = $css_id = preg_replace('/[^a-z0-9-]/i', '-', $plugin->getID());
 	$url = "$url#id";
-	$data = [
-		'list' => elgg_view('admin/plugins', ['list_only' => true]),
-	];
-	return elgg_ok_response($data, '', $url);
+	return elgg_ok_response('', '', $url);
 } else {
 	// forward to top of page with a failure so remove any #foo
 	$url = $_SERVER['HTTP_REFERER'];

--- a/actions/admin/plugins/deactivate.php
+++ b/actions/admin/plugins/deactivate.php
@@ -47,10 +47,7 @@ if (count($plugin_guids) == 1) {
 	$plugin = get_entity($plugin_guids[0]);
 	$id = preg_replace('/[^a-z0-9-]/i', '-', $plugin->getID());
 	$url = "$url#$id";
-	$data = [
-		'list' => elgg_view('admin/plugins', ['list_only' => true]),
-	];
-	return elgg_ok_response($data, '', $url);
+	return elgg_ok_response('', '', $url);
 } else {
 	forward(REFERER);
 }

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -342,6 +342,24 @@ function _elgg_admin_init() {
 	elgg_register_page_handler('admin', '_elgg_admin_page_handler');
 	elgg_register_page_handler('admin_plugin_text_file', '_elgg_admin_markdown_page_handler');
 	elgg_register_page_handler('robots.txt', '_elgg_robots_page_handler');
+	elgg_register_page_handler('admin_plugins_refresh', '_elgg_ajax_plugins_update');
+}
+
+/**
+ * Returns plugin listing and admin menu to the client (used after plugin (de)activation)
+ *
+ * @access private
+ * @return Elgg\Http\OkResponse
+ */
+function _elgg_ajax_plugins_update() {
+	elgg_admin_gatekeeper();
+	_elgg_admin_add_plugin_settings_menu();
+	elgg_set_context('admin');
+
+	return elgg_ok_response([
+		'list' => elgg_view('admin/plugins', ['list_only' => true]),
+		'sidebar' => elgg_view('admin/sidebar'),
+	]);
 }
 
 /**

--- a/views/default/elgg/Ajax.js
+++ b/views/default/elgg/Ajax.js
@@ -22,6 +22,7 @@ define(function (require) {
 		use_spinner = elgg.isNullOrUndefined(use_spinner) ? true : !!use_spinner;
 
 		var that = this;
+		var spinner_starts = 0;
 
 		/**
 		 * Fetch a value from an Ajax endpoint.
@@ -128,10 +129,14 @@ define(function (require) {
 			if (use_spinner) {
 				options.beforeSend = function () {
 					orig_options.beforeSend && orig_options.beforeSend.apply(null, arguments);
+					spinner_starts++;
 					spinner.start();
 				};
 				options.complete = function () {
-					spinner.stop();
+					spinner_starts--;
+					if (spinner_starts < 1) {
+						spinner.stop();
+					}
 					orig_options.complete && orig_options.complete.apply(null, arguments);
 				};
 			}

--- a/views/default/elgg/admin.js
+++ b/views/default/elgg/admin.js
@@ -22,16 +22,7 @@ define(function(require) {
 			}
 		});
 
-		// draggable plugin reordering
-		$('#elgg-plugin-list > ul').sortable({
-			items:                'li:has(> .elgg-state-draggable)',
-			handle:               '.elgg-head',
-			forcePlaceholderSize: true,
-			placeholder:          'elgg-widget-placeholder',
-			opacity:              0.8,
-			revert:               500,
-			stop:                 movePlugin
-		});
+		initPluginReordering();
 
 		// in-line editing for custom profile fields.
 		// @note this requires jquery.jeditable plugin
@@ -75,6 +66,18 @@ define(function(require) {
 		$(document).on('mouseenter', '.elgg-plugin-details-screenshots .elgg-plugin-screenshot', showPluginScreenshot);
 	}
 
+	function initPluginReordering() {
+		$('#elgg-plugin-list > ul').sortable({
+			items:                'li:has(> .elgg-state-draggable)',
+			handle:               '.elgg-head',
+			forcePlaceholderSize: true,
+			placeholder:          'elgg-widget-placeholder',
+			opacity:              0.8,
+			revert:               500,
+			stop:                 movePlugin
+		});
+	}
+
 	function toggleSinglePlugin(e) {
 		e.preventDefault();
 
@@ -86,10 +89,18 @@ define(function(require) {
 					return;
 				}
 
-				$('#elgg-plugin-list').html(output.list);
+				// second request because views list must be rebuilt and this can't be done
+				// within the first.
+				ajax.path('admin_plugins_refresh')
+					.done(function (output) {
 
-				// reapply category filtering
-				$(".elgg-admin-plugins-categories > li.elgg-state-selected > a").trigger('click');
+						$('#elgg-plugin-list').html(output.list);
+						$('.elgg-sidebar').html(output.sidebar);
+
+						// reapply category filtering
+						$(".elgg-admin-plugins-categories > li.elgg-state-selected > a").trigger('click');
+						initPluginReordering();
+					});
 			});
 	}
 


### PR DESCRIPTION
**chore(plugins): plugins page properly updates on ajax (de)activate**

When a plugin is (de)activated, the updated plugin list now correctly shows/hides links to settings pages, and the admin menu is updated according to the active plugins.

Fixes #10656

**fix(ajax): elgg/Ajax now uses spinner if 2nd fetch occurs in done handler**

Without this patch, fetches that occur in a done() handler would not show the spinner because jQuery's "complete" handler (which fires after) always stopped the spinner.