### PR TITLE
feature(messaging): improves admin notices and system messages

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -300,6 +300,7 @@ APIs that now accept only an ``$options`` array
  * ``ElggUser::getFriendsObjects`` (as part of ``Friendable``)
  * ``ElggUser::getObjects`` (as part of ``Friendable``)
  * ``find_active_users``
+ * ``elgg_get_admin_notices``
 
 Plugin functions that now require an explicit ``$plugin_id``
 ------------------------------------------------------------

--- a/engine/classes/Elgg/Database/AdminNotices.php
+++ b/engine/classes/Elgg/Database/AdminNotices.php
@@ -93,17 +93,17 @@ class AdminNotices {
 	/**
 	 * Get admin notices. An admin must be logged in since the notices are private.
 	 *
-	 * @param int $limit Limit
+	 * @param array $options Query options
 	 *
-	 * @return array Array of admin notices
+	 * @return \ElggObject[] Admin notices
 	 */
-	function find($limit = 10) {
-		return elgg_get_entities_from_metadata([
+	function find(array $options = []) {
+		$options = array_merge($options, [
 			'type' => 'object',
 			'subtype' => 'admin_notice',
-			'limit' => $limit,
-			'distinct' => false,
 		]);
+
+		return _elgg_services()->metadataTable->getEntities($options);
 	}
 	
 	/**

--- a/engine/js/ui.js
+++ b/engine/js/ui.js
@@ -11,7 +11,12 @@ elgg.ui.init = function () {
 	// if the user clicks a system message (not a link inside one), make it disappear
 	$(document).on('click', '.elgg-system-messages li', function(e) {
 		if (!$(e.target).is('a')) {
-			$(this).stop().fadeOut('fast');
+			var $this = $(this);
+
+			// slideUp allows dismissals without notices shifting around unpredictably
+			$this.clearQueue().slideUp(100, function () {
+				$this.remove();
+			});
 		}
 	});
 

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -96,17 +96,17 @@ function elgg_delete_admin_notice($id) {
 /**
  * Get admin notices. An admin must be logged in since the notices are private.
  *
- * @param int $limit Limit
+ * @param array $options Query options
  *
- * @return array Array of admin notices
+ * @return ElggObject[] Admin notices
  * @since 1.8.0
  */
-function elgg_get_admin_notices($limit = 10) {
-	return _elgg_services()->adminNotices->find($limit);
+function elgg_get_admin_notices(array $options = []) {
+	return _elgg_services()->adminNotices->find($options);
 }
 
 /**
- * Check if an admin notice is currently active.
+ * Check if an admin notice is currently active. (Ignores access)
  *
  * @param string $id The unique ID used to register the notice.
  *

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -478,6 +478,7 @@ function elgg_view_page($title, $body, $page_shell = 'default', $vars = []) {
 	$vars['title'] = $title;
 	$vars['body'] = $body;
 	$vars['sysmessages'] = $messages;
+	$vars['admin_notices'] = elgg_is_admin_logged_in() ? elgg_get_admin_notices() : [];
 	$vars['page_shell'] = $page_shell;
 
 	// head has keys 'title', 'metas', 'links'

--- a/views/default/admin.css.php
+++ b/views/default/admin.css.php
@@ -259,21 +259,7 @@ a.elgg-maintenance-mode-warning {
 	text-decoration: underline;
 }
 
-.elgg-admin-notices p {
-	color: #3B8BC9;
-	background-color: #E7F1F9;
-	border: 1px solid #B1D1E9;
-	padding: 20px;
-	border-radius: 3px;
-}
-.elgg-admin-notices a.elgg-admin-notice {
-	float: right;
-	text-decoration: none;
-}
-
-.elgg-admin-notices a {
-	text-decoration: underline;
-}
+<?= elgg_view('elements/components/admin_notices.css') ?>
 
 /* ***************************************
 	BODY

--- a/views/default/elements/components/admin_notices.css
+++ b/views/default/elements/components/admin_notices.css
@@ -1,0 +1,25 @@
+
+.elgg-admin-notices {
+	margin: 15px 0;
+}
+.elgg-item-object-admin_notice {
+	margin: 5px 0;
+}
+.elgg-admin-notices p {
+	color: #3B8BC9;
+	background-color: #E7F1F9;
+	border: 1px solid #B1D1E9;
+	padding: 15px 20px;
+	border-radius: 3px;
+}
+.elgg-admin-notices a.elgg-admin-notice {
+	float: right;
+	text-decoration: none;
+}
+.elgg-admin-notices a {
+	text-decoration: underline;
+}
+
+.elgg-page-admin .elgg-admin-notices {
+	margin: 0;
+}

--- a/views/default/elements/layout.css.php
+++ b/views/default/elements/layout.css.php
@@ -25,6 +25,7 @@
 	margin: 0 auto;
 	height: auto;
 }
+.elgg-page-default .elgg-page-admin-notices > .elgg-inner,
 .elgg-page-default .elgg-page-body > .elgg-inner {
 	max-width: 990px;
 	margin: 0 auto;
@@ -58,6 +59,8 @@
 .elgg-system-messages li {
 	margin-top: 10px;
 }
+
+<?= elgg_view('elements/components/admin_notices.css') ?>
 
 /***** PAGE HEADER ******/
 .elgg-page-header {

--- a/views/default/elgg/admin.js
+++ b/views/default/elgg/admin.js
@@ -18,7 +18,12 @@ define(function(require) {
 		$(document).off('click', '.elgg-system-messages li');
 		$(document).on('click', '.elgg-system-messages li', function(e) {
 			if (!$(e.target).is('a')) {
-				$(this).stop().slideUp('medium');
+				var $this = $(this);
+
+				// slideUp allows dismissals without notices shifting around unpredictably
+				$this.clearQueue().slideUp(100, function () {
+					$this.remove();
+				});
 			}
 		});
 
@@ -40,9 +45,6 @@ define(function(require) {
 			handle: 'span.elgg-state-draggable',
 			stop: moveProfileField
 		});
-
-		// admin notices delete ajax
-		$('a.elgg-admin-notice').click(deleteNotice);
 
 		// disable checkboxes (readonly does not work for them)
 		$(document).on('click', 'input:checkbox.elgg-state-disabled, label.elgg-state-disabled > input:checkbox', function() {
@@ -250,22 +252,6 @@ define(function(require) {
 
 		elgg.action('profile/fields/reorder', {
 			fieldorder: orderStr
-		});
-	}
-
-	/**
-	 * Fires the ajax action to delete the admin notice then hides the notice.
-	 *
-	 * @return void
-	 */
-	function deleteNotice (e) {
-		e.preventDefault();
-		var $container = $(this).closest('p');
-
-		elgg.action($(this).attr('href'), {
-			success: function(json) {
-				$container.slideUp('medium');
-			}
 		});
 	}
 

--- a/views/default/elgg/admin_notices.js
+++ b/views/default/elgg/admin_notices.js
@@ -1,0 +1,34 @@
+/**
+ * Handle deleting admin notices
+ */
+define(function(require) {
+	var $ = require('jquery');
+	var Ajax = require('elgg/Ajax');
+
+	var ajax = new Ajax();
+
+	$(document).on('click', 'a.elgg-admin-notice', function (e) {
+		e.preventDefault();
+		var $li = $(this).closest('.elgg-item-object-admin_notice');
+
+		// slideUp allows dismissals without notices shifting around unpredictably
+		$li.slideUp(100);
+
+		function restore() {
+			$li.show();
+		}
+
+		ajax.action(this.href).done(function (output, statusText, jqXHR) {
+			if (jqXHR.AjaxData.status == -1) {
+				restore();
+				return;
+			}
+
+			// When none left, remove container so it doesn't take up space. A few CSS solutions were
+			// tried, but left jerky transitions at the end of the animations.
+			if (!$('.elgg-item-object-admin_notice:visible').length) {
+				$('.elgg-admin-notices').remove();
+			}
+		}).fail(restore);
+	});
+});

--- a/views/default/object/admin_notice.php
+++ b/views/default/object/admin_notice.php
@@ -8,13 +8,15 @@ if (isset($vars['entity']) && elgg_instanceof($vars['entity'], 'object', 'admin_
 	$message = $notice->description;
 
 	$delete = elgg_view('output/url', [
-		'href' => "action/admin/delete_admin_notice?guid=$notice->guid",
+		'href' => "action/admin/delete_admin_notice?guid={$notice->guid}",
 		'text' => elgg_view_icon('delete'),
 		'is_action' => true,
 		'class' => 'elgg-admin-notice',
 		'is_trusted' => true,
 	]);
 
-	echo "<p>$delete$message</p>";
+	echo "<p>$delete $message</p>";
+
+	elgg_require_js('elgg/admin_notices');
 }
 

--- a/views/default/page/default.php
+++ b/views/default/page/default.php
@@ -3,14 +3,15 @@
 /**
  * Renders a standard HTML page shell
  *
- * @uses $vars['section']     An array of page sections to render
- * @uses $vars['html_attrs']  Attributes of the <html> tag
- * @uses $vars['head']        Parameters for the <head> element
- * @uses $vars['body_attrs']  Attributes of the <body> tag
- * @uses $vars['page_attrs']  Attributes of the .elgg-page container
- * @uses $vars['title']       Title of the page
- * @uses $vars['body']        The main content of the page
- * @uses $vars['sysmessages'] A 2d array of various message registers, passed from system_messages()
+ * @uses $vars['section']       An array of page sections to render
+ * @uses $vars['html_attrs']    Attributes of the <html> tag
+ * @uses $vars['head']          Parameters for the <head> element
+ * @uses $vars['body_attrs']    Attributes of the <body> tag
+ * @uses $vars['page_attrs']    Attributes of the .elgg-page container
+ * @uses $vars['title']         Title of the page
+ * @uses $vars['body']          The main content of the page
+ * @uses $vars['sysmessages']   A 2d array of various message registers, passed from system_messages()
+ * @uses $vars['admin_notices'] Array of ElggObject admin notices
  */
 
 $sections = elgg_extract('sections', $vars);
@@ -24,6 +25,9 @@ if (empty($sections)) {
 		'topbar' => elgg_view('page/elements/topbar', $vars),
 		'header' => elgg_view('page/elements/header', $vars),
 		'navbar' => elgg_view('page/elements/navbar', $vars),
+		'admin-notices' => elgg_view('page/elements/admin_notices', [
+			'notices' => $vars['admin_notices'],
+		]),
 		'body' => elgg_view('page/elements/body', $vars),
 		'footer' => elgg_view('page/elements/footer', $vars),
 	];

--- a/views/default/page/elements/admin_notices.php
+++ b/views/default/page/elements/admin_notices.php
@@ -1,6 +1,19 @@
 <?php
+/**
+ * Lists admin notices
+ *
+ * @uses $vars['notices'] Array of ElggObject notices
+ */
 
-echo elgg_list_entities([
-	'limit' => false,
+if (!isset($vars['notices'])) {
+	// legacy usage
+	echo elgg_list_entities([
+		'limit' => false,
+		'list_class' => 'elgg-admin-notices',
+	], 'elgg_get_admin_notices');
+	return;
+}
+
+echo elgg_view_entity_list($vars['notices'], [
 	'list_class' => 'elgg-admin-notices',
-], 'elgg_get_admin_notices');
+]);


### PR DESCRIPTION
Notices appear outside admin area.
Messages dismiss more responsibly.
Admin notice CSS moved to own view.

Fixes #10917

BREAKING CHANGE:
`elgg_get_admin_notices()` accepts only an array.