### PR TITLE
WIP chore(core): add experimental no-data boot service

### DIFF
--- a/engine/classes/Elgg/Database/Plugins.php
+++ b/engine/classes/Elgg/Database/Plugins.php
@@ -400,6 +400,10 @@ class Plugins {
 	 * @return \ElggPlugin[]
 	 */
 	function find($status = 'active') {
+		if (elgg_get_config('Database_none')) {
+			return [];
+		}
+
 		$db_prefix = elgg_get_config('dbprefix');
 		$priority = $this->namespacePrivateSetting('internal', 'priority');
 		$site_guid = 1;

--- a/engine/classes/Elgg/Project/NoDataBoot.php
+++ b/engine/classes/Elgg/Project/NoDataBoot.php
@@ -1,0 +1,115 @@
+<?php
+namespace Elgg\Project;
+
+use Elgg\Database\SiteSecret;
+use Elgg\Application\CacheHandler;
+use ElggPluginPackage;
+use ElggPlugin;
+
+/**
+ * Boot Elgg without DB or dataroot.
+ *
+ * @access private EXPERIMENTAL. DO NOT USE
+ */
+class NoDataBoot {
+
+	/**
+	 * Boot Elgg without a data directory or DB
+	 *
+	 * @param \stdClass $no_data_config Config data
+	 * @return void
+	 */
+	public function boot(\stdClass $no_data_config) {
+
+		$no_data_config->__DIR__ = rtrim($no_data_config->__DIR__, '/\\');
+
+		$config = new \Elgg\Config(null, false);
+		$sp = new \Elgg\Di\ServiceProvider($config);
+		$app = new \Elgg\Application($sp);
+
+		if (!$no_data_config->wwwroot) {
+			$no_data_config->wwwroot = $sp->request->getSchemeAndHttpHost() . $sp->request->getBaseUrl() . '/';
+		}
+		$config->set('wwwroot', $no_data_config->wwwroot);
+		$config->set('dataroot', '/fake/path');
+		$config->set('cacheroot', '/fake/path');
+		$config->set('language', 'en');
+		$config->set('simplecache_enabled', false);
+		$config->set('dbprefix', 'NOT_SET');
+		$config->set('sitename',  $no_data_config->site_name);
+		$config->set('sitedescription', $no_data_config->site_description);
+
+		// don't load settings.php, check DB for configs/plugins, or boot
+		$config->set('Database_none', true);
+		$config->set('Config_file', false);
+		$config->set('site_config_loaded', true);
+		$config->set('boot_complete', true);
+
+		// don't use DB session
+		$sp->setValue('session', new \ElggSession($no_data_config->symfony_session));
+
+		// use local key
+		$secret = new SiteSecret($sp->configTable);
+		$secret->setTestingSecret($no_data_config->site_secret);
+		$sp->setValue('siteSecret', $secret);
+
+		// define functions
+		$app->loadCore();
+
+		$sp->session->start();
+
+		// core translations
+		$sp->translator->loadTranslations();
+
+		// load local translations
+		register_translations($no_data_config->__DIR__ . '/languages');
+
+		// read elgg-plugin.php
+		$static_config = [];
+		$static_file = $no_data_config->__DIR__ . '/' . ElggPluginPackage::STATIC_CONFIG_FILENAME;
+		if (is_file($static_file) && is_readable($static_file)) {
+			$static_config = (require $static_file);
+		}
+
+		// need a site entity for the request
+		$site = new \ElggSite();
+		$site->url = $config->getSiteUrl();
+		$site->name = $no_data_config->site_name;
+		$site->description = $no_data_config->site_description;
+		$config->set('site', $site);
+
+		// register all core views
+		// elgg_views_boot() needs this
+		$sp->views->view_path = \Elgg\Application::elggDir()->getPath('views');
+		elgg_views_boot();
+
+		// add local views and views.php
+		if (!empty($static_config['views'])) {
+			$sp->views->mergeViewsSpec($static_file['views']);
+		}
+		$sp->views->registerPluginViews($no_data_config->__DIR__);
+
+		// add local static actions
+		if (!empty($static_config['actions'])) {
+			ElggPlugin::addActionsFromStaticConfig($static_config['actions'], $no_data_config->__DIR__);
+		}
+
+		// allow /cache to work
+		$path = $sp->request->getPathInfo();
+		if (0 === strpos($path, '/cache')) {
+			(new CacheHandler($app, $config, $_SERVER))->handleRequest($path);
+			exit;
+		}
+	}
+
+	/**
+	 * Start routing
+	 *
+	 * @return void
+	 */
+	public function route() {
+		if (!_elgg_services()->router->route(_elgg_services()->request)) {
+			forward('', '404');
+		}
+	}
+}

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -983,31 +983,45 @@ class ElggPlugin extends \ElggObject {
 	/**
 	 * Registers the plugin's actions provided in the plugin config file
 	 *
-	 * @throws PluginException
 	 * @return void
 	 */
 	protected function registerActions() {
-		$actions = _elgg_services()->actions;
+		self::addActionsFromStaticConfig($this->getStaticConfig('actions', []), $this->getPath());
+	}
 
-		$spec = (array) $this->getStaticConfig('actions', []);
-		
+	/**
+	 * Register a plugin's actions provided in the config file
+	 *
+	 * @todo move to a static config service
+	 *
+	 * @param array  $spec      'actions' section of static config
+	 * @param string $root_path Plugin path
+	 *
+	 * @return void
+	 * @access private
+	 * @internal
+	 */
+	public static function addActionsFromStaticConfig(array $spec, $root_path) {
+		$actions = _elgg_services()->actions;
+		$root_path = rtrim($root_path, '/\\');
+
 		foreach ($spec as $action => $action_spec) {
 			if (!is_array($action_spec)) {
 				continue;
 			}
-			
+
 			$options = [
 				'access' => 'logged_in',
 				'filename' => '', // assuming core action is registered
 			];
-			
+
 			$options = array_merge($options, $action_spec);
-			
-			$filename = "{$this->getPath()}actions/{$action}.php";
-			if (file_exists($filename)) {
+
+			$filename = "$root_path/actions/{$action}.php";
+			if (is_file($filename)) {
 				$options['filename'] = $filename;
 			}
-			
+
 			$actions->register($action, $options['filename'], $options['access']);
 		}
 	}

--- a/engine/js/languages.js
+++ b/engine/js/languages.js
@@ -22,13 +22,8 @@ elgg.add_translation = function(lang, translations) {
  * @return {String}
  */
 elgg.get_language = function() {
-	var user = elgg.get_logged_in_user_entity();
-
-	if (user && user.language) {
-		return user.language;
-	}
-
-	return elgg.config.language;
+	// set by _elgg_get_js_page_data()
+	return elgg.config.current_language;
 };
 
 /**

--- a/engine/lib/actions.php
+++ b/engine/lib/actions.php
@@ -298,8 +298,6 @@ function _elgg_csrf_token_refresh() {
 function actions_init() {
 	elgg_register_page_handler('action', '_elgg_action_handler');
 	elgg_register_page_handler('refresh_token', '_elgg_csrf_token_refresh');
-
-	elgg_register_simplecache_view('languages/en.js');
 }
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {

--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -133,6 +133,3 @@ function get_missing_language_keys($language) {
 function elgg_language_key_exists($key, $language = 'en') {
 	return _elgg_services()->translator->languageKeyExists($key, $language);
 }
-
-return function(\Elgg\EventsService $events) {
-};

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1921,6 +1921,7 @@ function elgg_views_boot() {
 	elgg_register_css('jquery.imgareaselect', elgg_get_simplecache_url('jquery.imgareaselect.css'));
 
 	elgg_register_ajax_view('languages.js');
+	elgg_register_simplecache_view('languages/en.js');
 
 	// pre-process CSS regardless of simplecache
 	elgg_register_plugin_hook_handler('cache:generate', 'css', '_elgg_views_preprocess_css');
@@ -2013,6 +2014,7 @@ function _elgg_get_js_page_data() {
 			'lastcache' => (int) elgg_get_config('lastcache'),
 			'viewtype' => elgg_get_viewtype(),
 			'simplecache_enabled' => (int) elgg_is_simplecache_enabled(),
+			'current_language' => get_current_language(),
 		],
 		'security' => [
 			'token' => [

--- a/engine/tests/js/prepare.js
+++ b/engine/tests/js/prepare.js
@@ -5,6 +5,7 @@ var elgg = elgg || {};
 elgg.config = elgg.config || {};
 
 elgg.config.wwwroot = 'http://www.elgg.org/';
+elgg.config.current_language = 'en';
 
 define('elgg', function() {
 	return elgg;

--- a/languages/en.php
+++ b/languages/en.php
@@ -1,5 +1,5 @@
 <?php
-use Symfony\Component\Yaml\Tests\A;
+
 return array(
 /**
  * Sites

--- a/no-data-demo/actions/no-data-demo.php
+++ b/no-data-demo/actions/no-data-demo.php
@@ -1,0 +1,7 @@
+<?php
+
+system_message('Ajax action called.');
+
+echo json_encode([
+	'cheese' => 1,
+]);

--- a/no-data-demo/elgg-plugin.php
+++ b/no-data-demo/elgg-plugin.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+	'actions' => [
+		'no-data-demo' => [
+			'access' => 'public',
+		],
+	],
+];

--- a/no-data-demo/index.php
+++ b/no-data-demo/index.php
@@ -1,0 +1,51 @@
+<?php
+
+use Symfony\Component\HttpFoundation\Session\Session;
+use Elgg\Project\NoDataBoot;
+
+date_default_timezone_set('UTC');
+
+$autoload_path = __DIR__ . '/../vendor/autoload.php';
+$autoload_available = include_once($autoload_path);
+if (!$autoload_available) {
+	die("Couldn't include '$autoload_path'. Did you run `composer install`?");
+}
+
+$boot = new NoDataBoot();
+$boot->boot((object) [
+	'site_secret' => 'zsHNgN6vQQtG6xUxBwh6srOFR3NB_L1',
+	'symfony_session' => new Session(), // or use mock
+	'wwwroot' => '', // sniff from request
+	'site_name' => 'No-data Elgg',
+	'site_description' => 'Demo of Elgg running without data sources',
+	'__DIR__' => __DIR__,
+]);
+
+// PLUGIN LOGIC /////////////////////////////////
+
+// no core menus are defined
+elgg_register_menu_item('site', [
+	'name' => 'en',
+	'href' => '/',
+	'text' => elgg_echo('en'),
+]);
+elgg_register_menu_item('site', [
+	'name' => 'es',
+	'href' => '/?hl=es',
+	'text' => elgg_echo('es'),
+]);
+
+// no logins please
+elgg_register_plugin_hook_handler('view_vars', 'core/account/login_dropdown', function () {
+	return ['__view_output' => ""];
+});
+
+// only a few core routes are defined
+elgg_register_page_handler('', function () {
+	echo elgg_view_resource('index');
+	return true;
+});
+
+// START ROUTING /////////////////////////////////
+
+$boot->route();

--- a/no-data-demo/languages/en.php
+++ b/no-data-demo/languages/en.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'no-data-proof' => 'Yes, Elgg works without a dataroot or MySQL.'
+];

--- a/no-data-demo/languages/es.php
+++ b/no-data-demo/languages/es.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'no-data-proof' => 'Si, Elgg funciona sin dataroot o MySQL.'
+];

--- a/no-data-demo/views/default/no-data-demo.js
+++ b/no-data-demo/views/default/no-data-demo.js
@@ -1,0 +1,15 @@
+define(function(require) {
+	var $ = require('jquery');
+	var elgg = require('elgg');
+	var Ajax = require('elgg/Ajax');
+
+	$('.no-data-echo').text(elgg.echo('no-data-proof'));
+
+	(new Ajax).action('no-data-demo').done(function (value) {
+		if (value.cheese) {
+			elgg.system_message('&#128077;');
+		} else {
+			elgg.register_error('&#128078;');
+		}
+	});
+});

--- a/no-data-demo/views/default/resources/index.php
+++ b/no-data-demo/views/default/resources/index.php
@@ -1,0 +1,28 @@
+<?php
+
+elgg_require_js('no-data-demo');
+
+$title = elgg_echo(get_current_language());
+
+ob_start();
+?>
+
+<h3>PHP elgg_echo:</h3>
+
+<?= elgg_echo('no-data-proof'); ?>
+
+<hr class='mtl mbl'>
+
+<h3>JS elgg.echo:</h3>
+
+<div class='no-data-echo'></div>
+
+<?php
+$content = ob_get_clean();
+
+$layout = elgg_view_layout('default', [
+	'title' => $title,
+	'content' => $content,
+]);
+
+echo elgg_view_page($title, $layout);


### PR DESCRIPTION
Can boot Elgg without a DB or data directory. Features:

Provide your own Symfony session.
Translation works.
Views and assets work.
Core views registered.
JS and Ajax work.
JS translation works.
Actions work.
System messages work.
`elgg-plugin.php` can config actions/views.

No plugins are loaded.
Settings file is not loaded.
Simplecache is off.
DB object exists (for services) but will fail if used.

Fixes #10916