### PR TITLE
chore(views): permits old elgg_view signature usage

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -332,6 +332,10 @@ function elgg_list_views($viewtype = 'default') {
  * @return string The parsed view
  */
 function elgg_view($view, $vars = [], $viewtype = '') {
+	if (func_num_args() == 5) {
+		elgg_log(__FUNCTION__ . ' now has only 3 arguments. Update your usage.', 'ERROR');
+		$viewtype = func_get_arg(4);
+	}
 	return _elgg_services()->views->renderView($view, $vars, $viewtype);
 }
 


### PR DESCRIPTION
Emits an error but allows usage of the old 5-argument signature for `elgg_view`.