### PR TITLE
chore(forms): the input section of a field is now wrapped in a div

### DIFF
--- a/docs/guides/actions.rst
+++ b/docs/guides/actions.rst
@@ -293,10 +293,12 @@ The above will generate the following markup:
 
    <div class="elgg-field elgg-field-required">
       <label for="elgg-field-1" class="elgg-field-label">Blog status<span title="Required" class="elgg-required-indicator">*</span></label>
-      <select required="required" name="status" data-rel="blog" id="elgg-field-1" class="elgg-input-dropdown">
-         <option value="draft">Draft</option>
-         <option value="published">Published</option>
-      </select>
+      <div class="elgg-field-input">
+      	 <select required="required" name="status" data-rel="blog" id="elgg-field-1" class="elgg-input-dropdown">
+            <option value="draft">Draft</option>
+            <option value="published">Published</option>
+         </select>
+      </div>
       <div class="elgg-field-help elgg-text-help">
          <span class="elgg-icon-help elgg-icon"></span>This indicates whether or not the blog is visible in the feed
       </div>

--- a/views/default/elements/forms/input.php
+++ b/views/default/elements/forms/input.php
@@ -6,4 +6,8 @@
 $input_type = elgg_extract('input_type', $vars);
 unset($vars['input_type']);
 
-echo elgg_view("input/$input_type", $vars);
+$input = elgg_view("input/$input_type", $vars);
+
+echo elgg_format_element('div', [
+	'class' => 'elgg-field-input',
+], $input);

--- a/views/default/elements/navigation.css.php
+++ b/views/default/elements/navigation.css.php
@@ -536,7 +536,7 @@
 .elgg-menu-longtext {
 	float: right;
 }
-.elgg-field-label + .elgg-menu-longtext {
+.elgg-field-input > .elgg-menu-longtext {
 	margin-top: -20px;
 }
 /* ***************************************

--- a/views/default/forms/profile/edit.php
+++ b/views/default/forms/profile/edit.php
@@ -66,9 +66,11 @@ if (is_array($profile_fields) && count($profile_fields) > 0) {
 			'name' => "accesslevel[$shortname]",
 			'value' => $access_id,
 		]);
-
+		
 		echo elgg_view('elements/forms/field', [
-			'input' => $input . $access_input,
+			'input' => elgg_format_element('div', [
+					'class' => 'elgg-field-input',
+				], $input . $access_input),
 			'label' => elgg_view('elements/forms/label', [
 				'label' => elgg_echo("profile:$shortname"),
 				'id' => $id,


### PR DESCRIPTION
This allows for easier selection of stuff inside the input part of a field...

Specifically handy for fields like the longtext that create multiple dom elements (with editor enabled)