### PR TITLE
fix(plugins): issue error about saving array values at correct location

### DIFF
--- a/actions/plugins/settings/save.php
+++ b/actions/plugins/settings/save.php
@@ -30,12 +30,8 @@ if (elgg_action_exists("$plugin_id/settings/save")) {
 	action("$plugin_id/settings/save");
 } else {
 	foreach ($params as $k => $v) {
-		if (is_array($v)) {
-			elgg_log('Plugin settings cannot store arrays.', 'ERROR');
-			$result = false;
-		} else {
-			$result = $plugin->setSetting($k, $v);
-		}
+		
+		$result = $plugin->setSetting($k, $v);
 		if (!$result) {
 			register_error(elgg_echo('plugins:settings:save:fail', array($plugin_name)));
 			forward(REFERER);

--- a/actions/plugins/usersettings/save.php
+++ b/actions/plugins/usersettings/save.php
@@ -43,12 +43,8 @@ if (elgg_action_exists("$plugin_id/usersettings/save")) {
 	action("$plugin_id/usersettings/save");
 } else {
 	foreach ($params as $k => $v) {
-		if (is_array($v)) {
-			elgg_log('Plugin user settings cannot store arrays.', 'ERROR');
-			$result = false;
-		} else {
-			$result = $plugin->setUserSetting($k, $v, $user->guid);
-		}
+		
+		$result = $plugin->setUserSetting($k, $v, $user->guid);
 		if (!$result) {
 			register_error(elgg_echo('plugins:usersettings:save:fail', array($plugin_name)));
 			forward(REFERER);

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -388,6 +388,11 @@ class ElggPlugin extends \ElggObject {
 			'value' => $value,
 		), $value);
 		
+		if (is_array($value)) {
+			elgg_log('Plugin settings cannot store arrays.', 'ERROR');
+			return false;
+		}
+		
 		return $this->setPrivateSetting($name, $value);
 	}
 
@@ -535,7 +540,12 @@ class ElggPlugin extends \ElggObject {
 			'name' => $name,
 			'value' => $value
 		), $value);
-
+		
+		if (is_array($value)) {
+			elgg_log('Plugin user settings cannot store arrays.', 'ERROR');
+			$result = false;
+		}
+		
 		// set the namespaced name.
 		$name = _elgg_namespace_plugin_private_setting('user_setting', $name, $this->getID());
 


### PR DESCRIPTION
Saving plugin (user)settings with array values causes an error. This
error is now issued at a better location, which allowed plugins to
repair the error before it occurs. Using the 'usersetting/setting'
'plugin' hook.

fixes #10974