### PR TITLE
fix(search): allows get_sql, access hook to be used correctly

### DIFF
--- a/mod/search/search_hooks.php
+++ b/mod/search/search_hooks.php
@@ -267,7 +267,10 @@ function search_tags_hook($hook, $type, $value, $params) {
 	$params['joins'][] = "JOIN {$db_prefix}metastrings msn on md.name_id = msn.id";
 	$params['joins'][] = "JOIN {$db_prefix}metastrings msv on md.value_id = msv.id";
 
-	$access = _elgg_get_access_where_sql(array('table_alias' => 'md'));
+	$access = _elgg_get_access_where_sql([
+		'table_alias' => 'md',
+		'guid_column' => 'entity_guid',
+	]);
 	$sanitised_tags = array();
 
 	foreach ($search_tag_names as $tag) {


### PR DESCRIPTION
Since we're telling users of this hook that we're referencing the metadata table, we must also tell them the correct name of the GUID column.

Fixes #10884