### PR TITLE
warning if metastring exceeded column length

### DIFF
--- a/engine/classes/ElggMetadata.php
+++ b/engine/classes/ElggMetadata.php
@@ -72,8 +72,8 @@ class ElggMetadata extends \ElggExtender {
 	public function save() {
 		if ($this->id > 0) {
 		     //if version of mysql is less than 5.7.5 if wouldn't have strict_trans_table function 
-		     if(strcmp(mysql_get_server_info(),"5.7.5")<0){
-			     throw new \IOException("warning");
+		     if(strcmp(mysql_get_server_info(),"5.7.5")<=0){
+			     throw new \IOException("Unable to save new " . get_class());
 			     //error message so that string size can be checked
 		        }
 			

--- a/engine/classes/ElggMetadata.php
+++ b/engine/classes/ElggMetadata.php
@@ -71,6 +71,12 @@ class ElggMetadata extends \ElggExtender {
 	 */
 	public function save() {
 		if ($this->id > 0) {
+		     //if version of mysql is less than 5.7.5 if wouldn't have strict_trans_table function 
+		     if(strcmp(mysql_get_server_info(),"5.7.5")<0){
+			     throw new \IOException("warning");
+			     //error message so that string size can be checked
+		        }
+			
 			return update_metadata($this->id, $this->name, $this->value,
 				$this->value_type, $this->owner_guid, $this->access_id);
 		} else {


### PR DESCRIPTION
Without STRICT_TRANS_TABLES MySQL truncates metastrings to fit the text column