### PR TITLE
feat(admin): content stats are separated in searchable and other content

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -559,8 +559,10 @@ return array(
 	'admin:widget:content_stats:help' => 'Keep track of the content created by your users',
 	'admin:widget:cron_status' => 'Cron status',
 	'admin:widget:cron_status:help' => 'Shows the status of the last time cron jobs finished',
-	'widget:content_stats:type' => 'Content type',
-	'widget:content_stats:number' => 'Number',
+	'admin:statistics:numentities:type' => 'Content type',
+	'admin:statistics:numentities:number' => 'Number',
+	'admin:statistics:numentities:searchable' => 'Searchable',
+	'admin:statistics:numentities:other' => 'Other',
 
 	'admin:widget:admin_welcome' => 'Welcome',
 	'admin:widget:admin_welcome:help' => "A short introduction to Elgg's admin area",

--- a/views/default/admin/statistics/overview/numentities.php
+++ b/views/default/admin/statistics/overview/numentities.php
@@ -1,28 +1,51 @@
 <?php
 // Get entity statistics
 $entity_stats = get_entity_statistics();
-$rows = '';
-foreach ($entity_stats as $k => $entry) {
-	arsort($entry);
-	foreach ($entry as $a => $b) {
-		if ($a == "__base__") {
-			$a = elgg_echo("item:{$k}");
-			if (empty($a))
-				$a = $k;
-		} else {
-			if (empty($a)) {
-				$a = elgg_echo("item:{$k}");
-			} else {
-				$a = elgg_echo("item:{$k}:{$a}");
-			}
 
-			if (empty($a)) {
-				$a = "$k $a";
-			}
+$registered_entity_types = get_registered_entity_types();
+
+$searchable = [];
+$other = [];
+
+foreach ($entity_stats as $type => $subtypes) {
+	foreach ($subtypes as $subtype => $value) {
+		
+		$is_registered = false;
+		if ($subtype == '__base__') {
+			$is_registered = array_key_exists($type, $registered_entity_types);
+			$name = elgg_echo("item:$type");
+		} else {
+			$is_registered = in_array($subtype, $registered_entity_types[$type]);
+			$name = elgg_echo("item:$type:$subtype");
 		}
 		
-		$rows .= "<tr><td>{$a}:</td><td>{$b}</td></tr>";
+		if ($is_registered) {
+			$searchable[$name] = $value;
+		} else {
+			$other[$name] = $value;
+		}
 	}
 }
 
-echo "<table class='elgg-table-alt'>$rows</table>";
+arsort($searchable);
+arsort($other);
+
+$header = '<tr><th>' . elgg_echo('admin:statistics:numentities:type') . '</th>';
+$header .= '<th>' . elgg_echo('admin:statistics:numentities:number') . '</th></tr>';
+
+$rows = '';
+
+foreach ($searchable as $name => $value) {
+	$rows .= "<tr><td>{$name}:</td><td>{$value}</td></tr>";
+}
+echo '<h4>' . elgg_echo('admin:statistics:numentities:searchable') . '</h4>';
+echo "<table class='elgg-table-alt'>{$header}{$rows}</table>";
+echo '<br />';
+
+
+$rows = '';
+foreach ($other as $name => $value) {
+	$rows .= "<tr><td>{$name}:</td><td>{$value}</td></tr>";
+}
+echo '<h4>' . elgg_echo('admin:statistics:numentities:other') . '</h4>';
+echo "<table class='elgg-table-alt'>{$header}{$rows}</table>";

--- a/views/default/widgets/content_stats/content.php
+++ b/views/default/widgets/content_stats/content.php
@@ -5,22 +5,32 @@
 
 $widget = elgg_extract('entity', $vars);
 
-$num_display = sanitize_int($widget->num_display, false);
-// set default value for display number
-if (!$num_display) {
-	$num_display = 8;
+$entity_stats = get_entity_statistics();
+
+$registered_entity_types = get_registered_entity_types();
+
+foreach ($registered_entity_types as $type => $subtypes) {
+	if (!empty($subtypes)) {
+		foreach ($subtypes as $subtype) {
+			$value = elgg_extract($subtype, $entity_stats[$type], false);
+			if ($value !== false) {
+				$stats[elgg_echo("item:$type:$subtype")] = $value;
+			}
+		}
+	} else {
+		$value = elgg_extract('__base__', $entity_stats[$type], false);
+		if ($value !== false) {
+			$stats[elgg_echo("item:$type")] = $value;
+		}
+	}
 }
 
-$entity_stats = get_entity_statistics();
-$object_stats = elgg_extract('object', $entity_stats);
-arsort($object_stats);
-$object_stats = array_slice($object_stats, 0, $num_display);
+arsort($stats);
 
 echo '<table class="elgg-table-alt">';
-echo '<tr><th>' . elgg_echo('widget:content_stats:type') . '</th>';
-echo '<th>' . elgg_echo('widget:content_stats:number') . '</th></tr>';
-foreach ($object_stats as $subtype => $num) {
-	$name = elgg_echo("item:object:$subtype");
+echo '<tr><th>' . elgg_echo('admin:statistics:numentities:type') . '</th>';
+echo '<th>' . elgg_echo('admin:statistics:numentities:number') . '</th></tr>';
+foreach ($stats as $name => $num) {
 	echo "<tr><td>$name</td><td>$num</td></tr>";
 }
 echo '</table>';

--- a/views/default/widgets/content_stats/edit.php
+++ b/views/default/widgets/content_stats/edit.php
@@ -1,9 +1,0 @@
-<?php
-/**
- * Content statistics widget edit view
- */
-
-echo elgg_view('object/widget/edit/num_display', [
-	'entity' => elgg_extract('entity', $vars),
-	'default' => 8,
-]);


### PR DESCRIPTION
The admin widget now only shows all searchable data. The statistics
overview show all entity stats but is divided between
registered/searchable entities and the rest.

Fixes #7862