### PR TITLE
chore(views): corrects missed instances during conversion to static method

### DIFF
--- a/engine/classes/Elgg/Cache/SimpleCache.php
+++ b/engine/classes/Elgg/Cache/SimpleCache.php
@@ -46,7 +46,7 @@ class SimpleCache {
 	 * @see elgg_get_simplecache_url()
 	 */
 	function registerView($view_name) {
-		$view_name = $this->views->canonicalizeViewName($view_name);
+		$view_name = Views::canonicalizeViewName($view_name);
 		elgg_register_external_view($view_name, true);
 	}
 
@@ -86,7 +86,7 @@ class SimpleCache {
 			$view = "$view/$subview";
 		}
 
-		$view = $this->views->canonicalizeViewName($view);
+		$view = Views::canonicalizeViewName($view);
 
 		// should be normalized to canonical form by now: `getUrl('blog/save_draft.js')`
 		$this->registerView($view);

--- a/engine/classes/Elgg/HooksRegistrationService.php
+++ b/engine/classes/Elgg/HooksRegistrationService.php
@@ -68,7 +68,7 @@ abstract class HooksRegistrationService {
 	 */
 	public function unregisterHandler($name, $type, $callback) {
 		if (($name == 'view' || $name == 'view_vars') && $type != 'all') {
-			$type = _elgg_services()->views->canonicalizeViewName($type);
+			$type = ViewsService::canonicalizeViewName($type);
 		}
 
 		if (empty($this->registrations[$name][$type])) {

--- a/engine/classes/Elgg/PluginHooksService.php
+++ b/engine/classes/Elgg/PluginHooksService.php
@@ -74,7 +74,7 @@ class PluginHooksService extends HooksRegistrationService {
 	 */
 	public function registerHandler($name, $type, $callback, $priority = 500) {
 		if (($name == 'view' || $name == 'view_vars') && $type !== 'all') {
-			$type = _elgg_services()->views->canonicalizeViewName($type);
+			$type = ViewsService::canonicalizeViewName($type);
 		}
 
 		return parent::registerHandler($name, $type, $callback, $priority);

--- a/engine/tests/phpunit/Elgg/ViewsServiceTest.php
+++ b/engine/tests/phpunit/Elgg/ViewsServiceTest.php
@@ -155,7 +155,7 @@ class ViewsServiceTest extends \Elgg\TestCase {
 	 * @dataProvider getExampleNormalizedViews
 	 */
 	public function testDefaultNormalizeBehavior($canonical, $alias) {
-		$this->assertEquals($canonical, $this->views->canonicalizeViewName($alias));
+		$this->assertEquals($canonical, ViewsService::canonicalizeViewName($alias));
 	}
 
 	public function testCanListViews() {


### PR DESCRIPTION
This method was made static in https://github.com/Elgg/Elgg/pull/11092/files#diff-e673c0a389cf72c11e7372c26cedb5f0L100