### PR TITLE
chore(docs): rename `param` to `params` in settings

### DIFF
--- a/docs/guides/settings.rst
+++ b/docs/guides/settings.rst
@@ -5,7 +5,7 @@ You need to perform some extra steps if your plugin needs settings to be saved a
 
 - Create a file in your plugin’s default view folder called ``plugins/your_plugin/settings.php``, where ``your_plugin`` is the name of your plugin’s directory in the ``mod`` hierarchy
 - Fill this file with the form elements you want to display together with :doc:`internationalised <i18n>` text labels
-- Set the name attribute in your form components to ``param[`varname`]`` where ``varname`` is the name of the variable. These will be saved as private settings attached to a plugin entity. So, if your variable is called ``param[myparameter]`` your plugin (which is also passed to this view as ``$vars['entity']``) will be called ``$vars['entity']->myparameter``
+- Set the name attribute in your form components to ``params[`varname`]`` where ``varname`` is the name of the variable. These will be saved as private settings attached to a plugin entity. So, if your variable is called ``params[myparameter]`` your plugin (which is also passed to this view as ``$vars['entity']``) will be called ``$vars['entity']->myparameter``
 
 An example ``settings.php`` would look like:
 


### PR DESCRIPTION
It's `params`, not `param` to pass settings as name.