### PR TITLE
feat(menus): reorganize entity and river menus to use dropdown

### DIFF
--- a/docs/guides/menus.rst
+++ b/docs/guides/menus.rst
@@ -187,6 +187,8 @@ Child menus can be configured using ``child_menu`` factory option on the parent 
 
 ``child_menu`` options array accepts ``display`` parameter, which can be used
 to set the child menu to open as ``dropdown`` or be displayed via ``toggle``.
+``allow_empty`` parameter can be used to remove the parent item, if the child
+menu is empty.
 All other key value pairs will be passed as attributes to the ``ul`` element.
 
 

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -522,6 +522,28 @@ function _elgg_page_menu_setup(\Elgg\Hook $hook) {
  * @access private
  */
 function _elgg_river_menu_setup($hook, $type, $return, $params) {
+
+	$toggle = elgg_view_icon('chevron-down', ['class' => 'elgg-state-closed']);
+	$toggle .= elgg_view_icon('chevron-up', ['class' => 'elgg-state-opened']);
+	
+	$return[] = \ElggMenuItem::factory([
+				'name' => 'actions',
+				'text' => elgg_echo('river:actions'),
+				'icon' => $toggle,
+				'href' => '#',
+				'child_menu' => [
+					'display' => 'dropdown',
+					'class' => 'elgg-river-child-menu',
+					'allow_empty' => false,
+					'data-position' => json_encode([
+						'at' => 'right bottom+5px',
+						'my' => 'right top',
+						'collision' => 'fit fit',
+					]),
+				],
+				'priority' => 9999,
+	]);
+
 	if (elgg_is_logged_in()) {
 		$item = $params['item'];
 		/* @var \ElggRiverItem $item */
@@ -531,8 +553,10 @@ function _elgg_river_menu_setup($hook, $type, $return, $params) {
 			if ($object->canComment()) {
 				$options = array(
 					'name' => 'comment',
+					'parent_name' => 'actions',
 					'href' => "#comments-add-{$object->guid}-{$item->id}",
-					'text' => elgg_view_icon('speech-bubble'),
+					'text' => elgg_echo('comment'),
+					'icon' => 'speech-bubble',
 					'title' => elgg_echo('comment:this'),
 					'rel' => 'toggle',
 					'priority' => 50,
@@ -544,11 +568,13 @@ function _elgg_river_menu_setup($hook, $type, $return, $params) {
 		if ($item->canDelete()) {
 			$options = array(
 				'name' => 'delete',
+				'parent_name' => 'actions',
 				'href' => elgg_add_action_tokens_to_url("action/river/delete?id={$item->id}"),
-				'text' => elgg_view_icon('delete'),
+				'text' => elgg_echo('delete'),
+				'icon' => 'delete',
 				'title' => elgg_echo('river:delete'),
 				'confirm' => elgg_echo('deleteconfirm'),
-				'priority' => 200,
+				'priority' => 900,
 			);
 			$return[] = \ElggMenuItem::factory($options);
 		}
@@ -562,10 +588,28 @@ function _elgg_river_menu_setup($hook, $type, $return, $params) {
  * @access private
  */
 function _elgg_entity_menu_setup($hook, $type, $return, $params) {
-	if (elgg_in_context('widgets')) {
-		return $return;
-	}
-	
+
+	$toggle = elgg_view_icon('chevron-down', ['class' => 'elgg-state-closed']);
+	$toggle .= elgg_view_icon('chevron-up', ['class' => 'elgg-state-opened']);
+
+	$return[] = \ElggMenuItem::factory([
+				'name' => 'actions',
+				'text' => elgg_echo('entity:actions'),
+				'icon' => $toggle,
+				'href' => '#',
+				'child_menu' => [
+					'display' => 'dropdown',
+					'class' => 'elgg-entity-child-menu',
+					'allow_empty' => false,
+					'data-position' => json_encode([
+						'at' => 'right bottom+5px',
+						'my' => 'right top',
+						'collision' => 'fit fit',
+					]),
+				],
+				'priority' => 9999,
+	]);
+
 	$entity = $params['entity'];
 	/* @var \ElggEntity $entity */
 	$handler = elgg_extract('handler', $params, false);
@@ -586,7 +630,9 @@ function _elgg_entity_menu_setup($hook, $type, $return, $params) {
 		// edit link
 		$options = array(
 			'name' => 'edit',
+			'parent_name' => 'actions',
 			'text' => elgg_echo('edit'),
+			'icon' => 'pencil',
 			'title' => elgg_echo('edit:this'),
 			'href' => "$handler/edit/{$entity->getGUID()}",
 			'priority' => 200,
@@ -603,11 +649,13 @@ function _elgg_entity_menu_setup($hook, $type, $return, $params) {
 		}
 		$options = array(
 			'name' => 'delete',
-			'text' => elgg_view_icon('delete'),
+			'parent_name' => 'actions',
+			'text' => elgg_echo('delete'),
+			'icon' => 'delete',
 			'title' => elgg_echo('delete:this'),
 			'href' => "$action?guid={$entity->getGUID()}",
 			'confirm' => elgg_echo('deleteconfirm'),
-			'priority' => 300,
+			'priority' => 900,
 		);
 		$return[] = \ElggMenuItem::factory($options);
 	}

--- a/mod/blog/views/default/object/blog.php
+++ b/mod/blog/views/default/object/blog.php
@@ -43,16 +43,13 @@ if ($blog->comments_on != 'Off') {
 
 $subtitle = "$by_line $comments_link $categories";
 
-$metadata = '';
-if (!elgg_in_context('widgets')) {
-	// only show entity menu outside of widgets
-	$metadata = elgg_view_menu('entity', array(
-		'entity' => $vars['entity'],
-		'handler' => 'blog',
-		'sort_by' => 'priority',
-		'class' => 'elgg-menu-hz',
-	));
-}
+$metadata = elgg_view_menu('entity', array(
+	'entity' => $vars['entity'],
+	'handler' => 'blog',
+	'sort_by' => 'priority',
+	'class' => 'elgg-menu-hz',
+));
+
 
 if ($full) {
 

--- a/mod/bookmarks/views/default/object/bookmarks.php
+++ b/mod/bookmarks/views/default/object/bookmarks.php
@@ -37,7 +37,7 @@ if ($comments_count != 0) {
 $subtitle = "$by_line $comments_link $categories";
 
 $metadata = '';
-if (!elgg_in_context('widgets') && !elgg_in_context('gallery')) {
+if (!elgg_in_context('gallery')) {
 	// only show entity menu outside of widgets and gallery view
 	$metadata = elgg_view_menu('entity', array(
 		'entity' => $vars['entity'],

--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -287,8 +287,10 @@ function discussion_add_to_river_menu($hook, $type, $return, $params) {
 		if ($object->canWriteToContainer(0, 'object', 'discussion_reply')) {
 				$options = array(
 				'name' => 'reply',
+				'parent_name' => 'actions',
 				'href' => "#discussion-reply-{$object->guid}",
-				'text' => elgg_view_icon('speech-bubble'),
+				'text' => elgg_echo('reply'),
+				'icon' => 'speech-bubble',
 				'title' => elgg_echo('reply:this'),
 				'rel' => 'toggle',
 				'priority' => 50,
@@ -551,10 +553,6 @@ function discussion_reply_menu_setup($hook, $type, $return, $params) {
 		return $return;
 	}
 
-	if (elgg_in_context('widgets')) {
-		return $return;
-	}
-
 	// Reply has the same access as the topic so no need to view it
 	$remove = array('access');
 
@@ -564,14 +562,18 @@ function discussion_reply_menu_setup($hook, $type, $return, $params) {
 	if ($reply->canEdit() && !elgg_in_context('activity')) {
 		$return[] = ElggMenuItem::factory(array(
 			'name' => 'edit',
+			'parent_name' => 'actions',
 			'text' => elgg_echo('edit'),
+			'icon' => 'pencil',
 			'href' => "discussion/reply/edit/{$reply->guid}",
 			'priority' => 150,
 		));
 
 		$return[] = ElggMenuItem::factory(array(
 			'name' => 'delete',
+			'parent_name' => 'actions',
 			'text' => elgg_view_icon('delete'),
+			'icon' => 'delete',
 			'href' => "action/discussion/reply/delete?guid={$reply->guid}",
 			'priority' => 150,
 			'is_action' => true,

--- a/mod/discussions/views/default/object/discussion.php
+++ b/mod/discussions/views/default/object/discussion.php
@@ -65,17 +65,12 @@ if ($num_replies != 0) {
 	));
 }
 
-// do not show the metadata and controls in widget view
-$metadata = '';
-if (!elgg_in_context('widgets')) {
-	// only show entity menu outside of widgets
-	$metadata = elgg_view_menu('entity', array(
-		'entity' => $vars['entity'],
-		'handler' => 'discussion',
-		'sort_by' => 'priority',
-		'class' => 'elgg-menu-hz',
-	));
-}
+$metadata = elgg_view_menu('entity', array(
+	'entity' => $vars['entity'],
+	'handler' => 'discussion',
+	'sort_by' => 'priority',
+	'class' => 'elgg-menu-hz',
+));
 
 if ($full) {
 	$subtitle = "$by_line $replies_link";

--- a/mod/discussions/views/default/object/discussion_reply.php
+++ b/mod/discussions/views/default/object/discussion_reply.php
@@ -10,16 +10,12 @@ if (!$reply) {
 	return true;
 }
 
-$metadata = '';
-if (!elgg_in_context('widgets')) {
-	// only show entity menu outside of widgets
-	$metadata = elgg_view_menu('entity', array(
-		'entity' => $vars['entity'],
-		'handler' => 'discussion_reply',
-		'sort_by' => 'priority',
-		'class' => 'elgg-menu-hz',
-	));
-}
+$metadata = elgg_view_menu('entity', array(
+	'entity' => $vars['entity'],
+	'handler' => 'discussion_reply',
+	'sort_by' => 'priority',
+	'class' => 'elgg-menu-hz',
+		));
 
 if (elgg_in_context('activity')) {
 	$content = '<div class="elgg-output elgg-inner" data-role="comment-text">';

--- a/mod/file/views/default/object/file.php
+++ b/mod/file/views/default/object/file.php
@@ -33,7 +33,7 @@ if ($comments_count != 0) {
 $subtitle = "$by_line $comments_link $categories";
 
 $metadata = '';
-if (!elgg_in_context('widgets') && !elgg_in_context('gallery')) {
+if (!elgg_in_context('gallery')) {
 	// only show entity menu outside of widgets and gallery view
 	$metadata = elgg_view_menu('entity', array(
 		'entity' => $vars['entity'],

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -354,9 +354,6 @@ function groups_activity_owner_block_menu($hook, $type, $return, $params) {
  * Add links/info to entity menu particular to group entities
  */
 function groups_entity_menu_setup($hook, $type, $return, $params) {
-	if (elgg_in_context('widgets')) {
-		return $return;
-	}
 
 	/* @var ElggGroup $entity */
 	$entity = $params['entity'];
@@ -404,6 +401,8 @@ function groups_entity_menu_setup($hook, $type, $return, $params) {
 
 		$return[] = ElggMenuItem::factory(array(
 			'name' => 'feature',
+			'parent_name' => 'actions',
+			'icon' => 'star',
 			'text' => elgg_echo("groups:makefeatured"),
 			'href' => elgg_add_action_tokens_to_url("action/groups/featured?group_guid={$entity->guid}&action_type=feature"),
 			'priority' => 300,
@@ -413,6 +412,8 @@ function groups_entity_menu_setup($hook, $type, $return, $params) {
 
 		$return[] = ElggMenuItem::factory(array(
 			'name' => 'unfeature',
+			'parent_name' => 'actions',
+			'icon' => 'star-half',
 			'text' => elgg_echo("groups:makeunfeatured"),
 			'href' => elgg_add_action_tokens_to_url("action/groups/featured?group_guid={$entity->guid}&action_type=unfeature"),
 			'priority' => 300,
@@ -447,6 +448,8 @@ function groups_user_entity_menu_setup($hook, $type, $return, $params) {
 		if ($group->canEdit() && $group->getOwnerGUID() != $entity->guid) {
 			$return[] = ElggMenuItem::factory([
 				'name' => 'removeuser',
+				'parent_name' => 'actions',
+				'icon' => 'user-times',
 				'href' => "action/groups/remove?user_guid={$entity->guid}&group_guid={$group->guid}",
 				'text' => elgg_echo('groups:removeuser'),
 				'confirm' => true,

--- a/mod/groups/views/default/group/default.php
+++ b/mod/groups/views/default/group/default.php
@@ -13,7 +13,7 @@ if (!($group instanceof \ElggGroup)) {
 $icon = elgg_view_entity_icon($group, 'tiny', $vars);
 
 $metadata = '';
-if (!elgg_in_context('owner_block') && !elgg_in_context('widgets')) {
+if (!elgg_in_context('owner_block')) {
 	// only show entity menu outside of widgets and owner block
 	$metadata = elgg_view_menu('entity', array(
 		'entity' => $group,

--- a/mod/likes/views/default/likes/css.php
+++ b/mod/likes/views/default/likes/css.php
@@ -11,6 +11,10 @@
 	width: 345px;
 }
 
-.elgg-menu .elgg-menu-item-likes-count {
-	margin-left: 3px;
+.elgg-menu > .elgg-menu-item-likes-count:not(:first-child) {
+    margin: 0;
+}
+
+.elgg-menu > .elgg-menu-item-likes-count:not(:first-child) > a {
+    margin-left: 15px;
 }

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -237,9 +237,6 @@ function pages_owner_block_menu($hook, $type, $return, $params) {
  * Add links/info to entity menu particular to pages plugin
  */
 function pages_entity_menu_setup($hook, $type, $return, $params) {
-	if (elgg_in_context('widgets')) {
-		return $return;
-	}
 
 	elgg_load_library('elgg:pages');
 	$entity = $params['entity'];
@@ -261,6 +258,8 @@ function pages_entity_menu_setup($hook, $type, $return, $params) {
 
 	$options = array(
 		'name' => 'history',
+		'parent_name' => 'actions',
+		'icon' => 'history',
 		'text' => elgg_echo('pages:history'),
 		'href' => "pages/history/$entity->guid",
 		'priority' => 150,

--- a/mod/pages/views/default/annotation/page.php
+++ b/mod/pages/views/default/annotation/page.php
@@ -42,15 +42,11 @@ $body = <<< HTML
 <p class="elgg-subtext">$subtitle</p>
 HTML;
 
-$menu = '';
-if (!elgg_in_context('widgets')) {
-	// only show annotation menu outside of widgets
-	$menu = elgg_view_menu('annotation', array(
-		'annotation' => $annotation,
-		'sort_by' => 'priority',
-		'class' => 'elgg-menu-hz float-alt',
-	));
-}
+$menu = elgg_view_menu('annotation', array(
+	'annotation' => $annotation,
+	'sort_by' => 'priority',
+	'class' => 'elgg-menu-hz float-alt',
+));
 
 $body = <<<HTML
 <div class="mbn">

--- a/mod/pages/views/default/object/page_top.php
+++ b/mod/pages/views/default/object/page_top.php
@@ -69,25 +69,20 @@ if ($comments_count != 0 && !$revision) {
 
 $subtitle = "$editor_text $comments_link $categories";
 
-$metadata = '';
-// do not show the metadata and controls in widget view
-if (!elgg_in_context('widgets')) {
-	// If we're looking at a revision, display annotation menu
-	if ($revision) {
-		$metadata = elgg_view_menu('annotation', array(
-			'annotation' => $annotation,
-			'sort_by' => 'priority',
-			'class' => 'elgg-menu-hz float-alt',
-		));
-	} else {
-		// Regular entity menu
-		$metadata = elgg_view_menu('entity', array(
-			'entity' => $vars['entity'],
-			'handler' => 'pages',
-			'sort_by' => 'priority',
-			'class' => 'elgg-menu-hz',
-		));
-	}
+if ($revision) {
+	$metadata = elgg_view_menu('annotation', array(
+		'annotation' => $annotation,
+		'sort_by' => 'priority',
+		'class' => 'elgg-menu-hz float-alt',
+	));
+} else {
+	// Regular entity menu
+	$metadata = elgg_view_menu('entity', array(
+		'entity' => $vars['entity'],
+		'handler' => 'pages',
+		'sort_by' => 'priority',
+		'class' => 'elgg-menu-hz',
+	));
 }
 
 if ($full) {

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -406,7 +406,9 @@ function thewire_setup_entity_menu_items($hook, $type, $value, $params) {
 	if (elgg_is_logged_in()) {
 		$options = array(
 			'name' => 'reply',
+			'parent_name' => 'actions',
 			'text' => elgg_echo('reply'),
+			'icon' => 'speech-bubble',
 			'href' => "thewire/reply/$entity->guid",
 			'priority' => 150,
 		);
@@ -416,6 +418,8 @@ function thewire_setup_entity_menu_items($hook, $type, $value, $params) {
 	if ($entity->reply) {
 		$options = array(
 			'name' => 'previous',
+			'parent_name' => 'actions',
+			'icon' => 'angle-double-left',
 			'text' => elgg_echo('previous'),
 			'href' => "thewire/previous/$entity->guid",
 			'priority' => 160,
@@ -427,6 +431,8 @@ function thewire_setup_entity_menu_items($hook, $type, $value, $params) {
 
 	$options = array(
 		'name' => 'thread',
+		'parent_name' => 'actions',
+		'icon' => 'comments-o',
 		'text' => elgg_echo('thewire:thread'),
 		'href' => "thewire/thread/$entity->wire_thread",
 		'priority' => 170,

--- a/mod/thewire/views/default/object/thewire.php
+++ b/mod/thewire/views/default/object/thewire.php
@@ -22,16 +22,12 @@ if (!$thread_id) {
 
 $subtitle = elgg_view('page/elements/by_line', $vars);
 
-$metadata = '';
-if (!elgg_in_context('widgets')) {
-	// only show entity menu outside of widgets
-	$metadata = elgg_view_menu('entity', array(
-		'entity' => $post,
-		'handler' => 'thewire',
-		'sort_by' => 'priority',
-		'class' => 'elgg-menu-hz',
-	));
-}
+$metadata = elgg_view_menu('entity', array(
+	'entity' => $post,
+	'handler' => 'thewire',
+	'sort_by' => 'priority',
+	'class' => 'elgg-menu-hz',
+));
 
 $params = array(
 	'entity' => $post,

--- a/views/default/elements/navigation.css.php
+++ b/views/default/elements/navigation.css.php
@@ -546,6 +546,12 @@
 	color: #5097cf;
 	text-decoration: none;
 }
+
+.elgg-menu-entity .elgg-menu-item-actions .elgg-anchor-label,
+.elgg-menu-annotation .elgg-menu-item-actions .elgg-anchor-label,
+.elgg-menu-river .elgg-menu-item-actions .elgg-anchor-label {
+    display: none;
+}
 /* ***************************************
 	OWNER BLOCK
 *************************************** */
@@ -711,19 +717,5 @@
 	.elgg-menu-site-more > li > a:hover {
 		background-color: #60B8F7;
 		color: #FFF;
-	}
-}
-
-@media (max-width: 600px) {
-	.elgg-menu-entity,
-	.elgg-menu-annotation,
-	.elgg-menu-river {
-		margin-left: 0;
-	}
-	.elgg-menu-entity > li,
-	.elgg-menu-annotation > li,
-	.elgg-menu-river > li {
-		margin-left: 0;
-		margin-right: 15px;
 	}
 }

--- a/views/default/navigation/menu/elements/item.php
+++ b/views/default/navigation/menu/elements/item.php
@@ -17,6 +17,13 @@ if (!$item instanceof ElggMenuItem) {
 $item_vars = [];
 
 $children = $item->getChildren();
+$child_menu_vars = $item->getChildMenuOptions();
+$allow_empty = elgg_extract('allow_empty', $child_menu_vars, true);
+
+if (empty($children) && !$allow_empty) {
+	return;
+}
+
 if (!empty($children)) {
 
 	$link_class = 'elgg-menu-closed';
@@ -27,7 +34,6 @@ if (!empty($children)) {
 
 	$item->addLinkClass('elgg-menu-parent');
 
-	$child_menu_vars = $item->getChildMenuOptions();
 	$child_menu_vars['items'] = $children;
 	$child_menu_vars['class'] = elgg_extract_class($child_menu_vars, ['elgg-menu', 'elgg-child-menu']);
 


### PR DESCRIPTION
Action items in entity and river menus are now displayed in a dropdown.
Menus are no longer hidden widget context.

Refs #10506 

![entity-menu](https://cloud.githubusercontent.com/assets/1202761/24053371/251ad0d6-0b39-11e7-84dc-398c61475c77.png)

- [ ] Add 'actions' parent item in annotation menu