### PR TITLE
feat(permissions): permissions for admin users or with ignored access are now universal

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -114,6 +114,8 @@ All the functions in ``engine/lib/deprecated-1.10.php`` were removed. See https:
  * ``notifications_plugin_pagesetup``
  * ``elgg_format_url``: Use elgg_format_element() or the "output/text" view for HTML escaping.
  * ``get_site_by_url``
+ * ``elgg_override_permissions``: No longer used as handler for ``permissions_check`` and ``container_permissions_check`` hooks
+ * ``elgg_check_access_overrides``
  * ``ElggEntity::addToSite``
  * ``ElggEntity::getSites``
  * ``ElggEntity::removeFromSite``
@@ -197,11 +199,23 @@ From the "users_entity" table, the ``password`` and ``hash`` columns have been r
 The ``geocode_cache`` table has been removed as it was no longer used.
 
 Metadata no longer are access-controlled
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------
 
 Metadata is available in all contexts. If your plugin created metadata with restricted access, those restrictions will not be honored. You should use annotations or entities instead, which do provide access control.
 
 Do not read or write to the ``access_id`` property on ElggMetadata objects.
+
+Permissions and Access
+----------------------
+
+User capabilities service will no longer trigger permission check hooks when:
+
+ - permissions are checked for an admin user
+ - permissions are checked when access is ignored with ``elgg_set_ignore_access()``
+
+This means that plugins can no longer alter permissions in aforementioned cases.
+
+``elgg_check_access_overrides()`` has been removed, as plugins will no longer need to validate access overrides.
 
 Multi Site Changes
 ------------------
@@ -214,7 +228,7 @@ You need to separate the different sites into separate databases/tables.
 Related to the removal of the Multi Site concept in Elgg, there is no longer a need for entities having a 'member_of_site' relationship with the Site Entity.
 All functions related to adding/removing this relationship has been removed. All existing relationships will be removed as part of this upgrade.
 
-Setting ``ElggSite::$url`` has no effect. Reading the site URL always pulls from the `$CONFIG->wwwroot` set in
+Setting ``ElggSite::$url`` has no effect. Reading the site URL always pulls from the ``$CONFIG->wwwroot`` set in
 settings.php, or computed by Symphony Request.
 
 ``ElggSite::save()`` will fail if it isn't the main site.

--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -1450,9 +1450,9 @@ class EntityTable {
 			// requested to check access for a specific user_guid, but there is no user entity, so the caller
 			// should cancel the check and return false
 			$message = $this->translator->translate('UserFetchFailureException', [$guid]);
-			$this->logger->warn($message);
+			// $this->logger->warn($message);
 
-			throw new UserFetchFailureException();
+			throw new UserFetchFailureException($message);
 		}
 
 		return $user;

--- a/engine/classes/Elgg/Database/Plugins.php
+++ b/engine/classes/Elgg/Database/Plugins.php
@@ -152,6 +152,7 @@ class Plugins {
 	
 		$physical_plugins = $this->getDirsInDir($mod_dir);
 		if (!$physical_plugins) {
+			elgg_set_ignore_access($old_ia);
 			return false;
 		}
 	

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -117,7 +117,7 @@ class ServiceProvider extends DiContainer {
 
 		$this->setFactory('accessCollections', function(ServiceProvider $c) {
 			return new \Elgg\Database\AccessCollections(
-					$c->config, $c->db, $c->entityTable, $c->accessCache, $c->hooks, $c->session, $c->translator);
+					$c->config, $c->db, $c->entityTable, $c->userCapabilities, $c->accessCache, $c->hooks, $c->session, $c->translator);
 		});
 
 		$this->setFactory('actions', function(ServiceProvider $c) {

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -409,10 +409,12 @@ abstract class ElggEntity extends \ElggData implements
 				// need to remove access restrictions right now to delete
 				// because this is the expected behavior
 				$ia = elgg_set_ignore_access(true);
-				if (false === elgg_delete_metadata($options)) {
+				$delete_result = elgg_delete_metadata($options);
+				elgg_set_ignore_access($ia);
+
+				if (false === $delete_result) {
 					return false;
 				}
-				elgg_set_ignore_access($ia);
 			}
 
 			$owner_guid = $owner_guid ? (int) $owner_guid : $this->owner_guid;
@@ -1341,7 +1343,7 @@ abstract class ElggEntity extends \ElggData implements
 
 			// If different owner than logged in, verify can write to container.
 
-			if ($user_guid != $owner_guid && !$owner->canWriteToContainer(0, $type, $subtype)) {
+			if ($user_guid != $owner_guid && !$owner->canWriteToContainer($user_guid, $type, $subtype)) {
 				_elgg_services()->logger->error("User $user_guid tried to create a ($type, $subtype) with owner"
 					. " $owner_guid, but the user wasn't permitted to write to the owner's container.");
 				return false;
@@ -1357,7 +1359,7 @@ abstract class ElggEntity extends \ElggData implements
 				return false;
 			}
 
-			if (!$container->canWriteToContainer(0, $type, $subtype)) {
+			if (!$container->canWriteToContainer($user_guid, $type, $subtype)) {
 				_elgg_services()->logger->error("User $user_guid tried to create a ($type, $subtype), but was not"
 					. " permitted to write to container $container_guid.");
 				return false;

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -1419,13 +1419,13 @@ class ElggInstaller {
 			return false;
 		}
 
-		elgg_set_ignore_access(true);
+		$ia = elgg_set_ignore_access(true);
 		if ($user->makeAdmin() == false) {
 			register_error(elgg_echo('install:error:adminaccess'));
 		} else {
 			$this->services->configTable->set('admin_registered', 1);
 		}
-		elgg_set_ignore_access(false);
+		elgg_set_ignore_access($ia);
 
 		// add validation data to satisfy user validation plugins
 		$user->validated = 1;

--- a/engine/tests/ElggCoreAccessCollectionsTest.php
+++ b/engine/tests/ElggCoreAccessCollectionsTest.php
@@ -271,10 +271,10 @@ class ElggCoreAccessCollectionsTest extends \ElggCoreUnitTest {
 			_elgg_services()->accessCache->clear();
 
 			// admin users run tests, so disable access
-			elgg_set_ignore_access(true);
+			$ia = elgg_set_ignore_access(true);
 			$access = $func($user->getGUID());
 
-			elgg_set_ignore_access(false);
+			elgg_set_ignore_access($ia);
 			$access2 = $func($user->getGUID());
 			$this->assertNotEqual($access, $access2, "Access test for $func");
 		}

--- a/engine/tests/ElggCoreGetEntitiesBaseTest.php
+++ b/engine/tests/ElggCoreGetEntitiesBaseTest.php
@@ -14,11 +14,14 @@ abstract class ElggCoreGetEntitiesBaseTest extends \ElggCoreUnitTest {
 	/** @var array */
 	protected $subtypes;
 
+	protected $ignore_access;
+
 	/**
 	 * Called before each test object.
 	 */
 	public function __construct() {
-		elgg_set_ignore_access(true);
+		$ia = elgg_set_ignore_access(true);
+
 		$this->entities = array();
 		$this->subtypes = array(
 			'object' => array(),
@@ -65,6 +68,8 @@ abstract class ElggCoreGetEntitiesBaseTest extends \ElggCoreUnitTest {
 			$this->subtypes['group'][] = $subtype;
 		}
 
+		elgg_set_ignore_access($ia);
+
 		parent::__construct();
 	}
 
@@ -72,6 +77,8 @@ abstract class ElggCoreGetEntitiesBaseTest extends \ElggCoreUnitTest {
 	 * Called after each test object.
 	 */
 	public function __destruct() {
+		$ia = elgg_set_ignore_access();
+
 		foreach ($this->entities as $e) {
 			$e->delete();
 		}
@@ -85,9 +92,18 @@ abstract class ElggCoreGetEntitiesBaseTest extends \ElggCoreUnitTest {
 			}
 		}
 
+		elgg_set_ignore_access($ia);
+
 		parent::__destruct();
 	}
 
+	public function setUp() {
+		$this->assertFalse(elgg_get_ignore_access());
+	}
+
+	public function tearDown() {
+		$this->assertFalse(elgg_get_ignore_access());
+	}
 
 	/*************************************************
 	 * Helpers for getting random types and subtypes *

--- a/engine/tests/ElggCoreMetadataAPITest.php
+++ b/engine/tests/ElggCoreMetadataAPITest.php
@@ -140,7 +140,7 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 		// good times without mocking.
 		$original_user = $this->replaceSession($u1);
 		
-		elgg_set_ignore_access(false);
+		$ia = elgg_set_ignore_access(false);
 
 		// add metadata as one user
 		$obj->test = $md_values;
@@ -177,6 +177,8 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 			$this->assertTrue(in_array($md->value, $md_values2));
 			$this->assertEqual('test', $md->name);
 		}
+
+		elgg_set_ignore_access($ia);
 
 		$this->replaceSession($original_user);
 

--- a/engine/tests/ElggEntityTest.php
+++ b/engine/tests/ElggEntityTest.php
@@ -390,14 +390,14 @@ class ElggCoreEntityTest extends \ElggCoreUnitTest {
 
 		$this->assertTrue($this->entity->save());
 
+		$user = new ElggUser();
+		$user->save();
+		$old_user = $this->replaceSession($user);
+
 		// even owner can't bypass permissions
 		elgg_register_plugin_hook_handler('permissions_check', 'object', [Elgg\Values::class, 'getFalse'], 999);
 		$this->assertFalse($this->entity->save());
 		elgg_unregister_plugin_hook_handler('permissions_check', 'object', [Elgg\Values::class, 'getFalse']);
-
-		$user = new ElggUser();
-		$user->save();
-		$old_user = $this->replaceSession($user);
 
 		$this->assertFalse($this->entity->save());
 

--- a/engine/tests/ElggObjectTest.php
+++ b/engine/tests/ElggObjectTest.php
@@ -155,24 +155,6 @@ class ElggCoreObjectTest extends \ElggCoreUnitTest {
 		$this->assertIdentical($keys, $object_keys);
 	}
 
-	public function xtestElggObjectAccessOverrides() {
-		// set entity to private access with no owner.
-		$entity = $this->entity;
-		$entity->access_id = ACCESS_PRIVATE;
-		$entity->owner_guid = 0;
-		$this->assertTrue($entity->save());
-		$guid = $entity->getGUID();
-
-		var_dump($guid);
-		// try to grab entity
-		$entity = false;
-		$entity = get_entity($guid);
-		var_dump($entity);
-		$this->assertFalse($entity);
-
-		$old = elgg_set_ignore_access(true);
-	}
-
 	// see https://github.com/elgg/elgg/issues/1196
 	public function testElggEntityRecursiveDisableWhenLoggedOut() {
 		$e1 = new \ElggObject();

--- a/engine/tests/phpunit/Elgg/Mocks/Di/MockServiceProvider.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Di/MockServiceProvider.php
@@ -18,6 +18,7 @@ use ElggSite;
  * @property-read \Elgg\Mocks\Database\SubtypeTable         $subtypeTable       Subtype table mock
  * @property-read \Elgg\Mocks\Database\AccessCollections    $accessCollections  ACL table mock
  * @property-read \Elgg\Mocks\Database\PrivateSettingsTable $privateSettings    Private settings table mock
+ * @property-read \Elgg\Mocks\Database\UserCapabilities     $userCapabilities   User capabilities
  *
  * @since 2.3
  */
@@ -74,6 +75,7 @@ class MockServiceProvider extends \Elgg\Di\DiContainer {
 				$sp->config,
 				$m->db,
 				$m->entityTable,
+				$m->userCapabilities,
 				$sp->accessCache,
 				$sp->hooks,
 				$sp->session,
@@ -87,6 +89,10 @@ class MockServiceProvider extends \Elgg\Di\DiContainer {
 				$m->entityTable,
 				$sp->pluginSettingsCache
 			);
+		});
+
+		$this->setFactory('userCapabilities', function(MockServiceProvider $m) use ($sp) {
+			return new \Elgg\UserCapabilities($sp->hooks, $m->entityTable, $m->session);
 		});
 	}
 

--- a/engine/tests/suite.php
+++ b/engine/tests/suite.php
@@ -98,6 +98,4 @@ if (TextReporter::inCli()) {
 	exit($result);
 }
 
-$old = elgg_set_ignore_access(true);
 $suite->Run(new HtmlReporter('utf-8'));
-elgg_set_ignore_access($old);

--- a/mod/friends/start.php
+++ b/mod/friends/start.php
@@ -180,6 +180,10 @@ function _elgg_send_friend_notification($event, $type, $object) {
 	$user_two = get_entity($object->guid_two);
 	/* @var ElggUser $user_two */
 
+	if (!$user_one instanceof ElggUser || !$user_two instanceof ElggUser) {
+		return;
+	}
+
 	// Notification subject
 	$subject = elgg_echo('friend:newfriend:subject', [
 		$user_one->name


### PR DESCRIPTION
BREAKING CHANGE
User capabilities service will no longer trigger permissions check hooks, when
a) permissions are checked for an admin user
b) permissions are check when access is ignored

Fixes #7999