### PR TITLE
fix(js): make sure elgg.forward() always reloads the page

### DIFF
--- a/js/lib/elgglib.js
+++ b/js/lib/elgglib.js
@@ -423,7 +423,19 @@ elgg.deprecated_notice = function(msg, dep_version) {
  * @param {String} url The url to forward to
  */
 elgg.forward = function(url) {
-	location.href = elgg.normalize_url(url);
+	var dest = elgg.normalize_url(url);
+
+	if (dest == location.href) {
+		location.reload();
+	}
+
+	// in case the href set below just changes the hash, we want to reload. There's sadly
+	// no way to force a reload and set a different hash at the same time.
+	$(window).on('hashchange', function () {
+		location.reload();
+	});
+
+	location.href = dest;
 };
 
 /**


### PR DESCRIPTION
If the destination URL has a hash, and the whole URL is identical to the current page, we must force `reload()`.