### PR TITLE
feat(htmlawed): now using htmlawed v1.2 with html5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "michelf/php-markdown": "^1.5.0",
         "misd/linkify": "~1.1.2",
         "league/flysystem-memory": "^1.0",
-        "htmlawed/htmlawed": "^1.1.22",
+        "vanilla/htmlawed": "~2.2.0",
         "imagine/imagine": "^0.6.3"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5c37e7545a05d02540f55616150e5d2",
+    "content-hash": "d8ca2c9228ad0a9b444f12a3e07ab716",
     "packages": [
         {
             "name": "bower-asset/jeditable",
@@ -1022,52 +1022,6 @@
             "time": "2016-10-24T15:52:54+00:00"
         },
         {
-            "name": "htmlawed/htmlawed",
-            "version": "1.1.22",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/kesar/HTMLawed.git",
-                "reference": "b270453ba016ee4c6dae585f047d1e4f3cc456a1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/kesar/HTMLawed/zipball/b270453ba016ee4c6dae585f047d1e4f3cc456a1",
-                "reference": "b270453ba016ee4c6dae585f047d1e4f3cc456a1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">4.4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "htmLawed.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0+",
-                "LGPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "Santosh Patnaik",
-                    "homepage": "http://www.bioinformatics.org/people/index.php?user_hash=558b661f92d0ff7b",
-                    "role": "Developer"
-                }
-            ],
-            "description": "htmLawed - Process text with HTML markup to make it more compliant with HTML standards and administrative policies",
-            "homepage": "http://www.bioinformatics.org/phplabware/internal_utilities/htmLawed/",
-            "keywords": [
-                "HTMLtidy",
-                "html",
-                "sanitize",
-                "strip",
-                "tags"
-            ],
-            "time": "2016-08-27T18:53:27+00:00"
-        },
-        {
             "name": "imagine/imagine",
             "version": "v0.6.3",
             "source": {
@@ -1958,6 +1912,45 @@
                 "sessions"
             ],
             "time": "2016-02-10T22:23:16+00:00"
+        },
+        {
+            "name": "vanilla/htmlawed",
+            "version": "v2.2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vanilla/htmlawed.git",
+                "reference": "d7c49fa7bfa3006973616141f35c67999fdc5132"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vanilla/htmlawed/zipball/d7c49fa7bfa3006973616141f35c67999fdc5132",
+                "reference": "d7c49fa7bfa3006973616141f35c67999fdc5132",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "tburry/pquery": "~1.0.1"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/Htmlawed.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Todd Burry",
+                    "email": "todd@vanillaforums.com"
+                }
+            ],
+            "description": "A composer wrapper for the htmLawed library to purify & filter HTML. Tested with PHPUnit and PhantomJS!",
+            "time": "2017-05-17T18:14:43+00:00"
         },
         {
             "name": "zendframework/zend-loader",

--- a/engine/classes/ElggPluginManifest.php
+++ b/engine/classes/ElggPluginManifest.php
@@ -398,7 +398,6 @@ class ElggPluginManifest {
 			'friends_collections',
 			'garbagecollector',
 			'groups',
-			'htmlawed',
 			'invitefriends',
 			'legacy_urls',
 			'likes',

--- a/engine/lib/input.php
+++ b/engine/lib/input.php
@@ -436,7 +436,7 @@ function _elgg_htmlawed_filter_tags($hook, $type, $result, $params = null) {
 	$spec = elgg_trigger_plugin_hook('spec', 'htmlawed', null, '');
 
 	if (!is_array($var)) {
-		return htmLawed($var, $config, $spec);
+		return Htmlawed::filter($var, $config, $spec);
 	} else {
 		array_walk_recursive($var, '_elgg_htmLawedArray', [$config, $spec]);
 		return $var;
@@ -449,7 +449,7 @@ function _elgg_htmlawed_filter_tags($hook, $type, $result, $params = null) {
  */
 function _elgg_htmLawedArray(&$v, $k, $config_spec) {
 	list ($config, $spec) = $config_spec;
-	$v = htmLawed($v, $config, $spec);
+	$v = Htmlawed::filter($v, $config, $spec);
 }
 // @codingStandardsIgnoreEnd
 

--- a/engine/tests/ElggHtmLawedTest.php
+++ b/engine/tests/ElggHtmLawedTest.php
@@ -172,8 +172,13 @@ class ElggHtmLawedTest extends ElggCoreUnitTest {
 			'<ul><li>item</li></ul>' => '<ul><li>item</li></ul>',
 
 			// 'deny_attribute' => 'class, on*',
-			'<span class="elgg-inner">Test</span>' => '<span>Test</span>',
+			'<div class="elgg-inner">Test</div>' => '<div>Test</div>',
 			'<button onclick="javascript:alert(\'test\')">Test</button>' => '<button>Test</button>',
+			
+			// naked span stripping
+			// https://github.com/vanilla/htmlawed/commit/995ef0ae4865d817a391ac62978f9d0e41d8a18b
+			'<span>Test</span>' => 'Test',
+			'<span id="test">Test</span>' => '<span id="test">Test</span>',
 		);
 
 		// test elements filtered by "safe" option

--- a/engine/tests/suite.php
+++ b/engine/tests/suite.php
@@ -15,7 +15,6 @@ require_once __DIR__ . '/ElggCoreGetEntitiesBaseTest.php';
 // plugins that contain unit tests
 $plugins = array(
 	'groups',
-	'htmlawed',
 	'thewire',
 	'web_services'
 );


### PR DESCRIPTION
This package is updated (and is updating more frequently)

Fixes #5489
Fixes #5498

Note:
Spans without attributes will be removed. This is a change made in vanilla/htmlawed and was not present in htmlawed/htmlawed. I had to update the tests accordingly.
https://github.com/vanilla/htmlawed/commit/995ef0ae4865d817a391ac62978f9d0e41d8a18b