### PR TITLE
fix(ckeditor): fixes basepath issues on some systems

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -240,6 +240,8 @@ Removed JavaScript APIs
  * ``elgg.ui.likesPopupHandler``
  * ``elgg.embed``: Use the ``elgg/embed`` module
  * ``embed/custom_insert_js``: Use the ``embed, editor`` JS hook
+ * ``elgg/ckeditor.js``: replaced by ``elgg-ckeditor.js``
+ * ``elgg/ckeditor/set-basepath.js``
  * ``elgg/ckeditor/insert.js``
  * ``likes.js``: The ``elgg/likes`` module is loaded automatically
  * ``messageboard.js``

--- a/mod/ckeditor/README.md
+++ b/mod/ckeditor/README.md
@@ -3,7 +3,7 @@ CKEditor WYSIWYG plugin
 
 Configuration options
 ----------------------
-CKEditor configuration is set in the view "ckeditor.js". The configuration object
+CKEditor configuration is set in the view "elgg-ckeditor.js". The configuration object
 is `elgg.ckeditor.config`. A plugin can modify the configuration object by registering
 a function to run before the ckeditor.init function on the `'init', 'system'` hook.
 This is where toolbar options and the skin are set.

--- a/mod/ckeditor/start.php
+++ b/mod/ckeditor/start.php
@@ -14,18 +14,14 @@ function ckeditor_init() {
 	elgg_extend_view('elgg/wysiwyg.css', 'elements/reset.css', 100);
 	elgg_extend_view('elgg/wysiwyg.css', 'elements/typography.css', 100);
 
-	elgg_define_js('ckeditor', [
-		'deps' => ['elgg/ckeditor/set-basepath'],
+	elgg_define_js('ckeditor/ckeditor', [
 		'exports' => 'CKEDITOR',
 	]);
 	elgg_define_js('jquery.ckeditor', [
-		'deps' => ['jquery', 'ckeditor'],
+		'deps' => ['jquery', 'ckeditor/ckeditor'],
 		'exports' => 'jQuery.fn.ckeditor',
 	]);
 
-	// need to set basepath early
-	elgg_extend_view('elgg.js', 'elgg/ckeditor/set-basepath.js');
-	
 	elgg_extend_view('input/longtext', 'ckeditor/init');
 
 	elgg_register_plugin_hook_handler('register', 'menu:longtext', 'ckeditor_longtext_menu');

--- a/mod/ckeditor/views.php
+++ b/mod/ckeditor/views.php
@@ -2,7 +2,6 @@
 
 return [
 	'default' => [
-		'ckeditor.js' => __DIR__ . '/vendors/ckeditor/ckeditor.js',
 		'ckeditor/' => __DIR__ . '/vendors/ckeditor/',
 		'jquery.ckeditor.js' => __DIR__ . '/vendors/ckeditor/adapters/jquery.js',
 	],

--- a/mod/ckeditor/views/default/ckeditor/init.php
+++ b/mod/ckeditor/views/default/ckeditor/init.php
@@ -25,7 +25,7 @@ if ($editor_type && elgg_view_exists("elgg/ckeditor/config/{$editor_type}.js")) 
 
 ?>
 <script>
-	require(['elgg/ckeditor'], function (elggCKEditor) {
+	require(['elgg-ckeditor'], function (elggCKEditor) {
 		elggCKEditor.bind('#<?php echo $id; ?>', '<?php echo $config; ?>');
 	});
 </script>

--- a/mod/ckeditor/views/default/elgg-ckeditor.js
+++ b/mod/ckeditor/views/default/elgg-ckeditor.js
@@ -1,14 +1,15 @@
 /**
  * This module can be used to bind CKEditor to a textarea
  * <code>
- *	  require(['elgg/ckeditor'], function(editor) {
+ *	  require(['elgg-ckeditor'], function(editor) {
  *	      editor.bind('textarea');
  *	  });
  * </code>
  *
- * Modify the config by creating a boot module and handling the [config, ckeditor] hook.
- *
- * @module elgg/ckeditor
+ * @warning It's important this module is not renamed so that it ends with "/ckeditor". This can confuse
+ *          the CKeditor library when it sniffs its resource directory.
+ * 
+ * @module elgg-ckeditor
  */
 define(function (require) {
 	var elgg = require('elgg');
@@ -17,48 +18,44 @@ define(function (require) {
 	var $ = require('jquery');
 	require('jquery.ckeditor');
 
-	var CKEDITOR = require('ckeditor');
+	var CKEDITOR = require('ckeditor/ckeditor');
+	var DEFAULT_CONFIG_MODULE = 'elgg/ckeditor/config';
 
 	var elggCKEditor = {
-		bind: function (selector, editor_config) {
-			var default_config = 'elgg/ckeditor/config';
-			
-			if (typeof editor_config === undefined) {
-				editor_config = default_config;
-			}
+		bind: function (selector, config_module) {
+			config_module = config_module || DEFAULT_CONFIG_MODULE;
 
-			require([editor_config], function(config) {
-				elggCKEditor.config = config;
-				
+			require([config_module], function (config) {
 				elggCKEditor.registerHandlers();
 				CKEDITOR = elgg.trigger_hook('prepare', 'ckeditor', null, CKEDITOR);
 				selector = selector || '.elgg-input-longtext';
 				if ($(selector).length === 0) {
 					return;
 				}
+
 				$(selector).not('[data-cke-init]')
-						.attr('data-cke-init', true)
-						.each(function () {
-							var opts = $(this).data('editorOpts') || {};
-	
-							if (opts.disabled) {
-								// Editor has been disabled
-								return;
-							}
-							delete opts.disabled;
-	
-							var visual = opts.state !== 'html';
-							delete opts.state;
-	
-							var config = $.extend({}, elggCKEditor.config, opts);
-							$(this).data('elggCKEeditorConfig', config);
-	
-							if (!visual) {
-								elggCKEditor.init(this, visual);
-							} else {
-								$(this).ckeditor(elggCKEditor.init, config);
-							}
-						});
+					.attr('data-cke-init', true)
+					.each(function () {
+						var opts = $(this).data('editorOpts') || {};
+
+						if (opts.disabled) {
+							// Editor has been disabled
+							return;
+						}
+						delete opts.disabled;
+
+						var visual = opts.state !== 'html';
+						delete opts.state;
+
+						var FINAL_CONFIG = $.extend({}, config, opts);
+						$(this).data('elggCKEeditorConfig', FINAL_CONFIG);
+
+						if (!visual) {
+							elggCKEditor.init(this, visual);
+						} else {
+							$(this).ckeditor(elggCKEditor.init, FINAL_CONFIG);
+						}
+					});
 			});
 		},
 
@@ -100,6 +97,7 @@ define(function (require) {
 			var target = $(this).attr('href');
 			elggCKEditor.toggle($(target)[0]);
 		},
+
 		/**
 		 * Toggles the CKEditor
 		 *
@@ -117,6 +115,7 @@ define(function (require) {
 				}
 			});
 		},
+
 		/**
 		 * Resets the CKEditor
 		 * Callback function for the reset event
@@ -128,6 +127,7 @@ define(function (require) {
 			event.preventDefault();
 			elggCKEditor.reset(this);
 		},
+
 		/**
 		 * Resets the CKEditor
 		 *
@@ -141,6 +141,7 @@ define(function (require) {
 				}
 			});
 		},
+
 		/**
 		 * Focuses the CKEditor
 		 * Callback function for the focus event
@@ -152,6 +153,7 @@ define(function (require) {
 			event.preventDefault();
 			elggCKEditor.focus(this);
 		},
+
 		/**
 		 * Focuses the CKEditor
 		 *
@@ -215,7 +217,7 @@ define(function (require) {
 					}
 				}
 			});
-		},
+		}
 	};
 
 	$(document).on('click', '.ckeditor-toggle-editor', elggCKEditor.toggleEditor);
@@ -226,4 +228,3 @@ define(function (require) {
 
 	return elggCKEditor;
 });
-

--- a/mod/ckeditor/views/default/elgg/ckeditor/set-basepath.js
+++ b/mod/ckeditor/views/default/elgg/ckeditor/set-basepath.js
@@ -1,9 +1,0 @@
-/**
- * This view extends elgg.js and sets ckeditor basepath before jquery.ckeditor is loaded
- */
-define('elgg/ckeditor/set-basepath', function (require) {
-	var elgg = require('elgg');
-	// This global variable must be set before the editor script loading.
-	CKEDITOR_BASEPATH = elgg.get_simplecache_url('ckeditor/');
-});
-


### PR DESCRIPTION
As the CKeditor library is not a real AMD library, its execution may not be controlled as well by RequireJS, causing a race condition with the module that sets the global `CKEDITOR_BASEPATH` constant.

This renames the module `elgg/ckeditor` to `elgg-ckeditor` which eliminates the need for setting `CKEDITOR_BASEPATH` at all. With the new filename, the CKeditor library is no longer confused when sniffing for its resources folder.

Fixes #10724

BREAKING CHANGES:
The AMD module `elgg/ckeditor` is now `elgg-ckeditor`. The module `elgg/ckeditor/set-basepath` was removed.