### PR TITLE
fix(admin): prevents simultaneous plugin (de)activation/reordering

### DIFF
--- a/views/default/admin.css.php
+++ b/views/default/admin.css.php
@@ -1526,6 +1526,17 @@ h6 > .elgg-icon {
 	margin-left: 5px;
 }
 
+#elgg-plugin-list-cover {
+	display: none;
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	background: white;
+	opacity: 0.5;
+}
+
 .elgg-plugin-settings {
 	font-weight: normal;
 	font-size: 0.9em;

--- a/views/default/admin/plugins.php
+++ b/views/default/admin/plugins.php
@@ -61,6 +61,7 @@ if ($add_context) {
 	elgg_push_context('admin');
 }
 $plugins_list = elgg_view_entity_list($installed_plugins, $list_options);
+$plugins_list .= "<div id='elgg-plugin-list-cover'></div>";
 if ($add_context) {
 	elgg_pop_context();
 }

--- a/views/default/elgg/admin.js
+++ b/views/default/elgg/admin.js
@@ -66,6 +66,13 @@ define(function(require) {
 		$(document).on('mouseenter', '.elgg-plugin-details-screenshots .elgg-plugin-screenshot', showPluginScreenshot);
 	}
 
+	function freezePlugins() {
+		$('#elgg-plugin-list-cover').css('display', 'block');
+	}
+	function unfreezePlugins() {
+		$('#elgg-plugin-list-cover').css('display', 'none');
+	}
+
 	function initPluginReordering() {
 		$('#elgg-plugin-list > ul').sortable({
 			items:                'li:has(> .elgg-state-draggable)',
@@ -79,6 +86,8 @@ define(function(require) {
 	}
 
 	function toggleSinglePlugin(e) {
+		freezePlugins();
+
 		e.preventDefault();
 
 		ajax.action(this.href)
@@ -100,6 +109,7 @@ define(function(require) {
 						// reapply category filtering
 						$(".elgg-admin-plugins-categories > li.elgg-state-selected > a").trigger('click');
 						initPluginReordering();
+						unfreezePlugins();
 					});
 			});
 	}
@@ -116,6 +126,8 @@ define(function(require) {
 		if (!confirm(elgg.echo('question:areyousure'))) {
 			return;
 		}
+
+		freezePlugins();
 
 		var guids = [],
 			state = $(this).data('desiredState'),
@@ -153,6 +165,8 @@ define(function(require) {
 	 * @return void
 	 */
 	function movePlugin (e, ui) {
+		freezePlugins();
+
 		// get guid from id like elgg-object-<guid>
 		var pluginGuid = ui.item.attr('id');
 		pluginGuid = pluginGuid.replace('elgg-object-', '');
@@ -171,6 +185,7 @@ define(function(require) {
 						updatePluginView($(this));
 					}
 				});
+				unfreezePlugins();
 			}
 		});
 	}


### PR DESCRIPTION
Problems can occur if a plugin order/activation change is requested while another change is being executed. This places a semi-opaque cover over the plugins list while an operation is executing so that the user cannot start another operation.

This will not prevent the problem for users navigating via keyboard.

Fixes #10706