### PR TITLE
feat(css): CSS is pre-processed by css-crush, all /cache output is filterable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "bower-asset/jquery-form": "^3.51",
         "bower-asset/jquery-colorbox": "^1.5.14",
         "bower-asset/sprintf": "~1.0.3",
+        "css-crush/css-crush": "^2.4.0",
         "FortAwesome/Font-Awesome": "^4.3",
         "michelf/php-markdown": "^1.5.0",
         "misd/linkify": "~1.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d15c1a8d288ddfff002415f7c59fc853",
+    "hash": "1740bd69b2e9a12b49caddafc4184567",
+    "content-hash": "aaf90119b4b3b48ba2d2fd35abc4fa3d",
     "packages": [
         {
             "name": "bower-asset/jquery",
@@ -313,7 +314,7 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2016-08-13T20:53:52+00:00"
+            "time": "2016-08-13 20:53:52"
         },
         {
             "name": "container-interop/container-interop",
@@ -344,7 +345,68 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
-            "time": "2017-02-14T19:40:03+00:00"
+            "time": "2017-02-14 19:40:03"
+        },
+        {
+            "name": "css-crush/css-crush",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/peteboere/css-crush.git",
+                "reference": "f632d04940d90054efbfe7a6675dc3aa8cac183f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/peteboere/css-crush/zipball/f632d04940d90054efbfe7a6675dc3aa8cac183f",
+                "reference": "f632d04940d90054efbfe7a6675dc3aa8cac183f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.1.*",
+                "psr/log": "1.0.*@dev",
+                "twig/twig": "1.*"
+            },
+            "bin": [
+                "bin/csscrush"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "CssCrush": "lib/"
+                },
+                "files": [
+                    "lib/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pete Boere",
+                    "email": "pete@the-echoplex.net"
+                },
+                {
+                    "name": "GitHub contributors",
+                    "homepage": "https://github.com/peteboere/css-crush/contributors"
+                }
+            ],
+            "description": "CSS preprocessor",
+            "homepage": "http://the-echoplex.net/csscrush",
+            "keywords": [
+                "css",
+                "preprocessor"
+            ],
+            "time": "2015-07-30 08:37:14"
         },
         {
             "name": "doctrine/annotations",
@@ -412,7 +474,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2017-02-24T16:22:25+00:00"
+            "time": "2017-02-24 16:22:25"
         },
         {
             "name": "doctrine/cache",
@@ -482,7 +544,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-10-29T11:16:17+00:00"
+            "time": "2016-10-29 11:16:17"
         },
         {
             "name": "doctrine/collections",
@@ -549,7 +611,7 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2017-01-03T10:49:41+00:00"
+            "time": "2017-01-03 10:49:41"
         },
         {
             "name": "doctrine/common",
@@ -622,7 +684,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2017-01-13T14:02:13+00:00"
+            "time": "2017-01-13 14:02:13"
         },
         {
             "name": "doctrine/dbal",
@@ -693,7 +755,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2017-02-08T12:53:47+00:00"
+            "time": "2017-02-08 12:53:47"
         },
         {
             "name": "doctrine/inflector",
@@ -760,7 +822,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06T14:35:42+00:00"
+            "time": "2015-11-06 14:35:42"
         },
         {
             "name": "doctrine/lexer",
@@ -814,7 +876,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09T13:34:57+00:00"
+            "time": "2014-09-09 13:34:57"
         },
         {
             "name": "elgg/data_views",
@@ -843,7 +905,7 @@
                 "elgg",
                 "plugin"
             ],
-            "time": "2016-02-22T15:52:06+00:00"
+            "time": "2016-02-22 15:52:06"
         },
         {
             "name": "elgg/login_as",
@@ -878,7 +940,7 @@
                 "elgg",
                 "plugin"
             ],
-            "time": "2015-09-03T12:18:17+00:00"
+            "time": "2015-09-03 12:18:17"
         },
         {
             "name": "fortawesome/font-awesome",
@@ -926,7 +988,7 @@
                 "font",
                 "icon"
             ],
-            "time": "2016-10-24T15:52:54+00:00"
+            "time": "2016-10-24 15:52:54"
         },
         {
             "name": "htmlawed/htmlawed",
@@ -972,7 +1034,7 @@
                 "strip",
                 "tags"
             ],
-            "time": "2016-08-27T18:53:27+00:00"
+            "time": "2016-08-27 18:53:27"
         },
         {
             "name": "imagine/imagine",
@@ -1029,7 +1091,7 @@
                 "image manipulation",
                 "image processing"
             ],
-            "time": "2015-09-19T16:54:05+00:00"
+            "time": "2015-09-19 16:54:05"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -1071,7 +1133,7 @@
                 "hashing",
                 "password"
             ],
-            "time": "2014-11-20T16:49:30+00:00"
+            "time": "2014-11-20 16:49:30"
         },
         {
             "name": "league/flysystem",
@@ -1154,7 +1216,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2017-03-18T16:02:30+00:00"
+            "time": "2017-03-18 16:02:30"
         },
         {
             "name": "league/flysystem-memory",
@@ -1205,7 +1267,7 @@
                 "adapter",
                 "memory"
             ],
-            "time": "2016-06-04T03:57:11+00:00"
+            "time": "2016-06-04 03:57:11"
         },
         {
             "name": "michelf/php-markdown",
@@ -1256,7 +1318,7 @@
             "keywords": [
                 "markdown"
             ],
-            "time": "2016-10-29T18:58:20+00:00"
+            "time": "2016-10-29 18:58:20"
         },
         {
             "name": "misd/linkify",
@@ -1301,7 +1363,7 @@
                 "link",
                 "url"
             ],
-            "time": "2017-02-18T13:30:02+00:00"
+            "time": "2017-02-18 13:30:02"
         },
         {
             "name": "mrclay/minify",
@@ -1346,7 +1408,7 @@
             ],
             "description": "Minify is a PHP5 app that helps you follow several rules for client-side performance. It combines multiple CSS or Javascript files, removes unnecessary whitespace and comments, and serves them with gzip encoding and optimal client-side cache headers",
             "homepage": "http://code.google.com/p/minify/",
-            "time": "2016-03-08T11:49:57+00:00"
+            "time": "2016-03-08 11:49:57"
         },
         {
             "name": "psr/cache",
@@ -1392,7 +1454,7 @@
                 "psr",
                 "psr-6"
             ],
-            "time": "2016-08-06T20:24:11+00:00"
+            "time": "2016-08-06 20:24:11"
         },
         {
             "name": "psr/container",
@@ -1441,7 +1503,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14T16:28:37+00:00"
+            "time": "2017-02-14 16:28:37"
         },
         {
             "name": "roave/security-advisories",
@@ -1576,7 +1638,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2017-03-16T14:24:35+00:00"
+            "time": "2017-03-16 14:24:35"
         },
         {
             "name": "symfony/http-foundation",
@@ -1631,7 +1693,7 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-04T12:20:59+00:00"
+            "time": "2017-03-04 12:20:59"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1690,7 +1752,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-php54",
@@ -1748,7 +1810,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-php55",
@@ -1804,7 +1866,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "tedivm/stash",
@@ -1864,7 +1926,7 @@
                 "redis",
                 "sessions"
             ],
-            "time": "2016-02-10T22:23:16+00:00"
+            "time": "2016-02-10 22:23:16"
         },
         {
             "name": "zendframework/zend-loader",
@@ -1908,7 +1970,7 @@
                 "loader",
                 "zf2"
             ],
-            "time": "2015-06-03T14:05:47+00:00"
+            "time": "2015-06-03 14:05:47"
         },
         {
             "name": "zendframework/zend-mail",
@@ -1968,7 +2030,7 @@
                 "mail",
                 "zf2"
             ],
-            "time": "2017-02-14T18:03:34+00:00"
+            "time": "2017-02-14 18:03:34"
         },
         {
             "name": "zendframework/zend-mime",
@@ -2017,7 +2079,7 @@
                 "mime",
                 "zf2"
             ],
-            "time": "2017-01-16T16:43:38+00:00"
+            "time": "2017-01-16 16:43:38"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -2062,7 +2124,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-09-13T14:38:50+00:00"
+            "time": "2016-09-13 14:38:50"
         },
         {
             "name": "zendframework/zend-validator",
@@ -2133,7 +2195,7 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2017-03-17T10:15:50+00:00"
+            "time": "2017-03-17 10:15:50"
         }
     ],
     "packages-dev": [
@@ -2189,7 +2251,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2015-06-14 21:17:01"
         },
         {
             "name": "elgg/sniffs",
@@ -2219,7 +2281,7 @@
                 "source": "https://github.com/Elgg/elgg-coding-standards/tree/3.x",
                 "issues": "https://github.com/Elgg/elgg-coding-standards/issues"
             },
-            "time": "2017-03-21T13:20:20+00:00"
+            "time": "2017-03-21 13:20:20"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -2268,7 +2330,7 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2015-02-03T12:10:50+00:00"
+            "time": "2015-02-03 12:10:50"
         },
         {
             "name": "phpspec/prophecy",
@@ -2331,7 +2393,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2017-03-02 20:05:34"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2393,7 +2455,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06T15:47:00+00:00"
+            "time": "2015-10-06 15:47:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2440,7 +2502,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -2481,7 +2543,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
@@ -2530,7 +2592,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2017-02-26 11:10:40"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -2579,7 +2641,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2017-02-27 10:12:30"
         },
         {
             "name": "phpunit/phpunit",
@@ -2651,7 +2713,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-06T05:18:07+00:00"
+            "time": "2017-02-06 05:18:07"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -2707,7 +2769,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02T06:51:40+00:00"
+            "time": "2015-10-02 06:51:40"
         },
         {
             "name": "sebastian/comparator",
@@ -2771,7 +2833,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2017-01-29 09:50:25"
         },
         {
             "name": "sebastian/diff",
@@ -2823,7 +2885,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "time": "2015-12-08 07:14:41"
         },
         {
             "name": "sebastian/environment",
@@ -2873,7 +2935,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18T05:49:44+00:00"
+            "time": "2016-08-18 05:49:44"
         },
         {
             "name": "sebastian/exporter",
@@ -2940,7 +3002,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17T09:04:28+00:00"
+            "time": "2016-06-17 09:04:28"
         },
         {
             "name": "sebastian/global-state",
@@ -2991,7 +3053,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2015-10-12 03:26:01"
         },
         {
             "name": "sebastian/recursion-context",
@@ -3044,7 +3106,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03T07:41:43+00:00"
+            "time": "2016-10-03 07:41:43"
         },
         {
             "name": "sebastian/version",
@@ -3079,7 +3141,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21T13:59:46+00:00"
+            "time": "2015-06-21 13:59:46"
         },
         {
             "name": "simpletest/simpletest",
@@ -3152,7 +3214,7 @@
                 "testing",
                 "unit-test"
             ],
-            "time": "2015-09-21T18:19:52+00:00"
+            "time": "2015-09-21 18:19:52"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -3230,7 +3292,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-03-01T22:17:45+00:00"
+            "time": "2017-03-01 22:17:45"
         },
         {
             "name": "symfony/yaml",
@@ -3285,7 +3347,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-07T16:47:02+00:00"
+            "time": "2017-03-07 16:47:02"
         }
     ],
     "aliases": [],

--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -94,7 +94,11 @@ System hooks
 	or return ``false`` to cancel the item creation.
 
 **simplecache:generate, <view>**
-	Triggered when generating the cached content of a view.
+	Filters the view output for a ``/cache`` URL when simplecache is enabled.
+
+**cache:generate, <view>**
+	Filters the view output for a ``/cache`` URL when simplecache is disabled. Note this will be fired
+	for every ``/cache`` request--no Expires headers are used when simplecache is disabled.
 
 **prepare, breadcrumbs**
     In ``elgg_get_breadcrumbs()``, this filters the registered breadcrumbs before

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -419,6 +419,8 @@ Notable changes in plugins:
  * Admin theme now reuses icon classes from ``elements/icons.css``
  * User "hover" icons are no longer covered with a "caret" icon.
 
+Also note, CSS views served via ``/cache`` URLs are pre-processed using `CSS Crush <http://the-echoplex.net/csscrush/>`_. If you make references to CSS variables or other elements, the definition must be located within the same view output. E.g. A variable defined in ``elgg.css`` cannot be referenced in a separate CSS file like ``colorbox.css``.
+
 Comment notifications
 ---------------------
 

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1756,6 +1756,27 @@ function _elgg_views_minify($hook, $type, $content, $params) {
 	}
 }
 
+/**
+ * Preprocesses CSS views sent by /cache URLs
+ *
+ * @param string $hook    The name of the hook "simplecache:generate" or "cache:generate"
+ * @param string $type    "css"
+ * @param string $content Content of the view
+ * @param array  $params  Array of parameters
+ *
+ * @return string|null View content
+ * @access private
+ */
+function _elgg_views_preprocess_css($hook, $type, $content, $params) {
+	$options = [
+		'minify' => false, // minify handled by _elgg_views_minify
+		'formatter' => 'single-line', // shows lowest byte size
+		'versioning' => false, // versioning done by Elgg
+		'rewrite_import_urls' => false,
+	];
+	
+	return csscrush_string($content, $options);
+}
 
 /**
  * Inserts module names into anonymous modules by handling the "simplecache:generate" hook.
@@ -1899,7 +1920,11 @@ function elgg_views_boot() {
 	elgg_register_css('jquery.imgareaselect', elgg_get_simplecache_url('jquery.imgareaselect.css'));
 
 	elgg_register_ajax_view('languages.js');
-	
+
+	// pre-process CSS regardless of simplecache
+	elgg_register_plugin_hook_handler('cache:generate', 'css', '_elgg_views_preprocess_css');
+	elgg_register_plugin_hook_handler('simplecache:generate', 'css', '_elgg_views_preprocess_css');
+
 	elgg_register_plugin_hook_handler('simplecache:generate', 'js', '_elgg_views_amd');
 	elgg_register_plugin_hook_handler('simplecache:generate', 'css', '_elgg_views_minify');
 	elgg_register_plugin_hook_handler('simplecache:generate', 'js', '_elgg_views_minify');

--- a/views/default/admin.css.php
+++ b/views/default/admin.css.php
@@ -292,9 +292,6 @@ a.elgg-maintenance-mode-warning {
 	width: 210px;
 	float: right;
 	margin-left: 30px;
-
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
 .elgg-main > .elgg-head {
@@ -497,9 +494,6 @@ input {
 	color: #666;
 	border-radius: 5px;
 	margin: 0;
-
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
 
@@ -567,9 +561,6 @@ select {
 	padding: 6px 12px;
 	margin-bottom: 5px;
 	cursor: pointer;
-
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
 

--- a/views/default/elements/buttons.css.php
+++ b/views/default/elements/buttons.css.php
@@ -11,9 +11,6 @@
 	cursor: pointer;
 	border-radius: 3px;
 	box-shadow: inset 0 0 1px rgba(255, 255, 255, 0.6);
-
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
 .elgg-button + .elgg-button {

--- a/views/default/elements/components.css.php
+++ b/views/default/elements/components.css.php
@@ -291,7 +291,6 @@
 /* Comment highlighting that automatically fades away */
 .elgg-comments .elgg-state-highlight,
 .elgg-river-comments .elgg-state-highlight {
-	-webkit-animation: comment-highlight 5s; /* Chrome, Safari, Opera */
 	animation: comment-highlight 5s;
 }
 /* Chrome, Safari, Opera */
@@ -344,8 +343,6 @@
 	padding: 3px;
 	background-color: #FFF;
 
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 
 	max-width: 100%;

--- a/views/default/elements/forms.css.php
+++ b/views/default/elements/forms.css.php
@@ -41,9 +41,6 @@ input, textarea {
 	padding: 7px 6px;
 	width: 100%;
 	border-radius: 3px;
-
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
 input[type=email]:focus,

--- a/views/default/elements/layout.css.php
+++ b/views/default/elements/layout.css.php
@@ -168,9 +168,6 @@
 	}
 	.elgg-main {
         padding: 12px 20px 10px;
-
-		-webkit-box-sizing: border-box;
-		-moz-box-sizing: border-box;
 		box-sizing: border-box;
     }
     .elgg-layout-one-sidebar .elgg-main,
@@ -186,9 +183,6 @@
 		float: left;
 		padding: 27px 20px 20px;
 		box-shadow: 0 3px 6px rgba(0, 0, 0, 0.05) inset;
-
-		-webkit-box-sizing: border-box;
-		-moz-box-sizing: border-box;
 		box-sizing: border-box;
 	}
 	.elgg-sidebar-alt {

--- a/views/default/elements/misc/checkbox_switch.css
+++ b/views/default/elements/misc/checkbox_switch.css
@@ -14,7 +14,6 @@
 	background-color: #F0F0F0;
 	border-radius: 3px;
 	box-shadow: inset 0 0.1em 0 rgba(0, 0, 0, 0.2);
-	-webkit-transition: all 100ms ease-in;
 	transition: all 100ms ease-in;
 }
 

--- a/views/default/elements/misc/spinner.css
+++ b/views/default/elements/misc/spinner.css
@@ -20,17 +20,14 @@
 	left: -10000px;
 	opacity: 0;
 
-	/* fade out over 300ms, then jump offscreen */
-	-webkit-transition: opacity 300ms ease-in-out, left 0s linear 300ms;
-	transition: opacity 300ms ease-in-out, left 0s linear 300ms;
+    /* fade out over 300ms, then jump offscreen */
+    transition: opacity 300ms ease-in-out, left 0s linear 300ms;
 }
 
 .elgg-spinner-active .elgg-spinner {
 	left: 50%;
 	opacity: 1;
 
-	/* set values immediately */
-	-webkit-transition: opacity 0s, left 0s;
-	transition: opacity 0s, left 0s;
+    /* set values immediately */
+    transition: opacity 0s, left 0s;
 }
-

--- a/views/default/maintenance.css.php
+++ b/views/default/maintenance.css.php
@@ -148,9 +148,6 @@ input, textarea {
 	padding: 7px 6px;
 	width: 100%;
 	border-radius: 3px;
-
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
 


### PR DESCRIPTION
All `/cache` output is now filtered by either the `simplecache:generate` or `cache:generate` hook, depending on whether Simplecache is enabled.

css-crush is used to pre-process all CSS `/cache` output.

Fixes #10625
Refs #10316

- [ ] test basic pre-processing

(replaces #10666)