### PR TITLE
Adds elgg_get_title_input and handles invalid UTF-8 better

### DIFF
--- a/engine/classes/Elgg/Logger.php
+++ b/engine/classes/Elgg/Logger.php
@@ -236,7 +236,7 @@ class Logger {
 
 		if ($display == true) {
 			echo '<pre class="elgg-logger-data">';
-			echo htmlspecialchars(print_r($data, true), ENT_QUOTES, 'UTF-8');
+			echo htmlspecialchars(print_r($data, true), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 			echo '</pre>';
 		}
 		

--- a/engine/lib/input.php
+++ b/engine/lib/input.php
@@ -43,6 +43,20 @@ function set_input($variable, $value) {
 }
 
 /**
+ * Get an HTML-escaped title from input. E.g. "How to use &lt;b&gt; tags"
+ *
+ * @param string $variable The desired variable name
+ * @param string $default  The default if none given
+ *
+ * @return string
+ * @since 3.0
+ */
+function elgg_get_title_input($variable = 'title', $default = '') {
+	$raw_input = get_input($variable, $default, false);
+	return htmlspecialchars($raw_input, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+/**
  * Filter tags from a given string based on registered hooks.
  *
  * @param mixed $var Anything that does not include an object (strings, ints, arrays)

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -236,7 +236,7 @@ function elgg_format_element($tag_name, array $attributes = [], $text = '', arra
 
 	if (!empty($options['encode_text'])) {
 		$double_encode = empty($options['double_encode']) ? false : true;
-		$text = htmlspecialchars($text, ENT_QUOTES, 'UTF-8', $double_encode);
+		$text = htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', $double_encode);
 	}
 
 	if ($attributes) {

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -240,7 +240,7 @@ function validate_username($username) {
 	for ($n = 0; $n < strlen($blacklist2); $n++) {
 		if (strpos($username, $blacklist2[$n]) !== false) {
 			$msg = elgg_echo('registration:invalidchars', [$blacklist2[$n], $blacklist2]);
-			$msg = htmlspecialchars($msg, ENT_QUOTES, 'UTF-8');
+			$msg = htmlspecialchars($msg, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 			throw new \RegistrationException($msg);
 		}
 	}

--- a/mod/blog/actions/blog/auto_save_revision.php
+++ b/mod/blog/actions/blog/auto_save_revision.php
@@ -7,7 +7,7 @@
 
 $guid = get_input('guid');
 $user = elgg_get_logged_in_user_entity();
-$title = htmlspecialchars(get_input('title', '', false), ENT_QUOTES, 'UTF-8');
+$title = elgg_get_title_input();
 $description = get_input('description');
 $excerpt = get_input('excerpt');
 

--- a/mod/blog/actions/blog/save.php
+++ b/mod/blog/actions/blog/save.php
@@ -64,7 +64,7 @@ $required = ['title', 'description'];
 // load from POST and do sanity and access checking
 foreach ($values as $name => $default) {
 	if ($name === 'title') {
-		$value = htmlspecialchars(get_input('title', $default, false), ENT_QUOTES, 'UTF-8');
+		$value = elgg_get_title_input();
 	} else {
 		$value = get_input($name, $default);
 	}

--- a/mod/bookmarks/actions/bookmarks/save.php
+++ b/mod/bookmarks/actions/bookmarks/save.php
@@ -5,7 +5,7 @@
 * @package Bookmarks
 */
 
-$title = htmlspecialchars(get_input('title', '', false), ENT_QUOTES, 'UTF-8');
+$title = elgg_get_title_input();
 $description = get_input('description');
 $address = get_input('address');
 $access_id = get_input('access_id');

--- a/mod/discussions/actions/discussion/save.php
+++ b/mod/discussions/actions/discussion/save.php
@@ -4,7 +4,7 @@
  */
 
 // Get variables
-$title = htmlspecialchars(get_input('title', '', false), ENT_QUOTES, 'UTF-8');
+$title = elgg_get_title_input();
 $desc = get_input("description");
 $status = get_input("status");
 $access_id = (int) get_input("access_id");

--- a/mod/file/actions/file/upload.php
+++ b/mod/file/actions/file/upload.php
@@ -6,7 +6,7 @@
  */
 
 // Get variables
-$title = htmlspecialchars(get_input('title', '', false), ENT_QUOTES, 'UTF-8');
+$title = elgg_get_title_input();
 $desc = get_input("description");
 $access_id = (int) get_input("access_id");
 $container_guid = (int) get_input('container_guid', 0);

--- a/mod/friends_collections/actions/friends/collections/edit.php
+++ b/mod/friends_collections/actions/friends/collections/edit.php
@@ -5,7 +5,7 @@
 
 elgg_make_sticky_form('friends/collections/edit');
 
-$collection_name = htmlspecialchars(get_input('collection_name', '', false), ENT_QUOTES, 'UTF-8');
+$collection_name = elgg_get_title_input('collection_name');
 $friend_guids = (array) get_input('collection_friends', []);
 $collection_id = get_input('collection_id');
 

--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -37,9 +37,9 @@ foreach (elgg_get_config('group') as $shortname => $valuetype) {
 }
 
 // only set if submitted
-$name = get_input('name', null, false);
+$name = elgg_get_title_input('name', null);
 if ($name !== null) {
-	$input['name'] = htmlspecialchars($name, ENT_QUOTES, 'UTF-8');
+	$input['name'] = $name;
 }
 
 $user = elgg_get_logged_in_user_entity();

--- a/mod/pages/actions/pages/edit.php
+++ b/mod/pages/actions/pages/edit.php
@@ -9,7 +9,7 @@ $variables = elgg_get_config('pages');
 $input = [];
 foreach ($variables as $name => $type) {
 	if ($name == 'title') {
-		$input[$name] = htmlspecialchars(get_input($name, '', false), ENT_QUOTES, 'UTF-8');
+		$input[$name] = elgg_get_title_input();
 	} else {
 		$input[$name] = get_input($name);
 	}

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -252,7 +252,7 @@ function thewire_save_post($text, $userid, $access_id, $parent_guid = 0, $method
 	}
 
 	// no html tags allowed so we escape
-	$post->description = htmlspecialchars($text, ENT_NOQUOTES, 'UTF-8');
+	$post->description = htmlspecialchars($text, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
 
 	$post->method = $method; //method: site, email, api, ...
 

--- a/views/default/input/longtext.php
+++ b/views/default/input/longtext.php
@@ -42,7 +42,7 @@ unset($vars['visual']);
 
 $vars['data-editor-opts'] = json_encode($editor_opts);
 
-$value = htmlspecialchars($vars['value'], ENT_QUOTES, 'UTF-8');
+$value = htmlspecialchars($vars['value'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 unset($vars['value']);
 
 echo elgg_view_menu('longtext', [

--- a/views/default/input/plaintext.php
+++ b/views/default/input/plaintext.php
@@ -23,7 +23,7 @@ $defaults = [
 
 $vars = array_merge($defaults, $vars);
 
-$value = htmlspecialchars($vars['value'], ENT_QUOTES, 'UTF-8');
+$value = htmlspecialchars($vars['value'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 unset($vars['value']);
 
 echo elgg_format_element('textarea', $vars, $value);

--- a/views/default/input/userpicker.php
+++ b/views/default/input/userpicker.php
@@ -21,16 +21,22 @@ if (empty($vars['name'])) {
 	$vars['name'] = 'members';
 }
 $name = $vars['name'];
-$name = htmlspecialchars($name, ENT_QUOTES, 'UTF-8');
 
 $guids = (array) elgg_extract('values', $vars, []);
 
 $handler = elgg_extract('handler', $vars, 'livesearch');
-$handler = htmlspecialchars($handler, ENT_QUOTES, 'UTF-8');
 
 $limit = (int) elgg_extract('limit', $vars, 0);
+
+$attrs = [
+	'class' => 'elgg-user-picker',
+	'data-limit' => $limit,
+	'data-name' => $name,
+	'data-handler' => $handler,
+];
+
 ?>
-<div class="elgg-user-picker" data-limit="<?php echo $limit ?>" data-name="<?php echo $name ?>" data-handler="<?php echo $handler ?>">
+<div <?= elgg_format_attributes($attrs) ?>>
 	<input type="text" class="elgg-input-user-picker" size="30"/>
 	<?php echo elgg_view('input/hidden', ['name' => $vars['name']]); ?>
 	<?php
@@ -57,6 +63,7 @@ $limit = (int) elgg_extract('limit', $vars, 0);
 </div>
 <script>
 	require(['elgg/UserPicker'], function (UserPicker) {
-		UserPicker.setup('.elgg-user-picker[data-name="<?php echo $name ?>"]');
+		var name = <?= json_encode($name) ?>;
+		UserPicker.setup('.elgg-user-picker[data-name="' + name + '"]');
 	});
 </script>

--- a/views/default/output/email.php
+++ b/views/default/output/email.php
@@ -10,8 +10,10 @@
  *
  */
 
-$encoded_value = htmlspecialchars($vars['value'], ENT_QUOTES, 'UTF-8');
-
 if (!empty($vars['value'])) {
-	echo "<a href=\"mailto:$encoded_value\">$encoded_value</a>";
+	echo elgg_view('output/url', [
+		'href' => 'mailto:' . $vars['value'],
+		'text' => $vars['value'],
+		'encode_text' => true,
+	]);
 }

--- a/views/default/output/text.php
+++ b/views/default/output/text.php
@@ -9,4 +9,4 @@
  * @uses $vars['value'] The text to display
  */
 
-echo htmlspecialchars($vars['value'], ENT_QUOTES, 'UTF-8', false);
+echo htmlspecialchars($vars['value'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', false);

--- a/views/default/page/upgrade.php
+++ b/views/default/page/upgrade.php
@@ -20,11 +20,15 @@ if (elgg_get_config('security_protect_upgrade')) {
 	$refresh_url = elgg_http_get_signed_url($refresh_url);
 }
 
-$refresh_url = htmlspecialchars($refresh_url);
 // render content before head so that JavaScript and CSS can be loaded. See #4032
 $body = "<div style='margin-top:200px'>" . elgg_view('graphics/ajax_loader', ['hidden' => false]) . "</div>";
 
 $head = elgg_view('page/elements/head', $vars['head']);
-$head .= "<meta http-equiv='refresh' content='1;url=$refresh_url' />";
+$head .= elgg_format_element([
+	'#tag_name' => 'meta',
+	'#options' => ['is_xml' => true],
+	'http-equiv' => 'refresh',
+	'content' => '1;url=' . $refresh_url,
+]);
 
 echo elgg_view("page/elements/html", ["head" => $head, "body" => $body]);


### PR DESCRIPTION
**feat(input): Adds function to get HTML-escaped input**

By convention Elgg stores user-given titles and names as HTML-escaped strings (instead of HTML-sanitized). This encapsulates that logic in `elgg_get_title_input` as well as better-handling invalid UTF-8 characters. Invalid chars are replaced by the standard replacement character.

**fix(input): better handling of invalid UTF-8 characters**

In these cases we want `htmlspecialchars` to replace invalid UTF-8 characters with the Unicode replacement character instead of emptying the string entirely.

Content coming from the DB has already been filtered so this should not be necessary for most output views. Some output views were altered, however, in case they're used to display content directly from input.

Fixes #5790

- [x] hold until #11092 is in, then rebase if necessary
- [x] little more testing