### PR TITLE
fix(groups): group delete button no longer misaligned

### DIFF
--- a/mod/groups/views/default/forms/groups/edit.php
+++ b/mod/groups/views/default/forms/groups/edit.php
@@ -28,20 +28,24 @@ if ($entity) {
 	));
 }
 
-$footer = elgg_view_field([
-	'#type' => 'submit',
-	'value' => elgg_echo('save'),
-]);
+// build form footer
+$footer = '';
 
-if ($entity) {
-	$delete_url = "action/groups/delete?guid=" . $entity->getGUID();
+if (!empty($entity) && $entity->canDelete()) {
+	// add delete link
 	$footer .= elgg_view("output/url", array(
 		"text" => elgg_echo("groups:delete"),
-		"href" => $delete_url,
+		"href" => "action/groups/delete?guid={$entity->guid}",
 		"confirm" => elgg_echo("groups:deletewarning"),
 		"class" => "elgg-button elgg-button-delete float-alt",
 	));
 }
+
+// save button
+$footer .= elgg_view_field([
+	'#type' => 'submit',
+	'value' => elgg_echo('save'),
+]);
 
 elgg_set_form_footer($footer);
 


### PR DESCRIPTION
Probaby due to the change to elgg_view_field the delete button was
misaligned.

Before:
![before](https://user-images.githubusercontent.com/881958/28665335-a5cbd9f4-72c3-11e7-90c5-5141feef6136.png)

After:
![after](https://user-images.githubusercontent.com/881958/28665343-a9eb6950-72c3-11e7-92dd-eb77b47d7507.png)
