### PR TITLE
chore(core): remove some static state storage

### DIFF
--- a/engine/classes/Elgg/Application/CacheHandler.php
+++ b/engine/classes/Elgg/Application/CacheHandler.php
@@ -47,9 +47,6 @@ class CacheHandler {
 		"text/xml",
 	];
 
-	/** @var Application */
-	private $application;
-
 	/** @var Config */
 	private $config;
 
@@ -59,13 +56,11 @@ class CacheHandler {
 	/**
 	 * Constructor
 	 *
-	 * @param Application $app                 Elgg Application
-	 * @param Config      $config              Elgg configuration
-	 * @param Request     $request             HTTP request
-	 * @param bool        $simplecache_enabled Is the simplecache enabled?
+	 * @param Config  $config              Elgg configuration
+	 * @param Request $request             HTTP request
+	 * @param bool    $simplecache_enabled Is the simplecache enabled?
 	 */
-	public function __construct(Application $app, Config $config, Request $request, $simplecache_enabled) {
-		$this->application = $app;
+	public function __construct(Config $config, Request $request, $simplecache_enabled) {
 		$this->config = $config;
 		$this->request = $request;
 		$this->simplecache_enabled = $simplecache_enabled;
@@ -74,10 +69,11 @@ class CacheHandler {
 	/**
 	 * Handle a request for a cached view
 	 *
-	 * @param array $path URL path
+	 * @param Request     $request Elgg request
+	 * @param Application $app     Elgg application
 	 * @return Response (unprepared)
 	 */
-	public function handleRequest(Request $request) {
+	public function handleRequest(Request $request, Application $app) {
 		$config = $this->config;
 
 		$parsed = $this->parsePath($request->getElggPath());
@@ -102,7 +98,7 @@ class CacheHandler {
 		}
 
 		if (!$this->simplecache_enabled) {
-			$this->application->bootCore();
+			$app->bootCore();
 			header_remove('Cache-Control');
 			header_remove('Pragma');
 			header_remove('Expires');
@@ -138,7 +134,7 @@ class CacheHandler {
 		}
 
 		// the hard way
-		$this->application->bootCore();
+		$app->bootCore();
 		header_remove('Cache-Control');
 		header_remove('Pragma');
 		header_remove('Expires');

--- a/engine/classes/Elgg/BootService.php
+++ b/engine/classes/Elgg/BootService.php
@@ -28,6 +28,13 @@ class BootService {
 	const DEFAULT_BOOT_CACHE_TTL = 0;
 
 	/**
+	 * Has the cache already been invalidated this request? Avoids thrashing
+	 *
+	 * @var bool
+	 */
+	private $was_cleared = false;
+
+	/**
 	 * Boots the engine
 	 *
 	 * @param ServiceProvider $services Services
@@ -147,11 +154,9 @@ class BootService {
 	 * @return void
 	 */
 	public function invalidateCache() {
-		// this gets called a lot on plugins page, avoid thrashing cache
-		static $cleared = false;
-		if (!$cleared) {
+		if (!$this->was_cleared) {
 			$this->getStashItem(_elgg_config())->clear();
-			$cleared = true;
+			$this->was_cleared = true;
 		}
 	}
 

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -21,7 +21,6 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\Ajax\Service                       $ajax
  * @property-read \Elgg\Amd\Config                         $amdConfig
  * @property-read \Elgg\Database\Annotations               $annotations
- * @property-read \Elgg\Application                        $app
  * @property-read \ElggAutoP                               $autoP
  * @property-read \Elgg\AutoloadManager                    $autoloadManager
  * @property-read \Elgg\BatchUpgrader                      $batchUpgrader
@@ -137,12 +136,6 @@ class ServiceProvider extends DiContainer {
 			return $obj;
 		});
 
-		/**
-		 * "app" is set when the application is constructed
-		 *
-		 * @see \Elgg\Application::__construct "app"
-		 */
-
 		$this->setFactory('annotations', function(ServiceProvider $c) {
 			return new \Elgg\Database\Annotations($c->db, $c->session, $c->hooks->getEvents());
 		});
@@ -166,7 +159,7 @@ class ServiceProvider extends DiContainer {
 			if ($simplecache_enabled === null) {
 				$simplecache_enabled = $c->configTable->get('simplecache_enabled');
 			}
-			return new \Elgg\Application\CacheHandler($c->app, $c->config, $c->request, $simplecache_enabled);
+			return new \Elgg\Application\CacheHandler($c->config, $c->request, $simplecache_enabled);
 		});
 
 		$this->setFactory('classLoader', function(ServiceProvider $c) {

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -129,7 +129,7 @@ class ElggInstaller {
 			// allows settings.php to be loaded, which might try to write to global $CONFIG
 			// which is only a problem due to the config values that deep-write to arrays,
 			// like cookies.
-			'overwrite_global_config' => false,
+			'set_global_config' => false,
 		]);
 		$app->loadCore();
 		$this->app = $app;

--- a/engine/lib/autoloader.php
+++ b/engine/lib/autoloader.php
@@ -10,16 +10,11 @@
 /**
  * Get the global service provider
  *
- * @param \Elgg\Di\ServiceProvider $services Elgg service provider. This must be set by the application.
  * @return \Elgg\Di\ServiceProvider
  * @access private
  */
-function _elgg_services(\Elgg\Di\ServiceProvider $services = null) {
-	static $inst;
-	if ($services !== null) {
-		$inst = $services;
-	}
-	return $inst;
+function _elgg_services() {
+	return elgg()->_services;
 }
 
 /**

--- a/engine/tests/phpunit/Elgg/Application/CacheHandlerTest.php
+++ b/engine/tests/phpunit/Elgg/Application/CacheHandlerTest.php
@@ -10,9 +10,8 @@ class CacheHandlerTest extends \Elgg\TestCase {
 	protected $handler;
 
 	public function setUp() {
-		$app = elgg();
 		$request = _elgg_services()->request;
-		$this->handler = new CacheHandler($app, _elgg_config(), $request, true);
+		$this->handler = new CacheHandler(_elgg_config(), $request, true);
 	}
 
 	protected function _testParseFail($input) {

--- a/engine/tests/phpunit/Elgg/ApplicationTest.php
+++ b/engine/tests/phpunit/Elgg/ApplicationTest.php
@@ -17,7 +17,7 @@ class ApplicationTest extends \Elgg\TestCase {
 		Application::factory([
 			'handle_shutdown' => false,
 			'handle_exceptions' => false,
-			'overwrite_global_config' => false,
+			'set_global_config' => false,
 			'config' => new Config(TestCase::getTestingConfigArray()),
 		]);
 		Application::$_instance = $app;

--- a/engine/tests/phpunit/Elgg/TestCase.php
+++ b/engine/tests/phpunit/Elgg/TestCase.php
@@ -84,7 +84,6 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 		// loadCore bails on repeated calls, so we need to manually inject this to make
 		// sure it happens before each test.
 		$app->loadCore();
-		_elgg_services($sp);
 
 		// Invalidate memcache
 		_elgg_get_memcache('new_entity_cache')->clear();


### PR DESCRIPTION
`_elgg_services` no longer has its own static storage.
`ServiceProvider` no longer stores an `Application` reference.
Fewer static vars.