### PR TITLE
chore(profile): no longer provide the profile/status extension point

### DIFF
--- a/mod/profile/views/default/profile/css.php
+++ b/mod/profile/views/default/profile/css.php
@@ -10,7 +10,6 @@
 	Profile
 *************************************** */
 .profile {
-	float: left;
 	margin-bottom: 15px;
 }
 .profile > .elgg-inner {
@@ -69,9 +68,5 @@
 	#profile-owner-block {
 		border-right: none;
 		width: auto;
-	}
-	#profile-details {
-		display: block;
-		float: left;
 	}
 }

--- a/mod/profile/views/default/profile/details.php
+++ b/mod/profile/views/default/profile/details.php
@@ -2,78 +2,11 @@
 /**
  * Elgg user display (details)
  *
- * @uses $vars['entity'] The user entity
- * @uses $vars['microformats'] Mapping of fieldnames to microformats
  */
 
-$microformats = [
-	'mobile' => 'tel p-tel',
-	'phone' => 'tel p-tel',
-	'website' => 'url u-url',
-	'contactemail' => 'email u-email',
-];
-$microformats = array_merge($microformats, (array) elgg_extract('microformats', $vars, []));
-
-$user = elgg_extract('entity', $vars);
-
-$profile_fields = elgg_get_config('profile_fields');
-
-$fields_output = '';
-if (is_array($profile_fields) && sizeof($profile_fields) > 0) {
-
-	// move description to the bottom of the list
-	if (isset($profile_fields['description'])) {
-		$temp = $profile_fields['description'];
-		unset($profile_fields['description']);
-		$profile_fields['description'] = $temp;
-	}
-	
-	foreach ($profile_fields as $shortname => $valtype) {
-		$annotations = $user->getAnnotations([
-			'annotation_names' => "profile:$shortname",
-			'limit' => false,
-		]);
-		$values = array_map(function (ElggAnnotation $a) {
-			return $a->value;
-		}, $annotations);
-
-		if (!$values) {
-			continue;
-		}
-		// emulate metadata API
-		$value = (count($values) === 1) ? $values[0] : $values;
-
-		// validate urls
-		if ($valtype == 'url' && !preg_match('~^https?\://~i', $value)) {
-			$value = "http://$value";
-		}
-
-		$class = elgg_extract($shortname, $microformats, '');
-
-		$field_title = elgg_echo("profile:{$shortname}");
-		$field_value = elgg_format_element('span', [
-			'class' => $class,
-		], elgg_view("output/{$valtype}", [
-			'value' => $value,
-		]));
-
-		$fields_output .= <<<___FIELD
-		<div class='clearfix profile-field'>
-			<div class='elgg-col elgg-col-1of5'>
-				<b>{$field_title}:</b>
-			</div>
-			<div class='elgg-col elgg-col-4of5'>
-				{$field_value}
-			</div>
-		</div>
-___FIELD;
-	}
-}
-
-$result = elgg_view('profile/status', ['entity' => $user]);
-$result .= $fields_output;
+$vars['fields'] = elgg_get_config('profile_fields');
 
 echo elgg_format_element('div', [
 	'id' => 'profile-details',
 	'class' => 'elgg-body pll',
-], $result);
+], elgg_view('profile/fields', $vars));

--- a/mod/profile/views/default/profile/fields.php
+++ b/mod/profile/views/default/profile/fields.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @uses $vars['entity']       The user entity
+ * @uses $vars['microformats'] Mapping of fieldnames to microformats
+ * @uses $vars['fields']       Array of profile fields to show
+ */
+
+$microformats = [
+	'mobile' => 'tel p-tel',
+	'phone' => 'tel p-tel',
+	'website' => 'url u-url',
+	'contactemail' => 'email u-email',
+];
+$microformats = array_merge($microformats, (array) elgg_extract('microformats', $vars, []));
+
+$user = elgg_extract('entity', $vars);
+if (!($user instanceof ElggUser)) {
+	return;
+}
+
+$fields = (array) elgg_extract('fields', $vars, []);
+if (empty($fields)) {
+	return;
+}
+
+// move description to the bottom of the list
+if (isset($fields['description'])) {
+	$temp = $fields['description'];
+	unset($fields['description']);
+	$fields['description'] = $temp;
+}
+
+foreach ($fields as $shortname => $valtype) {
+	$annotations = $user->getAnnotations([
+		'annotation_names' => "profile:$shortname",
+		'limit' => false,
+	]);
+	$values = array_map(function (ElggAnnotation $a) {
+		return $a->value;
+	}, $annotations);
+
+	if (!$values) {
+		continue;
+	}
+	// emulate metadata API
+	$value = (count($values) === 1) ? $values[0] : $values;
+
+	// validate urls
+	if ($valtype == 'url' && !preg_match('~^https?\://~i', $value)) {
+		$value = "http://$value";
+	}
+
+	$class = elgg_extract($shortname, $microformats, '');
+
+	$field_title = elgg_echo("profile:{$shortname}");
+	$field_value = elgg_format_element('span', [
+		'class' => $class,
+	], elgg_view("output/{$valtype}", [
+		'value' => $value,
+	]));
+
+	echo <<<___FIELD
+	<div class='clearfix profile-field'>
+		<div class='elgg-col elgg-col-1of5'>
+			<b>{$field_title}:</b>
+		</div>
+		<div class='elgg-col elgg-col-4of5'>
+			{$field_value}
+		</div>
+	</div>
+___FIELD;
+}

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -38,9 +38,6 @@ function thewire_init() {
 	// Extend system CSS with our own styles, which are defined in the thewire/css view
 	elgg_extend_view('elgg.css', 'thewire/css');
 
-	// Add a user's latest wire post to profile
-	elgg_extend_view('profile/status', 'thewire/profile_status');
-
 	// Register a page handler, so we can have nice URLs
 	elgg_register_page_handler('thewire', 'thewire_page_handler');
 


### PR DESCRIPTION
BREAKING CHANGE:
The profile/status view is no longer called. You can extend/prepend the
profile/fields view if you need a similar feature. Thewire is no longer
adding the last wirepost to the profile. A wire widget could offer
similar features.

Fixes #8697

Also fixes some styling issues on the profile page.