### PR TITLE
hide the owner_block menu on private pages

### DIFF
--- a/mod/activity/start.php
+++ b/mod/activity/start.php
@@ -8,8 +8,7 @@
  * @access private
  */
 function elgg_activity_page_handler($segments) {
-	elgg_set_page_owner_guid(elgg_get_logged_in_user_guid());
-
+	
 	// make a URL segment available in page handler script
 	$page_type = elgg_extract(0, $segments, 'all');
 	$page_type = preg_replace('[\W]', '', $page_type);

--- a/mod/activity/views/default/resources/river.php
+++ b/mod/activity/views/default/resources/river.php
@@ -26,6 +26,9 @@ if ($type != 'all') {
 
 switch ($page_type) {
 	case 'mine':
+		
+		elgg_set_page_owner_guid(elgg_get_logged_in_user_guid());
+		
 		$title = elgg_echo('river:mine');
 		$page_filter = 'mine';
 		$options['subject_guid'] = elgg_get_logged_in_user_guid();

--- a/mod/friends_collections/views/default/resources/friends/collections/add.php
+++ b/mod/friends_collections/views/default/resources/friends/collections/add.php
@@ -36,7 +36,8 @@ $content = elgg_view_form($form_name, [], $form_vars);
 
 $body = elgg_view_layout('one_sidebar', [
 	'title' => $title,
-	'content' => $content
+	'content' => $content,
+	'show_owner_block_menu' => false,
 ]);
 
 echo elgg_view_page($title, $body);

--- a/mod/friends_collections/views/default/resources/friends/collections/edit.php
+++ b/mod/friends_collections/views/default/resources/friends/collections/edit.php
@@ -42,7 +42,8 @@ $content = elgg_view_form($form_name, [], $form_vars);
 
 $body = elgg_view_layout('one_sidebar', [
 	'title' => $title,
-	'content' => $content
+	'content' => $content,
+	'show_owner_block_menu' => false,
 ]);
 
 echo elgg_view_page($title, $body);

--- a/mod/friends_collections/views/default/resources/friends/collections/owner.php
+++ b/mod/friends_collections/views/default/resources/friends/collections/owner.php
@@ -41,6 +41,7 @@ $content = elgg_view('collections/listing/owner', [
 $body = elgg_view_layout('one_sidebar', [
 	'content' => $content,
 	'title' => $title,
+	'show_owner_block_menu' => false,
 ]);
 
 echo elgg_view_page($title, $body);

--- a/mod/friends_collections/views/default/resources/friends/collections/view.php
+++ b/mod/friends_collections/views/default/resources/friends/collections/view.php
@@ -34,7 +34,8 @@ $content = elgg_view('collections/collection', [
 
 $body = elgg_view_layout('one_sidebar', [
 	'title' => $title,
-	'content' => $content
+	'content' => $content,
+	'show_owner_block_menu' => false,
 ]);
 
 echo elgg_view_page($title, $body);

--- a/mod/invitefriends/views/default/resources/invitefriends/invite.php
+++ b/mod/invitefriends/views/default/resources/invitefriends/invite.php
@@ -14,6 +14,7 @@ $title = elgg_echo('friends:invite');
 $body = elgg_view_layout('default', [
 	'content' => elgg_view_form('invitefriends/invite'),
 	'title' => $title,
+	'show_owner_block_menu' => false,
 ]);
 
 echo elgg_view_page($title, $body);

--- a/mod/messages/views/default/resources/messages/inbox.php
+++ b/mod/messages/views/default/resources/messages/inbox.php
@@ -50,6 +50,7 @@ $body = elgg_view_layout('content', [
 	'content' => $content,
 	'title' => elgg_echo('messages:inbox'),
 	'filter' => '',
+	'show_owner_block_menu' => false,
 ]);
 
 echo elgg_view_page($title, $body);

--- a/mod/messages/views/default/resources/messages/read.php
+++ b/mod/messages/views/default/resources/messages/read.php
@@ -56,6 +56,7 @@ $body = elgg_view_layout('content', [
 	'content' => $content,
 	'title' => $title,
 	'filter' => '',
+	'show_owner_block_menu' => false,
 ]);
 
 echo elgg_view_page($title, $body);

--- a/mod/messages/views/default/resources/messages/send.php
+++ b/mod/messages/views/default/resources/messages/send.php
@@ -21,6 +21,7 @@ $body = elgg_view_layout('content', [
 	'content' => $content,
 	'title' => $title,
 	'filter' => '',
+	'show_owner_block_menu' => false,
 ]);
 
 echo elgg_view_page($title, $body);

--- a/mod/messages/views/default/resources/messages/sent.php
+++ b/mod/messages/views/default/resources/messages/sent.php
@@ -51,6 +51,7 @@ $body = elgg_view_layout('content', [
 	'content' => $content,
 	'title' => $title,
 	'filter' => '',
+	'show_owner_block_menu' => false,
 ]);
 
 echo elgg_view_page($title, $body);

--- a/mod/notifications/views/default/resources/notifications/groups.php
+++ b/mod/notifications/views/default/resources/notifications/groups.php
@@ -34,6 +34,7 @@ $content = elgg_view('notifications/groups', [
 $layout = elgg_view_layout('one_sidebar', [
 	'content' => $content,
 	'title' => $title,
+	'show_owner_block_menu' => false,
 ]);
 
 echo elgg_view_page($title, $layout);

--- a/mod/notifications/views/default/resources/notifications/index.php
+++ b/mod/notifications/views/default/resources/notifications/index.php
@@ -33,6 +33,7 @@ $content = elgg_view('notifications/personal', [
 $layout = elgg_view_layout('one_sidebar', [
 	'content' => $content,
 	'title' => $title,
+	'show_owner_block_menu' => false,
 ]);
 
 echo elgg_view_page($title, $layout);

--- a/mod/site_notifications/views/default/resources/site_notifications/view.php
+++ b/mod/site_notifications/views/default/resources/site_notifications/view.php
@@ -36,6 +36,7 @@ $body = elgg_view_layout('content', [
 	'content' => $form,
 	'title' => $title,
 	'filter' => '',
+	'show_owner_block_menu' => false,
 ]);
 
 echo elgg_view_page($title, $body);

--- a/views/default/page/elements/owner_block.php
+++ b/views/default/page/elements/owner_block.php
@@ -3,9 +3,10 @@
  * Elgg owner block
  * Displays page ownership information
  *
+ * @uses $vars['show_owner_block_menu'] (bool) Show the owner_block menu for the current page owner (default: true)
+ *
  * @package Elgg
  * @subpackage Core
- *
  */
 
 elgg_push_context('owner_block');
@@ -15,7 +16,10 @@ $owner = elgg_get_page_owner_entity();
 if ($owner instanceof ElggGroup || $owner instanceof ElggUser) {
 	$header = elgg_view_entity($owner, ['full_view' => false]);
 
-	$body = elgg_view_menu('owner_block', ['entity' => $owner]);
+	$body = '';
+	if (elgg_extract('show_owner_block_menu', $vars, true)) {
+		$body .= elgg_view_menu('owner_block', ['entity' => $owner]);
+	}
 
 	$body .= elgg_view('page/elements/owner_block/extend', $vars);
 

--- a/views/default/resources/avatar/edit.php
+++ b/views/default/resources/avatar/edit.php
@@ -27,6 +27,7 @@ if ($entity->hasIcon('master')) {
 $params = [
 	'content' => $content,
 	'title' => $title,
+	'show_owner_block_menu' => false,
 ];
 $body = elgg_view_layout('one_sidebar', $params);
 

--- a/views/default/resources/profile/edit.php
+++ b/views/default/resources/profile/edit.php
@@ -27,6 +27,7 @@ $content = elgg_view_form('profile/edit', [], ['entity' => $user]);
 $params = [
 	'content' => $content,
 	'title' => $title,
+	'show_owner_block_menu' => false,
 ];
 $body = elgg_view_layout('one_sidebar', $params);
 

--- a/views/default/resources/settings/account.php
+++ b/views/default/resources/settings/account.php
@@ -26,6 +26,7 @@ $content = elgg_view('core/settings/account');
 $params = [
 	'content' => $content,
 	'title' => $title,
+	'show_owner_block_menu' => false,
 ];
 $body = elgg_view_layout('one_sidebar', $params);
 

--- a/views/default/resources/settings/statistics.php
+++ b/views/default/resources/settings/statistics.php
@@ -27,6 +27,7 @@ $content = elgg_view("core/settings/statistics");
 $params = [
 	'content' => $content,
 	'title' => $title,
+	'show_owner_block_menu' => false,
 ];
 $body = elgg_view_layout('one_sidebar', $params);
 

--- a/views/default/resources/settings/tools.php
+++ b/views/default/resources/settings/tools.php
@@ -45,6 +45,7 @@ $content = elgg_view_form('plugins/usersettings/save', [], ['entity' => $plugin]
 $params = [
 	'content' => $content,
 	'title' => $title,
+	'show_owner_block_menu' => false,
 ];
 $body = elgg_view_layout('one_sidebar', $params);
 


### PR DESCRIPTION
On private pages where only the user can come (or an admin) the
owner_block menu just adds noise. This fix removes the owner_block menu
from those pages.

ref: #10320