### PR TITLE
feat(core): add phpinfo page

### DIFF
--- a/docs/info/config.php
+++ b/docs/info/config.php
@@ -278,6 +278,16 @@ $CONFIG->exception_include = '';
 $CONFIG->action_time_limit;
 
 /**
+ * Allow access to PHPInfo
+ *
+ * This setting can be used to allow site administrators access to the PHPInfo page.
+ * By default this is not allowed.
+ *
+ * @global bool $CONFIG->allow_phpinfo
+ */
+$CONFIG->allow_phpinfo = false;
+
+/**
  * Paths to scan for autoloading languages.
  *
  * Languages are automatically loaded for the site or

--- a/elgg-config/settings.example.php
+++ b/elgg-config/settings.example.php
@@ -319,3 +319,13 @@ $CONFIG->exception_include = '';
  * @global int $CONFIG->action_time_limit
  */
 $CONFIG->action_time_limit = 120;
+
+/**
+ * Allow access to PHPInfo
+ *
+ * This setting can be used to allow site administrators access to the PHPInfo page.
+ * By default this is not allowed.
+ *
+ * @global bool $CONFIG->allow_phpinfo
+ */
+$CONFIG->allow_phpinfo = false;

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -227,6 +227,7 @@ function _elgg_admin_init() {
 	elgg_register_page_handler('admin', '_elgg_admin_page_handler');
 	elgg_register_page_handler('admin_plugin_text_file', '_elgg_admin_markdown_page_handler');
 	elgg_register_page_handler('robots.txt', '_elgg_robots_page_handler');
+	elgg_register_page_handler('phpinfo', '_elgg_phpinfo_page_handler');
 	elgg_register_page_handler('admin_plugins_refresh', '_elgg_ajax_plugins_update');
 }
 
@@ -675,6 +676,16 @@ function _elgg_admin_markdown_page_handler($pages) {
  */
 function _elgg_robots_page_handler() {
 	echo elgg_view_resource('robots.txt');
+	return true;
+}
+
+/**
+ * Handle request for phpinfo
+ *
+ * @access private
+ */
+function _elgg_phpinfo_page_handler() {
+	echo elgg_view_resource('phpinfo');
 	return true;
 }
 

--- a/languages/en.php
+++ b/languages/en.php
@@ -792,6 +792,7 @@ To go to the site, click here:
 
 	'admin:server:label:elgg' => 'Elgg',
 	'admin:server:label:php' => 'PHP',
+	'admin:server:label:phpinfo' => 'Show PHPInfo',
 	'admin:server:label:web_server' => 'Web Server',
 	'admin:server:label:server' => 'Server',
 	'admin:server:label:log_location' => 'Log Location',

--- a/views/default/admin/server/php.php
+++ b/views/default/admin/server/php.php
@@ -48,3 +48,14 @@ if ($upload_max_filesize > $post_max_size) {
 		<td><?= number_format($upload_max_filesize) . '&nbsp; ' . $post_max_size_warning; ?></td>
 	</tr>
 </table>
+<?php
+// Show phpinfo page
+if (elgg_get_config('allow_phpinfo') !== true) {
+	return;
+}
+
+echo elgg_format_element('div', ['class' => 'mts'], elgg_view('output/url', [
+	'text' => elgg_echo('admin:server:label:phpinfo'),
+	'href' => 'phpinfo',
+	'target' => '_blank',
+]));

--- a/views/default/resources/phpinfo.php
+++ b/views/default/resources/phpinfo.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Show phpinfo page
+ */
+
+if (elgg_get_config('allow_phpinfo') !== true) {
+	// page is not allowed in elgg-config/settings.php
+	forward('', '404');
+}
+
+// this page is only for admins
+elgg_admin_gatekeeper();
+
+phpinfo();


### PR DESCRIPTION
If the setting `allow_phpinfo` in the settings.php is set to `true` the
pagehandler /phpinfo will display the phpinfo() page.