### PR TITLE
Removed headers and messageID

### DIFF
--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -645,6 +645,9 @@ function elgg_send_email($from, $to, $subject, $body, array $params = null) {
 	$message->setSubject($subject);
 	$message->setBody($body);
 
+	foreach ($result['headers'] as $headerName => $headerValue) {
+
+	}
 
 	// allow others to modify the $message content
 	// eg. add html body, add attachments

--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -276,7 +276,7 @@ function _elgg_notifications_smtp_default_message_id_header($hook, $type, $retur
 	
 	$mt = microtime(true);
 	
-	$returnvalue['headers']['Message-ID'] = "<{$url_path}.default.{$mt}@{$hostname}>";
+	// $returnvalue['headers']['Message-ID'] = "<{$url_path}.default.{$mt}@{$hostname}>";
 	
 	return $returnvalue;
 }
@@ -645,9 +645,6 @@ function elgg_send_email($from, $to, $subject, $body, array $params = null) {
 	$message->setSubject($subject);
 	$message->setBody($body);
 
-	foreach ($result['headers'] as $headerName => $headerValue) {
-		$message->getHeaders()->addHeaderLine($headerName, $headerValue);
-	}
 
 	// allow others to modify the $message content
 	// eg. add html body, add attachments


### PR DESCRIPTION
Removed php based messageID, this gives in outlook.com errors and removed headers. So elgg emails wouldn't be marked as spam anymore.