### PR TITLE
chore(html): removes elgg_format_url()

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -88,6 +88,7 @@ All the functions in ``engine/lib/deprecated-1.10.php`` were removed. See https:
  * ``run_function_once``: Use ``Elgg\Upgrade\Batch`` interface
  * ``system_messages``
  * ``notifications_plugin_pagesetup``
+ * ``elgg_format_url()``: Use elgg_format_element() or the "output/text" view for HTML escaping.
  * ``ElggEntity::addToSite``
  * ``ElggEntity::getSites``
  * ``ElggEntity::removeFromSite``

--- a/engine/classes/Elgg/Assets/ExternalFiles.php
+++ b/engine/classes/Elgg/Assets/ExternalFiles.php
@@ -49,7 +49,6 @@ class ExternalFiles {
 			return false;
 		}
 	
-		$url = elgg_format_url($url);
 		$url = elgg_normalize_url($url);
 
 		$this->bootstrap($type);

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1109,7 +1109,7 @@ function elgg_http_build_url(array $parts, $html_encode = true) {
 	$string = $scheme . $host . $port . $path . $query . $fragment;
 
 	if ($html_encode) {
-		return elgg_format_url($string);
+		return htmlspecialchars($string, ENT_QUOTES, 'UTF-8', false);
 	} else {
 		return $string;
 	}

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -71,18 +71,6 @@ function elgg_get_excerpt($text, $num_chars = 250) {
 }
 
 /**
- * Handles formatting of ampersands in urls
- *
- * @param string $url The URL
- *
- * @return string
- * @since 1.7.1
- */
-function elgg_format_url($url) {
-	return preg_replace('/&(?!amp;)/', '&amp;', $url);
-}
-
-/**
  * Format bytes to a human readable format
  *
  * @param int $size      File size in bytes to format

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -584,7 +584,7 @@ function _elgg_views_prepare_head($title) {
 			'rel' => 'alternative',
 			'type' => 'application/rss+xml',
 			'title' => 'RSS',
-			'href' => elgg_format_url($url),
+			'href' => $url,
 		);
 	}
 	

--- a/mod/file/views/default/file/specialcontent/image/default.php
+++ b/mod/file/views/default/file/specialcontent/image/default.php
@@ -5,16 +5,21 @@
  * @uses $vars['entity']
  */
 
+if (empty($vars['full_view'])) {
+	return;
+}
+
 $file = $vars['entity'];
 
-$image_url = $file->getIconURL('large');
-$image_url = elgg_format_url($image_url);
-$download_url = elgg_get_download_url($file);
+$img = elgg_format_element('img', [
+	'class' => 'elgg-photo',
+	'src' => $file->getIconURL('large'),
+]);
+$a = elgg_format_element([
+	'#tag_name' => 'a',
+	'#text' => $img,
+	'href' => elgg_get_download_url($file),
+	'class' => 'elgg-lightbox-photo',
+]);
 
-if ($vars['full_view']) {
-	echo <<<HTML
-		<div class="file-photo">
-			<a href="$download_url" class="elgg-lightbox-photo"><img class="elgg-photo" src="$image_url" /></a>
-		</div>
-HTML;
-}
+?><div class="file-photo"><?= $a ?></div>

--- a/views/default/output/iframe.php
+++ b/views/default/output/iframe.php
@@ -10,8 +10,6 @@
 
 $src = elgg_extract('src', $vars);
 
-$src = elgg_normalize_url($src);
-$vars['src'] = elgg_format_url($src);
+$vars['src'] = elgg_normalize_url($src);
 
-$attributes = elgg_format_attributes($vars);
-echo "<iframe $attributes></iframe>";
+echo elgg_format_element('iframe', $vars);

--- a/views/default/output/img.php
+++ b/views/default/output/img.php
@@ -11,7 +11,5 @@ if (!isset($vars['alt'])) {
 }
 
 $vars['src'] = elgg_normalize_url($vars['src']);
-$vars['src'] = elgg_format_url($vars['src']);
 
-$attributes = elgg_format_attributes($vars);
-echo "<img $attributes/>";
+echo elgg_format_element('img', $vars);


### PR DESCRIPTION
This function was added before there we had a better pipeline for formatting HTML attributes and insufficiently escaped only ampersands.

Fixes #5617

BREAKING CHANGE:
`elgg_format_url()` has been removed. Use `elgg_format_element()` or the "output/text" view for HTML escaping.