### PR TITLE
chore(river): cleanup the use of elgg_delete_river

### DIFF
--- a/actions/avatar/crop.php
+++ b/actions/avatar/crop.php
@@ -31,8 +31,14 @@ if (!$owner->saveIconFromElggFile($owner->getIcon('master'), 'icon', $coords)) {
 }
 
 system_message(elgg_echo('avatar:crop:success'));
+// river item
 $view = 'river/user/default/profileiconupdate';
-_elgg_delete_river(['subject_guid' => $owner->guid, 'view' => $view]);
+// remove old river items
+$batch = new ElggBatch('elgg_get_river', [
+	'subject_guid' => $owner->guid,
+	'view' => $view,
+], 'elgg_batch_delete_callback', 25, false);
+// create new river item
 elgg_create_river_item([
 	'view' => $view,
 	'action_type' => 'update',

--- a/actions/avatar/upload.php
+++ b/actions/avatar/upload.php
@@ -24,9 +24,15 @@ if (!$owner->saveIconFromUploadedFile('avatar')) {
 
 if (elgg_trigger_event('profileiconupdate', $owner->type, $owner)) {
 	system_message(elgg_echo("avatar:upload:success"));
-
+	
+	// river item
 	$view = 'river/user/default/profileiconupdate';
-	_elgg_delete_river(['subject_guid' => $owner->guid, 'view' => $view]);
+	// remove old river items
+	$batch = new ElggBatch('elgg_get_river', [
+		'subject_guid' => $owner->guid,
+		'view' => $view,
+	], 'elgg_batch_delete_callback', 25, false);
+	// create new river item
 	elgg_create_river_item([
 		'view' => $view,
 		'action_type' => 'update',

--- a/engine/classes/ElggAnnotation.php
+++ b/engine/classes/ElggAnnotation.php
@@ -77,7 +77,9 @@ class ElggAnnotation extends \ElggExtender {
 	public function delete() {
 		$result = _elgg_delete_metastring_based_object_by_id($this->id, 'annotation');
 		if ($result) {
-			_elgg_delete_river(['annotation_id' => $this->id]);
+			$batch = new ElggBatch('elgg_get_river', [
+				'annotation_id' => $this->id,
+			], 'elgg_batch_delete_callback', 25, false);
 		}
 
 		return $result;

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1937,9 +1937,10 @@ abstract class ElggEntity extends \ElggData implements
 		access_show_hidden_entities($entity_disable_override);
 		elgg_set_ignore_access($ia);
 
-		_elgg_delete_river(['subject_guid' => $guid]);
-		_elgg_delete_river(['object_guid' => $guid]);
-		_elgg_delete_river(['target_guid' => $guid]);
+		$batch = new ElggBatch('elgg_get_river', ['subject_guid' => $guid], 'elgg_batch_delete_callback', 25, false);
+		$batch = new ElggBatch('elgg_get_river', ['object_guid' => $guid], 'elgg_batch_delete_callback', 25, false);
+		$batch = new ElggBatch('elgg_get_river', ['target_guid' => $guid], 'elgg_batch_delete_callback', 25, false);
+		
 		remove_all_private_settings($guid);
 
 		_elgg_invalidate_cache_for_entity($guid);

--- a/engine/tests/ElggCoreRiverAPITest.php
+++ b/engine/tests/ElggCoreRiverAPITest.php
@@ -18,13 +18,21 @@ class ElggCoreRiverAPITest extends \ElggCoreUnitTest {
 
 		$id = elgg_create_river_item($params);
 		$this->assertTrue(is_int($id));
-		$this->assertTrue(_elgg_delete_river(array('id' => $id)));
+		
+		$batch = new \ElggBatch('elgg_get_river', [
+			'id' => $id,
+		], 'elgg_batch_delete_callback', 25, false);
+		$this->assertTrue($batch->callbackResult);
 
 		$params['return_item'] = true;
 		$item = elgg_create_river_item($params);
 
 		$this->assertIsA($item, ElggRiveritem::class);
-		$this->assertTrue(_elgg_delete_river(array('id' => $item->id)));
+		
+		$batch = new \ElggBatch('elgg_get_river', [
+			'id' => $item->id,
+		], 'elgg_batch_delete_callback', 25, false);
+		$this->assertTrue($batch->callbackResult);
 	}
 
 	public function testRiverCreationEmitsHookAndEvent() {
@@ -187,8 +195,10 @@ class ElggCoreRiverAPITest extends \ElggCoreUnitTest {
 		elgg_register_event_handler('delete:before', 'river', $handler);
 		elgg_register_event_handler('delete:after', 'river', $handler);
 
-		_elgg_delete_river(['id' => $id]);
-
+		$batch = new \ElggBatch('elgg_get_river', [
+			'id' => $id,
+		], 'elgg_batch_delete_callback', 25, false);
+		
 		elgg_unregister_plugin_hook_handler('permissions_check:delete', 'river', $handler);
 		elgg_unregister_event_handler('delete:before', 'river', $handler);
 		elgg_unregister_event_handler('delete:after', 'river', $handler);

--- a/mod/blog/actions/blog/save.php
+++ b/mod/blog/actions/blog/save.php
@@ -165,10 +165,10 @@ if (!$error) {
 				$blog->save();
 			}
 		} elseif ($old_status == 'published' && $status == 'draft') {
-			_elgg_delete_river([
+			$batch = new ElggBatch('elgg_get_river', [
 				'object_guid' => $blog->guid,
 				'action_type' => 'create',
-			]);
+			], 'elgg_batch_delete_callback', 25, false);
 		}
 
 		if ($blog->status == 'published' || $save == false) {


### PR DESCRIPTION
Since this function is deprecated, remove the use of it in core

fixes: #10117