### PR TITLE
fix(files): mitigate issues with special chars in file names

### DIFF
--- a/engine/classes/Elgg/FileService/File.php
+++ b/engine/classes/Elgg/FileService/File.php
@@ -2,6 +2,8 @@
 
 namespace Elgg\FileService;
 
+use Elgg\Security\Base64Url;
+
 /**
  * File service
  * 
@@ -104,6 +106,12 @@ class File {
 		if (!$relative_path) {
 			elgg_log("Unable to resolve relative path of the file on the filestore");
 			return false;
+		}
+
+		if (preg_match('~[^a-zA-Z0-9_\./ ]~', $relative_path)) {
+			// Filenames may contain special characters that result in malformatted URLs
+			// and/or HMAC mismatches. We want to avoid that by encoding the path.
+			$relative_path = ':' . Base64Url::encode($relative_path);
 		}
 
 		$data = array(

--- a/engine/classes/Elgg/Security/Base64Url.php
+++ b/engine/classes/Elgg/Security/Base64Url.php
@@ -1,0 +1,33 @@
+<?php
+namespace Elgg\Security;
+
+/**
+ * Encode and decode Base 64 URL
+ *
+ * @access private
+ */
+class Base64Url {
+
+	/**
+	 * Encode base 64 URL
+	 *
+	 * @param string $bytes Bytes to encode
+	 * @return string
+	 */
+	public static function encode($bytes) {
+		$bytes = base64_encode($bytes);
+		$bytes = rtrim($bytes, '=');
+		return strtr($bytes, '+/', '-_');
+	}
+
+	/**
+	 * Decode base 64 URL
+	 *
+	 * @param string $bytes Bytes to decode
+	 * @return string|false
+	 */
+	public static function decode($bytes) {
+		$bytes = strtr($bytes, '-_', '+/');
+		return base64_decode($bytes);
+	}
+}

--- a/engine/classes/Elgg/Security/Hmac.php
+++ b/engine/classes/Elgg/Security/Hmac.php
@@ -54,7 +54,7 @@ class Hmac {
 	 */
 	public function getToken() {
 		$bytes = hash_hmac($this->algo, $this->data, $this->key, true);
-		return strtr(rtrim(base64_encode($bytes), '='), '+/', '-_');
+		return Base64Url::encode($bytes);
 	}
 
 	/**

--- a/engine/tests/phpunit/Elgg/Application/ServeFileHandlerTest.php
+++ b/engine/tests/phpunit/Elgg/Application/ServeFileHandlerTest.php
@@ -17,9 +17,6 @@ class ServeFileHandlerTest extends PHPUnit_Framework_TestCase {
 	protected $file;
 
 	public function setUp() {
-		$app = _elgg_testing_application();
-		$dataroot = _elgg_testing_config()->getDataPath();
-
 		$session = \ElggSession::getMock();
 		_elgg_services()->setValue('session', $session);
 		_elgg_services()->session->start();
@@ -28,9 +25,20 @@ class ServeFileHandlerTest extends PHPUnit_Framework_TestCase {
 
 		$file = new \ElggFile();
 		$file->owner_guid = 1;
-		$file->setFilename("foobar.txt");
+
+		// Using special characters to test against files that have been
+		// uploaded prior to implementation of filename sanitization
+		// See #10608
+		$file->setFilename("Iñtërn'âtiônàl-izætiøn.txt");
+		$file->open('write');
+		$file->write('Test file!');
+		$file->close();
 
 		$this->file = $file;
+	}
+
+	public function tearDown() {
+		$this->file->delete();
 	}
 
 	function createRequest(\Elgg\FileService\File $file) {


### PR DESCRIPTION
Relative paths to files that contain special characters in the name will now be encoded with base64 to avoid malformatted URLs and HMAC mismatches resulting from unescaped characters. URLs generated prior to this change will continue working.

Refs #10608