### PR TITLE
fix(cache): remove trailing slashes in cache symlink paths

### DIFF
--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -230,7 +230,7 @@ function elgg_flush_caches() {
  * @access private
  */
 function _elgg_is_cache_symlinked() {
-	$link = elgg_get_root_path() . 'cache/';
+	$link = elgg_get_root_path() . 'cache';
 	$target = elgg_get_cache_path() . 'views_simplecache/';
 	return is_dir($link) && realpath($target) == realpath($link);
 }


### PR DESCRIPTION
the slash broken the readlink() function and was not possible to enable the symlink_cache