### PR TITLE
chore(core): lots of clean up

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -147,6 +147,7 @@ Removed global vars
  * ``$SESSION``: Use the API provided by ``elgg_get_session()``
  * ``$CONFIG->site_id``: Use ``1``
  * ``$CONFIG->search_info``
+ * ``$CONFIG->input``: Use ``set_input`` and ``get_input``
 
 Removed classes/interfaces
 --------------------------

--- a/engine/classes/Elgg/Http/Input.php
+++ b/engine/classes/Elgg/Http/Input.php
@@ -12,20 +12,13 @@ namespace Elgg\Http;
  * @access private
  */
 class Input {
-	/**
-	 * Global Elgg configuration
-	 *
-	 * @var \stdClass
-	 */
-	private $CONFIG;
 
 	/**
-	 * Constructor
+	 * Data set from set_input() or from the request
+	 *
+	 * @var array
 	 */
-	public function __construct() {
-		global $CONFIG;
-		$this->CONFIG = $CONFIG;
-	}
+	private $data = [];
 
 	/**
 	 * Sets an input value that may later be retrieved by get_input
@@ -38,22 +31,16 @@ class Input {
 	 * @return void
 	 */
 	public function set($variable, $value) {
-		
-		if (!isset($this->CONFIG->input)) {
-			$this->CONFIG->input = [];
-		}
-	
 		if (is_array($value)) {
-			array_walk_recursive($value, function(&$v, $k) { $v = trim($v);
-
+			array_walk_recursive($value, function(&$v, $k) {
+				$v = trim($v);
 			});
-			$this->CONFIG->input[trim($variable)] = $value;
+			$this->data[trim($variable)] = $value;
 		} else {
-			$this->CONFIG->input[trim($variable)] = trim($value);
+			$this->data[trim($variable)] = trim($value);
 		}
 	}
-	
-	
+
 	/**
 	 * Get some input from variables passed submitted through GET or POST.
 	 *
@@ -72,16 +59,13 @@ class Input {
 	 * @return mixed
 	 */
 	function get($variable, $default = null, $filter_result = true) {
-			
-		
-	
 		$result = $default;
 	
 		elgg_push_context('input');
 
-		if (isset($this->CONFIG->input[$variable])) {
+		if (isset($this->data[$variable])) {
 			// a plugin has already set this variable
-			$result = $this->CONFIG->input[$variable];
+			$result = $this->data[$variable];
 			if ($filter_result) {
 				$result = filter_tags($result);
 			}
@@ -104,6 +88,5 @@ class Input {
 		elgg_pop_context();
 	
 		return $result;
-
 	}
 }

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -97,7 +97,7 @@ class ElggPlugin extends \ElggObject {
 	 */
 	public function save() {
 		// own by the current site so users can be deleted without affecting plugins
-		$site = _elgg_services()->configTable->get('site');
+		$site = elgg_get_site_entity();
 		$this->attributes['owner_guid'] = $site->guid;
 		$this->attributes['container_guid'] = $site->guid;
 		
@@ -230,7 +230,7 @@ class ElggPlugin extends \ElggObject {
 			return false;
 		}
 
-		$db_prefix = _elgg_services()->configTable->get('dbprefix');
+		$db = $this->getDatabase();
 		$name = _elgg_namespace_plugin_private_setting('internal', 'priority');
 		// if no priority assume a priority of 1
 		$old_priority = (int) $this->getPriority();
@@ -274,13 +274,13 @@ class ElggPlugin extends \ElggObject {
 			}
 
 			// displace the ones affected by this change
-			$q = "UPDATE {$db_prefix}private_settings
+			$q = "UPDATE {$db->prefix}private_settings
 				SET value = CAST(value as unsigned) $op 1
 				WHERE entity_guid != $this->guid
 				AND name = '$name'
 				AND $where";
 
-			if (!$this->getDatabase()->updateData($q)) {
+			if (!$db->updateData($q)) {
 				return false;
 			}
 
@@ -404,16 +404,16 @@ class ElggPlugin extends \ElggObject {
 		_elgg_services()->pluginSettingsCache->clear($this->guid);
 		_elgg_services()->boot->invalidateCache();
 
-		$db_prefix = _elgg_services()->configTable->get('dbprefix');
+		$db = $this->getDatabase();
 		$us_prefix = _elgg_namespace_plugin_private_setting('user_setting', '', $this->getID());
 		$is_prefix = _elgg_namespace_plugin_private_setting('internal', '', $this->getID());
 
-		$q = "DELETE FROM {$db_prefix}private_settings
+		$q = "DELETE FROM {$db->prefix}private_settings
 			WHERE entity_guid = $this->guid
 			AND name NOT LIKE '$us_prefix%'
 			AND name NOT LIKE '$is_prefix%'";
 
-		return $this->getDatabase()->deleteData($q);
+		return $db->deleteData($q);
 	}
 
 
@@ -563,14 +563,14 @@ class ElggPlugin extends \ElggObject {
 	 * @return bool
 	 */
 	public function unsetAllUserSettings($user_guid) {
-		$db_prefix = _elgg_services()->configTable->get('dbprefix');
+		$db = $this->getDatabase();
 		$ps_prefix = _elgg_namespace_plugin_private_setting('user_setting', '', $this->getID());
 
-		$q = "DELETE FROM {$db_prefix}private_settings
+		$q = "DELETE FROM {$db->prefix}private_settings
 			WHERE entity_guid = $user_guid
 			AND name LIKE '$ps_prefix%'";
 
-		return $this->getDatabase()->deleteData($q);
+		return $db->deleteData($q);
 	}
 
 	/**
@@ -582,13 +582,13 @@ class ElggPlugin extends \ElggObject {
 	 * @return bool
 	 */
 	public function unsetAllUsersSettings() {
-		$db_prefix = _elgg_services()->configTable->get('dbprefix');
+		$db = $this->getDatabase();
 		$ps_prefix = _elgg_namespace_plugin_private_setting('user_setting', '', $this->getID());
 
-		$q = "DELETE FROM {$db_prefix}private_settings
+		$q = "DELETE FROM {$db->prefix}private_settings
 			WHERE name LIKE '$ps_prefix%'";
 
-		return $this->getDatabase()->deleteData($q);
+		return $db->deleteData($q);
 	}
 
 
@@ -631,7 +631,7 @@ class ElggPlugin extends \ElggObject {
 			return false;
 		}
 
-		$site = _elgg_services()->configTable->get('site');
+		$site = elgg_get_site_entity();
 
 		if (!($site instanceof \ElggSite)) {
 			return false;
@@ -1157,8 +1157,7 @@ class ElggPlugin extends \ElggObject {
 			return false;
 		}
 
-		$site = _elgg_services()->configTable->get('site');
-		
+		$site = elgg_get_site_entity();
 		if ($active) {
 			$result = add_entity_relationship($this->guid, 'active_plugin', $site->guid);
 		} else {

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -186,8 +186,7 @@ class ElggSite extends \ElggEntity {
 	 * @throws SecurityException
 	 */
 	public function delete() {
-		global $CONFIG;
-		if ($CONFIG->site->getGUID() == $this->guid) {
+		if ($this->guid == 1) {
 			throw new \SecurityException('You cannot delete the current site');
 		}
 

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -878,7 +878,7 @@ function _elgg_php_exception_handler($exception) {
 	header("Cache-Control: no-cache, must-revalidate", true);
 	header('Expires: Fri, 05 Feb 1982 00:00:00 -0500', true);
 
-	global $CONFIG;
+	$CONFIG = _elgg_services()->config->getStorageObject();
 
 	try {
 		// allow custom scripts to trigger on exception
@@ -980,7 +980,7 @@ function _elgg_php_error_handler($errno, $errmsg, $filename, $linenum, $vars) {
 			break;
 
 		default:
-			global $CONFIG;
+			$CONFIG = _elgg_services()->config->getStorageObject();
 			if (isset($CONFIG->debug) && $CONFIG->debug === 'NOTICE') {
 				if (!elgg_log("PHP (errno $errno): $error", 'NOTICE')) {
 					error_log("PHP NOTICE: $error");

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -346,15 +346,12 @@ function logout() {
 function _elgg_session_boot() {
 	_elgg_services()->timer->begin([__FUNCTION__]);
 
-	elgg_register_action('login', '', 'public');
-	elgg_register_action('logout');
-	register_pam_handler('pam_auth_userpass');
-
 	$session = _elgg_services()->session;
 	$session->start();
 
 	// test whether we have a user session
 	if ($session->has('guid')) {
+		/** @var ElggUser $user */
 		$user = _elgg_services()->entityTable->get($session->get('guid'), 'user');
 		if (!$user) {
 			// OMG user has been deleted.
@@ -386,3 +383,7 @@ function _elgg_session_boot() {
 	_elgg_services()->timer->end([__FUNCTION__]);
 	return true;
 }
+
+return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
+	register_pam_handler('pam_auth_userpass');
+};

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -1007,7 +1007,9 @@ function users_init() {
 	elgg_register_plugin_hook_handler('register', 'menu:user_hover', 'elgg_user_hover_menu');
 	elgg_register_plugin_hook_handler('register', 'menu:page', '_elgg_user_page_menu');
 	elgg_register_plugin_hook_handler('register', 'menu:topbar', '_elgg_user_topbar_menu');
-	
+
+	elgg_register_action('login', '', 'public');
+	elgg_register_action('logout');
 	elgg_register_action('register', '', 'public');
 	elgg_register_action('useradd', '', 'admin');
 	elgg_register_action('avatar/upload');

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1866,8 +1866,6 @@ function _elgg_view_may_be_altered($view, $path) {
  * @elgg_event_handler boot system
  */
 function elgg_views_boot() {
-	global $CONFIG;
-
 	if (!elgg_get_config('system_cache_loaded')) {
 		// Core view files in /views
 		_elgg_services()->views->registerPluginViews(realpath(__DIR__ . '/../../'));

--- a/mod/uservalidationbyemail/start.php
+++ b/mod/uservalidationbyemail/start.php
@@ -55,7 +55,7 @@ function uservalidationbyemail_init() {
  * @param string $type
  * @param bool   $value
  * @param array  $params
- * @return bool
+ * @return void
  */
 function uservalidationbyemail_disable_new_user($hook, $type, $value, $params) {
 	$user = elgg_extract('user', $params);
@@ -68,12 +68,12 @@ function uservalidationbyemail_disable_new_user($hook, $type, $value, $params) {
 	// another plugin is requesting that registration be terminated
 	// no need for uservalidationbyemail
 	if (!$value) {
-		return $value;
+		return;
 	}
 
 	// has the user already been validated?
-	if (elgg_get_user_validation_status($user->guid) == true) {
-		return $value;
+	if (elgg_get_user_validation_status($user->guid)) {
+		return;
 	}
 
 	// disable user to prevent showing up on the site
@@ -94,8 +94,6 @@ function uservalidationbyemail_disable_new_user($hook, $type, $value, $params) {
 
 	elgg_pop_context();
 	access_show_hidden_entities($hidden_entities);
-
-	return $value;
 }
 
 /**


### PR DESCRIPTION
Less reliance on global $CONFIG for non-DB functionality. See #10916.

Move action/PAM registration out of session boot.

reloadAllTranslations: don't notice if global isn't set.

uservalidationbyemail_disable_new_user: simplified hook usage.

BREAKING CHANGE:
`$CONFIG->input` is no longer set or read. Use `set_input`/`get_input`.