### PR TITLE
feat(tests): migrate simpletest suite to phpunit integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,8 +83,8 @@ matrix:
        - php ./elgg-cli database:seed -vv
       script:
        - php -f ./.scripts/is_memcached_enabled.php
-       - ./vendor/bin/phpunit
        - php ./elgg-cli simpletest -p all
+       - ./vendor/bin/phpunit
       after_script:
        - php ./elgg-cli database:unseed -vv
 
@@ -98,8 +98,8 @@ matrix:
       install:
        - composer travis:install-with-mysql
       script:
-       - ./vendor/bin/phpunit
        - php ./elgg-cli simpletest -p all
+       - ./vendor/bin/phpunit
 
     # End to end tests
     - php: 5.6
@@ -115,8 +115,8 @@ matrix:
        - sleep 3 # give Web server some time to bind to sockets, etc
       script:
        - curl -o - http://localhost:8888/ | grep "<title>Elgg Travis Site</title>"
-       - ./vendor/bin/phpunit
        - php ./elgg-cli simpletest -p all
+       - ./vendor/bin/phpunit
       after_script:
        - php ./elgg-cli database:unseed -vv
 
@@ -137,12 +137,12 @@ matrix:
         - git checkout -
         - composer install --prefer-dist
         - php -f ./.scripts/travis/upgrade.php
-      script:
-        #- ./vendor/bin/phpunit  # not necessary
-        - php ./elgg-cli simpletest -p all
         - php -S localhost:8888 index.php &
         - sleep 3 # give Web server some time to bind to sockets, etc
+      script:
         - curl -o - http://localhost:8888/ | grep "<title>Elgg Travis Site</title>"
+        - php ./elgg-cli simpletest -p all
+        - ./vendor/bin/phpunit
       after_script:
         - php ./elgg-cli database:unseed -vv
 
@@ -156,12 +156,12 @@ before_install:
 install: composer travis:install-with-mysql
 
 script:
+  - php ./elgg-cli simpletest -p all -v
   # in this build, we want to make sure the test suites can bootstrap on their own
   # combined test runner is executed in e2e builds
   - ./vendor/bin/phpunit --testsuite unit
   - ./vendor/bin/phpunit --testsuite integration
   - ./vendor/bin/phpunit --testsuite plugins
-  - php ./elgg-cli simpletest -p all -v
 
 notifications:
   email:

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -216,14 +216,6 @@ class Application {
 		}
 
 		self::autoload();
-
-		$hooks = $this->_services->hooks;
-		$events = $hooks->getEvents();
-
-		// run setups
-		foreach (self::$_setups as $func) {
-			$func($events, $hooks);
-		}
 	}
 
 	/**
@@ -326,7 +318,13 @@ class Application {
 
 		$this->allowPathRewrite();
 
-		$events = $this->_services->hooks->getEvents();
+		$hooks = $this->_services->hooks;
+		$events = $hooks->getEvents();
+
+		// run setups
+		foreach (self::$_setups as $func) {
+			$func($events, $hooks);
+		}
 
 		// Allows registering handlers strictly before all init, system handlers
 		$events->trigger('plugins_boot', 'system');
@@ -746,12 +744,6 @@ class Application {
 		if (!class_exists(UnitTestCase::class)) {
 			throw new RuntimeException(__METHOD__ . ' can only be executed if Elgg is installed using composer install --dev');
 		}
-
-		if (!date_default_timezone_get()) {
-			date_default_timezone_set('America/Los_Angeles');
-		}
-
-		error_reporting(E_ALL | E_STRICT);
 
 		self::autoload();
 

--- a/engine/classes/Elgg/Cli/ConsoleInteractions.php
+++ b/engine/classes/Elgg/Cli/ConsoleInteractions.php
@@ -5,6 +5,8 @@
 
 namespace Elgg\Cli;
 
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
 trait ConsoleInteractions {

--- a/engine/classes/Elgg/Cli/SimpletestCommand.php
+++ b/engine/classes/Elgg/Cli/SimpletestCommand.php
@@ -3,10 +3,8 @@
 namespace Elgg\Cli;
 
 use Elgg\Application;
-use Elgg\Config;
 use Elgg\Project\Paths;
-use Exception;
-use RuntimeException;
+use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Input\InputOption;
 use TestSuite;
 use TextReporter;
@@ -41,115 +39,95 @@ class SimpletestCommand extends Command {
 			return 1;
 		}
 
+		if (!date_default_timezone_get()) {
+			date_default_timezone_set('America/Los_Angeles');
+		}
+
+		error_reporting(E_ALL | E_STRICT);
+
 		// Disable maximum execution time.
 		// Tests take a while...
 		set_time_limit(0);
 
-		ob_start();
-
-		$error = 0;
-
-		try {
-			$settings_path = $this->option('config');
-			if (!$settings_path) {
-				$settings_path = Paths::elgg() . 'engine/tests/elgg-config/simpletest.php';
-			}
-
-			$sp = _elgg_services();
-			$app = Application::factory([
-				'settings_path' => $settings_path,
-				'service_provider' => $sp,
-			]);
-			Application::setInstance($app);
-
-			// turn off system log
-			_elgg_services()->hooks->unregisterHandler('all', 'all', 'system_log_listener');
-			_elgg_services()->hooks->unregisterHandler('log', 'systemlog', 'system_log_default_logger');
-
-			$admin = array_shift(elgg_get_admins([
-				'limit' => 1,
-				'order_by' => 'e.time_created ASC',
-			]));
-
-			if (!login($admin)) {
-				throw new RuntimeException("Failed to login as administrator.");
-			}
-
-			// disable emails
-			elgg_set_email_transport(new \Zend\Mail\Transport\InMemory());
-
-			$plugins = $this->option('plugins');
-			if (in_array('all', $plugins)) {
-				$plugins = [];
-				$plugin_entities = elgg_get_plugins('inactive');
-				foreach ($plugin_entities as $plugin_entity) {
-					$plugins[] = $plugin_entity->getID();
-				}
-			} else if (empty($plugins)) {
-				// plugins that contain unit tests
-				$plugins = [
-					'groups',
-					'thewire',
-					'web_services'
-				];
-			}
-
-			$activated_plugins = [];
-
-			// activate plugins that are not activated on install
-			foreach ($plugins as $key => $id) {
-				$plugin = elgg_get_plugin_from_id($id);
-				if (!$plugin || $plugin->isActive()) {
-					unset($plugins[$key]);
-					continue;
-				}
-				if ($plugin->activate()) {
-					$activated_plugins[] = $id;
-				}
-			}
-
-			$suite = new TestSuite('Elgg Core Unit Tests');
-
-			$test_cases = _elgg_services()->hooks->trigger('unit_test', 'system', null, []);
-			foreach ($test_cases as $file) {
-				if (substr($file, -4, 4) === '.php') {
-					$suite->addFile($file);
-				} else if (class_exists($file)) {
-					if (is_subclass_of($file, \UnitTestCase::class)) {
-						$suite->add($file);
-					} else {
-						elgg_log($file . ' is not a valid simpletest class');
-					}
-				}
-			}
-
-			$start_time = microtime(true);
-
-			$reporter = new TextReporter();
-			$result = $suite->Run($reporter);
-
-			// deactivate plugins that were activated for test suite
-			foreach ($activated_plugins as $key => $id) {
-				$plugin = elgg_get_plugin_from_id($id);
-				$plugin->deactivate();
-			}
-
-			echo PHP_EOL . sprintf("Time: %.2f seconds, Memory: %.2fMb\n",
-					microtime(true) - $start_time,
-					memory_get_peak_usage() / 1048576.0 // in megabytes
-				) . PHP_EOL;
-
-			if (!$result) {
-				throw new RuntimeException('One or more tests have failed');
-			}
-		} catch (Exception $e) {
-			$error = $e->getCode() ? : 1;
-			elgg_log("Test suite has failed with " . get_class($e) . ': ' . $e->getMessage(), 'ERROR');
+		$settings_path = $this->option('config');
+		if (!$settings_path) {
+			$settings_path = Paths::elgg() . 'engine/tests/elgg-config/simpletest.php';
 		}
 
-		$this->write(ob_get_clean());
+		$sp = _elgg_services();
+		$app = Application::factory([
+			'settings_path' => $settings_path,
+			'service_provider' => $sp,
+			'handle_exceptions' => false,
+			'handle_shutdown' => false,
+		]);
 
-		return $error;
+		Application::setInstance($app);
+
+		// turn off system log
+		_elgg_services()->hooks->unregisterHandler('all', 'all', 'system_log_listener');
+		_elgg_services()->hooks->unregisterHandler('log', 'systemlog', 'system_log_default_logger');
+
+		// disable emails
+		elgg_set_email_transport(new \Zend\Mail\Transport\InMemory());
+
+		$plugins = (array) $this->option('plugins');
+		if (in_array('all', $plugins)) {
+			$plugins = [];
+			$plugin_entities = elgg_get_plugins('inactive');
+			foreach ($plugin_entities as $plugin_entity) {
+				$plugins[] = $plugin_entity->getID();
+			}
+		}
+
+		$activated_plugins = [];
+
+		// activate plugins that are not activated on install
+		foreach ($plugins as $key => $id) {
+			$plugin = elgg_get_plugin_from_id($id);
+			if (!$plugin || $plugin->isActive()) {
+				unset($plugins[$key]);
+				continue;
+			}
+			if ($plugin->activate()) {
+				$activated_plugins[] = $id;
+			}
+		}
+
+		$suite = new TestSuite('Elgg Core Unit Tests');
+
+		$test_cases = _elgg_services()->hooks->trigger('unit_test', 'system', null, []);
+		foreach ($test_cases as $file) {
+			if (substr($file, -4, 4) === '.php') {
+				$suite->addFile($file);
+			} else if (class_exists($file)) {
+				if (is_subclass_of($file, \UnitTestCase::class)) {
+					$suite->add($file);
+				} else {
+					elgg_log($file . ' is not a valid simpletest class');
+				}
+			}
+		}
+
+		$start_time = microtime(true);
+
+		$reporter = new TextReporter();
+		$result = $suite->Run($reporter);
+
+		// deactivate plugins that were activated for test suite
+		foreach ($activated_plugins as $key => $id) {
+			$plugin = elgg_get_plugin_from_id($id);
+			$plugin->deactivate();
+		}
+
+		$formatter = new FormatterHelper();
+		$message = $formatter->formatBlock(sprintf("Time: %.2f seconds, Memory: %.2fMb\n",
+			microtime(true) - $start_time,
+			memory_get_peak_usage() / 1048576.0 // in megabytes
+		), 'info');
+		$this->output->writeln($message);
+
+		return $result ? 0 : 1;
 	}
 
 }

--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -955,7 +955,7 @@ class EntityTable {
 								$subtype_ids[] = $subtype_id;
 							} else {
 								$valid_subtypes_count--;
-								$this->logger->warn("Type-subtype '$type:$subtype' does not exist!");
+								$this->logger->notice("Type-subtype '$type:$subtype' does not exist!");
 								continue;
 							}
 						}
@@ -1008,7 +1008,7 @@ class EntityTable {
 									ELGG_ENTITIES_NO_VALUE : $paired_subtype_id;
 						} else {
 							$valid_pairs_subtypes_count--;
-							$this->logger->warn("Type-subtype '$paired_type:$paired_subtype' does not exist!");
+							$this->logger->notice("Type-subtype '$paired_type:$paired_subtype' does not exist!");
 							// return false if we're all invalid subtypes in the only valid type
 							continue;
 						}

--- a/engine/classes/Elgg/Database/Seeds/Seeding.php
+++ b/engine/classes/Elgg/Database/Seeds/Seeding.php
@@ -89,7 +89,7 @@ trait Seeding {
 				$attributes['password'] = generate_random_cleartext_password();
 			}
 
-			if (empty($attributes['username'])) {
+			if (empty($attributes['name'])) {
 				$attributes['name'] = $this->faker()->name;
 			}
 
@@ -101,10 +101,14 @@ trait Seeding {
 				$attributes['email'] = "{$attributes['username']}@{$this->getEmailDomain()}";
 			}
 
+			if (empty($attributes['subtype'])) {
+				$attributes['subtype'] = null;
+			}
+
 			$user = false;
 
 			try {
-				$guid = register_user($attributes['username'], $attributes['password'], $attributes['name'], $attributes['email']);
+				$guid = register_user($attributes['username'], $attributes['password'], $attributes['name'], $attributes['email'], false, $attributes['subtype']);
 				$user = get_entity($guid);
 				/* @var $user ElggUser */
 
@@ -299,6 +303,14 @@ trait Seeding {
 				$attributes['description'] = $this->faker()->text($this->faker()->numberBetween(500, 1000));
 			}
 
+			if (empty($attributes['subtype'])) {
+				$attributes['subtype'] = strtolower($this->faker()->word);
+			}
+
+			if (empty($metadata['tags'])) {
+				$metadata['tags'] = $this->faker()->words(10);
+			}
+
 			if (empty($attributes['container_guid'])) {
 				if ($this->faker()->boolean()) {
 					$container = $this->getRandomGroup();
@@ -315,12 +327,9 @@ trait Seeding {
 				$attributes['container_guid'] = $container->guid;
 			}
 
-			if (empty($attributes['subtype'])) {
-				$attributes['subtype'] = strtolower($this->faker()->word);
-			}
-
-			if (empty($metadata['tags'])) {
-				$metadata['tags'] = $this->faker()->words(10);
+			$container = get_entity($attributes['container_guid']);
+			if (!$container) {
+				return false;
 			}
 
 			if (empty($attributes['owner_guid'])) {
@@ -347,13 +356,7 @@ trait Seeding {
 				return false;
 			}
 
-			$container = get_entity($attributes['container_guid']);
-			if (!$container) {
-				return false;
-			}
-
-			if (empty($attributes['access_id'])) {
-				//$attributes['access_id'] = $this->getRandomAccessId($owner, $container);
+			if (!isset($attributes['access_id'])) {
 				$attributes['access_id'] = ACCESS_PUBLIC;
 			}
 

--- a/engine/classes/Elgg/Database/UsersTable.php
+++ b/engine/classes/Elgg/Database/UsersTable.php
@@ -378,11 +378,12 @@ class UsersTable {
 	 * @param string $email                 The user's email address
 	 * @param bool   $allow_multiple_emails Allow the same email address to be
 	 *                                      registered multiple times?
+	 * @param string $subtype               Subtype of the user entity
 	 *
 	 * @return int|false The new user's GUID; false on failure
 	 * @throws RegistrationException
 	 */
-	public function register($username, $password, $name, $email, $allow_multiple_emails = false) {
+	public function register($username, $password, $name, $email, $allow_multiple_emails = false, $subtype = null) {
 
 		// no need to trim password
 		$username = trim($username);
@@ -421,7 +422,16 @@ class UsersTable {
 		access_show_hidden_entities($access_status);
 
 		// Create user
-		$user = new ElggUser();
+		$constructor = ElggUser::class;
+		if ($subtype) {
+			$class = get_subtype_class('user', $subtype);
+			if ($class && class_exists($class) && is_subclass_of($class, ElggUser::class)) {
+				$constructor = $class;
+			}
+		}
+
+		$user = new $constructor();
+		$user->subtype = $subtype;
 		$user->username = $username;
 		$user->email = $email;
 		$user->name = $name;

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -291,12 +291,13 @@ function validate_email_address($address) {
  * @param string $email                 The user's email address
  * @param bool   $allow_multiple_emails Allow the same email address to be
  *                                      registered multiple times?
+ * @param string $subtype               Subtype of the user entity
  *
  * @return int|false The new user's GUID; false on failure
  * @throws RegistrationException
  */
-function register_user($username, $password, $name, $email, $allow_multiple_emails = false) {
-	return _elgg_services()->usersTable->register($username, $password, $name, $email, $allow_multiple_emails);
+function register_user($username, $password, $name, $email, $allow_multiple_emails = false, $subtype = null) {
+	return _elgg_services()->usersTable->register($username, $password, $name, $email, $allow_multiple_emails, $subtype);
 }
 
 /**

--- a/engine/tests/classes/Elgg/IntegrationTestCase.php
+++ b/engine/tests/classes/Elgg/IntegrationTestCase.php
@@ -3,9 +3,7 @@
 namespace Elgg;
 
 use Elgg\Database\Seeds\Seeding;
-use Elgg\Database\Seeds\Users;
 use Elgg\Di\ServiceProvider;
-use PHPUnit_Framework_TestCase;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 /**
@@ -17,6 +15,9 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 abstract class IntegrationTestCase extends BaseTestCase {
 
 	use Seeding;
+
+	protected $_testing_hooks;
+	protected $_testing_events;
 
 	/**
 	 * @var array
@@ -47,6 +48,13 @@ abstract class IntegrationTestCase extends BaseTestCase {
 
 		$sp = new ServiceProvider($config);
 
+		// persistentLogin service needs this set to instantiate without calling DB
+		$sp->config->getCookieConfig();
+
+		$sp->setFactory('session', function() {
+			return \ElggSession::getMock();
+		});
+
 		$app = Application::factory([
 			'config' => $config,
 			'service_provider' => $sp,
@@ -55,18 +63,12 @@ abstract class IntegrationTestCase extends BaseTestCase {
 			'set_start_time' => false,
 		]);
 
-		$app->_services->setFactory('session', function(ServiceProvider $sp) {
-			return \ElggSession::getMock();
-		});
-
-		$app->_services->setFactory('mailer', function(ServiceProvider $sp) {
-			return new \Zend\Mail\Transport\InMemory();
-		});
+		$app->_services->setValue('testCase', null);
 
 		Application::setInstance($app);
 
 		if (in_array('--verbose', $_SERVER['argv'])) {
-			Logger::$verbosity = ConsoleOutput::VERBOSITY_VERBOSE;
+			Logger::$verbosity = ConsoleOutput::VERBOSITY_VERY_VERBOSE;
 		} else {
 			Logger::$verbosity = ConsoleOutput::VERBOSITY_NORMAL;
 		}
@@ -116,15 +118,49 @@ abstract class IntegrationTestCase extends BaseTestCase {
 	final protected function setUp() {
 		parent::setUp();
 
+		// Backup events and hooks so we can assert that the has clean up after iteself
+		$this->_testing_hooks = _elgg_services()->hooks->getAllHandlers();
+		$this->_testing_events = _elgg_services()->hooks->getEvents()->getAllHandlers();
+
+		// @todo: backup context stack
+		// @todo: backup page handlers
+		// @todo: count entities before the test
+
 		if (!Application::$_instance->getDbConnection()) {
 			$this->markTestSkipped("IntegrationTestCase requires an active database connection");
 		}
+
+		if ($this instanceof LegacyIntegrationTestCase) {
+			_elgg_services()->session->setLoggedInUser($this->getAdmin());
+		}
+
+		$this->up();
 	}
 
 	/**
 	 * {@inheritdoc}
 	 */
 	final protected function tearDown() {
+		$this->down();
+
+		if ($this instanceof LegacyIntegrationTestCase) {
+			_elgg_services()->session->removeLoggedInUser();
+		}
+
+
+		$this->assertEquals($this->_testing_hooks, _elgg_services()->hooks->getAllHandlers(), "
+			The test has failed to clean up hook registrations after itself.
+		");
+
+		$this->assertEquals($this->_testing_events, _elgg_services()->hooks->getEvents()->getAllHandlers(), "
+			The test has failed to clean up event registrations after itself.
+		");
+
+		// @todo: assert that context stack hasn't been messed with
+		// @todo: assert that page handlers have been unregistered after tests
+		// @todo: make an assertion that entity count after the test is as before
+		// Test should really clean up after themselves!
+
 		parent::tearDown();
 	}
 }

--- a/engine/tests/classes/Elgg/LegacyIntegrationTestCase.php
+++ b/engine/tests/classes/Elgg/LegacyIntegrationTestCase.php
@@ -1,13 +1,19 @@
 <?php
-/**
- *
- */
 
 namespace Elgg;
 
 use ElggUser;
 
-class LegacyIntegrationTestCase extends IntegrationTestCase {
+/**
+ * Proxies simpletest assertions and old simpletest unit case methods
+ * so that we can easily port existing simpletests to PHPUnit
+ *
+ * DO NOT EXTEND THIS CLASS IF YOU ARE WRITING NEW TESTS
+ *
+ * @deprecated
+ * @access private
+ */
+abstract class LegacyIntegrationTestCase extends IntegrationTestCase {
 
 	/**
 	 * Replace the current user session
@@ -56,48 +62,74 @@ class LegacyIntegrationTestCase extends IntegrationTestCase {
 		return $this->assert(new IdenticalEntityExpectation($first), $second, $message);
 	}
 
-	public function assertEqual($expected, $actual) {
-		return $this->assertEquals($expected, $actual);
+	public static function assertTrue($condition, $message = '') {
+		// PHPUnit expects an actual boolean
+		return \PHPUnit_Framework_TestCase::assertTrue((bool) $condition, $message);
 	}
 
-	public function assertNotEqual($expected, $actual) {
-		return $this->assertNotEquals($expected, $actual);
+	public static function assertFalse($condition, $message = '') {
+		// PHPUnit expects an actual boolean
+		return \PHPUnit_Framework_TestCase::assertFalse((bool) $condition, $message);
 	}
 
-	public function assertWithinMargin($expected, $actual, $margin) {
-		return $this->assertEquals($expected, $actual, '', $margin);
+	public function assertEqual($expected, $actual, $message = '') {
+		return $this->assertEquals($expected, $actual, $message);
 	}
 
-	public function assertIdentical($expected, $actual) {
-		return $this->assertSame($expected, $actual);
+	public function assertNotEqual($expected, $actual, $message = '') {
+		return $this->assertNotEquals($expected, $actual, $message);
 	}
 
-	public function assertNotIdentical($expected, $actual) {
-		return $this->assertNotSame($expected, $actual);
+	public function assertWithinMargin($expected, $actual, $margin, $message = '') {
+		return $this->assertEquals($expected, $actual, $message, $margin);
 	}
 
-	public function assertIsA($actual, $classname) {
+	public function assertIdentical($expected, $actual, $message = '') {
+		return $this->assertSame($expected, $actual, $message);
+	}
+
+	public function assertNotIdentical($expected, $actual, $message = '') {
+		return $this->assertNotSame($expected, $actual, $message);
+	}
+
+	public function assertIsA($actual, $classname, $message = '') {
 		switch ($classname) {
 			case 'array' :
-				return $this->assertEquals('array', gettype($actual));
+				return $this->assertEquals('array', gettype($actual), $message);
 			case 'int' :
-				return $this->assertInternalType('integer', $actual);
+				return $this->assertInternalType('integer', $actual, $message);
 			case 'string' :
-				return $this->assertInternalType('string', $actual);
+				return $this->assertInternalType('string', $actual, $message);
 		}
 
-		return $this->assertInstanceOf($classname, $actual);
+		return $this->assertInstanceOf($classname, $actual, $message);
 	}
 
-	public function assertPattern($pattern, $string) {
-		return $this->assertRegExp($pattern, $string);
+	public function assertPattern($pattern, $string, $message ='') {
+		return $this->assertRegExp($pattern, $string, $message);
 	}
 
-	public function assertNoPattern($pattern, $string) {
-		return $this->assertNotRegExp($pattern, $string);
+	public function assertNoPattern($pattern, $string, $message = '') {
+		return $this->assertNotRegExp($pattern, $string, $message);
 	}
 
-	public function expectError() {
-		return $this->setExpectedException('PHPUnit_Framework_Error');
+	public function expectError($message) {
+		return $this->setExpectedException(PHPUnit_Framework_Error::class, $message);
+	}
+
+	public function expectException($exception) {
+		return $this->setExpectedException(get_class($exception), $exception->getMessage());
+	}
+
+	public function skipUnless($condition, $message) {
+		if (!$condition) {
+			$this->markTestSkipped($message);
+		}
+	}
+
+	public function skipIf($condition, $message) {
+		if ($condition) {
+			$this->markTestSkipped($message);
+		}
 	}
 }

--- a/engine/tests/classes/Elgg/TestSeeder.php
+++ b/engine/tests/classes/Elgg/TestSeeder.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ *
+ */
+
+namespace Elgg;
+
+use Elgg\Database\Seeds\Seeding;
+
+/**
+ * Test can instantiate this class if they need to seed entities
+ * in static methods, e.g. during setUpBeforeClass
+ */
+class TestSeeder {
+	use Seeding;
+}

--- a/engine/tests/classes/Elgg/Testing.php
+++ b/engine/tests/classes/Elgg/Testing.php
@@ -7,12 +7,19 @@ namespace Elgg;
 
 use Elgg\Http\Request;
 use Elgg\Project\Paths;
+use ElggUser;
+use RuntimeException;
 
 /**
  * Testing trait that provides utility methods agnostic to testing framework
  * This trait can be shared e.g. between PHPUnit and Simpletest test cases
  */
 trait Testing {
+
+	/**
+	 * @var ElggUser
+	 */
+	protected $_testing_admin;
 
 	/**
 	 * Resolve test file name in /test_files
@@ -63,5 +70,33 @@ trait Testing {
 		}
 
 		return $request;
+	}
+
+	/**
+	 * Returns an admin user
+	 * @return ElggUser
+	 * @throws RuntimeException
+	 */
+	public function getAdmin() {
+
+		$admin = $this->_testing_admin;
+		if (!$admin) {
+			$admins = elgg_get_admins([
+				'limit' => 1,
+				'order_by' => 'e.time_created ASC',
+			]);
+
+			$admin = false;
+			if ($admins) {
+				$admin = array_shift($admins);
+			}
+			$this->_testing_admin = $admin;
+		}
+
+		if (!$admin instanceof ElggUser || !$admin->isAdmin()) {
+			throw new RuntimeException("Unable to load an administrator user entity to perform tests.");
+		}
+
+		return $admin;
 	}
 }

--- a/engine/tests/phpunit/bootstrap.php
+++ b/engine/tests/phpunit/bootstrap.php
@@ -1,5 +1,11 @@
 <?php
 
+if (!date_default_timezone_get()) {
+	date_default_timezone_set('America/Los_Angeles');
+}
+
+error_reporting(E_ALL | E_STRICT);
+
 ini_set('memory_limit', '2G');
 
 // Bootstrap test application

--- a/engine/tests/phpunit/integration/Elgg/Database/SeedingTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Database/SeedingTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Elgg\Database;
+
+use Elgg\LegacyIntegrationTestCase;
+
+/**
+ * @group IntegrationTests
+ */
+class SeedingTest extends LegacyIntegrationTestCase {
+
+	public function up() {
+
+	}
+
+	public function down() {
+
+	}
+
+	public function testCanGetRandomUser() {
+		$user = $this->createUser();
+
+		$this->assertInstanceOf(\ElggUser::class, $this->getRandomUser());
+
+		$user->delete();
+	}
+	public function testSeededUserDefaults() {
+
+		$user = $this->createUser();
+
+		$this->assertTrue(validate_email_address($user->email));
+		$this->assertNotEmpty($user->name);
+		$this->assertNotEmpty($user->username);
+		$this->assertEquals(0, $user->owner_guid);
+		$this->assertEquals(0, $user->container_guid);
+		$this->assertEquals(ACCESS_PUBLIC, $user->access_id);
+		$this->assertEmpty($user->getSubtype());
+		$this->assertFalse($user->isAdmin());
+		$this->assertFalse($user->isBanned());
+
+		$user->delete();
+	}
+
+	public function testCanCreateUserWithSubtype() {
+		$user = $this->createUser([
+			'subtype' => 'test_subtype',
+		]);
+
+		$this->assertInstanceOf(\ElggUser::class, $user);
+		$this->assertEquals('test_subtype', $user->getSubtype());
+
+		$user->delete();
+	}
+
+	public function testCanCreateAdminUser() {
+
+		$user = $this->createUser([
+			'admin' => true,
+		]);
+
+		$this->assertTrue($user->isAdmin());
+
+		$user->delete();
+	}
+
+	public function testCanCreateGroup() {
+
+		$group = $this->createGroup();
+
+		$this->assertNotEmpty($group->name);
+		$this->assertNotEmpty($group->description);
+		$this->assertTrue($group->owner_guid > 0);
+		$this->assertTrue($group->container_guid > 0);
+		$this->assertEquals(ACCESS_PUBLIC, $group->access_id);
+		$this->assertEmpty($group->getSubtype());
+
+		$this->assertEquals(\ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED, $group->getContentAccessMode());
+		$this->assertTrue($group->isPublicMembership());
+
+		$group->delete();
+	}
+
+	public function testCanCreateObject() {
+
+		$object = $this->createObject();
+
+		$this->assertNotEmpty($object->title);
+		$this->assertNotEmpty($object->description);
+		$this->assertTrue($object->owner_guid > 0);
+		$this->assertTrue($object->container_guid > 0);
+		$this->assertEquals(ACCESS_PUBLIC, $object->access_id);
+		$this->assertNotEmpty($object->getSubtype());
+
+		$object->delete();
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggBatchTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggBatchTest.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\BatchResult;
+use Elgg\LegacyIntegrationTestCase;
+use ElggBatch;
+use ElggObject;
+
+/**
+ * @group IntegrationTests
+ */
+class ElggBatchTest extends LegacyIntegrationTestCase {
+
+	public function up() {
+
+	}
+
+	public function down() {
+
+	}
+
+	// see https://github.com/elgg/elgg/issues/4288
+	public function testElggBatchIncOffset() {
+		// normal increment
+		$options = [
+			'offset' => 0,
+			'limit' => 11
+		];
+		$batch = new ElggBatch([
+			ElggBatchTest::class,
+			'elgg_batch_callback_test'
+		], $options,
+			null, 5);
+		$j = 0;
+		foreach ($batch as $e) {
+			$offset = floor($j / 5) * 5;
+			$this->assertEqual($offset, $e['offset']);
+			$this->assertEqual($j + 1, $e['index']);
+			$j++;
+		}
+
+		$this->assertEqual(11, $j);
+
+		// no increment, 0 start
+		ElggBatchTest::elgg_batch_callback_test([], true);
+		$options = [
+			'offset' => 0,
+			'limit' => 11
+		];
+		$batch = new ElggBatch([
+			ElggBatchTest::class,
+			'elgg_batch_callback_test'
+		], $options,
+			null, 5);
+		$batch->setIncrementOffset(false);
+
+		$j = 0;
+		foreach ($batch as $e) {
+			$this->assertEqual(0, $e['offset']);
+			// should always be the same 5
+			$this->assertEqual($e['index'], $j + 1 - (floor($j / 5) * 5));
+			$j++;
+		}
+		$this->assertEqual(11, $j);
+
+		// no increment, 3 start
+		ElggBatchTest::elgg_batch_callback_test([], true);
+		$options = [
+			'offset' => 3,
+			'limit' => 11
+		];
+		$batch = new ElggBatch([
+			ElggBatchTest::class,
+			'elgg_batch_callback_test'
+		], $options,
+			null, 5);
+		$batch->setIncrementOffset(false);
+
+		$j = 0;
+		foreach ($batch as $e) {
+			$this->assertEqual(3, $e['offset']);
+			// same 5 results
+			$this->assertEqual($e['index'], $j + 4 - (floor($j / 5) * 5));
+			$j++;
+		}
+
+		$this->assertEqual(11, $j);
+	}
+
+	public function testElggBatchReadHandlesBrokenEntities() {
+		$num_test_entities = 8;
+		$guids = [];
+		for ($i = $num_test_entities; $i > 0; $i--) {
+			$entity = new ElggObject();
+			$entity->type = 'object';
+			$entity->subtype = 'test_5357_subtype';
+			$entity->access_id = ACCESS_PUBLIC;
+			$entity->save();
+			$guids[] = $entity->guid;
+			_elgg_services()->entityCache->remove($entity->guid);
+		}
+
+		// break entities such that the first fetch has one incomplete
+		// and the second and third fetches have only incompletes!
+		$db_prefix = _elgg_config()->dbprefix;
+		delete_data("
+			DELETE FROM {$db_prefix}objects_entity
+			WHERE guid IN ({$guids[1]}, {$guids[2]}, {$guids[3]}, {$guids[4]}, {$guids[5]})
+		");
+
+		$options = [
+			'type' => 'object',
+			'subtype' => 'test_5357_subtype',
+			'order_by' => 'e.guid',
+		];
+
+		$entities_visited = [];
+		$batch = new ElggBatch('elgg_get_entities', $options, null, 2);
+		/* @var \ElggEntity[] $batch */
+		foreach ($batch as $entity) {
+			$entities_visited[] = $entity->guid;
+		}
+
+		// The broken entities should not have been visited
+		$this->assertEqual($entities_visited, [
+			$guids[0],
+			$guids[6],
+			$guids[7]
+		]);
+
+		// cleanup (including leftovers from previous tests)
+		$entity_rows = elgg_get_entities(array_merge($options, [
+			'callback' => '',
+			'limit' => false,
+		]));
+		$guids = [];
+		foreach ($entity_rows as $row) {
+			$guids[] = $row->guid;
+		}
+		delete_data("DELETE FROM {$db_prefix}entities WHERE guid IN (" . implode(',', $guids) . ")");
+		delete_data("DELETE FROM {$db_prefix}objects_entity WHERE guid IN (" . implode(',', $guids) . ")");
+		remove_subtype('object', 'test_5357_subtype');
+	}
+
+	public function testElggBatchDeleteHandlesBrokenEntities() {
+		$num_test_entities = 8;
+		$guids = [];
+		for ($i = $num_test_entities; $i > 0; $i--) {
+			$entity = new ElggObject();
+			$entity->type = 'object';
+			$entity->subtype = 'test_5357_subtype';
+			$entity->access_id = ACCESS_PUBLIC;
+			$entity->save();
+			$guids[] = $entity->guid;
+			_elgg_services()->entityCache->remove($entity->guid);
+		}
+
+		// break entities such that the first fetch has one incomplete
+		// and the second and third fetches have only incompletes!
+		$db_prefix = _elgg_config()->dbprefix;
+		delete_data("
+			DELETE FROM {$db_prefix}objects_entity
+			WHERE guid IN ({$guids[1]}, {$guids[2]}, {$guids[3]}, {$guids[4]}, {$guids[5]})
+		");
+
+		$options = [
+			'type' => 'object',
+			'subtype' => 'test_5357_subtype',
+			'order_by' => 'e.guid',
+		];
+
+		$entities_visited = [];
+		$batch = new ElggBatch('elgg_get_entities', $options, null, 2, false);
+		/* @var \ElggEntity[] $batch */
+		foreach ($batch as $entity) {
+			$entities_visited[] = $entity->guid;
+			$entity->delete();
+		}
+
+		// The broken entities should not have been visited
+		$this->assertEqual($entities_visited, [
+			$guids[0],
+			$guids[6],
+			$guids[7]
+		]);
+
+		// cleanup (including leftovers from previous tests)
+		$entity_rows = elgg_get_entities(array_merge($options, [
+			'callback' => '',
+			'limit' => false,
+		]));
+		$guids = [];
+		foreach ($entity_rows as $row) {
+			$guids[] = $row->guid;
+		}
+		delete_data("DELETE FROM {$db_prefix}entities WHERE guid IN (" . implode(',', $guids) . ")");
+		delete_data("DELETE FROM {$db_prefix}objects_entity WHERE guid IN (" . implode(',', $guids) . ")");
+	}
+
+	public function testBatchCanCount() {
+		$getter = function ($options) {
+			if ($options['count']) {
+				return 20;
+			}
+
+			return false;
+		};
+		$options = [
+			// Due to 10992, if count was present and false, it would fail
+			'count' => false,
+		];
+
+		$count1 = count(new ElggBatch($getter, $options));
+		$count2 = $getter(array_merge($options, ['count' => true]));
+
+		$this->assertEqual($count1, $count2);
+	}
+
+	public function testCanGetBatchFromAnEntityGetter() {
+
+		$subtype ='testCanGetBatchFromAnEntityGetter';
+		for ($i = 1; $i <=5; $i++) {
+			$this->createObject([
+				'subtype' => $subtype,
+			]);
+		}
+
+		$options = [
+			'type' => 'object',
+			'subtype' => 'testCanGetBatchFromAnEntityGetter',
+			'limit' => 5,
+			'callback' => function ($row) {
+				return $row->guid;
+			},
+		];
+
+		$guids1 = elgg_get_entities($options);
+
+		$batch = elgg_get_entities(array_merge($options, ['batch' => true]));
+
+		$this->assertIsA($batch, BatchResult::class);
+		/* @var ElggBatch $batch */
+
+		$guids2 = [];
+		foreach ($batch as $val) {
+			$guids2[] = $val;
+		}
+
+		$this->assertEqual($guids1, $guids2);
+	}
+
+	public static function elgg_batch_callback_test($options, $reset = false) {
+		static $count = 1;
+
+		if ($reset) {
+			$count = 1;
+
+			return true;
+		}
+
+		if ($count > 20) {
+			return false;
+		}
+
+		$return = [];
+
+		for ($j = 0; ($options['limit'] < 5) ? $j < $options['limit'] : $j < 5; $j++) {
+			$return[] = [
+				'offset' => $options['offset'],
+				'limit' => $options['limit'],
+				'count' => $count++,
+				'index' => 1 + $options['offset'] + $j
+			];
+		}
+
+		return $return;
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAccessCollectionsTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAccessCollectionsTest.php
@@ -1,0 +1,461 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\LegacyIntegrationTestCase;
+use ElggAccessCollection;
+
+/**
+ * Access Collections tests
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreAccessCollectionsTest extends LegacyIntegrationTestCase {
+
+
+	private $dbprefix;
+
+	public function up() {
+		$this->dbprefix = elgg_get_config("dbprefix");
+
+		$user = $this->createUser();
+
+		$this->user = $user;
+	}
+
+	public function down() {
+		$this->user->delete();
+	}
+
+	public function testCreateGetDeleteACL() {
+
+		$acl_name = 'test access collection';
+		$acl_id = create_access_collection($acl_name);
+
+		$this->assertTrue(is_int($acl_id));
+
+		$q = "SELECT * FROM {$this->dbprefix}access_collections WHERE id = $acl_id";
+		$acl = get_data_row($q);
+
+		$this->assertEqual($acl->id, $acl_id);
+
+		if ($acl) {
+			$this->assertEqual($acl->name, $acl_name);
+
+			$result = delete_access_collection($acl_id);
+			$this->assertTrue($result);
+
+			$q = "SELECT * FROM {$this->dbprefix}access_collections WHERE id = $acl_id";
+			$data = get_data($q);
+			$this->assertIdentical([], $data);
+		}
+	}
+
+	public function testAddRemoveUserToACL() {
+		$acl_id = create_access_collection('test acl');
+
+		$result = add_user_to_access_collection($this->user->guid, $acl_id);
+		$this->assertTrue($result);
+
+		if ($result) {
+			$result = remove_user_from_access_collection($this->user->guid, $acl_id);
+			$this->assertIdentical(true, $result);
+		}
+
+		delete_access_collection($acl_id);
+	}
+
+	public function testUpdateACL() {
+		// another fake user to test with
+		$user = $this->createUser();
+
+		$acl_id = create_access_collection('test acl');
+
+		$member_lists = [
+			// adding
+			[
+				$this->user->guid,
+				$user->guid
+			],
+			// removing one, keeping one.
+			[
+				$user->guid
+			],
+			// removing one, adding one
+			[
+				$this->user->guid,
+			],
+			// removing all.
+			[]
+		];
+
+		foreach ($member_lists as $members) {
+			$result = update_access_collection($acl_id, $members);
+			$this->assertTrue($result);
+
+			if ($result) {
+				$q = "SELECT * FROM {$this->dbprefix}access_collection_membership
+					WHERE access_collection_id = $acl_id";
+				$data = get_data($q);
+
+				if (count($members) == 0) {
+					$this->assertFalse($data);
+				} else {
+					$this->assertEqual(count($members), count($data));
+				}
+				foreach ($data as $row) {
+					$this->assertTrue(in_array($row->user_guid, $members));
+				}
+			}
+		}
+
+		delete_access_collection($acl_id);
+		$user->delete();
+	}
+
+	public function testCanEditACL() {
+		$acl_id = create_access_collection('test acl', $this->user->guid);
+
+		// should be true since it's the owner
+		$result = can_edit_access_collection($acl_id, $this->user->guid);
+		$this->assertTrue($result);
+
+		// should be true since IA is on.
+		$ia = elgg_set_ignore_access(true);
+		$result = can_edit_access_collection($acl_id);
+		$this->assertTrue($result);
+		elgg_set_ignore_access($ia);
+
+		$logged_in_user = _elgg_services()->session->getLoggedInUser();
+		_elgg_services()->session->removeLoggedInUser();
+
+		$ia = elgg_set_ignore_access(false);
+		$result = can_edit_access_collection($acl_id, $this->user->guid);
+		$result_no_user = can_edit_access_collection($acl_id);
+		$this->assertTrue($result);
+		$this->assertFalse($result_no_user);
+		elgg_set_ignore_access($ia);
+
+		_elgg_services()->session->setLoggedInUser($logged_in_user);
+
+		delete_access_collection($acl_id);
+	}
+
+	public function testCanEditACLHook() {
+		// if only we supported closures!
+		global $acl_test_info;
+
+		$acl_id = create_access_collection('test acl');
+
+		$acl_test_info = [
+			'acl_id' => $acl_id,
+			'user' => $this->user
+		];
+
+		$handler = function($hook, $type, $value, $params) {
+			global $acl_test_info;
+			if ($params['user_id'] == $acl_test_info['user']->guid) {
+				$acl = get_access_collection($acl_test_info['acl_id']);
+				$value[$acl->id] = $acl->name;
+			}
+
+			return $value;
+		};
+
+		elgg_register_plugin_hook_handler('access:collections:write', 'all', $handler, 600);
+
+		// enable security since we usually run as admin
+		$ia = elgg_set_ignore_access(false);
+		$result = can_edit_access_collection($acl_id, $this->user->guid);
+		$this->assertTrue($result);
+		$ia = elgg_set_ignore_access($ia);
+
+		elgg_unregister_plugin_hook_handler('access:collections:write', 'all', $handler);
+
+		delete_access_collection($acl_id);
+	}
+
+	// groups interface
+	// only runs if the groups plugin is enabled because implementation is split between
+	// core and the plugin.
+	public function testCreateDeleteGroupACL() {
+		if (!elgg_is_active_plugin('groups')) {
+			return;
+		}
+
+		$group = new \ElggGroup();
+		$group->name = 'Test group';
+		$group->save();
+
+		$this->assertNotNull($group->group_acl);
+
+		$acl = get_access_collection($group->group_acl);
+
+		// ACLs are owned by groups
+		$this->assertEqual($acl->owner_guid, $group->guid);
+
+		// removing group and acl
+		$this->assertTrue($group->delete());
+
+		$acl = get_access_collection($group->group_acl);
+		$this->assertFalse($acl);
+
+		$group->delete();
+	}
+
+	public function testJoinLeaveGroupACL() {
+		if (!elgg_is_active_plugin('groups')) {
+			$this->markTestSkipped('Groups plugin is inactive');
+		}
+
+		$group = new \ElggGroup();
+		$group->name = 'Test group';
+		$group->access_id = ACCESS_PUBLIC;
+		$group->save();
+
+		$result = $group->join($this->user);
+		$this->assertTrue($result);
+
+		// disable security since we run as admin
+		$ia = elgg_set_ignore_access(false);
+
+		if ($result) {
+			// This can't be true because user doesn't own the group
+			//$can_edit = can_edit_access_collection($group->group_acl, $this->user->guid);
+			//$this->assertTrue($can_edit);
+		}
+
+		$result = $group->leave($this->user);
+		$this->assertTrue($result);
+
+		if ($result) {
+			$can_edit = can_edit_access_collection($group->group_acl, $this->user->guid);
+			$this->assertFalse($can_edit);
+		}
+
+		elgg_set_ignore_access($ia);
+
+		$group->delete();
+
+		$this->markTestIncomplete("Verify what was the intention with editing access collections");
+	}
+
+	public function testAccessCaching() {
+		// create a new user to check against
+		$user = $this->createUser();
+
+		foreach ([
+					 'get_access_list',
+					 'get_access_array'
+				 ] as $func) {
+			_elgg_services()->accessCache->clear();
+
+			// admin users run tests, so disable access
+			$ia = elgg_set_ignore_access(true);
+			$access = $func($user->getGUID());
+
+			elgg_set_ignore_access($ia);
+			$access2 = $func($user->getGUID());
+			$this->assertNotEqual($access, $access2, "Access test for $func");
+		}
+
+		$user->delete();
+	}
+
+	public function testAddMemberToACLRemoveMember() {
+		// create a new user to check against
+		$user = $this->createUser();
+
+		$acl_id = create_access_collection('test acl');
+
+		$result = add_user_to_access_collection($user->guid, $acl_id);
+		$this->assertTrue($result);
+
+		if ($result) {
+			$this->assertTrue($user->delete());
+
+			// since there are no more members this should return false
+			$acl_members = get_members_of_access_collection($acl_id, true);
+			$this->assertFalse($acl_members);
+		}
+
+		delete_access_collection($acl_id);
+	}
+
+	public function testCanGetGuestReadAcccessArray() {
+		$logged_in_user = _elgg_services()->session->getLoggedInUser();
+		_elgg_services()->session->removeLoggedInUser();
+
+		$expected = [ACCESS_PUBLIC];
+		$actual = get_access_array();
+		$this->assertEqual($expected, $actual);
+
+		_elgg_services()->session->setLoggedInUser($logged_in_user);
+	}
+
+	public function testCanGetReadAccessArray() {
+
+		$ia = elgg_set_ignore_access(false);
+
+		// Default access array
+		$expected = [
+			ACCESS_PUBLIC,
+			ACCESS_LOGGED_IN
+		];
+		$actual = get_access_array($this->user->guid);
+
+		sort($expected);
+		sort($actual);
+		$this->assertEqual($expected, $actual);
+
+		$owned_collection_id = create_access_collection('test', $this->user->guid);
+
+		$joined_collection_id = create_access_collection('test2');
+		add_user_to_access_collection($this->user->guid, $joined_collection_id);
+
+		$expected[] = $owned_collection_id;
+		$expected[] = $joined_collection_id;
+
+		$actual = get_access_array($this->user->guid, null, true);
+
+		sort($expected);
+		sort($actual);
+		$this->assertEqual($expected, $actual);
+
+		elgg_set_ignore_access();
+
+		$expected[] = ACCESS_PRIVATE;
+		$actual = get_access_array($this->user->guid, null, true);
+
+		sort($expected);
+		sort($actual);
+		$this->assertEqual($expected, $actual);
+
+		delete_access_collection($owned_collection_id);
+		delete_access_collection($joined_collection_id);
+
+		elgg_set_ignore_access($ia);
+	}
+
+	public function testCanGetWriteAccessArray() {
+
+		$owned_collection_id = create_access_collection('test', $this->user->guid);
+
+		$expected = [
+			ACCESS_PUBLIC,
+			ACCESS_LOGGED_IN,
+			ACCESS_PRIVATE,
+			$owned_collection_id,
+		];
+
+		$actual = get_write_access_array($this->user->guid, null, true);
+
+		// remove ACCESS_FRIENDS in case it's added by an enabled plugin
+		unset($actual[ACCESS_FRIENDS]);
+
+		$actual = array_keys($actual);
+
+		sort($expected);
+		sort($actual);
+		$this->assertEqual($expected, $actual);
+
+	}
+
+	public function testCanGetAccessCollection() {
+
+		$owned_collection_id = create_access_collection('test', $this->user->guid);
+
+		$acl = get_access_collection($owned_collection_id);
+
+		$this->assertIsA($acl, ElggAccessCollection::class);
+		$this->assertEqual($acl->id, $owned_collection_id);
+		$this->assertEqual($acl->owner_guid, $this->user->guid);
+		$this->assertEqual($acl->name, 'test');
+
+		// We don't add owners to collection by default
+		$this->assertFalse($acl->hasMember($this->user->guid));
+
+	}
+
+	public function testCanSaveAccessCollection() {
+
+		$id = create_access_collection('test_collection', $this->user->guid);
+
+		$acl = new ElggAccessCollection((object) [
+			'id' => $id,
+			'owner_guid' => $this->user->guid,
+			'name' => 'test_collection',
+		]);
+
+		$loaded_acl = get_access_collection($id);
+
+		$this->assertEqual($loaded_acl->id, $id);
+		$this->assertEqual($loaded_acl->name, 'test_collection');
+		$this->assertEqual($loaded_acl->owner_guid, $this->user->guid);
+
+		$acl->name = 'test_collection_edited';
+		$acl->save();
+
+		$loaded_acl = get_access_collection($id);
+
+		$this->assertEqual($loaded_acl->id, $id);
+		$this->assertEqual($loaded_acl->name, 'test_collection_edited');
+		$this->assertEqual($loaded_acl->owner_guid, $this->user->guid);
+
+		$this->assertTrue($acl->delete());
+
+		$this->assertFalse(get_access_collection($id));
+	}
+
+	public function testCanUpdateAccessCollectionMembership() {
+
+		$member1 = $this->createUser();
+		$member2 = $this->createUser();
+
+		$id = create_access_collection('test_collection', $this->user->guid);
+		$acl = get_access_collection($id);
+
+		$this->assertIsA($acl, ElggAccessCollection::class);
+
+		$this->assertTrue($acl->addMember($member1->guid));
+		$this->assertTrue($acl->addMember($member2->guid));
+
+		$members = get_members_of_access_collection($id, true);
+
+		$this->assertTrue(!empty($members));
+
+		$this->assertTrue(in_array($member1->guid, $members));
+		$this->assertTrue(in_array($member2->guid, $members));
+
+		$acl->removeMember($member2->guid);
+
+		$members = get_members_of_access_collection($id, true);
+
+		$this->assertEqual([$member1->guid], $members);
+
+		$this->assertTrue($acl->hasMember($member1->guid));
+
+		$member1->delete();
+		$member2->delete();
+	}
+
+	public function testCanEditAccessCollection() {
+
+		$member = $this->createUser();
+
+		$ia = elgg_set_ignore_access(false);
+
+		$collection_id = create_access_collection('test', $this->user->guid);
+		add_user_to_access_collection($member->guid, $collection_id);
+
+		$acl = get_access_collection($collection_id);
+
+		$this->assertTrue($acl->canEdit($this->user->guid));
+		$this->assertFalse($acl->canEdit($member->guid));
+
+		elgg_set_ignore_access($ia);
+
+		$member->delete();
+	}
+
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAccessSQLTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAccessSQLTest.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\LegacyIntegrationTestCase;
+
+/**
+ * Access SQL tests
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreAccessSQLTest extends LegacyIntegrationTestCase {
+
+	/** @var \ElggUser */
+	protected $user;
+
+	public function up() {
+		$this->user = $this->createUser();
+		_elgg_services()->session->setLoggedInUser($this->user);
+		_elgg_services()->hooks->backup();
+	}
+
+	public function down() {
+		_elgg_services()->session->removeLoggedInUser();
+		$this->user->delete();
+		_elgg_services()->hooks->restore();
+	}
+
+	public function testCanBuildAccessSqlClausesWithIgnoredAccess() {
+		$sql = _elgg_get_access_where_sql([
+			'ignore_access' => true,
+		]);
+		$ans = "((1 = 1) AND (e.enabled = 'yes'))";
+		$this->assertSqlEqual($ans, $sql, "$sql does not match $ans");
+	}
+
+	public function testCanBuildAccessSqlClausesWithIgnoredAccessWithoutDisabledEntities() {
+		$sql = _elgg_get_access_where_sql([
+			'use_enabled_clause' => false,
+			'ignore_access' => true,
+		]);
+		$ans = "((1 = 1))";
+		$this->assertSqlEqual($ans, $sql, "$sql does not match $ans");
+	}
+
+	public function testCanBuildAccessSqlForLoggedInUser() {
+
+		$this->assertFalse(elgg_is_admin_logged_in());
+
+		$sql = _elgg_get_access_where_sql();
+
+		$friends_clause = $this->getFriendsClause($this->user->guid, 'e');
+		$owner_clause = $this->getOwnerClause($this->user->guid, 'e');
+		$access_clause = $this->getLoggedInAccessListClause('e');
+
+		$ans = "(($friends_clause OR $owner_clause OR $access_clause) AND (e.enabled = 'yes'))";
+
+		$this->assertSqlEqual($ans, $sql, "$sql does not match $ans");
+	}
+
+	public function testCanBuildAccessSqlWithCustomTableAlias() {
+		$sql = _elgg_get_access_where_sql([
+			'table_alias' => 'foo',
+		]);
+
+		$friends_clause = $this->getFriendsClause($this->user->guid, 'foo');
+		$owner_clause = $this->getOwnerClause($this->user->guid, 'foo');
+		$access_clause = $this->getLoggedInAccessListClause('foo');
+		$ans = "(($friends_clause OR $owner_clause OR $access_clause) AND (foo.enabled = 'yes'))";
+
+		$this->assertSqlEqual($ans, $sql, "$sql does not match $ans");
+
+		// test with no alias
+		$sql = _elgg_get_access_where_sql([
+			'user_guid' => $this->user->guid,
+			'table_alias' => '',
+		]);
+
+		$friends_clause = $this->getFriendsClause($this->user->guid, '');
+		$owner_clause = $this->getOwnerClause($this->user->guid, '');
+		$access_clause = $this->getLoggedInAccessListClause('');
+		$ans = "(($friends_clause OR $owner_clause OR $access_clause) AND (enabled = 'yes'))";
+
+		$this->assertSqlEqual($ans, $sql, "$sql does not match $ans");
+	}
+
+	public function testCanBuildAccessSqlWithCustomGuidColumn() {
+		$sql = _elgg_get_access_where_sql([
+			'owner_guid_column' => 'unit_test',
+		]);
+
+		$friends_clause = $this->getFriendsClause($this->user->guid, 'e', 'unit_test');
+		$owner_clause = $this->getOwnerClause($this->user->guid, 'e', 'unit_test');
+		$access_clause = $this->getLoggedInAccessListClause('e');
+		$ans = "(($friends_clause OR $owner_clause OR $access_clause) AND (e.enabled = 'yes'))";
+
+		$this->assertSqlEqual($ans, $sql, "$sql does not match $ans");
+	}
+
+	public function testCanBuildAccessSqlForLoggedOutUser() {
+
+		$user = _elgg_services()->session->getLoggedInUser();
+		_elgg_services()->session->removeLoggedInUser();
+
+		$sql = _elgg_get_access_where_sql();
+		$access_clause = $this->getLoggedOutAccessListClause('e');
+		$ans = "(($access_clause) AND (e.enabled = 'yes'))";
+
+		$this->assertSqlEqual($ans, $sql, "$sql does not match $ans");
+
+		_elgg_services()->session->setLoggedInUser($user);
+	}
+
+	public function testAccessPluginHookRemoveEnabled() {
+		elgg_register_plugin_hook_handler('get_sql', 'access', [
+			$this,
+			'removeEnabledCallback'
+		]);
+		$sql = _elgg_get_access_where_sql([
+			'ignore_access' => true,
+		]);
+		$ans = "((1 = 1))";
+		$this->assertSqlEqual($ans, $sql, "$sql does not match $ans");
+	}
+
+	public function removeEnabledCallback($hook, $type, $clauses, $params) {
+		$clauses['ands'] = [];
+
+		return $clauses;
+	}
+
+	public function testAccessPluginHookRemoveOrs() {
+		elgg_register_plugin_hook_handler('get_sql', 'access', [
+			$this,
+			'removeOrsCallback'
+		]);
+		$sql = _elgg_get_access_where_sql([
+			'ignore_access' => true,
+		]);
+		$ans = "((e.enabled = 'yes'))";
+		$this->assertSqlEqual($ans, $sql, "$sql does not match $ans");
+	}
+
+	public function removeOrsCallback($hook, $type, $clauses, $params) {
+		$clauses['ors'] = [];
+
+		return $clauses;
+	}
+
+	public function testAccessPluginHookAddOr() {
+		elgg_register_plugin_hook_handler('get_sql', 'access', [
+			$this,
+			'addOrCallback'
+		]);
+		$sql = _elgg_get_access_where_sql([
+			'ignore_access' => true,
+		]);
+		$ans = "((1 = 1 OR 57 > 32) AND (e.enabled = 'yes'))";
+		$this->assertSqlEqual($ans, $sql, "$sql does not match $ans");
+	}
+
+	public function addOrCallback($hook, $type, $clauses, $params) {
+		$clauses['ors'][] = '57 > 32';
+
+		return $clauses;
+	}
+
+	public function testAccessPluginHookAddAnd() {
+		elgg_register_plugin_hook_handler('get_sql', 'access', [
+			$this,
+			'addAndCallback'
+		]);
+		$sql = _elgg_get_access_where_sql([
+			'ignore_access' => true,
+		]);
+		$ans = "((1 = 1) AND (e.enabled = 'yes' AND 57 > 32))";
+		$this->assertSqlEqual($ans, $sql, "$sql does not match $ans");
+	}
+
+	public function testHasAccessToEntity() {
+
+		$session = elgg_get_session();
+
+		$viewer = $session->getLoggedInUser();
+
+		$ia = elgg_set_ignore_access(true);
+
+		$owner = $this->createUser();
+
+		$object = $this->createObject([
+			'owner_guid' => $owner->guid,
+			'access_id' => ACCESS_PRIVATE,
+		]);
+
+		elgg_set_ignore_access($ia);
+
+		$session->removeLoggedInUser();
+
+		$this->assertFalse(has_access_to_entity($object));
+		$this->assertFalse(has_access_to_entity($object, $viewer));
+		$this->assertTrue(has_access_to_entity($object, $owner));
+
+		$ia = elgg_set_ignore_access(true);
+		$object->access_id = ACCESS_PUBLIC;
+		$object->save();
+		elgg_set_ignore_access($ia);
+
+		$this->assertTrue(has_access_to_entity($object));
+		$this->assertTrue(has_access_to_entity($object, $viewer));
+		$this->assertTrue(has_access_to_entity($object, $owner));
+
+		$ia = elgg_set_ignore_access(true);
+		$object->access_id = ACCESS_LOGGED_IN;
+		$object->save();
+		elgg_set_ignore_access($ia);
+
+		$this->assertFalse(has_access_to_entity($object));
+		// even though user is logged out, existing users are presumed to have access to an entity
+		$this->assertTrue(has_access_to_entity($object, $viewer));
+		$this->assertTrue(has_access_to_entity($object, $owner));
+
+		$session->setLoggedInUser($viewer);
+		$this->assertTrue(has_access_to_entity($object));
+		$this->assertTrue(has_access_to_entity($object, $viewer));
+		$this->assertTrue(has_access_to_entity($object, $owner));
+		$session->removeLoggedInUser();
+
+		$ia = elgg_set_ignore_access(true);
+		$owner->addFriend($viewer->guid);
+		$object->access_id = ACCESS_FRIENDS;
+		$object->save();
+		elgg_set_ignore_access($ia);
+
+		$this->assertFalse(has_access_to_entity($object));
+		$this->assertTrue(has_access_to_entity($object, $viewer));
+		$this->assertTrue(has_access_to_entity($object, $owner));
+
+		$session->setLoggedInUser($viewer);
+		$this->assertTrue(has_access_to_entity($object));
+		$this->assertTrue(has_access_to_entity($object, $viewer));
+		$this->assertTrue(has_access_to_entity($object, $owner));
+
+		$ia = elgg_set_ignore_access(true);
+		$owner->delete();
+		$object->delete();
+		elgg_set_ignore_access($ia);
+
+		$session->setLoggedInUser($viewer);
+	}
+
+	public function addAndCallback($hook, $type, $clauses, $params) {
+		$clauses['ands'][] = '57 > 32';
+
+		return $clauses;
+	}
+
+	protected function assertSqlEqual($sql1, $sql2, $message = '') {
+		$sql1 = $this->normalizeSql($sql1);
+		$sql2 = $this->normalizeSql($sql2);
+
+		return $this->assertEquals($sql1, $sql2, $message);
+	}
+
+	protected function getFriendsClause($user_guid, $table_alias, $owner_guid = 'owner_guid') {
+		$CONFIG = _elgg_config();
+		$table_alias = $table_alias ? $table_alias . '.' : '';
+
+		return "{$table_alias}access_id = " . ACCESS_FRIENDS . "
+			AND {$table_alias}{$owner_guid} IN (
+				SELECT guid_one FROM {$CONFIG->dbprefix}entity_relationships
+				WHERE relationship = 'friend' AND guid_two = $user_guid
+			)";
+	}
+
+	protected function getOwnerClause($user_guid, $table_alias, $owner_guid = 'owner_guid') {
+		$table_alias = $table_alias ? $table_alias . '.' : '';
+
+		return "{$table_alias}{$owner_guid} = $user_guid";
+	}
+
+	protected function getLoggedInAccessListClause($table_alias) {
+		$table_alias = $table_alias ? $table_alias . '.' : '';
+
+		return "{$table_alias}access_id IN (2,1)";
+	}
+
+	protected function getLoggedOutAccessListClause($table_alias) {
+		$table_alias = $table_alias ? $table_alias . '.' : '';
+
+		return "{$table_alias}access_id IN (2)";
+	}
+
+	/**
+	 * Attempt to normalize whitespace in a query
+	 *
+	 * @param string $query Query
+	 * @return string
+	 */
+	private function normalizeSql($query) {
+		$query = trim($query);
+		$query = str_replace('  ', ' ', $query);
+		$query = strtolower($query);
+		$query = preg_replace('~\\s+~', ' ', $query);
+		return $query;
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAnnotationAPITest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAnnotationAPITest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\LegacyIntegrationTestCase;
+
+/**
+ * Elgg Test annotation api
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreAnnotationAPITest extends LegacyIntegrationTestCase {
+
+
+	public function up() {
+		$this->object = new \ElggObject();
+	}
+
+	public function down() {
+		unset($this->object);
+	}
+
+	public function testElggGetAnnotationsCount() {
+		$this->object->title = 'Annotation Unit Test';
+		$this->object->save();
+
+		$guid = $this->object->getGUID();
+		create_annotation($guid, 'tested', 'tested1', 'text', 0, ACCESS_PUBLIC);
+		create_annotation($guid, 'tested', 'tested2', 'text', 0, ACCESS_PUBLIC);
+
+		$count = (int) elgg_get_annotations([
+			'annotation_names' => ['tested'],
+			'guid' => $guid,
+			'count' => true,
+		]);
+
+		$this->assertIdentical($count, 2);
+
+		$this->object->delete();
+	}
+
+	public function testElggDeleteAnnotations() {
+		$e = new \ElggObject();
+		$e->save();
+
+		for ($i = 0; $i < 30; $i++) {
+			$e->annotate('test_annotation', rand(0, 10000));
+		}
+
+		$options = [
+			'guid' => $e->getGUID(),
+			'limit' => 0
+		];
+
+		$annotations = elgg_get_annotations($options);
+		$this->assertIdentical(30, count($annotations));
+
+		$this->assertTrue(elgg_delete_annotations($options));
+
+		$annotations = elgg_get_annotations($options);
+		$this->assertTrue(empty($annotations));
+
+		// nothing to delete so null returned
+		$this->assertNull(elgg_delete_annotations($options));
+
+		$this->assertTrue($e->delete());
+	}
+
+	public function testElggDisableAnnotations() {
+		$e = new \ElggObject();
+		$e->save();
+
+		for ($i = 0; $i < 30; $i++) {
+			$e->annotate('test_annotation', rand(0, 10000));
+		}
+
+		$options = [
+			'guid' => $e->getGUID(),
+			'limit' => 0
+		];
+
+		$this->assertTrue(elgg_disable_annotations($options));
+
+		$annotations = elgg_get_annotations($options);
+		$this->assertTrue(empty($annotations));
+
+		access_show_hidden_entities(true);
+		$annotations = elgg_get_annotations($options);
+		$this->assertIdentical(30, count($annotations));
+		access_show_hidden_entities(false);
+
+		$this->assertTrue($e->delete());
+	}
+
+	public function testElggEnableAnnotations() {
+		$e = new \ElggObject();
+		$e->save();
+
+		for ($i = 0; $i < 30; $i++) {
+			$e->annotate('test_annotation', rand(0, 10000));
+		}
+
+		$options = [
+			'guid' => $e->getGUID(),
+			'limit' => 0
+		];
+
+		$this->assertTrue(elgg_disable_annotations($options));
+
+		// cannot see any annotations so returns null
+		$this->assertNull(elgg_enable_annotations($options));
+
+		access_show_hidden_entities(true);
+		$this->assertTrue(elgg_enable_annotations($options));
+		access_show_hidden_entities(false);
+
+		$annotations = elgg_get_annotations($options);
+		$this->assertIdentical(30, count($annotations));
+
+		$this->assertTrue($e->delete());
+	}
+
+	public function testElggAnnotationExists() {
+		$e = new \ElggObject();
+		$e->save();
+		$guid = $e->getGUID();
+
+		$this->assertFalse(elgg_annotation_exists($guid, 'test_annotation'));
+
+		$e->annotate('test_annotation', rand(0, 10000));
+		$this->assertTrue(elgg_annotation_exists($guid, 'test_annotation'));
+		// this metastring should always exist but an annotation of this name should not
+		$this->assertFalse(elgg_annotation_exists($guid, 'email'));
+
+		$options = [
+			'guid' => $guid,
+			'limit' => 0
+		];
+		$this->assertTrue(elgg_disable_annotations($options));
+		$this->assertTrue(elgg_annotation_exists($guid, 'test_annotation'));
+
+		$this->assertTrue($e->delete());
+		$this->assertFalse(elgg_annotation_exists($guid, 'test_annotation'));
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAttributeLoaderTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAttributeLoaderTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\Config;
+use Elgg\LegacyIntegrationTestCase;
+
+/**
+ * Test attribute loader for entities
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreAttributeLoaderTest extends LegacyIntegrationTestCase {
+
+	private $entities = [];
+	
+	public function up() {
+		$types = Config::getEntityTypes();
+		
+		foreach ($types as $type) {
+			switch ($type) {
+				case 'group' :
+					$this->entities[] = $this->createGroup();
+					break;
+
+				case 'user' :
+					$this->entities[] = $this->createUser();
+					break;
+
+				case 'object' :
+					$this->entities[] = $this->createObject();
+					break;
+			}
+		}
+
+	}
+
+	public function down() {
+		foreach ($this->entities as $entity) {
+			$entity->delete();
+		}
+	}
+
+	/**
+	 * Checks if additional select columns are readable as volatile data
+	 *
+	 * https://github.com/Elgg/Elgg/issues/5543
+	 */
+	public function testSqlAdditionalSelectsAsVolatileData() {
+
+		$types = Config::getEntityTypes();
+		
+		foreach ($types as $type) {
+
+			$entities = elgg_get_entities([
+				'type' => $type,
+				'selects' => ['42 as added_col2'],
+				'limit' => 1,
+			]);
+
+			$this->assertFalse(empty($entities));
+
+			if ($entities) {
+				$entity = array_shift($entities);
+				$this->assertTrue($entity instanceof \ElggEntity);
+				$this->assertEqual($entity->added_col2, null, "Additional select columns are leaking to attributes for " . get_class($entity));
+				$this->assertEqual($entity->getVolatileData('select:added_col2'), 42);
+			}
+		}
+
+	}
+
+	/**
+	 * Checks if additional select columns are readable as volatile data even if we hit the cache while fetching entity.
+	 *
+	 * https://github.com/Elgg/Elgg/issues/5544
+	 */
+	public function testSqlAdditionalSelectsAsVolatileDataWithCache() {
+
+		$types = Config::getEntityTypes();
+
+		foreach ($types as $type) {
+			
+			$entities = elgg_get_entities([
+				'type' => $type,
+				'selects' => ['42 as added_col3'],
+				'limit' => 1,
+			]);
+			
+			$this->assertFalse(empty($entities));
+			
+			if ($entities) {
+				$entity = array_shift($entities);
+				$this->assertTrue($entity instanceof \ElggEntity);
+				$this->assertEqual($entity->added_col3, null, "Additional select columns are leaking to attributes for " . get_class($entity));
+				$this->assertEqual($entity->getVolatileData('select:added_col3'), 42);
+
+				// make sure we have cached the entity
+				$this->assertNotEqual(false, _elgg_services()->entityCache->get($entity->guid));
+			}
+		}
+
+		// run these again but with different value to make sure cache does not interfere
+		foreach ($types as $type) {
+			$entities = elgg_get_entities([
+				'type' => $type,
+				'selects' => ['64 as added_col3'],
+				'limit' => 1,
+			]);
+			
+			$this->assertFalse(empty($entities));
+			
+			if ($entities) {
+				$entity = array_shift($entities);
+				$this->assertTrue($entity instanceof \ElggEntity);
+				$this->assertEqual($entity->added_col3, null, "Additional select columns are leaking to attributes for " . get_class($entity));
+				$this->assertEqual($entity->getVolatileData('select:added_col3'), 64, "Failed to overwrite volatile data in cached entity");
+			}
+		}
+	}
+
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreCommentTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreCommentTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\LegacyIntegrationTestCase;
+use ElggComment;
+use ElggObject;
+
+/**
+ * Elgg Test \ElggComment
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreCommentTest extends LegacyIntegrationTestCase {
+	/**
+	 * @var ElggComment
+	 */
+	protected $comment;
+
+	/**
+	 * @var ElggObject
+	 */
+	protected $container;
+
+	public function up() {
+
+		$this->commenter = $this->createUser();
+
+		$this->container_owner = $this->createUser();
+		$this->container = $this->createObject([
+			'owner_guid' => $this->container_owner->guid,
+		]);
+
+		$this->comment = $this->createObject([
+			'subtype' => 'comment',
+			'container_guid' => $this->container->guid,
+			'owner_guid' => $this->commenter->guid,
+		]);
+	}
+
+	public function down() {
+		$this->commenter->delete();
+		$this->container_owner->delete();
+	}
+
+	public function testCommentAccessSync() {
+
+		$this->assertTrue(_elgg_services()->hooks->getEvents()->hasHandler('update:after', 'all', '_elgg_comments_access_sync'));
+
+		_elgg_services()->entityCache->disableCachingForEntity($this->comment->guid);
+		_elgg_services()->entityCache->disableCachingForEntity($this->container->guid);
+
+		$this->assertEqual($this->comment->access_id, $this->container->access_id);
+
+		// now change the access of the container
+		$this->container->access_id = ACCESS_LOGGED_IN;
+		$this->container->save();
+
+		$updated_container = get_entity($this->container->guid);
+		$updated_comment = get_entity($this->comment->guid);
+
+		$this->assertEqual($updated_comment->access_id, $updated_container->access_id);
+	}
+
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreConfigTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreConfigTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\LegacyIntegrationTestCase;
+
+/**
+ * Test configuration for site
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreConfigTest extends LegacyIntegrationTestCase {
+
+	public function up() {
+
+	}
+
+	public function down() {
+
+	}
+
+	public function testSetConfigWithTooLongName() {
+		_elgg_services()->logger->disable();
+
+		$name = '';
+		for ($i = 1; $i <= 256; $i++) {
+			$name .= 'a';
+		}
+		$this->assertFalse(elgg_save_config($name, 'foo'));
+
+		_elgg_services()->logger->enable();
+	}
+
+	public function testSetConfigWithNewName() {
+		$name = 'foo' . rand(0, 1000);
+		$value = 'test';
+		$this->assertTrue(elgg_save_config($name, $value));
+		$this->assertEqual($value, elgg_get_config($name));
+		$this->assertTrue(elgg_remove_config($name));
+	}
+
+	public function testSetConfigWithUsedName() {
+		$name = 'foo' . rand(0, 1000);
+		$value = 'test';
+		$this->assertTrue(elgg_save_config($name, 'not test'));
+		$this->assertTrue(elgg_save_config($name, $value));
+		$this->assertEqual($value, elgg_get_config($name));
+		$this->assertTrue(elgg_remove_config($name));
+	}
+
+	public function testSetConfigWithObject() {
+		$name = 'foo' . rand(0, 1000);
+		$value = new \stdClass();
+		$value->test = true;
+		$this->assertTrue(elgg_save_config($name, $value));
+		$this->assertIdentical($value, elgg_get_config($name));
+		$this->assertTrue(elgg_remove_config($name));
+	}
+
+	public function testSetConfigWithNonexistentName() {
+		$name = 'foo' . rand(0, 1000);
+		$this->assertIdentical(null, elgg_get_config($name));
+	}
+
+	public function testSetConfigWithCurrentSite() {
+		$CONFIG = _elgg_config();
+		$name = 'foo' . rand(0, 1000);
+		$value = 99;
+		$this->assertTrue(elgg_save_config($name, $value));
+		$this->assertIdentical($value, $CONFIG->$name);
+		$this->assertIdentical($value, elgg_get_config($name));
+		$this->assertTrue(elgg_remove_config($name));
+	}
+
+	public function testGetConfigAlreadyLoadedForCurrentSite() {
+		$CONFIG = _elgg_config();
+		$CONFIG->foo_unit_test = 35;
+		$this->assertIdentical(35, _elgg_config()->foo_unit_test);
+		unset($CONFIG->foo_unit_test);
+	}
+
+	public function testUnsetConfigWithNonexistentName() {
+		$this->assertTrue(elgg_remove_config('does_not_exist'));
+	}
+
+	public function testUnsetConfigClearsGlobalForCurrentSite() {
+		$CONFIG = _elgg_config();
+		$CONFIG->foo_unit_test = 35;
+		$this->assertIdentical(true, elgg_remove_config('foo_unit_test'));
+		$this->assertTrue(!isset($CONFIG->foo_unit_test));
+	}
+
+	public function testElggSaveConfigForCurrentSiteConfig() {
+		$CONFIG = _elgg_config();
+		$name = 'foo' . rand(0, 1000);
+		$value = 'test';
+		$this->assertTrue(elgg_save_config($name, $value));
+		$this->assertIdentical($value, elgg_get_config($name));
+		$this->assertIdentical($value, $CONFIG->$name);
+		$this->assertTrue(elgg_remove_config($name));
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreDatabaseQueueTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreDatabaseQueueTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\LegacyIntegrationTestCase;
+use Elgg\Queue\DatabaseQueue;
+
+/**
+ * \Elgg\Queue\DatabaseQueue tests
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreDatabaseQueueTest extends LegacyIntegrationTestCase {
+
+	public function up() {
+
+	}
+
+	public function down() {
+
+	}
+
+	public function testEnqueueAndDequeue() {
+		$queue = new DatabaseQueue('unit:test', _elgg_services()->db);
+		$first = array(1, 2, 3);
+		$second = array(4, 5, 6);
+
+		$result = $queue->enqueue($first);
+		$this->assertTrue((bool) $result);
+		$result = $queue->enqueue($second);
+		$this->assertTrue((bool) $result);
+
+		$this->assertIdentical(2, $queue->size());
+
+		$data = $queue->dequeue();
+		$this->assertIdentical($first, $data);
+		$data = $queue->dequeue();
+		$this->assertIdentical($second, $data);
+
+		$data = $queue->dequeue();
+		$this->assertIdentical(null, $data);
+	}
+
+	public function testMultipleQueues() {
+		$queue1 = new DatabaseQueue('unit:test1', _elgg_services()->db);
+		$queue2 = new DatabaseQueue('unit:test2', _elgg_services()->db);
+		$first = array(1, 2, 3);
+		$second = array(4, 5, 6);
+
+		$result = $queue1->enqueue($first);
+		$this->assertTrue((bool) $result);
+		$result = $queue2->enqueue($second);
+		$this->assertTrue((bool) $result);
+
+		$this->assertIdentical(1, $queue1->size());
+		$this->assertIdentical(1, $queue2->size());
+
+		$data = $queue2->dequeue();
+		$this->assertIdentical($second, $data);
+		$data = $queue1->dequeue();
+		$this->assertIdentical($first, $data);
+	}
+
+	public function testClear() {
+		$queue = new DatabaseQueue('unit:test',  _elgg_services()->db);
+		$first = array(1, 2, 3);
+		$second = array(4, 5, 6);
+
+		$result = $queue->enqueue($first);
+		$this->assertTrue((bool) $result);
+		$result = $queue->enqueue($second);
+		$this->assertTrue((bool) $result);
+
+		$queue->clear();
+		$data = $queue->dequeue();
+		$this->assertIdentical(null, $data);
+		$this->assertIdentical(0, $queue->size());
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreEntityTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreEntityTest.php
@@ -1,0 +1,616 @@
+<?php
+
+namespace Elgg\Integration;
+
+use ElggObject;
+use ElggUser;
+
+/**
+ * @group IntegrationTests
+ */
+class ElggCoreEntityTest extends \Elgg\LegacyIntegrationTestCase {
+
+	/**
+	 * @var ElggObject
+	 */
+	protected $entity;
+
+	public function up() {
+		// use \ElggObject since \ElggEntity is an abstract class
+		$this->entity = new ElggObject();
+		$this->entity->subtype = 'elgg_entity_test_subtype';
+
+		// Add temporary metadata, annotation and private settings
+		// to extend the scope of tests and catch issues with save operations
+		$this->entity->test_metadata = 'bar';
+		$this->entity->annotate('test_annotation', 'baz');
+		$this->entity->setPrivateSetting('test_setting', 'foo');
+
+		$this->entity->save();
+	}
+
+	public function down() {
+		if ($this->entity) {
+			$this->entity->delete();
+		}
+
+		remove_subtype('object', 'elgg_entity_test_subtype');
+	}
+
+	public function testSubtypePropertyReads() {
+		$this->assertTrue($this->entity->save());
+		$guid = $this->entity->guid;
+
+		$subtype_prop = $this->entity->subtype;
+		$this->assertIsA($subtype_prop, 'int');
+		$this->assertEqual($subtype_prop, get_subtype_id('object', 'elgg_entity_test_subtype'));
+
+		_elgg_services()->entityCache->remove($guid);
+		$this->entity = null;
+		$this->entity = get_entity($guid);
+
+		$subtype_prop = $this->entity->subtype;
+		$this->assertIsA($subtype_prop, 'int');
+		$this->assertEqual($subtype_prop, get_subtype_id('object', 'elgg_entity_test_subtype'));
+	}
+
+	public function testUnsavedEntitiesDontRecordAttributeSets() {
+		$entity = new ElggObject();
+		$entity->subtype = 'elgg_entity_test_subtype';
+		$entity->title = 'Foo';
+		$entity->description = 'Bar';
+		$entity->container_guid = elgg_get_logged_in_user_guid();
+
+		$this->assertEqual($entity->getOriginalAttributes(), []);
+	}
+
+	public function testAlreadyPersistedAttributeSetsAreRecorded() {
+		$this->entity->title = 'Foo';
+		$this->entity->description = 'Bar';
+		$this->entity->container_guid = elgg_get_site_entity()->guid;
+
+		$this->assertEqual($this->entity->getOriginalAttributes(), [
+			'title' => null,
+			'description' => null,
+			'container_guid' => elgg_get_logged_in_user_guid(),
+		]);
+	}
+
+	public function testModifiedAttributesAreAvailableDuringUpdateNotAfter() {
+		$this->entity->title = 'Foo';
+		$this->entity->description = 'Bar';
+		$this->entity->container_guid = elgg_get_site_entity()->guid;
+
+		$calls = 0;
+		$handler = function ($event, $type, ElggObject $object) use (&$calls) {
+			$calls++;
+			$this->assertEqual($object->getOriginalAttributes(), [
+				'title' => null,
+				'description' => null,
+				'container_guid' => elgg_get_logged_in_user_guid(),
+			]);
+		};
+
+		elgg_register_event_handler('update', 'object', $handler);
+		elgg_register_event_handler('update:after', 'object', $handler);
+		$this->entity->save();
+
+		$this->assertEqual($calls, 2);
+
+		elgg_unregister_event_handler('update', 'object', $handler);
+		elgg_unregister_event_handler('update:after', 'object', $handler);
+
+		$this->assertEqual($this->entity->getOriginalAttributes(), []);
+	}
+
+	public function testModifedAttributesSettingEmptyString() {
+		$this->entity->title = '';
+		$this->entity->description = '';
+
+		$this->assertEqual($this->entity->getOriginalAttributes(), []);
+
+		$this->entity->title = '';
+		$this->entity->description = '';
+
+		$this->assertEqual($this->entity->getOriginalAttributes(), []);
+	}
+
+	public function testModifedAttributesSettingIntsAsStrings() {
+		$this->entity->container_guid = elgg_get_logged_in_user_guid();
+		$this->entity->save();
+
+		$this->entity->container_guid = (string) elgg_get_logged_in_user_guid();
+		$this->assertEqual($this->entity->getOriginalAttributes(), []);
+	}
+
+	public function testMultipleAttributeSetsDontOverwriteOriginals() {
+		$this->entity->title = 'Foo';
+		$this->entity->title = 'Bar';
+
+		$this->assertEqual($this->entity->getOriginalAttributes(), [
+			'title' => null,
+		]);
+	}
+
+	public function testGetSubtype() {
+		$guid = $this->entity->guid;
+
+		$this->assertEqual($this->entity->getSubtype(), 'elgg_entity_test_subtype');
+
+		_elgg_services()->entityCache->remove($guid);
+		$this->entity = null;
+		$this->entity = get_entity($guid);
+
+		$this->assertEqual($this->entity->getSubtype(), 'elgg_entity_test_subtype');
+	}
+
+	public function testSubtypeAddRemove() {
+		$test_subtype = 'test_1389988642';
+		$object = new ElggObject();
+		$object->subtype = $test_subtype;
+		$object->save();
+
+		$this->assertTrue(is_numeric(get_subtype_id('object', $test_subtype)));
+
+		$object->delete();
+		remove_subtype('object', $test_subtype);
+
+		$this->assertFalse(get_subtype_id('object', $test_subtype));
+	}
+
+	public function testElggEntityGetAndSetAnnotations() {
+
+		$this->assertIdentical($this->entity->getAnnotations(['annotation_name' => 'non_existent']), []);
+
+		// save entity and check for annotation
+		$this->entity->annotate('non_existent', 'foo');
+		$annotations = $this->entity->getAnnotations(['annotation_name' => 'non_existent']);
+		$this->assertIsA($annotations[0], '\ElggAnnotation');
+		$this->assertIdentical($annotations[0]->name, 'non_existent');
+		$this->assertEqual($this->entity->countAnnotations('non_existent'), 1);
+
+		// @todo belongs in Annotations API test class
+		$this->assertEqual($annotations, elgg_get_annotations([
+			'guid' => $this->entity->getGUID(),
+			'annotation_name' => 'non_existent'
+		]));
+		$this->assertEqual($annotations, elgg_get_annotations([
+			'guid' => $this->entity->getGUID(),
+			'annotation_name' => 'non_existent',
+			'type' => 'object'
+		]));
+		$this->assertEqual(false, elgg_get_annotations([
+			'guid' => $this->entity->getGUID(),
+			'type' => 'object',
+			'subtype' => 'fail'
+		]));
+
+		//  clear annotation
+		$this->assertTrue($this->entity->deleteAnnotations());
+		$this->assertEqual($this->entity->countAnnotations('non_existent'), 0);
+
+		// @todo belongs in Annotations API test class
+		$this->assertIdentical([], elgg_get_annotations(['guid' => $this->entity->getGUID()]));
+		$this->assertIdentical([], elgg_get_annotations([
+			'guid' => $this->entity->getGUID(),
+			'type' => 'object'
+		]));
+	}
+
+	public function testElggEntitySaveAndDelete() {
+		// check attributes populated during create()
+		$time_minimum = time() - 5;
+		$this->assertTrue($this->entity->time_created > $time_minimum);
+		$this->assertTrue($this->entity->time_updated > $time_minimum);
+		$this->assertEqual($this->entity->container_guid, elgg_get_logged_in_user_guid());
+	}
+
+	public function testElggEntityDisableAndEnable() {
+		$CONFIG = _elgg_config();
+
+		// add annotations and metadata to check if they're disabled.
+		$annotation_id = create_annotation($this->entity->guid, 'test_annotation_' . rand(), 'test_value_' . rand());
+		$metadata_id = create_metadata($this->entity->guid, 'test_metadata_' . rand(), 'test_value_' . rand());
+
+		$this->assertTrue($this->entity->disable());
+
+		// ensure disabled by comparing directly with database
+		$entity = get_data_row("SELECT * FROM {$CONFIG->dbprefix}entities WHERE guid = '{$this->entity->guid}'");
+		$this->assertIdentical($entity->enabled, 'no');
+
+		$annotation = get_data_row("SELECT * FROM {$CONFIG->dbprefix}annotations WHERE id = '$annotation_id'");
+		$this->assertIdentical($annotation->enabled, 'no');
+
+		$metadata = get_data_row("SELECT * FROM {$CONFIG->dbprefix}metadata WHERE id = '$metadata_id'");
+		$this->assertIdentical($metadata->enabled, 'no');
+
+		// re-enable for deletion to work
+		$this->assertTrue($this->entity->enable());
+
+		// check enabled
+		// check annotations and metadata enabled.
+		$entity = get_data_row("SELECT * FROM {$CONFIG->dbprefix}entities WHERE guid = '{$this->entity->guid}'");
+		$this->assertIdentical($entity->enabled, 'yes');
+
+		$annotation = get_data_row("SELECT * FROM {$CONFIG->dbprefix}annotations WHERE id = '$annotation_id'");
+		$this->assertIdentical($annotation->enabled, 'yes');
+
+		$metadata = get_data_row("SELECT * FROM {$CONFIG->dbprefix}metadata WHERE id = '$metadata_id'");
+		$this->assertIdentical($metadata->enabled, 'yes');
+
+		$this->assertTrue($this->entity->delete());
+		$this->entity = null;
+	}
+
+	public function testElggEntityRecursiveDisableAndEnable() {
+		$CONFIG = _elgg_config();
+
+		$obj1 = new ElggObject();
+		$obj1->container_guid = $this->entity->getGUID();
+		$obj1->save();
+		$obj2 = new ElggObject();
+		$obj2->container_guid = $this->entity->getGUID();
+		$obj2->save();
+
+		// disable $obj2 before disabling the container
+		$this->assertTrue($obj2->disable());
+
+		// disable entities container by $this->entity
+		$this->assertTrue($this->entity->disable());
+		$entity = get_data_row("SELECT * FROM {$CONFIG->dbprefix}entities WHERE guid = '{$obj1->guid}'");
+		$this->assertIdentical($entity->enabled, 'no');
+
+		// enable entities that were disabled with the container (but not $obj2)
+		$this->assertTrue($this->entity->enable());
+		$entity = get_data_row("SELECT * FROM {$CONFIG->dbprefix}entities WHERE guid = '{$obj1->guid}'");
+		$this->assertIdentical($entity->enabled, 'yes');
+		$entity = get_data_row("SELECT * FROM {$CONFIG->dbprefix}entities WHERE guid = '{$obj2->guid}'");
+		$this->assertIdentical($entity->enabled, 'no');
+
+		// cleanup
+		$this->assertTrue($obj2->enable());
+		$this->assertTrue($obj2->delete());
+		$this->assertTrue($obj1->delete());
+	}
+
+	public function testElggEntityMetadata() {
+		// let's delete a non-existent metadata
+		$this->assertFalse($this->entity->deleteMetadata('important'));
+
+		// let's add the metadata
+		$this->entity->important = 'indeed!';
+		$this->assertIdentical('indeed!', $this->entity->important);
+		$this->entity->less_important = 'true, too!';
+		$this->assertIdentical('true, too!', $this->entity->less_important);
+
+		// test deleting incorrectly
+		// @link https://github.com/elgg/elgg/issues/2273
+		$this->assertNull($this->entity->deleteMetadata('impotent'));
+		$this->assertEqual($this->entity->important, 'indeed!');
+
+		// get rid of one metadata
+		$this->assertEqual($this->entity->important, 'indeed!');
+		$this->assertTrue($this->entity->deleteMetadata('important'));
+		$this->assertNull($this->entity->important);
+
+		// get rid of all metadata
+		$this->assertTrue($this->entity->deleteMetadata());
+		$this->assertNull($this->entity->less_important);
+	}
+
+	public function testElggEntityMultipleMetadata() {
+		foreach ([
+					 $this->entity,
+					 new ElggObject()
+				 ] as $obj) {
+			$md = [
+				'brett',
+				'bryan',
+				'brad'
+			];
+			$name = 'test_md_' . rand();
+
+			$obj->$name = $md;
+
+			$this->assertEqual($md, $obj->$name);
+		}
+	}
+
+	public function testElggEntitySingleElementArrayMetadata() {
+		foreach ([
+					 $this->entity,
+					 new ElggObject()
+				 ] as $obj) {
+			$md = ['test'];
+			$name = 'test_md_' . rand();
+
+			$obj->$name = $md;
+
+			$this->assertEqual($md[0], $obj->$name);
+		}
+	}
+
+	public function testElggEntityAppendMetadata() {
+		foreach ([
+					 $this->entity,
+					 new ElggObject()
+				 ] as $obj) {
+			$md = 'test';
+			$name = 'test_md_' . rand();
+
+			$obj->$name = $md;
+			$obj->setMetadata($name, 'test2', '', true);
+
+			$this->assertEqual([
+				'test',
+				'test2'
+			], $obj->$name);
+		}
+	}
+
+	public function testElggEntitySingleElementArrayAppendMetadata() {
+		foreach ([
+					 $this->entity,
+					 new ElggObject()
+				 ] as $obj) {
+			$md = 'test';
+			$name = 'test_md_' . rand();
+
+			$obj->$name = $md;
+			$obj->setMetadata($name, ['test2'], '', true);
+
+			$this->assertEqual([
+				'test',
+				'test2'
+			], $obj->$name);
+		}
+	}
+
+	public function testElggEntityArrayAppendMetadata() {
+		foreach ([
+					 $this->entity,
+					 new ElggObject()
+				 ] as $obj) {
+			$md = [
+				'brett',
+				'bryan',
+				'brad'
+			];
+			$md2 = [
+				'test1',
+				'test2',
+				'test3'
+			];
+			$name = 'test_md_' . rand();
+
+			$obj->$name = $md;
+			$obj->setMetadata($name, $md2, '', true);
+
+			$this->assertEqual(array_merge($md, $md2), $obj->$name);
+		}
+	}
+
+	public function testElggEntityGetIconURL() {
+
+		$handler = function ($hook, $type, $url, $params) {
+			$size = (string) elgg_extract('size', $params);
+
+			return "$size.jpg";
+		};
+
+		elgg_register_plugin_hook_handler('entity:icon:url', 'object', $handler, 99999);
+
+		$obj = new ElggObject();
+		$obj->save();
+
+		// Test default size
+		$this->assertEqual($obj->getIconURL(), elgg_normalize_url('medium.jpg'));
+		// Test size
+		$this->assertEqual($obj->getIconURL('small'), elgg_normalize_url('small.jpg'));
+		// Test mixed params
+		$this->assertEqual($obj->getIconURL('small'), $obj->getIconURL(['size' => 'small']));
+		// Test bad param
+		$this->assertEqual($obj->getIconURL(new \stdClass), elgg_normalize_url('medium.jpg'));
+
+		elgg_unregister_plugin_hook_handler('entity:icon:url', 'object', $handler, 99999);
+	}
+
+	public function testCreateWithContainerGuidEqualsZero() {
+		$user = $this->createUser();
+
+		$object = new ElggObject();
+		$object->owner_guid = $user->guid;
+		$object->container_guid = 0;
+
+		// If container_guid attribute is not updated with owner_guid attribute
+		// ElggEntity::getContainerEntity() would return false
+		// thus terminating save()
+		$this->assertTrue($object->save());
+
+		$this->assertEqual($user->guid, $object->getContainerGUID());
+
+		$user->delete();
+	}
+
+	public function testUpdateAbilityDependsOnCanEdit() {
+		$this->entity->access_id = ACCESS_PRIVATE;
+
+		$this->assertTrue($this->entity->save());
+
+		$user = $this->createUser();
+
+		$old_user = $this->replaceSession($user);
+
+		// even owner can't bypass permissions
+		elgg_register_plugin_hook_handler('permissions_check', 'object', [
+			\Elgg\Values::class,
+			'getFalse'
+		], 999);
+		$this->assertFalse($this->entity->save());
+		elgg_unregister_plugin_hook_handler('permissions_check', 'object', [
+			\Elgg\Values::class,
+			'getFalse'
+		]);
+
+		$this->assertFalse($this->entity->save());
+
+		elgg_register_plugin_hook_handler('permissions_check', 'object', [
+			\Elgg\Values::class,
+			'getTrue'
+		]);
+
+		// even though this user can't look up the entity via the DB, permission allows update.
+		$this->assertFalse(has_access_to_entity($this->entity, $user));
+		$this->assertTrue($this->entity->save());
+
+		elgg_unregister_plugin_hook_handler('permissions_check', 'object', [
+			\Elgg\Values::class,
+			'getTrue'
+		]);
+
+		// can save with access ignore
+		$ia = elgg_set_ignore_access();
+		$this->assertTrue($this->entity->save());
+		elgg_set_ignore_access($ia);
+
+		$this->replaceSession($old_user);
+		$user->delete();
+	}
+
+	/**
+	 * Make sure entity is loaded from cache during save operations
+	 * See #10612
+	 */
+	public function testNewObjectLoadedFromCacheDuringSaveOperations() {
+
+		$object = new ElggObject();
+		$object->subtype = 'elgg_entity_test_subtype';
+
+		// Add temporary metadata, annotation and private settings
+		// to extend the scope of tests and catch issues with save operations
+		$object->test_metadata = 'bar';
+		$object->annotate('test_annotation', 'baz');
+		$object->setPrivateSetting('test_setting', 'foo');
+
+		$metadata_called = false;
+		$metadata_event_handler = function ($event, $type, $metadata) use (&$metadata_called) {
+			/* @var $metadata \ElggMetadata */
+			$entity = get_entity($metadata->entity_guid);
+			$this->assertEqual($metadata->entity_guid, $entity->guid);
+			$metadata_called = true;
+		};
+
+		$annotation_called = false;
+		$annotation_event_handler = function ($event, $type, $annotation) use (&$annotation_called) {
+			/* @var $metadata \ElggAnnotation */
+			$entity = get_entity($annotation->entity_guid);
+			$this->assertEqual($annotation->entity_guid, $entity->guid);
+			$annotation_called = true;
+		};
+
+		elgg_register_event_handler('create', 'metadata', $metadata_event_handler);
+		elgg_register_event_handler('create', 'annotation', $annotation_event_handler);
+
+		$object->save();
+
+		elgg_unregister_event_handler('create', 'metadata', $metadata_event_handler);
+		elgg_unregister_event_handler('create', 'annotation', $annotation_event_handler);
+
+		$object->delete();
+
+		$this->assertTrue((bool) $metadata_called);
+		$this->assertTrue((bool) $annotation_called);
+	}
+
+	/**
+	 * Make sure entity is loaded from cache during save operations
+	 * See #10612
+	 */
+	public function testNewUserLoadedFromCacheDuringSaveOperations() {
+
+		$user = new ElggUser();
+		$user->username = $this->getRandomUsername();
+
+		// Add temporary metadata, annotation and private settings
+		// to extend the scope of tests and catch issues with save operations
+		$user->test_metadata = 'bar';
+		$user->annotate('test_annotation', 'baz');
+		$user->setPrivateSetting('test_setting', 'foo');
+
+		$metadata_called = false;
+		$metadata_event_handler = function ($event, $type, $metadata) use (&$metadata_called) {
+			/* @var $metadata \ElggMetadata */
+			$entity = get_entity($metadata->entity_guid);
+			$this->assertEqual($metadata->entity_guid, $entity->guid);
+			$metadata_called = true;
+		};
+
+		$annotation_called = false;
+		$annotation_event_handler = function ($event, $type, $annotation) use (&$annotation_called) {
+			/* @var $metadata \ElggAnnotation */
+			$entity = get_entity($annotation->entity_guid);
+			$this->assertEqual($annotation->entity_guid, $entity->guid);
+			$annotation_called = true;
+		};
+
+		elgg_register_event_handler('create', 'metadata', $metadata_event_handler);
+		elgg_register_event_handler('create', 'annotation', $annotation_event_handler);
+
+		$user->save();
+
+		elgg_unregister_event_handler('create', 'metadata', $metadata_event_handler);
+		elgg_unregister_event_handler('create', 'annotation', $annotation_event_handler);
+
+		$user->delete();
+
+		$this->assertTrue((bool) $metadata_called);
+		$this->assertTrue((bool) $annotation_called);
+	}
+
+	/**
+	 * Make sure entity is loaded from cache during save operations
+	 * See #10612
+	 */
+	public function testNewGroupLoadedFromCacheDuringSaveOperations() {
+
+		$group = new \ElggGroup();
+		$group->subtype = 'test_group_subtype';
+
+		// Add temporary metadata, annotation and private settings
+		// to extend the scope of tests and catch issues with save operations
+		$group->test_metadata = 'bar';
+		$group->annotate('test_annotation', 'baz');
+		$group->setPrivateSetting('test_setting', 'foo');
+
+		$metadata_called = false;
+		$metadata_event_handler = function ($event, $type, $metadata) use (&$metadata_called) {
+			/* @var $metadata \ElggMetadata */
+			$entity = get_entity($metadata->entity_guid);
+			$this->assertEqual($metadata->entity_guid, $entity->guid);
+			$metadata_called = true;
+		};
+
+		$annotation_called = false;
+		$annotation_event_handler = function ($event, $type, $annotation) use (&$annotation_called) {
+			/* @var $metadata \ElggAnnotation */
+			$entity = get_entity($annotation->entity_guid);
+			$this->assertEqual($annotation->entity_guid, $entity->guid);
+			$annotation_called = true;
+		};
+
+		elgg_register_event_handler('create', 'metadata', $metadata_event_handler);
+		elgg_register_event_handler('create', 'annotation', $annotation_event_handler);
+
+		$group->save();
+
+		elgg_unregister_event_handler('create', 'metadata', $metadata_event_handler);
+		elgg_unregister_event_handler('create', 'annotation', $annotation_event_handler);
+
+		$group->delete();
+
+		$this->assertTrue((bool) $metadata_called);
+		$this->assertTrue((bool) $annotation_called);
+	}
+
+
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreFilestoreTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreFilestoreTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\EntityDirLocator;
+use Elgg\LegacyIntegrationTestCase;
+use ElggFile;
+
+/**
+ * Elgg Test Skeleton
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreFilestoreTest extends LegacyIntegrationTestCase {
+
+	public function up() {
+		$this->filestore = new \ElggDiskFilestore();
+	}
+
+	public function down() {
+		unset($this->filestore);
+	}
+	
+	public function testFilenameOnFilestore() {
+		$CONFIG = _elgg_config();
+		
+		// create a user to own the file
+		$user = $this->createUser();
+		$dir = new EntityDirLocator($user->guid);
+		
+		// setup a test file
+		$file = new ElggFile();
+		$file->owner_guid = $user->guid;
+		$file->setFilename('testing/filestore.txt');
+		$file->open('write');
+		$file->write('Testing!');
+		$this->assertTrue($file->close());
+		
+		// ensure filename and path is expected
+		$filename = $file->getFilenameOnFilestore();
+		$filepath = $CONFIG->dataroot . $dir . 'testing/filestore.txt';
+		$this->assertIdentical($filename, $filepath);
+		$this->assertTrue(file_exists($filepath));
+		
+		// ensure file removed on user delete
+		// deleting the user calls _elgg_clear_entity_files()
+		$user->delete();
+		$this->assertFalse(file_exists($filepath));
+	}
+
+	function testElggFileDelete() {
+		$CONFIG = _elgg_config();
+		
+		$user = $this->createUser();
+		$dir = new EntityDirLocator($user->guid);
+		
+		$file = new ElggFile();
+		$file->owner_guid = $user->guid;
+		$file->setFilename('testing/ElggFileDelete');
+		$this->assertTrue(is_resource($file->open('write')));
+		$this->assertTrue($file->write('Test'));
+		$this->assertTrue($file->close());
+		$file->save();
+
+		$filename = $file->getFilenameOnFilestore();
+		$filepath = $CONFIG->dataroot . $dir . "testing/ElggFileDelete";
+		$this->assertIdentical($filename, $filepath);
+		$this->assertTrue(file_exists($filepath));
+
+		$this->assertTrue($file->delete());
+		$this->assertFalse(file_exists($filepath));
+		$user->delete();
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGetEntitiesBaseTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGetEntitiesBaseTest.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\Database\Seeder;
+use Elgg\LegacyIntegrationTestCase;
+use Elgg\TestSeeder;
+use ElggGroup;
+use ElggObject;
+use ElggUser;
+
+/**
+ * Setup entities for getter tests
+ */
+abstract class ElggCoreGetEntitiesBaseTest extends LegacyIntegrationTestCase {
+
+	/**
+	 * @var \ElggEntity[]
+	 */
+	static private $_entities;
+
+	/**
+	 * @var string[]
+	 */
+	static private $_types;
+
+	/**
+	 * @var string[]
+	 */
+	static private $_subtypes;
+
+	/**
+	 * @var \ElggEntity[]
+	 */
+	protected $entities;
+
+	/**
+	 * @var string[]
+	 */
+	protected $types;
+
+	/**
+	 * @var string[]
+	 */
+	protected $subtypes;
+
+	/**
+	 * @var bool
+	 */
+	protected $ignore_access;
+
+	public function up() {
+		$this->entities = self::$_entities;
+		$this->types = self::$_types;
+		$this->subtypes = self::$_subtypes;
+	}
+
+	public function down() {
+
+	}
+
+	/**
+	 *
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		$seeder = new TestSeeder();
+
+		$ia = elgg_set_ignore_access();
+
+		self::$_entities = [];
+		self::$_subtypes = [
+			'object' => [],
+			'user' => [],
+			'group' => [],
+			//'site'	=> array()
+		];
+
+		// sites are a bit wonky.  Don't use them just now.
+		self::$_types = [
+			'object',
+			'user',
+			'group'
+		];
+
+		// create some fun objects to play with.
+		// 5 with random subtypes
+		for ($i = 0; $i < 5; $i++) {
+			$subtype = 'test_object_subtype_' . rand();
+			$e = $seeder->createObject([
+				'subtype' => $subtype,
+			]);
+
+			self::$_entities[] = $e;
+			self::$_subtypes['object'][] = $subtype;
+		}
+
+		// and users
+		for ($i = 0; $i < 5; $i++) {
+			$subtype = "test_user_subtype_" . rand();
+			$e = $seeder->createUser([
+				'subtype' => $subtype,
+			]);
+
+			self::$_entities[] = $e;
+			self::$_subtypes['user'][] = $subtype;
+		}
+
+		// and groups
+		for ($i = 0; $i < 5; $i++) {
+			$subtype = "test_group_subtype_" . rand();
+			$e = $seeder->createGroup([
+				'subtype' => $subtype,
+			]);
+
+			self::$_entities[] = $e;
+			self::$_subtypes['group'][] = $subtype;
+		}
+
+		elgg_set_ignore_access($ia);
+	}
+
+	public static function tearDownAfterClass() {
+
+		$ia = elgg_set_ignore_access();
+
+		foreach (self::$_entities as $e) {
+			$e->delete();
+		}
+
+		// manually remove subtype entries since there is no way
+		// to using the API.
+		foreach (self::$_subtypes as $type => $subtypes) {
+			foreach ($subtypes as $subtype) {
+				remove_subtype($type, $subtype);
+			}
+		}
+
+		elgg_set_ignore_access($ia);
+
+		parent::tearDownAfterClass();
+	}
+
+	/*************************************************
+	 * Helpers for getting random types and subtypes *
+	 *************************************************/
+
+	/**
+	 * Get a random valid subtype
+	 *
+	 * @param int $num
+	 *
+	 * @return array
+	 */
+	protected function getRandomValidTypes($num = 1) {
+		$r = [];
+
+		for ($i = 1; $i <= $num; $i++) {
+			do {
+				$t = $this->types[array_rand($this->types)];
+			} while (in_array($t, $r) && count($r) < count($this->types));
+
+			$r[] = $t;
+		}
+
+		shuffle($r);
+
+		return $r;
+	}
+
+	/**
+	 * Get a random valid subtype (that we just created)
+	 *
+	 * @param array $types Type of objects to return valid subtypes for.
+	 * @param int   $num   of subtypes.
+	 *
+	 * @return array
+	 */
+	protected function getRandomValidSubtypes(array $types, $num = 1) {
+		$r = [];
+
+		for ($i = 1; $i <= $num; $i++) {
+			do {
+				// make sure at least one subtype of each type is returned.
+				if ($i - 1 < count($types)) {
+					$type = $types[$i - 1];
+				} else {
+					$type = $types[array_rand($types)];
+				}
+
+				$k = array_rand($this->subtypes[$type]);
+				$t = $this->subtypes[$type][$k];
+			} while (in_array($t, $r));
+
+			$r[] = $t;
+		}
+
+		shuffle($r);
+
+		return $r;
+	}
+
+	/**
+	 * Return an array of invalid strings for type or subtypes.
+	 *
+	 * @param int $num
+	 *
+	 * @return string[]
+	 */
+	protected function getRandomInvalids($num = 1) {
+		$r = [];
+
+		for ($i = 1; $i <= $num; $i++) {
+			$r[] = 'random_invalid_' . rand();
+		}
+
+		return $r;
+	}
+
+	/**
+	 * Get a mix of valid and invalid types
+	 *
+	 * @param int $num
+	 *
+	 * @return array
+	 */
+	protected function getRandomMixedTypes($num = 2) {
+		$r = [];
+
+		// need at least one of each type.
+		$valid_n = rand(1, $num - 1);
+		$r = array_merge($r, $this->getRandomValidTypes($valid_n));
+		$r = array_merge($r, $this->getRandomInvalids($num - $valid_n));
+
+		shuffle($r);
+
+		return $r;
+	}
+
+	/**
+	 * Get random mix of valid and invalid subtypes for types given.
+	 *
+	 * @param array $types
+	 * @param int   $num
+	 *
+	 * @return array
+	 */
+	protected function getRandomMixedSubtypes(array $types, $num = 2) {
+		$types_c = count($types);
+		$r = [];
+
+		// this can be more efficient but I'm very sleepy...
+
+		// want at least one of valid and invalid of each type sent.
+		for ($i = 0; $i < $types_c && $num > 0; $i++) {
+			// make sure we have a valid and invalid for each type
+			if (true) {
+				$type = $types[$i];
+				$r = array_merge($r, $this->getRandomValidSubtypes([$type], 1));
+				$r = array_merge($r, $this->getRandomInvalids(1));
+
+				$num -= 2;
+			}
+		}
+
+		if ($num > 0) {
+			$valid_n = rand(1, $num);
+			$r = array_merge($r, $this->getRandomValidSubtypes($types, $valid_n));
+			$r = array_merge($r, $this->getRandomInvalids($num - $valid_n));
+		}
+
+		//shuffle($r);
+		return $r;
+	}
+
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGetEntitiesFromAnnotationsTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGetEntitiesFromAnnotationsTest.php
@@ -1,0 +1,686 @@
+<?php
+
+namespace Elgg\Integration;
+
+/**
+ * Test elgg_get_entities_from_annotations() and
+ * elgg_get_entities_from_annotation_calculation()
+ */
+class ElggCoreGetEntitiesFromAnnotationsTest extends ElggCoreGetEntitiesBaseTest {
+
+	/**
+	 * Creates random annotations on $entity
+	 *
+	 * @param \ElggEntity $entity
+	 * @param int         $max
+	 */
+	protected function createRandomAnnotations($entity, $max = 1) {
+		$annotations = [];
+		for ($i = 0; $i < $max; $i++) {
+			$name = 'test_annotation_name_' . rand();
+			$value = rand();
+			$id = create_annotation($entity->getGUID(), $name, $value, 'integer', $entity->getGUID());
+			$annotations[] = elgg_get_annotation_from_id($id);
+		}
+
+		return $annotations;
+	}
+
+	public function testCanGetEntitiesByAnnotationCreationTime() {
+		$prefix = _elgg_config()->dbprefix;
+		$users = elgg_get_entities([
+			'type' => 'user',
+			'subtypes' => $this->getRandomValidSubtypes(['user'], 5),
+			'limit' => 1
+		]);
+
+		// create some test annotations
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$annotation_name = 'test_annotation_name_' . rand();
+
+		// our targets
+		$valid1 = new \ElggObject();
+		$valid1->subtype = $subtype;
+		$valid1->save();
+		$id1 = $valid1->annotate($annotation_name, 1, ACCESS_PUBLIC, $users[0]->guid);
+
+		// this one earlier
+		$yesterday = time() - 86400;
+		update_data("
+			UPDATE {$prefix}annotations
+			SET time_created = $yesterday
+			WHERE id = $id1
+		");
+
+		$valid2 = new \ElggObject();
+		$valid2->subtype = $subtype;
+		$valid2->save();
+		$valid2->annotate($annotation_name, 1, ACCESS_PUBLIC, $users[0]->guid);
+
+		$options = [
+			'annotation_owner_guid' => $users[0]->guid,
+			'annotation_created_time_lower' => (time() - 3600),
+			'annotation_name' => $annotation_name,
+		];
+
+		$entities = elgg_get_entities_from_annotations($options);
+
+		$this->assertEqual(1, count($entities));
+		$this->assertEqual($valid2->guid, $entities[0]->guid);
+
+		$options = [
+			'annotation_owner_guid' => $users[0]->guid,
+			'annotation_created_time_upper' => (time() - 3600),
+			'annotation_name' => $annotation_name,
+		];
+
+		$entities = elgg_get_entities_from_annotations($options);
+
+		$this->assertEqual(1, count($entities));
+		$this->assertEqual($valid1->guid, $entities[0]->guid);
+
+		$valid1->delete();
+		$valid2->delete();
+	}
+
+	public function testElggApiGettersEntitiesFromAnnotation() {
+
+		// grab a few different users to annotation
+		// there will always be at least 2 here because of the construct.
+		$users = elgg_get_entities([
+			'type' => 'user',
+			'subtypes' => $this->getRandomValidSubtypes(['user'], 5),
+			'limit' => 2
+		]);
+
+		// create some test annotations
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$annotation_name = 'test_annotation_name_' . rand();
+		$annotation_value = rand(1000, 9999);
+		$annotation_name2 = 'test_annotation_name_' . rand();
+		$annotation_value2 = rand(1000, 9999);
+		$guids = [];
+
+		// our targets
+		$valid = $this->createObject([
+			'subtype' => $subtype,
+		]);
+		$guids[] = $valid->getGUID();
+		create_annotation($valid->getGUID(), $annotation_name, $annotation_value, 'integer', $users[0]->getGUID());
+
+		$valid2 = $this->createObject([
+			'subtype' => $subtype,
+		]);
+		$guids[] = $valid2->getGUID();
+		create_annotation($valid2->getGUID(), $annotation_name2, $annotation_value2, 'integer', $users[1]->getGUID());
+
+		$options = [
+			'annotation_owner_guid' => $users[0]->getGUID(),
+			'annotation_name' => $annotation_name
+		];
+
+		$entities = elgg_get_entities_from_annotations($options);
+
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $guids));
+			$annotations = $entity->getAnnotations(['annotation_name' => $annotation_name]);
+			$this->assertEqual(count($annotations), 1);
+
+			$this->assertEqual($annotations[0]->name, $annotation_name);
+			$this->assertEqual($annotations[0]->value, $annotation_value);
+			$this->assertEqual($annotations[0]->owner_guid, $users[0]->getGUID());
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+	/**
+	 * This function tests the deprecated behaviour of egef_annotations
+	 * discussed in https://github.com/Elgg/Elgg/issues/6638
+	 */
+	public function testElggApiGettersEntitiesFromAnnotationOrderByMaxtime() {
+
+		// grab a few different users to annotation
+		// there will always be at least 2 here because of the construct.
+		$users = elgg_get_entities([
+			'type' => 'user',
+			'subtypes' => $this->getRandomValidSubtypes(['user'], 5),
+			'limit' => 2
+		]);
+
+		// create some test annotations
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$annotation_name = 'test_annotation_name_' . rand();
+		$annotation_value = rand(1000, 9999);
+		$annotation_name2 = 'test_annotation_name_' . rand();
+		$annotation_value2 = rand(1000, 9999);
+		$guids = [];
+
+		// our targets
+		$valid = new \ElggObject();
+		$valid->subtype = $subtype;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+		create_annotation($valid->getGUID(), $annotation_name, $annotation_value, 'integer', $users[0]->getGUID());
+
+		$valid2 = new \ElggObject();
+		$valid2->subtype = $subtype;
+		$valid2->save();
+		$guids[] = $valid2->getGUID();
+		create_annotation($valid2->getGUID(), $annotation_name2, $annotation_value2, 'integer', $users[1]->getGUID());
+
+		$options = [
+			'annotation_owner_guid' => $users[0]->getGUID(),
+			'annotation_name' => $annotation_name,
+			'selects' => ['MAX(n_table.time_created) AS maxtime'],
+			'group_by' => 'n_table.entity_guid',
+			'order_by' => 'maxtime'
+		];
+
+		$entities = elgg_get_entities_from_annotations($options);
+
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $guids));
+			$annotations = $entity->getAnnotations(['annotation_name' => $annotation_name]);
+			$this->assertEqual(count($annotations), 1);
+
+			$this->assertEqual($annotations[0]->name, $annotation_name);
+			$this->assertEqual($annotations[0]->value, $annotation_value);
+			$this->assertEqual($annotations[0]->owner_guid, $users[0]->getGUID());
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+
+	/**
+	 * Get entities ordered by various MySQL calculations on their annotations
+	 *
+	 * @dataProvider calculationTypesProvider
+	 */
+	public function testElggGetEntitiesFromAnnotationsCalculateX($type) {
+
+		$num_entities = 5;
+
+		// these are chosen to avoid the sums, means, mins, maxs being the same
+		// note that the calculation is cast to an int in SQL
+		$numbers = [
+			[
+				0,
+				5
+			],
+			[
+				2,
+				13
+			],
+			[
+				-3,
+				11
+			],
+			[
+				7,
+				9
+			],
+			[
+				1.2,
+				22
+			],
+		];
+
+		$subtypes = $this->getRandomValidSubtypes(['object'], $num_entities);
+		$name = "test_annotation_tegefacx_$type";
+		$values = [];
+		$options = [
+			'type' => 'object',
+			'subtypes' => $subtypes,
+			'limit' => $num_entities,
+		];
+
+		$es = elgg_get_entities($options);
+
+		foreach ($es as $index => $e) {
+			$e->deleteAnnotations($name);
+
+			$value = $numbers[$index][0];
+			$e->annotate($name, $value);
+
+			$value2 = $numbers[$index][1];
+			$e->annotate($name, $value2);
+
+			switch ($type) {
+				case 'sum':
+					$calc_value = $value + $value2;
+					break;
+
+				case 'avg':
+					$calc_value = ($value + $value2) / 2;
+					break;
+
+				case 'min':
+					$calc_value = min([
+						$value,
+						$value2
+					]);
+					break;
+
+				case 'max':
+					$calc_value = max([
+						$value,
+						$value2
+					]);
+					break;
+			}
+
+			$values[$e->guid] = $calc_value;
+		}
+
+		arsort($values);
+		
+		$expected_order = array_keys($values);
+
+		$options = [
+			'type' => 'object',
+			'subtypes' => $subtypes,
+			'guids' => array_keys($values),
+			'annotation_name' => $name,
+			'calculation' => $type
+		];
+
+		$es = elgg_get_entities_from_annotation_calculation($options);
+
+		$actual_order = array_map(function ($e) {
+			return $e->guid;
+		}, $es);
+
+		foreach ($es as $i => $e) {
+			$value = 0;
+			$as = $e->getAnnotations(['annotation_name' => $name]);
+			// should only ever be 2
+			$this->assertEqual(2, count($as));
+
+			$value = $as[0]->value;
+			$value2 = $as[1]->value;
+
+			switch ($type) {
+				case 'sum':
+					$calc_value = $value + $value2;
+					break;
+
+				case 'avg':
+					$calc_value = ($value + $value2) / 2;
+					break;
+
+				case 'min':
+					$calc_value = min([
+						$value,
+						$value2
+					]);
+					break;
+
+				case 'max':
+					$calc_value = max([
+						$value,
+						$value2
+					]);
+					break;
+			}
+
+			$this->assertEqual($values[$e->guid], $calc_value);
+			$this->assertEqual($calc_value, $e->getVolatileData('select:annotation_calculation'));
+		}
+
+		$this->assertEqual($expected_order, $actual_order);
+
+		$options['count'] = true;
+		$es_count = elgg_get_entities_from_annotation_calculation($options);
+		$this->assertEqual($es_count, $num_entities);
+	}
+
+	public function calculationTypesProvider() {
+		return [
+			['sum'],
+			['avg'],
+			['min'],
+			['max'],
+		];
+	}
+
+	/**
+	 * Get entities ordered by various MySQL calculations on their annotations constrained by a where clause
+	 *
+	 * @group  AnnotationCalculation
+	 */
+	public function testElggGetEntitiesFromAnnotationsCalculateConstrainedByWhere() {
+
+		$num_entities = 3;
+
+		$subtypes = $this->getRandomValidSubtypes(['object'], $num_entities);
+		$name = "test_annotation_tegefacxwhere_" . rand(0, 9999);
+
+		$values = [
+			// Annotation values for entity 1
+			[
+				-3,
+				0,
+				5,
+				8,
+				'foo'
+			],
+			// Annotation values for entity 2
+			[
+				-8,
+				-5,
+				-2,
+				0,
+				1,
+			],
+			// Annotation values for entity 3
+			[
+				-4,
+				-2,
+				-1,
+				'bar',
+			]
+		];
+
+		$options = [
+			'type' => 'object',
+			'subtypes' => $subtypes,
+			'limit' => $num_entities,
+		];
+
+		$entities = elgg_get_entities($options);
+
+		$this->assertEqual($num_entities, count($entities));
+
+		$guids = [];
+
+		foreach ($entities as $index => $entity) {
+			$entity->deleteAnnotations($name);
+
+			$guids[] = $entity->guid;
+			foreach ($values[$index] as $value) {
+				$entity->annotate($name, $value);
+			}
+		}
+
+		$options = [
+			'type' => 'object',
+			'subtypes' => $subtypes,
+			'guids' => $guids,
+			'annotation_name' => $name,
+			'annotation_values' => array_unique(call_user_func_array('array_merge', $values)),
+			'calculation' => 'sum',
+			'wheres' => [
+				"CAST(n_table.value as DECIMAL(10, 2)) > 0"
+			]
+		];
+
+		$es = elgg_get_entities_from_annotation_calculation($options);
+
+		foreach ($es as $i => $e) {
+
+			$assertion_values = [];
+
+			foreach ($values[$i] as $value) {
+				if (is_numeric($value) && $value > 0) {
+					$assertion_values[] = $value;
+				}
+			}
+
+			$annotations = $e->getAnnotations([
+				'annotation_name' => $name,
+				'where' => ["CAST(n_table.value AS DECIMAL(10, 2)) > 0"],
+				'limit' => 0,
+			]);
+
+			if (count($assertion_values)) {
+				$this->assertIsA($annotations, 'array');
+				$this->assertEqual(count($assertion_values), count($annotations));
+			} else {
+				$this->assertFalse($annotations);
+			}
+
+			$annotation_values = [];
+			foreach ($annotations as $ann) {
+				$annotation_values[] = $ann->value;
+			}
+
+			$this->assertEqual(array_sum($assertion_values), array_sum($annotation_values));
+			$this->assertEqual(array_sum($assertion_values), $e->getVolatileData('select:annotation_calculation'));
+		}
+
+		$options['count'] = true;
+
+		$es_count = elgg_get_entities_from_annotation_calculation($options);
+
+		// We have two entities with annotations values > 0
+		$this->assertEqual(2, $es_count);
+	}
+
+	/**
+	 * Get a count of entities using egefac()
+	 * Testing to make sure that the count includes each entity with multiple annotations of the same name only once
+	 * Irrespective of the calculation type passed
+	 */
+	public function testElggGetEntitiesFromAnnotationCalculationCount() {
+		// add two annotations with a unique name to a set of entities
+		// then count the number of entities using egefac()
+
+		$subtypes = $this->getRandomValidSubtypes(['object'], 3);
+		$name = 'test_annotation_' . rand(0, 9999);
+
+		$options = [
+			'type' => 'object',
+			'subtypes' => $subtypes,
+			'limit' => 3
+		];
+
+		$entities = elgg_get_entities($options);
+
+		foreach ($entities as $entity) {
+			$entity->deleteAnnotations($name);
+			$value = rand(0, 9999);
+			$entity->annotate($name, $value);
+			$value = rand(0, 9999);
+			$entity->annotate($name, $value);
+		}
+
+		$options = [
+			'type' => 'object',
+			'subtypes' => $subtypes,
+			'annotation_name' => $name,
+			'count' => true,
+		];
+
+		$calculations = [
+			'sum',
+			'avg',
+			'min',
+			'max'
+		];
+		foreach ($calculations as $calculation) {
+			$options['calculation'] = $calculation;
+			$count = elgg_get_entities_from_annotation_calculation($options);
+			$this->assertIdentical(3, $count);
+		}
+	}
+
+	/**
+	 * Get a count of entities annotated with the same value but different annotation names
+	 * Irrespective of the calculation
+	 */
+	public function testElggGetEntitiesFromAnnotationCalculationCountFromAnnotationValues() {
+
+		$subtypes = $this->getRandomValidSubtypes(['object'], 3);
+		$value = rand(0, 9999);
+
+		$options = [
+			'type' => 'object',
+			'subtypes' => $subtypes,
+			'limit' => 3
+		];
+
+		$es = elgg_get_entities($options);
+
+		foreach ($es as $e) {
+			$name = 'test_annotation_egefacval_' . rand(0, 9999);
+			$e->deleteAnnotations($name);
+			$e->annotate($name, $value);
+		}
+
+		$options = [
+			'type' => 'object',
+			'subtypes' => $subtypes,
+			'annotation_value' => $value,
+			'count' => true,
+		];
+		$calculations = [
+			'sum',
+			'avg',
+			'min',
+			'max'
+		];
+		foreach ($calculations as $calculation) {
+			$options['calculation'] = $calculation;
+			$count = elgg_get_entities_from_annotation_calculation($options);
+			$this->assertIdentical(3, $count);
+		}
+	}
+
+	/**
+	 * Get a count of entities annotated with the same name => value annotation pairs
+	 * Irrespective of the calculation
+	 */
+	public function testElggGetEntitiesFromAnnotationCalculationCountFromAnnotationNameValuesPairs() {
+
+		$subtypes = $this->getRandomValidSubtypes(['object'], 3);
+		$value = rand(0, 9999);
+		$name = 'test_annotation_egefacnv';
+
+		$options = [
+			'type' => 'object',
+			'subtypes' => $subtypes,
+			'limit' => 3
+		];
+
+		$es = elgg_get_entities($options);
+
+		foreach ($es as $e) {
+			$e->deleteAnnotations($name);
+			$e->annotate($name, $value);
+		}
+
+		$options = [
+			'type' => 'object',
+			'subtypes' => $subtypes,
+			'annotation_name' => $name,
+			'annotation_value' => $value,
+			'count' => true,
+		];
+
+		$calculations = [
+			'sum',
+			'avg',
+			'min',
+			'max'
+		];
+		foreach ($calculations as $calculation) {
+			$options['calculation'] = $calculation;
+			$count = elgg_get_entities_from_annotation_calculation($options);
+			$this->assertIdentical(3, $count);
+		}
+	}
+
+	public function testElggGetAnnotationsAnnotationNames() {
+		$options = ['annotation_names' => []];
+		$a_e_map = [];
+
+		// create test annotations on a few entities.
+		for ($i = 0; $i < 3; $i++) {
+			do {
+				$e = $this->entities[array_rand($this->entities)];
+			} while (in_array($e->guid, $a_e_map));
+			$annotations = $this->createRandomAnnotations($e);
+
+			foreach ($annotations as $a) {
+				$options['annotation_names'][] = $a->name;
+				$a_e_map[$a->id] = $e->guid;
+			}
+		}
+
+		$as = elgg_get_annotations($options);
+
+		$this->assertEqual(count($a_e_map), count($as));
+
+		foreach ($as as $a) {
+			$this->assertEqual($a_e_map[$a->id], $a->entity_guid);
+		}
+	}
+
+	public function testElggGetAnnotationsAnnotationValues() {
+		$options = ['annotation_values' => []];
+		$a_e_map = [];
+
+		// create test annotations on a few entities.
+		for ($i = 0; $i < 3; $i++) {
+			do {
+				$e = $this->entities[array_rand($this->entities)];
+			} while (in_array($e->guid, $a_e_map));
+			$annotations = $this->createRandomAnnotations($e);
+
+			foreach ($annotations as $a) {
+				$options['annotation_values'][] = $a->value;
+				$a_e_map[$a->id] = $e->guid;
+			}
+		}
+
+		$as = elgg_get_annotations($options);
+
+		$this->assertEqual(count($a_e_map), count($as));
+
+		foreach ($as as $a) {
+			$this->assertEqual($a_e_map[$a->id], $a->entity_guid);
+		}
+	}
+
+	public function testElggGetAnnotationsAnnotationOwnerGuids() {
+		$options = ['annotation_owner_guids' => []];
+		$a_e_map = [];
+
+		// create test annotations on a single entity
+		for ($i = 0; $i < 3; $i++) {
+			do {
+				$e = $this->entities[array_rand($this->entities)];
+			} while (in_array($e->guid, $a_e_map));
+
+			// remove annotations left over from previous tests.
+			elgg_delete_annotations(['annotation_owner_guid' => $e->guid]);
+			$annotations = $this->createRandomAnnotations($e);
+
+			foreach ($annotations as $a) {
+				$options['annotation_owner_guids'][] = $e->guid;
+				$a_e_map[$a->id] = $e->guid;
+			}
+		}
+
+		$as = elgg_get_annotations($options);
+		$this->assertEqual(count($a_e_map), count($as));
+
+		foreach ($as as $a) {
+			$this->assertEqual($a_e_map[$a->id], $a->owner_guid);
+		}
+	}
+
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGetEntitiesFromAttributesTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGetEntitiesFromAttributesTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Elgg\Integration;
+
+/**
+ * Test elgg_get_entities_from_attributes()
+ */
+class ElggCoreGetEntitiesFromAttributesTest extends ElggCoreGetEntitiesBaseTest {
+
+	public function testWithoutType() {
+		$this->expectException(new \InvalidArgumentException('The entity type must be defined for elgg_get_entities_from_attributes()'));
+		elgg_get_entities_from_attributes();
+	}
+
+	public function testWithMoreThanOneType() {
+		$this->expectException(new \InvalidArgumentException('Only one type can be passed to elgg_get_entities_from_attributes()'));
+		elgg_get_entities_from_attributes([
+			'types' => [
+				'one',
+				'two'
+			]
+		]);
+	}
+
+	public function testWithInvalidType() {
+		$this->expectException(new \InvalidArgumentException("Invalid type 'test' passed to elgg_get_entities_from_attributes()"));
+		elgg_get_entities_from_attributes(['type' => 'test']);
+	}
+
+	public function testWithInvalidPair() {
+		$this->expectException(new \InvalidArgumentException("attribute_name_value_pairs must be an array for elgg_get_entities_from_attributes()"));
+		elgg_get_entities_from_attributes([
+			'types' => 'object',
+			'attribute_name_value_pairs' => 'invalid',
+		]);
+	}
+
+	public function testGetSqlWithNoAttributePairs() {
+		$result = _elgg_get_entity_attribute_where_sql([
+			'types' => 'object',
+			'attribute_name_value_pairs' => ELGG_ENTITIES_ANY_VALUE,
+		]);
+		$this->assertIdentical([
+			'joins' => [],
+			'wheres' => []
+		], $result);
+	}
+
+	public function testGetSqlWithEmptyPairs() {
+		$result = _elgg_get_entity_attribute_where_sql([
+			'types' => 'object',
+			'attribute_name_value_pairs' => [],
+		]);
+		$this->assertIdentical([
+			'joins' => [],
+			'wheres' => []
+		], $result);
+	}
+
+	public function testGetSqlWithSinglePairAndStringValue() {
+		$result = _elgg_get_entity_attribute_where_sql([
+			'types' => 'object',
+			'attribute_name_value_pairs' => [
+				'name' => 'title',
+				'value' => 'foo',
+			],
+			'attribute_name_value_pairs_operator' => 'AND',
+		]);
+		$CONFIG = _elgg_config();
+		$expected = [
+			'joins' => ["JOIN {$CONFIG->dbprefix}objects_entity type_table ON e.guid = type_table.guid"],
+			'wheres' => ["((type_table.title = 'foo'))"],
+		];
+		$this->assertIdentical($expected, $result);
+	}
+
+	public function testGetSqlWithSinglePairAndOperand() {
+		$result = _elgg_get_entity_attribute_where_sql([
+			'types' => 'object',
+			'attribute_name_value_pairs' => [
+				'name' => 'title',
+				'value' => 'foo',
+				'operand' => '<',
+			],
+			'attribute_name_value_pairs_operator' => 'AND',
+		]);
+		$CONFIG = _elgg_config();
+		$expected = [
+			'joins' => ["JOIN {$CONFIG->dbprefix}objects_entity type_table ON e.guid = type_table.guid"],
+			'wheres' => ["((type_table.title < 'foo'))"],
+		];
+		$this->assertIdentical($expected, $result);
+	}
+
+	public function testGetSqlWithSinglePairAndNumericValue() {
+		$result = _elgg_get_entity_attribute_where_sql([
+			'types' => 'object',
+			'attribute_name_value_pairs' => [
+				'name' => 'title',
+				'value' => '32',
+			],
+			'attribute_name_value_pairs_operator' => 'AND',
+		]);
+		$CONFIG = _elgg_config();
+		$expected = [
+			'joins' => ["JOIN {$CONFIG->dbprefix}objects_entity type_table ON e.guid = type_table.guid"],
+			'wheres' => ["((type_table.title = 32))"],
+		];
+		$this->assertIdentical($expected, $result);
+	}
+
+	public function testGetSqlWithSinglePairAndNumericArrayValue() {
+		$result = _elgg_get_entity_attribute_where_sql([
+			'types' => 'object',
+			'attribute_name_value_pairs' => [
+				'name' => 'title',
+				'value' => [
+					1,
+					2,
+					3
+				],
+			],
+			'attribute_name_value_pairs_operator' => 'AND',
+		]);
+		$CONFIG = _elgg_config();
+		$expected = [
+			'joins' => ["JOIN {$CONFIG->dbprefix}objects_entity type_table ON e.guid = type_table.guid"],
+			'wheres' => ["((type_table.title IN (1, 2, 3)))"],
+		];
+		$this->assertIdentical($expected, $result);
+	}
+
+	public function testGetSqlWithSinglePairAndStringArrayValue() {
+		$result = _elgg_get_entity_attribute_where_sql([
+			'types' => 'object',
+			'attribute_name_value_pairs' => [
+				'name' => 'title',
+				'value' => [
+					'one',
+					'two'
+				],
+			],
+			'attribute_name_value_pairs_operator' => 'AND',
+		]);
+		$CONFIG = _elgg_config();
+		$expected = [
+			'joins' => ["JOIN {$CONFIG->dbprefix}objects_entity type_table ON e.guid = type_table.guid"],
+			'wheres' => ["((type_table.title IN ('one', 'two')))"],
+		];
+		$this->assertIdentical($expected, $result);
+	}
+
+	public function testGetSqlWithTwoPairs() {
+		$result = _elgg_get_entity_attribute_where_sql([
+			'types' => 'user',
+			'attribute_name_value_pairs' => [
+				[
+					'name' => 'username',
+					'value' => 'user2'
+				],
+				[
+					'name' => 'email',
+					'value' => 'test@example.org'
+				],
+			],
+			'attribute_name_value_pairs_operator' => 'AND',
+		]);
+		$CONFIG = _elgg_config();
+		$expected = [
+			'joins' => ["JOIN {$CONFIG->dbprefix}users_entity type_table ON e.guid = type_table.guid"],
+			'wheres' => ["((type_table.username = 'user2') AND (type_table.email = 'test@example.org'))"],
+		];
+		$this->assertIdentical($expected, $result);
+	}
+
+	public function testGetSqlWithSinglePairAndCaseInsensitiveStringValue() {
+		$result = _elgg_get_entity_attribute_where_sql([
+			'types' => 'object',
+			'attribute_name_value_pairs' => [
+				'name' => 'title',
+				'value' => 'foo',
+				'case_sensitive' => true,
+			],
+			'attribute_name_value_pairs_operator' => 'AND',
+		]);
+		$CONFIG = _elgg_config();
+		$expected = [
+			'joins' => ["JOIN {$CONFIG->dbprefix}objects_entity type_table ON e.guid = type_table.guid"],
+			'wheres' => ["((BINARY type_table.title = 'foo'))"],
+		];
+		$this->assertIdentical($expected, $result);
+	}
+
+	public function testGetUserByUsername() {
+		// grab a user
+		foreach ($this->entities as $e) {
+			if (elgg_instanceof($e, 'user')) {
+				break;
+			}
+		}
+
+		$result = elgg_get_entities_from_attributes([
+			'type' => 'user',
+			'attribute_name_value_pairs' => [
+				'name' => 'username',
+				'value' => $e->username,
+			],
+		]);
+		$this->assertEqual($e->guid, $result[0]->guid);
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGetEntitiesFromMetadataTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGetEntitiesFromMetadataTest.php
@@ -1,0 +1,1383 @@
+<?php
+
+namespace Elgg\Integration;
+
+use ElggObject;
+
+/**
+ * Test elgg_get_entities_from_metadata()
+ */
+class ElggCoreGetEntitiesFromMetadataTest extends ElggCoreGetEntitiesBaseTest {
+
+	//names
+	function testElggApiGettersEntityMetadataNameValidSingle() {
+		// create a new entity with a subtype we know
+		// use an existing type so it will clean up automatically
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $md_value;
+		$e->save();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name' => $md_name
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 1);
+
+		foreach ($entities as $entity) {
+			$this->assertEqual($entity->getGUID(), $e->getGUID());
+			$this->assertEqual($entity->$md_name, $md_value);
+		}
+
+		$e->delete();
+	}
+
+	function testElggApiGettersEntityMetadataNameValidMultiple() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_names = [];
+
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+		$md_names[] = $md_name;
+		$e_guids = [];
+
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $md_value;
+		$e->save();
+		$e_guids[] = $e->getGUID();
+
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+		$md_names[] = $md_name;
+
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $md_value;
+		$e->save();
+		$e_guids[] = $e->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_names' => $md_names
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 2);
+
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $e_guids));
+			$entity->delete();
+		}
+	}
+
+	function testElggApiGettersEntityMetadataNameInvalidSingle() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $md_value;
+		$e->save();
+
+		$md_invalid_name = 'test_metadata_name_' . rand();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name' => $md_invalid_name
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIdentical([], $entities);
+
+		$e->delete();
+	}
+
+	function testElggApiGettersEntityMetadataNameInvalidMultiple() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $md_value;
+		$e->save();
+
+		$md_invalid_names = [];
+		$md_invalid_names[] = 'test_metadata_name_' . rand();
+		$md_invalid_names[] = 'test_metadata_name_' . rand();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_names' => $md_invalid_names
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIdentical([], $entities);
+
+		$e->delete();
+	}
+
+
+	function testElggApiGettersEntityMetadataNameMixedMultiple() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_names = [];
+
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+		$md_names[] = $md_name;
+		$e_guids = [];
+
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = $md_value;
+		$valid->save();
+		$e_guids[] = $valid->getGUID();
+
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+
+		// add a random invalid name.
+		$md_names[] = 'test_metadata_name_' . rand();
+
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $md_value;
+		$e->save();
+		$e_guids[] = $e->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_names' => $md_names
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 1);
+
+		foreach ($entities as $entity) {
+			$this->assertEqual($entity->getGUID(), $valid->getGUID());
+		}
+
+		foreach ($e_guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+
+	// values
+	function testElggApiGettersEntityMetadataValueValidSingle() {
+		// create a new entity with a subtype we know
+		// use an existing type so it will clean up automatically
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $md_value;
+		$e->save();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_value' => $md_value
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 1);
+
+		foreach ($entities as $entity) {
+			$this->assertEqual($entity->getGUID(), $e->getGUID());
+			$this->assertEqual($entity->$md_name, $md_value);
+		}
+
+		$e->delete();
+	}
+
+	function testElggApiGettersEntityMetadataValueValidMultiple() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_values = [];
+
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+		$md_values[] = $md_value;
+		$e_guids = [];
+
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $md_value;
+		$e->save();
+		$e_guids[] = $e->getGUID();
+
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+		$md_values[] = $md_value;
+
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $md_value;
+		$e->save();
+		$e_guids[] = $e->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_values' => $md_values
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 2);
+
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $e_guids));
+			$entity->delete();
+		}
+	}
+
+	function testElggApiGettersEntityMetadataValueInvalidSingle() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $md_value;
+		$e->save();
+
+		$md_invalid_value = 'test_metadata_value_' . rand();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_value' => $md_invalid_value
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIdentical([], $entities);
+
+		$e->delete();
+	}
+
+	function testElggApiGettersEntityMetadataValueInvalidMultiple() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $md_value;
+		$e->save();
+
+		$md_invalid_values = [];
+		$md_invalid_values[] = 'test_metadata_value_' . rand();
+		$md_invalid_values[] = 'test_metadata_value_' . rand();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_values' => $md_invalid_values
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIdentical([], $entities);
+
+		$e->delete();
+	}
+
+
+	function testElggApiGettersEntityMetadataValueMixedMultiple() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_values = [];
+
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+		$md_values[] = $md_value;
+		$e_guids = [];
+
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = $md_value;
+		$valid->save();
+		$e_guids[] = $valid->getGUID();
+
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+
+		// add a random invalid value.
+		$md_values[] = 'test_metadata_value_' . rand();
+
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $md_value;
+		$e->save();
+		$e_guids[] = $e->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_values' => $md_values
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 1);
+
+		foreach ($entities as $entity) {
+			$this->assertEqual($entity->getGUID(), $valid->getGUID());
+		}
+
+		foreach ($e_guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+
+	// name_value_pairs
+
+
+	function testElggApiGettersEntityMetadataNVPValidNValidVEquals() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+		$guids = [];
+
+		// our target
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = $md_value;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+
+		// make some bad ones
+		$invalid_md_name = 'test_metadata_name_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$invalid_md_name = $md_value;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$invalid_md_value = 'test_metadata_value_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $invalid_md_value;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name_value_pairs' => [
+				[
+					'name' => $md_name,
+					'value' => $md_value
+				]
+			]
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 1);
+
+		foreach ($entities as $entity) {
+			$this->assertEqual($entity->getGUID(), $valid->getGUID());
+			$this->assertEqual($entity->$md_name, $md_value);
+			$entity->delete();
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+	function testElggApiGettersEntityMetadataNVPValidNValidVEqualsTriple() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+
+		$md_name2 = 'test_metadata_name_' . rand();
+		$md_value2 = 'test_metadata_value_' . rand();
+
+		$md_name3 = 'test_metadata_name_' . rand();
+		$md_value3 = 'test_metadata_value_' . rand();
+
+		$guids = [];
+
+		// our target
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = $md_value;
+		$valid->$md_name2 = $md_value2;
+		$valid->$md_name3 = $md_value3;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+
+		// make some bad ones
+		$invalid_md_name = 'test_metadata_name_' . rand();
+		$invalid_md_name2 = 'test_metadata_name_' . rand();
+		$invalid_md_name3 = 'test_metadata_name_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$invalid_md_name = $md_value;
+		$e->$invalid_md_name2 = $md_value2;
+		$e->$invalid_md_name3 = $md_value3;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$invalid_md_value = 'test_metadata_value_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $invalid_md_value;
+		$e->$md_name2 = $invalid_md_value;
+		$e->$md_name3 = $invalid_md_value;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name_value_pairs' => [
+				[
+					'name' => $md_name,
+					'value' => $md_value
+				],
+				[
+					'name' => $md_name2,
+					'value' => $md_value2
+				],
+				[
+					'name' => $md_name3,
+					'value' => $md_value3
+				]
+			]
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 1);
+
+		foreach ($entities as $entity) {
+			$this->assertEqual($entity->getGUID(), $valid->getGUID());
+			$this->assertEqual($entity->$md_name, $md_value);
+			$entity->delete();
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+	function testElggApiGettersEntityMetadataNVPValidNValidVEqualsDouble() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+
+		$md_name2 = 'test_metadata_name_' . rand();
+		$md_value2 = 'test_metadata_value_' . rand();
+
+		$guids = [];
+
+		// our target
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = $md_value;
+		$valid->$md_name2 = $md_value2;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+
+		// make some bad ones
+		$invalid_md_name = 'test_metadata_name_' . rand();
+		$invalid_md_name2 = 'test_metadata_name_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$invalid_md_name = $md_value;
+		$e->$invalid_md_name2 = $md_value2;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$invalid_md_value = 'test_metadata_value_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $invalid_md_value;
+		$e->$md_name2 = $invalid_md_value;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name_value_pairs' => [
+				[
+					'name' => $md_name,
+					'value' => $md_value
+				],
+				[
+					'name' => $md_name2,
+					'value' => $md_value2
+				]
+			]
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 1);
+
+		foreach ($entities as $entity) {
+			$this->assertEqual($entity->getGUID(), $valid->getGUID());
+			$this->assertEqual($entity->$md_name, $md_value);
+			$entity->delete();
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+	// this keeps locking up my database...
+	function xtestElggApiGettersEntityMetadataNVPValidNValidVEqualsStupid() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+
+		$md_name2 = 'test_metadata_name_' . rand();
+		$md_value2 = 'test_metadata_value_' . rand();
+
+		$md_name3 = 'test_metadata_name_' . rand();
+		$md_value3 = 'test_metadata_value_' . rand();
+
+		$md_name4 = 'test_metadata_name_' . rand();
+		$md_value4 = 'test_metadata_value_' . rand();
+
+		$md_name5 = 'test_metadata_name_' . rand();
+		$md_value5 = 'test_metadata_value_' . rand();
+
+		$guids = [];
+
+		// our target
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = $md_value;
+		$valid->$md_name2 = $md_value2;
+		$valid->$md_name3 = $md_value3;
+		$valid->$md_name4 = $md_value4;
+		$valid->$md_name5 = $md_value5;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+
+		// make some bad ones
+		$invalid_md_name = 'test_metadata_name_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$invalid_md_name = $md_value;
+		$e->$md_name2 = $md_value2;
+		$e->$md_name3 = $md_value3;
+		$e->$md_name4 = $md_value4;
+		$e->$md_name5 = $md_value5;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$invalid_md_value = 'test_metadata_value_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $invalid_md_value;
+		$e->$md_name2 = $invalid_md_value;
+		$e->$md_name3 = $invalid_md_value;
+		$e->$md_name4 = $invalid_md_value;
+		$e->$md_name5 = $invalid_md_value;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name_value_pairs' => [
+				[
+					'name' => $md_name,
+					'value' => $md_value
+				],
+				[
+					'name' => $md_name2,
+					'value' => $md_value2
+				],
+				[
+					'name' => $md_name3,
+					'value' => $md_value3
+				],
+				[
+					'name' => $md_name4,
+					'value' => $md_value4
+				],
+				[
+					'name' => $md_name5,
+					'value' => $md_value5
+				],
+			]
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 1);
+
+		foreach ($entities as $entity) {
+			$this->assertEqual($entity->getGUID(), $valid->getGUID());
+			$this->assertEqual($entity->$md_name, $md_value);
+			$entity->delete();
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+	/**
+	 * Name value pair with valid name and invalid value
+	 */
+	function testElggApiGettersEntityMetadataNVPValidNInvalidV() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+		$guids = [];
+
+		// make some bad ones
+		$invalid_md_name = 'test_metadata_name_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$invalid_md_name = $md_value;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$invalid_md_value = 'test_metadata_value_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $invalid_md_value;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name_value_pairs' => [
+				[
+					'name' => $md_name,
+					'value' => 'test_metadata_value_' . rand()
+				]
+			]
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIdentical([], $entities);
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+	/**
+	 * Name value pair with invalid name and valid value
+	 */
+	function testElggApiGettersEntityMetadataNVPInvalidNValidV() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+		$guids = [];
+
+		// make some bad ones
+		$invalid_md_name = 'test_metadata_name_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$invalid_md_name = $md_value;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$invalid_md_value = 'test_metadata_value_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $invalid_md_value;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name_value_pairs' => [
+				[
+					'name' => 'test_metadata_name_' . rand(),
+					'value' => $md_value
+				]
+			]
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIdentical([], $entities);
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+
+	function testElggApiGettersEntityMetadataNVPValidNValidVOperandIn() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+		$guids = [];
+		$valid_guids = [];
+
+		// our targets
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = $md_value;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid->getGUID();
+
+		$md_name2 = 'test_metadata_name_' . rand();
+		$md_value2 = 'test_metadata_value_' . rand();
+
+		$valid2 = new ElggObject();
+		$valid2->subtype = $subtype;
+		$valid2->$md_name2 = $md_value2;
+		$valid2->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid2->getGUID();
+
+		// make some bad ones
+		$invalid_md_name = 'test_metadata_name_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$invalid_md_name = $md_value;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$invalid_md_value = 'test_metadata_value_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $invalid_md_value;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$md_valid_values = "'$md_value', '$md_value2'";
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name_value_pairs' => [
+				[
+					'name' => $md_name,
+					'value' => $md_valid_values,
+					'operand' => 'IN'
+				],
+				[
+					'name' => $md_name2,
+					'value' => $md_valid_values,
+					'operand' => 'IN'
+				],
+			],
+			'metadata_name_value_pairs_operator' => 'OR'
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 2);
+
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $valid_guids));
+			$entity->delete();
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+	function testElggApiGettersEntityMetadataNVPValidNValidVPlural() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$md_value = 'test_metadata_value_' . rand();
+		$guids = [];
+		$valid_guids = [];
+
+		// our targets
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = $md_value;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid->getGUID();
+
+		$md_name2 = 'test_metadata_name_' . rand();
+		$md_value2 = 'test_metadata_value_' . rand();
+
+		$valid2 = new ElggObject();
+		$valid2->subtype = $subtype;
+		$valid2->$md_name2 = $md_value2;
+		$valid2->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid2->getGUID();
+
+		// make some bad ones
+		$invalid_md_name = 'test_metadata_name_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$invalid_md_name = $md_value;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$invalid_md_value = 'test_metadata_value_' . rand();
+		$e = new ElggObject();
+		$e->subtype = $subtype;
+		$e->$md_name = $invalid_md_value;
+		$e->save();
+		$guids[] = $e->getGUID();
+
+		$md_valid_values = [
+			$md_value,
+			$md_value2
+		];
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name_value_pairs' => [
+				[
+					'name' => $md_name,
+					'value' => $md_valid_values,
+					'operand' => 'IN'
+				],
+				[
+					'name' => $md_name2,
+					'value' => $md_valid_values,
+					'operand' => 'IN'
+				],
+			],
+			'metadata_name_value_pairs_operator' => 'OR'
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 2);
+
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $valid_guids));
+			$entity->delete();
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+	function testElggApiGettersEntityMetadataNVPOrderByMDText() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$guids = [];
+		$valid_guids = [];
+
+		// our targets
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = 1;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid->getGUID();
+
+		$valid2 = new ElggObject();
+		$valid2->subtype = $subtype;
+		$valid2->$md_name = 2;
+		$valid2->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid2->getGUID();
+
+		$valid3 = new ElggObject();
+		$valid3->subtype = $subtype;
+		$valid3->$md_name = 3;
+		$valid3->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid3->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			//'metadata_name' => $md_name,
+			'order_by_metadata' => [
+				'name' => $md_name,
+				'as' => 'integer'
+			]
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 3);
+
+		$i = 1;
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $valid_guids));
+			$this->assertEqual($entity->$md_name, $i);
+			$i++;
+			$entity->delete();
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+	function testElggApiGettersEntityMetadataNVPOrderByMDString() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$guids = [];
+		$valid_guids = [];
+
+		// our targets
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = 'a';
+		$valid->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid->getGUID();
+
+		$valid2 = new ElggObject();
+		$valid2->subtype = $subtype;
+		$valid2->$md_name = 'b';
+		$valid2->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid2->getGUID();
+
+		$valid3 = new ElggObject();
+		$valid3->subtype = $subtype;
+		$valid3->$md_name = 'c';
+		$valid3->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid3->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name' => $md_name,
+			'order_by_metadata' => [
+				'name' => $md_name,
+				'as' => 'text'
+			]
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 3);
+
+		$alpha = [
+			'a',
+			'b',
+			'c'
+		];
+
+		$i = 0;
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $valid_guids));
+			$this->assertEqual($entity->$md_name, $alpha[$i]);
+			$i++;
+			$entity->delete();
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+	// test getting by name sorting by value as integer
+	function testElggApiGettersEntityMetadataNOrderByMDInt() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$guids = [];
+		$valid_guids = [];
+
+		// our targets
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = 5;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid->getGUID();
+
+		$valid2 = new ElggObject();
+		$valid2->subtype = $subtype;
+		$valid2->$md_name = 1;
+		$valid2->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid2->getGUID();
+
+		$valid3 = new ElggObject();
+		$valid3->subtype = $subtype;
+		$valid3->$md_name = 15;
+		$valid3->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid3->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name' => $md_name,
+			'order_by_metadata' => [
+				'name' => $md_name,
+				'as' => 'integer'
+			]
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 3);
+
+		$num = [
+			1,
+			5,
+			15
+		];
+
+		$i = 0;
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $valid_guids));
+			$this->assertEqual($entity->$md_name, $num[$i]);
+			$i++;
+			$entity->delete();
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+	// test getting by name sorting by value as integer with defined values
+	function testElggApiGettersEntityMetadataNOrderByMDIntDefinedVals() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$guids = [];
+		$valid_guids = [];
+
+		// our targets
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = 5;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid->getGUID();
+
+		$valid2 = new ElggObject();
+		$valid2->subtype = $subtype;
+		$valid2->$md_name = 1;
+		$valid2->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid2->getGUID();
+
+		$valid3 = new ElggObject();
+		$valid3->subtype = $subtype;
+		$valid3->$md_name = 15;
+		$valid3->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid3->getGUID();
+
+		$num = [
+			1,
+			5,
+			15
+		];
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name' => $md_name,
+			'metadata_values' => $num,
+			'order_by_metadata' => [
+				'name' => $md_name,
+				'as' => 'integer'
+			]
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 3);
+
+		$i = 0;
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $valid_guids));
+			$this->assertEqual($entity->$md_name, $num[$i]);
+			$i++;
+			$entity->delete();
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+	// test getting by name_value_pairs sorting by value as integer
+	// because string comparison '5' > '15'
+	function testElggApiGettersEntityMetadataNVPOrderByMDInt() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$guids = [];
+		$valid_guids = [];
+
+		// our targets
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = 5;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid->getGUID();
+
+		$valid2 = new ElggObject();
+		$valid2->subtype = $subtype;
+		$valid2->$md_name = 1;
+		$valid2->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid2->getGUID();
+
+		$valid3 = new ElggObject();
+		$valid3->subtype = $subtype;
+		$valid3->$md_name = 15;
+		$valid3->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid3->getGUID();
+
+		$num = [
+			1,
+			5,
+			15
+		];
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name_value_pairs' => [
+				'name' => $md_name,
+				'value' => $num
+			],
+			'order_by_metadata' => [
+				'name' => $md_name,
+				'as' => 'integer'
+			]
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 3);
+
+		$i = 0;
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $valid_guids));
+			$this->assertEqual($entity->$md_name, $num[$i]);
+			$i++;
+			$entity->delete();
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+	// test getting by name sorting by value as integer with defined values
+	function testElggApiGettersEntityMetadataNVPGreaterThanInt() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$guids = [];
+		$valid_guids = [];
+
+		// our targets
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = 5;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid->getGUID();
+
+		$valid2 = new ElggObject();
+		$valid2->subtype = $subtype;
+		$valid2->$md_name = 1;
+		$valid2->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid2->getGUID();
+
+		$valid3 = new ElggObject();
+		$valid3->subtype = $subtype;
+		$valid3->$md_name = 15;
+		$valid3->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid3->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name_value_pairs' => [
+				'name' => $md_name,
+				'value' => 4,
+				'operand' => '>'
+			],
+			'order_by_metadata' => [
+				'name' => $md_name,
+				'as' => 'integer'
+			]
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 2);
+
+		$num = [
+			5,
+			15
+		];
+
+		$i = 0;
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $valid_guids));
+			$this->assertEqual($entity->$md_name, $num[$i]);
+			$i++;
+			$entity->delete();
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+	// test getting from string value interpreted as numeric
+	// see https://github.com/Elgg/Elgg/issues/7009
+	function testElggApiGettersEntityMetadataNVPInvalidDouble() {
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$md_name = 'test_metadata_name_' . rand();
+		$guids = [];
+		$valid_guids = [];
+
+		$value = '052e866869';
+
+		// our targets
+		$valid = new ElggObject();
+		$valid->subtype = $subtype;
+		$valid->$md_name = $value;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+		$valid_guids[] = $valid->getGUID();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'metadata_name_value_pairs' => [
+				'name' => $md_name,
+				'value' => $value
+			]
+		];
+
+		$entities = elgg_get_entities_from_metadata($options);
+
+		$this->assertIsA($entities, 'array');
+		$this->assertEqual(count($entities), 1);
+
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $valid_guids));
+			$this->assertEqual($entity->$md_name, $value);
+			$entity->delete();
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGetEntitiesFromPrivateSettingsTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGetEntitiesFromPrivateSettingsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Elgg\Integration;
+
+/**
+ * Test elgg_get_entities_from_private_settings()
+ */
+class ElggCoreGetEntitiesFromPrivateSettingsTest extends ElggCoreGetEntitiesBaseTest {
+
+	public function testElggApiGettersEntitiesFromPrivateSettings() {
+
+		// create some test private settings
+		$setting_name = 'test_setting_name_' . rand();
+		$setting_value = rand(1000, 9999);
+		$setting_name2 = 'test_setting_name_' . rand();
+		$setting_value2 = rand(1000, 9999);
+
+		$subtypes = $this->getRandomValidSubtypes(['object'], 1);
+		$subtype = $subtypes[0];
+		$guids = [];
+
+		// our targets
+		$valid = new \ElggObject();
+		$valid->subtype = $subtype;
+		$valid->save();
+		$guids[] = $valid->getGUID();
+		set_private_setting($valid->getGUID(), $setting_name, $setting_value);
+		set_private_setting($valid->getGUID(), $setting_name2, $setting_value2);
+
+		$valid2 = new \ElggObject();
+		$valid2->subtype = $subtype;
+		$valid2->save();
+		$guids[] = $valid2->getGUID();
+		set_private_setting($valid2->getGUID(), $setting_name, $setting_value);
+		set_private_setting($valid2->getGUID(), $setting_name2, $setting_value2);
+
+		// simple test with name
+		$options = [
+			'private_setting_name' => $setting_name
+		];
+
+		$entities = elgg_get_entities_from_private_settings($options);
+
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $guids));
+			$value = get_private_setting($entity->getGUID(), $setting_name);
+			$this->assertEqual($value, $setting_value);
+		}
+
+		// simple test with value
+		$options = [
+			'private_setting_value' => $setting_value
+		];
+
+		$entities = elgg_get_entities_from_private_settings($options);
+
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $guids));
+			$value = get_private_setting($entity->getGUID(), $setting_name);
+			$this->assertEqual($value, $setting_value);
+		}
+
+		// test pairs
+		$options = [
+			'type' => 'object',
+			'subtype' => $subtype,
+			'private_setting_name_value_pairs' => [
+				[
+					'name' => $setting_name,
+					'value' => $setting_value
+				],
+				[
+					'name' => $setting_name2,
+					'value' => $setting_value2
+				]
+			]
+		];
+
+		$entities = elgg_get_entities_from_private_settings($options);
+		$this->assertEqual(2, count($entities));
+		foreach ($entities as $entity) {
+			$this->assertTrue(in_array($entity->getGUID(), $guids));
+		}
+
+		foreach ($guids as $guid) {
+			if ($e = get_entity($guid)) {
+				$e->delete();
+			}
+		}
+	}
+
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGetEntitiesFromRelationshipTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGetEntitiesFromRelationshipTest.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace Elgg\Integration;
+
+use ElggObject;
+
+/**
+ * Test elgg_get_entities_from_relationship() and
+ * elgg_get_entities_from_relationship_count()
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreGetEntitiesFromRelationshipTest extends ElggCoreGetEntitiesBaseTest {
+
+	// Make sure metadata doesn't affect getting entities by relationship.  See #2274
+	public function testElggApiGettersEntityRelationshipWithMetadata() {
+		$guids = [];
+
+		$obj1 = new ElggObject();
+		$obj1->test_md = 'test';
+		$obj1->save();
+		$guids[] = $obj1->guid;
+
+		$obj2 = new ElggObject();
+		$obj2->test_md = 'test';
+		$obj2->save();
+		$guids[] = $obj2->guid;
+
+		add_entity_relationship($guids[0], 'test', $guids[1]);
+
+		$options = [
+			'relationship' => 'test',
+			'relationship_guid' => $guids[0]
+		];
+
+		$es = elgg_get_entities_from_relationship($options);
+		$this->assertTrue(is_array($es));
+		$this->assertIdentical(count($es), 1);
+
+		foreach ($es as $e) {
+			$this->assertEqual($guids[1], $e->guid);
+		}
+
+		foreach ($guids as $guid) {
+			$e = get_entity($guid);
+			$e->delete();
+		}
+	}
+
+	public function testElggApiGettersEntityRelationshipWithOutMetadata() {
+		$guids = [];
+
+		$obj1 = new ElggObject();
+		$obj1->save();
+		$guids[] = $obj1->guid;
+
+		$obj2 = new ElggObject();
+		$obj2->save();
+		$guids[] = $obj2->guid;
+
+		add_entity_relationship($guids[0], 'test', $guids[1]);
+
+		$options = [
+			'relationship' => 'test',
+			'relationship_guid' => $guids[0]
+		];
+
+		$es = elgg_get_entities_from_relationship($options);
+		$this->assertTrue(is_array($es));
+		$this->assertIdentical(count($es), 1);
+
+		foreach ($es as $e) {
+			$this->assertEqual($guids[1], $e->guid);
+		}
+
+		foreach ($guids as $guid) {
+			$e = get_entity($guid);
+			$e->delete();
+		}
+	}
+
+	public function testElggApiGettersEntityRelationshipWithMetadataIncludingRealMetadata() {
+		$guids = [];
+
+		$obj1 = new ElggObject();
+		$obj1->test_md = 'test';
+		$obj1->save();
+		$guids[] = $obj1->guid;
+
+		$obj2 = new ElggObject();
+		$obj2->test_md = 'test';
+		$obj2->save();
+		$guids[] = $obj2->guid;
+
+		add_entity_relationship($guids[0], 'test', $guids[1]);
+
+		$options = [
+			'relationship' => 'test',
+			'relationship_guid' => $guids[0],
+			'metadata_name' => 'test_md',
+			'metadata_value' => 'test',
+		];
+
+		$es = elgg_get_entities_from_relationship($options);
+		$this->assertTrue(is_array($es));
+		$this->assertIdentical(count($es), 1);
+
+		foreach ($es as $e) {
+			$this->assertEqual($guids[1], $e->guid);
+		}
+
+		foreach ($guids as $guid) {
+			$e = get_entity($guid);
+			$e->delete();
+		}
+	}
+
+	public function testElggApiGettersEntityRelationshipWithMetadataIncludingFakeMetadata() {
+		$guids = [];
+
+		$obj1 = new ElggObject();
+		$obj1->test_md = 'test';
+		$obj1->save();
+		$guids[] = $obj1->guid;
+
+		$obj2 = new ElggObject();
+		$obj2->test_md = 'test';
+		$obj2->save();
+		$guids[] = $obj2->guid;
+
+		add_entity_relationship($guids[0], 'test', $guids[1]);
+
+		$options = [
+			'relationship' => 'test',
+			'relationship_guid' => $guids[0],
+			'metadata_name' => 'test_md',
+			'metadata_value' => 'invalid',
+		];
+
+		$es = elgg_get_entities_from_relationship($options);
+
+		$this->assertTrue(empty($es));
+
+		foreach ($guids as $guid) {
+			$e = get_entity($guid);
+			$e->delete();
+		}
+	}
+
+	public function testElggGetEntitiesFromRelationshipCount() {
+		$entities = $this->entities;
+		$relationships = [];
+		$count = count($entities);
+		$max = $count - 1;
+		$relationship_name = 'test_relationship_' . rand(0, 1000);
+
+		for ($i = 0; $i < $count; $i++) {
+			do {
+				$popular_entity = $entities[array_rand($entities)];
+			} while (array_key_exists($popular_entity->guid, $relationships));
+
+			$relationships[$popular_entity->guid] = [];
+
+			for ($c = 0; $c < $max; $c++) {
+				do {
+					$fan_entity = $entities[array_rand($entities)];
+				} while ($fan_entity->guid == $popular_entity->guid || in_array($fan_entity->guid, $relationships[$popular_entity->guid]));
+
+				$relationships[$popular_entity->guid][] = $fan_entity->guid;
+				add_entity_relationship($fan_entity->guid, $relationship_name, $popular_entity->guid);
+			}
+
+			$max--;
+		}
+
+		$options = [
+			'relationship' => $relationship_name,
+			'limit' => $count
+		];
+
+		$entities = elgg_get_entities_from_relationship_count($options);
+
+		foreach ($entities as $e) {
+			$options = [
+				'relationship' => $relationship_name,
+				'limit' => 100,
+				'relationship_guid' => $e->guid,
+				'inverse_relationship' => true
+			];
+
+			$fan_entities = elgg_get_entities_from_relationship($options);
+
+			$this->assertEqual(count($fan_entities), count($relationships[$e->guid]));
+
+			foreach ($fan_entities as $fan_entity) {
+				$this->assertTrue(in_array($fan_entity->guid, $relationships[$e->guid]));
+				$this->assertNotIdentical(false, check_entity_relationship($fan_entity->guid, $relationship_name, $e->guid));
+			}
+		}
+	}
+
+	/**
+	 * Make sure elgg_get_entities_from_relationship() returns distinct (unique) results when relationship_guid is not
+	 * set See #5775
+	 */
+	public function testElggApiGettersEntityRelationshipDistinctResult() {
+
+		$obj1 = new ElggObject();
+		$obj1->save();
+
+		$obj2 = new ElggObject();
+		$obj2->save();
+
+		$obj3 = new ElggObject();
+		$obj3->save();
+
+		add_entity_relationship($obj2->guid, 'test_5775', $obj1->guid);
+		add_entity_relationship($obj3->guid, 'test_5775', $obj1->guid);
+
+		$options = [
+			'relationship' => 'test_5775',
+			'inverse_relationship' => false,
+			'count' => true,
+		];
+
+		$count = elgg_get_entities_from_relationship($options);
+		$this->assertIdentical($count, 1);
+
+		unset($options['count']);
+		$objects = elgg_get_entities_from_relationship($options);
+		$this->assertTrue(is_array($objects));
+		$this->assertIdentical(count($objects), 1);
+
+		$obj1->delete();
+		$obj2->delete();
+		$obj3->delete();
+	}
+
+	/**
+	 * Make sure changes related to #5775 do not affect inverse relationship queries
+	 */
+	public function testElggApiGettersEntityRelationshipDistinctResultInverse() {
+
+
+		$obj1 = new ElggObject();
+		$obj1->save();
+
+		$obj2 = new ElggObject();
+		$obj2->save();
+
+		$obj3 = new ElggObject();
+		$obj3->save();
+
+		add_entity_relationship($obj2->guid, 'test_5775_inverse', $obj1->guid);
+		add_entity_relationship($obj3->guid, 'test_5775_inverse', $obj1->guid);
+
+		$options = [
+			'relationship' => 'test_5775_inverse',
+			'inverse_relationship' => true,
+			'count' => true,
+		];
+
+		$count = elgg_get_entities_from_relationship($options);
+		$this->assertIdentical($count, 2);
+
+		unset($options['count']);
+		$objects = elgg_get_entities_from_relationship($options);
+		$this->assertTrue(is_array($objects));
+		$this->assertIdentical(count($objects), 2);
+
+		$obj1->delete();
+		$obj2->delete();
+		$obj3->delete();
+	}
+
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGetEntitiesTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGetEntitiesTest.php
@@ -1,0 +1,854 @@
+<?php
+
+namespace Elgg\Integration;
+
+/**
+ * Test elgg_get_entities()
+ */
+class ElggCoreGetEntitiesTest extends ElggCoreGetEntitiesBaseTest {
+
+	/***********************************
+	 * TYPE TESTS
+	 ***********************************
+	 * check for getting a valid type in all ways we can.
+	 * note that these aren't wonderful tests as there will be
+	 * existing entities so we can't test against the ones we just created.
+	 * So these just test that some are returned and match the type(s) requested.
+	 * It could definitely be the case that the first 10 entities retrieved are all
+	 * objects.  Maybe best to limit to 4 and group by type.
+	 */
+	public function testElggAPIGettersValidTypeUsingType() {
+		$type_arr = $this->getRandomValidTypes();
+		$type = $type_arr[0];
+		$options = [
+			'type' => $type,
+			'group_by' => 'e.type'
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		// should only ever return one object because of group by
+		$this->assertIdentical(count($es), 1);
+		foreach ($es as $e) {
+			$this->assertTrue(in_array($e->getType(), $type_arr));
+		}
+	}
+
+	public function testElggAPIGettersValidTypeUsingTypesAsString() {
+		$type_arr = $this->getRandomValidTypes();
+		$type = $type_arr[0];
+		$options = [
+			'types' => $type,
+			'group_by' => 'e.type'
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		// should only ever return one object because of group by
+		$this->assertIdentical(count($es), 1);
+		foreach ($es as $e) {
+			$this->assertTrue(in_array($e->getType(), $type_arr));
+		}
+	}
+
+	public function testElggAPIGettersValidTypeUsingTypesAsArray() {
+		$type_arr = $this->getRandomValidTypes();
+		$options = [
+			'types' => $type_arr,
+			'group_by' => 'e.type'
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		// should only ever return one object because of group by
+		$this->assertIdentical(count($es), 1);
+		foreach ($es as $e) {
+			$this->assertTrue(in_array($e->getType(), $type_arr));
+		}
+	}
+
+	public function testElggAPIGettersValidTypeUsingTypesAsArrayPlural() {
+		$num = 2;
+		$types = $this->getRandomValidTypes($num);
+		$options = [
+			'types' => $types,
+			'group_by' => 'e.type'
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		// one of object and one of group
+		$this->assertIdentical(count($es), $num);
+
+		foreach ($es as $e) {
+			$this->assertTrue(in_array($e->getType(), $types));
+		}
+	}
+
+
+	/*
+	 * Test mixed valid and invalid types.
+	 */
+
+
+	public function testElggAPIGettersValidAndInvalidTypes() {
+		//@todo replace this with $this->getRandomMixedTypes().
+		$t = $this->getRandomValidTypes();
+		$valid = $t[0];
+
+		$t = $this->getRandomInvalids();
+		$invalid = $t[0];
+		$options = [
+			'types' => [
+				$invalid,
+				$valid
+			],
+			'group_by' => 'e.type'
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		// should only ever return one object because of group by
+		$this->assertIdentical(count($es), 1);
+		$this->assertIdentical($es[0]->getType(), $valid);
+	}
+
+	public function testElggAPIGettersValidAndInvalidTypesPlural() {
+		$valid_num = 2;
+		$invalid_num = 3;
+		$valid = $this->getRandomValidTypes($valid_num);
+		$invalid = $this->getRandomInvalids($invalid_num);
+
+		$types = [];
+		foreach ($valid as $t) {
+			$types[] = $t;
+		}
+
+		foreach ($invalid as $t) {
+			$types[] = $t;
+		}
+
+		shuffle($types);
+		$options = [
+			'types' => $types,
+			'group_by' => 'e.type'
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		// should only ever return one object because of group by
+		$this->assertIdentical(count($es), $valid_num);
+		foreach ($es as $e) {
+			$this->assertTrue(in_array($e->getType(), $valid));
+		}
+	}
+
+
+	/**************************************
+	 * SUBTYPE TESTS
+	 **************************************
+	 *
+	 * Here we can use the subtypes we created to test more finely.
+	 * Subtypes are bound to types, so we must pass a type.
+	 * This is where the fun logic starts.
+	 */
+
+	public function testElggAPIGettersValidSubtypeUsingSubtypeSingularType() {
+		$types = $this->getRandomValidTypes();
+		$subtypes = $this->getRandomValidSubtypes($types);
+		$subtype = $subtypes[0];
+
+		$options = [
+			'types' => $types,
+			'subtype' => $subtype
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		$this->assertIdentical(count($es), 1);
+		foreach ($es as $e) {
+			$this->assertTrue(in_array($e->getType(), $types));
+			$this->assertTrue(in_array($e->getSubtype(), $subtypes));
+		}
+	}
+
+	public function testElggAPIGettersValidSubtypeUsingSubtypesAsStringSingularType() {
+		$types = $this->getRandomValidTypes();
+		$subtypes = $this->getRandomValidSubtypes($types);
+		$subtype = $subtypes[0];
+
+		$options = [
+			'types' => $types,
+			'subtypes' => $subtype
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		$this->assertIdentical(count($es), 1);
+		foreach ($es as $e) {
+			$this->assertTrue(in_array($e->getType(), $types));
+			$this->assertTrue(in_array($e->getSubtype(), $subtypes));
+		}
+	}
+
+	public function testElggAPIGettersValidSubtypeUsingSubtypesAsArraySingularType() {
+		$types = $this->getRandomValidTypes();
+		$subtypes = $this->getRandomValidSubtypes($types);
+
+		$options = [
+			'types' => $types,
+			'subtypes' => $subtypes
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		$this->assertIdentical(count($es), 1);
+		foreach ($es as $e) {
+			$this->assertTrue(in_array($e->getType(), $types));
+			$this->assertTrue(in_array($e->getSubtype(), $subtypes));
+		}
+	}
+
+	public function testElggAPIGettersValidSubtypeUsingPluralSubtypesSingularType() {
+		$subtype_num = 2;
+		$types = $this->getRandomValidTypes();
+		$subtypes = $this->getRandomValidSubtypes($types, $subtype_num);
+
+		$options = [
+			'types' => $types,
+			'subtypes' => $subtypes
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		$this->assertIdentical(count($es), $subtype_num);
+		foreach ($es as $e) {
+			$this->assertTrue(in_array($e->getType(), $types));
+			$this->assertTrue(in_array($e->getSubtype(), $subtypes));
+		}
+	}
+
+
+	/*
+	Because we're looking for type OR subtype (sorta)
+	it's possible that we've pulled in entities that aren't
+	of the subtype we've requested.
+	THIS COMBINATION MAKES LITTLE SENSE.
+	There is no mechanism in elgg to retrieve a subtype without a type, so
+	this combo gets trimmed down to only including subtypes that are valid to
+	each particular type.
+	FOR THE LOVE OF ALL GOOD PLEASE JUST USE TYPE_SUBTYPE_PAIRS!
+	 */
+	public function testElggAPIGettersValidSubtypeUsingPluralSubtypesPluralTypes() {
+		$type_num = 2;
+		$subtype_num = 2;
+		$types = $this->getRandomValidTypes($type_num);
+		$subtypes = $this->getRandomValidSubtypes($types, $subtype_num);
+
+		$options = [
+			'types' => $types,
+			'subtypes' => $subtypes
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		// this will unset all invalid subtypes for each type that that only
+		// one entity exists of each.
+		$this->assertIdentical(count($es), $subtype_num);
+		foreach ($es as $e) {
+			// entities must at least be in the type.
+			$this->assertTrue(in_array($e->getType(), $types));
+
+			// test that this is a valid subtype for the entity type.
+			$this->assertTrue(in_array($e->getSubtype(), $this->subtypes[$e->getType()]));
+		}
+	}
+
+	/*
+	 * This combination will remove all invalid subtypes for this type.
+	 */
+	public function testElggAPIGettersValidSubtypeUsingPluralMixedSubtypesSingleType() {
+		$type_num = 1;
+		$subtype_num = 2;
+		$types = $this->getRandomValidTypes($type_num);
+
+
+		//@todo replace this with $this->getRandomMixedSubtypes()
+		// we want this to return an invalid subtype for the returned type.
+		$subtype_types = $types;
+		$i = 1;
+		while ($i <= $subtype_num) {
+			$type = $this->types[$i - 1];
+
+			if (!in_array($type, $subtype_types)) {
+				$subtype_types[] = $type;
+			}
+			$i++;
+		}
+
+		$subtypes = $this->getRandomValidSubtypes($subtype_types, $type_num);
+
+		$options = [
+			'types' => $types,
+			'subtypes' => $subtypes
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		// this will unset all invalid subtypes for each type that that only
+		// one entity exists of each.
+		$this->assertIdentical(count($es), $type_num);
+		foreach ($es as $e) {
+			// entities must at least be in the type.
+			$this->assertTrue(in_array($e->getType(), $types));
+
+			// test that this is a valid subtype for the entity type.
+			$this->assertTrue(in_array($e->getSubtype(), $this->subtypes[$e->getType()]));
+		}
+	}
+
+
+	/***************************
+	 * TYPE_SUBTYPE_PAIRS
+	 ***************************/
+
+	/**
+	 * Valid type, valid subtype pairs
+	 */
+	public function testElggAPIGettersTSPValidTypeValidSubtype() {
+		$type_num = 1;
+		$subtype_num = 1;
+		$types = $this->getRandomValidTypes($type_num);
+		$subtypes = $this->getRandomValidSubtypes($types, $subtype_num);
+
+		$pair = [$types[0] => $subtypes[0]];
+
+		$options = [
+			'type_subtype_pairs' => $pair
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		$this->assertIdentical(count($es), $type_num);
+		foreach ($es as $e) {
+			$this->assertTrue(in_array($e->getType(), $types));
+			$this->assertTrue(in_array($e->getSubtype(), $subtypes));
+		}
+	}
+
+	/**
+	 * Valid type, multiple valid subtypes
+	 */
+	public function testElggAPIGettersTSPValidTypeValidPluralSubtype() {
+		$type_num = 1;
+		$subtype_num = 3;
+		$types = $this->getRandomValidTypes($type_num);
+		$subtypes = $this->getRandomValidSubtypes($types, $subtype_num);
+
+		$pair = [$types[0] => $subtypes];
+
+		$options = [
+			'type_subtype_pairs' => $pair
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		$this->assertIdentical(count($es), $subtype_num);
+		foreach ($es as $e) {
+			$this->assertTrue(in_array($e->getType(), $types));
+			$this->assertTrue(in_array($e->getSubtype(), $subtypes));
+		}
+	}
+
+	/**
+	 * Valid type, both valid and invalid subtypes
+	 */
+	public function testElggAPIGettersTSPValidTypeMixedPluralSubtype() {
+		$type_num = 1;
+		$valid_subtype_num = 2;
+		$types = $this->getRandomValidTypes($type_num);
+		$valid = $this->getRandomValidSubtypes($types, $valid_subtype_num);
+		$invalid = $this->getRandomInvalids();
+
+		$subtypes = array_merge($valid, $invalid);
+		shuffle($subtypes);
+
+		$pair = [$types[0] => $subtypes];
+
+		$options = [
+			'type_subtype_pairs' => $pair
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertIsA($es, 'array');
+
+		$this->assertIdentical(count($es), $valid_subtype_num);
+		foreach ($es as $e) {
+			$this->assertTrue(in_array($e->getType(), $types));
+			$this->assertTrue(in_array($e->getSubtype(), $valid));
+		}
+	}
+
+
+	/****************************
+	 * false-RETURNING TESTS
+	 ****************************
+	 * The original bug returned
+	 * all entities when invalid subtypes were passed.
+	 * Because there's a huge numer of combinations that
+	 * return entities, I'm only writing tests for
+	 * things that should return false.
+	 *
+	 * I'm leaving the above in case anyone is inspired to
+	 * write out the rest of the possible combinations
+	 */
+
+
+	/**
+	 * Test invalid types with singular 'type'.
+	 */
+	public function testElggApiGettersInvalidTypeUsingType() {
+		_elgg_services()->logger->disable();
+
+		$type_arr = $this->getRandomInvalids();
+		$type = $type_arr[0];
+
+		$options = [
+			'type' => $type
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertFalse($es);
+
+		_elgg_services()->logger->enable();
+	}
+
+	/**
+	 * Test invalid types with plural 'types'.
+	 */
+	public function testElggApiGettersInvalidTypeUsingTypesAsString() {
+		_elgg_services()->logger->disable();
+
+		$type_arr = $this->getRandomInvalids();
+		$type = $type_arr[0];
+
+		$options = [
+			'types' => $type
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertFalse($es);
+
+		_elgg_services()->logger->enable();
+	}
+
+	/**
+	 * Test invalid types with plural 'types' and an array of a single type
+	 */
+	public function testElggApiGettersInvalidTypeUsingTypesAsArray() {
+		_elgg_services()->logger->disable();
+
+		$type_arr = $this->getRandomInvalids(1);
+
+		$options = [
+			'types' => $type_arr
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertFalse($es);
+
+		_elgg_services()->logger->enable();
+	}
+
+	/**
+	 * Test invalid types with plural 'types' and an array of a two types
+	 */
+	public function testElggApiGettersInvalidTypes() {
+		_elgg_services()->logger->disable();
+
+		$type_arr = $this->getRandomInvalids(2);
+
+		$options = [
+			'types' => $type_arr
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertFalse($es);
+
+		_elgg_services()->logger->enable();
+	}
+
+	public function testElggApiGettersInvalidSubtypeValidType() {
+		_elgg_services()->logger->disable();
+
+		$type_num = 1;
+		$subtype_num = 1;
+		$types = $this->getRandomValidTypes($type_num);
+		$subtypes = $this->getRandomInvalids($subtype_num);
+
+		$options = [
+			'types' => $types,
+			'subtypes' => $subtypes
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertFalse($es);
+
+		_elgg_services()->logger->enable();
+	}
+
+	public function testElggApiGettersInvalidSubtypeValidTypes() {
+		_elgg_services()->logger->disable();
+
+		$type_num = 2;
+		$subtype_num = 1;
+		$types = $this->getRandomValidTypes($type_num);
+		$subtypes = $this->getRandomInvalids($subtype_num);
+
+		$options = [
+			'types' => $types,
+			'subtypes' => $subtypes
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertFalse($es);
+
+		_elgg_services()->logger->enable();
+	}
+
+	public function testElggApiGettersInvalidSubtypesValidType() {
+		_elgg_services()->logger->disable();
+
+		$type_num = 1;
+		$subtype_num = 2;
+		$types = $this->getRandomValidTypes($type_num);
+		$subtypes = $this->getRandomInvalids($subtype_num);
+
+		$options = [
+			'types' => $types,
+			'subtypes' => $subtypes
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertFalse($es);
+
+		_elgg_services()->logger->enable();
+	}
+
+	public function testElggApiGettersInvalidSubtypesValidTypes() {
+		_elgg_services()->logger->disable();
+
+		$type_num = 2;
+		$subtype_num = 2;
+		$types = $this->getRandomValidTypes($type_num);
+		$subtypes = $this->getRandomInvalids($subtype_num);
+
+		$options = [
+			'types' => $types,
+			'subtypes' => $subtypes
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertFalse($es);
+
+		_elgg_services()->logger->enable();
+	}
+
+	public function testElggApiGettersTSPInvalidType() {
+		$type_num = 1;
+		$types = $this->getRandomInvalids($type_num);
+
+		$pair = [];
+
+		foreach ($types as $type) {
+			$pair[$type] = null;
+		}
+
+		$options = [
+			'type_subtype_pairs' => $pair
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertFalse($es);
+	}
+
+	public function testElggApiGettersTSPInvalidTypes() {
+		$type_num = 2;
+		$types = $this->getRandomInvalids($type_num);
+
+		$pair = [];
+		foreach ($types as $type) {
+			$pair[$type] = null;
+		}
+
+		$options = [
+			'type_subtype_pairs' => $pair
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertFalse($es);
+	}
+
+	public function testElggApiGettersTSPValidTypeInvalidSubtype() {
+		$type_num = 1;
+		$subtype_num = 1;
+		$types = $this->getRandomValidTypes($type_num);
+		$subtypes = $this->getRandomInvalids($subtype_num);
+
+		$pair = [$types[0] => $subtypes[0]];
+
+		$options = [
+			'type_subtype_pairs' => $pair
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertFalse($es);
+	}
+
+	public function testElggApiGettersTSPValidTypeInvalidSubtypes() {
+		$type_num = 1;
+		$subtype_num = 2;
+		$types = $this->getRandomValidTypes($type_num);
+		$subtypes = $this->getRandomInvalids($subtype_num);
+
+		$pair = [
+			$types[0] => [
+				$subtypes[0],
+				$subtypes[0]
+			]
+		];
+
+		$options = [
+			'type_subtype_pairs' => $pair
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertFalse($es);
+	}
+
+	public function testElggApiGettersTSPValidTypesInvalidSubtypes() {
+		$type_num = 2;
+		$subtype_num = 2;
+		$types = $this->getRandomValidTypes($type_num);
+		$subtypes = $this->getRandomInvalids($subtype_num);
+
+		$pair = [];
+		foreach ($types as $type) {
+			$pair[$type] = $subtypes;
+		}
+
+		$options = [
+			'type_subtype_pairs' => $pair
+		];
+
+		$es = elgg_get_entities($options);
+		$this->assertFalse($es);
+	}
+
+	public function testElggApiGettersEntityNoSubtype() {
+		// create an entity we can later delete.
+		// order by guid and limit by 1 should == this entity.
+
+		$e = new \ElggObject();
+		$e->save();
+
+		$options = [
+			'type' => 'object',
+			'limit' => 1,
+			'order_by' => 'guid desc'
+		];
+
+		// grab ourself again to fill out attributes.
+		$e = get_entity($e->getGUID());
+
+		$entities = elgg_get_entities($options);
+
+		$this->assertEqual(count($entities), 1);
+
+		foreach ($entities as $entity) {
+			$this->assertIdentical($e->getGUID(), $entity->getGUID());
+		}
+
+		$e->delete();
+	}
+
+	public function testElggApiGettersEntityNoValueSubtypeNotSet() {
+		// create an entity we can later delete.
+		// order by time created and limit by 1 should == this entity.
+
+		$e = new \ElggObject();
+		$e->save();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => ELGG_ENTITIES_NO_VALUE,
+			'limit' => 1,
+			'order_by' => 'guid desc'
+		];
+
+		// grab ourself again to fill out attributes.
+		$e = get_entity($e->getGUID());
+
+		$entities = elgg_get_entities($options);
+
+		$this->assertEqual(count($entities), 1);
+
+		foreach ($entities as $entity) {
+			$this->assertIdentical($e->getGUID(), $entity->getGUID());
+		}
+
+		$e->delete();
+	}
+
+	public function testElggApiGettersEntityNoValueSubtypeSet() {
+		$CONFIG = _elgg_config();
+		// create an entity we can later delete.
+		// order by time created and limit by 1 should == this entity.
+
+		$subtype = 'subtype_' . rand();
+
+		$e_subtype = new \ElggObject();
+		$e_subtype->subtype = $subtype;
+		$e_subtype->save();
+
+		$e = new \ElggObject();
+		$e->save();
+
+		$options = [
+			'type' => 'object',
+			'subtype' => ELGG_ENTITIES_NO_VALUE,
+			'limit' => 1,
+			'order_by' => 'guid desc'
+		];
+
+		// grab ourself again to fill out attributes.
+		$e = get_entity($e->getGUID());
+
+		$entities = elgg_get_entities($options);
+
+		$this->assertEqual(count($entities), 1);
+
+		// this entity should NOT be the entity we just created
+		// and should have no subtype
+		foreach ($entities as $entity) {
+			$this->assertEqual($entity->subtype_id, 0);
+		}
+
+		$e_subtype->delete();
+		$e->delete();
+
+		$q = "DELETE FROM {$CONFIG->dbprefix}entity_subtypes WHERE subtype = '$subtype'";
+		delete_data($q);
+	}
+
+	public function testElggGetEntitiesByGuidSingular() {
+		foreach ($this->entities as $e) {
+			$options = [
+				'guid' => $e->guid
+			];
+			$es = elgg_get_entities($options);
+
+			$this->assertEqual(count($es), 1);
+			$this->assertEqual($es[0]->guid, $e->guid);
+		}
+	}
+
+	public function testElggGetEntitiesByGuidPlural() {
+		$guids = [];
+
+		foreach ($this->entities as $e) {
+			$guids[] = $e->guid;
+		}
+
+		$options = [
+			'guids' => $guids,
+			'limit' => 100
+		];
+
+		$es = elgg_get_entities($options);
+
+		$this->assertEqual(count($es), count($this->entities));
+
+		foreach ($es as $e) {
+			$this->assertTrue(in_array($e->guid, $guids));
+		}
+	}
+
+
+	public function testElggGetEntitiesBadWheres() {
+		$options = [
+			'container_guid' => 'abc'
+		];
+
+		$entities = elgg_get_entities($options);
+		$this->assertFalse($entities);
+	}
+
+	public function testEGEEmptySubtypePlurality() {
+		$options = [
+			'type' => 'user',
+			'subtypes' => ''
+		];
+
+		$entities = elgg_get_entities($options);
+		$this->assertTrue(is_array($entities));
+
+		$options = [
+			'type' => 'user',
+			'subtype' => ''
+		];
+
+		$entities = elgg_get_entities($options);
+		$this->assertTrue(is_array($entities));
+
+		$options = [
+			'type' => 'user',
+			'subtype' => ['']
+		];
+
+		$entities = elgg_get_entities($options);
+		$this->assertTrue(is_array($entities));
+
+		$options = [
+			'type' => 'user',
+			'subtypes' => ['']
+		];
+
+		$entities = elgg_get_entities($options);
+		$this->assertTrue(is_array($entities));
+	}
+
+	public function testDistinctCanBeDisabled() {
+		$prefix = _elgg_config()->dbprefix;
+		$options = [
+			'callback' => '',
+			'joins' => [
+				"RIGHT JOIN {$prefix}metadata m ON (e.guid = m.entity_guid)"
+			],
+			'wheres' => [
+				'm.entity_guid = ' . elgg_get_logged_in_user_guid(),
+			],
+		];
+
+		$users = elgg_get_entities($options);
+		$this->assertEqual(1, count($users));
+
+		$options['distinct'] = false;
+		$users = elgg_get_entities($options);
+		$this->assertTrue(count($users) > 1);
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGroupTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGroupTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\GroupItemVisibility;
+use Elgg\LegacyIntegrationTestCase;
+use ElggGroup;
+
+/**
+ * Elgg Test \ElggGroup
+ *
+ * @group IntegrationTests
+ * @subpackage Test
+ */
+class ElggCoreGroupTest extends LegacyIntegrationTestCase {
+	/**
+	 * @var ElggGroup
+	 */
+	protected $group;
+
+	/**
+	 * @var \ElggUser
+	 */
+	protected $user;
+
+	public function up() {
+		$this->group = new ElggGroup();
+		$this->group->membership = ACCESS_PUBLIC;
+		$this->group->access_id = ACCESS_PUBLIC;
+		$this->group->save();
+
+		$this->user = $this->createUser();
+	}
+
+	public function down() {
+		$this->group->delete();
+		$this->user->delete();
+	}
+
+	public function testContentAccessMode() {
+		$unrestricted = ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED;
+		$membersonly = ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY;
+
+		// if mode not set, open groups are unrestricted
+		$this->assertEqual($this->group->getContentAccessMode(), $unrestricted);
+
+		// after first check, metadata is set
+		$this->assertEqual($this->group->content_access_mode, $unrestricted);
+
+		// if mode not set, closed groups are membersonly
+		$this->group->deleteMetadata('content_access_mode');
+		$this->group->membership = ACCESS_PRIVATE;
+		$this->assertEqual($this->group->getContentAccessMode(), $membersonly);
+
+		// test set
+		$this->group->setContentAccessMode($unrestricted);
+		$this->assertEqual($this->group->getContentAccessMode(), $unrestricted);
+		$this->group->setContentAccessMode($membersonly);
+		$this->assertEqual($this->group->getContentAccessMode(), $membersonly);
+	}
+
+	public function testGroupItemVisibility() {
+		$original_user = _elgg_services()->session->getLoggedInUser();
+		_elgg_services()->session->setLoggedInUser($this->user);
+		$group_guid = $this->group->guid;
+
+		// unrestricted: pass non-members
+		$this->group->setContentAccessMode(ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED);
+		$vis = GroupItemVisibility::factory($group_guid, false);
+
+		$this->assertFalse($vis->shouldHideItems);
+
+		// membersonly: non-members fail
+		$this->group->setContentAccessMode(ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY);
+		$vis = GroupItemVisibility::factory($group_guid, false);
+
+		$this->assertTrue($vis->shouldHideItems);
+
+		// members succeed
+		$this->group->join($this->user);
+		$vis = GroupItemVisibility::factory($group_guid, false);
+
+		$this->assertFalse($vis->shouldHideItems);
+
+		// non-member admins succeed - assumes admin logged in
+		_elgg_services()->session->setLoggedInUser($original_user);
+		$vis = GroupItemVisibility::factory($group_guid, false);
+
+		$this->assertFalse($vis->shouldHideItems);
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreHelpersTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreHelpersTest.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\LegacyIntegrationTestCase;
+use ElggObject;
+
+/**
+ * Elgg Test helper functions
+ *
+ *
+ * @package    Elgg
+ * @subpackage Test
+ */
+class ElggCoreHelpersTest extends LegacyIntegrationTestCase {
+
+	public function up() {
+
+	}
+
+	public function down() {
+		_elgg_services()->externalFiles->reset();
+	}
+
+	/**
+	 * Test elgg_instanceof()
+	 */
+	public function testElggInstanceOf() {
+		$entity = new ElggObject();
+		$entity->subtype = 'test_subtype';
+		$entity->save();
+
+		$this->assertTrue(elgg_instanceof($entity));
+		$this->assertTrue(elgg_instanceof($entity, 'object'));
+		$this->assertTrue(elgg_instanceof($entity, 'object', 'test_subtype'));
+
+		$this->assertFalse(elgg_instanceof($entity, 'object', 'invalid_subtype'));
+		$this->assertFalse(elgg_instanceof($entity, 'user', 'test_subtype'));
+
+		$entity->delete();
+
+		$bad_entity = false;
+		$this->assertFalse(elgg_instanceof($bad_entity));
+		$this->assertFalse(elgg_instanceof($bad_entity, 'object'));
+		$this->assertFalse(elgg_instanceof($bad_entity, 'object', 'test_subtype'));
+
+		remove_subtype('object', 'test_subtype');
+	}
+
+	/**
+	 * Test elgg_normalize_url()
+	 */
+	public function testElggNormalizeURL() {
+		$conversions = [
+			'http://example.com' => 'http://example.com',
+			'https://example.com' => 'https://example.com',
+			'http://example-time.com' => 'http://example-time.com',
+
+			'http://in:valid~url' => elgg_get_site_url() . 'http://in:valid~url',
+			'https://in:valid~url' => elgg_get_site_url() . 'https://in:valid~url',
+
+			'//example.com' => '//example.com',
+			'ftp://example.com/file' => 'ftp://example.com/file',
+			'mailto:brett@elgg.org' => 'mailto:brett@elgg.org',
+			'javascript:alert("test")' => 'javascript:alert("test")',
+			'app://endpoint' => 'app://endpoint',
+			'tel:+1111111111' => 'tel:+1111111111',
+
+			'example.com' => 'http://example.com',
+			'example.com/subpage' => 'http://example.com/subpage',
+
+			'http://example.com/ИмяПользователя' => 'http://example.com/ИмяПользователя',
+
+			'http://example.com/a b' => 'http://example.com/a%20b',
+			'http://example.com/?a=1 2' => 'http://example.com/?a=1%202',
+
+			'page/handler' => elgg_get_site_url() . 'page/handler',
+			'page/handler?p=v&p2=v2' => elgg_get_site_url() . 'page/handler?p=v&p2=v2',
+			'mod/plugin/file.php' => elgg_get_site_url() . 'mod/plugin/file.php',
+			'mod/plugin/file.php?p=v&p2=v2' => elgg_get_site_url() . 'mod/plugin/file.php?p=v&p2=v2',
+			'rootfile.php' => elgg_get_site_url() . 'rootfile.php',
+			'rootfile.php?p=v&p2=v2' => elgg_get_site_url() . 'rootfile.php?p=v&p2=v2',
+
+			'/page/handler' => elgg_get_site_url() . 'page/handler',
+			'/page/handler?p=v&p2=v2' => elgg_get_site_url() . 'page/handler?p=v&p2=v2',
+			'/mod/plugin/file.php' => elgg_get_site_url() . 'mod/plugin/file.php',
+			'/mod/plugin/file.php?p=v&p2=v2' => elgg_get_site_url() . 'mod/plugin/file.php?p=v&p2=v2',
+			'/rootfile.php' => elgg_get_site_url() . 'rootfile.php',
+			'/rootfile.php?p=v&p2=v2' => elgg_get_site_url() . 'rootfile.php?p=v&p2=v2',
+		];
+
+		foreach ($conversions as $input => $output) {
+			$this->assertIdentical($output, elgg_normalize_url($input));
+		}
+	}
+
+	/**
+	 * Test elgg_register_js()
+	 */
+	public function testElggRegisterJS() {
+		// specify name
+		$result = elgg_register_js('key', 'http://test1.com', 'footer');
+		$this->assertTrue((bool) $result);
+
+		$item = _elgg_services()->externalFiles->getFile('js', 'key');
+		$this->assertNotNull($item);
+		$this->assertTrue($item->priority !== false);
+		$this->assertIdentical('http://test1.com', $item->url);
+
+		// send a bad url
+		$result = elgg_register_js('bad', null);
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * Test elgg_register_css()
+	 */
+	public function testElggRegisterCSS() {
+		// specify name
+		$result = elgg_register_css('key', 'http://test1.com');
+		$this->assertTrue((bool) $result);
+
+		$item = _elgg_services()->externalFiles->getFile('css', 'key');
+		$this->assertNotNull($item);
+		$this->assertTrue($item->priority !== false);
+		$this->assertIdentical('http://test1.com', $item->url);
+	}
+
+	/**
+	 * Test elgg_unregister_js()
+	 */
+	public function testElggUnregisterJS() {
+		$api = _elgg_services()->externalFiles;
+
+		$base = trim(elgg_get_site_url(), "/");
+		$urls = [
+			'id1' => "$base/urla",
+			'id2' => "$base/urlb",
+			'id3' => "$base/urlc",
+		];
+
+		foreach ($urls as $id => $url) {
+			elgg_register_js($id, $url);
+		}
+
+		$result = elgg_unregister_js('id1');
+		$this->assertTrue((bool) $result);
+		$this->assertNull($api->getFile('js', 'id1'));
+
+		$elements = $api->getRegisteredFiles('js', 'head');
+
+		foreach ($elements as $element) {
+			if (isset($element->name)) {
+				$this->assertFalse($element->name == 'id1');
+			}
+		}
+
+		$this->assertFalse(elgg_unregister_js('id1'));
+
+		$this->assertFalse(elgg_unregister_js('does_not_exist'));
+
+		elgg_unregister_js('id2');
+
+		$elements = $api->getRegisteredFiles('js', 'head');
+		foreach ($elements as $element) {
+			if (isset($element->name)) {
+				$this->assertFalse($element->name == 'id2');
+			}
+		}
+
+		$priority = $api->getFile('js', 'id3')->priority;
+		$this->assertTrue($priority !== false);
+	}
+
+	/**
+	 * Test elgg_load_js()
+	 */
+	public function testElggLoadJS() {
+		// load before register
+		elgg_load_js('key');
+		$result = elgg_register_js('key', 'http://test1.com', 'footer');
+		$this->assertTrue((bool) $result);
+
+		$js_urls = elgg_get_loaded_js('footer');
+		$this->assertIdentical([500 => 'http://test1.com'], $js_urls);
+	}
+
+	/**
+	 * Test elgg_get_loaded_js()
+	 */
+	public function testElggGetJS() {
+		$base = trim(elgg_get_site_url(), "/");
+
+		$urls = [
+			'id1' => "$base/urla",
+			'id2' => "$base/urlb",
+			'id3' => "$base/urlc"
+		];
+
+		foreach ($urls as $id => $url) {
+			elgg_register_js($id, $url);
+			elgg_load_js($id);
+		}
+
+		$js_urls = elgg_get_loaded_js('head');
+
+		$this->assertIdentical($js_urls[500], $urls['id1']);
+		$this->assertIdentical($js_urls[501], $urls['id2']);
+		$this->assertIdentical($js_urls[502], $urls['id3']);
+
+		$js_urls = elgg_get_loaded_js('footer');
+		$this->assertIdentical([], $js_urls);
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreMetadataAPITest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreMetadataAPITest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\LegacyIntegrationTestCase;
+use ElggObject;
+use ElggUser;
+use ElggMetadata;
+
+/**
+ * Elgg Test metadata API
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreMetadataAPITest extends LegacyIntegrationTestCase {
+
+	/**
+	 * @var ElggObject
+	 */
+	protected $object;
+
+	public function up() {
+		$this->object = new ElggObject();
+	}
+
+	public function down() {
+		unset($this->object);
+	}
+
+
+	public function testElggGetEntitiesFromMetadata() {
+		
+		$this->object->title = 'Meta Unit Test';
+		$this->object->save();
+
+		// create_metadata returns id of metadata on success
+		$this->assertNotEqual(false, create_metadata($this->object->guid, 'metaUnitTest', 'tested'));
+
+		// check value with improper case
+		$options = array('metadata_names' => 'metaUnitTest', 'metadata_values' => 'Tested', 'limit' => 10, 'metadata_case_sensitive' => true);
+		$this->assertIdentical(array(), elgg_get_entities_from_metadata($options));
+
+		// compare forced case with ignored case
+		$options = array('metadata_names' => 'metaUnitTest', 'metadata_values' => 'tested', 'limit' => 10, 'metadata_case_sensitive' => true);
+		$case_true = elgg_get_entities_from_metadata($options);
+		$this->assertIsA($case_true, 'array');
+
+		$options = array('metadata_names' => 'metaUnitTest', 'metadata_values' => 'Tested', 'limit' => 10, 'metadata_case_sensitive' => false);
+		$case_false = elgg_get_entities_from_metadata($options);
+		$this->assertIsA($case_false, 'array');
+
+		$this->assertIdentical($case_true, $case_false);
+
+		// clean up
+		$this->object->delete();
+	}
+
+	public function testElggGetMetadataCount() {
+		$this->object->title = 'Meta Unit Test';
+		$this->object->save();
+
+		$guid = $this->object->getGUID();
+		create_metadata($guid, 'tested', 'tested1', 'text', 0, null, true);
+		create_metadata($guid, 'tested', 'tested2', 'text', 0, null, true);
+
+		$count = (int)elgg_get_metadata(array(
+			'metadata_names' => array('tested'),
+			'guid' => $guid,
+			'count' => true,
+		));
+
+		$this->assertIdentical($count, 2);
+
+		$this->object->delete();
+	}
+
+	public function testElggDeleteMetadata() {
+		$e = new ElggObject();
+		$e->save();
+
+		for ($i = 0; $i < 30; $i++) {
+			$name = "test_metadata$i";
+			$e->$name = rand(0, 10000);
+		}
+
+		$options = array(
+			'guid' => $e->getGUID(),
+			'limit' => 0,
+		);
+
+		$md = elgg_get_metadata($options);
+		$this->assertIdentical(30, count($md));
+
+		$this->assertTrue(elgg_delete_metadata($options));
+
+		$md = elgg_get_metadata($options);
+		$this->assertTrue(empty($md));
+
+		$e->delete();
+	}
+
+	/**
+	 * https://github.com/Elgg/Elgg/issues/4867
+	 */
+	public function testElggGetEntityMetadataWhereSqlWithFalseValue() {
+		$pair = array('name' => 'test' , 'value' => false);
+		$result = _elgg_get_entity_metadata_where_sql('e', 'metadata', null, null, $pair);
+		$where = preg_replace( '/\s+/', ' ', $result['wheres'][0]);
+		$this->assertTrue(strpos($where, "n_table1.name = 'test' AND BINARY n_table1.value = 0") > 0);
+
+		$result = _elgg_get_entity_metadata_where_sql('e', 'metadata', array('test'), array(false));
+		$where = preg_replace( '/\s+/', ' ', $result['wheres'][0]);
+		$this->assertTrue(strpos($where, "n_table.name IN ('test')) AND ( BINARY n_table.value IN ('0')"));
+	}
+
+	// Make sure metadata with multiple values is correctly deleted when re-written
+	// by another user
+	// https://github.com/elgg/elgg/issues/2776
+	public function test_elgg_metadata_multiple_values() {
+		$u1 = $this->createUser();
+
+		$u2 = $this->createUser();
+
+		$obj = new ElggObject();
+		$obj->owner_guid = $u1->guid;
+		$obj->container_guid = $u1->guid;
+		$obj->access_id = ACCESS_PUBLIC;
+		$obj->save();
+
+		$md_values = array(
+			'one',
+			'two',
+			'three'
+		);
+
+		// need to fake different logins.
+		// good times without mocking.
+		$original_user = $this->replaceSession($u1);
+		
+		$ia = elgg_set_ignore_access(false);
+
+		// add metadata as one user
+		$obj->test = $md_values;
+
+		// check only these md exists
+		$db_prefix = _elgg_config()->dbprefix;
+		$q = "SELECT * FROM {$db_prefix}metadata WHERE entity_guid = $obj->guid";
+		$data = get_data($q);
+
+		$this->assertEqual(count($md_values), count($data));
+		foreach ($data as $md_row) {
+			$md = elgg_get_metadata_from_id($md_row->id);
+			$this->assertTrue(in_array($md->value, $md_values));
+			$this->assertEqual('test', $md->name);
+		}
+
+		// add md w/ same name as a different user
+		$this->replaceSession($u2);
+		$md_values2 = array(
+			'four',
+			'five',
+			'six',
+			'seven'
+		);
+
+		$obj->test = $md_values2;
+
+		$q = "SELECT * FROM {$db_prefix}metadata WHERE entity_guid = $obj->guid";
+		$data = get_data($q);
+
+		$this->assertEqual(count($md_values2), count($data));
+		foreach ($data as $md_row) {
+			$md = elgg_get_metadata_from_id($md_row->id);
+			$this->assertTrue(in_array($md->value, $md_values2));
+			$this->assertEqual('test', $md->name);
+		}
+
+		elgg_set_ignore_access($ia);
+
+		$this->replaceSession($original_user);
+
+		$obj->delete();
+		$u1->delete();
+		$u2->delete();
+	}
+
+	public function testDefaultOrderedById() {
+		$ia = elgg_set_ignore_access(true);
+
+		$obj = new ElggObject();
+		$obj->owner_guid = elgg_get_site_entity()->guid;
+		$obj->container_guid = elgg_get_site_entity()->guid;
+		$obj->access_id = ACCESS_PUBLIC;
+		$obj->save();
+
+		$obj->test_md = [1, 2, 3];
+
+		$time = time();
+		$prefix = _elgg_services()->db->prefix;
+
+		// reverse the times
+		$mds = elgg_get_metadata([
+			'metadata_owner_guids' => $obj->guid,
+			'metadata_names' => 'test_md',
+			'order_by' => 'n_table.id ASC',
+		]);
+		foreach ($mds as $i => $md) {
+			update_data("
+				UPDATE {$prefix}metadata
+				SET time_created = " . ($time - $i) . "
+				WHERE id = {$md->id}
+			");
+		}
+
+		// verify ID order
+		$mds = elgg_get_metadata([
+			'guid' => $obj->guid,
+			'metadata_names' => 'test_md',
+		]);
+		$md_values = array_map(function (ElggMetadata $md) {
+			return (int)$md->value;
+		}, $mds);
+		$this->assertEqual($md_values, [1, 2, 3]);
+
+		// ignore access bypasses the MD cache, so we try it both ways
+		elgg_set_ignore_access(false);
+		_elgg_services()->metadataCache->clear($obj->guid);
+		$md_values = $obj->test_md;
+		$this->assertEqual($md_values, [1, 2, 3]);
+
+		elgg_set_ignore_access(true);
+		_elgg_services()->metadataCache->clear($obj->guid);
+		$md_values = $obj->test_md;
+		$this->assertEqual($md_values, [1, 2, 3]);
+
+		$obj->delete();
+		elgg_set_ignore_access($ia);
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreMetadataCacheTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreMetadataCacheTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\Cache\MetadataCache;
+use Elgg\LegacyIntegrationTestCase;
+
+/**
+ * Elgg Test metadata cache
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreMetadataCacheTest extends LegacyIntegrationTestCase {
+
+	/**
+	 * @var MetadataCache
+	 */
+	protected $cache;
+
+	/**
+	 * @var \ElggObject
+	 */
+	protected $obj1;
+
+	/**
+	 * @var int
+	 */
+	protected $guid1;
+
+	/**
+	 * @var \ElggObject
+	 */
+	protected $obj2;
+
+	/**
+	 * @var int
+	 */
+	protected $guid2;
+
+	protected $name = 'test';
+	protected $value = 'test';
+	protected $ignoreAccess;
+
+	public function up() {
+		$this->ignoreAccess = elgg_set_ignore_access(false);
+
+		$this->cache = _elgg_services()->metadataCache;
+
+		$this->obj1 = new \ElggObject();
+		$this->obj1->save();
+		$this->guid1 = $this->obj1->guid;
+
+		$this->obj2 = new \ElggObject();
+		$this->obj2->save();
+		$this->guid2 = $this->obj2->guid;
+	}
+
+	public function down() {
+		$this->obj1->delete();
+		$this->obj2->delete();
+
+		elgg_set_ignore_access($this->ignoreAccess);
+	}
+
+	public function testHas() {
+		$cache = new MetadataCache();
+
+		$cache->inject(1, ['foo1' => 'bar']);
+		$cache->inject(2, []);
+		$this->assertTrue($cache->isLoaded(1));
+		$this->assertTrue($cache->isLoaded(2));
+		$this->assertFalse($cache->isLoaded(3));
+	}
+
+	public function testLoad() {
+		$cache = new MetadataCache();
+
+		$cache->inject(1, ['foo1' => 'bar']);
+		$cache->inject(2, []);
+
+		$this->assertIdentical($cache->getSingle(1, 'foo1'), 'bar');
+		$this->assertNull($cache->getSingle(1, 'foo2'));
+		$this->assertNull($cache->getSingle(2, 'foo1'));
+	}
+
+	public function testDirectInvalidation() {
+		$cache = new MetadataCache();
+
+		$cache->inject(1, ['foo1' => 'bar']);
+		$cache->inject(2, []);
+
+		$cache->invalidateByOptions(['guid' => 1]);
+		$this->assertFalse($cache->isLoaded(1));
+		$this->assertTrue($cache->isLoaded(2));
+
+		$cache->invalidateByOptions([]);
+		$this->assertFalse($cache->isLoaded(1));
+		$this->assertFalse($cache->isLoaded(2));
+	}
+
+	public function testMetadataReadsFillsCache() {
+		// test that reads fill cache
+		$this->obj1->setMetadata($this->name, [1, 2]);
+		$this->cache->clearAll();
+
+		$this->obj1->getMetadata($this->name);
+		$this->assertIdentical($this->cache->getSingle($this->guid1, $this->name), [1, 2]);
+	}
+
+	public function testWritesInvalidate() {
+		// elgg_delete_metadata
+		$this->cache->inject($this->guid1, ['foo' => 'bar']);
+		$this->cache->inject($this->guid2, ['bing' => 'bar']);
+		elgg_delete_metadata(array(
+			'guid' => $this->guid1,
+		));
+		$this->assertFalse($this->cache->isLoaded($this->guid1));
+		$this->assertTrue($this->cache->isLoaded($this->guid2));
+
+		$this->cache->inject($this->guid1, ['foo' => 'bar']);
+		$this->cache->inject($this->guid2, ['bing' => 'bar']);
+		elgg_delete_metadata(['guids' => [$this->guid1, $this->guid2]]);
+		$this->assertFalse($this->cache->isLoaded($this->guid1));
+		$this->assertFalse($this->cache->isLoaded($this->guid2));
+
+		// setMetadata
+		$this->cache->inject($this->guid1, ['foo' => 'bar']);
+		$this->obj1->setMetadata($this->name, $this->value);
+		$this->assertFalse($this->cache->isLoaded($this->guid1));
+
+		// deleteMetadata
+		$this->cache->inject($this->guid1, ['foo' => 'bar']);
+		$this->obj1->deleteMetadata($this->name);
+		$this->assertFalse($this->cache->isLoaded($this->guid1));
+
+		// create_metadata
+		$this->cache->inject($this->guid1, ['foo' => 'bar']);
+		create_metadata($this->guid1, 'foo', 'bar', 'text');
+		$this->assertFalse($this->cache->isLoaded($this->guid1));
+
+		// disableMetadata
+		$this->obj1->setMetadata($this->name, $this->value);
+		$this->cache->inject($this->guid1, ['foo' => 'bar']);
+		$this->obj1->disableMetadata($this->name);
+		$this->assertFalse($this->cache->isLoaded($this->guid1));
+
+		// enableMetadata
+		$this->cache->inject($this->guid1, ['foo' => 'bar']);
+		$this->obj1->enableMetadata($this->name);
+		$this->assertFalse($this->cache->isLoaded($this->guid1));
+	}
+
+	public function testPopulateFromEntities() {
+		// test populating cache from set of entities
+		$this->obj1->setMetadata($this->name, $this->value);
+		$this->obj1->setMetadata($this->name, 4, 'integer', true);
+		$this->obj1->setMetadata("{$this->name}-2", "{$this->value}-2");
+		$this->obj2->setMetadata($this->name, $this->value);
+
+		$this->cache->clearAll();
+		$this->cache->populateFromEntities(array($this->guid1, $this->guid2));
+
+		$this->assertIdentical($this->cache->getSingle($this->guid1, $this->name), [
+			$this->value,
+			4,
+		]);
+		$this->assertIdentical($this->cache->getSingle($this->guid1, "{$this->name}-2"), "{$this->value}-2");
+		$this->assertIdentical($this->cache->getSingle($this->guid2, $this->name), $this->value);
+	}
+
+	public function testFilterHeavyEntities() {
+		$big_str = str_repeat('-', 5000);
+		$this->obj2->setMetadata($this->name, array($big_str, $big_str));
+
+		$guids = array($this->guid1, $this->guid2);
+		$expected = array($this->guid1);
+		$actual = $this->cache->filterMetadataHeavyEntities($guids, 6000);
+		$this->assertIdentical($actual, $expected);
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreMetastringsTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreMetastringsTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Elgg\Integration;
+
+use ElggAnnotation;
+
+/**
+ * Elgg Metastrings test
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreMetastringsTest extends \Elgg\LegacyIntegrationTestCase {
+
+	public $metastringTypes = [
+		'metadata',
+		'annotation'
+	];
+	public $metastringTables = [
+		'metadata' => 'metadata',
+		'annotation' => 'annotations',
+	];
+
+	public function up() {
+		$this->object = $this->createObject();
+	}
+
+	public function down() {
+		$this->object->delete();
+
+		access_show_hidden_entities(true);
+		elgg_delete_annotations([
+			'guid' => $this->object->guid,
+		]);
+		access_show_hidden_entities(false);
+	}
+
+	public function createAnnotations($max = 1) {
+		$annotations = [];
+		for ($i = 0; $i < $max; $i++) {
+			$name = 'test_annotation_name' . rand();
+			$value = 'test_annotation_value' . rand();
+			$id = create_annotation($this->object->guid, $name, $value);
+			$annotations[] = $id;
+		}
+
+		return $annotations;
+	}
+
+	public function createMetadata($max = 1) {
+		$metadata = [];
+		for ($i = 0; $i < $max; $i++) {
+			$name = 'test_metadata_name' . rand();
+			$value = 'test_metadata_value' . rand();
+			$id = create_metadata($this->object->guid, $name, $value);
+			$metadata[] = $id;
+		}
+
+		return $metadata;
+	}
+
+	public function testDeleteByID() {
+		$db_prefix = _elgg_config()->dbprefix;
+		$annotation = $this->createAnnotations(1);
+		$metadata = $this->createMetadata(1);
+
+		foreach ($this->metastringTypes as $type) {
+			$id = ${$type}[0];
+			$table = $db_prefix . $this->metastringTables[$type];
+			$q = "SELECT * FROM $table WHERE id = $id";
+			$test = get_data($q);
+
+			$this->assertEqual($test[0]->id, $id);
+			$this->assertTrue(_elgg_delete_metastring_based_object_by_id($id, $type));
+			$this->assertIdentical([], get_data($q));
+		}
+	}
+
+	public function testGetMetastringObjectFromID() {
+		$db_prefix = _elgg_config()->dbprefix;
+		$annotation = $this->createAnnotations(1);
+		$metadata = $this->createMetadata(1);
+
+		foreach ($this->metastringTypes as $type) {
+			$id = ${$type}[0];
+			$test = _elgg_get_metastring_based_object_from_id($id, $type);
+
+			$this->assertEqual($id, $test->id);
+			$this->assertTrue(_elgg_delete_metastring_based_object_by_id($id, $type));
+		}
+	}
+
+	public function testGetMetastringObjectFromIDWithDisabledAnnotation() {
+
+		$name = 'test_annotation_name' . rand();
+		$value = 'test_annotation_value' . rand();
+
+		$id = create_annotation($this->object->guid, $name, $value);
+
+		$this->assertTrue((bool) $id);
+
+		$ia = elgg_set_ignore_access(true);
+
+		$annotation = elgg_get_annotation_from_id($id);
+
+		$this->assertIsA($annotation, ElggAnnotation::class);
+
+		$this->assertTrue($annotation->disable());
+
+		$test = _elgg_get_metastring_based_object_from_id($id, 'annotation');
+		$this->assertEqual(false, $test);
+
+		$prev = access_get_show_hidden_status();
+		access_show_hidden_entities(true);
+		$this->assertTrue(_elgg_delete_metastring_based_object_by_id($id, 'annotation'));
+		access_show_hidden_entities($prev);
+
+		elgg_set_ignore_access($ia);
+	}
+
+	public function testGetMetastringBasedObjectWithDisabledAnnotation() {
+		$name = 'test_annotation_name' . rand();
+		$value = 'test_annotation_value' . rand();
+		$id = create_annotation($this->object->guid, $name, $value);
+
+		$annotation = elgg_get_annotation_from_id($id);
+		$this->assertTrue($annotation->disable());
+
+		$test = _elgg_get_metastring_based_objects([
+			'metastring_type' => 'annotations',
+			'guid' => $this->object->guid,
+		]);
+		$this->assertEqual([], $test);
+
+		$prev = access_get_show_hidden_status();
+		access_show_hidden_entities(true);
+		$this->assertTrue(_elgg_delete_metastring_based_object_by_id($id, 'annotation'));
+		access_show_hidden_entities($prev);
+	}
+
+	public function testEnableDisableByID() {
+		$db_prefix = _elgg_config()->dbprefix;
+		$annotation = $this->createAnnotations(1);
+		$metadata = $this->createMetadata(1);
+
+		foreach ($this->metastringTypes as $type) {
+			$id = ${$type}[0];
+			$table = $db_prefix . $this->metastringTables[$type];
+			$q = "SELECT * FROM $table WHERE id = $id";
+			$test = get_data($q);
+
+			// disable
+			$this->assertEqual($test[0]->enabled, 'yes');
+			$this->assertTrue(_elgg_set_metastring_based_object_enabled_by_id($id, 'no', $type));
+
+			$test = get_data($q);
+			$this->assertEqual($test[0]->enabled, 'no');
+
+			// enable
+			$ashe = access_get_show_hidden_status();
+			access_show_hidden_entities(true);
+			$this->assertTrue(_elgg_set_metastring_based_object_enabled_by_id($id, 'yes', $type));
+
+			$test = get_data($q);
+			$this->assertEqual($test[0]->enabled, 'yes');
+
+			access_show_hidden_entities($ashe);
+			$this->assertTrue(_elgg_delete_metastring_based_object_by_id($id, $type));
+		}
+	}
+
+	public function testKeepMeFromDeletingEverything() {
+		foreach ($this->metastringTypes as $type) {
+			$required = [
+				'guid',
+				'guids'
+			];
+
+			switch ($type) {
+				case 'metadata':
+					$metadata_required = [
+						'metadata_owner_guid',
+						'metadata_owner_guids',
+						'metadata_name',
+						'metadata_names',
+						'metadata_value',
+						'metadata_values'
+					];
+
+					$required = array_merge($required, $metadata_required);
+					break;
+
+				case 'annotation':
+					$annotations_required = [
+						'annotation_owner_guid',
+						'annotation_owner_guids',
+						'annotation_name',
+						'annotation_names',
+						'annotation_value',
+						'annotation_values'
+					];
+
+					$required = array_merge($required, $annotations_required);
+					break;
+			}
+
+			$options = [];
+			$this->assertFalse(_elgg_is_valid_options_for_batch_operation($options, $type));
+
+			// limit alone isn't valid:
+			$options = ['limit' => 10];
+			$this->assertFalse(_elgg_is_valid_options_for_batch_operation($options, $type));
+
+			foreach ($required as $key) {
+				$options = [];
+
+				$options[$key] = ELGG_ENTITIES_ANY_VALUE;
+				$this->assertFalse(_elgg_is_valid_options_for_batch_operation($options, $type), "Sent $key = ELGG_ENTITIES_ANY_VALUE");
+
+				$options[$key] = ELGG_ENTITIES_NO_VALUE;
+				$this->assertFalse(_elgg_is_valid_options_for_batch_operation($options, $type), "Sent $key = ELGG_ENTITIES_NO_VALUE");
+
+				$options[$key] = false;
+				$this->assertFalse(_elgg_is_valid_options_for_batch_operation($options, $type), "Sent $key = bool false");
+
+				$options[$key] = true;
+				$this->assertTrue(_elgg_is_valid_options_for_batch_operation($options, $type), "Sent $key = bool true");
+
+				$options[$key] = 'test';
+				$this->assertTrue(_elgg_is_valid_options_for_batch_operation($options, $type), "Sent $key = 'test'");
+
+				$options[$key] = ['test'];
+				$this->assertTrue(_elgg_is_valid_options_for_batch_operation($options, $type), "Sent $key = array('test')");
+			}
+		}
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreObjectTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreObjectTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace Elgg\Integration;
+
+/**
+ * Elgg Test \ElggObject
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreObjectTest extends \Elgg\LegacyIntegrationTestCase {
+
+	/**
+	 * @var \ElggEntity
+	 */
+	protected $entity;
+
+	public function up() {
+		$this->entity = new ElggObjectWithExposableAttributes();
+	}
+
+	public function down() {
+		unset($this->entity);
+	}
+
+	public function testElggObjectConstructor() {
+		$attributes = array();
+		$attributes['guid'] = null;
+		$attributes['type'] = 'object';
+		$attributes['subtype'] = null;
+		$attributes['owner_guid'] = elgg_get_logged_in_user_guid();
+		$attributes['container_guid'] = elgg_get_logged_in_user_guid();
+		$attributes['access_id'] = ACCESS_PRIVATE;
+		$attributes['time_created'] = null;
+		$attributes['time_updated'] = null;
+		$attributes['last_action'] = null;
+		$attributes['enabled'] = 'yes';
+		$attributes['title'] = null;
+		$attributes['description'] = null;
+		ksort($attributes);
+
+		$entity_attributes = $this->entity->expose_attributes();
+		ksort($entity_attributes);
+
+		$this->assertIdentical($entity_attributes, $attributes);
+	}
+
+	public function testElggObjectSave() {
+		// new object
+		$this->AssertEqual($this->entity->getGUID(), 0);
+		$guid = $this->entity->save();
+		$this->AssertNotEqual($guid, 0);
+
+		$entity_row = $this->get_entity_row($guid);
+		$this->assertIsA($entity_row, '\stdClass');
+
+		// update existing object
+		$this->entity->title = 'testing';
+		$this->entity->description = '\ElggObject';
+		$this->assertEqual($this->entity->save(), $guid);
+
+		$object_row = $this->get_object_row($guid);
+		$this->assertIsA($object_row, '\stdClass');
+		$this->assertIdentical($object_row->title, 'testing');
+		$this->assertIdentical($object_row->description, '\ElggObject');
+
+		// clean up
+		$this->entity->delete();
+	}
+
+	public function testElggObjectClone() {
+		$this->entity->title = 'testing';
+		$this->entity->description = '\ElggObject';
+		$this->entity->var1 = "test";
+		$this->entity->var2 = 1;
+		$this->entity->var3 = true;
+		$this->entity->save();
+
+		// add tag array
+		$tag_string = 'tag1, tag2, tag3';
+		$tagarray = string_to_tag_array($tag_string);
+		$this->entity->tags = $tagarray;
+
+		// a cloned \ElggEntity has the guid reset
+		$object = clone $this->entity;
+		$this->assertIdentical(0, (int)$object->guid);
+
+		// make sure attributes were copied over
+		$this->assertIdentical($object->title, 'testing');
+		$this->assertIdentical($object->description, '\ElggObject');
+
+		$guid = $object->save();
+		$this->assertTrue($guid !== 0);
+		$this->assertTrue($guid !== $this->entity->guid);
+
+		// test that metadata was transfered
+		$this->assertIdentical($this->entity->var1, $object->var1);
+		$this->assertIdentical($this->entity->var2, $object->var2);
+		$this->assertIdentical($this->entity->var3, $object->var3);
+		$this->assertIdentical($this->entity->tags, $object->tags);
+
+		// clean up
+		$object->delete();
+		$this->entity->delete();
+	}
+
+	public function testElggObjectContainer() {
+		$this->assertEqual($this->entity->getContainerGUID(), elgg_get_logged_in_user_guid());
+
+		// create and save to group
+		$group = new \ElggGroup();
+		$guid = $group->save();
+		$this->assertTrue($this->entity->setContainerGUID($guid));
+
+		// check container
+		$this->assertEqual($this->entity->getContainerGUID(), $guid);
+		$this->assertIdenticalEntities($group, $this->entity->getContainerEntity());
+
+		// clean up
+		$group->delete();
+	}
+
+	public function testElggObjectToObject() {
+		$keys = array(
+			'guid',
+			'type',
+			'subtype',
+			'time_created',
+			'time_updated',
+			'container_guid',
+			'owner_guid',
+			'url',
+			'read_access',
+			'title',
+			'description',
+			'tags',
+		);
+
+		$object = $this->entity->toObject();
+		$object_keys = array_keys(get_object_vars($object));
+		sort($keys);
+		sort($object_keys);
+		$this->assertIdentical($keys, $object_keys);
+	}
+
+	// see https://github.com/elgg/elgg/issues/1196
+	public function testElggEntityRecursiveDisableWhenLoggedOut() {
+		$e1 = new \ElggObject();
+		$e1->access_id = ACCESS_PUBLIC;
+		$e1->owner_guid = 0;
+		$e1->container_guid = 0;
+		$e1->save();
+		$guid1 = $e1->getGUID();
+
+		$e2 = new \ElggObject();
+		$e2->container_guid = $guid1;
+		$e2->access_id = ACCESS_PUBLIC;
+		$e2->owner_guid = 0;
+		$e2->save();
+		$guid2 = $e2->getGUID();
+
+		// fake being logged out
+		$old_user = $this->replaceSession();
+		$ia = elgg_set_ignore_access(true);
+
+		$this->assertTrue($e1->disable(null, true));
+
+		// "log in" original user
+		$this->replaceSession($old_user);
+		elgg_set_ignore_access($ia);
+
+		$this->assertFalse((bool) get_entity($guid1));
+		$this->assertFalse((bool) get_entity($guid2));
+
+		$db_prefix = _elgg_config()->dbprefix;
+		$q = "SELECT * FROM {$db_prefix}entities WHERE guid = $guid1";
+		$r = get_data_row($q);
+		$this->assertEqual('no', $r->enabled);
+
+		$q = "SELECT * FROM {$db_prefix}entities WHERE guid = $guid2";
+		$r = get_data_row($q);
+		$this->assertEqual('no', $r->enabled);
+
+		access_show_hidden_entities(true);
+		$e1->delete();
+		$e2->delete();
+		access_show_hidden_entities(false);
+	}
+
+	public function testElggRecursiveDelete() {
+		$types = array('group', 'object', 'user');
+		$db_prefix = _elgg_config()->dbprefix;
+
+		foreach ($types as $type) {
+			switch ($type) {
+				case 'group' :
+					$parent = $this->createGroup();
+					break;
+
+				case 'user' :
+					$parent = $this->createUser();
+					break;
+
+				case 'object' :
+					$parent = $this->createObject();
+					break;
+			}
+
+			$child = $this->createObject([
+				'container_guid' => $parent->guid,
+			]);
+
+			$grandchild = $this->createObject([
+				'container_guid' => $child->guid,
+			]);
+
+			$this->assertTrue($parent->delete(true));
+
+			$q = "SELECT * FROM {$db_prefix}entities WHERE guid = $parent->guid";
+			$r = get_data($q);
+			$this->assertFalse($r);
+
+			$q = "SELECT * FROM {$db_prefix}entities WHERE guid = $child->guid";
+			$r = get_data($q);
+			$this->assertFalse($r);
+
+			$q = "SELECT * FROM {$db_prefix}entities WHERE guid = $grandchild->guid";
+			$r = get_data($q);
+			$this->assertFalse($r);
+		}
+
+		// object that owns itself
+		// can't check container_guid because of infinite loops in can_edit_entity()
+		$obj = new \ElggObject();
+		$obj->save();
+		$obj->owner_guid = $obj->guid;
+		$obj->save();
+
+		$q = "SELECT * FROM {$db_prefix}entities WHERE guid = $obj->guid";
+		$r = get_data_row($q);
+		$this->assertEqual($obj->guid, $r->owner_guid);
+
+		$this->assertTrue($obj->delete(true));
+
+		$q = "SELECT * FROM {$db_prefix}entities WHERE guid = $obj->guid";
+		$r = get_data_row($q);
+		$this->assertFalse($r);
+	}
+
+	protected function get_object_row($guid) {
+		$CONFIG = _elgg_config();
+		return get_data_row("SELECT * FROM {$CONFIG->dbprefix}objects_entity WHERE guid='$guid'");
+	}
+
+	protected function get_entity_row($guid) {
+		$CONFIG = _elgg_config();
+		return get_data_row("SELECT * FROM {$CONFIG->dbprefix}entities WHERE guid='$guid'");
+	}
+}
+
+class ElggObjectWithExposableAttributes extends \ElggObject {
+	public function expose_attributes() {
+		return $this->attributes;
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCorePluginsAPITest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCorePluginsAPITest.php
@@ -1,0 +1,437 @@
+<?php
+
+namespace Elgg\Integration;
+
+use ElggPluginManifest;
+use ElggPluginPackage;
+
+/**
+ * Elgg Plugins Test
+ *
+ * @group IntegrationTests
+ */
+class ElggCorePluginsAPITest extends \Elgg\LegacyIntegrationTestCase {
+
+	/**
+	 * @var ElggPluginManifest
+	 */
+	var $manifest18;
+
+	/**
+	 * @var ElggPluginPackage
+	 */
+	var $package18;
+
+	public function up() {
+		$this->manifest18 = new ElggPluginManifest($this->normalizeTestFilePath('plugin_18/manifest.xml'), 'plugin_test_18');
+		$this->package18 = new ElggPluginPackage($this->normalizeTestFilePath('plugin_18'));
+	}
+
+	public function down() {
+
+	}
+
+	// generic tests
+	public function testElggPluginManifestFromString() {
+		$manifest_file = file_get_contents($this->normalizeTestFilePath('plugin_18/manifest.xml'));
+		$manifest = new ElggPluginManifest($manifest_file);
+
+		$this->assertIsA($manifest, ElggPluginManifest::class);
+	}
+
+	public function testElggPluginManifestFromFile() {
+		$file = $this->normalizeTestFilePath('plugin_18/manifest.xml');
+		$manifest = new ElggPluginManifest($file);
+
+		$this->assertIsA($manifest, ElggPluginManifest::class);
+	}
+
+	public function testElggPluginManifestFromXMLEntity() {
+		$manifest_file = file_get_contents($this->normalizeTestFilePath('plugin_18/manifest.xml'));
+		$xml = new \ElggXMLElement($manifest_file);
+		$manifest = new ElggPluginManifest($xml);
+
+		$this->assertIsA($manifest, ElggPluginManifest::class);
+	}
+
+	// exact manifest values
+	// 1.8 interface
+	public function testElggPluginManifest18() {
+		$manifest_array = [
+			'name' => 'Test Manifest',
+			'author' => 'Anyone',
+			'version' => '1.0',
+			'blurb' => 'A concise description.',
+			'description' => 'A longer, more interesting description.',
+			'website' => 'http://www.elgg.org/',
+			'repository' => 'https://github.com/Elgg/Elgg',
+			'bugtracker' => 'https://github.com/elgg/elgg/issues',
+			'donations' => 'http://elgg.org/supporter.php',
+			'copyright' => '(C) Elgg Foundation 2011',
+			'license' => 'GNU General Public License version 2',
+
+			'requires' => [
+				[
+					'type' => 'elgg_release',
+					'version' => '1.8-svn'
+				],
+				[
+					'type' => 'php_extension',
+					'name' => 'gd'
+				],
+				[
+					'type' => 'php_ini',
+					'name' => 'short_open_tag',
+					'value' => 'off'
+				],
+				[
+					'type' => 'php_version',
+					'version' => '5.6'
+				],
+				[
+					'type' => 'php_extension',
+					'name' => 'made_up',
+					'version' => '1.0'
+				],
+				[
+					'type' => 'plugin',
+					'name' => 'fake_plugin',
+					'version' => '1.0'
+				],
+				[
+					'type' => 'plugin',
+					'name' => 'profile',
+					'version' => '1.0'
+				],
+				[
+					'type' => 'plugin',
+					'name' => 'profile_api',
+					'version' => '1.3',
+					'comparison' => 'lt'
+				],
+				[
+					'type' => 'priority',
+					'priority' => 'after',
+					'plugin' => 'profile'
+				],
+			],
+
+			'screenshot' => [
+				[
+					'description' => 'Fun things to do 1',
+					'path' => 'graphics/plugin_ss1.png'
+				],
+				[
+					'description' => 'Fun things to do 2',
+					'path' => 'graphics/plugin_ss2.png'
+				],
+			],
+
+			'contributor' => [
+				[
+					'name' => 'Evan Winslow',
+					'email' => 'evan@elgg.org',
+					'website' => 'http://evanwinslow.com/',
+					'username' => 'ewinslow',
+					'description' => "Description of Evan's role in the project"
+				],
+				[
+					'name' => 'Cash Costello',
+					'email' => 'cash@elgg.org',
+					'description' => "Description of Cash's role in the project"
+				],
+			],
+
+			'category' => [
+				'Admin',
+				'ServiceAPI'
+			],
+
+			'conflicts' => [
+				[
+					'type' => 'plugin',
+					'name' => 'profile_api',
+					'version' => '1.0'
+				]
+			],
+
+			'provides' => [
+				[
+					'type' => 'plugin',
+					'name' => 'profile_api',
+					'version' => '1.3'
+				],
+				[
+					'type' => 'php_extension',
+					'name' => 'big_math',
+					'version' => '1.0'
+				]
+			],
+
+			'suggests' => [
+				[
+					'type' => 'plugin',
+					'name' => 'facebook_connect',
+					'version' => '1.0'
+				],
+			],
+
+			// string because we are reading from a file
+			'activate_on_install' => 'true',
+		];
+
+		$this->assertIdentical($this->manifest18->getManifest(), $manifest_array);
+	}
+
+	public function testElggPluginManifestGetApiVersion() {
+		$this->assertEqual($this->manifest18->getApiVersion(), 1.8);
+	}
+
+	public function testElggPluginManifestGetPluginID() {
+		$this->assertEqual($this->manifest18->getPluginID(), 'plugin_test_18');
+	}
+
+	// normalized attributes
+	public function testElggPluginManifestGetName() {
+		$this->assertEqual($this->manifest18->getName(), 'Test Manifest');
+	}
+
+	public function testElggPluginManifestGetAuthor() {
+		$this->assertEqual($this->manifest18->getAuthor(), 'Anyone');
+	}
+
+	public function testElggPluginManifestGetVersion() {
+		$this->assertEqual($this->manifest18->getVersion(), 1.0);
+	}
+
+	public function testElggPluginManifestGetBlurb() {
+		$this->assertEqual($this->manifest18->getBlurb(), 'A concise description.');
+	}
+
+	public function testElggPluginManifestGetWebsite() {
+		$this->assertEqual($this->manifest18->getWebsite(), 'http://www.elgg.org/');
+	}
+
+	public function testElggPluginManifestGetRepository() {
+		$this->assertEqual($this->manifest18->getRepositoryURL(), 'https://github.com/Elgg/Elgg');
+	}
+
+	public function testElggPluginManifestGetBugtracker() {
+		$this->assertEqual($this->manifest18->getBugTrackerURL(), 'https://github.com/elgg/elgg/issues');
+	}
+
+	public function testElggPluginManifestGetDonationsPage() {
+		$this->assertEqual($this->manifest18->getDonationsPageURL(), 'http://elgg.org/supporter.php');
+	}
+
+	public function testElggPluginManifestGetCopyright() {
+		$this->assertEqual($this->manifest18->getCopyright(), '(C) Elgg Foundation 2011');
+	}
+
+	public function testElggPluginManifestGetLicense() {
+		$this->assertEqual($this->manifest18->getLicense(), 'GNU General Public License version 2');
+	}
+
+
+	public function testElggPluginManifestGetRequires() {
+		$requires = [
+			[
+				'type' => 'elgg_release',
+				'version' => '1.8-svn',
+				'comparison' => 'ge'
+			],
+			[
+				'type' => 'php_extension',
+				'name' => 'gd',
+				'version' => '',
+				'comparison' => '='
+			],
+			[
+				'type' => 'php_ini',
+				'name' => 'short_open_tag',
+				'value' => 0,
+				'comparison' => '='
+			],
+			[
+				'type' => 'php_version',
+				'version' => '5.6',
+				'comparison' => 'ge'
+			],
+			[
+				'type' => 'php_extension',
+				'name' => 'made_up',
+				'version' => '1.0',
+				'comparison' => '='
+			],
+			[
+				'type' => 'plugin',
+				'name' => 'fake_plugin',
+				'version' => '1.0',
+				'comparison' => 'ge'
+			],
+			[
+				'type' => 'plugin',
+				'name' => 'profile',
+				'version' => '1.0',
+				'comparison' => 'ge'
+			],
+			[
+				'type' => 'plugin',
+				'name' => 'profile_api',
+				'version' => '1.3',
+				'comparison' => 'lt'
+			],
+			[
+				'type' => 'priority',
+				'priority' => 'after',
+				'plugin' => 'profile'
+			],
+		];
+
+		$this->assertIdentical($this->package18->getManifest()->getRequires(), $requires);
+	}
+
+	public function testElggPluginManifestGetSuggests() {
+		$suggests = [
+			[
+				'type' => 'plugin',
+				'name' => 'facebook_connect',
+				'version' => '1.0',
+				'comparison' => 'ge'
+			],
+		];
+
+		$this->assertIdentical($this->package18->getManifest()->getSuggests(), $suggests);
+	}
+
+	public function testElggPluginManifestGetDescription() {
+		$this->assertEqual($this->package18->getManifest()->getDescription(), 'A longer, more interesting description.');
+	}
+
+	public function testElggPluginManifestGetCategories() {
+		$categories = [
+			'Admin',
+			'ServiceAPI'
+		];
+
+		$this->assertIdentical($this->package18->getManifest()->getCategories(), $categories);
+	}
+
+	public function testElggPluginManifestGetScreenshots() {
+		$screenshots = [
+			[
+				'description' => 'Fun things to do 1',
+				'path' => 'graphics/plugin_ss1.png'
+			],
+			[
+				'description' => 'Fun things to do 2',
+				'path' => 'graphics/plugin_ss2.png'
+			],
+		];
+
+		$this->assertIdentical($this->package18->getManifest()->getScreenshots(), $screenshots);
+	}
+
+	public function testElggPluginManifestGetContributors() {
+		$contributors = [
+			[
+				'name' => 'Evan Winslow',
+				'email' => 'evan@elgg.org',
+				'website' => 'http://evanwinslow.com/',
+				'username' => 'ewinslow',
+				'description' => "Description of Evan's role in the project"
+			],
+			[
+				'name' => 'Cash Costello',
+				'email' => 'cash@elgg.org',
+				'website' => '',
+				'username' => '',
+				'description' => "Description of Cash's role in the project"
+			],
+		];
+
+		$this->assertIdentical($this->package18->getManifest()->getContributors(), $contributors);
+	}
+
+	public function testElggPluginManifestGetProvides() {
+		$provides = [
+			[
+				'type' => 'plugin',
+				'name' => 'profile_api',
+				'version' => '1.3'
+			],
+			[
+				'type' => 'php_extension',
+				'name' => 'big_math',
+				'version' => '1.0'
+			],
+			[
+				'type' => 'plugin',
+				'name' => 'plugin_18',
+				'version' => '1.0'
+			]
+		];
+
+		$this->assertIdentical($this->package18->getManifest()->getProvides(), $provides);
+	}
+
+	public function testElggPluginManifestGetConflicts() {
+		$conflicts = [
+			[
+				'type' => 'plugin',
+				'name' => 'profile_api',
+				'version' => '1.0',
+				'comparison' => '='
+			]
+		];
+
+		$this->assertIdentical($this->manifest18->getConflicts(), $conflicts);
+	}
+
+	public function testElggPluginManifestGetActivateOnInstall() {
+		$this->assertIdentical($this->manifest18->getActivateOnInstall(), true);
+	}
+
+	// \ElggPluginPackage
+	public function testElggPluginPackageDetectIDFromPath() {
+		$this->assertEqual($this->package18->getID(), 'plugin_18');
+	}
+
+	public function testElggPluginPackageDetectIDFromPluginID() {
+		$package = new ElggPluginPackage('profile');
+		$this->assertEqual($package->getID(), 'profile');
+	}
+
+	// \ElggPlugin
+	public function testElggPluginIsValid() {
+
+		$test_plugin = new \ElggPlugin(elgg_get_plugins_path() . 'profile');
+
+		$this->assertIdentical(true, $test_plugin->isValid());
+	}
+
+	public function testElggPluginGetID() {
+
+		$test_plugin = new \ElggPlugin(elgg_get_plugins_path() . 'profile');
+
+		$this->assertIdentical('profile', $test_plugin->getID());
+	}
+
+	public function testGetSettingRespectsDefaults() {
+		$plugin = elgg_get_plugin_from_id('profile');
+		if (!$plugin) {
+			return;
+		}
+
+		$cache = _elgg_services()->pluginSettingsCache;
+		$cache->setCachedValues([
+			$plugin->guid => [
+				__METHOD__ => 'foo',
+			],
+		]);
+
+		$this->assertEqual('foo', $plugin->getSetting(__METHOD__, 'bar'));
+		$cache->clearAll();
+		$this->assertEqual('bar', $plugin->getSetting(__METHOD__, 'bar'));
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreRegressionBugsTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreRegressionBugsTest.php
@@ -1,0 +1,473 @@
+<?php
+
+namespace Elgg\Integration;
+
+use ElggObject;
+use ElggUser;
+use ElggXMLElement;
+use SimpleXMLElement;
+
+/**
+ * Elgg Regression Tests -- GitHub Bugfixes
+ * Any bugfixes from GitHub that require testing belong here.
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreRegressionBugsTest extends \Elgg\LegacyIntegrationTestCase {
+
+	public function up() {
+		$this->ia = elgg_set_ignore_access(true);
+	}
+
+	public function down() {
+		elgg_set_ignore_access($this->ia);
+	}
+
+	/**
+	 * #1558
+	 */
+	public function testElggObjectDeleteAnnotations() {
+		$this->entity = new ElggObject();
+		$guid = $this->entity->save();
+
+		$this->entity->annotate('test', 'hello', ACCESS_PUBLIC);
+
+		$this->entity->deleteAnnotations('does not exist');
+
+		$num = $this->entity->countAnnotations('test');
+
+		//$this->assertIdentical($num, 1);
+		$this->assertEqual($num, 1);
+
+		// clean up
+		$this->entity->delete();
+	}
+
+	/**
+	 * #2063 - get_resized_image_from_existing_file() fails asked for image larger than selection and not scaling an
+	 * image up Test get_image_resize_parameters().
+	 */
+	public function testElggResizeImage() {
+		$orig_width = 100;
+		$orig_height = 150;
+
+		// test against selection > max
+		$options = [
+			'maxwidth' => 50,
+			'maxheight' => 50,
+			'square' => true,
+			'upscale' => false,
+
+			'x1' => 25,
+			'y1' => 75,
+			'x2' => 100,
+			'y2' => 150
+		];
+
+		// should get back the same x/y offset == x1, y1 and an image of 50x50
+		$params = get_image_resize_parameters($orig_width, $orig_height, $options);
+
+		$this->assertEqual($params['newwidth'], $options['maxwidth']);
+		$this->assertEqual($params['newheight'], $options['maxheight']);
+		$this->assertEqual($params['xoffset'], $options['x1']);
+		$this->assertEqual($params['yoffset'], $options['y1']);
+
+		// test against selection < max
+		$options = [
+			'maxwidth' => 50,
+			'maxheight' => 50,
+			'square' => true,
+			'upscale' => false,
+
+			'x1' => 75,
+			'y1' => 125,
+			'x2' => 100,
+			'y2' => 150
+		];
+
+		// should get back the same x/y offset == x1, y1 and an image of 25x25 because no upscale
+		$params = get_image_resize_parameters($orig_width, $orig_height, $options);
+
+		$this->assertEqual($params['newwidth'], 25);
+		$this->assertEqual($params['newheight'], 25);
+		$this->assertEqual($params['xoffset'], $options['x1']);
+		$this->assertEqual($params['yoffset'], $options['y1']);
+	}
+
+	// #3722 Check canEdit() works for contains regardless of groups
+	function test_can_write_to_container() {
+		$user = new ElggUser();
+		$user->username = 'test_user_' . rand();
+		$user->name = 'test_user_name_' . rand();
+		$user->email = 'test@user.net';
+		$user->container_guid = 0;
+		$user->owner_guid = 0;
+		$user->save();
+
+		$object = new ElggObject();
+		$object->save();
+
+		$group = new \ElggGroup();
+		$group->save();
+
+		// disable access overrides because we're admin.
+		$ia = elgg_set_ignore_access(false);
+
+		$this->assertFalse(can_write_to_container($user->guid, $object->guid));
+
+		global $elgg_test_user;
+		$elgg_test_user = $user;
+
+		// register hook to allow access
+		$handler = /** @noinspection PhpInconsistentReturnPointsInspection */
+			function ($hook, $type, $value, $params) {
+				global $elgg_test_user;
+
+				if ($params['user']->getGUID() == $elgg_test_user->getGUID()) {
+					return true;
+				}
+			};
+
+		elgg_register_plugin_hook_handler('container_permissions_check', 'all', $handler, 600);
+		$this->assertTrue(can_write_to_container($user->guid, $object->guid));
+		elgg_unregister_plugin_hook_handler('container_permissions_check', 'all', $handler);
+
+		$this->assertFalse(can_write_to_container($user->guid, $group->guid));
+		$group->join($user);
+		$this->assertTrue(can_write_to_container($user->guid, $group->guid));
+
+		elgg_set_ignore_access($ia);
+
+		$user->delete();
+		$object->delete();
+		$group->delete();
+	}
+
+	/**
+	 * https://github.com/elgg/elgg/issues/3210 - Don't remove -s in friendly titles
+	 * https://github.com/elgg/elgg/issues/2276 - improve char encoding
+	 */
+	public function test_friendly_title() {
+		$cases = [
+			// acid test
+			"B&N > Amazon, OK? <bold> 'hey!' $34"
+			=> "bn-amazon-ok-bold-hey-34",
+
+			// hyphen, underscore and ASCII whitespace replaced by separator,
+			// other non-alphanumeric ASCII removed
+			"a-a_a a\na\ra\ta\va!a\"a#a\$a%aa'a(a)a*a+a,a.a/a:a;a=a?a@a[a\\a]a^a`a{a|a}a~a"
+			=> "a-a-a-a-a-a-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+
+			// separators trimmed
+			"-_ hello _-"
+			=> "hello",
+
+			// accents removed, lower case, other multibyte chars are URL encoded
+			"I\xC3\xB1t\xC3\xABrn\xC3\xA2ti\xC3\xB4n\xC3\xA0liz\xC3\xA6ti\xC3\xB8n, AND \xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E"
+			// Iñtërnâtiônàlizætiøn, AND 日本語
+			=> 'internationalizaetion-and-%E6%97%A5%E6%9C%AC%E8%AA%9E',
+		];
+
+		// where available, string is converted to NFC before transliteration
+		if (\Elgg\Translit::hasNormalizerSupport()) {
+			$form_d = "A\xCC\x8A"; // A followed by 'COMBINING RING ABOVE' (U+030A)
+			$cases[$form_d] = "a";
+		}
+
+		foreach ($cases as $case => $expected) {
+			$friendly_title = elgg_get_friendly_title($case);
+			$this->assertIdentical($expected, $friendly_title);
+		}
+	}
+
+	/**
+	 * Test #5369 -- parse_urls()
+	 * https://github.com/Elgg/Elgg/issues/5369
+	 */
+	public function test_parse_urls() {
+
+		$cases = [
+			'no.link.here' =>
+				'no.link.here',
+			'simple link http://example.org test' =>
+				'simple link <a href="http://example.org" rel="nofollow">http://example.org</a> test',
+			'non-ascii http://ñew.org/ test' =>
+				'non-ascii <a href="http://ñew.org/" rel="nofollow">http://ñew.org/</a> test',
+
+			// section 2.1
+			'percent encoded http://example.org/a%20b test' =>
+				'percent encoded <a href="http://example.org/a%20b" rel="nofollow">http://example.org/a%20b</a> test',
+			// section 2.2: skipping single quote and parenthese
+			'reserved characters http://example.org/:/?#[]@!$&*+,;= test' =>
+				'reserved characters <a href="http://example.org/:/?#[]@!$&*+,;=" rel="nofollow">http://example.org/:/?#[]@!$&*+,;=</a> test',
+			// section 2.3
+			'unreserved characters http://example.org/a1-._~ test' =>
+				'unreserved characters <a href="http://example.org/a1-._~" rel="nofollow">http://example.org/a1-._~</a> test',
+
+			'parameters http://example.org/?val[]=1&val[]=2 test' =>
+				'parameters <a href="http://example.org/?val[]=1&val[]=2" rel="nofollow">http://example.org/?val[]=1&val[]=2</a> test',
+			'port http://example.org:80/ test' =>
+				'port <a href="http://example.org:80/" rel="nofollow">http://example.org:80/</a> test',
+
+			'parentheses (http://www.google.com) test' =>
+				'parentheses (<a href="http://www.google.com" rel="nofollow">http://www.google.com</a>) test',
+			'comma http://elgg.org, test' =>
+				'comma <a href="http://elgg.org" rel="nofollow">http://elgg.org</a>, test',
+			'period http://elgg.org. test' =>
+				'period <a href="http://elgg.org" rel="nofollow">http://elgg.org</a>. test',
+			'exclamation http://elgg.org! test' =>
+				'exclamation <a href="http://elgg.org" rel="nofollow">http://elgg.org</a>! test',
+
+			'already anchor <a href="http://twitter.com/">twitter</a> test' =>
+				'already anchor <a href="http://twitter.com/">twitter</a> test',
+
+			'ssl https://example.org/ test' =>
+				'ssl <a href="https://example.org/" rel="nofollow">https://example.org/</a> test',
+			'ftp ftp://example.org/ test' =>
+				'ftp <a href="ftp://example.org/" rel="nofollow">ftp://example.org/</a> test',
+
+			'web archive anchor <a href="http://web.archive.org/web/20000229040250/http://www.google.com/">google</a>' =>
+				'web archive anchor <a href="http://web.archive.org/web/20000229040250/http://www.google.com/">google</a>',
+
+			'single quotes already anchor <a href=\'http://www.yahoo.com\'>yahoo</a>' =>
+				'single quotes already anchor <a href=\'http://www.yahoo.com\'>yahoo</a>',
+
+			'unquoted already anchor <a href=http://www.yahoo.com>yahoo</a>' =>
+				'unquoted already anchor <a href=http://www.yahoo.com>yahoo</a>',
+
+			'parens in uri http://thedailywtf.com/Articles/A-(Long-Overdue)-BuildMaster-Introduction.aspx' =>
+				'parens in uri <a href="http://thedailywtf.com/Articles/A-(Long-Overdue)-BuildMaster-Introduction.aspx" rel="nofollow">http://thedailywtf.com/Articles/A-(Long-Overdue)-BuildMaster-Introduction.aspx</a>'
+		];
+		foreach ($cases as $input => $output) {
+			$this->assertEqual($output, parse_urls($input));
+		}
+	}
+
+	/**
+	 * Test #10398 -- elgg_parse_emails()
+	 * https://github.com/Elgg/Elgg/pull/10398
+	 */
+	public function test_elgg_parse_emails() {
+		$cases = [
+			'no.email.here' =>
+				'no.email.here',
+			'simple email mail@test.com test' =>
+				'simple email <a href="mailto:mail@test.com" rel="nofollow">mail@test.com</a> test',
+			'simple paragraph <p>mail@test.com</p>' =>
+				'simple paragraph <p><a href="mailto:mail@test.com" rel="nofollow">mail@test.com</a></p>',
+			'multiple matches mail@test.com test mail@test.com test' =>
+				'multiple matches <a href="mailto:mail@test.com" rel="nofollow">mail@test.com</a> test <a href="mailto:mail@test.com" rel="nofollow">mail@test.com</a> test',
+			'invalid email 1 @invalid.com test' =>
+				'invalid email 1 @invalid.com test',
+			'invalid email 2 mail@invalid. test' =>
+				'invalid email 2 mail@invalid. test',
+			'no double parsing <a href="mailto:mail@test.com" rel="nofollow">mail@test.com</a> test' =>
+				'no double parsing <a href="mailto:mail@test.com" rel="nofollow">mail@test.com</a> test',
+			'no double parsing 2 <a href="#">mail@test.com</a> test' =>
+				'no double parsing 2 <a href="#">mail@test.com</a> test',
+			'no double parsing 3 <a href="#">with a lot of text - mail@test.com - around it</a> test' =>
+				'no double parsing 3 <a href="#">with a lot of text - mail@test.com - around it</a> test',
+		];
+		foreach ($cases as $input => $output) {
+			$this->assertEqual($output, elgg_parse_emails($input));
+		}
+	}
+
+	/**
+	 * Ensure additional select columns do not end up in entity attributes.
+	 *
+	 * https://github.com/Elgg/Elgg/issues/5538
+	 */
+	public function test_extra_columns_dont_appear_in_attributes() {
+		// may not have groups in DB - let's create one
+		$group = new \ElggGroup();
+		$group->name = 'test_group';
+		$group->access_id = ACCESS_PUBLIC;
+		$this->assertTrue($group->save() !== false);
+
+		// entity cache interferes with our test
+		_elgg_services()->entityCache->clear();
+
+		foreach ([
+					 'site',
+					 'user',
+					 'group',
+					 'object'
+				 ] as $type) {
+
+			$entities = elgg_get_entities([
+				'type' => $type,
+				'selects' => ['1 as _nonexistent_test_column'],
+				'limit' => 1,
+			]);
+
+			$this->assertTrue($entities, "Query for '$type' did not return an entity.");
+
+			$entity = $entities[0];
+			$this->assertNull($entity->_nonexistent_test_column, "Additional select columns are leaking to attributes for '$type'");
+		}
+
+		$group->delete();
+	}
+
+	/**
+	 * Ensure that \ElggBatch doesn't go into infinite loop when disabling annotations recursively when show hidden is
+	 * enabled.
+	 *
+	 * https://github.com/Elgg/Elgg/issues/5952
+	 */
+	public function test_disabling_annotations_infinite_loop() {
+
+		//let's have some entity
+		$group = new \ElggGroup();
+		$group->name = 'test_group';
+		$group->access_id = ACCESS_PUBLIC;
+		$this->assertTrue($group->save() !== false);
+
+		$total = 51;
+		//add some annotations
+		for ($cnt = 0; $cnt < $total; $cnt++) {
+			$group->annotate('test_annotation', 'value_' . $total);
+		}
+
+		//disable them
+		$show_hidden = access_get_show_hidden_status();
+		access_show_hidden_entities(true);
+		$options = [
+			'guid' => $group->guid,
+			'limit' => $total,
+			//using strict limit to avoid real infinite loop and just see \ElggBatch limiting on it before finishing the work
+		];
+		elgg_disable_annotations($options);
+		access_show_hidden_entities($show_hidden);
+
+		//confirm all being disabled
+		$annotations = $group->getAnnotations([
+			'limit' => $total,
+		]);
+		foreach ($annotations as $annotation) {
+			$this->assertTrue($annotation->enabled == 'no');
+		}
+
+		//delete group and annotations
+		$group->delete();
+	}
+
+	public function test_ElggXMLElement_does_not_load_external_entities() {
+		$elLast = libxml_disable_entity_loader(false);
+
+		// build payload that should trigger loading of external entity
+		$payload = file_get_contents($this->normalizeTestFilePath('xxe/request.xml'));
+		$path = realpath($this->normalizeTestFilePath('xxe/external_entity.txt'));
+		$path = str_replace('\\', '/', $path);
+		if ($path[0] != '/') {
+			$path = '/' . $path;
+		}
+		$path = 'file://' . $path;
+		$payload = sprintf($payload, $path);
+
+		// make sure we can actually this in this environment
+		$element = new SimpleXMLElement($payload);
+		$can_load_entity = preg_match('/secret/', (string) $element->methodName);
+
+		$this->skipUnless($can_load_entity, "XXE vulnerability cannot be tested on this system");
+
+		if ($can_load_entity) {
+			$this->expectError("SimpleXMLElement::__construct(): I/O warning : failed to load external entity &quot;" . $path . "&quot;");
+			$el = new ElggXMLElement($payload);
+			$chidren = $el->getChildren();
+			$content = $chidren[0]->getContent();
+			$this->assertNoPattern('/secret/', $content);
+		}
+
+		libxml_disable_entity_loader($elLast);
+	}
+
+	public function test_update_handlers_can_change_attributes() {
+		$object = new ElggObject();
+		$object->subtype = 'issue6225';
+		$object->access_id = ACCESS_PUBLIC;
+		$object->save();
+		$guid = $object->guid;
+
+		elgg_register_event_handler('update', 'object', [
+			ElggCoreRegressionBugsTest::class,
+			'handleUpdateForIssue6225test'
+		]);
+
+		$object->save();
+
+		elgg_unregister_event_handler('update', 'object', [
+			ElggCoreRegressionBugsTest::class,
+			'handleUpdateForIssue6225test'
+		]);
+
+		_elgg_services()->entityCache->remove($guid);
+
+		$object = get_entity($guid);
+		$this->assertEqual($object->access_id, ACCESS_PRIVATE);
+
+		$object->delete();
+	}
+
+	public static function handleUpdateForIssue6225test($event, $type, ElggObject $object) {
+		$object->access_id = ACCESS_PRIVATE;
+	}
+
+	/**
+	 * elgg_admin_sort_page_menu() should not expect that the supplied menu has a certain hierarchy
+	 *
+	 * https://github.com/Elgg/Elgg/issues/6379
+	 */
+	function test_admin_sort_page_menu() {
+
+		elgg_push_context('admin');
+
+		elgg_register_plugin_hook_handler('prepare', 'menu:page', 'elgg_admin_sort_page_menu');
+		$result = elgg_trigger_plugin_hook('prepare', 'menu:page', [], []);
+		$this->assertTrue(is_array($result), "Admin page menu fails to prepare for viewing");
+		elgg_unregister_plugin_hook_handler('prepare', 'menu:page', 'elgg_admin_sort_page_menu');
+
+		elgg_pop_context();
+	}
+
+	/**
+	 * Tests get_entity_statistics() without owner
+	 */
+	function test_global_get_entity_statistics() {
+
+		$subtype = 'issue7845' . rand(0, 100);
+
+		$object = new ElggObject();
+		$object->subtype = $subtype;
+		$object->save();
+
+		$stats = get_entity_statistics();
+
+		$this->assertEqual($stats['object'][$subtype], 1);
+
+		$object->delete();
+	}
+
+	/**
+	 * Tests get_entity_statistics() with an owner
+	 */
+	function test_owned_get_entity_statistics() {
+
+		$user = $this->createUser();
+
+		$subtype = 'issue7845' . rand(0, 100);
+
+		$object = new ElggObject();
+		$object->subtype = $subtype;
+		$object->owner_guid = $user->guid;
+		$object->save();
+
+		$stats = get_entity_statistics($user->guid);
+
+		$this->assertEqual($stats['object'][$subtype], 1);
+
+		$user->delete();
+	}
+
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreRiverAPITest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreRiverAPITest.php
@@ -1,0 +1,389 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\Values;
+use ElggEntity;
+use ElggRiveritem;
+use ElggUser;
+
+/**
+ * Elgg Test river api
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreRiverAPITest extends \Elgg\LegacyIntegrationTestCase {
+
+	/**
+	 * @var ElggEntity
+	 */
+	protected $entity;
+
+	/**
+	 * @var ElggUser
+	 */
+	protected $user;
+
+	public function up() {
+		$user = $this->createUser();
+
+		$entity = $this->createObject([
+			'owner_guid' => $user->guid,
+		]);
+
+		$this->user = $user;
+		$this->entity = $entity;
+
+		_elgg_services()->session->setLoggedInUser($user);
+
+		// By default, only admins are allowed to delete river items
+		// For the sake of this test case, we will allow the user to delete items
+		elgg_register_plugin_hook_handler('permissions_check:delete', 'river', [
+			$this,
+			'allowDelete'
+		]);
+	}
+
+	public function down() {
+		_elgg_services()->session->setLoggedInUser($this->getAdmin());
+
+		$this->user->delete();
+
+		elgg_unregister_plugin_hook_handler('permissions_check:delete', 'river', [
+			$this,
+			'allowDelete'
+		]);
+	}
+
+	public function allowDelete($hook, $type, $return, $params) {
+		$hook_user = elgg_extract('user', $params);
+		if (!$hook_user) {
+			return;
+		}
+
+		if ($this->user->guid === $hook_user->guid) {
+			return true;
+		}
+	}
+
+	public function testCanCreateRiverItem() {
+
+		$params = [
+			'view' => 'river/relationship/friend/create',
+			'action_type' => 'create',
+			'subject_guid' => $this->entity->guid,
+			'object_guid' => $this->entity->guid,
+		];
+
+		$id = elgg_create_river_item($params);
+		$this->assertTrue(is_int($id));
+		$this->assertTrue(elgg_delete_river(['id' => $id]));
+
+		$params['return_item'] = true;
+		$item = elgg_create_river_item($params);
+
+		$this->assertIsA($item, ElggRiveritem::class);
+		$this->assertTrue(elgg_delete_river(['id' => $item->id]));
+	}
+
+	public function testRiverCreationEmitsHookAndEvent() {
+		$params = [
+			'view' => 'river/relationship/friend/create',
+			'action_type' => 'create',
+			'subject_guid' => $this->entity->guid,
+			'object_guid' => $this->entity->guid,
+			'posted' => time(),
+			'return_item' => true,
+		];
+
+		$captured = [];
+		$hook_handler = function ($hook, $type, $value, $params) use (&$captured) {
+			$captured['hook_value'] = $value;
+		};
+		$event_handler = function ($event, $type, $object) use (&$captured) {
+			$captured['event_object'] = $object;
+		};
+
+		elgg_register_plugin_hook_handler('creating', 'river', $hook_handler);
+		elgg_register_event_handler('created', 'river', $event_handler);
+		$item = elgg_create_river_item($params);
+		elgg_unregister_plugin_hook_handler('creating', 'river', $hook_handler);
+		elgg_unregister_event_handler('created', 'river', $event_handler);
+
+		$expected_values = [
+			'type' => $this->entity->getType(),
+			'subtype' => $this->entity->getSubtype(),
+			'action_type' => $params['action_type'],
+			'access_id' => $this->entity->access_id,
+			'view' => $params['view'],
+			'subject_guid' => $params['subject_guid'],
+			'object_guid' => $params['object_guid'],
+			'target_guid' => 0,
+			'annotation_id' => 0,
+			'posted' => $params['posted'],
+		];
+		foreach ($expected_values as $key => $value) {
+			$this->assertEqual($captured['hook_value'][$key], $value);
+		}
+		$this->assertSame($item, $captured['event_object']);
+
+		$this->assertTrue($item->delete());
+	}
+
+	public function testCanCancelRiverItemViaHook() {
+		$params = [
+			'view' => 'river/relationship/friend/create',
+			'action_type' => 'create',
+			'subject_guid' => $this->entity->guid,
+			'object_guid' => $this->entity->guid,
+		];
+
+		elgg_register_plugin_hook_handler('creating', 'river', [
+			Values::class,
+			'getFalse'
+		]);
+		$id = elgg_create_river_item($params);
+		elgg_unregister_plugin_hook_handler('creating', 'river', [
+			Values::class,
+			'getFalse'
+		]);
+
+		$this->assertTrue($id === true); // prevented
+	}
+
+	public function testCanCancelRiverDeleteByEvent() {
+		$params = [
+			'view' => 'river/relationship/friend/create',
+			'action_type' => 'create',
+			'subject_guid' => $this->entity->guid,
+			'object_guid' => $this->entity->guid,
+			'return_item' => true,
+		];
+		$item = elgg_create_river_item($params);
+
+		elgg_register_event_handler('delete:before', 'river', [
+			Values::class,
+			'getFalse'
+		]);
+		$this->assertFalse($item->delete());
+		elgg_unregister_event_handler('delete:before', 'river', [
+			Values::class,
+			'getFalse'
+		]);
+
+		$items = elgg_get_river(['id' => $item->id]);
+		$this->assertEqual(count($items), 1);
+
+		$this->assertTrue($item->delete());
+	}
+
+	public function testRiverDeleteFiresAfterEvent() {
+		// [delete:after, river]
+
+		$params = [
+			'view' => 'river/relationship/friend/create',
+			'action_type' => 'create',
+			'subject_guid' => $this->entity->guid,
+			'object_guid' => $this->entity->guid,
+			'return_item' => true,
+		];
+		$item = elgg_create_river_item($params);
+
+		$captured = null;
+		$event_handler = function ($event, $type, $object) use (&$captured) {
+			$captured = $object;
+		};
+
+		elgg_register_event_handler('delete:after', 'river', $event_handler);
+		$item->delete();
+		elgg_unregister_event_handler('delete:after', 'river', $event_handler);
+
+		$this->assertSame($item, $captured);
+	}
+
+	public function testRiverDeleteUsesPermissionHook() {
+		$params = [
+			'view' => 'river/relationship/friend/create',
+			'action_type' => 'create',
+			'subject_guid' => $this->entity->guid,
+			'object_guid' => $this->entity->guid,
+			'return_item' => true,
+		];
+		$item = elgg_create_river_item($params);
+
+		//permissions_check:delete, river
+		$this->assertTrue($item->canDelete());
+
+		$captured = null;
+		$handler = function () use (&$captured) {
+			$captured = func_get_args();
+
+			return false;
+		};
+
+		elgg_register_plugin_hook_handler('permissions_check:delete', 'river', $handler);
+
+		$this->assertFalse($item->canDelete());
+		$this->assertTrue($captured[2]);
+		$this->assertSame($captured[3]['item'], $item);
+		$this->assertSame($captured[3]['user'], elgg_get_logged_in_user_entity());
+
+		$this->assertFalse($item->delete());
+
+		elgg_unregister_plugin_hook_handler('permissions_check:delete', 'river', $handler);
+
+		$this->assertTrue($item->delete());
+	}
+
+	public function testDeleteRiverFunctionTriggersEventsPerms() {
+		$params = [
+			'view' => 'river/relationship/friend/create',
+			'action_type' => 'create',
+			'subject_guid' => $this->entity->guid,
+			'object_guid' => $this->entity->guid,
+		];
+		$id = elgg_create_river_item($params);
+
+		$owner = $this->entity->getOwnerEntity();
+		$old_user = _elgg_services()->session->getLoggedInUser();
+		_elgg_services()->session->setLoggedInUser($owner);
+
+		$events_fired = 0;
+		$handler = function () use (&$events_fired) {
+			$events_fired++;
+		};
+
+		elgg_register_plugin_hook_handler('permissions_check:delete', 'river', $handler);
+		elgg_register_event_handler('delete:before', 'river', $handler);
+		elgg_register_event_handler('delete:after', 'river', $handler);
+
+		elgg_delete_river(['id' => $id]);
+
+		elgg_unregister_plugin_hook_handler('permissions_check:delete', 'river', $handler);
+		elgg_unregister_event_handler('delete:before', 'river', $handler);
+		elgg_unregister_event_handler('delete:after', 'river', $handler);
+
+		$this->assertEqual($events_fired, 3);
+
+		_elgg_services()->session->setLoggedInUser($old_user);
+	}
+
+	public function testElggCreateRiverItemMissingRequiredParam() {
+		$params = [
+			'view' => 'river/relationship/friend/create',
+			'action_type' => 'create',
+			'subject_guid' => $this->entity->guid,
+			'object_guid' => $this->entity->guid,
+		];
+
+		$no_view = $params;
+		unset($no_view['view']);
+		$this->assertFalse(elgg_create_river_item($no_view));
+
+		$no_action = $params;
+		unset($no_action['action_type']);
+		$this->assertFalse(elgg_create_river_item($no_action));
+
+		$no_subject = $params;
+		unset($no_subject['subject_guid']);
+		$this->assertFalse(elgg_create_river_item($no_subject));
+
+		$no_object = $params;
+		unset($no_object['object_guid']);
+		$this->assertFalse(elgg_create_river_item($no_object));
+	}
+
+	public function testElggCreateRiverItemViewNotExist() {
+		$params = [
+			'view' => 'river/relationship/foo/create',
+			'action_type' => 'create',
+			'subject_guid' => $this->entity->guid,
+			'object_guid' => $this->entity->guid,
+		];
+
+		$this->assertFalse(elgg_create_river_item($params));
+	}
+
+	public function testElggCreateRiverItemBadEntity() {
+		$params = [
+			'view' => 'river/relationship/friend/create',
+			'action_type' => 'create',
+			'subject_guid' => $this->entity->guid,
+			'object_guid' => $this->entity->guid,
+			'target_guid' => $this->entity->guid,
+		];
+
+		$bad_subject = $params;
+		$bad_subject['subject_guid'] = -1;
+		$this->assertFalse(elgg_create_river_item($bad_subject));
+
+		$bad_object = $params;
+		$bad_object['object_guid'] = -1;
+		$this->assertFalse(elgg_create_river_item($bad_object));
+
+		$bad_target = $params;
+		$bad_target['target_guid'] = -1;
+		$this->assertFalse(elgg_create_river_item($bad_target));
+	}
+
+	public function testElggTypeSubtypeWhereSQL() {
+		$types = ['object'];
+		$subtypes = ['blog'];
+		$result = _elgg_get_river_type_subtype_where_sql('rv', $types, $subtypes, null);
+		$this->assertIdentical($result, "((rv.type = 'object') AND ((rv.subtype = 'blog')))");
+
+		$types = ['object'];
+		$subtypes = [
+			'blog',
+			'file'
+		];
+		$result = _elgg_get_river_type_subtype_where_sql('rv', $types, $subtypes, null);
+		$this->assertIdentical($result, "((rv.type = 'object') AND ((rv.subtype = 'blog') OR (rv.subtype = 'file')))");
+	}
+
+	public function testElggRiverDisableEnable() {
+
+		$this->assertTrue(_elgg_services()->hooks->getEvents()->hasHandler('disable:after', 'all', '_elgg_river_disable'));
+
+		$user = $this->createUser();
+		$this->entity = $this->createObject();
+
+		$params = [
+			'view' => 'river/relationship/friend/create',
+			'action_type' => 'create',
+			'subject_guid' => $user->guid,
+			'object_guid' => $this->entity->guid,
+		];
+
+		$id = elgg_create_river_item($params);
+
+		$river = elgg_get_river(['ids' => [$id]]);
+
+		$this->assertIdentical($river[0]->enabled, 'yes');
+
+		$ia = elgg_set_ignore_access(true);
+		$this->assertTrue($user->disable());
+		elgg_set_ignore_access($ia);
+
+		// should no longer be able to get the river
+		$river = elgg_get_river(['ids' => [$id]]);
+
+		$this->assertIdentical($river, []);
+
+		// renabling the user should re-enable the river
+		$ia = elgg_set_ignore_access(true);
+		$ha = access_get_show_hidden_status();
+		access_show_hidden_entities(true);
+		$user->enable();
+		access_show_hidden_entities($ha);
+		elgg_set_ignore_access($ia);
+
+		$river = elgg_get_river(['ids' => [$id]]);
+
+		$this->assertIdentical($river[0]->enabled, 'yes');
+
+		$user->delete();
+		$this->entity->delete();
+	}
+
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreSiteTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreSiteTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Elgg\Integration;
+
+/**
+ * Elgg Test \ElggSite
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreSiteTest extends \Elgg\LegacyIntegrationTestCase {
+
+	/**
+	 * @var ElggSiteWithExposableAttributes
+	 */
+	public $site;
+
+	public function up() {
+		$this->site = new ElggSiteWithExposableAttributes();
+	}
+
+	public function down() {
+		unset($this->site);
+	}
+
+	public function testElggSiteConstructor() {
+		$attributes = [];
+		$attributes['guid'] = null;
+		$attributes['type'] = 'site';
+		$attributes['subtype'] = null;
+		$attributes['owner_guid'] = elgg_get_logged_in_user_guid();
+		$attributes['container_guid'] = elgg_get_logged_in_user_guid();
+		$attributes['access_id'] = ACCESS_PRIVATE;
+		$attributes['time_created'] = null;
+		$attributes['time_updated'] = null;
+		$attributes['last_action'] = null;
+		$attributes['enabled'] = 'yes';
+		$attributes['name'] = null;
+		$attributes['description'] = null;
+		$attributes['url'] = null;
+		ksort($attributes);
+
+		$entity_attributes = $this->site->expose_attributes();
+		ksort($entity_attributes);
+
+		$this->assertIdentical($entity_attributes, $attributes);
+	}
+
+	public function testElggSiteGetUrl() {
+		$this->assertIdentical($this->site->getURL(), elgg_get_site_url());
+	}
+}
+
+class ElggSiteWithExposableAttributes extends \ElggSite {
+	public function expose_attributes() {
+		return $this->attributes;
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreUserTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreUserTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Elgg\Integration;
+
+/**
+ * Elgg Test \ElggUser
+ *
+ * @group IntegrationTests
+ */
+class ElggCoreUserTest extends \Elgg\LegacyIntegrationTestCase {
+
+	/**
+	 * @var ElggUserWithExposableAttributes
+	 */
+	private $user;
+
+	public function up() {
+		$this->user = new ElggUserWithExposableAttributes();
+		$this->user->username = $this->getRandomUsername();
+	}
+
+	public function down() {
+		$this->user->delete();
+		unset($this->user);
+	}
+
+
+	public function testElggUserConstructor() {
+		$attributes = array();
+		$attributes['guid'] = null;
+		$attributes['type'] = 'user';
+		$attributes['subtype'] = null;
+		$attributes['owner_guid'] = elgg_get_logged_in_user_guid();
+		$attributes['container_guid'] = elgg_get_logged_in_user_guid();
+		$attributes['access_id'] = ACCESS_PRIVATE;
+		$attributes['time_created'] = null;
+		$attributes['time_updated'] = null;
+		$attributes['last_action'] = null;
+		$attributes['enabled'] = 'yes';
+ 		$attributes['name'] = null;
+		$attributes['username'] = null;
+		$attributes['password_hash'] = null;
+		$attributes['email'] = null;
+		$attributes['language'] = null;
+		$attributes['banned'] = 'no';
+		$attributes['admin'] = 'no';
+		$attributes['prev_last_action'] = null;
+		$attributes['last_login'] = null;
+		$attributes['prev_last_login'] = null;
+		ksort($attributes);
+
+		$user = new ElggUserWithExposableAttributes();
+		$entity_attributes = $user->expose_attributes();
+		ksort($entity_attributes);
+
+		$this->assertIdentical($entity_attributes, $attributes);
+	}
+
+	public function testElggUserLoad() {
+		// new object
+		$object = new \ElggObject();
+		$this->AssertEqual($object->getGUID(), 0);
+		$guid = $object->save();
+		$this->AssertNotEqual($guid, 0);
+
+		// fail on wrong type
+		$this->assertFalse(get_user($guid));
+
+		// clean up
+		$object->delete();
+	}
+
+	public function testElggUserSave() {
+		// new object
+		$this->AssertEqual($this->user->getGUID(), 0);
+		$guid = $this->user->save();
+		$this->AssertNotEqual($guid, 0);
+
+		// clean up
+		$this->user->delete();
+	}
+
+	public function testElggUserDelete() {
+		$guid = $this->user->save();
+
+		// delete object
+		$this->assertIdentical(true, $this->user->delete());
+
+		// check GUID not in database
+		$this->assertFalse($this->fetchUser($guid));
+	}
+
+	public function testElggUserNameCache() {
+		// issue https://github.com/elgg/elgg/issues/1305
+
+		// very unlikely a user would have this username
+		$name = (string)time();
+		$this->user->username = $name;
+
+		$guid = $this->user->save();
+
+		$user = get_user_by_username($name);
+
+		$this->assertTrue($user->delete());
+
+		$user = get_user_by_username($name);
+		$this->assertFalse($user);
+	}
+
+	public function testGetUserByUsernameAcceptsUrlEncoded() {
+
+		$username = $this->getRandomUsername();
+		$this->user->username = $username;
+		$guid = $this->user->save();
+
+		// percent encode first letter
+		$first_letter = $username[0];
+		$first_letter = str_pad('%' . dechex(ord($first_letter)), 2, '0', STR_PAD_LEFT);
+		$username =   $first_letter . substr($username, 1);
+
+		$user = get_user_by_username($username);
+		$this->assertTrue((bool) $user);
+		$this->assertEqual($guid, $user->guid);
+
+		$this->user->delete();
+	}
+
+	public function testElggUserMakeAdmin() {
+		$CONFIG = _elgg_config();
+
+		// need to save user to have a guid
+		$guid = $this->user->save();
+
+		$this->assertTrue($this->user->makeAdmin());
+
+		$row = _elgg_services()->db->getDataRow("
+			SELECT admin FROM {$CONFIG->dbprefix}users_entity WHERE guid = $guid
+		");
+		$this->assertEqual($row->admin, 'yes');
+
+		$this->user->delete();
+	}
+
+	public function testElggUserRemoveAdmin() {
+		$CONFIG = _elgg_config();
+
+		// need to save user to have a guid
+		$guid = $this->user->save();
+
+		$this->assertTrue($this->user->makeAdmin());
+		
+		$this->assertTrue($this->user->removeAdmin());
+
+		$row = _elgg_services()->db->getDataRow("
+			SELECT admin FROM {$CONFIG->dbprefix}users_entity WHERE guid = $guid
+		");
+		$this->assertEqual($row->admin, 'no');
+
+		$this->user->delete();
+	}
+
+	public function testElggUserIsAdmin() {
+		// need to grab a real user with a guid and everything.
+		$guid = $this->user->save();
+
+		$this->assertTrue($this->user->makeAdmin());
+
+		// this is testing the function, not the SQL.
+		// that's been tested above.
+		$this->assertTrue($this->user->isAdmin());
+
+		$this->user->delete();
+	}
+
+	public function testElggUserIsNotAdmin() {
+		// need to grab a real user with a guid and everything.
+		$guid = $this->user->save();
+
+		$this->assertTrue($this->user->removeAdmin());
+
+		// this is testing the function, not the SQL.
+		// that's been tested above.
+		$this->assertFalse($this->user->isAdmin());
+
+		$this->user->delete();
+	}
+
+	public function testElggUserNotificationSettings() {
+
+		elgg_register_notification_method('method1');
+		elgg_register_notification_method('method2');
+
+		$this->user->setNotificationSetting('method1', true);
+		$this->user->setNotificationSetting('method2', false);
+		$this->user->setNotificationSetting('method3', true);
+
+		$settings = $this->user->getNotificationSettings();
+		$this->assertTrue($settings['method1']);
+		$this->assertFalse($settings['method2']);
+		$this->assertTrue(!isset($settings['method3']));
+
+		$this->user->delete();
+	}
+
+	protected function fetchUser($guid) {
+		$CONFIG = _elgg_config();
+
+		return get_data_row("SELECT * FROM {$CONFIG->dbprefix}users_entity WHERE guid = '$guid'");
+	}
+}
+
+class ElggUserWithExposableAttributes extends \ElggUser {
+	public function expose_attributes() {
+		return $this->attributes;
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggDataFunctionsTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggDataFunctionsTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Elgg\Integration;
+
+use ElggUser;
+
+/**
+ * @group IntegrationTests
+ */
+class ElggDataFunctionsTest extends \Elgg\LegacyIntegrationTestCase {
+
+	private $prefix;
+
+	/**
+	 * @var ElggUser
+	 */
+	private $user;
+
+	public function up() {
+		$this->prefix = _elgg_services()->db->prefix;
+
+		$users = elgg_get_entities([
+			'type' => 'user',
+			'limit' => 1,
+			'order_by' => 'e.guid ASC',
+		]);
+		$this->user = $users[0];
+	}
+
+	public function down() {
+
+	}
+
+	public function testCanGetData() {
+		$row1 = get_data("
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = '" . sanitize_string($this->user->username) . "'
+		");
+		$row1 = $row1[0];
+
+		$row2 = get_data("
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = ?
+		", null, [$this->user->username]);
+		$row2 = $row2[0];
+
+		$row3 = get_data("
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = :username
+		", null, [
+			':username' => $this->user->username,
+		]);
+		$row3 = $row3[0];
+
+		$row4 = get_data("
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = :username
+		", function ($row) {
+			return (array)$row;
+		}, [
+			':username' => $this->user->username,
+		]);
+		$row4 = $row4[0];
+
+		$this->assertIsA($row1, 'stdClass');
+		$this->assertSame($row1->username, $this->user->username);
+		$this->assertEqual($row1, $row2);
+		$this->assertEqual($row1, $row3);
+		$this->assertIsA($row4, 'array');
+		$this->assertEqual((array)$row1, $row4);
+	}
+
+	public function testCanGetDataRow() {
+		$row1 = get_data_row("
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = '" . sanitize_string($this->user->username) . "'
+		");
+
+		$row2 = get_data_row("
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = ?
+		", null, [$this->user->username]);
+
+		$row3 = get_data_row("
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = :username
+		", null, [
+			':username' => $this->user->username,
+		]);
+
+		$this->assertIsA($row1, 'stdClass');
+		$this->assertEqual($row1->username, $this->user->username);
+		$this->assertEqual($row1, $row2);
+		$this->assertEqual($row1, $row3);
+	}
+
+	public function testCanInsert() {
+		$time = time();
+
+		$id1 = insert_data("
+			INSERT INTO {$this->prefix}entity_relationships
+			       (guid_one, relationship, guid_two, time_created)
+			VALUES ({$this->user->guid}, 'test_self1', {$this->user->guid}, $time)
+			ON DUPLICATE KEY UPDATE time_created = $time
+		");
+		$id2 = insert_data("
+			INSERT INTO {$this->prefix}entity_relationships
+			       (guid_one, relationship, guid_two, time_created)
+			VALUES (:guid1,   :rel,         :guid2,   :time)
+			ON DUPLICATE KEY UPDATE time_created = :time
+		", [
+			':guid1' => $this->user->guid,
+			':guid2' => $this->user->guid,
+			':rel' => 'test_self2',
+			':time' => $time,
+		]);
+
+		$rows = get_data("
+			SELECT *
+			FROM {$this->prefix}entity_relationships
+			WHERE guid_one = ?
+			  AND guid_two = ?
+			  AND time_created = ?
+			ORDER BY id ASC
+		", null, [$this->user->guid, $this->user->guid, $time]);
+
+		$this->assertIsA($id1, 'int');
+		$this->assertIsA($id2, 'int');
+		$this->assertEqual($rows[0]->id, $id1);
+		$this->assertEqual($rows[1]->id, $id2);
+
+		remove_entity_relationship($this->user->guid, 'test_self1', $this->user->guid);
+		remove_entity_relationship($this->user->guid, 'test_self2', $this->user->guid);
+	}
+
+	public function testCanUpdate() {
+		add_entity_relationship($this->user->guid, 'test_self1', $this->user->guid);
+		$rel = check_entity_relationship($this->user->guid, 'test_self1', $this->user->guid);
+
+		$res = update_data("
+			UPDATE {$this->prefix}entity_relationships
+			SET relationship = 'test_self2'
+			WHERE id = {$rel->id}
+		");
+		$rel = get_relationship($rel->id);
+
+		$this->assertIdentical($res, true);
+		$this->assertEqual($rel->relationship, 'test_self2');
+
+		$num_rows = update_data("
+			UPDATE {$this->prefix}entity_relationships
+			SET relationship = 'test_self3'
+			WHERE id = {$rel->id}
+		", [], true);
+		$rel = get_relationship($rel->id);
+
+		$this->assertIdentical($num_rows, 1);
+		$this->assertEqual($rel->relationship, 'test_self3');
+
+		$num_rows = update_data("
+			UPDATE {$this->prefix}entity_relationships
+			SET relationship = :rel
+			WHERE id = :id
+		", [
+			':rel' => 'test_self4',
+			':id' => $rel->id,
+		], true);
+		$rel = get_relationship($rel->id);
+
+		$this->assertIdentical($num_rows, 1);
+		$this->assertEqual($rel->relationship, 'test_self4');
+
+		$rel->delete();
+	}
+
+	public function testCanDelete() {
+		$new_rel = function () {
+			add_entity_relationship($this->user->guid, 'test_self1', $this->user->guid);
+			return check_entity_relationship($this->user->guid, 'test_self1', $this->user->guid);
+		};
+
+		$rel = $new_rel();
+		$res = delete_data("
+			DELETE FROM {$this->prefix}entity_relationships
+			WHERE id = {$rel->id}
+		");
+		$this->assertIdentical($res, 1);
+		$this->assertFalse(check_entity_relationship($this->user->guid, 'test_self1', $this->user->guid));
+
+		$rel = $new_rel();
+		$res = delete_data("
+			DELETE FROM {$this->prefix}entity_relationships
+			WHERE id = :id
+		", [
+			':id' => $rel->id,
+		]);
+		$this->assertIdentical($res, 1);
+		$this->assertFalse(check_entity_relationship($this->user->guid, 'test_self1', $this->user->guid));
+	}
+
+	public function testCanSanitize() {
+		$data = [
+			"'" => "\\'",
+			"\"" => "\\\"",
+			"\\" => "\\\\",
+			"\n" => "\\n",
+			"\r" => "\\r",
+		];
+		foreach ($data as $in => $out) {
+			$this->assertIdentical($out, sanitize_string($in));
+		}
+	}
+
+	/**
+	 * @expectedException \DatabaseException
+	 * @expectedExceptionMessage Elgg\Database::sanitizeString() and serialize_string() cannot accept arrays.
+	 */
+	public function testSanitizeRejectsArrays() {
+		sanitise_string(['foo']);
+	}
+
+	public function testCanDelayQuery() {
+		$sql = "
+			SELECT *
+			FROM {$this->prefix}users_entity
+			WHERE username = :username
+		";
+		$params = [
+			':username' => $this->user->username,
+		];
+
+		// capture what's passed to callback
+		$captured = null;
+		$callback = function ($stmt) use (&$captured) {
+			$captured = $stmt;
+			return $stmt;
+		};
+		execute_delayed_read_query($sql, $callback, $params);
+
+		_elgg_services()->db->executeDelayedQueries();
+
+		/* @var \Doctrine\DBAL\Driver\Statement $captured */
+
+		$this->assertIsA($captured, \Doctrine\DBAL\Driver\Statement::class);
+
+		$rows = $captured->fetchAll(\PDO::FETCH_OBJ);
+		$this->assertEqual($rows[0]->username, $this->user->username);
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggEntityPreloaderIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggEntityPreloaderIntegrationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Elgg\Integration;
+
+/**
+ * @group IntegrationTests
+ */
+class ElggEntityPreloaderIntegrationTest extends \Elgg\LegacyIntegrationTestCase {
+
+	protected $realPreloader;
+
+	/**
+	 * @var MockEntityPreloader20140623
+	 */
+	protected $mockPreloader;
+
+	public function up() {
+		$this->realPreloader = _elgg_services()->entityPreloader;
+
+		$this->mockPreloader = new MockEntityPreloader20140623(
+			_elgg_services()->entityCache, _elgg_services()->entityTable);
+
+		_elgg_services()->setValue('entityPreloader', $this->mockPreloader);
+	}
+
+	public function down() {
+		_elgg_services()->setValue('entityPreloader', $this->realPreloader);
+	}
+
+	public function testEGECanUsePreloader() {
+		$options = [
+			'limit' => 3,
+		];
+
+		elgg_get_entities($options);
+		$this->assertNull($this->mockPreloader->preloaded);
+
+		$options['preload_owners'] = true;
+		elgg_get_entities($options);
+		$this->assertEqual(3, count($this->mockPreloader->preloaded));
+	}
+
+	public function testEGMCanUsePreloader() {
+		$options = [
+			'limit' => 3,
+		];
+
+		elgg_get_metadata($options);
+		$this->assertNull($this->mockPreloader->preloaded);
+
+		$options['preload_owners'] = true;
+		elgg_get_metadata($options);
+		$this->assertEqual(3, count($this->mockPreloader->preloaded));
+	}
+}
+
+class MockEntityPreloader20140623 extends \Elgg\EntityPreloader {
+	public $preloaded;
+
+	public function preload($objects, array $guid_properties) {
+		$this->preloaded = $objects;
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggHtmLawedTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggHtmLawedTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\LegacyIntegrationTestCase;
+
+class ElggHtmLawedTest extends LegacyIntegrationTestCase {
+
+	protected $configHooks = [];
+	protected $styleHooks = [];
+
+	// 'schemes' => '*:http,https,ftp,news,mailto,rtsp,teamspeak,gopher,mms,callto',
+	protected $validSchemes = [
+		'http',
+		'https',
+		'ftp',
+		'news',
+		'mailto',
+		'rtsp',
+		'teamspeak',
+		'gopher',
+		'mms',
+		'callto'
+	];
+
+	protected $validStyles = [
+		'color',
+		'cursor',
+		'text-align',
+		'vertical-align',
+		'font-size',
+		'font-weight',
+		'font-style',
+		'border',
+		'border-top',
+		'background-color',
+		'border-bottom',
+		'border-left',
+		'border-right',
+		'margin',
+		'margin-top',
+		'margin-bottom',
+		'margin-left',
+		'margin-right',
+		'padding',
+		'float',
+		'text-decoration'
+	];
+
+	public function up() {
+
+	}
+
+	public function down() {
+
+	}
+
+	/**
+	 * Test anchor tags as input
+	 */
+	public function testHtmlawedFilterTagsAnchorsInput() {
+		$tests = [];
+
+		// these should all work
+		foreach ($this->validSchemes as $scheme) {
+			$input = "<a href=\"$scheme://test\">Test</a>";
+			$tests[$input] = "<a href=\"$scheme://test\">Test</a>";
+		}
+
+		$bad_schemes = [
+			'javascript',
+			'itmss',
+			'magnet'
+		];
+
+		// these should be denied
+		foreach ($bad_schemes as $scheme) {
+			$input = "<a href=\"$scheme://test\">Test</a>";
+			$tests[$input] = "<a href=\"denied:$scheme://test\">Test</a>";
+		}
+
+		// set context to input to avoid adding nofollow
+		elgg_push_context('input');
+
+		foreach ($tests as $input => $expected) {
+			$result = _elgg_htmlawed_filter_tags(null, null, $input);
+			$this->assertEqual($expected, $result);
+		}
+
+		$weird_schemes = [
+			'<a href="http://javascript:alert">Test</a>' => '<a href="http://javascript:alert">Test</a>',
+			'<a href="javascript:https://">Test</a>' => '<a href="denied:javascript:https://">Test</a>',
+			'<a href="ftp:\/\/">Test</a>' => '<a href="ftp:\/\/">Test</a>',
+		];
+
+		foreach ($weird_schemes as $input => $expected) {
+			$result = _elgg_htmlawed_filter_tags(null, null, $input);
+			$this->assertEqual($expected, $result);
+		}
+
+		elgg_pop_context();
+	}
+
+	/**
+	 * Test anchor tags as output (adds nofollow)
+	 */
+	public function testHtmlawedFilterTagsAnchorsOutput() {
+		$tests = [];
+
+		foreach ($this->validSchemes as $scheme) {
+			$input = "<a href=\"$scheme://test\">Test</a>";
+			$tests[$input] = "<a rel=\"nofollow\" href=\"$scheme://test\">Test</a>";
+		}
+
+		foreach ($tests as $input => $expected) {
+			$result = _elgg_htmlawed_filter_tags(null, null, $input);
+			$this->assertEqual($expected, $result);
+		}
+	}
+
+	/**
+	 * Test styles attribute
+	 */
+	public function testHtmlawedFilterTagsStyles() {
+		$tests = [];
+
+		// valid
+		foreach ($this->validStyles as $style) {
+			$input = "<div style=\"{$style}: inherit;\">Test</div>";
+			$tests[$input] = $input;
+		}
+
+		// valid without trailing ;
+		foreach ($this->validStyles as $style) {
+			$input = "<div style=\"{$style}: inherit\">Test</div>";
+			$tests[$input] = "<div style=\"{$style}: inherit;\">Test</div>";
+		}
+
+		// invalid
+		$bad_styles = [
+			'height',
+			'width',
+			'z-index'
+		];
+
+		foreach ($bad_styles as $style) {
+			$input = "<div style=\"{$style}: inherit;\">Test</div>";
+			$tests[$input] = "<div>Test</div>";
+		}
+
+		// combine valid with invalid, should only get valid
+		foreach ($this->validStyles as $style) {
+			$input = "<div style=\"{$style}: inherit; height: 15px;\">Test</div>";
+			$tests[$input] = "<div style=\"{$style}: inherit;\">Test</div>";
+		}
+
+		foreach ($tests as $input => $expected) {
+			$result = _elgg_htmlawed_filter_tags(null, null, $input);
+			$this->assertEqual($expected, $result);
+		}
+	}
+
+	/**
+	 * Test other tags and attributes
+	 */
+	public function testHtmlawedFilterTags() {
+		// test input => expected
+		$tests = [
+			// duplicate closing tags, #311
+			'<ul><li>item</li></ul>' => '<ul><li>item</li></ul>',
+
+			// 'deny_attribute' => 'class, on*',
+			'<div class="elgg-inner">Test</div>' => '<div>Test</div>',
+			'<button onclick="javascript:alert(\'test\')">Test</button>' => '<button>Test</button>',
+
+			// naked span stripping
+			// https://github.com/vanilla/htmlawed/commit/995ef0ae4865d817a391ac62978f9d0e41d8a18b
+			'<span>Test</span>' => 'Test',
+			'<span id="test">Test</span>' => '<span id="test">Test</span>',
+		];
+
+		// test elements filtered by "safe" option
+		// http://www.bioinformatics.org/phplabware/internal_utilities/htmLawed/htmLawed_README.htm#s3.3
+		$unsafe = [
+			'applet',
+			'embed',
+			'iframe',
+			'object',
+			'script'
+		];
+
+		foreach ($unsafe as $tag) {
+			$input = "<$tag>Test</$tag>";
+			$tests[$input] = 'Test';
+		}
+
+		foreach ($tests as $input => $expected) {
+			$result = _elgg_htmlawed_filter_tags(null, null, $input);
+			$this->assertEqual($expected, $result);
+		}
+	}
+
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggRelationshipTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggRelationshipTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Elgg\Integration;
+
+use Elgg\LegacyIntegrationTestCase;
+use ElggEntity;
+use ElggObject;
+
+/**
+ * @group IntegrationTests
+ */
+class ElggRelationshipTest extends LegacyIntegrationTestCase {
+
+	/**
+	 * @var ElggEntity
+	 */
+	protected $entity1;
+	protected $entity2;
+	protected $entity3;
+
+	public function up() {
+		_elgg_services()->hooks->getEvents()->backup();
+
+		$this->entity1 = new ElggObject();
+		$this->entity1->subtype = 'elgg_relationship_test';
+		$this->entity1->access_id = ACCESS_PUBLIC;
+		$this->entity1->save();
+
+		$this->entity2 = new ElggObject();
+		$this->entity2->subtype = 'elgg_relationship_test';
+		$this->entity2->access_id = ACCESS_PUBLIC;
+		$this->entity2->save();
+
+		$this->entity3 = new ElggObject();
+		$this->entity3->subtype = 'elgg_relationship_test';
+		$this->entity3->access_id = ACCESS_PUBLIC;
+		$this->entity3->save();
+	}
+
+	public function down() {
+		if ($this->entity1) {
+			$this->entity1->delete();
+		}
+
+		if ($this->entity2) {
+			$this->entity2->delete();
+		}
+
+		if ($this->entity3) {
+			$this->entity3->delete();
+		}
+		remove_subtype('object', 'elgg_relationship_test');
+
+		_elgg_services()->hooks->getEvents()->restore();
+	}
+
+	/**
+	 * Tests
+	 */
+	public function testAddRelationship() {
+		// test adding a relationship
+		$this->assertTrue(add_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+
+		$r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+	}
+
+	public function testRemoveRelationship() {
+		// test adding a relationship
+		$this->assertTrue(add_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+
+		$r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+
+		$this->assertTrue(remove_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+
+		$this->assertFalse(check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+	}
+
+	public function testPreventAddRelationship() {
+		// test event handler - should prevent the addition of a relationship
+		elgg_register_event_handler('create', 'relationship', 'Elgg\Values::getFalse');
+
+		$this->assertFalse(add_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+
+		elgg_unregister_event_handler('create', 'relationship', 'Elgg\Values::getFalse');
+
+		$this->assertFalse(check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+	}
+
+	public function testPreventRemoveRelationship() {
+		$this->assertTrue(add_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+		$r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+
+		elgg_register_event_handler('delete', 'relationship', 'Elgg\Values::getFalse');
+
+		$this->assertFalse(remove_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+
+		elgg_unregister_event_handler('delete', 'relationship', 'Elgg\Values::getFalse');
+
+		$r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+	}
+
+	public function testRelationshipSave() {
+		$this->assertTrue(add_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+		$r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+		$old_id = $r->id;
+
+		// note - string because that's how it's returned when getting a new object
+		$r->guid_two = (string) $this->entity3->guid;
+		$new_id = $r->save();
+		$this->assertIsA($new_id, 'int');
+		$this->assertNotEqual($new_id, $old_id);
+
+		$test_r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity3->guid);
+		$this->assertIsA($test_r, 'ElggRelationship');
+		$this->assertIdentical($r->guid_one, $test_r->guid_one);
+		$this->assertIdentical($r->guid_two, $test_r->guid_two);
+		$this->assertIdentical($r->relationship, $test_r->relationship);
+
+		// the original shouldn't exist anymore
+		$this->assertFalse(check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+	}
+
+	public function testRelationshipDelete() {
+		$this->assertTrue(add_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+		$r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+
+		$this->assertTrue($r->delete());
+		$this->assertFalse(check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+	}
+
+	public function testRelationshipOnEntityDelete() {
+		$this->assertTrue(add_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+
+		// test deleting entity in guid_one position
+		$this->entity1->delete();
+		$this->assertFalse(check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+
+		$this->assertTrue(add_entity_relationship($this->entity2->guid, 'test_relationship', $this->entity3->guid));
+
+		// test deleting entity in guid_two position
+		$this->entity3->delete();
+		$this->assertFalse(check_entity_relationship($this->entity2->guid, 'test_relationship', $this->entity3->guid));
+	}
+
+	public function testPreventRelationshipOnEntityDelete() {
+		$this->assertTrue(add_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+		$this->assertTrue(add_entity_relationship($this->entity2->guid, 'test_relationship', $this->entity1->guid));
+		$guid = $this->entity1->guid;
+
+		elgg_register_event_handler('delete', 'relationship', 'Elgg\Values::getFalse');
+
+		$this->assertTrue($this->entity1->delete());
+
+		elgg_unregister_event_handler('delete', 'relationship', 'Elgg\Values::getFalse');
+
+		// relationships should still be gone as there is no entity
+		// despite the fact we have a handler trying to prevent it
+		$this->assertFalse(check_entity_relationship($guid, 'test_relationship', $this->entity2->guid));
+		$this->assertFalse(check_entity_relationship($this->entity2->guid, 'test_relationship', $guid));
+	}
+
+	public function testEntityMethodAddRelationship() {
+		$this->assertTrue($this->entity1->addRelationship($this->entity2->guid, 'test_relationship'));
+		$r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+	}
+
+	public function testEntityMethodRemoveRelationship() {
+		$this->assertTrue($this->entity1->addRelationship($this->entity2->guid, 'test_relationship'));
+		$r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+
+		$this->assertTrue($this->entity1->removeRelationship($this->entity2->guid, 'test_relationship'));
+		$this->assertFalse(check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+	}
+
+	public function testEntityMethodDeleteRelationships() {
+		$this->assertTrue($this->entity1->addRelationship($this->entity2->guid, 'test_relationship'));
+		$r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+
+		$this->assertTrue($this->entity1->addRelationship($this->entity3->guid, 'test_relationship'));
+		$r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity3->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+
+		$this->assertTrue($this->entity3->addRelationship($this->entity1->guid, 'test_relationship'));
+		$r = check_entity_relationship($this->entity3->guid, 'test_relationship', $this->entity1->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+
+		$this->assertTrue($this->entity1->deleteRelationships('test_relationship'));
+		$this->assertFalse(check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+		$this->assertFalse(check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity3->guid));
+
+		// inverse relationships should be gone too
+		$this->assertFalse(check_entity_relationship($this->entity3->guid, 'test_relationship', $this->entity1->guid));
+
+
+		// Repeat above test, but with no relationship - should remove all relationships
+		$this->assertTrue($this->entity1->addRelationship($this->entity2->guid, 'test_relationship'));
+		$r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+
+		$this->assertTrue($this->entity1->addRelationship($this->entity3->guid, 'test_relationship'));
+		$r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity3->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+
+		$this->assertTrue($this->entity3->addRelationship($this->entity1->guid, 'test_relationship'));
+		$r = check_entity_relationship($this->entity3->guid, 'test_relationship', $this->entity1->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+
+		$this->assertTrue($this->entity1->addRelationship($this->entity2->guid, 'test_relationship2'));
+		$r = check_entity_relationship($this->entity1->guid, 'test_relationship2', $this->entity2->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+
+		$this->assertTrue($this->entity1->addRelationship($this->entity3->guid, 'test_relationship2'));
+		$r = check_entity_relationship($this->entity1->guid, 'test_relationship2', $this->entity3->guid);
+		$this->assertIsA($r, 'ElggRelationship');
+
+		$this->assertTrue($this->entity1->deleteRelationships());
+		$this->assertFalse(check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+		$this->assertFalse(check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity3->guid));
+		$this->assertFalse(check_entity_relationship($this->entity1->guid, 'test_relationship2', $this->entity2->guid));
+		$this->assertFalse(check_entity_relationship($this->entity1->guid, 'test_relationship2', $this->entity3->guid));
+
+		// inverse relationships should be gone too
+		$this->assertFalse(check_entity_relationship($this->entity3->guid, 'test_relationship', $this->entity1->guid));
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggTravisInstallTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggTravisInstallTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Elgg\Integration;
+
+class ElggTravisInstallTest extends \Elgg\LegacyIntegrationTestCase {
+
+	public function up() {
+		if (!getenv('TRAVIS')) {
+			$this->skipIf(true, "Not Travis VM");
+		}
+	}
+
+	public function down() {
+
+	}
+
+	public function testDbWasInstalled() {
+		$this->assertNotNull(_elgg_services()->configTable->get('installed'));
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/IntegrationTestCaseIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/IntegrationTestCaseIntegrationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Elgg;
+
+/**
+ * @group IntegrationTests
+ */
+class IntegrationTestCaseIntegrationTest extends IntegrationTestCase {
+
+	/**
+	 * @var \ElggObject
+	 */
+	private $entity;
+
+	public function up() {
+		$this->entity = $this->createObject([
+			'access_id' => ACCESS_PUBLIC,
+		]);
+	}
+
+	public function down() {
+		$ia = elgg_set_ignore_access();
+		$this->entity->delete();
+		elgg_set_ignore_access($ia);
+	}
+
+	public function testCanLoadSeededEntity() {
+		$count = elgg_get_entities([
+			'guids' => $this->entity->guid,
+			'count' => true,
+		]);
+
+		$this->assertTrue($count === 1);
+	}
+
+}

--- a/engine/tests/phpunit/unit/Elgg/ActionsServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/ActionsServiceUnitTest.php
@@ -1134,7 +1134,9 @@ class ActionsServiceUnitTest extends \Elgg\UnitTestCase {
 		]);
 		set_input('session_token', $session_token);
 
+		_elgg_services()->logger->disable();
 		$this->route();
+		_elgg_services()->logger->enable();
 
 		$response = _elgg_services()->responseFactory->getSentResponse();
 		$this->assertInstanceOf(Response::class, $response);

--- a/engine/tests/simpletest/ElggCoreAttributeLoaderTest.php
+++ b/engine/tests/simpletest/ElggCoreAttributeLoaderTest.php
@@ -1,4 +1,5 @@
 <?php
+use Elgg\Config;
 
 /**
  * Test attribute loader for entities
@@ -6,11 +7,30 @@
 class ElggCoreAttributeLoaderTest extends \ElggCoreUnitTest {
 
 	public function up() {
+		$types = Config::getEntityTypes();
+
+		foreach ($types as $type) {
+			switch ($type) {
+				case 'group' :
+					$this->entities[] = $this->createGroup();
+					break;
+
+				case 'user' :
+					$this->entities[] = $this->createUser();
+					break;
+
+				case 'object' :
+					$this->entities[] = $this->createObject();
+					break;
+			}
+		}
 
 	}
 
 	public function down() {
-
+		foreach ($this->entities as $entity) {
+			$entity->delete();
+		}
 	}
 
 	/**
@@ -20,27 +40,18 @@ class ElggCoreAttributeLoaderTest extends \ElggCoreUnitTest {
 	 */
 	public function testSqlAdditionalSelectsAsVolatileData() {
 
-		// remove ignore access as it disables entity cache
-		$access = elgg_set_ignore_access(false);
+		$types = Config::getEntityTypes();
 
-		// may not have groups in DB but guaranteed to have user, object, site
-		$group = new \ElggGroup();
-		$group->name = 'test_group';
-		$group->access_id = ACCESS_PUBLIC;
-		$this->assertTrue($group->save() !== false);
+		foreach ($types as $type) {
 
-		foreach ([
-					 'site',
-					 'user',
-					 'group',
-					 'object'
-				 ] as $type) {
 			$entities = elgg_get_entities([
 				'type' => $type,
 				'selects' => ['42 as added_col2'],
 				'limit' => 1,
 			]);
+
 			$this->assertFalse(empty($entities));
+
 			if ($entities) {
 				$entity = array_shift($entities);
 				$this->assertTrue($entity instanceof \ElggEntity);
@@ -49,9 +60,6 @@ class ElggCoreAttributeLoaderTest extends \ElggCoreUnitTest {
 			}
 		}
 
-		elgg_set_ignore_access($access);
-
-		$group->delete();
 	}
 
 	/**
@@ -61,27 +69,18 @@ class ElggCoreAttributeLoaderTest extends \ElggCoreUnitTest {
 	 */
 	public function testSqlAdditionalSelectsAsVolatileDataWithCache() {
 
-		// remove ignore access as it disables entity cache
-		$access = elgg_set_ignore_access(false);
+		$types = Config::getEntityTypes();
 
-		// may not have groups in DB - let's create one
-		$group = new \ElggGroup();
-		$group->name = 'test_group';
-		$group->access_id = ACCESS_PUBLIC;
-		$this->assertTrue($group->save() !== false);
+		foreach ($types as $type) {
 
-		foreach ([
-					 'site',
-					 'user',
-					 'group',
-					 'object'
-				 ] as $type) {
 			$entities = elgg_get_entities([
 				'type' => $type,
 				'selects' => ['42 as added_col3'],
 				'limit' => 1,
 			]);
+
 			$this->assertFalse(empty($entities));
+
 			if ($entities) {
 				$entity = array_shift($entities);
 				$this->assertTrue($entity instanceof \ElggEntity);
@@ -94,18 +93,15 @@ class ElggCoreAttributeLoaderTest extends \ElggCoreUnitTest {
 		}
 
 		// run these again but with different value to make sure cache does not interfere
-		foreach ([
-					 'site',
-					 'user',
-					 'group',
-					 'object'
-				 ] as $type) {
+		foreach ($types as $type) {
 			$entities = elgg_get_entities([
 				'type' => $type,
 				'selects' => ['64 as added_col3'],
 				'limit' => 1,
 			]);
+
 			$this->assertFalse(empty($entities));
+
 			if ($entities) {
 				$entity = array_shift($entities);
 				$this->assertTrue($entity instanceof \ElggEntity);
@@ -113,10 +109,6 @@ class ElggCoreAttributeLoaderTest extends \ElggCoreUnitTest {
 				$this->assertEqual($entity->getVolatileData('select:added_col3'), 64, "Failed to overwrite volatile data in cached entity");
 			}
 		}
-
-		elgg_set_ignore_access($access);
-
-		$group->delete();
 	}
 
 }

--- a/engine/tests/simpletest/ElggCoreFilestoreTest.php
+++ b/engine/tests/simpletest/ElggCoreFilestoreTest.php
@@ -19,7 +19,7 @@ class ElggCoreFilestoreTest extends \ElggCoreUnitTest {
 		$CONFIG = _elgg_config();
 		
 		// create a user to own the file
-		$user = $this->createTestUser();
+		$user = $this->createUser();
 		$dir = new \Elgg\EntityDirLocator($user->guid);
 		
 		// setup a test file
@@ -45,10 +45,10 @@ class ElggCoreFilestoreTest extends \ElggCoreUnitTest {
 	function testElggFileDelete() {
 		$CONFIG = _elgg_config();
 		
-		$user = $this->createTestUser();
+		$user = $this->createUser();
 		$filestore = $this->filestore;
 		$dir = new \Elgg\EntityDirLocator($user->guid);
-		
+
 		$file = new \ElggFile();
 		$file->owner_guid = $user->guid;
 		$file->setFilename('testing/ElggFileDelete');
@@ -65,20 +65,5 @@ class ElggCoreFilestoreTest extends \ElggCoreUnitTest {
 		$this->assertTrue($file->delete());
 		$this->assertFalse(file_exists($filepath));
 		$user->delete();
-	}
-
-	protected function createTestUser($username = 'fileTest') {
-		// in case a test failure left the user
-		$user = get_user_by_username($username);
-		if ($user) {
-			return $user;
-		}
-
-		$user = new \ElggUser();
-		$user->username = $username;
-		$guid = $user->save();
-		
-		// load user to have access to creation time
-		return get_entity($guid);
 	}
 }

--- a/engine/tests/simpletest/ElggCoreGetEntitiesBaseTest.php
+++ b/engine/tests/simpletest/ElggCoreGetEntitiesBaseTest.php
@@ -49,9 +49,9 @@ abstract class ElggCoreGetEntitiesBaseTest extends \ElggCoreUnitTest {
 		// 5 with random subtypes
 		for ($i = 0; $i < 5; $i++) {
 			$subtype = 'test_object_subtype_' . rand();
-			$e = new \ElggObject();
-			$e->subtype = $subtype;
-			$e->save();
+			$e = $this->createObject([
+				'subtype' => $subtype,
+			]);
 
 			$this->entities[] = $e;
 			$this->subtypes['object'][] = $subtype;
@@ -60,10 +60,9 @@ abstract class ElggCoreGetEntitiesBaseTest extends \ElggCoreUnitTest {
 		// and users
 		for ($i = 0; $i < 5; $i++) {
 			$subtype = "test_user_subtype_" . rand();
-			$e = new \ElggUser();
-			$e->username = "test_user_" . rand();
-			$e->subtype = $subtype;
-			$e->save();
+			$e = $this->createUser([
+				'subtype' => $subtype,
+			]);
 
 			$this->entities[] = $e;
 			$this->subtypes['user'][] = $subtype;
@@ -72,9 +71,9 @@ abstract class ElggCoreGetEntitiesBaseTest extends \ElggCoreUnitTest {
 		// and groups
 		for ($i = 0; $i < 5; $i++) {
 			$subtype = "test_group_subtype_" . rand();
-			$e = new \ElggGroup();
-			$e->subtype = $subtype;
-			$e->save();
+			$e = $this->createGroup([
+				'subtype' => $subtype,
+			]);
 
 			$this->entities[] = $e;
 			$this->subtypes['group'][] = $subtype;

--- a/engine/tests/simpletest/ElggCoreGroupTest.php
+++ b/engine/tests/simpletest/ElggCoreGroupTest.php
@@ -17,13 +17,8 @@ class ElggCoreGroupTest extends \ElggCoreUnitTest {
 	protected $user;
 
 	public function up() {
-		$this->group = new \ElggGroup();
-		$this->group->membership = ACCESS_PUBLIC;
-		$this->group->access_id = ACCESS_PUBLIC;
-		$this->group->save();
-		$this->user = new \ElggUser();
-		$this->user->username = 'test_user_' . rand();
-		$this->user->save();
+		$this->group = $this->createGroup([], ['membership' => ACCESS_PUBLIC]);
+		$this->user = $this->createUser();
 	}
 
 	public function down() {

--- a/engine/tests/simpletest/ElggCoreMetadataAPITest.php
+++ b/engine/tests/simpletest/ElggCoreMetadataAPITest.php
@@ -110,19 +110,19 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 	// by another user
 	// https://github.com/elgg/elgg/issues/2776
 	public function test_elgg_metadata_multiple_values() {
-		$u1 = new \ElggUser();
-		$u1->username = rand();
-		$u1->save();
+		$u1 = $this->createUser();
 
-		$u2 = new \ElggUser();
-		$u2->username = rand();
-		$u2->save();
+		$u2 = $this->createUser();
 
-		$obj = new \ElggObject();
-		$obj->owner_guid = $u1->guid;
-		$obj->container_guid = $u1->guid;
-		$obj->access_id = ACCESS_PUBLIC;
-		$obj->save();
+		$obj = $this->createObject([
+			'owner_guid' => $u1->guid,
+			'container_guid' => $u1->guid,
+		]);
+
+		elgg_delete_metadata([
+			'limit' => 0,
+			'guids' => $obj->guid,
+		]);
 
 		$md_values = array(
 			'one',

--- a/engine/tests/simpletest/ElggCoreMetastringsTest.php
+++ b/engine/tests/simpletest/ElggCoreMetastringsTest.php
@@ -22,13 +22,13 @@ class ElggCoreMetastringsTest extends \ElggCoreUnitTest {
 	}
 
 	public function down() {
-		$this->object->delete();
-
+		$ha = access_get_show_hidden_status();
 		access_show_hidden_entities(true);
 		elgg_delete_annotations([
 			'guid' => $this->object->guid,
 		]);
-		access_show_hidden_entities(false);
+		$this->object->delete();
+		access_show_hidden_entities($ha);
 	}
 
 	public function createAnnotations($max = 1) {

--- a/engine/tests/simpletest/ElggCoreObjectTest.php
+++ b/engine/tests/simpletest/ElggCoreObjectTest.php
@@ -39,9 +39,9 @@ class ElggCoreObjectTest extends \ElggCoreUnitTest {
 
 	public function testElggObjectSave() {
 		// new object
-		$this->AssertEqual($this->entity->getGUID(), 0);
+		$this->assertEqual($this->entity->getGUID(), 0);
 		$guid = $this->entity->save();
-		$this->AssertNotEqual($guid, 0);
+		$this->assertNotEqual($guid, 0);
 
 		$entity_row = $this->get_entity_row($guid);
 		$this->assertIsA($entity_row, '\stdClass');
@@ -180,20 +180,31 @@ class ElggCoreObjectTest extends \ElggCoreUnitTest {
 	}
 
 	public function testElggRecursiveDelete() {
-		$types = array('\ElggGroup', '\ElggObject', '\ElggUser');
+		$types = array('group', 'object', 'user');
 		$db_prefix = _elgg_config()->dbprefix;
 
 		foreach ($types as $type) {
-			$parent = new $type();
-			$this->assertTrue($parent->save());
-			
-			$child = new \ElggObject();
-			$child->container_guid = $parent->guid;
-			$this->assertTrue($child->save());
+			switch ($type) {
+				case 'group' :
+					$parent = $this->createGroup();
+					break;
 
-			$grandchild = new \ElggObject();
-			$grandchild->container_guid = $child->guid;
-			$this->assertTrue($grandchild->save());
+				case 'user' :
+					$parent = $this->createUser();
+					break;
+
+				case 'object' :
+					$parent = $this->createObject();
+					break;
+			}
+			
+			$child = $this->createObject([
+				'container_guid' => $parent->guid,
+			]);
+
+			$grandchild = $this->createObject([
+				'container_guid' => $child->guid,
+			]);
 
 			$this->assertTrue($parent->delete(true));
 

--- a/engine/tests/simpletest/ElggCoreUserTest.php
+++ b/engine/tests/simpletest/ElggCoreUserTest.php
@@ -9,6 +9,7 @@ class ElggCoreUserTest extends \ElggCoreUnitTest {
 
 	public function up() {
 		$this->user = new \ElggUserWithExposableAttributes();
+		$this->user->username = $this->getRandomUsername();
 	}
 
 	public function down() {
@@ -40,7 +41,8 @@ class ElggCoreUserTest extends \ElggCoreUnitTest {
 		$attributes['prev_last_login'] = null;
 		ksort($attributes);
 
-		$entity_attributes = $this->user->expose_attributes();
+		$user = new \ElggUserWithExposableAttributes();
+		$entity_attributes = $user->expose_attributes();
 		ksort($entity_attributes);
 
 		$this->assertIdentical($entity_attributes, $attributes);
@@ -49,9 +51,9 @@ class ElggCoreUserTest extends \ElggCoreUnitTest {
 	public function testElggUserLoad() {
 		// new object
 		$object = new \ElggObject();
-		$this->AssertEqual($object->getGUID(), 0);
+		$this->assertEqual($object->getGUID(), 0);
 		$guid = $object->save();
-		$this->AssertNotEqual($guid, 0);
+		$this->assertNotEqual($guid, 0);
 
 		// fail on wrong type
 		$this->assertFalse(get_user($guid));
@@ -62,9 +64,9 @@ class ElggCoreUserTest extends \ElggCoreUnitTest {
 
 	public function testElggUserSave() {
 		// new object
-		$this->AssertEqual($this->user->getGUID(), 0);
+		$this->assertEqual($this->user->getGUID(), 0);
 		$guid = $this->user->save();
-		$this->AssertNotEqual($guid, 0);
+		$this->assertNotEqual($guid, 0);
 
 		// clean up
 		$this->user->delete();

--- a/engine/tests/simpletest/ElggEntityTest.php
+++ b/engine/tests/simpletest/ElggEntityTest.php
@@ -407,8 +407,7 @@ class ElggCoreEntityTest extends \ElggCoreUnitTest {
 	}
 
 	public function testCreateWithContainerGuidEqualsZero() {
-		$user = new \ElggUser();
-		$user->save();
+		$user = $this->createUser();
 
 		$object = new \ElggObject();
 		$object->owner_guid = $user->guid;
@@ -429,8 +428,7 @@ class ElggCoreEntityTest extends \ElggCoreUnitTest {
 
 		$this->assertTrue($this->entity->save());
 
-		$user = new ElggUser();
-		$user->save();
+		$user = $this->createUser();
 		$old_user = $this->replaceSession($user);
 
 		// even owner can't bypass permissions
@@ -521,6 +519,7 @@ class ElggCoreEntityTest extends \ElggCoreUnitTest {
 	public function testNewUserLoadedFromCacheDuringSaveOperations() {
 
 		$user = new \ElggUser();
+		$user->username = $this->getRandomUsername();
 
 		// Add temporary metadata, annotation and private settings
 		// to extend the scope of tests and catch issues with save operations


### PR DESCRIPTION
Updates testing bootstrap with lessons learnt in terms of dev usability
running all the suites manually and debugging issues.

Duplicates all simpletest cases in PHPUnit integration suite.

Fixes several issues that were overlooked in tests.