### PR TITLE
chore(core): removed setting a deprecated PHP setting

### DIFF
--- a/engine/lib/mb_wrapper.php
+++ b/engine/lib/mb_wrapper.php
@@ -248,10 +248,5 @@ return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hoo
 	// if mb functions are available, set internal encoding to UTF8
 	if (is_callable('mb_internal_encoding')) {
 		mb_internal_encoding("UTF-8");
-		if (version_compare('5.6.0', PHP_VERSION, '<')) {
-			if (ini_get("mbstring.internal_encoding")) {
-				ini_set("mbstring.internal_encoding", 'UTF-8');
-			}
-		}
 	}
 };


### PR DESCRIPTION
The ini setting `mbstring.internal_encoding` has been deprecated in PHP
5.6. Since Elgg requires PHP 5.6+ setting this setting is unneeded.

fixes: #10976