### PR TITLE
chore(views): cleans up elgg_view()

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -337,6 +337,7 @@ Miscellaneous API changes
  * ``ElggUser::$password`` no longer exists as an attribute, nor is it used for authentication
  * ``elgg_get_widget_types`` no longer supports ``$exact`` as the 2nd argument
  * ``elgg_instanceof`` no longer supports the fourth ``class`` argument
+ * ``elgg_view``: The 3rd and 4th (unused) arguments have been removed. If you use the ``$viewtype`` argument, you must update your usage.
  * ``elgg_view_icon`` no longer supports ``true`` as the 2nd argument
  * ``elgg_list_entities`` no longer supports the option ``view_type_toggle``
  * ``elgg_list_registered_entities`` no longer supports the option ``view_type_toggle``

--- a/engine/classes/Elgg/ViewsService.php
+++ b/engine/classes/Elgg/ViewsService.php
@@ -234,7 +234,7 @@ class ViewsService {
 	public function renderDeprecatedView($view, array $vars, $suggestion, $version) {
 		$view = $this->canonicalizeViewName($view);
 
-		$rendered = $this->renderView($view, $vars, false, '', false);
+		$rendered = $this->renderView($view, $vars, '', false);
 		if ($rendered) {
 			elgg_deprecated_notice("The $view view has been deprecated. $suggestion", $version, 3);
 		}
@@ -261,7 +261,7 @@ class ViewsService {
 	/**
 	 * @access private
 	 */
-	public function renderView($view, array $vars = [], $ignored = false, $viewtype = '', $issue_missing_notice = true) {
+	public function renderView($view, array $vars = [], $viewtype = '', $issue_missing_notice = true) {
 		$view = $this->canonicalizeViewName($view);
 
 		if (!is_string($view) || !is_string($viewtype)) {

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -326,15 +326,13 @@ function elgg_list_views($viewtype = 'default') {
  *
  * @param string  $view     The name and location of the view to use
  * @param array   $vars     Variables to pass to the view.
- * @param boolean $ignore1  This argument is ignored and will be removed eventually
- * @param boolean $ignore2  This argument is ignored and will be removed eventually
  * @param string  $viewtype If set, forces the viewtype for the elgg_view call to be
  *                          this value (default: standard detection)
  *
  * @return string The parsed view
  */
-function elgg_view($view, $vars = [], $ignore1 = false, $ignore2 = false, $viewtype = '') {
-	return _elgg_services()->views->renderView($view, $vars, $ignore1, $viewtype);
+function elgg_view($view, $vars = [], $viewtype = '') {
+	return _elgg_services()->views->renderView($view, $vars, $viewtype);
 }
 
 /**
@@ -516,7 +514,7 @@ function elgg_view_resource($name, array $vars = []) {
 	}
 
 	if (elgg_get_viewtype() !== 'default' && elgg_view_exists($view, 'default')) {
-		return _elgg_services()->views->renderView($view, $vars, false, 'default');
+		return _elgg_services()->views->renderView($view, $vars, 'default');
 	}
 
 	_elgg_services()->logger->error("The view $view is missing.");
@@ -926,13 +924,11 @@ function elgg_view_menu_item(\ElggMenuItem $item, array $vars = []) {
  * @param array       $vars   Array of variables to pass to the entity view.
  *      'full_view'        Whether to show a full or condensed view. (Default: true)
  *      'item_view'        Alternative view used to render this entity
- * @param boolean     $bypass Ignored and will be removed eventually
- * @param boolean     $debug  Complain if views are missing
  *
  * @return string HTML to display or false
  * @todo The annotation hook might be better as a generic plugin hook to append content.
  */
-function elgg_view_entity(\ElggEntity $entity, array $vars = [], $bypass = false, $debug = false) {
+function elgg_view_entity(\ElggEntity $entity, array $vars = []) {
 
 	// No point continuing if entity is null
 	if (!$entity || !($entity instanceof \ElggEntity)) {
@@ -964,7 +960,7 @@ function elgg_view_entity(\ElggEntity $entity, array $vars = [], $bypass = false
 	$contents = '';
 	foreach ($entity_views as $view) {
 		if (elgg_view_exists($view)) {
-			$contents = elgg_view($view, $vars, $bypass, $debug);
+			$contents = elgg_view($view, $vars);
 			break;
 		}
 	}
@@ -1041,12 +1037,10 @@ function elgg_view_entity_icon(\ElggEntity $entity, $size = 'medium', $vars = []
  * @param \ElggAnnotation $annotation The annotation to display
  * @param array           $vars       Variable array for view.
  *      'item_view'  Alternative view used to render an annotation
- * @param bool            $bypass     Ignored and will be removed eventually
- * @param bool            $debug      Complain if views are missing
  *
  * @return string/false Rendered annotation
  */
-function elgg_view_annotation(\ElggAnnotation $annotation, array $vars = [], $bypass = false, $debug = false) {
+function elgg_view_annotation(\ElggAnnotation $annotation, array $vars = []) {
 	elgg_register_rss_link();
 
 	$defaults = [
@@ -1070,7 +1064,7 @@ function elgg_view_annotation(\ElggAnnotation $annotation, array $vars = [], $by
 	$contents = '';
 	foreach ($annotation_views as $view) {
 		if (elgg_view_exists($view)) {
-			$contents = elgg_view($view, $vars, $bypass, $debug);
+			$contents = elgg_view($view, $vars);
 			break;
 		}
 	}

--- a/engine/tests/phpunit/Elgg/RouterTest.php
+++ b/engine/tests/phpunit/Elgg/RouterTest.php
@@ -426,7 +426,7 @@ class RouterTest extends \Elgg\TestCase {
 		$response = _elgg_services()->responseFactory->getSentResponse();
 		$this->assertInstanceOf(Response::class, $response);
 		$this->assertEquals(ELGG_HTTP_OK, $response->getStatusCode());
-		$this->assertEquals(elgg_view('response', [], false, false, 'json'), $response->getContent());
+		$this->assertEquals(elgg_view('response', [], 'json'), $response->getContent());
 		$this->assertContains('application/json', $response->headers->get('Content-Type'));
 		$this->assertContains('charset=utf-8', strtolower($response->headers->get('Content-Type')));
 	}
@@ -672,7 +672,7 @@ class RouterTest extends \Elgg\TestCase {
 		$this->assertContains('charset=utf-8', strtolower($response->headers->get('Content-Type')));
 
 		// no forward, so API outputs view contents
-		$this->assertEquals(elgg_view('response', [], false, false, 'json'), $response->getContent());
+		$this->assertEquals(elgg_view('response', [], 'json'), $response->getContent());
 	}
 
 	public function testCanRespondToAjaxRequestForPageThatForwards() {

--- a/engine/tests/phpunit/Elgg/ViewsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ViewsServiceTest.php
@@ -91,7 +91,7 @@ class ViewsServiceTest extends \Elgg\TestCase {
 	public function testViewsCanExistBasedOnViewtypeFallback() {
 		$this->views->registerViewtypeFallback('mobile');
 		$this->assertTrue($this->views->viewExists('js/interpreted.js', 'mobile'));
-		$this->assertEquals('// PHP', $this->views->renderView('js/interpreted.js', array(), false, 'mobile'));
+		$this->assertEquals('// PHP', $this->views->renderView('js/interpreted.js', array(), 'mobile'));
 	}
 
 	public function testCanRegisterViewsAsCacheable() {

--- a/views/json/river/item.php
+++ b/views/json/river/item.php
@@ -8,7 +8,7 @@
 $item = $vars['item'];
 $object = $item->toObject();
 if (elgg_view_exists($item->view, 'default')) {
-	$object->description = elgg_view('river/elements/summary', ['item' => $item], false, false, 'default');
+	$object->description = elgg_view('river/elements/summary', ['item' => $item], 'default');
 }
 
 echo json_encode($object);

--- a/views/rss/output/url.php
+++ b/views/rss/output/url.php
@@ -3,4 +3,4 @@
  * RSS url output view
  *
  */
-echo elgg_view('output/url', $vars, false, false, 'default');
+echo elgg_view('output/url', $vars, 'default');

--- a/views/rss/river/elements/layout.php
+++ b/views/rss/river/elements/layout.php
@@ -11,7 +11,7 @@ $name = htmlspecialchars($name, ENT_NOQUOTES, 'UTF-8');
 $title = elgg_echo('river:update', [$name]);
 
 $timestamp = date('r', $item->getTimePosted());
-$summary = elgg_view('river/elements/summary', $vars, false, false, 'default');
+$summary = elgg_view('river/elements/summary', $vars, 'default');
 $body = elgg_extract('summary', $vars, $summary);
 
 

--- a/views/rss/river/item.php
+++ b/views/rss/river/item.php
@@ -10,7 +10,7 @@ $item = $vars['item'];
 $output = elgg_view($item->getView(), $vars);
 
 if (empty($output)) {
-	$output = elgg_view($item->getView(), $vars, false, false, 'default');
+	$output = elgg_view($item->getView(), $vars, 'default');
 }
 
 $rss_item = <<<__ITEM


### PR DESCRIPTION
Removes unused arguments from `elgg_view` and related functions.

BREAKING CHANGES:
The argument list for `elgg_view()` has changed. If you use the `$viewtype` argument, you must remove the 2 previous arguments.