### PR TITLE
chore(js): improves ajax login workflow

### DIFF
--- a/actions/login.php
+++ b/actions/login.php
@@ -85,4 +85,9 @@ $output = [
 	'forward' => $forward_url,
 ];
 
+if (elgg_is_xhr()) {
+	// Hold the system messages until the client refreshes the page.
+	set_input('elgg_fetch_messages', 0);
+}
+
 return elgg_ok_response($output, $message, $forward_url);

--- a/engine/classes/Elgg/Ajax/Service.php
+++ b/engine/classes/Elgg/Ajax/Service.php
@@ -63,15 +63,8 @@ class Service {
 		$this->input = $input;
 		$this->amd_config = $amdConfig;
 
-		if ($this->input->get('elgg_fetch_messages', true)) {
-			$message_filter = [$this, 'appendMessages'];
-			$this->hooks->registerHandler(AjaxResponse::RESPONSE_HOOK, 'all', $message_filter, 999);
-		}
-
-		if ($this->input->get('elgg_fetch_deps', true)) {
-			$deps_filter = [$this, 'appendDeps'];
-			$this->hooks->registerHandler(AjaxResponse::RESPONSE_HOOK, 'all', $deps_filter, 999);
-		}
+		$message_filter = [$this, 'prepareResponse'];
+		$this->hooks->registerHandler(AjaxResponse::RESPONSE_HOOK, 'all', $message_filter, 999);
 	}
 
 	/**
@@ -228,7 +221,7 @@ class Service {
 	}
 
 	/**
-	 * Send system messages back with the response
+	 * Prepare the response with additional metadata, like system messages and required AMD modules
 	 *
 	 * @param string       $hook     "ajax_response"
 	 * @param string       $type     "all"
@@ -239,31 +232,19 @@ class Service {
 	 * @access private
 	 * @internal
 	 */
-	public function appendMessages($hook, $type, $response, $params) {
+	public function prepareResponse($hook, $type, $response, $params) {
 		if (!$response instanceof AjaxResponse) {
 			return;
 		}
-		$response->getData()->_elgg_msgs = (object)$this->msgs->dumpRegister();
-		return $response;
-	}
 
-	/**
-	 * Send required AMD modules list back with the response
-	 *
-	 * @param string       $hook     "ajax_response"
-	 * @param string       $type     "all"
-	 * @param AjaxResponse $response Ajax response
-	 * @param array        $params   Hook params
-	 *
-	 * @return AjaxResponse
-	 * @access private
-	 * @internal
-	 */
-	public function appendDeps($hook, $type, $response, $params) {
-		if (!$response instanceof AjaxResponse) {
-			return;
+		if ($this->input->get('elgg_fetch_messages', true)) {
+			$response->getData()->_elgg_msgs = (object)$this->msgs->dumpRegister();
 		}
-		$response->getData()->_elgg_deps = (array) $this->amd_config->getDependencies();
+
+		if ($this->input->get('elgg_fetch_deps', true)) {
+			$response->getData()->_elgg_deps = (array) $this->amd_config->getDependencies();
+		}
+
 		return $response;
 	}
 

--- a/views/default/forms/login.js
+++ b/views/default/forms/login.js
@@ -1,23 +1,32 @@
-define(['jquery', 'elgg', 'elgg/Ajax'], function($, elgg, Ajax) {
-	var ajax = new Ajax();
-	
+define(function(require) {
+	var $ = require('jquery');
+	var elgg = require('elgg');
+	var Ajax = require('elgg/Ajax');
+	var spinner = require('elgg/spinner');
+
+	// manage Spinner manually
+	var ajax = new Ajax(false);
+
 	$(document).on('submit', '.elgg-form-login', function(e) {
 		var $form = $(this);
 
+		spinner.start();
 		ajax.action($form.prop('action'), {
 			data: ajax.objectify($form)
-		}).success(function(json, status, xhr) {
-			if (typeof json.forward !== 'undefined') {
+		}).done(function(json, status, jqXHR) {
+			if (jqXHR.AjaxData.status == -1) {
+				$('input[name=password]', $form).val('').focus();
+				spinner.stop();
+				return;
+			}
+
+			if (json && (typeof json.forward === 'string')) {
 				elgg.forward(json.forward);
-			} else if (json === '') {
-				// BC fallback if action did not return a forward url
-				// elgg_ok_response will have the forward url
-				// elgg_error_response will have the error text
-				// everything else is unknown, so forward
-				elgg.forward();				
+			} else {
+				elgg.forward();
 			}
 		});
-		
+
 		e.preventDefault();
 	});
 });


### PR DESCRIPTION
On successful login, the spinner is shown and system messages held until the page refreshes. On login failure, only the password field is cleared and focused.

The script no longer fails if `json.forward` is returned as `-1`.

Ajax/Service is modified slightly to allow setting the input params `elgg_fetch_messages` and/or `elgg_fetch_deps` from plugin code.

Fixes #10774
Fixes #10805