### PR TITLE
security(exceptions): show admins less on exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 # This helps builds go quicker on Travis since it enables caching of dependencies
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
-
+dist: precise
 
 branches:
   except:

--- a/mod/developers/views/failsafe/messages/exceptions/admin_exception.php
+++ b/mod/developers/views/failsafe/messages/exceptions/admin_exception.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Elgg exception (failsafe mode)
+ * Displays a single exception
+ *
+ * @package Elgg
+ * @subpackage Core
+ *
+ * @uses $vars['object'] An exception
+ */
+
+$exception = $vars['object'];
+/* @var \Exception $exception */
+?>
+
+<p class="elgg-messages-exception">
+	<span title="<?= get_class($exception); ?>">
+	<?= nl2br($exception->getMessage()); ?>
+		<br /><br />
+		Log at time <?= $vars['ts']; ?> may have more data.
+	</span>
+</p>
+
+<?php
+if ($exception instanceof \DatabaseException) {
+	// likely contains credentials
+	return;
+}
+?>
+
+<p class="elgg-messages-exception">
+	<?= nl2br(htmlentities(print_r($exception, true), ENT_QUOTES, 'UTF-8')); ?>
+</p>

--- a/views/failsafe/messages/exceptions/admin_exception.php
+++ b/views/failsafe/messages/exceptions/admin_exception.php
@@ -3,6 +3,8 @@
  * Elgg exception (failsafe mode)
  * Displays a single exception
  *
+ * @tip Enable "developers" to give admins a stacktrace view.
+ *
  * @package Elgg
  * @subpackage Core
  *
@@ -12,19 +14,9 @@
 ?>
 
 <p class="elgg-messages-exception">
-	<span title="<?php echo get_class($vars['object']); ?>">
-	<?php
-
-		echo nl2br($vars['object']->getMessage());
-
-	?>
+	<span title="Unrecoverable Error">
+		<?php echo elgg_echo('exception:contact_admin'); ?>
+		<br /><br />
+		Exception at time <?php echo $vars['ts']; ?>.
 	</span>
-</p>
-
-<p class="elgg-messages-exception">
-	<?php
-
-		echo nl2br(htmlentities(print_r($vars['object'], true), ENT_QUOTES, 'UTF-8'));
-
-	?>
 </p>


### PR DESCRIPTION
Exception pages no longer dump the exception state for
`DatabaseException`s as these may contain credentials. Unless
`developers` is enabled, admins are not shown exception details at all.

Fixes #10521