### PR TITLE
fix(groups): remove membership request when user is already member

### DIFF
--- a/mod/groups/actions/groups/membership/add.php
+++ b/mod/groups/actions/groups/membership/add.php
@@ -12,45 +12,50 @@ if (!is_array($user_guid)) {
 }
 $group_guid = get_input('group_guid');
 $group = get_entity($group_guid);
-/* @var ElggGroup $group */
+if (!($group instanceof ElggGroup) || !$group->canEdit()) {
+	register_error(elgg_echo('actionunauthorized'));
+	forward(REFERER);
+}
 
 $errors = array();
 if (sizeof($user_guid)) {
 	foreach ($user_guid as $u_guid) {
 		$user = get_user($u_guid);
+		if (empty($user)) {
+			continue;
+		}
+		
+		if (!$group->isMember($user)) {
+			if (groups_join_group($group, $user)) {
 
-		if ($user && elgg_instanceof($group, 'group') && $group->canEdit()) {
-			if (!$group->isMember($user)) {
-				if (groups_join_group($group, $user)) {
+				$subject = elgg_echo('groups:welcome:subject', array($group->name), $user->language);
 
-					$subject = elgg_echo('groups:welcome:subject', array($group->name), $user->language);
+				$body = elgg_echo('groups:welcome:body', array(
+					$user->name,
+					$group->name,
+					$group->getURL(),
+				), $user->language);
+				
+				$params = [
+					'action' => 'add_membership',
+					'object' => $group,
+				];
 
-					$body = elgg_echo('groups:welcome:body', array(
-						$user->name,
-						$group->name,
-						$group->getURL(),
-					), $user->language);
-					
-					$params = [
-						'action' => 'add_membership',
-						'object' => $group,
-					];
+				// Send welcome notification to user
+				notify_user($user->getGUID(), $group->owner_guid, $subject, $body, $params);
 
-					// Send welcome notification to user
-					notify_user($user->getGUID(), $group->owner_guid, $subject, $body, $params);
-
-					system_message(elgg_echo('groups:addedtogroup'));
-				}
-				else {
-					$errors[] = elgg_echo('groups:error:addedtogroup', array($user->name));
-				}
+				system_message(elgg_echo('groups:addedtogroup'));
+			} else {
+				$errors[] = elgg_echo('groups:error:addedtogroup', array($user->name));
 			}
-			else {
-				$errors[] = elgg_echo('groups:add:alreadymember', array($user->name));
+		} else {
+			$errors[] = elgg_echo('groups:add:alreadymember', array($user->name));
 
-				// if an invitation is still pending clear it up, we don't need it
-				remove_entity_relationship($group->guid, 'invited', $user->guid);
-			}
+			// if an invitation is still pending clear it up, we don't need it
+			remove_entity_relationship($group->guid, 'invited', $user->guid);
+			
+			// if a membership request is still pending clear it up, we don't need it
+			remove_entity_relationship($user->guid, 'membership_request', $group->guid);
 		}
 	}
 }


### PR DESCRIPTION
When accepting a membership request and the user is already a member of
the group, cleanup the membership request. This will make sure the user
gets removed from the list of pending requests.