### PR TITLE
WIP feat(access): the friends access is now an access collection

### DIFF
--- a/docs/contribute/code.rst
+++ b/docs/contribute/code.rst
@@ -513,7 +513,7 @@ Naming
 
 * All other function names must begin with ``_elgg_``.
 
-* Name globals and constants in ``ALL_CAPS`` (``ACCESS_FRIENDS``, ``$CONFIG``).
+* Name globals and constants in ``ALL_CAPS`` (``ACCESS_PUBLIC``, ``$CONFIG``).
 
 Miscellaneous
 ^^^^^^^^^^^^^

--- a/docs/design/database.rst
+++ b/docs/design/database.rst
@@ -725,7 +725,6 @@ Pre-defined access controls
 -  ``ACCESS_PRIVATE`` (value: 0) Private.
 -  ``ACCESS_LOGGED_IN`` (value: 1) Logged in users.
 -  ``ACCESS_PUBLIC`` (value: 2) Public data.
--  ``ACCESS_FRIENDS`` (value: -2) Owner and his/her friends.
 
 User defined access controls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/guides/database.rst
+++ b/docs/guides/database.rst
@@ -45,7 +45,6 @@ object will be private, and only the creator user will be able to see
 it. Elgg defines constants for the special values of ``access_id``:
 
 -  **ACCESS_PRIVATE** Only the owner can see it
--  **ACCESS_FRIENDS** Only the owner and his/her friends can see it
 -  **ACCESS_LOGGED_IN** Any logged in user can see it
 -  **ACCESS_PUBLIC** Even visitors not logged in can see it
 

--- a/engine/classes/Elgg/Database/AccessCollections.php
+++ b/engine/classes/Elgg/Database/AccessCollections.php
@@ -300,13 +300,6 @@ class AccessCollections {
 		if ($options['ignore_access']) {
 			$clauses['ors']['ignore_access'] = '1 = 1';
 		} else if ($options['user_guid']) {
-			// include content of user's friends
-			$clauses['ors']['friends_access'] = "$table_alias{$options['access_column']} = " . ACCESS_FRIENDS . "
-				AND $table_alias{$options['owner_guid_column']} IN (
-					SELECT guid_one FROM {$prefix}entity_relationships
-					WHERE relationship = 'friend' AND guid_two = {$options['user_guid']}
-				)";
-
 			// include user's content
 			$clauses['ors']['owner_access'] = "$table_alias{$options['owner_guid_column']} = {$options['user_guid']}";
 		}
@@ -443,7 +436,7 @@ class AccessCollections {
 			$collections = $this->getEntityCollections($user_guid);
 			if ($collections) {
 				foreach ($collections as $collection) {
-					$access_array[$collection->id] = $collection->name;
+					$access_array[$collection->id] = $this->getReadableAccessLevel($collection->id);
 				}
 			}
 
@@ -456,7 +449,21 @@ class AccessCollections {
 			'user_id' => $user_guid,
 			'input_params' => $input_params,
 		];
-		return $this->hooks->trigger('access:collections:write', 'user', $options, $access_array);
+		$access_array = $this->hooks->trigger('access:collections:write', 'user', $options, $access_array);
+		
+		// move logged in and public to the end of the array
+		foreach ([ACCESS_LOGGED_IN, ACCESS_PUBLIC] as $access) {
+			if (!isset($access_array[$access])) {
+				continue;
+			}
+		
+			$temp = $access_array[$access];
+			unset($access_array[$access]);
+			$access_array[$access] = $temp;
+		}
+		
+		
+		return $access_array;
 	}
 
 	/**
@@ -506,13 +513,19 @@ class AccessCollections {
 	 * Memberships to collections are in access_collections_membership.
 	 *
 	 * @param string $name       The name of the collection.
-	 * @param int    $owner_guid The GUID of the owner (default: currently logged in user).
+	 * @param int    $owner_guid The GUID of the owner (default: currently logged in user).+
+	 * @param string $subtype    The subtype indicates the usage of the acl
 	 *
 	 * @return int|false The collection ID if successful and false on failure.
 	 */
-	public function create($name, $owner_guid = 0) {
+	public function create($name, $owner_guid = 0, $subtype = null) {
 		$name = trim($name);
 		if (empty($name)) {
+			return false;
+		}
+
+		$subtype = trim($subtype);
+		if (strlen($subtype) > 255) {
 			return false;
 		}
 
@@ -523,11 +536,13 @@ class AccessCollections {
 		$query = "
 			INSERT INTO {$this->table}
 			SET name = :name,
+				subtype = :subtype,
 				owner_guid = :owner_guid
 		";
 
 		$params = [
 			':name' => $name,
+			':subtype' => $subtype,
 			':owner_guid' => (int) $owner_guid,
 		];
 
@@ -542,6 +557,7 @@ class AccessCollections {
 			'collection_id' => $id,
 			'name' => $name,
 			'owner_guid' => $owner_guid,
+			'subtype' => $subtype,
 		];
 
 		if (!$this->hooks->trigger('access:collections:addcollection', 'collection', $hook_params, true)) {
@@ -836,6 +852,32 @@ class AccessCollections {
 
 		return $this->db->getData($query, $callback, $params);
 	}
+	
+	/**
+	 * Returns access collections owned by the user filtered by a subtype
+	 *
+	 * @param int    $owner_guid GUID of the owner
+	 * @param string $subtype    Subtype of the collection
+	 * @return ElggAccessCollection[]|false
+	 */
+	public function getEntityCollectionsBySubtype($owner_guid, $subtype) {
+
+		$callback = [$this, 'rowToElggAccessCollection'];
+
+		$query = "
+			SELECT * FROM {$this->table}
+				WHERE owner_guid = :owner_guid
+				AND subtype = :subtype
+				ORDER BY name ASC
+		";
+
+		$params = [
+			':owner_guid' => (int) $owner_guid,
+			':subtype' => $subtype,
+		];
+
+		return $this->db->getData($query, $callback, $params);
+	}
 
 	/**
 	 * Get members of an access collection
@@ -903,7 +945,6 @@ class AccessCollections {
 		// Check if entity access id is a defined global constant
 		$access_array = [
 			ACCESS_PRIVATE => $translator->translate("PRIVATE"),
-			ACCESS_FRIENDS => $translator->translate("access:friends:label"),
 			ACCESS_LOGGED_IN => $translator->translate("LOGGED_IN"),
 			ACCESS_PUBLIC => $translator->translate("PUBLIC"),
 		];

--- a/engine/classes/ElggAccessCollection.php
+++ b/engine/classes/ElggAccessCollection.php
@@ -9,6 +9,7 @@
  * @property-read int    $id         The unique identifier (read-only)
  * @property      int    $owner_guid GUID of the owner
  * @property      string $name       Name of the collection
+ * @property      string $subtype    Subtype of the collection
  */
 class ElggAccessCollection extends ElggData {
 
@@ -38,6 +39,7 @@ class ElggAccessCollection extends ElggData {
 		$this->attributes['id'] = null;
 		$this->attributes['owner_guid'] = null;
 		$this->attributes['name'] = null;
+		$this->attributes['subtype'] = null;
 	}
 
 	/**
@@ -49,7 +51,7 @@ class ElggAccessCollection extends ElggData {
 	 * @throws RuntimeException
 	 */
 	public function __set($name, $value) {
-		if (in_array($name, ['id', 'owner_guid'])) {
+		if (in_array($name, ['id', 'owner_guid', 'subtype'])) {
 			throw new RuntimeException("$name can not be set at runtime");
 		}
 		$this->attributes[$name] = $value;
@@ -230,7 +232,7 @@ class ElggAccessCollection extends ElggData {
 	 * {@inheritdoc}
 	 */
 	public function getSubtype() {
-		return $this->name;
+		return $this->subtype;
 	}
 
 }

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1316,7 +1316,11 @@ abstract class ElggEntity extends \ElggData implements
 		$container_guid = (int) $container_guid;
 
 		if ($access_id == ACCESS_DEFAULT) {
-			throw new \InvalidParameterException('ACCESS_DEFAULT is not a valid access level. See its documentation in elgglib.h');
+			throw new \InvalidParameterException('ACCESS_DEFAULT is not a valid access level. See its documentation in elgglib.php');
+		}
+	
+		if ($access_id == ACCESS_FRIENDS) {
+			throw new \InvalidParameterException('ACCESS_FRIENDS is not a valid access level. See its documentation in elgglib.php');
 		}
 
 		$user_guid = elgg_get_logged_in_user_guid();
@@ -1444,6 +1448,10 @@ abstract class ElggEntity extends \ElggData implements
 
 		if ($access_id == ACCESS_DEFAULT) {
 			throw new \InvalidParameterException('ACCESS_DEFAULT is not a valid access level. See its documentation in elgglib.php');
+		}
+
+		if ($access_id == ACCESS_FRIENDS) {
+			throw new \InvalidParameterException('ACCESS_FRIENDS is not a valid access level. See its documentation in elgglib.php');
 		}
 
 		$ret = _elgg_services()->entityTable->updateRow($guid, (object) [

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1947,8 +1947,8 @@ function _elgg_api_test($hook, $type, $value, $params) {
 /**#@+
  * Controls access levels on \ElggEntity entities, metadata, and annotations.
  *
- * @warning ACCESS_DEFAULT is a place holder for the input/access view. Do not
- * use it when saving an entity.
+ * @warning ACCESS_DEFAULT and ACCESS_FRIENDS are placeholders for the input/access view.
+ * Do not use them when saving or updating an entity.
  *
  * @var int
  */

--- a/engine/lib/upgrades/2017032900-3.0.0_add_friends_acl-77c94ffca0a0a5d8.php
+++ b/engine/lib/upgrades/2017032900-3.0.0_add_friends_acl-77c94ffca0a0a5d8.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Elgg 3.0.0 upgrade 2017032900
+ * add_friends_acl
+ *
+ * Introduces friends acls
+ */
+
+
+set_time_limit(0);
+$show_hidden = access_show_hidden_entities(true);
+
+$db = _elgg_services()->db;
+	
+// add subtype to access collections table
+$db->updateData("
+	ALTER TABLE {$db->prefix}access_collections
+	ADD COLUMN `subtype` varchar(255) NOT NULL DEFAULT '' AFTER `name`
+");
+
+// loop all users
+$users = elgg_get_entities([
+	'type' => 'user',
+	'limit' => false,
+	'batch' => true,
+]);
+
+foreach ($users as $user) {
+	// create friends acl for all users
+	$acl_id = create_access_collection('friends', $user->guid, 'friends');
+	if (!$acl_id) {
+		continue;
+	}
+
+	// add friends as members of newly create acl
+	$acl_query = "
+		INSERT INTO {$db->prefix}access_collection_membership
+			SET access_collection_id = {$acl_id},
+			    user_guid = :user_guid
+			ON DUPLICATE KEY UPDATE user_guid = user_guid
+	";
+	
+	elgg_get_entities_from_relationship([
+		'relationship' => 'friend',
+		'relationship_guid' => $user->guid,
+		'type' => 'user',
+		'limit' => false,
+		'callback' => function ($row) use ($db, $acl_query) {
+			
+			$db->insertData($acl_query, [
+				':user_guid' => (int) $row->guid,
+			]);
+			
+			return $row->guid;
+		},
+	]);
+		
+	// update ACCESS_FRIENDS of user to new ACL id
+	$friends_entities = elgg_get_entities([
+		'owner_guid' => $user->guid,
+		'limit' => false,
+		'batch' => true,
+		'wheres' => [
+			'e.access_id = ' . ACCESS_FRIENDS,
+		],
+	]);
+	
+	// need to do normal entity update to allow entities to auto update child entities
+	foreach ($friends_entities as $entity) {
+		$entity->access_id = $acl_id;
+		$entity->save();
+	}
+}
+
+// restore hidden access
+access_show_hidden_entities($show_hidden);

--- a/engine/schema/mysql.sql
+++ b/engine/schema/mysql.sql
@@ -13,6 +13,7 @@ CREATE TABLE `prefix_access_collection_membership` (
 CREATE TABLE `prefix_access_collections` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` text NOT NULL,
+  `subtype` varchar(255) NOT NULL DEFAULT '',
   `owner_guid` bigint(20) unsigned NOT NULL,
   PRIMARY KEY (`id`),
   KEY `owner_guid` (`owner_guid`)

--- a/engine/tests/ElggCoreAccessCollectionsTest.php
+++ b/engine/tests/ElggCoreAccessCollectionsTest.php
@@ -5,7 +5,7 @@
  *
  * @package Elgg
  * @subpackage Test
- * 
+ *
  * TODO(ewinslow): Move this to Elgg\Database\AccessCollectionsTest
  */
 class ElggCoreAccessCollectionsTest extends \ElggCoreUnitTest {
@@ -365,9 +365,6 @@ class ElggCoreAccessCollectionsTest extends \ElggCoreUnitTest {
 		];
 
 		$actual = get_write_access_array($this->user->guid, null, true);
-
-		// remove ACCESS_FRIENDS in case it's added by an enabled plugin
-		unset($actual[ACCESS_FRIENDS]);
 
 		$actual = array_keys($actual);
 		

--- a/engine/tests/phpunit/Elgg/Mocks/Database/EntityTable.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Database/EntityTable.php
@@ -329,10 +329,6 @@ class EntityTable extends DbEntityTable {
 			return true;
 		}
 
-		if ($row->access_id == ACCESS_FRIENDS && check_entity_relationship($row->owner_guid, 'friend', $user->guid)) {
-			return true;
-		}
-
 		$access_list = _elgg_services()->accessCollections->getAccessList($user->guid);
 		if (in_array($row->access_id, $access_list)) {
 			return true;

--- a/mod/friends/start.php
+++ b/mod/friends/start.php
@@ -199,38 +199,6 @@ function _elgg_send_friend_notification($event, $type, $object) {
 }
 
 /**
- * Add ACCESS_FRIENDS to the available access levels
- *
- * @param string $hook         "access:collections:write"
- * @param string $type         "user"
- * @param array  $access_array Access array
- * @param array  $params       Hook params
- *
- * @return array
- */
-function _elgg_friends_write_access($hook, $type, $access_array, $params) {
-
-	// rebuild array, putting friends 1st or 2nd
-	$ret = [];
-
-	// private exists, it goes first
-	if (isset($access_array[ACCESS_PRIVATE])) {
-		$ret[ACCESS_PRIVATE] = $access_array[ACCESS_PRIVATE];
-		unset($access_array[ACCESS_PRIVATE]);
-	}
-
-	// friends
-	$ret[ACCESS_FRIENDS] = get_readable_access_level(ACCESS_FRIENDS);
-
-	// rest
-	foreach ($access_array as $key => $value) {
-		$ret[$key] = $value;
-	}
-
-	return $ret;
-}
-
-/**
  * Add "Friends" tab to common filter
  *
  * @param string $hook   "filter_tabs"

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -327,12 +327,6 @@ function pages_write_permission_check($hook, $entity_type, $returnvalue, $params
 				// Elgg's default decision is what we want
 				return null;
 				break;
-			case ACCESS_FRIENDS:
-				$owner = $entity->getOwnerEntity();
-				if (($owner instanceof ElggUser) && $owner->isFriendsWith($user->guid)) {
-					return true;
-				}
-				break;
 			default:
 				$list = get_access_array($user->guid);
 				if (in_array($write_permission, $list)) {

--- a/version.php
+++ b/version.php
@@ -11,7 +11,7 @@
 
 // YYYYMMDD = Elgg Date
 // XX = Interim incrementer
-$version = 2016110900;
+$version = 2017032900;
 
 $composerJson = file_get_contents(dirname(__FILE__) . "/composer.json");
 if ($composerJson === false) {

--- a/views/default/input/access.php
+++ b/views/default/input/access.php
@@ -63,6 +63,13 @@ if (!$params['container_guid'] && $container) {
 	$params['container_guid'] = $container->guid;
 }
 
+if ($vars['value'] == ACCESS_FRIENDS) {
+	unset($vars['value']);
+	if (elgg_is_logged_in()) {
+		// @todo add users friends acl id
+	}
+}
+
 // don't call get_default_access() unless we need it
 if (!isset($vars['value']) || $vars['value'] == ACCESS_DEFAULT) {
 	if ($entity) {

--- a/views/default/object/elements/access.php
+++ b/views/default/object/elements/access.php
@@ -26,9 +26,6 @@ if ($access === false || !elgg_is_logged_in()) {
 }
 
 switch ($access) {
-	case ACCESS_FRIENDS :
-		$icon_name = 'user';
-		break;
 	case ACCESS_PUBLIC :
 	case ACCESS_LOGGED_IN :
 		$icon_name = 'globe';
@@ -38,6 +35,11 @@ switch ($access) {
 		break;
 	default:
 		$icon_name = 'cog';
+		
+		$collection = get_access_collection($access);
+		if ($collection && ($collection->getSubtype() == 'friends')) {
+			$icon_name = 'user';
+		}
 		break;
 }
 

--- a/views/default/output/access.php
+++ b/views/default/output/access.php
@@ -22,10 +22,6 @@ if (!isset($access_id)) {
 $access_id_string = get_readable_access_level($access_id);
 
 switch ($access_id) {
-	case ACCESS_FRIENDS :
-		$class[] = 'elgg-access-friends';
-		break;
-
 	case ACCESS_PUBLIC :
 		$class[] = 'elgg-access-public';
 		break;
@@ -53,7 +49,11 @@ switch ($access_id) {
 				$class[] = 'elgg-access-group-closed';
 			}
 		} else {
-			$class[] = 'elgg-access-limited';
+			if ($collection && !empty($collection->getSubtype())) {
+				$class[] = 'elgg-access-' . elgg_get_friendly_title($collection->getSubtype());
+			} else {
+				$class[] = 'elgg-access-limited';
+			}
 		}
 		break;
 }


### PR DESCRIPTION
This PR removes the usage of ACCESS_FRIENDS in Elgg. The define is still usable, but only for default access usage in input/access (similar as ACCESS_DEFAULT). This PR adds a column `subtype` to the `access_collection` table and includes a migration of all current entities/metadata/annotations to new friends ACLs.

- [ ] correctly use ACCESS_FRIENDS in input/access
- [ ] add test for API changes
- [x] add #7363
- [ ] migrate annotations/metadata/river access_id
 
This same approach can also be used for ACCESS_PRIVATE

Fixes #3391, #5038
Refs #8073, #3872 