### PR TITLE
deprecate(logging): removes warnings about metadata/annotation value casting

### DIFF
--- a/docs/design/database.rst
+++ b/docs/design/database.rst
@@ -318,6 +318,9 @@ Each annotation has:
 -  An access permission distinct from the entity it's attached to
 -  An owner
 
+Like metadata, values are stored as strings unless the value given is a PHP integer (``is_int($value)`` is true),
+or unless the ``$vartype`` is manually specified as ``integer``.
+
 Adding an annotation
 --------------------
 
@@ -396,6 +399,8 @@ reference). What you need to know is:
    to the owner of the entity it's attached to
 -  You can potentially have multiple items of each type of metadata
    attached to a single entity
+-  Like annotations, values are stored as strings unless the value given is a PHP integer (``is_int($value)`` is true),
+   or unless the ``$value_type`` is manually specified as ``integer`` (see below).
 
 .. note:: Metadata's ``access_id`` value will be ignored in Elgg 3.0 and all metadata values will be available in all contexts.
 
@@ -486,7 +491,7 @@ defined as follows:
             $entity_guid,           // The GUID of the parent entity
             $name,                  // The name of the metadata (eg 'tags')
             $value,                 // The metadata value
-            $value_type,            // Currently either 'string' or 'integer'
+            $value_type,            // Currently either 'text' or 'integer'
             $owner_guid,            // The owner of the metadata
             $access_id = 0,         // The access restriction
             $allow_multiple = false // Do we have more than one value?

--- a/engine/classes/Elgg/Database/Annotations.php
+++ b/engine/classes/Elgg/Database/Annotations.php
@@ -87,7 +87,7 @@ class Annotations {
 		$result = false;
 	
 		$entity_guid = (int)$entity_guid;
-		$value_type = detect_extender_valuetype($value, $value_type);
+		$value_type = \ElggExtender::detectValueType($value, $value_type);
 	
 		$owner_guid = (int)$owner_guid;
 		if ($owner_guid == 0) {
@@ -157,7 +157,7 @@ class Annotations {
 		}
 	
 		$name = trim($name);
-		$value_type = detect_extender_valuetype($value, $value_type);
+		$value_type = \ElggExtender::detectValueType($value, $value_type);
 	
 		$owner_guid = (int)$owner_guid;
 		if ($owner_guid == 0) {

--- a/engine/classes/Elgg/Database/MetadataTable.php
+++ b/engine/classes/Elgg/Database/MetadataTable.php
@@ -118,7 +118,7 @@ class MetadataTable {
 
 		$entity_guid = (int)$entity_guid;
 		// name and value are encoded in add_metastring()
-		$value_type = detect_extender_valuetype($value, $this->db->sanitizeString(trim($value_type)));
+		$value_type = \ElggExtender::detectValueType($value, trim($value_type));
 		$time = $this->getCurrentTime()->getTimestamp();
 		$owner_guid = (int)$owner_guid;
 		$allow_multiple = (boolean)$allow_multiple;
@@ -221,7 +221,7 @@ class MetadataTable {
 			return false;
 		}
 	
-		$value_type = detect_extender_valuetype($value, $this->db->sanitizeString(trim($value_type)));
+		$value_type = \ElggExtender::detectValueType($value, trim($value_type));
 	
 		$owner_guid = (int)$owner_guid;
 		if ($owner_guid == 0) {

--- a/engine/classes/ElggExtender.php
+++ b/engine/classes/ElggExtender.php
@@ -58,7 +58,7 @@ abstract class ElggExtender extends \ElggData {
 
 		$this->attributes[$name] = $value;
 		if ($name == 'value') {
-			$this->attributes['value_type'] = detect_extender_valuetype($value);
+			$this->attributes['value_type'] = self::detectValueType($value);
 		}
 	}
 
@@ -72,7 +72,7 @@ abstract class ElggExtender extends \ElggData {
 	 */
 	public function setValue($value, $value_type = '') {
 		$this->attributes['value'] = $value;
-		$this->attributes['value_type'] = detect_extender_valuetype($value, $value_type);
+		$this->attributes['value_type'] = self::detectValueType($value, $value_type);
 	}
 
 	/**
@@ -315,4 +315,21 @@ abstract class ElggExtender extends \ElggData {
 		return elgg_normalize_url($url);
 	}
 
+	/**
+	 * Detect the value_type for a value to be stored as metadata or an annotation
+	 *
+	 * @param mixed  $value      The value
+	 * @param string $value_type If specified as "text" or "integer", overrides the detection.
+	 *
+	 * @return string
+	 * @access private
+	 * @internal
+	 */
+	public static function detectValueType($value, $value_type = "") {
+		if ($value_type === 'integer' || $value_type === 'text') {
+			return $value_type;
+		}
+
+		return is_int($value) ? 'integer' : 'text';
+	}
 }

--- a/engine/lib/extender.php
+++ b/engine/lib/extender.php
@@ -8,37 +8,17 @@
  */
 
 /**
- * Detect the value_type for a given value.
- * Currently this is very crude.
- *
- * @todo Make better!
+ * Alias of ElggExtender::detectValueType
  *
  * @param mixed  $value      The value
  * @param string $value_type If specified, overrides the detection.
  *
  * @return string
+ * @todo delete in 3.0
+ * @deprecated This will be removed in Elgg 3.0
  */
 function detect_extender_valuetype($value, $value_type = "") {
-	if ($value_type === 'integer' || $value_type === 'text') {
-		return $value_type;
-	}
+	elgg_deprecated_notice(__FUNCTION__ . ' will be removed in Elgg 3.0. Do not use it.', '2.3');
 
-	// This is crude
-	if (is_int($value)) {
-		return 'integer';
-	}
-
-	// Catch floating point values which are not integer
-	if (is_numeric($value)) {
-		return 'text';
-	}
-
-	if (is_string($value) || (is_object($value) && method_exists($value, '__toString'))) {
-		return 'text';
-	}
-
-	$type = gettype($value);
-	_elgg_services()->logger->warn("Metadata and annotations store only integers and strings. $type given.");
-
-	return 'text';
+	return ElggExtender::detectValueType($value, $value_type);
 }

--- a/engine/tests/phpunit/Elgg/Mocks/Database/MetadataTable.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Database/MetadataTable.php
@@ -61,7 +61,7 @@ class MetadataTable extends DbMetadataTabe {
 			'value' => $value,
 			'time_created' => $this->getCurrentTime()->getTimestamp(),
 			'access_id' => (int) $access_id,
-			'value_type' => detect_extender_valuetype($value, $this->db->sanitizeString(trim($value_type))),
+			'value_type' => \ElggExtender::detectValueType($value, trim($value_type)),
 		];
 
 		$this->rows[$id] = $row;
@@ -81,7 +81,7 @@ class MetadataTable extends DbMetadataTabe {
 		$row = $this->rows[$id];
 		$row->name = $name;
 		$row->value = $value;
-		$row->value_type = detect_extender_valuetype($value, $this->db->sanitizeString(trim($value_type)));
+		$row->value_type = \ElggExtender::detectValueType($value, trim($value_type));
 		$row->owner_guid = $owner_guid;
 		$row->access_id = $access_id;
 

--- a/engine/tests/phpunit/ElggExtenderTest.php
+++ b/engine/tests/phpunit/ElggExtenderTest.php
@@ -31,47 +31,23 @@ class ElggExtenderTest extends \Elgg\TestCase {
 	}
 
 	public function testIntsAreTypedAsInteger() {
-		$this->assertSame('integer', detect_extender_valuetype(-1));
-		$this->assertSame('integer', detect_extender_valuetype(0));
-		$this->assertSame('integer', detect_extender_valuetype(2));
+		$this->assertSame('integer', \ElggExtender::detectValueType(-1));
+		$this->assertSame('integer', \ElggExtender::detectValueType(0));
+		$this->assertSame('integer', \ElggExtender::detectValueType(2));
 	}
 
 	public function testFloatsAndNumericsAndStringableObjectsAreTypedAsText() {
-		$this->assertSame('text', detect_extender_valuetype(3.14));
-		$this->assertSame('text', detect_extender_valuetype('3.14'));
-		$this->assertSame('text', detect_extender_valuetype(new ElggExtenderTest_Object));
-	}
-
-	public function testOthersTypedAsTextWithWarning() {
-		_elgg_services()->logger->disable();
-
-		$this->assertSame('text', detect_extender_valuetype(null));
-		$this->assertSame('text', detect_extender_valuetype(true));
-		$this->assertSame('text', detect_extender_valuetype((object) []));
-
-		$expected = [
-			[
-				'message' => 'Metadata and annotations store only integers and strings. NULL given.',
-        		'level' => 300,
-			],
-			[
-				'message' => 'Metadata and annotations store only integers and strings. boolean given.',
-				'level' => 300,
-			],
-			[
-				'message' => 'Metadata and annotations store only integers and strings. object given.',
-        		'level' => 300,
-			]
-		];
-		$this->assertSame($expected, _elgg_services()->logger->enable());
+		$this->assertSame('text', \ElggExtender::detectValueType(3.14));
+		$this->assertSame('text', \ElggExtender::detectValueType('3.14'));
+		$this->assertSame('text', \ElggExtender::detectValueType(new ElggExtenderTest_Object));
 	}
 
 	public function testAcceptRecognizedTypes() {
-		$this->assertSame('text', detect_extender_valuetype(123, 'text'));
-		$this->assertSame('integer', detect_extender_valuetype(123, 'invalid'));
+		$this->assertSame('text', \ElggExtender::detectValueType(123, 'text'));
+		$this->assertSame('integer', \ElggExtender::detectValueType(123, 'invalid'));
 
-		$this->assertSame('integer', detect_extender_valuetype('hello', 'integer'));
-		$this->assertSame('text', detect_extender_valuetype('hello', 'invalid'));
+		$this->assertSame('integer', \ElggExtender::detectValueType('hello', 'integer'));
+		$this->assertSame('text', \ElggExtender::detectValueType('hello', 'invalid'));
 	}
 
 }


### PR DESCRIPTION
Metadata/annotation casting is now explained in the docs.

Deprecates `detect_extender_valuetype()` and moves its logic to a static `ElggExtender` method.

Fixes #10749