### PR TITLE
feat(views): added a generic entity navigation view for full views

### DIFF
--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -606,6 +606,62 @@ function _elgg_entity_menu_setup($hook, $type, $return, $params) {
 }
 
 /**
+ * Entity navigation menu is previous/next link for an entity
+ *
+ * @param \Elgg\Hook hook
+ *
+ * @access private
+ */
+function _elgg_entity_navigation_menu_setup(\Elgg\Hook $hook) {
+	$entity = $hook->getEntityParam();
+	if (!$entity) {
+		return;
+	}
+
+	$return = $hook->getValue();
+
+	$options = [
+		'type' => $entity->getType(),
+		'subtype' => $entity->getSubtype(),
+		'container_guid' => $entity->container_guid,
+		'wheres' => ["e.guid != {$entity->guid}"],
+		'limit' => 1,
+	];
+	
+	$previous_options = $options;
+	$previous_options['created_time_upper'] = $entity->time_created;
+	$previous_options['order_by'] = 'e.time_created DESC, e.guid DESC';
+	
+	$previous = elgg_get_entities($previous_options);
+	if ($previous) {
+		$previous = $previous[0];
+		$return[] = \ElggMenuItem::factory([
+			'name' => 'previous',
+			'text' => elgg_echo('previous'),
+			'href' => $previous->getUrl(),
+			'title' => $previous->getDisplayName(),
+		]);
+	}
+	
+	$next_options = $options;
+	$next_options['created_time_lower'] = $entity->time_created;
+	$next_options['order_by'] = 'e.time_created ASC, e.guid ASC';
+	
+	$next = elgg_get_entities($next_options);
+	if ($next) {
+		$next = $next[0];
+		$return[] = \ElggMenuItem::factory([
+			'name' => 'next',
+			'text' => elgg_echo('next'),
+			'href' => $next->getUrl(),
+			'title' => $next->getDisplayName(),
+		]);
+	}
+	
+	return $return;
+}
+
+/**
  * Widget menu is a set of widget controls
  * @access private
  */
@@ -714,6 +770,7 @@ function _elgg_nav_init() {
 	elgg_register_plugin_hook_handler('register', 'menu:widget', '_elgg_widget_menu_setup');
 	elgg_register_plugin_hook_handler('register', 'menu:login', '_elgg_login_menu_setup');
 	elgg_register_plugin_hook_handler('register', 'menu:footer', '_elgg_rss_menu_setup');
+	elgg_register_plugin_hook_handler('register', 'menu:entity_navigation', '_elgg_entity_navigation_menu_setup');
 
 	elgg_register_plugin_hook_handler('public_pages', 'walled_garden', '_elgg_nav_public_pages');
 

--- a/mod/blog/views/default/object/blog.php
+++ b/mod/blog/views/default/object/blog.php
@@ -83,6 +83,7 @@ if ($full) {
 		'icon' => $owner_icon,
 		'body' => $body,
 		'responses' => $responses,
+		'show_navigation' => true,
 	]);
 } else {
 	// brief view

--- a/mod/bookmarks/views/default/object/bookmarks.php
+++ b/mod/bookmarks/views/default/object/bookmarks.php
@@ -75,6 +75,7 @@ HTML;
 		'summary' => $summary,
 		'body' => $body,
 		'responses' => $responses,
+		'show_navigation' => true,
 	]);
 } elseif (elgg_in_context('gallery')) {
 	echo <<<HTML

--- a/mod/discussions/views/default/object/discussion.php
+++ b/mod/discussions/views/default/object/discussion.php
@@ -113,6 +113,7 @@ if ($full) {
 		'summary' => $summary,
 		'body' => $body,
 		'responses' => $responses,
+		'show_navigation' => true,
 	]);
 } else {
 	// brief view

--- a/mod/file/views/default/object/file.php
+++ b/mod/file/views/default/object/file.php
@@ -79,6 +79,7 @@ if ($full && !elgg_in_context('gallery')) {
 		'body' => $body,
 		'attachments' => $extra,
 		'responses' => $responses,
+		'show_navigation' => true,
 	]);
 } elseif (elgg_in_context('gallery')) {
 	echo '<div class="file-gallery-item">';

--- a/views/default/elements/navigation.css.php
+++ b/views/default/elements/navigation.css.php
@@ -99,6 +99,41 @@
 }
 
 /* ***************************************
+	ENTITY NAVIGATION
+*************************************** */
+
+.elgg-menu-entity-navigation {
+	margin-top: 10px;
+	
+	a {
+		padding: 6px 15px;
+		color: #444;
+		border: 1px solid #DCDCDC;
+	}
+	a:hover {
+		color: #999;
+		text-decoration: none;
+	}
+	
+	.elgg-menu-item-previous {
+		float: left;
+		
+		> a:before {
+			content: "\ab";
+			margin-right: 6px;
+		}
+	}
+	.elgg-menu-item-next {
+		float: right;
+		
+		> a:after {
+			content: "\bb";
+			margin-left: 6px;
+		}
+	}
+}
+
+/* ***************************************
 	TABS
 *************************************** */
 .elgg-tabs {

--- a/views/default/object/elements/full.php
+++ b/views/default/object/elements/full.php
@@ -3,15 +3,16 @@
 /**
  * Object full view
  *
- * @uses $vars['entity']        ElggEntity
- * @uses $vars['icon']          HTML for the content icon
- * @uses $vars['summary']       HTML for the content summary
- * @uses $vars['body']          HTML for the content body
- * @uses $vars['attachments']   HTML for the attachments
- * @uses $vars['responses']     HTML for the responses
- * @uses $vars['class']         Optional additional class for the content wrapper
- * @uses $vars['header_params'] Vars to pass to the header image block wrapper
- * @uses $vars['body_params']   Attributes to pass to the body wrapper
+ * @uses $vars['entity']          ElggEntity
+ * @uses $vars['icon']            HTML for the content icon
+ * @uses $vars['summary']         HTML for the content summary
+ * @uses $vars['body']            HTML for the content body
+ * @uses $vars['attachments']     HTML for the attachments
+ * @uses $vars['responses']       HTML for the responses
+ * @uses $vars['show_navigation'] Boolean (default false) to determine if entity navigation should be shown
+ * @uses $vars['class']           Optional additional class for the content wrapper
+ * @uses $vars['header_params']   Vars to pass to the header image block wrapper
+ * @uses $vars['body_params']     Attributes to pass to the body wrapper
  */
 $entity = elgg_extract('entity', $vars);
 if (!$entity instanceof ElggEntity) {
@@ -21,14 +22,15 @@ if (!$entity instanceof ElggEntity) {
 $class = elgg_extract_class($vars, ['elgg-listing-full', 'elgg-content', 'clearfix']);
 unset($vars['class']);
 
-$header = elgg_view('object/elements/full/header', $vars);
-$body = elgg_view('object/elements/full/body', $vars);
-$attachments = elgg_view('object/elements/full/attachments', $vars);
-$responses = elgg_view('object/elements/full/responses', $vars);
+$content = elgg_view('object/elements/full/header', $vars);
+$content .= elgg_view('object/elements/full/body', $vars);
+$content .= elgg_view('object/elements/full/attachments', $vars);
+if (elgg_extract('show_navigation', $vars, false)) {
+	$content .= elgg_view('object/elements/full/navigation', $vars);
+}
+$content .= elgg_view('object/elements/full/responses', $vars);
 
 echo elgg_format_element('div', [
 	'class' => $class,
 	'data-guid' => $entity->guid,
-		], $header . $body . $attachments . $responses);
-
-
+], $content);

--- a/views/default/object/elements/full/navigation.php
+++ b/views/default/object/elements/full/navigation.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Outputs entity previous/next navigation elements
+ *
+ * @uses $vars['entity'] Entity used to determine previous/next urls
+ */
+
+$entity = elgg_extract('entity', $vars);
+if (!($entity instanceof \ElggEntity)) {
+	return;
+}
+
+echo elgg_format_element('div', [
+	'class' => 'elgg-listing-full-navigation',
+], elgg_view_menu('entity_navigation', $vars));


### PR DESCRIPTION
fixes #4457

Can be applied to any entity so very reusable. Did not apply it to pages as i think it will be confusing as a page also has its own page navigation (the document tree).

The buttons are a menu so overriding the text is hookable.

Also checkout the nesting used in the css... 