### PR TITLE
fix(menus): return to default of sorting menus by text

### DIFF
--- a/engine/classes/Elgg/Menu/Service.php
+++ b/engine/classes/Elgg/Menu/Service.php
@@ -71,7 +71,7 @@ class Service {
 		$params = $this->hooks->trigger('parameters', "menu:$name", $params, $params);
 
 		if (!isset($params['sort_by'])) {
-			$params['sort_by'] = 'priority';
+			$params['sort_by'] = 'text';
 		}
 
 		$items = $this->hooks->trigger('register', "menu:$name", $params, $items);


### PR DESCRIPTION
This was accidentally changed in #9522, which overhauled menu creation for Elgg 2.2.

Fixes #10737