### PR TITLE
Small tweaks from mrclay branch

### DIFF
--- a/actions/login.php
+++ b/actions/login.php
@@ -66,14 +66,7 @@ try {
 	return elgg_error_response($e->getMessage());
 }
 
-// elgg_echo() caches the language and does not provide a way to change the language.
-// @todo we need to use the config object to store this so that the current language
-// can be changed. Refs #4171
-if ($user->language) {
-	$message = elgg_echo('loginok', [], $user->language);
-} else {
-	$message = elgg_echo('loginok');
-}
+$message = elgg_echo('loginok', [], $user->getLanguage(get_current_language()));
 
 // clear after login in case login fails
 $session->remove('last_forward_from');

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -94,6 +94,8 @@ All the functions in ``engine/lib/deprecated-1.10.php`` were removed. See https:
  * ``elgg_get_metastring_map``
  * ``elgg_register_class``
  * ``elgg_register_classes``
+ * ``elgg_register_viewtype``
+ * ``elgg_is_registered_viewtype``
  * ``get_default_filestore``
  * ``garbagecollector_orphaned_metastrings``
  * ``groups_setup_sidebar_menus``
@@ -149,6 +151,7 @@ All the functions in ``engine/lib/deprecated-1.10.php`` were removed. See https:
 Removed global vars
 -------------------
 
+ * ``$CURRENT_SYSTEM_VIEWTYPE``
  * ``$DEFAULT_FILE_STORE``
  * ``$ENTITY_CACHE``
  * ``$SESSION``: Use the API provided by ``elgg_get_session()``

--- a/docs/info/config.php
+++ b/docs/info/config.php
@@ -330,11 +330,3 @@ $_ELGG->translations;
  * @access private
  */
 $_ELGG->registered_tag_metadata_names;
-
-/**
- * A list of valid view types as discovered.
- *
- * @global array $_ELGG->view_types
- * @access private
- */
-$_ELGG->view_types;

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -292,14 +292,8 @@ class Application {
 			}
 		}
 
-
-		// @todo move loading plugins into a single boot function that replaces 'boot', 'system' event
-		// and then move this code in there.
-		// This validates the view type - first opportunity to do it is after plugins load.
-		$viewtype = elgg_get_viewtype();
-		if (!elgg_is_registered_viewtype($viewtype)) {
-			elgg_set_viewtype('default');
-		}
+		// after plugins are started we know which viewtypes are populated
+		$this->services->views->clampViewtypeToPopulatedViews();
 
 		$this->allowPathRewrite();
 

--- a/engine/classes/Elgg/Cache/MetadataCache.php
+++ b/engine/classes/Elgg/Cache/MetadataCache.php
@@ -1,6 +1,9 @@
 <?php
 namespace Elgg\Cache;
 
+use ElggSharedMemoryCache;
+use Elgg\Cache\NullCache;
+
 /**
  * In memory cache of known metadata values stored by entity.
  *
@@ -21,12 +24,20 @@ class MetadataCache {
 	protected $session;
 
 	/**
+	 * @var ElggSharedMemoryCache
+	 */
+	protected $cache;
+
+	/**
 	 * Constructor
 	 *
-	 * @param \ElggSession $session The session service
+	 * @param ElggSharedMemoryCache $cache Cache
 	 */
-	public function __construct(\ElggSession $session) {
-		$this->session = $session;
+	public function __construct(ElggSharedMemoryCache $cache = null) {
+		if (!$cache) {
+			$cache = new NullCache();
+		}
+		$this->cache = $cache;
 	}
 
 	/**
@@ -67,13 +78,14 @@ class MetadataCache {
 	}
 
 	/**
-	 * Forget about all metadata for an entity. For safety this affects all access states.
+	 * Forget about all metadata for an entity.
 	 *
 	 * @param int $entity_guid The GUID of the entity
 	 * @return void
 	 */
 	public function clear($entity_guid) {
 		unset($this->values[$entity_guid]);
+		$this->cache->delete($entity_guid);
 	}
 
 	/**
@@ -92,6 +104,9 @@ class MetadataCache {
 	 * @return void
 	 */
 	public function clearAll() {
+		foreach (array_keys($this->values) as $guid) {
+			$this->cache->delete($guid);
+		}
 		$this->values = [];
 	}
 
@@ -131,6 +146,17 @@ class MetadataCache {
 			$guids = [$guids];
 		}
 		$guids = array_unique($guids);
+
+		foreach ($guids as $i => $guid) {
+			$value = $this->cache->load($guid);
+			if ($value !== false) {
+				$this->values[$guid] = unserialize($value);
+				unset($guids[$i]);
+			}
+		}
+		if (empty($guids)) {
+			return;
+		}
 
 		// could be useful at some point in future
 		//$guids = $this->filterMetadataHeavyEntities($guids);
@@ -174,6 +200,10 @@ class MetadataCache {
 				$this->values[$guid] = $metadata;
 			}
 			$last_guid = $guid;
+		}
+
+		foreach ($guids as $guid) {
+			$this->cache->save($guid, serialize($this->values[$guid]));
 		}
 	}
 

--- a/engine/classes/Elgg/Database/UsersTable.php
+++ b/engine/classes/Elgg/Database/UsersTable.php
@@ -545,6 +545,7 @@ class UsersTable {
 			':guid' => (int) $user->guid,
 		];
 
+		// these writes actually work, we just type hint read-only.
 		$user->prev_last_action = $user->last_action;
 		$user->last_action = $time;
 
@@ -589,6 +590,7 @@ class UsersTable {
 			':guid' => (int) $user->guid,
 		];
 
+		// these writes actually work, we just type hint read-only.
 		$user->prev_last_login = $user->last_login;
 		$user->last_login = $time;
 

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -271,7 +271,8 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		});
 
 		$this->setFactory('metadataCache', function (ServiceProvider $c) {
-			return new \Elgg\Cache\MetadataCache($c->session);
+			$cache = _elgg_get_memcache('metadata');
+			return new \Elgg\Cache\MetadataCache($cache);
 		});
 
 		$this->setFactory('memcacheStashPool', function(ServiceProvider $c) {

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -477,7 +477,7 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		});
 
 		$this->setFactory('views', function(ServiceProvider $c) {
-			return new \Elgg\ViewsService($c->hooks, $c->logger);
+			return new \Elgg\ViewsService($c->hooks, $c->logger, $c->input);
 		});
 
 		$this->setClassName('widgets', \Elgg\WidgetsService::class);

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1754,6 +1754,7 @@ abstract class ElggEntity extends \ElggData implements
 		$this->disableAnnotations();
 
 		_elgg_services()->entityCache->remove($guid);
+		_elgg_get_memcache('new_entity_cache')->delete($guid);
 		
 		$sql = "
 			UPDATE {$dbprefix}entities

--- a/engine/js/languages.js
+++ b/engine/js/languages.js
@@ -22,13 +22,8 @@ elgg.add_translation = function(lang, translations) {
  * @return {String}
  */
 elgg.get_language = function() {
-	var user = elgg.get_logged_in_user_entity();
-
-	if (user && user.language) {
-		return user.language;
-	}
-
-	return elgg.config.language;
+	// set by _elgg_get_js_page_data()
+	return elgg.config.current_language;
 };
 
 /**

--- a/engine/lib/actions.php
+++ b/engine/lib/actions.php
@@ -298,8 +298,6 @@ function _elgg_csrf_token_refresh() {
 function actions_init() {
 	elgg_register_page_handler('action', '_elgg_action_handler');
 	elgg_register_page_handler('refresh_token', '_elgg_csrf_token_refresh');
-
-	elgg_register_simplecache_view('languages/en.js');
 }
 
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -347,7 +347,7 @@ function elgg_unregister_external_file($type, $name) {
  * @since 1.8.0
  */
 function elgg_load_external_file($type, $name) {
-	return _elgg_services()->externalFiles->load($type, $name);
+	_elgg_services()->externalFiles->load($type, $name);
 }
 
 /**

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -15,7 +15,7 @@ use Elgg\Database\EntityTable\UserFetchFailureException;
  * unless writing their own SQL queries.  Use {@link \ElggEntity::getSubtype()}
  * to return the string subtype.
  *
- * @internal Subtypes are stored in the entity_subtypes table.  There is a foreign
+ * Subtypes are stored in the entity_subtypes table.  There is a foreign
  * key in the entities table.
  *
  * @param string $type    Type

--- a/engine/lib/languages.php
+++ b/engine/lib/languages.php
@@ -133,6 +133,3 @@ function get_missing_language_keys($language) {
 function elgg_language_key_exists($key, $language = 'en') {
 	return _elgg_services()->translator->languageKeyExists($key, $language);
 }
-
-return function(\Elgg\EventsService $events) {
-};

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -813,10 +813,11 @@ function _elgg_user_ban_notification($event, $type, $user) {
 	}
 	
 	$site = elgg_get_site_entity();
+	$language = $user->getLanguage();
 	
 	$subject = elgg_echo('user:notification:ban:subject', [$site->name], $language);
 	$body = elgg_echo('user:notification:ban:body', [
-		$recipient->name,
+		$user->name,
 		$site->name,
 		$site->getURL(),
 	], $language);

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -2004,6 +2004,7 @@ function _elgg_get_js_page_data() {
 			'lastcache' => (int) elgg_get_config('lastcache'),
 			'viewtype' => elgg_get_viewtype(),
 			'simplecache_enabled' => (int) elgg_is_simplecache_enabled(),
+			'current_language' => get_current_language(),
 		],
 		'security' => [
 			'token' => [

--- a/engine/tests/ElggCoreMetadataCacheTest.php
+++ b/engine/tests/ElggCoreMetadataCacheTest.php
@@ -67,7 +67,7 @@ class ElggCoreMetadataCacheTest extends \ElggCoreUnitTest {
 	}
 
 	public function testHas() {
-		$cache = new MetadataCache(ElggSession::getMock());
+		$cache = new MetadataCache();
 
 		$cache->inject(1, ['foo1' => 'bar']);
 		$cache->inject(2, []);
@@ -77,7 +77,7 @@ class ElggCoreMetadataCacheTest extends \ElggCoreUnitTest {
 	}
 
 	public function testLoad() {
-		$cache = new MetadataCache(ElggSession::getMock());
+		$cache = new MetadataCache();
 
 		$cache->inject(1, ['foo1' => 'bar']);
 		$cache->inject(2, []);
@@ -88,7 +88,7 @@ class ElggCoreMetadataCacheTest extends \ElggCoreUnitTest {
 	}
 
 	public function testDirectInvalidation() {
-		$cache = new MetadataCache(ElggSession::getMock());
+		$cache = new MetadataCache();
 
 		$cache->inject(1, ['foo1' => 'bar']);
 		$cache->inject(2, []);

--- a/engine/tests/ElggUserTest.php
+++ b/engine/tests/ElggUserTest.php
@@ -83,12 +83,6 @@ class ElggCoreUserTest extends \ElggCoreUnitTest {
 		$object->delete();
 	}
 
-	public function testElggUserConstructorByDbRow() {
-		$row = $this->fetchUser(elgg_get_logged_in_user_guid());
-		$user = new \ElggUser($row);
-		$this->assertIdenticalEntities($user, elgg_get_logged_in_user_entity());
-	}
-
 	public function testElggUserSave() {
 		// new object
 		$this->AssertEqual($this->user->getGUID(), 0);

--- a/engine/tests/js/prepare.js
+++ b/engine/tests/js/prepare.js
@@ -5,6 +5,7 @@ var elgg = elgg || {};
 elgg.config = elgg.config || {};
 
 elgg.config.wwwroot = 'http://www.elgg.org/';
+elgg.config.current_language = 'en';
 
 define('elgg', function() {
 	return elgg;

--- a/engine/tests/phpunit/Elgg/RouterTest.php
+++ b/engine/tests/phpunit/Elgg/RouterTest.php
@@ -84,6 +84,7 @@ class RouterTest extends \Elgg\TestCase {
 		$this->createService();
 
 		_elgg_services()->logger->disable();
+		_elgg_services()->views->setViewtype('');
 	}
 
 	public function tearDown() {

--- a/engine/tests/phpunit/ElggCoreViewtypeTest.php
+++ b/engine/tests/phpunit/ElggCoreViewtypeTest.php
@@ -3,10 +3,9 @@
 class ElggCoreViewtypeTest extends \Elgg\TestCase {
 
 	protected function setUp() {
-		global $CURRENT_SYSTEM_VIEWTYPE, $CONFIG;
-		$CURRENT_SYSTEM_VIEWTYPE = '';
 		set_input('view', '');
-		unset($CONFIG->view);
+		elgg_set_config('view', null);
+		elgg_set_viewtype('');
 	}
 
 	protected function tearDown() {
@@ -28,8 +27,7 @@ class ElggCoreViewtypeTest extends \Elgg\TestCase {
 	}
 
 	public function testConfigSetsInitialViewtype() {
-		global $CONFIG;
-		$CONFIG->view = 'bar';
+		elgg_set_config('view', 'bar');
 
 		$this->assertEquals('bar', elgg_get_viewtype());
 	}
@@ -42,13 +40,11 @@ class ElggCoreViewtypeTest extends \Elgg\TestCase {
 	}
 
 	public function testSettingConfigDoesNotChangeViewtype() {
-		global $CONFIG;
-
 		$this->assertEquals('default', elgg_get_viewtype());
 
-		$CONFIG->view = 'foo';
+		elgg_set_config('view', 'foo');
 		$this->assertEquals('default', elgg_get_viewtype());
-		unset($CONFIG->view);
+		elgg_set_config('view', null);
 	}
 
 	public function testElggIsValidViewtype() {

--- a/mod/externalpages/elgg-plugin.php
+++ b/mod/externalpages/elgg-plugin.php
@@ -1,6 +1,23 @@
 <?php
 
 return [
+	'entities' => [
+		[
+			'type' => 'object',
+			'subtype' => 'about',
+			'searchable' => false,
+		],
+		[
+			'type' => 'object',
+			'subtype' => 'terms',
+			'searchable' => false,
+		],
+		[
+			'type' => 'object',
+			'subtype' => 'privacy',
+			'searchable' => false,
+		],
+	],
 	'actions' => [
 		'expages/edit' => [
 			'access' => 'admin',

--- a/mod/externalpages/start.php
+++ b/mod/externalpages/start.php
@@ -76,7 +76,7 @@ function expages_page_handler($page, $handler) {
 	$type = strtolower($handler);
 
 	$title = elgg_echo("expages:$type");
-	
+
 	$object = elgg_get_entities([
 		'type' => 'object',
 		'subtype' => $type,


### PR DESCRIPTION
**fix(entities): memcache no longer returns disabled entities**

Fixes #10970

**perf(metadata): memcache most metadata**

All metadata fetched through the MetadataCache is also stored in memcached.

**fix(expages): don't log notice if pages aren't created**

**fix(notifications): fixes banned user notification language/name**

**chore(tests): removes unneeded and flaky test**

**chore(actions): removes unneeded login code**

**chore(usersTable): document writing to read-only properties**

**fix(i18n): set language via GET var works for client-side translation**

Eg. Add `?hl=es` to URL and `elgg.echo('post')` in console.

**chore(views): removes API around viewtypes**

BREAKING CHANGES:
`elgg_register_viewtype` and `elgg_is_registered_viewtype` are no longer available.