### PR TITLE
chore(river): warn devs that elgg_get_river() has no "views" option

### DIFF
--- a/engine/lib/deprecated-2.1.php
+++ b/engine/lib/deprecated-2.1.php
@@ -108,7 +108,11 @@ function elgg_delete_river(array $options = array()) {
 
 	// allow core to use this in 2.x w/o warnings
 	if (empty($options['__bypass_notice'])) {
-		elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use elgg_get_river() and call delete() on the returned item(s)', '2.3');
+		$msg = __FUNCTION__ . ' is deprecated. Use elgg_get_river() and call delete() on the returned item(s)';
+		if (isset($options['view']) || isset($options['views'])) {
+			$msg .= '. You must use the "wheres" option to specify value(s) for the "rv.view" column.';
+		}
+		elgg_deprecated_notice($msg, '2.3');
 	}
 
 	$defaults = array(

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -233,6 +233,12 @@ function elgg_get_river(array $options = array()) {
 		'joins'                => array(),
 	);
 
+	if (isset($options['view']) || isset($options['views'])) {
+		$msg = __FUNCTION__ . ' does not support the "views" option, though you may specify values for'
+			. ' the "rv.view" column using the "wheres" option.';
+		elgg_log($msg, 'WARNING');
+	}
+
 	$options = array_merge($defaults, $options);
 
 	if ($options['batch'] && !$options['count']) {


### PR DESCRIPTION
Devs who refactor `elgg_delete_river()` code to use `elgg_get_river()` may be surprised that it doesn't support this option.

Fixes #10791