### PR TITLE
chore(widgets): no longer set default values in edit form

### DIFF
--- a/mod/activity/views/default/widgets/group_activity/content.php
+++ b/mod/activity/views/default/widgets/group_activity/content.php
@@ -5,7 +5,7 @@
 
 $widget = elgg_extract('entity', $vars);
 
-$num = (int) $widget->num_display;
+$num = (int) $widget->num_display ?: 8;
 $guid = (int) $widget->group_guid;
 
 if (empty($guid)) {

--- a/mod/activity/views/default/widgets/group_activity/edit.php
+++ b/mod/activity/views/default/widgets/group_activity/edit.php
@@ -23,13 +23,9 @@ echo elgg_view_field([
 	'options_values' => $mygroups,
 ]);
 
-// set default value
-if (!isset($widget->num_display)) {
-	$widget->num_display = 8;
-}
-
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
+	'default' => 8,
 ]);
 
 echo elgg_view('input/hidden', ['name' => 'title']);

--- a/mod/blog/views/default/widgets/blog/content.php
+++ b/mod/blog/views/default/widgets/blog/content.php
@@ -5,11 +5,13 @@
 
 $widget = elgg_extract('entity', $vars);
 
+$num_display = (int) $widget->num_display ?: 4;
+
 $content = elgg_list_entities([
 	'type' => 'object',
 	'subtype' => 'blog',
 	'container_guid' => $widget->owner_guid,
-	'limit' => $widget->num_display,
+	'limit' => $num_display,
 	'pagination' => false,
 	'distinct' => false,
 ]);

--- a/mod/blog/views/default/widgets/blog/edit.php
+++ b/mod/blog/views/default/widgets/blog/edit.php
@@ -4,13 +4,10 @@
  */
 
 $widget = elgg_extract('entity', $vars);
-// set default value
-if (!isset($widget->num_display)) {
-	$widget->num_display = 4;
-}
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
 	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 	'label' => elgg_echo('blog:numbertodisplay'),
+	'default' => 4,
 ]);

--- a/mod/bookmarks/views/default/widgets/bookmarks/content.php
+++ b/mod/bookmarks/views/default/widgets/bookmarks/content.php
@@ -5,11 +5,13 @@
 
 $widget = elgg_extract('entity', $vars);
 
+$num_display = (int) $widget->num_display ?: 4;
+
 $content = elgg_list_entities([
 	'type' => 'object',
 	'subtype' => 'bookmarks',
 	'container_guid' => $widget->owner_guid,
-	'limit' => $widget->num_display,
+	'limit' => $num_display,
 	'pagination' => false,
 	'distinct' => false,
 ]);

--- a/mod/bookmarks/views/default/widgets/bookmarks/edit.php
+++ b/mod/bookmarks/views/default/widgets/bookmarks/edit.php
@@ -4,13 +4,10 @@
  */
 
 $widget = elgg_extract('entity', $vars);
-// set default value
-if (!isset($widget->num_display)) {
-	$widget->num_display = 4;
-}
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
 	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 	'label' => elgg_echo('bookmarks:numbertodisplay'),
+	'default' => 4,
 ]);

--- a/mod/file/views/default/widgets/filerepo/content.php
+++ b/mod/file/views/default/widgets/filerepo/content.php
@@ -5,11 +5,13 @@
 
 $widget = elgg_extract('entity', $vars);
 
+$num_display = (int) $widget->num_display ?: 4;
+
 $content = elgg_list_entities([
 	'type' => 'object',
 	'subtype' => 'file',
 	'container_guid' => $widget->owner_guid,
-	'limit' => $widget->num_display,
+	'limit' => $num_display,
 	'pagination' => false,
 	'distinct' => false,
 ]);

--- a/mod/file/views/default/widgets/filerepo/edit.php
+++ b/mod/file/views/default/widgets/filerepo/edit.php
@@ -4,13 +4,10 @@
  */
 
 $widget = elgg_extract('entity', $vars);
-// set default value
-if (!isset($widget->num_display)) {
-	$widget->num_display = 4;
-}
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
 	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20],
 	'label' => elgg_echo('file:num_files'),
+	'default' => 4,
 ]);

--- a/mod/friends/views/default/widgets/friends/content.php
+++ b/mod/friends/views/default/widgets/friends/content.php
@@ -21,7 +21,7 @@ echo elgg_list_entities_from_relationship([
 	'relationship' => 'friend',
 	'relationship_guid' => $owner->guid,
 	'limit' => $num_display,
-	'size' => $widget->icon_size,
+	'size' => $widget->icon_size ?: 'small',
 	'list_type' => 'gallery',
 	'pagination' => false,
 	'no_results' => elgg_echo('friends:none'),

--- a/mod/friends/views/default/widgets/friends/edit.php
+++ b/mod/friends/views/default/widgets/friends/edit.php
@@ -5,11 +5,6 @@
 
 $widget = elgg_extract('entity', $vars);
 
-// set default value for icon size
-if (!isset($widget->icon_size)) {
-	$widget->icon_size = 'small';
-}
-
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
 	'default' => 12,
@@ -21,7 +16,7 @@ echo elgg_view_field([
 	'#type' => 'select',
 	'name' => 'params[icon_size]',
 	'#label' => elgg_echo('friends:icon_size'),
-	'value' => $widget->icon_size,
+	'value' => $widget->icon_size ?: 'small',
 	'options_values' => [
 		'small' => elgg_echo('friends:small'),
 		'tiny' => elgg_echo('friends:tiny'),

--- a/mod/groups/views/default/widgets/a_users_groups/content.php
+++ b/mod/groups/views/default/widgets/a_users_groups/content.php
@@ -5,11 +5,13 @@
 
 $widget = elgg_extract('entity', $vars);
 
+$num_display = (int) $widget->num_display ?: 4;
+
 echo elgg_list_entities_from_relationship([
 	'type' => 'group',
 	'relationship' => 'member',
 	'relationship_guid' => $widget->owner_guid,
-	'limit' => $widget->num_display,
+	'limit' => $num_display,
 	'pagination' => false,
 	'no_results' => elgg_echo('groups:none'),
 ]);

--- a/mod/groups/views/default/widgets/a_users_groups/edit.php
+++ b/mod/groups/views/default/widgets/a_users_groups/edit.php
@@ -4,13 +4,10 @@
  */
 
 $widget = elgg_extract('entity', $vars);
-// set default value
-if (!isset($widget->num_display)) {
-	$widget->num_display = 4;
-}
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
 	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20],
 	'label' => elgg_echo('groups:widget:num_display'),
+	'default' => 4,
 ]);

--- a/mod/messageboard/views/default/widgets/messageboard/content.php
+++ b/mod/messageboard/views/default/widgets/messageboard/content.php
@@ -10,10 +10,12 @@ if (elgg_is_logged_in()) {
 	echo elgg_view_form('messageboard/add', ['name' => 'elgg-messageboard']);
 }
 
+$num_display = (int) $widget->num_display ?: 5;
+
 echo elgg_list_annotations([
 	'annotations_name' => 'messageboard',
 	'guid' => $owner->guid,
-	'limit' => $widget->num_display,
+	'limit' => $num_display,
 	'pagination' => false,
 	'reverse_order_by' => true,
 ]);

--- a/mod/messageboard/views/default/widgets/messageboard/edit.php
+++ b/mod/messageboard/views/default/widgets/messageboard/edit.php
@@ -4,13 +4,10 @@
  */
 
 $widget = elgg_extract('entity', $vars);
-// set default value
-if (!isset($widget->num_display)) {
-	$widget->num_display = 5;
-}
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
 	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 	'label' => elgg_echo('messageboard:num_display'),
+	'default' => 5,
 ]);

--- a/mod/pages/views/default/widgets/pages/content.php
+++ b/mod/pages/views/default/widgets/pages/content.php
@@ -5,11 +5,13 @@
 
 $widget = elgg_extract('entity', $vars);
 
+$num_display = (int) $widget->pages_num ?: 5;
+
 $content = elgg_list_entities([
 	'type' => 'object',
 	'subtype' => 'page_top',
 	'container_guid' => $widget->owner_guid,
-	'limit' => $widget->pages_num,
+	'limit' => $num_display,
 	'pagination' => false,
 ]);
 

--- a/mod/pages/views/default/widgets/pages/edit.php
+++ b/mod/pages/views/default/widgets/pages/edit.php
@@ -4,14 +4,11 @@
  */
 
 $widget = elgg_extract('entity', $vars);
-// set default value
-if (!isset($widget->pages_num)) {
-	$widget->pages_num = 5;
-}
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
 	'name' => 'pages_num',
 	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 	'label' => elgg_echo('pages:num'),
+	'default' => 5,
 ]);

--- a/mod/reportedcontent/views/default/widgets/reportedcontent/content.php
+++ b/mod/reportedcontent/views/default/widgets/reportedcontent/content.php
@@ -3,10 +3,14 @@
  * List the latest reports
  */
 
+$widget = elgg_extract('entity', $vars);
+
+$num_display = (int) $widget->num_display ?: 4;
+
 $list = elgg_list_entities_from_metadata([
 	'type' => 'object',
 	'subtype' => 'reported_content',
-	'limit' => $vars['entity']->num_display,
+	'limit' => $num_display,
 	'pagination' => false,
 	'order_by_metadata' => [
 		'name' => 'state',

--- a/mod/reportedcontent/views/default/widgets/reportedcontent/edit.php
+++ b/mod/reportedcontent/views/default/widgets/reportedcontent/edit.php
@@ -4,13 +4,10 @@
  */
 
 $widget = elgg_extract('entity', $vars);
-// set default value
-if (!isset($widget->num_display)) {
-	$widget->num_display = 4;
-}
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
 	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 	'label' => elgg_echo('reportedcontent:numbertodisplay'),
+	'default' => 4,
 ]);

--- a/mod/tagcloud/views/default/widgets/tagcloud/content.php
+++ b/mod/tagcloud/views/default/widgets/tagcloud/content.php
@@ -5,11 +5,13 @@
 
 $widget = elgg_extract('entity', $vars);
 
+$num_display = (int) $widget->num_items ?: 30;
+
 elgg_push_context('tags');
 echo elgg_view_tagcloud([
 	'owner_guid' => $widget->owner_guid,
 	'threshold' => 1,
-	'limit' => $widget->num_items,
+	'limit' => $num_display,
 	'tag_name' => 'tags',
 ]);
 elgg_pop_context();

--- a/mod/tagcloud/views/default/widgets/tagcloud/edit.php
+++ b/mod/tagcloud/views/default/widgets/tagcloud/edit.php
@@ -4,14 +4,11 @@
  */
 
 $widget = elgg_extract('entity', $vars);
-// set default value
-if (!isset($widget->num_items)) {
-	$widget->num_items = 30;
-}
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
 	'name' => 'num_items',
 	'options' => [10, 20, 30, 50, 100],
 	'label' => elgg_echo('tagcloud:widget:numtags'),
+	'default' => 30,
 ]);

--- a/mod/thewire/views/default/widgets/thewire/content.php
+++ b/mod/thewire/views/default/widgets/thewire/content.php
@@ -5,11 +5,13 @@
 
 $widget = elgg_extract('entity', $vars);
 
+$num_display = (int) $widget->num_display ?: 4;
+
 $content = elgg_list_entities([
 	'type' => 'object',
 	'subtype' => 'thewire',
 	'container_guid' => $widget->owner_guid,
-	'limit' => $widget->num_display,
+	'limit' => $num_display,
 	'pagination' => false,
 ]);
 

--- a/mod/thewire/views/default/widgets/thewire/edit.php
+++ b/mod/thewire/views/default/widgets/thewire/edit.php
@@ -4,13 +4,10 @@
  */
 
 $widget = elgg_extract('entity', $vars);
-// set default value
-if (!isset($widget->num_display)) {
-	$widget->num_display = 4;
-}
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
 	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 	'label' => elgg_echo('thewire:num'),
+	'default' => 4,
 ]);

--- a/views/default/widgets/river_widget/content.php
+++ b/views/default/widgets/river_widget/content.php
@@ -18,7 +18,8 @@ $options = [
 ];
 
 if (elgg_in_context('dashboard')) {
-	if ($widget->content_type == 'friends') {
+	$content_type = $widget->content_type ?: 'friends';
+	if ($content_type == 'friends') {
 		$options['relationship_guid'] = $widget->getOwnerGUID();
 		$options['relationship'] = 'friend';
 	}


### PR DESCRIPTION
BREAKING CHANGE:
As widget edit forms could not be on the current page it is a bad
practice to rely on widget config values to be always available. This PR
corrects this behaviour. If you override core widget content views you
may need to update these views.

Fixes #10244