### PR TITLE
fix(site_notifications): cast read state of site notifications to int before saving as metadata

### DIFF
--- a/mod/site_notifications/classes/SiteNotification.php
+++ b/mod/site_notifications/classes/SiteNotification.php
@@ -64,7 +64,7 @@ class SiteNotification extends ElggObject {
 	 * @param bool $read Has the notification been read
 	 */
 	public function setRead($read) {
-		$this->read = $read;
+		$this->read = (int)$read;
 	}
 
 	/**


### PR DESCRIPTION
Meant to fix https://github.com/Elgg/Elgg/issues/10738.