### PR TITLE
feat(notifications): target URLs for notifications are now set explicitly

### DIFF
--- a/engine/classes/Elgg/Notifications/Notification.php
+++ b/engine/classes/Elgg/Notifications/Notification.php
@@ -34,6 +34,9 @@ class Notification {
 	/** @var array Additional parameters */
 	public $params;
 
+	/** @var string Target URL */
+	public $url;
+
 	/**
 	 * Create a notification
 	 *
@@ -60,6 +63,10 @@ class Notification {
 		$this->body = $body;
 		$this->summary = $summary;
 		$this->params = $params;
+
+		if (isset($this->params['url'])) {
+			$this->url = $this->params['url'];
+		}
 	}
 
 	/**

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -833,6 +833,8 @@ function _elgg_admin_prepare_admin_notification_make_admin($hook, $type, $return
 		$object->getURL(),
 		$site->getURL(),
 	], $language);
+
+	$return_value->url = elgg_normalize_url('admin/users/admins');
 	
 	return $return_value;
 }
@@ -878,6 +880,8 @@ function _elgg_admin_prepare_admin_notification_remove_admin($hook, $type, $retu
 		$object->getURL(),
 		$site->getURL(),
 	], $language);
+
+	$return_value->url = elgg_normalize_url('admin/users/admins');
 	
 	return $return_value;
 }
@@ -956,6 +960,8 @@ function _elgg_admin_prepare_user_notification_make_admin($hook, $type, $return_
 		$site->name,
 		$site->getURL(),
 	], $language);
+
+	$return_value->url = elgg_normalize_url('admin');
 	
 	return $return_value;
 }
@@ -999,6 +1005,8 @@ function _elgg_admin_prepare_user_notification_remove_admin($hook, $type, $retur
 		$site->name,
 		$site->getURL(),
 	], $language);
+
+	$return_value->url = false;
 	
 	return $return_value;
 }

--- a/engine/lib/comments.php
+++ b/engine/lib/comments.php
@@ -456,6 +456,8 @@ function _elgg_comments_prepare_notification($hook, $type, $returnvalue, $params
 		$commenter->getDisplayName(),
 		$commenter->getURL(),
 	], $language);
+
+	$returnvalue->url = $comment->getURL();
 	
 	return $returnvalue;
 }

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -933,6 +933,8 @@ function _elgg_user_prepare_unban_notification($hook, $type, $return_value, $par
 		$site->name,
 		$site->getURL(),
 	], $language);
+
+	$return_value->url = $recipient->getURL();
 	
 	return $return_value;
 }

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -299,7 +299,8 @@ function blog_prepare_notification($hook, $type, $notification, $params) {
 		$entity->getURL()
 	), $language);
 	$notification->summary = elgg_echo('blog:notify:summary', array($entity->title), $language);
-
+	$notification->url = $entity->getURL();
+	
 	return $notification;
 }
 

--- a/mod/bookmarks/start.php
+++ b/mod/bookmarks/start.php
@@ -206,7 +206,7 @@ function bookmarks_prepare_notification($hook, $type, $notification, $params) {
 		$entity->getURL()
 	), $language);
 	$notification->summary = elgg_echo('bookmarks:notify:summary', array($entity->title), $language);
-
+	$notification->url = $entity->getURL();
 	return $notification;
 }
 

--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -335,7 +335,7 @@ function discussion_prepare_notification($hook, $type, $notification, $params) {
 		$entity->getURL()
 	), $language);
 	$notification->summary = elgg_echo('discussion:topic:notify:summary', array($entity->title), $language);
-
+	$notification->url = $entity->getURL();
 	return $notification;
 }
 
@@ -362,7 +362,8 @@ function discussion_prepare_reply_notification($hook, $type, $notification, $par
 		$reply->getURL(),
 	), $language);
 	$notification->summary = elgg_echo('discussion:reply:notify:summary', array($topic->title), $language);
-
+	$notification->url = $reply->getURL();
+	
 	return $notification;
 }
 

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -205,7 +205,7 @@ function file_prepare_notification($hook, $type, $notification, $params) {
 		$entity->getURL()
 	), $language);
 	$notification->summary = elgg_echo('file:notify:summary', array($entity->title), $language);
-
+	$notification->url = $entity->getURL();
 	return $notification;
 }
 

--- a/mod/friends/start.php
+++ b/mod/friends/start.php
@@ -192,6 +192,7 @@ function _elgg_send_friend_notification($event, $type, $object) {
 		'action' => 'add_friend',
 		'object' => $user_one,
 		'friend' => $user_two,
+		'url' => $user_two->getURL(),
 	];
 
 	return notify_user($user_two->guid, $object->guid_one, $subject, $body, $params);

--- a/mod/groups/actions/groups/membership/add.php
+++ b/mod/groups/actions/groups/membership/add.php
@@ -34,6 +34,7 @@ if (sizeof($user_guid)) {
 					$params = [
 						'action' => 'add_membership',
 						'object' => $group,
+						'url' => $group->getURL(),
 					];
 
 					// Send welcome notification to user

--- a/mod/groups/actions/groups/membership/invite.php
+++ b/mod/groups/actions/groups/membership/invite.php
@@ -51,6 +51,7 @@ if (count($user_guids) > 0 && elgg_instanceof($group, 'group') && $group->canEdi
 		$params = [
 			'action' => 'invite',
 			'object' => $group,
+			'url' => $url,
 		];
 
 		// Send notification

--- a/mod/groups/actions/groups/membership/join.php
+++ b/mod/groups/actions/groups/membership/join.php
@@ -66,6 +66,7 @@ if ($user && ($group instanceof ElggGroup)) {
 		$params = [
 			'action' => 'membership_request',
 			'object' => $group,
+			'url' => $url,
 		];
 		
 		// Notify group owner

--- a/mod/likes/actions/likes/add.php
+++ b/mod/likes/actions/likes/add.php
@@ -88,6 +88,7 @@ if ($entity->owner_guid != $user->guid) {
 			'action' => 'create',
 			'object' => $annotation,
 			'summary' => $summary,
+			'url' => $entity->getURL(),
 		)
 	);
 }

--- a/mod/messageboard/start.php
+++ b/mod/messageboard/start.php
@@ -91,11 +91,12 @@ function messageboard_add($poster, $owner, $message, $access_id = ACCESS_PUBLIC)
 	if ($poster->guid != $owner->guid) {
 
 		$subject = elgg_echo('messageboard:email:subject', array(), $owner->language);
+		$url = elgg_get_site_url() . "messageboard/owner/" . $owner->username;
 
 		$body = elgg_echo('messageboard:email:body', array(
 			$poster->name,
 			$message,
-			elgg_get_site_url() . "messageboard/owner/" . $owner->username,
+			$url,
 			$poster->name,
 			$poster->getURL()
 		), $owner->language);
@@ -103,6 +104,7 @@ function messageboard_add($poster, $owner, $message, $access_id = ACCESS_PUBLIC)
 		$params = [
 			'action' => 'create',
 			'object' => elgg_get_annotation_from_id($result_id),
+			'url' => $url,
 		];
 		notify_user($owner->guid, $poster->guid, $subject, $body, $params);
 	}

--- a/mod/messages/start.php
+++ b/mod/messages/start.php
@@ -325,6 +325,7 @@ function messages_send($subject, $body, $recipient_guid, $sender_guid = 0, $orig
 		$params = [
 			'object' => $message_to,
 			'action' => 'send',
+			'url' => $message_to->getURL(),
 		];
 		notify_user($recipient_guid, $sender_guid, $subject, $body, $params);
 	}

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -297,7 +297,7 @@ function pages_prepare_notification($hook, $type, $notification, $params) {
 		$entity->getURL(),
 	), $language);
 	$notification->summary = elgg_echo('pages:notify:summary', array($entity->title), $language);
-
+	$notification->url = $entity->getURL();
 	return $notification;
 }
 

--- a/mod/site_notifications/classes/SiteNotificationFactory.php
+++ b/mod/site_notifications/classes/SiteNotificationFactory.php
@@ -9,25 +9,33 @@ abstract class SiteNotificationFactory {
 	 * @param string     $message   Notification message
 	 * @param ElggUser   $actor     User who caused the notification event
 	 * @param ElggData   $object    Optional object involved in the notification event
+	 * @param string     $url       Target URL
 	 * @return SiteNotification|null
 	 */
-	public static function create($recipient, $message, $actor, $object = null) {
+	public static function create($recipient, $message, $actor, $object = null, $url = null) {
 		$note = new SiteNotification();
 		$note->owner_guid = $recipient->guid;
 		$note->container_guid = $recipient->guid;
 		$note->access_id = ACCESS_PRIVATE;
 		$note->description = $message;
-		if ($object) {
+
+		if (!isset($url) && $object) {
 			// TODO Add support for setting an URL for a notification about a new relationship
 			switch ($object->getType()) {
 				case 'annotation':
 					// Annotations do not have an URL so we use the entity URL
-					$note->setURL($object->getEntity()->getURL());
+					$url = $object->getEntity()->getURL();
 					break;
 				default:
-					$note->setURL($object->getURL());
+					$url = $object->getURL();
+					break;
 			}
 		}
+
+		if ($url && $url != elgg_get_site_url()) {
+			$note->setURL($url);
+		}
+		
 		$note->setRead(false);
 
 		if ($note->save()) {

--- a/mod/site_notifications/start.php
+++ b/mod/site_notifications/start.php
@@ -92,9 +92,10 @@ function site_notifications_send($hook, $type, $result, $params) {
 
 	$actor = $notification->getSender();
 	$recipient = $notification->getRecipient();
-
+	$url = $notification->url;
+	
 	$ia = elgg_set_ignore_access(true);
-	$note = SiteNotificationFactory::create($recipient, $message, $actor, $object);
+	$note = SiteNotificationFactory::create($recipient, $message, $actor, $object, $url);
 	elgg_set_ignore_access($ia);
 	if ($note) {
 		return true;

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -178,7 +178,7 @@ function thewire_prepare_notification($hook, $type, $notification, $params) {
 	$notification->subject = $subject;
 	$notification->body = $body;
 	$notification->summary = elgg_echo('thewire:notify:summary', array($descr), $language);
-
+	$notification->url = $entity->getURL();
 	return $notification;
 }
 


### PR DESCRIPTION
Given that notification targets vary, it is now advised that URL be set
explicitly for instant and subscription notifications. This will allow custom
handlers (e.g. site notifications) to point users to correct URL, rather
than second guessing and making wrong assumptions.