### PR TITLE
chore(core): overhauls async upgrade process

### DIFF
--- a/docs/guides/upgrading-data.rst
+++ b/docs/guides/upgrading-data.rst
@@ -31,13 +31,15 @@ Example from ``mod/blog/elgg-plugin.php`` file:
 	];
 
 The class names in the example refer to the classes:
- - `mod/blog/classes/Blog/Upgrades/AccessLevelFix`
- - `mod/blog/classes/Blog/Upgrades/DraftStatusUpgrade`
+ - ``mod/blog/classes/Blog/Upgrades/AccessLevelFix``
+ - ``mod/blog/classes/Blog/Upgrades/DraftStatusUpgrade``
+
+.. note:: Elgg core upgrade classes can be declared in ``engine/lib/upgrades/async-upgrades.php``.
 
 The upgrade class
 -----------------
 
-A class implemening the ``Elgg\Upgrade\Batch`` interface has a lot of freedom
+A class implementing the ``Elgg\Upgrade\Batch`` interface has a lot of freedom
 on how it wants to handle the actual processing of the data. It must however
 declare some constant variables and also take care of marking whether each
 processed item was upgraded successfully or not.
@@ -49,63 +51,73 @@ The basic structure of the class is the following:
 	<?php
 	
 	namespace Blog\Upgrades;
+
+	use Elgg\Upgrade\Batch;
+	use Elgg\Upgrade\Result;
 	
 	/**
 	 * Fixes invalid blog access values
 	 */
-	class AccessLevelFix implements \Elgg\Upgrade\Batch {
-		const INCREMENT_OFFSET = true;
-		
-		const VERSION = 2016120300;
-		
+	class AccessLevelFix implements Batch {
+
 		/**
-		 * Check whether the upgrade is needed
+		 * Version of the upgrade
+		 *
+		 * @return int
+		 */
+		public function getVersion() {
+			return 2016120300;
+		}
+
+		/**
+		 * Should the run() method receive an offset representing all processed items?
 		 *
 		 * @return bool
 		 */
-		public function isRequired() {
-		
+		public function needsIncrementOffset() {
+			return true;
 		}
 		
 		/**
-		 * Count the amount of items that need to be processed
+		 * Should this upgrade be skipped?
+		 *
+		 * @return bool
+		 */
+		public function shouldBeSkipped() {
+			return false;
+		}
+		
+		/**
+		 * The total number of items to process in the upgrade
 		 *
 		 * @return int
 		 */
 		public function countItems() {
-		
+			// return count of all blogs
 		}
 		
 		/**
-		 * Run the upgrade
+		 * Runs upgrade on a single batch of items
 		 *
-		 * @param Result $result
-		 * @param int    $offset
-		 * @return Result result
+		 * @param Result $result Result of the batch (this must be returned)
+		 * @param int    $offset Number to skip when processing
+		 *
+		 * @return Result Instance of \Elgg\Upgrade\Result
 		 */
-		public function run(\Elgg\Upgrade\Result $result, $offset) {
-		
+		public function run(Result $result, $offset) {
+			// fix 50 blogs skipping the first $offset
 		}
 	}
 
-Class constants
-~~~~~~~~~~~~~~~
+.. warning:: Do not assume when your class will be instantiated or when/how often its public methods will be called.
 
-The class must declare the following constant variables:
+Class methods
+~~~~~~~~~~~~~
 
-INCREMENT_OFFSET
-^^^^^^^^^^^^^^^^
+getVersion()
+^^^^^^^^^^^^
 
-This is a boolean value that tells Elgg core whether it should increment
-the offset of the upgrade after each run. If the upgrade leaves the data
-itself intact and simply modifies it in some way, the value should be
-set to ``true``. If the upgrade either moves or completely deletes the
-items within the data, the value should be ``false``.  
-
-VERSION
-^^^^^^^
-
-The version constant tells the date when the upgrade was added. It consists
+This must return an integer representing the date the upgrade was added. It consists
 of eight digits and is in format ``yyyymmddnn`` where:
 
    - ``yyyy`` is the year
@@ -114,43 +126,58 @@ of eight digits and is in format ``yyyymmddnn`` where:
    - ``nn`` is an incrementing number (starting from ``00``) that is used in case
      two separate upgrades have been added during the same day
 
-Class methods
-~~~~~~~~~~~~~
+shouldBeSkipped()
+^^^^^^^^^^^^^^^^^
 
-isRequired()
-^^^^^^^^^^^^
+This should return ``false`` unless the upgrade won't be needed.
 
-Checks the database or the dataroot whether there are items that
-need to be upgraded.
+.. warning:: If ``true`` is returned the upgrade cannot be run later.
+
+needsIncrementOffset()
+^^^^^^^^^^^^^^^^^^^^^^
+
+If ``true``, your ``run()`` method will receive as ``$offset`` the number of items
+aready processed. This is useful if you are only modifying data, and need to use the
+``$offset`` in a function like ``elgg_get_entities*()`` to know how many you've already
+handled.
+
+If ``false``, your ``run()`` method will receive as ``$offset`` the total number of
+failures. ``false`` should be used if your process deletes or moves data out of the
+way of the process. E.g. if you delete 50 objects on each ``run()``, you don't really
+need the ``$offset``.
 
 countItems()
 ^^^^^^^^^^^^
 
-Counts and returns the total amount of items that need to be processed
-by the upgrade.
+Get the total number of items to process during the upgrade. If unknown, ``Batch::UNKNOWN_COUNT``
+can be returned, but ``run()`` must manually mark the upgrade complete.
 
 run()
 ^^^^^
 
-Takes care of the actual upgrade. It takes two parameters:
+This must perform a portion of the actual upgrade. And depending on how long it takes, it may be
+called multiple times during a single request.
+
+It receives two arguments:
 
   - ``$result``: An instance of ``Elgg\Upgrade\Result`` object
-  - ``$offset``: The offset where the next upgrade batch should start 
+  - ``$offset``: The offset where the next upgrade portion should start (or total number of failures)
  
- For each item the method processes, it must call either:
+For each item the method processes, it must call either:
  
   - ``$result->addSuccesses()``: If the item was upgraded successfully
   - ``$result->addFailures()``: If it failed to upgrade the item
 
-Both methods default to one item, but you can optionally pass in
-the number of items.
+Both methods default to one item, but you can optionally pass in the number of items.
   
-Additionally it can set as many error messages as it sees necessary in case
-something goes wrong:
+Additionally it can set as many error messages as it sees necessary in case something goes wrong:
 
  - ``$result->addError("Error message goes here")``
 
-In most cases the ``$offset`` parameter is passed directly to one of the
+If ``countItems()`` returned ``Batch::UNKNOWN_COUNT``, then at some point ``run()`` must call
+``$result->markComplete()`` to finish the upgrade.
+
+In most cases your ``run()`` method will want to pass the ``$offset`` parameter to one of the
 ``elgg_get_entities*()`` functions:
 
 .. code:: php
@@ -158,7 +185,7 @@ In most cases the ``$offset`` parameter is passed directly to one of the
 	/**
 	 * Process blog posts
 	 *
-	 * @param Result $result Object that holds results of the batch
+	 * @param Result $result The batch result (will be modified and returned)
 	 * @param int    $offset Starting point of the batch
 	 * @return Result Instance of \Elgg\Upgrade\Result;
 	 */
@@ -170,9 +197,8 @@ In most cases the ``$offset`` parameter is passed directly to one of the
 		]);
 		
 		foreach ($blogs as $blog) {
-			// Do something to the blog objects here
-			if (do_something($blog)) {
-				$result->addSuccesses()
+			if ($this->fixBlogPost($blog)) {
+				$result->addSuccesses();
 			} else {
 				$result->addFailures();
 				$result->addError("Failed to fix the blog {$blog->guid}.");

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -525,8 +525,9 @@ class Application {
 				forward($forward_url);
 			}
 
-			// Find unprocessed batch uprade classes and save them as ElggUpgrade objects
-			$has_pending_upgrades = _elgg_services()->upgradeLocator->run();
+			// Find unprocessed batch upgrade classes and save them as ElggUpgrade objects
+			$core_upgrades = (require self::elggDir()->getPath('engine/lib/upgrades/async-upgrades.php'));
+			$has_pending_upgrades = _elgg_services()->upgradeLocator->run($core_upgrades);
 
 			if ($has_pending_upgrades) {
 				// Forward to the list of pending upgrades

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -21,6 +21,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\Amd\Config                         $amdConfig
  * @property-read \Elgg\Database\Annotations               $annotations
  * @property-read \ElggAutoP                               $autoP
+ * @property-read \Elgg\BatchUpgrader                      $batchUpgrader
  * @property-read \Elgg\BootService                        $boot
  * @property-read \Elgg\ClassLoader                        $classLoader
  * @property-read \Elgg\AutoloadManager                    $autoloadManager
@@ -77,7 +78,6 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\I18n\Translator                    $translator
  * @property-read \Elgg\UpgradeService                     $upgrades
  * @property-read \Elgg\Upgrade\Locator                    $upgradeLocator
- * @property-read \Elgg\BatchUpgrader                      $batchUpgrader
  * @property-read \Elgg\UploadService                      $uploads
  * @property-read \Elgg\UserCapabilities                   $userCapabilities
  * @property-read \Elgg\Database\UsersTable                $usersTable

--- a/engine/classes/Elgg/Upgrade/Batch.php
+++ b/engine/classes/Elgg/Upgrade/Batch.php
@@ -2,8 +2,6 @@
 
 namespace Elgg\Upgrade;
 
-use \Elgg\Upgrade\Result;
-
 /**
  * Long running upgrades should implement this interface
  *
@@ -12,25 +10,70 @@ use \Elgg\Upgrade\Result;
 interface Batch {
 
 	/**
-	 * Checks whether there are items that need to be upgraded.
-	 *
-	 * @return boolean
+	 * countItems() should return this if it doesn't know how many items remain.
 	 */
-	public function isRequired();
+	const UNKNOWN_COUNT = -1;
 
 	/**
-	 * Runs upgrade on a single batch of items
+	 * Version of the upgrade
 	 *
-	 * @param Result $result Object that holds results of the batch
-	 * @param int    $offset Starting point of the batch
-	 * @return Result Instance of \Elgg\Upgrade\Result
+	 * This tells the date when the upgrade was added. It consists of eight digits and is in format ``yyyymmddnn``
+	 * where:
+	 *
+	 * - ``yyyy`` is the year
+	 * - ``mm`` is the month (with leading zero)
+	 * - ``dd`` is the day (with leading zero)
+	 * - ``nn`` is an incrementing number (starting from ``00``) that is used in case two separate upgrades
+	 *          have been added during the same day
+	 *
+	 * @return int E.g. 2016123101
 	 */
-	public function run(Result $result, $offset);
+	public function getVersion();
 
 	/**
-	 * Gets the amount of items that need to be upgraded
+	 * Should this upgrade be skipped?
+	 *
+	 * If true, the upgrade will not be performed and cannot be accessed later.
+	 *
+	 * @return bool
+	 */
+	public function shouldBeSkipped();
+
+	/**
+	 * Should the run() method receive an offset representing all processed items?
+	 *
+	 * If true, run() will receive as $offset the number of items already processed. This is useful
+	 * if you are only modifying data, and need to use the $offset in a function like elgg_get_entities*()
+	 * to know how many to skip over.
+	 *
+	 * If false, run() will receive as $offset the total number of failures. This should be used if your
+	 * process deletes or moves data out of the way of the process. E.g. if you delete 50 objects on each
+	 * run(), you may still use the $offset to skip objects that already failed once.
+	 *
+	 * @return bool
+	 */
+	public function needsIncrementOffset();
+
+	/**
+	 * The total number of items to process during the upgrade
+	 *
+	 * If unknown, Batch::UNKNOWN_COUNT should be returned, and run() must manually mark the result
+	 * as complete.
 	 *
 	 * @return int
 	 */
 	public function countItems();
+
+	/**
+	 * Runs upgrade on a single batch of items
+	 *
+	 * If countItems() returns Batch::UNKNOWN_COUNT, this method must call $result->markCompleted()
+	 * when the upgrade is complete.
+	 *
+	 * @param Result $result Result of the batch (this must be returned)
+	 * @param int    $offset Number to skip when processing
+	 *
+	 * @return Result Instance of \Elgg\Upgrade\Result
+	 */
+	public function run(Result $result, $offset);
 }

--- a/engine/classes/Elgg/Upgrade/Locator.php
+++ b/engine/classes/Elgg/Upgrade/Locator.php
@@ -4,7 +4,6 @@ namespace Elgg\Upgrade;
 
 use Elgg\Database\PrivateSettingsTable;
 use Elgg\Database\Plugins;
-use Elgg\Upgrade\Batch;
 use Elgg\Logger;
 use ElggUpgrade;
 
@@ -37,31 +36,51 @@ class Locator {
 	/**
 	 * Constructor
 	 *
-	 * @param Plugins              $plugins         Plugins
-	 * @param Logger               $logger          Logger
-	 * @param PrivateSettingsTable $privateSettings PrivateSettingsTable
+	 * @param Plugins              $plugins          Plugins
+	 * @param Logger               $logger           Logger
+	 * @param PrivateSettingsTable $private_settings PrivateSettingsTable
 	 */
-	public function __construct(
-	Plugins $plugins, Logger $logger, PrivateSettingsTable $privateSettings) {
+	public function __construct(Plugins $plugins, Logger $logger, PrivateSettingsTable $private_settings) {
 		$this->plugins = $plugins;
 		$this->logger = $logger;
-		$this->privateSettings = $privateSettings;
+		$this->privateSettings = $private_settings;
 	}
 
 	/**
 	 * Looks for upgrades and saves them as ElggUpgrade entities
 	 *
+	 * @param string[] $core_upgrades Class names of core upgrades
+	 *
 	 * @return boolean $pending_upgrades Are there pending upgrades
 	 */
-	public function run() {
+	public function run(array $core_upgrades) {
 		$pending_upgrades = false;
+
+		// Check for core upgrades
+		foreach ($core_upgrades as $class) {
+			$upgrade = $this->getUpgrade($class, 'core');
+
+			if ($upgrade) {
+				$pending_upgrades = true;
+			}
+		}
 
 		$plugins = $this->plugins->find('active');
 
+		// Check for plugin upgrades
 		foreach ($plugins as $plugin) {
-			$upgrades = $this->getUpgrades($plugin);
-			if (!empty($upgrades)) {
-				$pending_upgrades = true;
+			$batches = $plugin->getStaticConfig('upgrades');
+
+			if (empty($batches)) {
+				continue;
+			}
+
+			$plugin_id = $plugin->getID();
+
+			foreach ($batches as $class) {
+				if ($this->getUpgrade($class, $plugin_id)) {
+					$pending_upgrades = true;
+				}
 			}
 		}
 
@@ -69,62 +88,49 @@ class Locator {
 	}
 
 	/**
-	 * Creates new ElggUpgrade instance from plugin's static config
+	 * Gets intance of an ElggUpgrade based on the given class and id
 	 *
-	 * @param \ElggPlugin $plugin Plugin
-	 * @return \ElggUpgrade[]
+	 * @param string $class Class implementing Elgg\Upgrade\Batch
+	 * @param string $id    Either plugin_id or "core"
+	 * @return ElggUpgrade|null
 	 */
-	public function getUpgrades(\ElggPlugin $plugin) {
+	public function getUpgrade($class, $id) {
+		$batch = $this->getBatch($class);
 
-		$upgrades = [];
-		$batches = $plugin->getStaticConfig('upgrades');
-
-		if (empty($batches)) {
-			// No upgrades available for this plugin
-			return $upgrades;
+		if (!$batch) {
+			return;
 		}
 
-		$plugin_id = $plugin->getID();
+		$version = $batch->getVersion();
+		$upgrade_id = "{$id}:{$version}";
 
-		foreach ($batches as $class) {
-			$batch = $this->getBatch($class);
-			if (!$batch) {
-				continue;
-			}
-
-			$version = $batch::VERSION;
-			$upgrade_id = "{$plugin_id}:{$version}";
-
-			// Database holds the information of which upgrades have been processed
-			if ($this->upgradeExists($upgrade_id)) {
-				$this->logger->info("Upgrade $upgrade_id has already been processed");
-				continue;
-			}
-
-			// Create a new ElggUpgrade to represent the upgrade in the database
-			$object = new ElggUpgrade();
-			$object->setId($upgrade_id);
-			$object->setClass($class);
-			$object->title = "{$plugin_id}:upgrade:{$version}:title";
-			$object->description = "{$plugin_id}:upgrade:{$version}:description";
-			$object->offset = 0;
-
-			try {
-				$object->save();
-				$upgrades[] = $object;
-			} catch (\UnexpectedValueException $ex) {
-				$this->logger->error($ex->getMessage());
-			}
+		// Database holds the information of which upgrades have been processed
+		if ($this->upgradeExists($upgrade_id)) {
+			$this->logger->info("Upgrade $id has already been processed");
+			return;
 		}
 
-		return $upgrades;
+		// Create a new ElggUpgrade to represent the upgrade in the database
+		$object = new ElggUpgrade();
+		$object->setId($upgrade_id);
+		$object->setClass($class);
+		$object->title = "{$id}:upgrade:{$version}:title";
+		$object->description = "{$id}:upgrade:{$version}:description";
+		$object->offset = 0;
+
+		try {
+			$object->save();
+			return $object;
+		} catch (\UnexpectedValueException $ex) {
+			$this->logger->error($ex->getMessage());
+		}
 	}
 
 	/**
 	 * Validates class and returns an instance of batch
 	 *
 	 * @param string $class The fully qualified class name
-	 * @return boolean True if valid upgrade
+	 * @return Batch|false if invalid upgrade
 	 */
 	public function getBatch($class) {
 		if (!class_exists($class)) {
@@ -134,19 +140,21 @@ class Locator {
 
 		$batch = new $class;
 		if (!$batch instanceof Batch) {
-			$this->logger->error("Upgrade class $class should implement Elgg\Upgrade\Batch");
+			$this->logger->error("Upgrade class $class should implement " . Batch::class);
 			return false;
 		}
 
-		$version = $batch::VERSION;
+		// check version before shouldBeSkipped() so authors can get immediate feedback on an
+		// invalid batch.
+		$version = $batch->getVersion();
 
 		// Version must be in format yyyymmddnn
 		if (preg_match("/^[0-9]{10}$/", $version) == 0) {
-			$this->logger->error("Upgrade $class defines an invalid upgrade version: $version");
+			$this->logger->error("Upgrade $class returned an invalid version: $version");
 			return false;
 		}
 
-		if (!$batch->isRequired()) {
+		if ($batch->shouldBeSkipped()) {
 			return false;
 		}
 
@@ -163,11 +171,14 @@ class Locator {
 		$upgrade = $this->privateSettings->getEntities([
 			'type' => 'object',
 			'subtype' => 'elgg_upgrade',
-			'private_setting_name' => 'id',
-			'private_setting_value' => $upgrade_id,
+			'private_setting_name_value_pairs' => [
+				[
+					'name' => 'id',
+					'value' => (string) $upgrade_id,
+				],
+			],
 		]);
 
 		return !empty($upgrade);
 	}
-
 }

--- a/engine/classes/Elgg/Upgrade/Result.php
+++ b/engine/classes/Elgg/Upgrade/Result.php
@@ -12,6 +12,8 @@ final class Result {
 
 	private $success_count = 0;
 
+	private $is_complete = false;
+
 	/**
 	 * Add new error message to the batch
 	 *
@@ -46,7 +48,7 @@ final class Result {
 	/**
 	 * Get count of failures within the current batch
 	 *
-	 * @return $failure_count Amount of failures
+	 * @return int $failure_count Amount of failures
 	 */
 	public function getFailureCount() {
 		return $this->failure_count;
@@ -65,9 +67,29 @@ final class Result {
 	/**
 	 * Get count of successfully upgraded items within the current batch
 	 *
-	 * @return $failure_count Amount of failures
+	 * @return int $failure_count Amount of failures
 	 */
 	public function getSuccessCount() {
 		return $this->success_count;
+	}
+
+	/**
+	 * Mark the upgrade as complete (not necessarily successful)
+	 *
+	 * @return void
+	 */
+	public function markComplete() {
+		$this->is_complete = true;
+	}
+
+	/**
+	 * Has the upgrade been marked complete?
+	 *
+	 * @internal
+	 * @access private
+	 * @return bool
+	 */
+	public function wasMarkedComplete() {
+		return $this->is_complete === true;
 	}
 }

--- a/engine/lib/upgrades/async-upgrades.php
+++ b/engine/lib/upgrades/async-upgrades.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Return a list of class names of asynchronous core upgrades. Any unfinished upgrades will
+ * be presented to the site administrator in order of appearance here.
+ *
+ * @see Elgg\Upgrade\Locator
+ */
+
+return [
+	// \Elgg\Upgrades\ExampleUpgrade::class
+];

--- a/engine/tests/phpunit/Elgg/BatchUpgraderTest.php
+++ b/engine/tests/phpunit/Elgg/BatchUpgraderTest.php
@@ -4,6 +4,7 @@ namespace Elgg;
 
 use Elgg\Upgrade\TestBatch;
 use Elgg\Upgrade\TestNoIncrementBatch;
+use Elgg\Upgrade\UnknownSizeTestBatch;
 use ElggUpgrade;
 
 /**
@@ -32,6 +33,7 @@ class BatchUpgraderTest extends TestCase {
 			'errors' => [0, 25, 50, 75],
 			'numErrors' => 40,
 			'numSuccess' => 60,
+			'isComplete' => false,
 		];
 
 		$this->assertEquals($expected, $result);
@@ -58,6 +60,7 @@ class BatchUpgraderTest extends TestCase {
 			'errors' => [50, 75],
 			'numErrors' => 20,
 			'numSuccess' => 30,
+			'isComplete' => false,
 		];
 
 		$this->assertEquals($expected, $result);
@@ -80,9 +83,32 @@ class BatchUpgraderTest extends TestCase {
 			'errors' => [0, 10, 20, 30],
 			'numErrors' => 40,
 			'numSuccess' => 60,
+			'isComplete' => false,
 		];
 
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testCanRunUpgradeWithoutTotal() {
+
+		$upgrade = new ElggUpgrade();
+		$upgrade->setClass(UnknownSizeTestBatch::class);
+		$upgrade->setId("test_plugin:2016101902");
+		$upgrade->title = 'test_plugin:upgrade:2016101902:title';
+		$upgrade->description = 'test_plugin:upgrade:2016101902:title';
+		$upgrade->save();
+
+		$config = _elgg_services()->config;
+		$upgrader = new BatchUpgrader($config);
+		$result = $upgrader->run($upgrade);
+
+		$expected = [
+			'errors' => [],
+			'numErrors' => 0,
+			'numSuccess' => 20,
+			'isComplete' => true,
+		];
+
+		$this->assertEquals($expected, $result);
+	}
 }

--- a/engine/tests/phpunit/Elgg/Upgrade/LocatorTest.php
+++ b/engine/tests/phpunit/Elgg/Upgrade/LocatorTest.php
@@ -36,22 +36,13 @@ class LocatorTest extends \Elgg\TestCase {
 		$this->markTestIncomplete();
 	}
 
-	public function testCanGetPluginUpgrades() {
-		$this->plugin
-			->expects($this->any())
-			->method('getStaticConfig')
-			->will($this->returnCallback(function($name) {
-				if ($name == 'upgrades') {
-					return [\Elgg\Upgrade\TestBatch::class];
-				}
-			}));
+	public function testCanGetPluginUpgrade() {
+		$class = \Elgg\Upgrade\TestBatch::class;
 
-		$upgrades = _elgg_services()->upgradeLocator->getUpgrades($this->plugin);
-
-		$this->assertNotEmpty($upgrades);
-
-		$upgrade = array_shift($upgrades);
+		$upgrade = _elgg_services()->upgradeLocator->getUpgrade($class, 'test_plugin');
 		/* @var $upgrade \ElggUpgrade */
+
+		$this->assertNotEmpty($upgrade);
 
 		$this->assertInstanceOf(\ElggUpgrade::class, $upgrade);
 		$this->assertEquals('test_plugin:2016101900', $upgrade->id);
@@ -66,18 +57,10 @@ class LocatorTest extends \Elgg\TestCase {
 	}
 
 	public function testIgnoresNonRequiredUpgrade() {
-		// Mock an upgrade that does not need to be ran
-		$this->plugin
-			->expects($this->any())
-			->method('getStaticConfig')
-			->will($this->returnCallback(function($name) {
-				if ($name == 'upgrades') {
-					return [\Elgg\Upgrade\NonRequiredTestBatch::class];
-				}
-			}));
+		$class = \Elgg\Upgrade\NonRequiredTestBatch::class;
 
-		$upgrades = _elgg_services()->upgradeLocator->getUpgrades($this->plugin);
+		$upgrade = _elgg_services()->upgradeLocator->getUpgrade($class, 'test_plugin');
 
-		$this->assertEmpty($upgrades);
+		$this->assertEmpty($upgrade);
 	}
 }

--- a/engine/tests/phpunit/Elgg/Upgrade/NonRequiredTestBatch.php
+++ b/engine/tests/phpunit/Elgg/Upgrade/NonRequiredTestBatch.php
@@ -4,11 +4,16 @@ namespace Elgg\Upgrade;
 
 class NonRequiredTestBatch implements \Elgg\Upgrade\Batch {
 
-	const INCREMENT_OFFSET = true;
-	const VERSION = 2016101900;
+	public function getVersion() {
+		return 2016101900;
+	}
 
-	public function isRequired() {
-		return false;
+	public function needsIncrementOffset() {
+		return true;
+	}
+
+	public function shouldBeSkipped() {
+		return true;
 	}
 
 	public function countItems() {

--- a/engine/tests/phpunit/Elgg/Upgrade/TestNoIncrementBatch.php
+++ b/engine/tests/phpunit/Elgg/Upgrade/TestNoIncrementBatch.php
@@ -4,13 +4,18 @@ namespace Elgg\Upgrade;
 
 class TestNoIncrementBatch implements \Elgg\Upgrade\Batch {
 
-	const INCREMENT_OFFSET = false;
-	const VERSION = 2016101901;
+	public function getVersion() {
+		return 2016101901;
+	}
+
+	public function needsIncrementOffset() {
+		return false;
+	}
 
 	private $count = 100;
 
-	public function isRequired() {
-		return true;
+	public function shouldBeSkipped() {
+		return false;
 	}
 
 	public function countItems() {

--- a/engine/tests/phpunit/Elgg/Upgrade/UnknownSizeTestBatch.php
+++ b/engine/tests/phpunit/Elgg/Upgrade/UnknownSizeTestBatch.php
@@ -2,10 +2,12 @@
 
 namespace Elgg\Upgrade;
 
-class TestBatch implements \Elgg\Upgrade\Batch {
+class UnknownSizeTestBatch implements \Elgg\Upgrade\Batch {
+
+	private $i = 0;
 
 	public function getVersion() {
-		return 2016101900;
+		return 2016101902;
 	}
 
 	public function needsIncrementOffset() {
@@ -17,14 +19,15 @@ class TestBatch implements \Elgg\Upgrade\Batch {
 	}
 
 	public function countItems() {
-		return 100;
+		return Batch::UNKNOWN_COUNT;
 	}
 
 	public function run(Result $result, $offset) {
-		$result->addError($offset);
-		$result->addSuccesses(15);
-		$result->addFailures(10);
+		$result->addSuccesses(10);
+		$this->i++;
+		if ($this->i === 2) {
+			$result->markComplete();
+		}
 		return $result;
 	}
-
 }

--- a/mod/groups/classes/Elgg/Groups/Upgrades/GroupIconTransfer.php
+++ b/mod/groups/classes/Elgg/Groups/Upgrades/GroupIconTransfer.php
@@ -2,29 +2,36 @@
 
 namespace Elgg\Groups\Upgrades;
 
+use Elgg\Upgrade\Batch;
+use Elgg\Upgrade\Result;
+
 /**
  * Moves group icons owned by user to directory owned by the groups itself.
  *
  * BEFORE: /dataroot/<bucket>/<owner_guid>/groups/<group_guid><size>.jpg
  * AFTER:  /dataroot/<bucket>/<group_guid>/icons/icon/<size>.jpg
  */
-class GroupIconTransfer implements \Elgg\Upgrade\Batch {
+class GroupIconTransfer implements Batch {
 
-	const INCREMENT_OFFSET = true;
+	public function getVersion() {
+		return 2016101900;
+	}
 
-	const VERSION = 2016101900;
+	public function needsIncrementOffset() {
+		return true;
+	}
 
 	/**
 	 * {@inheritdoc}
 	 */
-	public function isRequired() {
+	public function shouldBeSkipped() {
 		$groups = elgg_get_entities_from_metadata([
 			'types' => 'group',
 			'metadata_names' => 'icontime',
 		]);
 
 		if (empty($groups)) {
-			return false;
+			return true;
 		}
 
 		$group = array_pop($groups);
@@ -46,11 +53,11 @@ class GroupIconTransfer implements \Elgg\Upgrade\Batch {
 			$filestorename = "{$dataroot}{$dir}{$prefix}{$filename}";
 			if (file_exists($filestorename)) {
 				// A group icon was found meaning that the upgrade is needed.
-				return true;
+				return false;
 			}
 		}
 
-		return false;
+		return true;
 	}
 
 	/**
@@ -66,7 +73,7 @@ class GroupIconTransfer implements \Elgg\Upgrade\Batch {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function run(\Elgg\Upgrade\Result $result, $offset) {
+	public function run(Result $result, $offset) {
 
 		$groups = elgg_get_entities([
 			'types' => 'group',
@@ -89,11 +96,11 @@ class GroupIconTransfer implements \Elgg\Upgrade\Batch {
 	 * In 3.0, we are moving these to default filestore location
 	 * relative to group's filestore directory
 	 *
-	 * @param \ElggGroup           $group  Group entity
-	 * @param \Elgg\Upgrade\Result $result Upgrade result
-	 * @return \Elgg\Upgrade\Result
+	 * @param \ElggGroup $group  Group entity
+	 * @param Result     $result Upgrade result
+	 * @return Result
 	 */
-	public function transferIcons(\ElggGroup $group, \Elgg\Upgrade\Result $result) {
+	public function transferIcons(\ElggGroup $group, Result $result) {
 
 		$sizes = elgg_get_icon_sizes('group', $group->getSubtype());
 

--- a/views/default/object/elgg_upgrade.php
+++ b/views/default/object/elgg_upgrade.php
@@ -3,6 +3,8 @@
  * ElggUpgrade view
  */
 
+use Elgg\Upgrade\Batch;
+
 $entity = elgg_extract('entity', $vars);
 /* @var $entity \ElggUpgrade */
 
@@ -12,11 +14,13 @@ if (!$batch) {
 	return;
 }
 
+$count = $batch->countItems();
+
 $data = elgg_format_element(
 	'span',
 	[
 		'class' => 'upgrade-data hidden',
-		'data-total' => $batch->countItems(),
+		'data-total' => $count,
 	]
 );
 
@@ -29,7 +33,7 @@ $timer = elgg_format_element(
 $counter = elgg_format_element(
 	'span',
 	['class' => 'upgrade-counter float-alt'],
-	"0/{$batch->countItems()}"
+	$count === Batch::UNKNOWN_COUNT ? "0/???" : "0/$count"
 );
 
 $progressbar = elgg_format_element('div', [


### PR DESCRIPTION
Allows core to declare async upgrades.
Batch methods renamed to add clarity.
Docs improved.

Async upgrades no longer require knowing how many items must be processed. The batch can simply keep processing items and mark the result object complete at the end. Client-side the progress bar just moves ahead 50% of the remaining distance.

Fixes #10513