### PR TITLE
fix(search): no longer fatals if comment container hidden

### DIFF
--- a/mod/search/views/default/search/object/comment/entity.php
+++ b/mod/search/views/default/search/object/comment/entity.php
@@ -11,6 +11,10 @@ $owner = $entity->getOwnerEntity();
 $icon = elgg_view_entity_icon($owner, 'tiny');
 
 $container = $entity->getContainerEntity();
+if (!$container) {
+	elgg_log("Search found comment {$entity->guid}, but the user cannot see its container.", 'WARNING');
+	return;
+}
 
 if ($container->getType() == 'object') {
 	$title = $container->title;


### PR DESCRIPTION
If search returns a comment whose container can't be loaded we log a warning and don't render it.

Fixes #10902