### PR TITLE
fix(menus): log error if factory missing 'name' or 'text'

### DIFF
--- a/engine/classes/Elgg/Menu/Service.php
+++ b/engine/classes/Elgg/Menu/Service.php
@@ -4,6 +4,7 @@ namespace Elgg\Menu;
 use Elgg\PluginHooksService;
 use Elgg\Config;
 use ElggMenuBuilder;
+use ElggMenuItem;
 
 /**
  * Methods to construct and prepare menus for rendering
@@ -148,10 +149,10 @@ class Service {
 		foreach ($items as $item) {
 			if (is_array($item)) {
 				$options = $item;
-				$item = \ElggMenuItem::factory($options);
+				$item = ElggMenuItem::factory($options);
 			}
 
-			if (!$item instanceof \ElggMenuItem) {
+			if (!$item instanceof ElggMenuItem) {
 				continue;
 			}
 			
@@ -160,5 +161,4 @@ class Service {
 
 		return $prepared_items;
 	}
-
 }

--- a/engine/classes/ElggMenuItem.php
+++ b/engine/classes/ElggMenuItem.php
@@ -98,8 +98,12 @@ class ElggMenuItem {
 	 *
 	 *    name        => STR  Menu item identifier (required)
 	 *    text        => STR  Menu item display text as HTML (required)
-	 *    href        => STR  Menu item URL (required) (false for non-links.
-	 *                        @warning If you disable the href the <a> tag will
+	 *    href        => STR  Menu item URL (required)
+	 *                        false = do not create a link.
+	 *                        null = current URL.
+	 *                        "" = current URL.
+	 *                        "/" = site home page.
+	 *                        @warning If href is false, the <a> tag will
 	 *                        not appear, so the link_class will not apply. If you
 	 *                        put <a> tags in manually through the 'text' option
 	 *                        the default CSS selector .elgg-menu-$menu > li > a
@@ -120,6 +124,7 @@ class ElggMenuItem {
 	 */
 	public static function factory($options) {
 		if (!isset($options['name']) || !isset($options['text'])) {
+			elgg_log(__METHOD__ . ': $options "name" and "text" are required.', 'ERROR');
 			return null;
 		}
 		if (!isset($options['href'])) {

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -68,8 +68,12 @@
  * @param mixed  $menu_item A \ElggMenuItem object or an array of options in format:
  *                          name        => STR  Menu item identifier (required)
  *                          text        => STR  Menu item display text as HTML (required)
- *                          href        => STR  Menu item URL (required) (false for non-links.
- *                                              @warning If you disable the href the <a> tag will
+ *                          href        => STR  Menu item URL (required)
+ *                                              false = do not create a link.
+ *                                              null = current URL.
+ *                                              "" = current URL.
+ *                                              "/" = site home page.
+ *                                              @warning If href is false, the <a> tag will
  *                                              not appear, so the link_class will not apply. If you
  *                                              put <a> tags in manually through the 'text' option
  *                                              the default CSS selector .elgg-menu-$menu > li > a

--- a/engine/tests/phpunit/ElggMenuItemTest.php
+++ b/engine/tests/phpunit/ElggMenuItemTest.php
@@ -210,8 +210,16 @@ class ElggMenuItemTest extends \Elgg\TestCase {
 		$logged = _elgg_services()->logger->enable();
 		$this->assertEquals([
 			[
+				'message' => 'ElggMenuItem::factory: $options "name" and "text" are required.',
+				'level' => 400,
+			],
+			[
 				'message' => 'Unable to add menu item \'MISSING NAME\' to \'foo\' menu',
 				'level' => 300,
+			],
+			[
+				'message' => 'ElggMenuItem::factory: $options "name" and "text" are required.',
+				'level' => 400,
 			],
 			[
 				'message' => 'Unable to add menu item \'MISSING NAME\' to \'foo\' menu',

--- a/views/default/output/url.php
+++ b/views/default/output/url.php
@@ -6,8 +6,10 @@
  * @package Elgg
  * @subpackage Core
  *
- * @uses string $vars['text']        The string between the <a></a> tags.
- * @uses string $vars['href']        The unencoded url string
+ * @uses string $vars['text']        The HTML between the <a></a> tags.
+ * @uses string $vars['href']        The raw, un-encoded URL.
+ *                                   "" = current URL.
+ *                                   "/" = site home page.
  * @uses bool   $vars['encode_text'] Run $vars['text'] through htmlspecialchars() (false)
  * @uses bool   $vars['is_action']   Is this a link to an action (false)
  * @uses bool   $vars['is_trusted']  Is this link trusted (false)


### PR DESCRIPTION
Also documents a few values of href in ElggMenuItem and the `output/url` view.