### PR TITLE
fix(discussions): river entries are once again visible to logged out …

### DIFF
--- a/mod/discussions/views/default/river/object/discussion/create.php
+++ b/mod/discussions/views/default/river/object/discussion/create.php
@@ -3,10 +3,6 @@
  * River view for new discussion topics
  */
 
-if (!elgg_is_logged_in()) {
-	return;
-}
-
 $item = $vars['item'];
 /* @var ElggRiverItem $item */
 


### PR DESCRIPTION
…users

River items about new discussions are once again visible to logged out users.
Discussion replies (but not the form) will be visible as well.

Replaces #10685