### PR TITLE
fix(db): warn devs about sanitizing array values

### DIFF
--- a/actions/plugins/settings/save.php
+++ b/actions/plugins/settings/save.php
@@ -30,7 +30,12 @@ if (elgg_action_exists("$plugin_id/settings/save")) {
 	action("$plugin_id/settings/save");
 } else {
 	foreach ($params as $k => $v) {
-		$result = $plugin->setSetting($k, $v);
+		if (is_array($v)) {
+			elgg_log('Plugin settings cannot store arrays.', 'ERROR');
+			$result = false;
+		} else {
+			$result = $plugin->setSetting($k, $v);
+		}
 		if (!$result) {
 			register_error(elgg_echo('plugins:settings:save:fail', array($plugin_name)));
 			forward(REFERER);

--- a/actions/plugins/usersettings/save.php
+++ b/actions/plugins/usersettings/save.php
@@ -43,10 +43,12 @@ if (elgg_action_exists("$plugin_id/usersettings/save")) {
 	action("$plugin_id/usersettings/save");
 } else {
 	foreach ($params as $k => $v) {
-		// Save
-		$result = $plugin->setUserSetting($k, $v, $user->guid);
-
-		// Error?
+		if (is_array($v)) {
+			elgg_log('Plugin user settings cannot store arrays.', 'ERROR');
+			$result = false;
+		} else {
+			$result = $plugin->setUserSetting($k, $v, $user->guid);
+		}
 		if (!$result) {
 			register_error(elgg_echo('plugins:usersettings:save:fail', array($plugin_name)));
 			forward(REFERER);

--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -698,6 +698,9 @@ class Database {
 	 * @deprecated Use query parameters where possible
 	 */
 	public function sanitizeString($value) {
+		if (is_array($value)) {
+			throw new \DatabaseException(__METHOD__ . '() and serialize_string() cannot accept arrays.');
+		}
 		$quoted = $this->getConnection('read')->quote($value);
 		if ($quoted[0] !== "'" || substr($quoted, -1) !== "'") {
 			throw new \DatabaseException("PDO::quote did not return surrounding single quotes.");

--- a/engine/tests/ElggDataFunctionsTest.php
+++ b/engine/tests/ElggDataFunctionsTest.php
@@ -207,6 +207,16 @@ class ElggDataFunctionsTest extends \ElggCoreUnitTest {
 		}
 	}
 
+	public function testSanitizeRejectsArrays() {
+		try {
+			sanitise_string(['foo']);
+			$this->fail();
+		} catch (\DatabaseException $e) {
+			$this->assertEqual($e->getMessage(), 'Elgg\\Database::sanitizeString() and serialize_string() '
+				. 'cannot accept arrays.');
+		}
+	}
+
 	public function testCanDelayQuery() {
 		$sql = "
 			SELECT *


### PR DESCRIPTION
Trying to DB sanitize an array results in a more useful exception message.

When trying to save an array plugin setting, the action fails more gracefully with a logged error.

Fixes #10921