### PR TITLE
fix(menus): provide admin link in case JS fails

### DIFF
--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -801,10 +801,13 @@ function _elgg_user_topbar_menu($hook, $type, $return, $params) {
 	$toggle = elgg_view_icon('chevron-down', ['class' => 'elgg-state-closed']);
 	$toggle .= elgg_view_icon('chevron-up', ['class' => 'elgg-state-opened']);
 
+	// If JS fails here, allow easy access to place where they can upgrade/flush caches
+	$href = elgg_is_admin_logged_in() ? elgg_get_login_url() : '#';
+
 	$return[] = \ElggMenuItem::factory([
 		'name' => 'account',
 		'text' => elgg_echo('account') . $toggle,
-		'href' => '#',
+		'href' => $href,
 		'priority' => 800,
 		'section' => 'alt',
 		'child_menu' => [


### PR DESCRIPTION
If JS fails, the Account drop down menu may not load. This just sends admins to the dashboard where they can flush cache/run upgrades if necessary.