### PR TITLE
feat(blogs): more consitency in blog data during save operations

### DIFF
--- a/mod/blog/actions/blog/auto_save_revision.php
+++ b/mod/blog/actions/blog/auto_save_revision.php
@@ -1,10 +1,10 @@
 <?php
+
 /**
  * Action called by AJAX periodic auto saving when editing.
  *
  * @package Blog
  */
-
 $guid = get_input('guid');
 $user = elgg_get_logged_in_user_entity();
 $title = htmlspecialchars(get_input('title', '', false), ENT_QUOTES, 'UTF-8');
@@ -16,77 +16,61 @@ if (empty($excerpt)) {
 	$excerpt = $description;
 }
 
-// store errors to pass along
-$error = false;
-
-if ($title && $description) {
-	if ($guid) {
-		$entity = get_entity($guid);
-		if (elgg_instanceof($entity, 'object', 'blog') && $entity->canEdit()) {
-			$blog = $entity;
-		} else {
-			$error = elgg_echo('blog:error:post_not_found');
-		}
-	} else {
-		$blog = new ElggBlog();
-		$blog->subtype = 'blog';
-
-		// force draft and private for autosaves.
-		$blog->status = 'unsaved_draft';
-		$blog->access_id = ACCESS_PRIVATE;
-		$blog->title = $title;
-		$blog->description = $description;
-		$blog->excerpt = elgg_get_excerpt($excerpt);
-
-		// mark this as a brand new post so we can work out the
-		// river / revision logic in the real save action.
-		$blog->new_post = true;
-
-		if (!$blog->save()) {
-			$error = elgg_echo('blog:error:cannot_save');
-		}
-	}
-
-	// creat draft annotation
-	if (!$error) {
-		// annotations don't have a "time_updated" so
-		// we have to delete everything or the times are wrong.
-
-		// don't save if nothing changed
-		$auto_save_annotations = $blog->getAnnotations([
-			'annotation_name' => 'blog_auto_save',
-			'limit' => 1,
-		]);
-		if ($auto_save_annotations) {
-			$auto_save = $auto_save_annotations[0];
-		} else {
-			$auto_save = false;
-		}
-
-		if (!$auto_save) {
-			$annotation_id = $blog->annotate('blog_auto_save', $description);
-		} elseif ($auto_save instanceof ElggAnnotation && $auto_save->value != $description) {
-			$blog->deleteAnnotations('blog_auto_save');
-			$annotation_id = $blog->annotate('blog_auto_save', $description);
-		} elseif ($auto_save instanceof ElggAnnotation && $auto_save->value == $description) {
-			// this isn't an error because we have an up to date annotation.
-			$annotation_id = $auto_save->id;
-		}
-
-		if (!$annotation_id) {
-			$error = elgg_echo('blog:error:cannot_auto_save');
-		}
-	}
-} else {
-	$error = elgg_echo('blog:error:missing:description');
+if (!$title || !$description) {
+	return elgg_error_response(elgg_echo('blog:error:missing:description'));
 }
 
-if ($error) {
-	$json = ['success' => false, 'message' => $error];
-	echo json_encode($json);
+if ($guid) {
+	$blog = get_entity($guid);
+	if (!$blog instanceof ElggBlog || !$blog->canEdit()) {
+		return elgg_error_response(elgg_echo('blog:error:post_not_found'));
+	}
 } else {
-	$msg = elgg_echo('blog:message:saved');
-	$json = ['success' => true, 'message' => $msg, 'guid' => $blog->getGUID()];
-	echo json_encode($json);
+	$blog = new ElggBlog();
+
+	// force draft and private for autosaves.
+	$blog->status = ElggBlog::UNSAVED_DRAFT;
+	$blog->access_id = ACCESS_PRIVATE;
+	$blog->title = $title;
+	$blog->description = $description;
+	$blog->excerpt = elgg_get_excerpt($excerpt);
+
+	if (!$blog->save()) {
+		return elgg_error_response(elgg_echo('blog:error:cannot_save'));
+	}
 }
-exit;
+
+// creat draft annotation
+// annotations don't have a "time_updated" so
+// we have to delete everything or the times are wrong.
+// don't save if nothing changed
+$auto_save_annotations = $blog->getAnnotations([
+	'annotation_name' => 'blog_auto_save',
+	'limit' => 1,
+]);
+
+if ($auto_save_annotations) {
+	$auto_save = array_shift($auto_save_annotations);
+} else {
+	$auto_save = false;
+}
+
+if (!$auto_save) {
+	$annotation_id = $blog->annotate('blog_auto_save', $description);
+} else if ($auto_save->value != $description) {
+	$blog->deleteAnnotations('blog_auto_save');
+	$annotation_id = $blog->annotate('blog_auto_save', $description);
+} else {
+	// this isn't an error because we have an up to date annotation.
+	$annotation_id = $auto_save->id;
+}
+
+if (!$annotation_id) {
+	return elgg_error_response(elgg_echo('blog:error:cannot_auto_save'));
+}
+
+return elgg_ok_response([
+	'guid' => $blog->guid,
+	'status_time' => date('F j, Y @ H:i', $blog->time_updated),
+]);
+

--- a/mod/blog/actions/blog/save.php
+++ b/mod/blog/actions/blog/save.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Save blog entity
  *
@@ -10,177 +11,76 @@
  *
  * @package Blog
  */
-
-// start a new sticky form session in case of failure
 elgg_make_sticky_form('blog');
 
-// save or preview
-$save = (bool) get_input('save');
-
-// store errors to pass along
-$error = false;
-$error_forward_url = REFERER;
 $user = elgg_get_logged_in_user_entity();
 
-// edit or create a new entity
 $guid = get_input('guid');
-
 if ($guid) {
-	$entity = get_entity($guid);
-	if (elgg_instanceof($entity, 'object', 'blog') && $entity->canEdit()) {
-		$blog = $entity;
-	} else {
-		register_error(elgg_echo('blog:error:post_not_found'));
-		forward(get_input('forward', REFERER));
+	$blog = get_entity($guid);
+	if (!$blog instanceof ElggBlog || !$blog->canEdit()) {
+		$error = elgg_echo('blog:error:post_not_found');
+		return elgg_error_response($error);
 	}
-
-	// save some data for revisions once we save the new edit
-	$revision_text = $blog->description;
-	$new_post = $blog->new_post;
 } else {
 	$blog = new ElggBlog();
-	$blog->subtype = 'blog';
-	$new_post = true;
 }
 
-// set the previous status for the hooks to update the time_created and river entries
-$old_status = $blog->status;
-
-// set defaults and required values.
-$values = [
-	'title' => '',
-	'description' => '',
-	'status' => 'draft',
-	'access_id' => ACCESS_DEFAULT,
-	'comments_on' => 'On',
-	'excerpt' => '',
-	'tags' => '',
-	'container_guid' => (int) get_input('container_guid'),
-];
-
-// fail if a required entity isn't set
-$required = ['title', 'description'];
-
-// load from POST and do sanity and access checking
-foreach ($values as $name => $default) {
-	if ($name === 'title') {
-		$value = htmlspecialchars(get_input('title', $default, false), ENT_QUOTES, 'UTF-8');
-	} else {
-		$value = get_input($name, $default);
-	}
-
-	if (in_array($name, $required) && empty($value)) {
-		$error = elgg_echo("blog:error:missing:$name");
-	}
-
-	if ($error) {
-		break;
-	}
-
-	switch ($name) {
-		case 'tags':
-			$values[$name] = string_to_tag_array($value);
-			break;
-
-		case 'excerpt':
-			if ($value) {
-				$values[$name] = elgg_get_excerpt($value);
-			}
-			break;
-
-		case 'container_guid':
-			// this can't be empty or saving the base entity fails
-			if (!empty($value)) {
-				$container = get_entity($value);
-				if ($container && $container->canWriteToContainer(0, 'object', 'blog')) {
-					$values[$name] = $value;
-				} else {
-					$error = elgg_echo("blog:error:cannot_write_to_container");
-				}
-			} else {
-				unset($values[$name]);
-			}
-			break;
-
-		default:
-			$values[$name] = $value;
-			break;
-	}
-}
-
-// if preview, force status to be draft
-if ($save == false) {
-	$values['status'] = 'draft';
-}
-
-// if draft, set access to private and cache the future access
-if ($values['status'] == 'draft') {
-	$values['future_access'] = $values['access_id'];
-	$values['access_id'] = ACCESS_PRIVATE;
-}
-
-// assign values to the entity, stopping on error.
-if (!$error) {
-	foreach ($values as $name => $value) {
-		$blog->$name = $value;
-	}
-}
-
-// only try to save base entity if no errors
-if (!$error) {
-	if ($blog->save()) {
-		// remove sticky form entries
-		elgg_clear_sticky_form('blog');
-
-		// remove autosave draft if exists
-		$blog->deleteAnnotations('blog_auto_save');
-
-		// no longer a brand new post.
-		$blog->deleteMetadata('new_post');
-
-		// if this was an edit, create a revision annotation
-		if (!$new_post && $revision_text) {
-			$blog->annotate('blog_revision', $revision_text);
-		}
-
-		system_message(elgg_echo('blog:message:saved'));
-
-		$status = $blog->status;
-
-		// add to river if changing status or published, regardless of new post
-		// because we remove it for drafts.
-		if (($new_post || $old_status == 'draft') && $status == 'published') {
-			elgg_create_river_item([
-				'view' => 'river/object/blog/create',
-				'action_type' => 'create',
-				'subject_guid' => $blog->owner_guid,
-				'object_guid' => $blog->getGUID(),
-			]);
-
-			elgg_trigger_event('publish', 'object', $blog);
-
-			// reset the creation time for posts that move from draft to published
-			if ($guid) {
-				$blog->time_created = time();
-				$blog->save();
-			}
-		} elseif ($old_status == 'published' && $status == 'draft') {
-			_elgg_delete_river([
-				'object_guid' => $blog->guid,
-				'action_type' => 'create',
-			]);
-		}
-
-		if ($blog->status == 'published' || $save == false) {
-			forward($blog->getURL());
-		} else {
-			forward("blog/edit/$blog->guid");
-		}
-	} else {
-		register_error(elgg_echo('blog:error:cannot_save'));
-		forward($error_forward_url);
+if (!$blog->guid || $blog->status == ElggBlog::UNSAVED_DRAFT) {
+	$container_guid = get_input('container_guid', elgg_get_logged_in_user_guid());
+	$container = get_entity($container_guid);
+	if (!$container || !$container->canWriteToContainer(0, 'object', 'blog')) {
+		$error = elgg_echo('blog:error:cannot_write_to_container');
+		return elgg_error_response($error);
 	}
 } else {
-	register_error($error);
-	forward($error_forward_url);
+	$container = $blog->getContainerEntity();
 }
+
+$title = htmlspecialchars(get_input('title', '', false), ENT_QUOTES, 'UTF-8');
+if (empty($title)) {
+	$error = elgg_echo('blog:error:missing:title');
+	return elgg_error_response($error);
+}
+
+$description = get_input('description');
+if (empty($description)) {
+	$error = elgg_echo('blog:error:missing:description');
+	return elgg_error_response($error);
+}
+
+$access_id = get_input('access_id', get_default_access());
+
+$blog->container_guid = $container->guid;
+$blog->title = $title;
+$blog->description = $description;
+$blog->tags = string_to_tag_array(get_input('tags', ''));
+$blog->excerpt = elgg_get_excerpt(get_input('excerpt', ''));
+$blog->comments_on = get_input('comments_on') == 'On' ? 'On' : 'Off';
+// When previewing, force status to draft
+$blog->previous_status = $blog->status ?: ElggBlog::DRAFT;
+$blog->status = (bool) get_input('save') ? get_input('status', ElggBlog::DRAFT) : ElggBlog::DRAFT;
+
+if ($blog->status == ElggBlog::DRAFT) {
+	// If draft, set access to private and cache the future access
+	$blog->future_access = $access_id;
+	$blog->access_id = ACCESS_PRIVATE;
+} else {
+	$blog->access_id = $access_id;
+}
+
+if (!$blog->save()) {
+	$error = elgg_echo('blog:error:cannot_save');
+	return elgg_error_response($error);
+}
+
+elgg_clear_sticky_form('blog');
+
+$data = [
+	'entity' => $blog,
+];
+
+$forward_url = $blog->getURL();
+$message = elgg_echo('blog:message:saved');
+
+return elgg_ok_response($data, $message, $forward_url);

--- a/mod/blog/classes/ElggBlog.php
+++ b/mod/blog/classes/ElggBlog.php
@@ -2,11 +2,18 @@
 /**
  * Extended class to override the time_created
  *
- * @property string $status      The published status of the blog post (published, draft)
- * @property string $comments_on Whether commenting is allowed (Off, On)
- * @property string $excerpt     An excerpt of the blog post used when displaying the post
+ * @property string $status          The published status of the blog post (published, draft)
+ * @property string $previous_status The status before blog was saved (used by event system to detect changes in the status)
+ * @property string $comments_on     Whether commenting is allowed (Off, On)
+ * @property string $excerpt         An excerpt of the blog post used when displaying the post
  */
 class ElggBlog extends ElggObject {
+
+	use Elgg\TimeUsing;
+
+	const UNSAVED_DRAFT = 'unsaved_draft';
+	const DRAFT = 'draft';
+	const PUBLISHED = 'published';
 
 	/**
 	 * Set subtype to blog.
@@ -57,4 +64,27 @@ class ElggBlog extends ElggObject {
 		}
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
+	public function save() {
+
+		if (!isset($this->status)) {
+			$this->status = self::DRAFT;
+		}
+
+		if (!isset($this->previous_status)) {
+			$this->previous_status = self::DRAFT;
+		}
+
+		if (!isset($this->comments_on)) {
+			$this->comments_on = 'On';
+		}
+
+		if ($this->status !== $this->previous_status) {
+			$this->time_created = $this->getCurrentTime()->getTimestamp();
+		}
+
+		return parent::save();
+	}
 }

--- a/mod/blog/lib/blog.php
+++ b/mod/blog/lib/blog.php
@@ -213,7 +213,7 @@ function blog_prepare_form_vars($post = null, $revision = null) {
 	$values = [
 		'title' => null,
 		'description' => null,
-		'status' => 'published',
+		'status' => ElggBlog::PUBLISHED,
 		'access_id' => ACCESS_DEFAULT,
 		'comments_on' => 'On',
 		'excerpt' => null,
@@ -231,7 +231,7 @@ function blog_prepare_form_vars($post = null, $revision = null) {
 			}
 		}
 
-		if ($post->status == 'draft') {
+		if ($post->status == ElggBlog::DRAFT) {
 			$values['access_id'] = $post->future_access;
 		}
 	}

--- a/mod/blog/views/default/blog/sidebar/revisions.php
+++ b/mod/blog/views/default/blog/sidebar/revisions.php
@@ -43,7 +43,7 @@ $load_base_url = "blog/edit/{$blog->getGUID()}";
 
 // show the "published revision"
 $published_item = '';
-if ($blog->status == 'published') {
+if ($blog->status == ElggBlog::PUBLISHED) {
 	$load = elgg_view('output/url', [
 		'href' => $load_base_url,
 		'text' => elgg_echo('status:published'),

--- a/mod/blog/views/default/elgg/blog/save_draft.js
+++ b/mod/blog/views/default/elgg/blog/save_draft.js
@@ -3,55 +3,45 @@
  *
  * @package Blog
  */
-define(function(require) {
+define(function (require) {
 	var $ = require('jquery');
 	var elgg = require('elgg');
+	var Ajax = require('elgg/Ajax');
+	var ajax = new Ajax(false);
 
-	var saveDraftCallback = function(data, textStatus, XHR) {
-		if (textStatus == 'success' && data.success == true) {
-			var form = $('form[id=blog-post-edit]');
-
-			// update the guid input element for new posts that now have a guid
-			form.find('input[name=guid]').val(data.guid);
-
-			oldDescription = form.find('textarea[name=description]').val();
-
-			var d = new Date();
-			var mins = d.getMinutes() + '';
-			if (mins.length == 1) {
-				mins = '0' + mins;
-			}
-			$(".blog-save-status-time").html(d.toLocaleDateString() + " @ " + d.getHours() + ":" + mins);
-		} else {
+	var saveDraftCallback = function (data, textStatus, jqXHR) {
+		if (jqXHR.AjaxData.status === -1) {
 			$(".blog-save-status-time").html(elgg.echo('error'));
+			return;
 		}
+
+		var form = $('form[id=blog-post-edit]');
+
+		// update the guid input element for new posts that now have a guid
+		form.find('input[name=guid]').val(data.guid);
+
+		oldDescription = form.find('textarea[name=description]').val();
+
+		$(".blog-save-status-time").html(data.status_time);
 	};
 
-	var saveDraft = function() {
-		if (typeof(tinyMCE) != 'undefined') {
+	var saveDraft = function () {
+		if (typeof tinyMCE !== 'undefined') {
 			tinyMCE.triggerSave();
 		}
 
 		// only save on changed content
-		var form = $('form[id=blog-post-edit]');
-		var description = form.find('textarea[name=description]').val();
-		var title = form.find('input[name=title]').val();
+		var $form = $('form[id=blog-post-edit]');
+		var description = $form.find('textarea[name=description]').val();
+		var title = $form.find('input[name=title]').val();
 
-		if (!(description && title) || (description == oldDescription)) {
+		if (!description || !title || description === oldDescription) {
 			return false;
 		}
 
-		var draftURL = elgg.config.wwwroot + "action/blog/auto_save_revision";
-		var postData = form.serializeArray();
-
-		// force draft status
-		$(postData).each(function(i, e) {
-			if (e.name == 'status') {
-				e.value = 'draft';
-			}
-		});
-
-		$.post(draftURL, postData, saveDraftCallback, 'json');
+		return ajax.action('blog/auto_save_revision', {
+			data: ajax.objectify($form)
+		}).done(saveDraftCallback);
 	};
 
 	var init = function() {

--- a/mod/blog/views/default/forms/blog/save.php
+++ b/mod/blog/views/default/forms/blog/save.php
@@ -76,8 +76,8 @@ $fields = [
 		'id' => 'blog_status',
 		'value' => elgg_extract('status', $vars),
 		'options_values' => [
-			'draft' => elgg_echo('status:draft'),
-			'published' => elgg_echo('status:published'),
+			ElggBlog::DRAFT => elgg_echo('status:draft'),
+			ElggBlog::PUBLISHED => elgg_echo('status:published'),
 		],
 	],
 	[
@@ -98,7 +98,7 @@ foreach ($fields as $field) {
 
 $save_status = elgg_echo('blog:save_status');
 if ($blog) {
-	$saved = date('F j, Y @ H:i', $blog->time_created);
+	$saved = date('F j, Y @ H:i', $blog->time_updated);
 } else {
 	$saved = elgg_echo('never');
 }
@@ -115,7 +115,7 @@ $footer .= elgg_view('input/submit', [
 ]);
 
 // published blogs do not get the preview button
-if (!$blog || $blog->status != 'published') {
+if (!$blog || $blog->status != ElggBlog::PUBLISHED) {
 	$footer .= elgg_view('input/submit', [
 		'value' => elgg_echo('preview'),
 		'name' => 'preview',
@@ -123,7 +123,7 @@ if (!$blog || $blog->status != 'published') {
 	]);
 }
 
-if ($blog) {
+if ($blog && $blog->canDelete()) {
 	// add a delete button if editing
 	$footer .= elgg_view('output/url', [
 		'href' => "action/blog/delete?guid={$vars['guid']}",


### PR DESCRIPTION
Blog attributes and metadata are now consistently updated when blog is saved
irrespective of whether the operation takes part in an action or outside of it.
Auto save action now uses new Ajax API.

BREAKING CHANGE
Response values of the blog/auto_save_revision action have been changed to use
new response API, instead of custom JSON objects.
Status changes to the blog entities that take place outside of the blog/save
action will now be reflected in the river.
ElggBlog class methods have been updated, so overriding classes may need to
reflect these changes