### PR TITLE
chore(river): no empty responses html element for comment/create.

### DIFF
--- a/views/default/river/object/comment/create.php
+++ b/views/default/river/object/comment/create.php
@@ -36,7 +36,4 @@ echo elgg_view('river/elements/layout', [
 	'item' => $vars['item'],
 	'message' => elgg_get_excerpt($comment->description),
 	'summary' => $summary,
-
-	// truthy value to bypass responses rendering
-	'responses' => ' ',
 ]);


### PR DESCRIPTION
Fixes #9985