### PR TITLE
chore(core): allows static analysis/autocomplete of internal config usage

### DIFF
--- a/engine/classes/Elgg/ActionsService.php
+++ b/engine/classes/Elgg/ActionsService.php
@@ -104,7 +104,7 @@ class ActionsService {
 			}
 		}
 	
-		$forwarder = str_replace($this->config->getSiteUrl(), "", $forwarder);
+		$forwarder = str_replace($this->config->wwwroot, "", $forwarder);
 		$forwarder = str_replace("http://", "", $forwarder);
 		$forwarder = str_replace("@", "", $forwarder);
 		if (substr($forwarder, 0, 1) == "/") {
@@ -174,7 +174,7 @@ class ActionsService {
 		}
 
 		// set the maximum execution time for actions
-		$action_timeout = $this->config->get('action_time_limit');
+		$action_timeout = $this->config->action_time_limit;
 		if (isset($action_timeout)) {
 			set_time_limit($action_timeout);
 		}
@@ -262,7 +262,7 @@ class ActionsService {
 					if (elgg_is_xhr()) {
 						register_error(_elgg_services()->translator->translate(
 							'js:security:token_refresh_failed',
-							[$this->config->getSiteUrl()]
+							[$this->config->wwwroot]
 						));
 					} else {
 						register_error(_elgg_services()->translator->translate('actiongatekeeper:timeerror'));
@@ -271,7 +271,7 @@ class ActionsService {
 			} else if ($visible_errors) {
 				// this is necessary because of #5133
 				if (elgg_is_xhr()) {
-					register_error(_elgg_services()->translator->translate('js:security:token_refresh_failed', [$this->config->getSiteUrl()]));
+					register_error(_elgg_services()->translator->translate('js:security:token_refresh_failed', [$this->config->wwwroot]));
 				} else {
 					register_error(_elgg_services()->translator->translate('actiongatekeeper:tokeninvalid'));
 				}
@@ -317,7 +317,7 @@ class ActionsService {
 	 * @return int number of seconds that action token is valid
 	 */
 	public function getActionTokenTimeout() {
-		if (($timeout = $this->config->get('action_token_timeout')) === null) {
+		if (($timeout = $this->config->action_token_timeout) === null) {
 			// default to 2 hours
 			$timeout = 2;
 		}

--- a/engine/classes/Elgg/BatchUpgrader.php
+++ b/engine/classes/Elgg/BatchUpgrader.php
@@ -30,9 +30,9 @@ class BatchUpgrader {
 	public function __construct(Config $config) {
 		$this->config = $config;
 
-		// Custom limit can be defined in elgg-config/settings.php if necessary
-		if (empty($this->config->get('batch_run_time_in_secs'))) {
-			$this->config->set('batch_run_time_in_secs', 4);
+		// Custom limit can be defined in settings.php if necessary
+		if (empty($this->config->batch_run_time_in_secs)) {
+			$this->config->batch_run_time_in_secs = 4;
 		}
 	}
 
@@ -72,7 +72,7 @@ class BatchUpgrader {
 		$result = null;
 
 		$condition = function () use (&$count, &$processed, &$result, $started) {
-			if ((microtime(true) - $started) >= $this->config->get('batch_run_time_in_secs')) {
+			if ((microtime(true) - $started) >= $this->config->batch_run_time_in_secs) {
 				return false;
 			}
 			if ($result && $result->wasMarkedComplete()) {

--- a/engine/classes/Elgg/Cache/MetadataCache.php
+++ b/engine/classes/Elgg/Cache/MetadataCache.php
@@ -136,7 +136,7 @@ class MetadataCache {
 			return;
 		}
 		
-		$version = (int) elgg_get_config('version');
+		$version = (int) _elgg_config()->version;
 		if (!empty($version) && ($version < 2016110900)) {
 			// can't use this during upgrade from 2.x to 3.0
 			return;
@@ -161,7 +161,6 @@ class MetadataCache {
 		// could be useful at some point in future
 		//$guids = $this->filterMetadataHeavyEntities($guids);
 
-		$db_prefix = _elgg_services()->db->prefix;
 		$options = [
 			'guids' => $guids,
 			'limit' => 0,
@@ -217,7 +216,7 @@ class MetadataCache {
 	 * @return array
 	 */
 	public function filterMetadataHeavyEntities(array $guids, $limit = 1024000) {
-		$db_prefix = _elgg_services()->config->get('dbprefix');
+		$db_prefix = _elgg_config()->dbprefix;
 
 		$options = [
 			'guids' => $guids,

--- a/engine/classes/Elgg/Cache/SimpleCache.php
+++ b/engine/classes/Elgg/Cache/SimpleCache.php
@@ -102,7 +102,7 @@ class SimpleCache {
 	function getRoot() {
 		$viewtype = elgg_get_viewtype();
 		if ($this->isEnabled()) {
-			$lastcache = (int) $this->config->get('lastcache');
+			$lastcache = (int) $this->config->lastcache;
 		} else {
 			$lastcache = 0;
 		}
@@ -116,7 +116,7 @@ class SimpleCache {
 	 * @return bool
 	 */
 	function isEnabled() {
-		return (bool) $this->config->get('simplecache_enabled');
+		return (bool) $this->config->simplecache_enabled;
 	}
 
 	/**
@@ -139,7 +139,7 @@ class SimpleCache {
 	 * @return void
 	 */
 	function disable() {
-		if ($this->config->get('simplecache_enabled')) {
+		if ($this->config->simplecache_enabled) {
 			$this->config->save('simplecache_enabled', 0);
 
 			$this->invalidate();
@@ -167,7 +167,7 @@ class SimpleCache {
 
 		$time = time();
 		$this->config->save("simplecache_lastupdate", $time);
-		$this->config->set('lastcache', $time);
+		$this->config->lastcache = $time;
 
 		return true;
 	}
@@ -178,9 +178,9 @@ class SimpleCache {
 	 * @return void
 	 */
 	function init() {
-		$lastcache = $this->config->get('lastcache');
+		$lastcache = $this->config->lastcache;
 		if (!defined('UPGRADING') && empty($lastcache)) {
-			$this->config->set('lastcache', (int) $this->config->get('simplecache_lastupdate'));
+			$this->config->lastcache = (int) $this->config->simplecache_lastupdate;
 		}
 	}
 }

--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -11,6 +11,88 @@ use Elgg\Database\ConfigTable;
  * Access to configuration values
  *
  * @since 1.10.0
+ *
+ * @property int           $action_time_limit
+ * @property int           $action_token_timeout
+ * @property bool          $allow_registration
+ * @property string        $allow_user_default_access
+ * @property bool          $auto_disable_plugins
+ * @property int           $batch_run_time_in_secs
+ * @property bool          $boot_complete
+ * @property int           $boot_cache_ttl
+ * @property array         $breadcrumbs
+ * @property string        $cacheroot         Path of cache storage with trailing "/"
+ * @property string        $dataroot          Path of data storage with trailing "/"
+ * @property bool          $data_dir_override
+ * @property array         $db
+ * @property string        $dbencoding
+ * @property string        $dbname
+ * @property string        $dbuser
+ * @property string        $dbhost
+ * @property string        $dbpass
+ * @property string        $dbprefix
+ * @property string        $debug
+ * @property int           $default_access
+ * @property int           $default_limit
+ * @property array         $default_widget_info
+ * @property bool          $elgg_config_locks The application will lock some settings (default true)
+ * @property string[]      $elgg_cron_periods
+ * @property bool          $elgg_load_sync_code
+ * @property bool          $elgg_maintenance_mode
+ * @property string        $elgg_settings_file
+ * @property bool          $enable_profiling
+ * @property mixed         $embed_tab
+ * @property string        $exception_include
+ * @property string[]      $group
+ * @property array         $group_tool_options
+ * @property bool          $i18n_loaded_from_cache
+ * @property array         $icon_sizes
+ * @property string        $installed
+ * @property bool          $installer_running
+ * @property string        $language     Site language code
+ * @property int           $lastcache
+ * @property \ElggLogCache $log_cache
+ * @property array         $libraries
+ * @property bool          $memcache
+ * @property array         $memcache_servers
+ * @property array         $menus
+ * @property int           $min_password_length
+ * @property string[]      $pages
+ * @property-read string   $path         Path of composer install with trailing "/"
+ * @property-read string   $pluginspath  Alias of plugins_path
+ * @property-read string   $plugins_path Path of project "mod/" directory
+ * @property array         $profile_custom_fields
+ * @property array         $profile_fields
+ * @property string        $profiling_minimum_percentage
+ * @property bool          $profiling_sql
+ * @property array         $processed_upgrades
+ * @property string[]      $registered_entities
+ * @property bool          $security_disable_password_autocomplete
+ * @property bool          $security_email_require_password
+ * @property bool          $security_notify_admins
+ * @property bool          $security_notify_user_admin
+ * @property bool          $security_notify_user_ban
+ * @property bool          $security_protect_cron
+ * @property bool          $security_protect_upgrade
+ * @property int           $simplecache_enabled
+ * @property int           $simplecache_lastupdate
+ * @property bool          $simplecache_minify_css
+ * @property bool          $simplecache_minify_js
+ * @property \ElggSite     $site
+ * @property string        $sitedescription
+ * @property string        $sitename
+ * @property string[]      $site_custom_menu_items
+ * @property string[]      $site_featured_menu_names
+ * @property-read int      $site_guid
+ * @property bool          $system_cache_enabled
+ * @property bool          $system_cache_loaded
+ * @property string        $url          Alias of "wwwroot"
+ * @property int           $version
+ * @property string        $view         Default viewtype (usually not set)
+ * @property bool          $walled_garden
+ * @property string        $wwwroot      Site URL
+ * @property bool          $_boot_cache_hit
+ * @property bool          $_elgg_autofeed
  */
 class Config implements Services\Config {
 	/**
@@ -161,6 +243,16 @@ class Config implements Services\Config {
 	}
 
 	/**
+	 * Use get() to read a property
+	 *
+	 * @param string $name Name
+	 * @return mixed
+	 */
+	public function __get($name) {
+		return $this->get($name);
+	}
+
+	/**
 	 * {@inheritdoc}
 	 */
 	public function getVolatile($name) {
@@ -173,6 +265,39 @@ class Config implements Services\Config {
 	public function set($name, $value) {
 		$name = trim($name);
 		$this->config->$name = $value;
+	}
+
+	/**
+	 * Set an Elgg configuration value
+	 *
+	 * @warning This does not persist the configuration setting. Use elgg_save_config()
+	 *
+	 * @param string $name  Name
+	 * @param mixed  $value Value
+	 * @return void
+	 */
+	public function __set($name, $value) {
+		$this->set($name, $value);
+	}
+
+	/**
+	 * Handle isset()
+	 *
+	 * @param string $name Name
+	 * @return bool
+	 */
+	public function __isset($name) {
+		return $this->get($name) !== null;
+	}
+
+	/**
+	 * Handle unset()
+	 *
+	 * @param string $name Name
+	 * @return void
+	 */
+	public function __unset($name) {
+		unset($this->config->{$name});
 	}
 
 	/**

--- a/engine/classes/Elgg/Database/ConfigTable.php
+++ b/engine/classes/Elgg/Database/ConfigTable.php
@@ -101,7 +101,7 @@ class ConfigTable {
 			':value' => serialize($value),
 		];
 		
-		$version = (int) elgg_get_config('version');
+		$version = (int) _elgg_config()->version;
 		
 		if (!empty($version) && $version < 2016102500) {
 			// need to do this the old way as long as site_guid columns have not been dropped

--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -520,7 +520,7 @@ class EntityTable {
 			'reverse_order_by'      => false,
 			'order_by'              => 'e.time_created desc',
 			'group_by'              => ELGG_ENTITIES_ANY_VALUE,
-			'limit'                 => $this->config->get('default_limit'),
+			'limit'                 => $this->config->default_limit,
 			'offset'                => 0,
 			'count'                 => false,
 			'selects'               => [],

--- a/engine/classes/Elgg/Database/Plugins.php
+++ b/engine/classes/Elgg/Database/Plugins.php
@@ -115,7 +115,7 @@ class Plugins {
 	function generateEntities() {
 	
 		$mod_dir = elgg_get_plugins_path();
-		$db_prefix = elgg_get_config('dbprefix');
+		$db_prefix = _elgg_config()->dbprefix;
 	
 		// ignore access in case this is called with no admin logged in - needed for creating plugins perhaps?
 		$old_ia = elgg_set_ignore_access(true);
@@ -218,7 +218,7 @@ class Plugins {
 	function get($plugin_id) {
 		return $this->plugins_by_id->get($plugin_id, function () use ($plugin_id) {
 			$plugin_id = sanitize_string($plugin_id);
-			$db_prefix = elgg_get_config('dbprefix');
+			$db_prefix = _elgg_config()->dbprefix;
 
 			$options = [
 				'type' => 'object',
@@ -261,7 +261,7 @@ class Plugins {
 	 * @access private
 	 */
 	function getMaxPriority() {
-		$db_prefix = elgg_get_config('dbprefix');
+		$db_prefix = _elgg_config()->dbprefix;
 		$priority = $this->namespacePrivateSetting('internal', 'priority');
 		$plugin_subtype = get_subtype_id('object', 'plugin');
 	
@@ -342,8 +342,10 @@ class Plugins {
 			}
 			return false;
 		}
+
+		$config = _elgg_config();
 	
-		if (elgg_get_config('system_cache_loaded')) {
+		if ($config->system_cache_loaded) {
 			$start_flags = $start_flags & ~ELGG_PLUGIN_REGISTER_VIEWS;
 		}
 	
@@ -364,7 +366,7 @@ class Plugins {
 				$plugin->start($start_flags);
 				$this->active_guids[$id] = $plugin->guid;
 			} catch (Exception $e) {
-				$disable_plugins = elgg_get_config('auto_disable_plugins');
+				$disable_plugins = _elgg_config()->auto_disable_plugins;
 				if ($disable_plugins === null) {
 					$disable_plugins = true;
 				}

--- a/engine/classes/Elgg/Database/UsersTable.php
+++ b/engine/classes/Elgg/Database/UsersTable.php
@@ -333,7 +333,7 @@ class UsersTable {
 	
 		$options = array_merge([
 			'seconds' => 600,
-			'limit' => $this->config->get('default_limit'),
+			'limit' => $this->config->default_limit,
 		], $options);
 
 		// cast options we're sending to hook
@@ -356,7 +356,7 @@ class UsersTable {
 			return $data;
 		}
 
-		$dbprefix = $this->config->get('dbprefix');
+		$dbprefix = $this->config->dbprefix;
 		$time = $this->getCurrentTime()->getTimestamp() - $options['seconds'];
 		return elgg_get_entities([
 			'type' => 'user',

--- a/engine/classes/Elgg/Debug/Inspector.php
+++ b/engine/classes/Elgg/Debug/Inspector.php
@@ -226,7 +226,7 @@ class Inspector {
 	 */
 	public function getMenus() {
 
-		$menus = elgg_get_config('menus');
+		$menus = _elgg_config()->menus;
 
 		// get JIT menu items
 		// note that 'river' is absent from this list - hooks attempt to get object/subject entities cause problems

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -350,7 +350,7 @@ class ServiceProvider extends \Elgg\Di\DiContainer {
 		$this->setFactory('redirects', function(ServiceProvider $c) {
 			$url = current_page_url();
 			$is_xhr = $c->request->isXmlHttpRequest();
-			return new \Elgg\RedirectService($c->session, $is_xhr, $c->config->getSiteUrl(), $url);
+			return new \Elgg\RedirectService($c->session, $is_xhr, $c->config->wwwroot, $url);
 		});
 
 		$this->setFactory('relationshipsTable', function(ServiceProvider $c) {

--- a/engine/classes/Elgg/EntityIconService.php
+++ b/engine/classes/Elgg/EntityIconService.php
@@ -470,7 +470,7 @@ class EntityIconService {
 			$type = 'icon';
 		}
 		if ($type == 'icon') {
-			$sizes = $this->config->get('icon_sizes');
+			$sizes = $this->config->icon_sizes;
 		}
 		$params = [
 			'type' => $type,

--- a/engine/classes/Elgg/PasswordService.php
+++ b/engine/classes/Elgg/PasswordService.php
@@ -76,7 +76,7 @@ final class PasswordService {
 		$user->setPrivateSetting('passwd_conf_time', time());
 
 		// generate link
-		$link = _elgg_services()->config->getSiteUrl() . "changepassword?u=$user_guid&c=$code";
+		$link = _elgg_services()->config->wwwroot . "changepassword?u=$user_guid&c=$code";
 		$link = _elgg_services()->urlSigner->sign($link, '+1 day');
 		
 		// generate email

--- a/engine/classes/Elgg/Profiler.php
+++ b/engine/classes/Elgg/Profiler.php
@@ -96,7 +96,7 @@ class Profiler {
 	 */
 	public static function handlePageOutput($hook, $type, $html, $params) {
 		$profiler = new self();
-		$min_percentage = elgg_get_config('profiling_minimum_percentage');
+		$min_percentage = _elgg_config()->profiling_minimum_percentage;
 		if ($min_percentage !== null) {
 			$profiler->minimum_percentage = $min_percentage;
 		}

--- a/engine/classes/Elgg/Router.php
+++ b/engine/classes/Elgg/Router.php
@@ -53,7 +53,7 @@ class Router {
 			$segments = [];
 		}
 
-		$is_walled_garden = _elgg_services()->config->get('walled_garden');
+		$is_walled_garden = _elgg_config()->walled_garden;
 		$is_logged_in = _elgg_services()->session->isLoggedIn();
 		$url = elgg_normalize_url($identifier . '/' . implode('/', $segments));
 		
@@ -218,7 +218,7 @@ class Router {
 		$url = elgg_http_build_url($parts);
 		$url = rtrim($url, '/') . '/';
 
-		$site_url = _elgg_services()->config->getSiteUrl();
+		$site_url = _elgg_services()->config->wwwroot;
 
 		if ($url == $site_url) {
 			// always allow index page

--- a/engine/classes/Elgg/UpgradeService.php
+++ b/engine/classes/Elgg/UpgradeService.php
@@ -191,7 +191,7 @@ class UpgradeService {
 	 * @return mixed Array of processed upgrade filenames or false
 	 */
 	protected function getProcessedUpgrades() {
-		return $this->config->get('processed_upgrades');
+		return $this->config->processed_upgrades;
 	}
 
 	/**
@@ -261,7 +261,7 @@ class UpgradeService {
 		}
 
 		if ($processed_upgrades === null) {
-			$processed_upgrades = $this->config->get('processed_upgrades');
+			$processed_upgrades = $this->config->processed_upgrades;
 			if (!is_array($processed_upgrades)) {
 				$processed_upgrades = [];
 			}
@@ -277,7 +277,7 @@ class UpgradeService {
 	 * @return bool
 	 */
 	protected function processUpgrades() {
-		$dbversion = (int) $this->config->get('version');
+		$dbversion = (int) $this->config->version;
 
 		if ($this->upgradeCode($dbversion)) {
 			system_message($this->translator->translate('upgrade:core'));

--- a/engine/classes/ElggBatch.php
+++ b/engine/classes/ElggBatch.php
@@ -221,7 +221,7 @@ class ElggBatch implements BatchResult {
 
 		// store these so we can compare later
 		$this->offset = elgg_extract('offset', $options, 0);
-		$this->limit = elgg_extract('limit', $options, elgg_get_config('default_limit'));
+		$this->limit = elgg_extract('limit', $options, _elgg_config()->default_limit);
 
 		// if passed a callback, create a new \ElggBatch with the same options
 		// and pass each to the callback.

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1711,7 +1711,7 @@ abstract class ElggEntity extends \ElggData implements
 			$this->disable_reason = $reason;
 		}
 
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 		
 		$guid = (int) $this->guid;
 		
@@ -1950,7 +1950,7 @@ abstract class ElggEntity extends \ElggData implements
 		_elgg_invalidate_cache_for_entity($guid);
 		_elgg_invalidate_memcache_for_entity($guid);
 
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 		
 		$sql = "
 			DELETE FROM {$dbprefix}entities

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -367,7 +367,7 @@ class ElggInstaller {
 			],
 			'wwwroot' => [
 				'type' => 'url',
-				'value' => _elgg_services()->config->getSiteUrl(),
+				'value' => _elgg_services()->config->wwwroot,
 				'required' => true,
 			],
 			'timezone' => [
@@ -620,7 +620,7 @@ class ElggInstaller {
 	 */
 	protected function getNextStepUrl($currentStep) {
 		$nextStep = $this->getNextStep($currentStep);
-		return _elgg_services()->config->getSiteUrl() . "install.php?step=$nextStep";
+		return _elgg_services()->config->wwwroot . "install.php?step=$nextStep";
 	}
 
 	/**
@@ -1153,7 +1153,7 @@ class ElggInstaller {
 	 */
 	protected function checkRewriteRules(&$report) {
 		$tester = new ElggRewriteTester();
-		$url = _elgg_services()->config->getSiteUrl() . "rewrite.php";
+		$url = _elgg_services()->config->wwwroot . "rewrite.php";
 		$report['rewrite'] = [$tester->run($url, Directory\Local::root()->getPath())];
 	}
 

--- a/engine/classes/ElggMemcache.php
+++ b/engine/classes/ElggMemcache.php
@@ -40,7 +40,7 @@ class ElggMemcache extends \ElggSharedMemoryCache {
 		$this->stash_pool = $pool;
 
 		if ($ttl === null) {
-			$ttl = _elgg_services()->config->get('memcache_expires');
+			$ttl = _elgg_config()->memcache_expires;
 		}
 		if (isset($ttl)) {
 			$this->ttl = $ttl;

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -59,7 +59,7 @@ class ElggPlugin extends \ElggObject {
 		if (is_object($path)) {
 			// database object
 			parent::__construct($path);
-			$this->path = _elgg_services()->config->getPluginsPath() . $this->getID();
+			$this->path = _elgg_services()->config->pluginspath . $this->getID();
 			_elgg_cache_plugin_by_id($this);
 			return;
 		}
@@ -344,7 +344,7 @@ class ElggPlugin extends \ElggObject {
 			return false;
 		}
 
-		$db_prefix = _elgg_services()->config->get('dbprefix');
+		$db_prefix = _elgg_config()->dbprefix;
 		// need to remove all namespaced private settings.
 		$us_prefix = _elgg_namespace_plugin_private_setting('user_setting', '', $this->getID());
 
@@ -476,7 +476,7 @@ class ElggPlugin extends \ElggObject {
 
 		$defaults = $this->getStaticConfig('user_settings', []);
 		
-		$db_prefix = _elgg_services()->config->get('dbprefix');
+		$db_prefix = _elgg_config()->dbprefix;
 		// send an empty name so we just get the first part of the namespace
 		$ps_prefix = _elgg_namespace_plugin_private_setting('user_setting', '', $this->getID());
 		$ps_prefix_len = strlen($ps_prefix);

--- a/engine/classes/ElggPluginPackage.php
+++ b/engine/classes/ElggPluginPackage.php
@@ -100,7 +100,7 @@ class ElggPluginPackage {
 	 * @throws PluginException
 	 */
 	public function __construct($plugin, $validate = true) {
-		$plugin_path = _elgg_services()->config->getPluginsPath();
+		$plugin_path = _elgg_services()->config->pluginspath;
 		// @todo wanted to avoid another is_dir() call here.
 		// should do some profiling to see how much it affects
 		if (strpos($plugin, $plugin_path) === 0 || is_dir($plugin)) {

--- a/engine/classes/ElggRewriteTester.php
+++ b/engine/classes/ElggRewriteTester.php
@@ -102,7 +102,7 @@ class ElggRewriteTester {
 	 * @return boolean
 	 */
 	public function runLocalhostAccessTest() {
-		$url = _elgg_services()->config->getSiteUrl();
+		$url = _elgg_services()->config->wwwroot;
 		return (bool) $this->fetchUrl($url);
 	}
 

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -113,7 +113,7 @@ class ElggSite extends \ElggEntity {
 	 * @return string The URL
 	 */
 	public function getURL() {
-		return _elgg_services()->config->getSiteUrl();
+		return _elgg_services()->config->wwwroot;
 	}
 
 	/**

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -29,15 +29,15 @@
  * @since 1.8.0
  */
 function elgg_get_admins(array $options = []) {
-	global $CONFIG;
+	$config = _elgg_config();
 
 	if (isset($options['joins'])) {
 		if (!is_array($options['joins'])) {
 			$options['joins'] = [$options['joins']];
 		}
-		$options['joins'][] = "join {$CONFIG->dbprefix}users_entity u on e.guid=u.guid";
+		$options['joins'][] = "join {$config->dbprefix}users_entity u on e.guid=u.guid";
 	} else {
-		$options['joins'] = ["join {$CONFIG->dbprefix}users_entity u on e.guid=u.guid"];
+		$options['joins'] = ["join {$config->dbprefix}users_entity u on e.guid=u.guid"];
 	}
 
 	if (isset($options['wheres'])) {
@@ -806,7 +806,7 @@ function _elgg_add_admin_widgets($event, $type, $user) {
  */
 function _elgg_admin_get_admin_subscribers_admin_action($hook, $type, $return_value, $params) {
 	
-	if (!elgg_get_config('security_notify_admins')) {
+	if (!_elgg_config()->security_notify_admins) {
 		return;
 	}
 	
@@ -947,7 +947,7 @@ function _elgg_admin_prepare_admin_notification_remove_admin($hook, $type, $retu
  */
 function _elgg_admin_get_user_subscriber_admin_action($hook, $type, $return_value, $params) {
 	
-	if (!elgg_get_config('security_notify_user_admin')) {
+	if (!_elgg_config()->security_notify_user_admin) {
 		return;
 	}
 	

--- a/engine/lib/autoloader.php
+++ b/engine/lib/autoloader.php
@@ -23,6 +23,16 @@ function _elgg_services(\Elgg\Di\ServiceProvider $services = null) {
 }
 
 /**
+ * Get the Elgg config service
+ *
+ * @return \Elgg\Config
+ * @access private
+ */
+function _elgg_config() {
+	return _elgg_services()->config;
+}
+
+/**
  * Delete the autoload system cache
  *
  * @access private

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -23,7 +23,7 @@ use Elgg\Filesystem\Directory;
  * @since 1.8.0
  */
 function elgg_get_site_url() {
-	return _elgg_services()->config->getSiteUrl();
+	return _elgg_services()->config->wwwroot;
 }
 
 /**
@@ -33,7 +33,7 @@ function elgg_get_site_url() {
  * @since 1.8.0
  */
 function elgg_get_plugins_path() {
-	return _elgg_services()->config->getPluginsPath();
+	return _elgg_services()->config->pluginspath;
 }
 
 /**
@@ -96,7 +96,7 @@ function elgg_get_config($name) {
 		elgg_deprecated_notice($msg, '2.2');
 	}
 
-	return _elgg_services()->config->get($name);
+	return _elgg_config()->$name;
 }
 
 /**
@@ -111,7 +111,7 @@ function elgg_get_config($name) {
  * @since 1.8.0
  */
 function elgg_set_config($name, $value) {
-	_elgg_services()->config->set($name, $value);
+	_elgg_config()->$name = $value;
 }
 
 /**
@@ -124,7 +124,7 @@ function elgg_set_config($name, $value) {
  * @since 1.8.0
  */
 function elgg_save_config($name, $value) {
-	return _elgg_services()->config->save($name, $value);
+	return _elgg_config()->save($name, $value);
 }
 
 /**
@@ -135,7 +135,7 @@ function elgg_save_config($name, $value) {
  * @return bool Success or failure
  */
 function elgg_remove_config($name) {
-	return _elgg_services()->config->remove($name);
+	return _elgg_config()->remove($name);
 }
 
 /**

--- a/engine/lib/cron.php
+++ b/engine/lib/cron.php
@@ -110,13 +110,13 @@ function _elgg_cron_page_handler($page) {
 		forward();
 	}
 
-	if (PHP_SAPI !== 'cli' && elgg_get_config('security_protect_cron')) {
+	if (PHP_SAPI !== 'cli' && _elgg_config()->security_protect_cron) {
 		elgg_signed_request_gatekeeper();
 	}
 	
 	$period = strtolower($page[0]);
 
-	$allowed_periods = elgg_get_config('elgg_cron_periods');
+	$allowed_periods = _elgg_config()->elgg_cron_periods;
 
 	if (($period != 'run') && !in_array($period, $allowed_periods)) {
 		throw new \CronException("$period is not a recognized cron period.");
@@ -160,7 +160,7 @@ function _elgg_cron_page_handler($page) {
  */
 function _elgg_cron_monitor($hook, $period, $output, $params) {
 	$time = $params['time'];
-	$periods = elgg_get_config('elgg_cron_periods');
+	$periods = _elgg_config()->elgg_cron_periods;
 
 	if (in_array($period, $periods)) {
 		$key = "cron_latest:$period:ts";

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -33,14 +33,12 @@ function elgg() {
  * @since 1.8.0
  */
 function elgg_register_library($name, $location) {
-	$config = _elgg_services()->config;
-
-	$libraries = $config->get('libraries');
+	$libraries = _elgg_config()->libraries;
 	if ($libraries === null) {
 		$libraries = [];
 	}
 	$libraries[$name] = $location;
-	$config->set('libraries', $libraries);
+	_elgg_config()->libraries = $libraries;
 }
 
 /**
@@ -61,7 +59,7 @@ function elgg_load_library($name) {
 		return;
 	}
 
-	$libraries = _elgg_services()->config->get('libraries');
+	$libraries = _elgg_config()->libraries;
 
 	if (!isset($libraries[$name])) {
 		$error = "$name is not a registered library";

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -397,7 +397,7 @@ function elgg_list_entities(array $options = [], $getter = 'elgg_get_entities',
 
 	$defaults = [
 		'offset' => (int) max(get_input($offset_key, 0), 0),
-		'limit' => (int) max(get_input('limit', elgg_get_config('default_limit')), 0),
+		'limit' => (int) max(get_input('limit', _elgg_config()->default_limit), 0),
 		'full_view' => false,
 		'list_type_toggle' => false,
 		'pagination' => true,

--- a/engine/lib/filestore.php
+++ b/engine/lib/filestore.php
@@ -305,7 +305,7 @@ function delete_directory($directory) {
  */
 function _elgg_clear_entity_files($entity) {
 	$dir = new \Elgg\EntityDirLocator($entity->guid);
-	$file_path = elgg_get_config('dataroot') . $dir;
+	$file_path = _elgg_config()->dataroot . $dir;
 	if (file_exists($file_path)) {
 		delete_directory($file_path);
 	}

--- a/engine/lib/group.php
+++ b/engine/lib/group.php
@@ -17,11 +17,10 @@
  * @access private
  */
 function get_group_entity_as_row($guid) {
-	global $CONFIG;
-
 	$guid = (int) $guid;
 
-	return get_data_row("SELECT * from {$CONFIG->dbprefix}groups_entity where guid=$guid");
+	$prefix = _elgg_config()->dbprefix;
+	return get_data_row("SELECT * from {$prefix}groups_entity where guid=$guid");
 }
 
 /**
@@ -37,19 +36,16 @@ function get_group_entity_as_row($guid) {
  * @since 1.5.0
  */
 function add_group_tool_option($name, $label, $default_on = true) {
-	global $CONFIG;
-
-	if (!isset($CONFIG->group_tool_options)) {
-		$CONFIG->group_tool_options = [];
+	$options = _elgg_config()->group_tool_options;
+	if (!$options) {
+		$options = [];
 	}
-
-	$group_tool_option = new \stdClass;
-
-	$group_tool_option->name = $name;
-	$group_tool_option->label = $label;
-	$group_tool_option->default_on = $default_on;
-
-	$CONFIG->group_tool_options[] = $group_tool_option;
+	$options[] = (object) [
+		'name' => $name,
+		'label' => $label,
+		'default_on' => $default_on,
+	];
+	_elgg_config()->group_tool_options = $options;
 }
 
 /**
@@ -63,17 +59,18 @@ function add_group_tool_option($name, $label, $default_on = true) {
  * @since 1.7.5
  */
 function remove_group_tool_option($name) {
-	global $CONFIG;
-
-	if (!isset($CONFIG->group_tool_options)) {
+	$options = _elgg_config()->group_tool_options;
+	if (!is_array($options)) {
 		return;
 	}
 
-	foreach ($CONFIG->group_tool_options as $i => $option) {
+	foreach ($options as $i => $option) {
 		if ($option->name == $name) {
-			unset($CONFIG->group_tool_options[$i]);
+			unset($options[$i]);
 		}
 	}
+
+	_elgg_config()->group_tool_options = $options;
 }
 
 /**

--- a/engine/lib/input.php
+++ b/engine/lib/input.php
@@ -193,7 +193,7 @@ function elgg_clear_sticky_value($form_name, $variable) {
  * @access private
  */
 function input_livesearch_page_handler($page) {
-	$dbprefix = elgg_get_config('dbprefix');
+	$dbprefix = _elgg_config()->dbprefix;
 
 	// only return results to logged in users.
 	if (!$user = elgg_get_logged_in_user_entity()) {
@@ -227,7 +227,7 @@ function input_livesearch_page_handler($page) {
 		$owner_guid = $user->getGUID();
 	}
 
-	$limit = sanitise_int(get_input('limit', elgg_get_config('default_limit')));
+	$limit = sanitise_int(get_input('limit', _elgg_config()->default_limit));
 
 	// grab a list of entities and send them in json.
 	$results = [];
@@ -549,7 +549,7 @@ function _elgg_htmlawed_test($hook, $type, $value, $params) {
  */
 function _elgg_disable_password_autocomplete($hook, $type, $return_value, $params) {
 	
-	if (!elgg_get_config('security_disable_password_autocomplete')) {
+	if (!_elgg_config()->security_disable_password_autocomplete) {
 		return;
 	}
 	

--- a/engine/lib/metastrings.php
+++ b/engine/lib/metastrings.php
@@ -92,7 +92,7 @@ function _elgg_get_metastring_based_objects($options) {
 
 		// sql
 		'order_by' => 'n_table.time_created ASC, n_table.id ASC',
-		'limit' => elgg_get_config('default_limit'),
+		'limit' => _elgg_config()->default_limit,
 		'offset' => 0,
 		'count' => false,
 		'selects' => [],
@@ -145,7 +145,7 @@ function _elgg_get_metastring_based_objects($options) {
 		return false;
 	}
 
-	$db_prefix = elgg_get_config('dbprefix');
+	$db_prefix = _elgg_config()->dbprefix;
 
 	// evaluate where clauses
 	if (!is_array($options['wheres'])) {
@@ -331,7 +331,7 @@ function _elgg_get_metastring_sql($table, $names = null, $values = null,
 		return [];
 	}
 
-	$db_prefix = elgg_get_config('dbprefix');
+	$db_prefix = _elgg_config()->dbprefix;
 
 	// binary forces byte-to-byte comparision of strings, making
 	// it case- and diacritical-mark- sensitive.
@@ -481,7 +481,7 @@ function _elgg_normalize_metastrings_options(array $options = []) {
  */
 function _elgg_set_metastring_based_object_enabled_by_id($id, $enabled, $type) {
 	$id = (int) $id;
-	$db_prefix = elgg_get_config('dbprefix');
+	$db_prefix = _elgg_config()->dbprefix;
 
 	$object = _elgg_get_metastring_based_object_from_id($id, $type);
 
@@ -586,7 +586,7 @@ function _elgg_get_metastring_based_object_from_id($id, $type) {
  */
 function _elgg_delete_metastring_based_object_by_id($id, $type) {
 	$id = (int) $id;
-	$db_prefix = elgg_get_config('dbprefix');
+	$db_prefix = _elgg_config()->dbprefix;
 
 	switch ($type) {
 		case 'annotations':

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -110,9 +110,13 @@ function elgg_register_menu_item($menu_name, $menu_item) {
 		return false;
 	}
 
-	$menus = _elgg_services()->config->get('menus', []);
+	$menus = _elgg_config()->menus;
+	if (!$menus) {
+		$menus = [];
+	}
+
 	$menus[$menu_name][] = $menu_item;
-	elgg_set_config('menus', $menus);
+	_elgg_config()->menus = $menus;
 
 	return true;
 }
@@ -127,7 +131,7 @@ function elgg_register_menu_item($menu_name, $menu_item) {
  * @since 1.8.0
  */
 function elgg_unregister_menu_item($menu_name, $item_name) {
-	$menus = _elgg_services()->config->get('menus', []);
+	$menus = _elgg_config()->menus;
 	if (!$menus) {
 		return null;
 	}
@@ -155,7 +159,10 @@ function elgg_unregister_menu_item($menu_name, $item_name) {
  * @since 1.8.0
  */
 function elgg_is_menu_item_registered($menu_name, $item_name) {
-	$menus = _elgg_services()->config->get('menus', []);
+	$menus = _elgg_config()->menus;
+	if (!$menus) {
+		return false;
+	}
 
 	if (!isset($menus[$menu_name])) {
 		return false;
@@ -181,7 +188,10 @@ function elgg_is_menu_item_registered($menu_name, $item_name) {
  * @since 1.9.0
  */
 function elgg_get_menu_item($menu_name, $item_name) {
-	$menus = _elgg_services()->config->get('menus', []);
+	$menus = _elgg_config()->menus;
+	if (!$menus) {
+		return null;
+	}
 
 	if (!isset($menus[$menu_name])) {
 		return null;
@@ -250,7 +260,7 @@ function elgg_register_title_button($handler = null, $name = 'add', $entity_type
  * @see elgg_get_breadcrumbs
  */
 function elgg_push_breadcrumb($title, $link = null) {
-	$breadcrumbs = (array) elgg_get_config('breadcrumbs');
+	$breadcrumbs = (array) _elgg_config()->breadcrumbs;
 	$breadcrumbs[] = ['title' => $title, 'link' => $link];
 	elgg_set_config('breadcrumbs', $breadcrumbs);
 }
@@ -262,7 +272,7 @@ function elgg_push_breadcrumb($title, $link = null) {
  * @since 1.8.0
  */
 function elgg_pop_breadcrumb() {
-	$breadcrumbs = (array) elgg_get_config('breadcrumbs');
+	$breadcrumbs = (array) _elgg_config()->breadcrumbs;
 
 	if (empty($breadcrumbs)) {
 		return [];
@@ -297,7 +307,7 @@ function elgg_pop_breadcrumb() {
 function elgg_get_breadcrumbs(array $breadcrumbs = null) {
 	if (!isset($breadcrumbs)) {
 		// if no crumbs set, still allow hook to populate it
-		$breadcrumbs = (array) elgg_get_config('breadcrumbs');
+		$breadcrumbs = (array) _elgg_config()->breadcrumbs;
 	}
 
 	if (!is_array($breadcrumbs)) {
@@ -405,12 +415,12 @@ function elgg_get_filter_tabs($context = null, $selected = null, ElggUser $user 
  */
 function _elgg_site_menu_setup($hook, $type, $return, $params) {
 
-	$featured_menu_names = elgg_get_config('site_featured_menu_names');
-	$custom_menu_items = elgg_get_config('site_custom_menu_items');
+	$featured_menu_names = _elgg_config()->site_featured_menu_names;
+	$custom_menu_items = _elgg_config()->site_custom_menu_items;
 	if ($featured_menu_names || $custom_menu_items) {
 		// we have featured or custom menu items
 
-		$registered = $return['default'];
+		$registered = isset($return['default']) ? $return['default'] : [];
 		/* @var \ElggMenuItem[] $registered */
 
 		// set up featured menu items
@@ -708,7 +718,7 @@ function _elgg_widget_menu_setup($hook, $type, $return, $params) {
  */
 function _elgg_login_menu_setup($hook, $type, $return, $params) {
 
-	if (elgg_get_config('allow_registration')) {
+	if (_elgg_config()->allow_registration) {
 		$return[] = \ElggMenuItem::factory([
 			'name' => 'register',
 			'href' => elgg_get_registration_url(),

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -112,7 +112,7 @@ function elgg_create_river_item(array $options = []) {
 		return true;
 	}
 
-	$dbprefix = elgg_get_config('dbprefix');
+	$dbprefix = _elgg_config()->dbprefix;
 
 	foreach ($values as $name => $value) {
 		$sql_columns[] = $name;
@@ -195,8 +195,6 @@ function elgg_create_river_item(array $options = []) {
  * @since 1.8.0
  */
 function elgg_get_river(array $options = []) {
-	global $CONFIG;
-
 	$defaults = [
 		'ids'                  => ELGG_ENTITIES_ANY_VALUE,
 
@@ -277,7 +275,7 @@ function elgg_get_river(array $options = []) {
 		$wheres[] = "rv.enabled = 'yes'";
 	}
 
-	$dbprefix = elgg_get_config('dbprefix');
+	$dbprefix = _elgg_config()->dbprefix;
 
 	// joins
 	$joins = [];
@@ -313,16 +311,17 @@ function elgg_get_river(array $options = []) {
 
 	// remove identical where clauses
 	$wheres = array_unique($wheres);
+	$prefix = _elgg_config()->dbprefix;
 
 	if (!$options['count']) {
 		$distinct = $options['distinct'] ? "DISTINCT" : "";
 
-		$query = "SELECT $distinct rv.* FROM {$CONFIG->dbprefix}river rv ";
+		$query = "SELECT $distinct rv.* FROM {$prefix}river rv ";
 	} else {
 		// note: when DISTINCT unneeded, it's slightly faster to compute COUNT(*) than IDs
 		$count_expr = $options['distinct'] ? "DISTINCT rv.id" : "*";
 
-		$query = "SELECT COUNT($count_expr) as total FROM {$CONFIG->dbprefix}river rv ";
+		$query = "SELECT COUNT($count_expr) as total FROM {$prefix}river rv ";
 	}
 
 	// add joins
@@ -469,7 +468,7 @@ function elgg_list_river(array $options = []) {
 
 	$defaults = [
 		'offset'     => (int) max(get_input('offset', 0), 0),
-		'limit'      => (int) max(get_input('limit', max(20, elgg_get_config('default_limit'))), 0),
+		'limit'      => (int) max(get_input('limit', max(20, _elgg_config()->default_limit)), 0),
 		'pagination' => true,
 		'list_class' => 'elgg-list-river',
 		'no_results' => '',
@@ -666,7 +665,7 @@ function _elgg_river_get_view_where_sql($views) {
  */
 function update_river_access_by_object($object_guid, $access_id) {
 	
-	$dbprefix = elgg_get_config('dbprefix');
+	$dbprefix = _elgg_config()->dbprefix;
 	$query = "
 		UPDATE {$dbprefix}river
 		SET access_id = :access_id
@@ -706,7 +705,7 @@ function _elgg_river_disable($event, $type, $entity) {
 		return true;
 	}
 
-	$dbprefix = elgg_get_config('dbprefix');
+	$dbprefix = _elgg_config()->dbprefix;
 	$query = <<<QUERY
 	UPDATE {$dbprefix}river AS rv
 	SET rv.enabled = 'no'
@@ -733,7 +732,7 @@ function _elgg_river_enable($event, $type, $entity) {
 		return true;
 	}
 
-	$dbprefix = elgg_get_config('dbprefix');
+	$dbprefix = _elgg_config()->dbprefix;
 	$query = <<<QUERY
 	UPDATE {$dbprefix}river AS rv
 	LEFT JOIN {$dbprefix}entities AS se ON se.guid = rv.subject_guid

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -75,7 +75,7 @@ function elgg_is_admin_user($user_guid) {
 	}
 
 	// cannot use magic metadata here because of recursion
-	$dbprefix = elgg_get_config('dbprefix');
+	$dbprefix = _elgg_config()->dbprefix;
 	$query = "SELECT 1 FROM {$dbprefix}users_entity as e
 		WHERE (
 			e.guid = {$user_guid}

--- a/engine/lib/system_log.php
+++ b/engine/lib/system_log.php
@@ -31,8 +31,6 @@ function get_system_log($by_user = "", $event = "", $class = "", $type = "", $su
 						$offset = 0, $count = false, $timebefore = 0, $timeafter = 0, $object_id = 0,
 						$ip_address = "") {
 
-	global $CONFIG;
-
 	$by_user_orig = $by_user;
 	if (is_array($by_user) && sizeof($by_user) > 0) {
 		foreach ($by_user as $key => $val) {
@@ -48,7 +46,7 @@ function get_system_log($by_user = "", $event = "", $class = "", $type = "", $su
 	$subtype = sanitise_string($subtype);
 	$ip_address = sanitise_string($ip_address);
 	if ($limit === null) {
-		$limit = elgg_get_config('default_limit');
+		$limit = _elgg_config()->default_limit;
 	}
 	$limit = (int) $limit;
 	$offset = (int) $offset;
@@ -92,7 +90,9 @@ function get_system_log($by_user = "", $event = "", $class = "", $type = "", $su
 	if ($count) {
 		$select = "count(*) as count";
 	}
-	$query = "SELECT $select from {$CONFIG->dbprefix}system_log where 1 ";
+
+	$prefix = _elgg_config()->dbprefix;
+	$query = "SELECT $select from {$prefix}system_log where 1 ";
 	foreach ($where as $w) {
 		$query .= " and $w";
 	}
@@ -122,11 +122,10 @@ function get_system_log($by_user = "", $event = "", $class = "", $type = "", $su
  * @return mixed
  */
 function get_log_entry($entry_id) {
-	global $CONFIG;
-
 	$entry_id = (int) $entry_id;
 
-	return get_data_row("SELECT * from {$CONFIG->dbprefix}system_log where id=$entry_id");
+	$prefix = _elgg_config()->dbprefix;
+	return get_data_row("SELECT * from {$prefix}system_log where id=$entry_id");
 }
 
 /**
@@ -188,13 +187,12 @@ function get_object_from_log_entry($entry) {
  * @return void
  */
 function system_log($object, $event) {
-	global $CONFIG;
 	static $log_cache;
 	static $cache_size = 0;
 
 	if ($object instanceof Loggable) {
 		/* @var \ElggEntity|\ElggExtender $object */
-		if (elgg_get_config('version') < 2012012000) {
+		if (_elgg_config()->version < 2012012000) {
 			// this is a site that doesn't have the ip_address column yet
 			return;
 		}
@@ -237,7 +235,8 @@ function system_log($object, $event) {
 
 		// Create log if we haven't already created it
 		if (!isset($log_cache[$time][$object_id][$event])) {
-			$query = "INSERT into {$CONFIG->dbprefix}system_log
+			$prefix = _elgg_config()->dbprefix;
+			$query = "INSERT into {$prefix}system_log
 				(object_id, object_class, object_type, object_subtype, event,
 				performed_by_guid, owner_guid, access_id, enabled, time_created, ip_address)
 			VALUES
@@ -260,16 +259,15 @@ function system_log($object, $event) {
  * @return bool
  */
 function archive_log($offset = 0) {
-	global $CONFIG;
-
 	$offset = (int) $offset;
 	$now = time(); // Take a snapshot of now
+	$prefix = _elgg_config()->dbprefix;
 
 	$ts = $now - $offset;
 
 	// create table
-	$query = "CREATE TABLE {$CONFIG->dbprefix}system_log_$now as
-		SELECT * from {$CONFIG->dbprefix}system_log WHERE time_created<$ts";
+	$query = "CREATE TABLE {$prefix}system_log_$now as
+		SELECT * from {$prefix}system_log WHERE time_created<$ts";
 
 	if (!update_data($query)) {
 		return false;
@@ -277,12 +275,12 @@ function archive_log($offset = 0) {
 
 	// delete
 	// Don't delete on time since we are running in a concurrent environment
-	if (delete_data("DELETE from {$CONFIG->dbprefix}system_log WHERE time_created<$ts") === false) {
+	if (delete_data("DELETE from {$prefix}system_log WHERE time_created<$ts") === false) {
 		return false;
 	}
 
 	// alter table to engine
-	if (!update_data("ALTER TABLE {$CONFIG->dbprefix}system_log_$now engine=archive")) {
+	if (!update_data("ALTER TABLE {$prefix}system_log_$now engine=archive")) {
 		return false;
 	}
 

--- a/engine/lib/tags.php
+++ b/engine/lib/tags.php
@@ -74,14 +74,12 @@ function string_to_tag_array($string) {
  * @since 1.7.1
  */
 function elgg_get_tags(array $options = []) {
-	global $CONFIG;
-
 	_elgg_check_unsupported_site_guid($options);
 	
 	$defaults = [
 		'threshold' => 1,
 		'tag_names' => [],
-		'limit' => elgg_get_config('default_limit'),
+		'limit' => _elgg_config()->default_limit,
 
 		'types' => ELGG_ENTITIES_ANY_VALUE,
 		'subtypes' => ELGG_ENTITIES_ANY_VALUE,
@@ -150,7 +148,8 @@ function elgg_get_tags(array $options = []) {
 
 	$joins = $options['joins'];
 
-	$joins[] = "JOIN {$CONFIG->dbprefix}metadata md on md.entity_guid = e.guid";
+	$prefix = _elgg_config()->dbprefix;
+	$joins[] = "JOIN {$prefix}metadata md on md.entity_guid = e.guid";
 
 	// remove identical join clauses
 	$joins = array_unique($joins);
@@ -164,7 +163,7 @@ function elgg_get_tags(array $options = []) {
 	}
 
 	$query  = "SELECT md.value as tag, count(md.id) as total ";
-	$query .= "FROM {$CONFIG->dbprefix}entities e ";
+	$query .= "FROM {$prefix}entities e ";
 
 	// add joins
 	foreach ($joins as $j) {

--- a/engine/lib/upgrade.php
+++ b/engine/lib/upgrade.php
@@ -72,7 +72,7 @@ function elgg_get_upgrade_files($upgrade_path = null) {
  * @todo the hack in the 2011010101 upgrade requires this
  */
 function _elgg_upgrade_unlock() {
-	global $CONFIG;
-	delete_data("drop table {$CONFIG->dbprefix}upgrade_lock");
+	$prefix = _elgg_config()->dbprefix;
+	delete_data("drop table {$prefix}upgrade_lock");
 	elgg_log('Upgrade unlocked.', 'NOTICE');
 }

--- a/engine/lib/upgrades/2015062900-1.11.2-discussion_plugin-e28c7afa4f5f24ec.php
+++ b/engine/lib/upgrades/2015062900-1.11.2-discussion_plugin-e28c7afa4f5f24ec.php
@@ -8,7 +8,7 @@
  * 'groupforumtopic' into 'discussion'.
  */
 
-$dbprefix = elgg_get_config('dbprefix');
+$dbprefix = _elgg_config()->dbprefix;
 
 // Update subtype "groupforumtopic" into "discussion"
 update_data("UPDATE {$dbprefix}entity_subtypes

--- a/engine/lib/upgrades/2016110400-3.0.0-remove_member_of_site-eefe9f305fa83188.php
+++ b/engine/lib/upgrades/2016110400-3.0.0-remove_member_of_site-eefe9f305fa83188.php
@@ -6,7 +6,7 @@
  * Removes all member_of_site relationships in the relationships table
  */
 
-$dbprefix = elgg_get_config('dbprefix');
+$dbprefix = _elgg_config()->dbprefix;
 
 delete_data("DELETE FROM {$dbprefix}entity_relationships
 	WHERE relationship = 'member_of_site'");

--- a/engine/lib/upgrades/2016110600-3.0.0-datalist_into_config-1e14f06b40cb9b66.php
+++ b/engine/lib/upgrades/2016110600-3.0.0-datalist_into_config-1e14f06b40cb9b66.php
@@ -6,7 +6,7 @@
  * Merges datalists table data into config
  */
 
-$dbprefix = elgg_get_config('dbprefix');
+$dbprefix = _elgg_config()->dbprefix;
 
 $exists = get_data_row("SHOW TABLES LIKE '{$dbprefix}datalists'");
 if (!$exists) {

--- a/engine/lib/user_settings.php
+++ b/engine/lib/user_settings.php
@@ -272,7 +272,7 @@ function _elgg_set_user_email() {
 		return;
 	}
 	
-	if (elgg_get_config('security_email_require_password') && ($user->getGUID() === elgg_get_logged_in_user_guid())) {
+	if (_elgg_config()->security_email_require_password && ($user->getGUID() === elgg_get_logged_in_user_guid())) {
 		// validate password
 		$pwd = get_input('email_password');
 		$auth = elgg_authenticate($user->username, $pwd);
@@ -308,7 +308,7 @@ function _elgg_set_user_email() {
  */
 function _elgg_set_user_default_access() {
 
-	if (!elgg_get_config('allow_user_default_access')) {
+	if (!_elgg_config()->allow_user_default_access) {
 		return;
 	}
 

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -470,7 +470,7 @@ function user_avatar_hook($hook, $type, $return, $params) {
 		return;
 	}
 
-	if (elgg_get_config('walled_garden')) {
+	if (_elgg_config()->walled_garden) {
 		return;
 	}
 
@@ -768,7 +768,7 @@ function _elgg_user_set_icon_file($hook, $type, $icon, $params) {
  */
 function _elgg_user_get_subscriber_unban_action($hook, $type, $return_value, $params) {
 	
-	if (!elgg_get_config('security_notify_user_ban')) {
+	if (!_elgg_config()->security_notify_user_ban) {
 		return;
 	}
 	
@@ -804,7 +804,7 @@ function _elgg_user_get_subscriber_unban_action($hook, $type, $return_value, $pa
  */
 function _elgg_user_ban_notification($event, $type, $user) {
 	
-	if (!elgg_get_config('security_notify_user_ban')) {
+	if (!_elgg_config()->security_notify_user_ban) {
 		return;
 	}
 	

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -458,9 +458,9 @@ function _elgg_views_prepare_head($title) {
 	];
 
 	if (empty($title)) {
-		$params['title'] = elgg_get_config('sitename');
+		$params['title'] = _elgg_config()->sitename;
 	} else {
-		$params['title'] = $title . ' : ' . elgg_get_config('sitename');
+		$params['title'] = $title . ' : ' . _elgg_config()->sitename;
 	}
 
 	$params['metas']['content-type'] = [
@@ -470,7 +470,7 @@ function _elgg_views_prepare_head($title) {
 
 	$params['metas']['description'] = [
 		'name' => 'description',
-		'content' => elgg_get_config('sitedescription')
+		'content' => _elgg_config()->sitedescription
 	];
 
 	// https://developer.chrome.com/multidevice/android/installtohomescreen
@@ -1586,7 +1586,7 @@ function elgg_view_icon($name, $vars = []) {
  * @return void
  */
 function elgg_register_rss_link() {
-	_elgg_services()->config->set('_elgg_autofeed', true);
+	_elgg_config()->_elgg_autofeed = true;
 }
 
 /**
@@ -1595,7 +1595,7 @@ function elgg_register_rss_link() {
  * @return void
  */
 function elgg_unregister_rss_link() {
-	_elgg_services()->config->set('_elgg_autofeed', false);
+	_elgg_config()->_elgg_autofeed = false;
 }
 
 /**
@@ -1651,11 +1651,11 @@ function _elgg_views_minify($hook, $type, $content, $params) {
 	}
 
 	if ($type == 'js') {
-		if (elgg_get_config('simplecache_minify_js')) {
+		if (_elgg_config()->simplecache_minify_js) {
 			return JSMin::minify($content);
 		}
 	} elseif ($type == 'css') {
-		if (elgg_get_config('simplecache_minify_css')) {
+		if (_elgg_config()->simplecache_minify_css) {
 			$cssmin = new CSSmin();
 			return $cssmin->run($content);
 		}
@@ -1872,7 +1872,7 @@ function elgg_views_boot() {
  * @access private
  */
 function _elgg_get_js_site_data() {
-	$language = elgg_get_config('language');
+	$language = _elgg_config()->language;
 	if (!$language) {
 		$language = 'en';
 	}
@@ -1904,7 +1904,7 @@ function _elgg_get_js_page_data() {
 
 	$elgg = [
 		'config' => [
-			'lastcache' => (int) elgg_get_config('lastcache'),
+			'lastcache' => (int) _elgg_config()->lastcache,
 			'viewtype' => elgg_get_viewtype(),
 			'simplecache_enabled' => (int) elgg_is_simplecache_enabled(),
 			'current_language' => get_current_language(),
@@ -1922,7 +1922,7 @@ function _elgg_get_js_page_data() {
 		'_data' => (object) $data,
 	];
 
-	if (elgg_get_config('elgg_load_sync_code')) {
+	if (_elgg_config()->elgg_load_sync_code) {
 		$elgg['config']['load_sync_code'] = true;
 	}
 

--- a/engine/lib/widgets.php
+++ b/engine/lib/widgets.php
@@ -242,10 +242,9 @@ function _elgg_widgets_init() {
  * @access private
  */
 function _elgg_default_widgets_init() {
-	global $CONFIG;
 	$default_widgets = elgg_trigger_plugin_hook('get_list', 'default_widgets', null, []);
 
-	$CONFIG->default_widget_info = $default_widgets;
+	_elgg_config()->default_widget_info = $default_widgets;
 
 	if ($default_widgets) {
 		elgg_register_menu_item('page', [
@@ -293,7 +292,7 @@ function _elgg_default_widgets_init() {
  * @access private
  */
 function _elgg_create_default_widgets($event, $type, $entity) {
-	$default_widget_info = elgg_get_config('default_widget_info');
+	$default_widget_info = _elgg_config()->default_widget_info;
 
 	if (!$default_widget_info || !$entity) {
 		return;

--- a/engine/tests/ElggBatchTest.php
+++ b/engine/tests/ElggBatchTest.php
@@ -82,7 +82,7 @@ class ElggBatchTest extends \ElggCoreUnitTest {
 
 		// break entities such that the first fetch has one incomplete
 		// and the second and third fetches have only incompletes!
-		$db_prefix = elgg_get_config('dbprefix');
+		$db_prefix = _elgg_config()->dbprefix;
 		delete_data("
 			DELETE FROM {$db_prefix}objects_entity
 			WHERE guid IN ({$guids[1]}, {$guids[2]}, {$guids[3]}, {$guids[4]}, {$guids[5]})
@@ -133,7 +133,7 @@ class ElggBatchTest extends \ElggCoreUnitTest {
 
 		// break entities such that the first fetch has one incomplete
 		// and the second and third fetches have only incompletes!
-		$db_prefix = elgg_get_config('dbprefix');
+		$db_prefix = _elgg_config()->dbprefix;
 		delete_data("
 			DELETE FROM {$db_prefix}objects_entity
 			WHERE guid IN ({$guids[1]}, {$guids[2]}, {$guids[3]}, {$guids[4]}, {$guids[5]})

--- a/engine/tests/ElggCoreConfigTest.php
+++ b/engine/tests/ElggCoreConfigTest.php
@@ -59,9 +59,9 @@ class ElggCoreConfigTest extends \ElggCoreUnitTest {
 	}
 
 	public function testGetConfigAlreadyLoadedForCurrentSite() {
-		global $CONFIG;
+		$CONFIG = _elgg_config();
 		$CONFIG->foo_unit_test = 35;
-		$this->assertIdentical(35, elgg_get_config('foo_unit_test'));
+		$this->assertIdentical(35, _elgg_config()->foo_unit_test);
 		unset($CONFIG->foo_unit_test);
 	}
 

--- a/engine/tests/ElggCoreGetEntitiesFromAnnotationsTest.php
+++ b/engine/tests/ElggCoreGetEntitiesFromAnnotationsTest.php
@@ -24,7 +24,7 @@ class ElggCoreGetEntitiesFromAnnotationsTest extends \ElggCoreGetEntitiesBaseTes
 	}
 
 	public function testCanGetEntitiesByAnnotationCreationTime() {
-		$prefix = elgg_get_config('dbprefix');
+		$prefix = _elgg_config()->dbprefix;
 		$users = elgg_get_entities(array('type' => 'user', 'limit' => 1));
 
 		// create some test annotations

--- a/engine/tests/ElggCoreGetEntitiesTest.php
+++ b/engine/tests/ElggCoreGetEntitiesTest.php
@@ -794,7 +794,7 @@ class ElggCoreGetEntitiesTest extends \ElggCoreGetEntitiesBaseTest {
 	}
 
 	public function testDistinctCanBeDisabled() {
-		$prefix = _elgg_services()->config->get('dbprefix');
+		$prefix = _elgg_config()->dbprefix;
 		$options = array(
 			'callback' => '',
 			'joins' => array(

--- a/engine/tests/ElggCoreMetadataAPITest.php
+++ b/engine/tests/ElggCoreMetadataAPITest.php
@@ -146,7 +146,7 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 		$obj->test = $md_values;
 
 		// check only these md exists
-		$db_prefix = elgg_get_config('dbprefix');
+		$db_prefix = _elgg_config()->dbprefix;
 		$q = "SELECT * FROM {$db_prefix}metadata WHERE entity_guid = $obj->guid";
 		$data = get_data($q);
 

--- a/engine/tests/ElggCoreMetastringsTest.php
+++ b/engine/tests/ElggCoreMetastringsTest.php
@@ -68,7 +68,7 @@ class ElggCoreMetastringsTest extends \ElggCoreUnitTest {
 	}
 
 	public function testDeleteByID() {
-		$db_prefix = elgg_get_config('dbprefix');
+		$db_prefix = _elgg_config()->dbprefix;
 		$annotation = $this->createAnnotations(1);
 		$metadata = $this->createMetadata(1);
 
@@ -85,7 +85,7 @@ class ElggCoreMetastringsTest extends \ElggCoreUnitTest {
 	}
 
 	public function testGetMetastringObjectFromID() {
-		$db_prefix = elgg_get_config('dbprefix');
+		$db_prefix = _elgg_config()->dbprefix;
 		$annotation = $this->createAnnotations(1);
 		$metadata = $this->createMetadata(1);
 
@@ -134,7 +134,7 @@ class ElggCoreMetastringsTest extends \ElggCoreUnitTest {
 	}
 
 	public function testEnableDisableByID() {
-		$db_prefix = elgg_get_config('dbprefix');
+		$db_prefix = _elgg_config()->dbprefix;
 		$annotation = $this->createAnnotations(1);
 		$metadata = $this->createMetadata(1);
 

--- a/engine/tests/ElggObjectTest.php
+++ b/engine/tests/ElggObjectTest.php
@@ -202,7 +202,7 @@ class ElggCoreObjectTest extends \ElggCoreUnitTest {
 		$this->assertFalse(get_entity($guid1));
 		$this->assertFalse(get_entity($guid2));
 
-		$db_prefix = elgg_get_config('dbprefix');
+		$db_prefix = _elgg_config()->dbprefix;
 		$q = "SELECT * FROM {$db_prefix}entities WHERE guid = $guid1";
 		$r = get_data_row($q);
 		$this->assertEqual('no', $r->enabled);
@@ -219,7 +219,7 @@ class ElggCoreObjectTest extends \ElggCoreUnitTest {
 
 	public function testElggRecursiveDelete() {
 		$types = array('\ElggGroup', '\ElggObject', '\ElggUser');
-		$db_prefix = elgg_get_config('dbprefix');
+		$db_prefix = _elgg_config()->dbprefix;
 
 		foreach ($types as $type) {
 			$parent = new $type();

--- a/engine/tests/phpunit/Elgg/Application/ServeFileHandlerTest.php
+++ b/engine/tests/phpunit/Elgg/Application/ServeFileHandlerTest.php
@@ -45,7 +45,7 @@ class ServeFileHandlerTest extends \Elgg\TestCase {
 		$path = substr($url, strlen($site_url));
 		$request = \Elgg\Http\Request::create("/$path");
 
-		$cookie_name = _elgg_services()->config->getCookieConfig()['session']['name'];
+		$cookie_name = _elgg_config()->getCookieConfig()['session']['name'];
 		$session_id = _elgg_services()->session->getId();
 		$request->cookies->set($cookie_name, $session_id);
 		return $request;
@@ -115,7 +115,7 @@ class ServeFileHandlerTest extends \Elgg\TestCase {
 		$this->assertEquals(200, $response->getStatusCode());
 
 		_elgg_services()->session->invalidate();
-		$cookie_name = _elgg_services()->config->getCookieConfig()['session']['name'];
+		$cookie_name = _elgg_config()->getCookieConfig()['session']['name'];
 		$session_id = _elgg_services()->session->getId();
 		$request->cookies->set($cookie_name, $session_id);
 

--- a/engine/tests/phpunit/Elgg/BatchUpgraderTest.php
+++ b/engine/tests/phpunit/Elgg/BatchUpgraderTest.php
@@ -25,8 +25,7 @@ class BatchUpgraderTest extends TestCase {
 		$upgrade->description = 'test_plugin:upgrade:2016101900:title';
 		$upgrade->save();
 		
-		$config = _elgg_services()->config;
-		$upgrader = new BatchUpgrader($config);
+		$upgrader = new BatchUpgrader(_elgg_config());
 		$result = $upgrader->run($upgrade);
 
 		$expected = [
@@ -52,8 +51,7 @@ class BatchUpgraderTest extends TestCase {
 		$upgrade->offset = 50;
 		$upgrade->has_errors = false;
 
-		$config = _elgg_services()->config;
-		$upgrader = new BatchUpgrader($config);
+		$upgrader = new BatchUpgrader(_elgg_config());
 		$result = $upgrader->run($upgrade);
 
 		$expected = [
@@ -75,8 +73,7 @@ class BatchUpgraderTest extends TestCase {
 		$upgrade->description = 'test_plugin:upgrade:2016101901:title';
 		$upgrade->save();
 		
-		$config = _elgg_services()->config;
-		$upgrader = new BatchUpgrader($config);
+		$upgrader = new BatchUpgrader(_elgg_config());
 		$result = $upgrader->run($upgrade);
 
 		$expected = [
@@ -98,8 +95,7 @@ class BatchUpgraderTest extends TestCase {
 		$upgrade->description = 'test_plugin:upgrade:2016101902:title';
 		$upgrade->save();
 
-		$config = _elgg_services()->config;
-		$upgrader = new BatchUpgrader($config);
+		$upgrader = new BatchUpgrader(_elgg_config());
 		$result = $upgrader->run($upgrade);
 
 		$expected = [

--- a/engine/tests/phpunit/Elgg/Cache/EntityCacheTest.php
+++ b/engine/tests/phpunit/Elgg/Cache/EntityCacheTest.php
@@ -175,6 +175,7 @@ class EntityCacheTest extends \Elgg\TestCase {
 			'time_updated' => $time,
 			'last_action' => $time,
 		]);
+		/** @var \ElggObject $object */
 		
 		$this->assertEquals($object, _elgg_services()->entityCache->get($object->guid));
 
@@ -184,7 +185,6 @@ class EntityCacheTest extends \Elgg\TestCase {
 		
 		$this->assertNotEquals($posted, $time);
 		$this->assertEquals($posted, $object->last_action);
-
 	}
 
 	public function testRemovesBannedUserFromCache() {

--- a/engine/tests/phpunit/Elgg/Database/EntityTableTest.php
+++ b/engine/tests/phpunit/Elgg/Database/EntityTableTest.php
@@ -58,7 +58,7 @@ class EntityTableTest extends \Elgg\TestCase {
 		$last_action = $object->updateLastAction();
 		$this->assertEquals($last_action, $object->last_action);
 
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 		$sql = "
 			UPDATE {$dbprefix}entities
 			SET last_action = :last_action

--- a/engine/tests/phpunit/Elgg/Database/SubtypeTableTest.php
+++ b/engine/tests/phpunit/Elgg/Database/SubtypeTableTest.php
@@ -37,7 +37,7 @@ class SubtypeTableTest extends \Elgg\TestCase {
 	}
 
 	public function setupFetchAllQuery() {
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 		$this->db->addQuerySpec([
 			'sql' => "SELECT * FROM {$dbprefix}entity_subtypes",
 			'results' => [$this, 'fetchAllResults'],
@@ -80,7 +80,7 @@ class SubtypeTableTest extends \Elgg\TestCase {
 
 	public function testCanAddSubtype() {
 
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 
 		$type = 'object';
 		$subtype = 'bar';
@@ -107,7 +107,7 @@ class SubtypeTableTest extends \Elgg\TestCase {
 
 	public function testCanUpdateSubtype() {
 
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 
 		$this->setupFetchAllQuery();
 
@@ -138,7 +138,7 @@ class SubtypeTableTest extends \Elgg\TestCase {
 
 	public function testCanRemoveSubtype() {
 
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 
 		$this->setupFetchAllQuery();
 

--- a/engine/tests/phpunit/Elgg/EntityIconServiceTest.php
+++ b/engine/tests/phpunit/Elgg/EntityIconServiceTest.php
@@ -143,7 +143,7 @@ class EntityIconServiceTest extends \Elgg\TestCase {
 		$service = $this->createService();
 
 		// Should return config values, as we do not have any registered hook
-		$this->assertEquals($this->config()->get('icon_sizes'), $service->getSizes());
+		$this->assertEquals($this->config()->icon_sizes, $service->getSizes());
 
 		// If type is not 'icon', should return an empty array
 		$this->logger->disable();
@@ -349,7 +349,7 @@ class EntityIconServiceTest extends \Elgg\TestCase {
 	 */
 	public function testThrowsExceptionIfLocalFileIsNotReadable() {
 		$service = $this->createService();
-		$local_file = $this->config()->get('dataroot') . '_______empty';
+		$local_file = $this->config()->dataroot . '_______empty';
 		$service->saveIconFromLocalFile($this->entity, $local_file);
 	}
 
@@ -360,7 +360,7 @@ class EntityIconServiceTest extends \Elgg\TestCase {
 
 		$service = $this->createService();
 
-		$local_file = $this->config()->get('dataroot') . '1/1/400x300.png';
+		$local_file = $this->config()->dataroot . '1/1/400x300.png';
 		$service->saveIconFromLocalFile($this->entity, $local_file);
 
 		$this->assertTrue($service->hasIcon($this->entity, 'master'));
@@ -385,7 +385,7 @@ class EntityIconServiceTest extends \Elgg\TestCase {
 		$tmp->owner_guid = $this->user->guid;
 		$tmp->setFilename('tmp.gif');
 		$tmp->open('write');
-		$tmp->write(file_get_contents($this->config()->get('dataroot') . '1/1/400x300.gif'));
+		$tmp->write(file_get_contents($this->config()->dataroot . '1/1/400x300.gif'));
 		$tmp->close();
 
 		$uploaded_file = $tmp->getFilenameOnFilestore();
@@ -419,7 +419,7 @@ class EntityIconServiceTest extends \Elgg\TestCase {
 
 		$service = $this->createService();
 
-		$local_file = $this->config()->get('dataroot') . '1/1/400x300.png';
+		$local_file = $this->config()->dataroot . '1/1/400x300.png';
 		$service->saveIconFromLocalFile($this->entity, $local_file);
 
 		$this->assertTrue($service->hasIcon($this->entity, 'small'));
@@ -439,7 +439,7 @@ class EntityIconServiceTest extends \Elgg\TestCase {
 
 		$service = $this->createService();
 
-		$local_file = $this->config()->get('dataroot') . '1/1/400x300.png';
+		$local_file = $this->config()->dataroot . '1/1/400x300.png';
 		$service->saveIconFromLocalFile($this->entity, $local_file);
 
 		$this->assertTrue($service->hasIcon($this->entity, 'small'));
@@ -459,7 +459,7 @@ class EntityIconServiceTest extends \Elgg\TestCase {
 
 		$service = $this->createService();
 
-		$local_file = $this->config()->get('dataroot') . '1/1/400x300.png';
+		$local_file = $this->config()->dataroot . '1/1/400x300.png';
 		$service->saveIconFromLocalFile($this->entity, $local_file);
 
 		$this->assertTrue($service->hasIcon($this->entity, 'small'));

--- a/engine/tests/phpunit/Elgg/Mocks/Database/EntityTable.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Database/EntityTable.php
@@ -200,7 +200,7 @@ class EntityTable extends DbEntityTable {
 	 */
 	public function addSelectQuerySpecs(stdClass $row) {
 
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 
 		// Access SQL for this row might differ based on:
 		//  - logged in user
@@ -354,7 +354,7 @@ class EntityTable extends DbEntityTable {
 	 */
 	public function addInsertQuerySpecs(stdClass $row) {
 
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 		
 		$sql = "
 			INSERT INTO {$dbprefix}entities
@@ -410,7 +410,7 @@ class EntityTable extends DbEntityTable {
 	 */
 	public function addUpdateQuerySpecs(stdClass $row) {
 
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 
 		$sql = "
 			UPDATE {$dbprefix}entities
@@ -549,7 +549,7 @@ class EntityTable extends DbEntityTable {
 	 */
 	public function addDeleteQuerySpecs(\stdClass $row) {
 
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 
 		$sql = "
 			DELETE FROM {$dbprefix}entities

--- a/engine/tests/phpunit/Elgg/Mocks/Database/MetadataTable.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Database/MetadataTable.php
@@ -150,7 +150,7 @@ class MetadataTable extends DbMetadataTabe {
 		// Return this metadata object when _elgg_get_metastring_based_objects() is called
 		$e_access_sql = _elgg_get_access_where_sql(array('table_alias' => 'e'));
 		
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 		$sql = "SELECT DISTINCT  n_table.*
 			FROM {$dbprefix}metadata n_table
 				JOIN {$dbprefix}entities e ON n_table.entity_guid = e.guid

--- a/engine/tests/phpunit/Elgg/Mocks/Database/RelationshipsTable.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Database/RelationshipsTable.php
@@ -83,7 +83,7 @@ class RelationshipsTable extends DbRelationshipsTable {
 
 		$this->clearQuerySpecs($row->id);
 
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 
 		// Insert a new relationship
 		$sql = "

--- a/engine/tests/phpunit/Elgg/Mocks/Di/MockServiceProvider.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Di/MockServiceProvider.php
@@ -105,7 +105,7 @@ class MockServiceProvider extends \Elgg\Di\DiContainer {
 		$conf->db['write'][0]['dbpass'] = 'xxxx1';
 		$conf->db['write'][0]['dbname'] = 'elgg1';
 
-		$conf->dbprefix = elgg_get_config('dbprefix');
+		$conf->dbprefix = _elgg_config()->dbprefix;
 
 		return new \Elgg\Database\Config($conf);
 	}

--- a/engine/tests/phpunit/Elgg/TestCase.php
+++ b/engine/tests/phpunit/Elgg/TestCase.php
@@ -156,13 +156,13 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 		if ($config) {
 			_elgg_services()->setValue('config', $config);
 		}
-		return _elgg_services()->config;
+		return _elgg_config();
 	}
 
 	/**
 	 * Retuns mocking utility library
 	 *
-	 * @return \Elgg\TestCaseMocks
+	 * @return MockServiceProvider
 	 */
 	public static function mocks() {
 		if (!isset(self::$_mocks)) {
@@ -201,11 +201,11 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 		_elgg_services()->annotations->setCurrentTime($dt);
 		_elgg_services()->usersTable->setCurrentTime($dt);
 
-		_elgg_services()->config->set('site', self::mocks()->getSite([
-			'url' => _elgg_services()->config->get('wwwroot'),
+		_elgg_config()->site = self::mocks()->getSite([
+			'url' => _elgg_config()->wwwroot,
 			'name' => 'Testing Site',
 			'description' => 'Testing Site',
-		]));
+		]);
 	}
 
 	/**
@@ -230,7 +230,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 
 		$request = Request::create($path, $method, $parameters);
 
-		$cookie_name = _elgg_services()->config->getCookieConfig()['session']['name'];
+		$cookie_name = _elgg_config()->getCookieConfig()['session']['name'];
 		$session_id = _elgg_services()->session->getId();
 		$request->cookies->set($cookie_name, $session_id);
 

--- a/engine/tests/phpunit/Elgg/UploadServiceTest.php
+++ b/engine/tests/phpunit/Elgg/UploadServiceTest.php
@@ -31,7 +31,7 @@ class UploadServiceTest extends \Elgg\TestCase {
 		$this->owner_guid = $this->user->guid;
 
 		$dir = (new EntityDirLocator($this->owner_guid))->getPath();
-		$this->owner_dir_path = elgg_get_config('dataroot') . $dir;
+		$this->owner_dir_path = _elgg_config()->dataroot . $dir;
 
 		_elgg_services()->hooks->backup();
 		_elgg_services()->events->backup();
@@ -72,7 +72,7 @@ class UploadServiceTest extends \Elgg\TestCase {
 		$tmp->owner_guid = $this->owner_guid;
 		$tmp->setFilename('tmp.gif');
 		$tmp->open('write');
-		$tmp->write(file_get_contents(elgg_get_config('dataroot') . '1/1/400x300.gif'));
+		$tmp->write(file_get_contents(_elgg_config()->dataroot . '1/1/400x300.gif'));
 		$tmp->close();
 
 		$tmp_file = $tmp->getFilenameOnFilestore();
@@ -96,7 +96,7 @@ class UploadServiceTest extends \Elgg\TestCase {
 		$tmp->owner_guid = $this->owner_guid;
 		$tmp->setFilename('tmp.gif');
 		$tmp->open('write');
-		$tmp->write(file_get_contents(elgg_get_config('dataroot') . '1/1/400x300.gif'));
+		$tmp->write(file_get_contents(_elgg_config()->dataroot . '1/1/400x300.gif'));
 		$tmp->close();
 
 		$tmp_gif = $tmp->getFilenameOnFilestore();
@@ -106,7 +106,7 @@ class UploadServiceTest extends \Elgg\TestCase {
 		$tmp->owner_guid = $this->owner_guid;
 		$tmp->setFilename('tmp.png');
 		$tmp->open('write');
-		$tmp->write(file_get_contents(elgg_get_config('dataroot') . '1/1/400x300.png'));
+		$tmp->write(file_get_contents(_elgg_config()->dataroot . '1/1/400x300.png'));
 		$tmp->close();
 
 		$tmp_png = $tmp->getFilenameOnFilestore();
@@ -143,7 +143,7 @@ class UploadServiceTest extends \Elgg\TestCase {
 		$tmp->owner_guid = $this->owner_guid;
 		$tmp->setFilename('tmp.gif');
 		$tmp->open('write');
-		$tmp->write(file_get_contents(elgg_get_config('dataroot') . '1/1/400x300.gif'));
+		$tmp->write(file_get_contents(_elgg_config()->dataroot . '1/1/400x300.gif'));
 		$tmp->close();
 
 		$tmp_file = $tmp->getFilenameOnFilestore();
@@ -177,7 +177,7 @@ class UploadServiceTest extends \Elgg\TestCase {
 		$tmp->owner_guid = $this->owner_guid;
 		$tmp->setFilename('tmp.gif');
 		$tmp->open('write');
-		$tmp->write(file_get_contents(elgg_get_config('dataroot') . '1/1/400x300.gif'));
+		$tmp->write(file_get_contents(_elgg_config()->dataroot . '1/1/400x300.gif'));
 		$tmp->close();
 
 		$tmp_file = $tmp->getFilenameOnFilestore();

--- a/engine/tests/phpunit/ElggFileTest.php
+++ b/engine/tests/phpunit/ElggFileTest.php
@@ -21,7 +21,7 @@ class ElggFileTest extends \Elgg\TestCase {
 
 		$this->file = $file;
 
-		$dataroot = elgg_get_config('dataroot');
+		$dataroot = _elgg_config()->dataroot;
 		if (is_dir($dataroot . '1/2/')) {
 			// we use this for writing new files
 			_elgg_rmdir($dataroot . '1/2/');
@@ -29,7 +29,7 @@ class ElggFileTest extends \Elgg\TestCase {
 	}
 
 	public function tearDown() {
-		$dataroot = elgg_get_config('dataroot');
+		$dataroot = _elgg_config()->dataroot;
 		if (is_dir($dataroot . '1/2/')) {
 			// we use this for writing new files
 			_elgg_rmdir($dataroot . '1/2/');
@@ -186,7 +186,7 @@ class ElggFileTest extends \Elgg\TestCase {
 		$contents = $this->file->grabFile();
 		$this->assertTrue($this->file->close());
 
-		$dataroot = _elgg_services()->config->get('dataroot');
+		$dataroot = _elgg_config()->dataroot;
 		$expected = file_get_contents("{$dataroot}1/1/foobar.txt");
 
 		$this->assertEquals($expected, $contents);
@@ -278,7 +278,7 @@ class ElggFileTest extends \Elgg\TestCase {
 
 		$filename = "foo/bar.txt";
 
-		$dataroot = _elgg_services()->config->get('dataroot');
+		$dataroot = _elgg_config()->dataroot;
 		$dir = new \Elgg\EntityDirLocator(123);
 
 		$file = new ElggFile();
@@ -298,7 +298,7 @@ class ElggFileTest extends \Elgg\TestCase {
 
 		$symlink_name = "symlink.txt";
 
-		$dataroot = _elgg_services()->config->get('dataroot');
+		$dataroot = _elgg_config()->dataroot;
 		$dir = new \Elgg\EntityDirLocator(2);
 
 		// Remove symlink in case it exists
@@ -424,7 +424,7 @@ class ElggFileTest extends \Elgg\TestCase {
 	 */
 	public function testCanTransferFile() {
 
-		$dataroot = elgg_get_config('dataroot');
+		$dataroot = _elgg_config()->dataroot;
 
 		$file = new \ElggFile();
 		$file->owner_guid = 3;

--- a/engine/tests/phpunit/ElggMetadataTest.php
+++ b/engine/tests/phpunit/ElggMetadataTest.php
@@ -113,7 +113,7 @@ class ElggMetadataTest extends TestCase {
 		$id = _elgg_services()->metadataTable->iterator + 1;
 
 		// Insert
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 		$sql = "INSERT INTO {$dbprefix}metadata
 				(entity_guid, name, value, value_type, owner_guid, time_created, access_id)
 				VALUES (:entity_guid, :name, :value, :value_type, :owner_guid, :time_created, :access_id)";
@@ -151,7 +151,7 @@ class ElggMetadataTest extends TestCase {
 
 		$this->assertInstanceOf(\ElggMetadata::class, $metadata);
 		
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 		_elgg_services()->db->addQuerySpec([
 			'sql' => "DELETE FROM {$dbprefix}metadata WHERE id = :id",
 			'params' => [

--- a/engine/tests/phpunit/ElggObjectTest.php
+++ b/engine/tests/phpunit/ElggObjectTest.php
@@ -103,7 +103,7 @@ class ElggObjectTest extends \Elgg\TestCase {
 		$object->setCurrentTime();
 
 		// Update river
-		$dbprefix = elgg_get_config('dbprefix');
+		$dbprefix = _elgg_config()->dbprefix;
 		$query = "
 			UPDATE {$dbprefix}river
 				SET access_id = :access_id

--- a/engine/tests/suite.php
+++ b/engine/tests/suite.php
@@ -48,8 +48,7 @@ if (!TextReporter::inCli()) {
 		$plugin->activate();
 	}
 
-	global $CONFIG;
-	$CONFIG->debug = 'NOTICE';
+	_elgg_config()->debug = 'NOTICE';
 }
 
 // turn off system log

--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -177,7 +177,7 @@ function discussion_redirect_to_reply($reply_guid, $fallback_guid) {
 	]);
 	$limit = (int) get_input('limit', 0);
 	if (!$limit) {
-		$limit = _elgg_services()->config->get('default_limit');
+		$limit = _elgg_config()->default_limit;
 	}
 	$offset = floor($count / $limit) * $limit;
 	if (!$offset) {

--- a/mod/web_services/classes/GenericResult.php
+++ b/mod/web_services/classes/GenericResult.php
@@ -96,7 +96,7 @@ abstract class GenericResult {
 	 * @return stdClass Object containing the serialised result.
 	 */
 	public function export() {
-		global $ERRORS, $CONFIG, $_PAM_HANDLERS_MSG;
+		global $ERRORS, $_PAM_HANDLERS_MSG;
 
 		$result = new stdClass;
 
@@ -110,7 +110,7 @@ abstract class GenericResult {
 			$result->result = $resultdata;
 		}
 
-		if (isset($CONFIG->debug)) {
+		if (elgg_get_config('debug')) {
 			if (count($ERRORS)) {
 				$result->runtime_errors = $ERRORS;
 			}


### PR DESCRIPTION
`_elgg_config()` returns the Config object and property reads call get().
Removes many usages of $CONFIG.