### PR TITLE
chore(entities): removes isFullyLoaded() method

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -96,6 +96,7 @@ All the functions in ``engine/lib/deprecated-1.10.php`` were removed. See https:
  * ``ElggEntity::addToSite``
  * ``ElggEntity::getSites``
  * ``ElggEntity::removeFromSite``
+ * ``ElggEntity::isFullyLoaded``
  * ``ElggFile::setFilestore``: ElggFile objects can no longer use custom filestores.
  * ``ElggFile::size``: Use ``getSize``
  * ``ElggDiskFilestore::makeFileMatrix``: Use ``Elgg\EntityDirLocator``

--- a/engine/classes/Elgg/Cache/EntityCache.php
+++ b/engine/classes/Elgg/Cache/EntityCache.php
@@ -55,12 +55,12 @@ class EntityCache {
 	 *
 	 * @param int $guid The GUID
 	 *
-	 * @return \ElggEntity|false false if entity not cached, or not fully loaded
+	 * @return \ElggEntity|false false if entity not cached
 	 */
 	public function get($guid) {
 		$guid = (int) $guid;
 
-		if (isset($this->entities[$guid]) && $this->entities[$guid]->isFullyLoaded()) {
+		if (isset($this->entities[$guid])) {
 			return $this->entities[$guid];
 		}
 

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1241,15 +1241,6 @@ abstract class ElggEntity extends \ElggData implements
 	}
 
 	/**
-	 * Tests to see whether the object has been persisted.
-	 *
-	 * @return bool
-	 */
-	public function isFullyLoaded() {
-		return (bool) $this->guid;
-	}
-
-	/**
 	 * Save an entity.
 	 *
 	 * @return bool|int


### PR DESCRIPTION
This is no longer necessary.

Fixes #8950

BREAKING CHANGE:
Entities no longer have an `isFullyLoaded()` method.