### PR TITLE
fix(entities): batch count now works when $options already count set to false

### DIFF
--- a/engine/classes/Elgg/Views/TableColumn/ViewColumn.php
+++ b/engine/classes/Elgg/Views/TableColumn/ViewColumn.php
@@ -51,11 +51,11 @@ class ViewColumn implements TableColumn {
 	 * {@inheritdoc}
 	 */
 	public function renderCell($item, $type, $item_vars) {
-		$vars = $this->vars + [
+		$vars = array_merge($this->vars, [
 			'item' => $item,
 			'item_vars' => $item_vars,
 			'type' => $type,
-		];
+		]);
 
 		return elgg_view($this->view, $vars);
 	}

--- a/engine/classes/ElggBatch.php
+++ b/engine/classes/ElggBatch.php
@@ -453,7 +453,7 @@ class ElggBatch implements BatchResult {
 			throw new RuntimeException("Getter is not callable: " . $inspector->describeCallable($this->getter));
 		}
 
-		$options = $this->options + ['count' => true];
+		$options = array_merge($this->options, ['count' => true]);
 
 		return call_user_func($this->getter, $options);
 	}

--- a/engine/tests/ElggBatchTest.php
+++ b/engine/tests/ElggBatchTest.php
@@ -176,10 +176,13 @@ class ElggBatchTest extends \ElggCoreUnitTest {
 			}
 			return false;
 		};
-		$options = [];
+		$options = [
+			// Due to 10992, if count was present and false, it would fail
+			'count' => false,
+		];
 
 		$count1 = count(new ElggBatch($getter, $options));
-		$count2 = $getter($options + ['count' => true]);
+		$count2 = $getter(array_merge($options, ['count' => true]));
 
 		$this->assertEqual($count1, $count2);
 	}
@@ -194,7 +197,7 @@ class ElggBatchTest extends \ElggCoreUnitTest {
 		];
 		$guids1 = elgg_get_entities($options);
 
-		$batch = elgg_get_entities($options + ['batch' => true]);
+		$batch = elgg_get_entities(array_merge($options, ['batch' => true]));
 
 		$this->assertIsA($batch, BatchResult::class);
 		/* @var ElggBatch $batch */


### PR DESCRIPTION
Due to the use of the (poorly understood) array addition operator, the batch `count()` method failed to set `$options['count']` to true if it was already set to false.

This also removes a few other uses of array addition I could find.

Fixes #10992