### PR TITLE
fixed: correctly manipulate ini setting to return readable bytes

### DIFF
--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1475,6 +1475,10 @@ function elgg_get_ini_setting_in_bytes($setting) {
 
 	// convert INI setting when shorthand notation is used
 	$last = strtolower($val[strlen($val) - 1]);
+	if (in_array($last, ['g', 'm', 'k'])) {
+		$val = substr($val, 0, -1);
+	}
+	$val = (int) $val;
 	switch($last) {
 		case 'g':
 			$val *= 1024;


### PR DESCRIPTION
If short notation was used (eg '8M') the calculation was done on '8M'
instead of '8', this caused PHP errors.