### PR TITLE
fix(output): elgg_normalize_url() again handles multibyte chars and spaces

### DIFF
--- a/engine/tests/ElggCoreHelpersTest.php
+++ b/engine/tests/ElggCoreHelpersTest.php
@@ -63,6 +63,11 @@ class ElggCoreHelpersTest extends \ElggCoreUnitTest {
 			'example.com' => 'http://example.com',
 			'example.com/subpage' => 'http://example.com/subpage',
 
+			'http://example.com/ИмяПользователя' => 'http://example.com/ИмяПользователя',
+
+			'http://example.com/a b' => 'http://example.com/a%20b',
+			'http://example.com/?a=1 2' => 'http://example.com/?a=1%202',
+
 			'page/handler' =>                	elgg_get_site_url() . 'page/handler',
 			'page/handler?p=v&p2=v2' =>      	elgg_get_site_url() . 'page/handler?p=v&p2=v2',
 			'mod/plugin/file.php' =>            elgg_get_site_url() . 'mod/plugin/file.php',

--- a/mod/developers/start.php
+++ b/mod/developers/start.php
@@ -103,7 +103,9 @@ function developers_setup_menu() {
 		foreach ($inspect_options as $key => $value) {
 			elgg_register_menu_item('page', array(
 				'name' => 'dev_inspect_' . elgg_get_friendly_title($key),
-				'href' => "admin/develop_tools/inspect?inspect_type={$key}",
+				'href' => "admin/develop_tools/inspect?" . http_build_query([
+					'inspect_type' => $key,
+				]),
 				'text' => $value,
 				'context' => 'admin',
 				'section' => 'develop',


### PR DESCRIPTION
Our use of `filter_var()`/`FILTER_VALIDATE_URL` can now handle multibyte chars.

Previous Elgg versions passed through invalid URLs that contained spaces. Since even core code created these URLs, we compromise by auto-encoding spaces rather than rejecting those URLs.

Fixes #10771