### PR TITLE
fix(ajax): elgg/Ajax view() and form() set $vars as expected

### DIFF
--- a/js/tests/ElggAjaxTest.js
+++ b/js/tests/ElggAjaxTest.js
@@ -115,25 +115,34 @@ define(function(require) {
 			expect(ajax._ajax_options.method).toEqual('POST');
 		});
 
+		it("path(): non-empty object data changes default to POST", function() {
+			ajax.path('foo', {
+				data: {bar: 'bar'}
+			});
+			expect(ajax._ajax_options.method).toEqual('POST');
+		});
+
+		it("path(): non-empty string data changes default to POST", function() {
+			ajax.path('foo', {
+				data: '?bar=bar'
+			});
+			expect(ajax._ajax_options.method).toEqual('POST');
+		});
+
+		$.each(['form', 'view'], function (i, method) {
+			it(method + "(): non-empty object data left as GET", function() {
+				ajax[method]('foo', {
+					data: {bar: 'bar'}
+				});
+				expect(ajax._ajax_options.method).toEqual('GET');
+			});
+		});
+
 		$.each(['path', 'form', 'view'], function (i, method) {
 
 			it(method + "() defaults to GET", function() {
 				ajax[method]('foo');
 				expect(ajax._ajax_options.method).toEqual('GET');
-			});
-
-			it(method + "(): non-empty object data changes default to POST", function() {
-				ajax[method]('foo', {
-					data: {bar: 'bar'}
-				});
-				expect(ajax._ajax_options.method).toEqual('POST');
-			});
-
-			it(method + "(): non-empty string data changes default to POST", function() {
-				ajax[method]('foo', {
-					data: '?bar=bar'
-				});
-				expect(ajax._ajax_options.method).toEqual('POST');
 			});
 
 			it(method + "(): empty string data leaves default as GET", function() {

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -18,6 +18,7 @@ function developers_init() {
 	elgg_register_page_handler('developers_ajax_demo', 'developers_ajax_demo_controller');
 
 	elgg_register_external_view('developers/ajax'); // for lightbox in sandbox
+	elgg_register_ajax_view('developers/ajax_demo.html');
 	$sandbox_css = elgg_get_simplecache_url('theme_sandbox.css');
 	elgg_register_css('dev.theme_sandbox', $sandbox_css);
 

--- a/mod/developers/views/default/developers/ajax_demo.html
+++ b/mod/developers/views/default/developers/ajax_demo.html
@@ -1,1 +1,0 @@
-<p>view demo</p>

--- a/mod/developers/views/default/developers/ajax_demo.html.php
+++ b/mod/developers/views/default/developers/ajax_demo.html.php
@@ -1,0 +1,7 @@
+<?php
+
+if (!isset($vars['entity']) || !$vars['entity'] instanceof ElggSite) {
+	register_error('$vars not set by ajax.form()');
+}
+
+?><p>view demo</p>

--- a/mod/developers/views/default/developers/ajax_demo.js
+++ b/mod/developers/views/default/developers/ajax_demo.js
@@ -52,14 +52,18 @@ define(function(require) {
 			if (html_page.indexOf('path demo') != -1) {
 				log("PASS path()");
 
-				return ajax.view('developers/ajax_demo.html');
+				return ajax.view('developers/ajax_demo.html', {
+					data: {guid: 1}
+				});
 			}
 		})
 		.then(function (div) {
 			if (div.indexOf('view demo') != -1) {
 				log("PASS view()");
 
-				return ajax.form('developers/ajax_demo');
+				return ajax.form('developers/ajax_demo', {
+					data: {guid: 1}
+				});
 			}
 		})
 		.then(function (form) {

--- a/mod/developers/views/default/forms/developers/ajax_demo.php
+++ b/mod/developers/views/default/forms/developers/ajax_demo.php
@@ -1,4 +1,8 @@
 <?php
 // This will be fetched via ajax by the developers/ajax_example AMD module
 
+if (!isset($vars['entity']) || !$vars['entity'] instanceof ElggSite) {
+	register_error('$vars not set by ajax.view()');
+}
+
 echo "form demo";

--- a/views/default/elgg/Ajax.js
+++ b/views/default/elgg/Ajax.js
@@ -246,6 +246,7 @@ define(function (require) {
 
 			options = options || {};
 			options.url = 'ajax/view/' + view;
+			options.method = options.method || 'GET';
 
 			// remove query
 			view = view.replace(query_pattern, '').replace(slashes_pattern, '');
@@ -274,6 +275,7 @@ define(function (require) {
 
 			options = options || {};
 			options.url = 'ajax/form/' + action;
+			options.method = options.method || 'GET';
 
 			// remove query
 			action = action.replace(query_pattern, '').replace(slashes_pattern, '');


### PR DESCRIPTION
The `elgg/Ajax` module was auto-converting any request with `options.data` to use the `POST` method. This makes sense for things like actions, which may send a large amount of form data, but it caused `$vars` to not be populated as expected because only `GET` params are injected.

If you specified `options.data` with these methods before, note the server will no longer receive this data in `$_POST`.

Fixes #10667