### PR TITLE
feat(services): decouple session from other services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /mod/*
 /composer.phar
 /cache
+/system_cache
 
 # don't ignore example settings
 !/elgg-config/settings.example.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ branches:
     - 1.8
 
 matrix:
+  allow_failures:
+    - env: JOB_NAME=simpletests VARIA=true
+
   fast_finish: true
 
   include:
@@ -75,7 +78,6 @@ matrix:
        - php ./elgg-cli database:seed --limit=5 -vv
       script:
        - php -f ./.scripts/is_memcached_enabled.php
-       - php ./elgg-cli simpletest -p all
        - ./vendor/bin/phpunit
       after_script:
        - php ./elgg-cli database:unseed -vv
@@ -101,12 +103,23 @@ matrix:
         - sleep 3 # give Web server some time to bind to sockets, etc
       script:
         - curl -o - http://localhost:8888/ | grep "<title>Elgg Travis Site</title>"
-        - php ./elgg-cli simpletest -p all
         - ./vendor/bin/phpunit
       after_script:
         - php ./elgg-cli database:unseed -vv
 
     # HHVM not officially supported https://github.com/Elgg/Elgg/issues/11185
+
+    # Legacy simpletests
+    - php: 5.6
+      services:
+        - mysql
+      env: JOB_NAME=simpletests VARIA=true
+      before_install:
+        - phpenv config-rm xdebug.ini
+        - composer config -g github-oauth.github.com ${GITHUB_TOKEN}
+      install:
+        - composer travis:install-with-mysql
+        - php ./elgg-cli simpletest -p all
 
 services:
   - mysql
@@ -116,17 +129,20 @@ before_install:
   - composer config -g github-oauth.github.com ${GITHUB_TOKEN}
 
 install:
+  # make sure index works and sends us to installation page
+  - composer travis:install
   - bash .scripts/travis/check_commit_msgs.sh
+  - php -S localhost:8888 index.php &
+  - sleep 3 # give Web server some time to bind to sockets, etc
+  #- curl -o - http://localhost:8888/ | grep "<title>Elgg Install&#58; Welcome</title>"
+
   - composer travis:install-with-mysql
   - composer lint
   - php -f ./.scripts/travis/enable_plugins.php
   - php ./elgg-cli database:seed --limit=5 -vv
-  - php -S localhost:8888 index.php &
-  - sleep 3 # give Web server some time to bind to sockets, etc
 
 script:
   - curl -o - http://localhost:8888/ | grep "<title>Elgg Travis Site</title>"
-  - php ./elgg-cli simpletest -p all -v
   # in this build, we want to make sure the test suites can bootstrap on their own
   # combined test runner is executed in e2e builds
   - ./vendor/bin/phpunit --testsuite unit

--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -156,6 +156,12 @@ All the functions in ``engine/lib/deprecated-1.10.php`` were removed. See https:
  * ``profile_pagesetup``
  * ``groups_setup_sidebar_menus``
  * ``groups_set_icon_url``
+ * ``ban_user``: Use ``ElggUser::ban()``
+ * ``unban_user``: Use ``ElggUser::unban()``
+ * ``make_user_admin``: Use ``ElggUser::makeAdmin()``
+ * ``remove_user_admin``: Use ``ElggUser::removeAdmin()``
+ * ``set_last_login``: Use ``ElggUser::setLastLogin()``
+ * ``set_last_action``: Use ``ElggUser::updateLastAction()``
 
 Removed global vars
 -------------------

--- a/engine/classes/Elgg/ActionsService.php
+++ b/engine/classes/Elgg/ActionsService.php
@@ -18,22 +18,17 @@ use ElggSession;
  */
 class ActionsService {
 
-	use \Elgg\TimeUsing;
-	
+	use TimeUsing;
+
 	/**
 	 * @var Config
 	 */
-	private $config;
-
-	/**
-	 * @var ElggSession
-	 */
-	private $session;
+	protected $config;
 
 	/**
 	 * @var ElggCrypto
 	 */
-	private $crypto;
+	protected $crypto;
 
 	/**
 	 * Registered actions storage
@@ -44,13 +39,13 @@ class ActionsService {
 	 *
 	 * @var array
 	 */
-	private $actions = [];
+	protected $actions = [];
 
 	/**
 	 * The current action being processed
 	 * @var string
 	 */
-	private $currentAction = null;
+	protected $currentAction = null;
 
 	/**
 	 * @var string[]
@@ -61,12 +56,10 @@ class ActionsService {
 	 * Constructor
 	 *
 	 * @param Config      $config  Config
-	 * @param ElggSession $session Session
 	 * @param ElggCrypto  $crypto  Crypto service
 	 */
-	public function __construct(Config $config, ElggSession $session, ElggCrypto $crypto) {
+	public function __construct(Config $config, ElggCrypto $crypto) {
 		$this->config = $config;
-		$this->session = $session;
 		$this->crypto = $crypto;
 	}
 
@@ -142,7 +135,7 @@ class ActionsService {
 			return $forward('actionundefined', ELGG_HTTP_NOT_IMPLEMENTED);
 		}
 
-		$user = $this->session->getLoggedInUser();
+		$user = elgg_get_session()->getLoggedInUser();
 
 		// access checks
 		switch ($this->actions[$action]['access']) {
@@ -241,7 +234,7 @@ class ActionsService {
 			$ts = get_input('__elgg_ts');
 		}
 
-		$session_id = $this->session->getId();
+		$session_id = elgg_get_session()->getId();
 
 		if (($token) && ($ts) && ($session_id)) {
 			if ($this->validateTokenOwnership($token, $ts)) {
@@ -486,11 +479,11 @@ class ActionsService {
 			'token' => [
 				'__elgg_ts' => $ts,
 				'__elgg_token' => $token,
-				'logged_in' => $this->session->isLoggedIn(),
+				'logged_in' => elgg_get_session()->isLoggedIn(),
 			],
 			'valid_tokens' => $valid_tokens,
-			'session_token' => $this->session->get('__elgg_session'),
-			'user_guid' => $this->session->getLoggedInUserGuid(),
+			'session_token' => elgg_get_session()->get('__elgg_session'),
+			'user_guid' => elgg_get_session()->getLoggedInUserGuid(),
 		];
 
 		elgg_set_http_header("Content-Type: application/json;charset=utf-8");

--- a/engine/classes/Elgg/BootService.php
+++ b/engine/classes/Elgg/BootService.php
@@ -137,7 +137,7 @@ class BootService {
 		// we always need site->email and user->icontime, so load them together
 		$user_guid = $services->session->getLoggedInUserGuid();
 		if ($user_guid) {
-			$services->metadataCache->populateFromEntities([$user_guid]);
+			$services->session->metadataCache->populateFromEntities([$user_guid]);
 		}
 
 		// invalidate on some actions just in case other invalidation triggers miss something

--- a/engine/classes/Elgg/Cache/MetadataCache.php
+++ b/engine/classes/Elgg/Cache/MetadataCache.php
@@ -19,25 +19,17 @@ class MetadataCache {
 	protected $values = [];
 
 	/**
-	 * @var \ElggSession
-	 */
-	protected $session;
-
-	/**
 	 * @var ElggSharedMemoryCache
 	 */
-	protected $cache;
+	protected $persisted_cache;
 
 	/**
 	 * Constructor
 	 *
 	 * @param ElggSharedMemoryCache $cache Cache
 	 */
-	public function __construct(ElggSharedMemoryCache $cache = null) {
-		if (!$cache) {
-			$cache = new NullCache();
-		}
-		$this->cache = $cache;
+	public function __construct(ElggSharedMemoryCache $cache) {
+		$this->persisted_cache = $cache;
 	}
 
 	/**
@@ -85,7 +77,7 @@ class MetadataCache {
 	 */
 	public function clear($entity_guid) {
 		unset($this->values[$entity_guid]);
-		$this->cache->delete($entity_guid);
+		$this->persisted_cache->delete($entity_guid);
 	}
 
 	/**
@@ -105,7 +97,7 @@ class MetadataCache {
 	 */
 	public function clearAll() {
 		foreach (array_keys($this->values) as $guid) {
-			$this->cache->delete($guid);
+			$this->persisted_cache->delete($guid);
 		}
 		$this->values = [];
 	}
@@ -148,7 +140,7 @@ class MetadataCache {
 		$guids = array_unique($guids);
 
 		foreach ($guids as $i => $guid) {
-			$value = $this->cache->load($guid);
+			$value = $this->persisted_cache->load($guid);
 			if ($value !== false) {
 				$this->values[$guid] = unserialize($value);
 				unset($guids[$i]);
@@ -202,7 +194,7 @@ class MetadataCache {
 		}
 
 		foreach ($guids as $guid) {
-			$this->cache->save($guid, serialize($this->values[$guid]));
+			$this->persisted_cache->save($guid, serialize($this->values[$guid]));
 		}
 	}
 

--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -6,6 +6,7 @@ use Elgg\Config\WwwrootSettingMigrator;
 use Elgg\Database\ConfigTable;
 use ConfigurationException;
 use Elgg\Project\Paths;
+use InstallationException;
 
 /**
  * Access to configuration values
@@ -169,11 +170,15 @@ class Config {
 			$settings_path = $_ENV['ELGG_SETTINGS_FILE'];
 		}
 
-		if ($settings_path) {
-			$config = self::fromFile($settings_path, $reason1);
-		} else {
-			$config = self::fromFile(Paths::settingsFile(Paths::SETTINGS_PHP), $reason1);
+		if (!$settings_path) {
+			$settings_path = Paths::settingsFile(Paths::SETTINGS_PHP);
 		}
+
+		if (!is_file($settings_path)) {
+			throw new InstallationException();
+		}
+
+		$config = self::fromFile($settings_path, $reason1);
 
 		if (!$config) {
 			$msg = __METHOD__ . ": Reading configs failed: $reason1 $reason2";

--- a/engine/classes/Elgg/Database/Annotations.php
+++ b/engine/classes/Elgg/Database/Annotations.php
@@ -1,10 +1,15 @@
 <?php
+
 namespace Elgg\Database;
+
+use Elgg\Database;
+use Elgg\PluginHooksService;
+use Elgg\TimeUsing;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
  *
- * @access private
+ * @access     private
  *
  * @package    Elgg.Core
  * @subpackage Database
@@ -12,34 +17,27 @@ namespace Elgg\Database;
  */
 class Annotations {
 
-	use \Elgg\TimeUsing;
-	
+	use TimeUsing;
+
 	/**
-	 * @var \Elgg\Database
+	 * @var Database
 	 */
 	protected $db;
 
 	/**
-	 * @var \ElggSession
+	 * @var PluginHooksService
 	 */
-	protected $session;
-
-	/**
-	 * @var \Elgg\EventsService
-	 */
-	protected $events;
+	protected $hooks;
 
 	/**
 	 * Constructor
 	 *
-	 * @param \Elgg\Database      $db      Database
-	 * @param \ElggSession        $session Session
-	 * @param \Elgg\EventsService $events  Events
+	 * @param Database           $db    Database
+	 * @param PluginHooksService $hooks Plugin hooks
 	 */
-	public function __construct(\Elgg\Database $db, \ElggSession $session, \Elgg\EventsService $events) {
+	public function __construct(Database $db, PluginHooksService $hooks) {
 		$this->db = $db;
-		$this->session = $session;
-		$this->events = $events;
+		$this->hooks = $hooks;
 	}
 
 	/**
@@ -54,11 +52,12 @@ class Annotations {
 	function get($id) {
 		return _elgg_get_metastring_based_object_from_id($id, 'annotation');
 	}
-	
+
 	/**
 	 * Deletes an annotation using its ID.
 	 *
 	 * @param int $id The annotation ID to delete.
+	 *
 	 * @return bool
 	 */
 	function delete($id) {
@@ -66,9 +65,10 @@ class Annotations {
 		if (!$annotation) {
 			return false;
 		}
+
 		return $annotation->delete();
 	}
-	
+
 	/**
 	 * Create a new annotation.
 	 *
@@ -82,17 +82,17 @@ class Annotations {
 	 * @return int|bool id on success or false on failure
 	 */
 	function create($entity_guid, $name, $value, $value_type = '', $owner_guid = 0, $access_id = ACCESS_PRIVATE) {
-		
+
 		$result = false;
-	
+
 		$entity_guid = (int) $entity_guid;
 		$value_type = \ElggExtender::detectValueType($value, $value_type);
 
 		$owner_guid = (int) $owner_guid;
 		if ($owner_guid == 0) {
-			$owner_guid = $this->session->getLoggedInUserGuid();
+			$owner_guid = elgg_get_session()->getLoggedInUserGuid();
 		}
-	
+
 		$access_id = (int) $access_id;
 
 		$entity = get_entity($entity_guid);
@@ -104,12 +104,12 @@ class Annotations {
 			$entity_type = $entity->type;
 		}
 
-		if ($this->events->trigger('annotate', $entity_type, $entity)) {
+		if ($this->hooks->getEvents()->trigger('annotate', $entity_type, $entity)) {
 			$sql = "INSERT INTO {$this->db->prefix}annotations
 				(entity_guid, name, value, value_type, owner_guid, time_created, access_id)
 				VALUES
 				(:entity_guid, :name, :value, :value_type, :owner_guid, :time_created, :access_id)";
-	
+
 			$result = $this->db->insertData($sql, [
 				':entity_guid' => $entity_guid,
 				':name' => $name,
@@ -119,22 +119,23 @@ class Annotations {
 				':time_created' => $this->getCurrentTime()->getTimestamp(),
 				':access_id' => $access_id,
 			]);
-				
+
 			if ($result !== false) {
 				$obj = elgg_get_annotation_from_id($result);
-				if ($this->events->trigger('create', 'annotation', $obj)) {
+				if ($this->hooks->getEvents()->trigger('create', 'annotation', $obj)) {
 					return $result;
 				} else {
 					// plugin returned false to reject annotation
 					elgg_delete_annotation_by_id($result);
+
 					return false;
 				}
 			}
 		}
-	
+
 		return $result;
 	}
-	
+
 	/**
 	 * Update an annotation.
 	 *
@@ -150,7 +151,7 @@ class Annotations {
 	function update($annotation_id, $name, $value, $value_type, $owner_guid, $access_id) {
 
 		$annotation_id = (int) $annotation_id;
-	
+
 		$annotation = $this->get($annotation_id);
 		if (!$annotation) {
 			return false;
@@ -158,17 +159,17 @@ class Annotations {
 		if (!$annotation->canEdit()) {
 			return false;
 		}
-	
+
 		$name = trim($name);
 		$value_type = \ElggExtender::detectValueType($value, $value_type);
-	
+
 		$owner_guid = (int) $owner_guid;
 		if ($owner_guid == 0) {
-			$owner_guid = $this->session->getLoggedInUserGuid();
+			$owner_guid = elgg_get_session()->getLoggedInUserGuid();
 		}
-	
+
 		$access_id = (int) $access_id;
-				
+
 		$sql = "UPDATE {$this->db->prefix}annotations
 			(name, value, value_type, access_id, owner_guid)
 			VALUES
@@ -183,16 +184,16 @@ class Annotations {
 			':owner_guid' => $owner_guid,
 			':annotation_id' => $annotation_id,
 		]);
-			
+
 		if ($result !== false) {
 			// @todo add plugin hook that sends old and new annotation information before db access
 			$obj = $this->get($annotation_id);
-			$this->events->trigger('update', 'annotation', $obj);
+			$this->hooks->getEvents()->trigger('update', 'annotation', $obj);
 		}
-	
+
 		return $result;
 	}
-	
+
 	/**
 	 * Returns annotations.  Accepts all elgg_get_entities() options for entity
 	 * restraints.
@@ -228,11 +229,12 @@ class Annotations {
 			$options['annotation_calculation'] = 'count';
 			unset($options['count']);
 		}
-		
+
 		$options['metastring_type'] = 'annotations';
+
 		return _elgg_get_metastring_based_objects($options);
 	}
-	
+
 	/**
 	 * Deletes annotations based on $options.
 	 *
@@ -241,38 +243,42 @@ class Annotations {
 	 *          annotation_name(s), annotation_value(s), or guid(s) must be set.
 	 *
 	 * @param array $options An options array. {@link elgg_get_annotations()}
+	 *
 	 * @return bool|null true on success, false on failure, null if no annotations to delete.
 	 */
 	function deleteAll(array $options) {
 		if (!_elgg_is_valid_options_for_batch_operation($options, 'annotation')) {
 			return false;
 		}
-	
+
 		$options['metastring_type'] = 'annotations';
+
 		return _elgg_batch_metastring_based_objects($options, 'elgg_batch_delete_callback', false);
 	}
-	
+
 	/**
 	 * Disables annotations based on $options.
 	 *
 	 * @warning Unlike elgg_get_annotations() this will not accept an empty options array!
 	 *
 	 * @param array $options An options array. {@link elgg_get_annotations()}
+	 *
 	 * @return bool|null true on success, false on failure, null if no annotations disabled.
 	 */
 	function disableAll(array $options) {
 		if (!_elgg_is_valid_options_for_batch_operation($options, 'annotation')) {
 			return false;
 		}
-		
+
 		// if we can see hidden (disabled) we need to use the offset
 		// otherwise we risk an infinite loop if there are more than 50
 		$inc_offset = access_get_show_hidden_status();
-	
+
 		$options['metastring_type'] = 'annotations';
+
 		return _elgg_batch_metastring_based_objects($options, 'elgg_batch_disable_callback', $inc_offset);
 	}
-	
+
 	/**
 	 * Enables annotations based on $options.
 	 *
@@ -282,17 +288,19 @@ class Annotations {
 	 * {@link access_show_hidden_entities()}.
 	 *
 	 * @param array $options An options array. {@link elgg_get_annotations()}
+	 *
 	 * @return bool|null true on success, false on failure, null if no metadata enabled.
 	 */
 	function enableAll(array $options) {
 		if (!$options || !is_array($options)) {
 			return false;
 		}
-	
+
 		$options['metastring_type'] = 'annotations';
+
 		return _elgg_batch_metastring_based_objects($options, 'elgg_batch_enable_callback');
 	}
-	
+
 	/**
 	 * Returns entities based upon annotations.  Also accepts all options available
 	 * to elgg_get_entities() and elgg_get_entities_from_metadata().
@@ -302,19 +310,19 @@ class Annotations {
 	 *
 	 * @param array $options Array in format:
 	 *
-	 * 	annotation_names => null|ARR annotations names
+	 *    annotation_names => null|ARR annotations names
 	 *
-	 * 	annotation_values => null|ARR annotations values
+	 *    annotation_values => null|ARR annotations values
 	 *
-	 * 	annotation_name_value_pairs => null|ARR (name = 'name', value => 'value',
-	 * 	'operator' => '=', 'case_sensitive' => true) entries.
-	 * 	Currently if multiple values are sent via an array (value => array('value1', 'value2')
-	 * 	the pair's operator will be forced to "IN".
+	 *    annotation_name_value_pairs => null|ARR (name = 'name', value => 'value',
+	 *    'operator' => '=', 'case_sensitive' => true) entries.
+	 *    Currently if multiple values are sent via an array (value => array('value1', 'value2')
+	 *    the pair's operator will be forced to "IN".
 	 *
-	 * 	annotation_name_value_pairs_operator => null|STR The operator to use for combining
+	 *    annotation_name_value_pairs_operator => null|STR The operator to use for combining
 	 *  (name = value) OPERATOR (name = value); default AND
 	 *
-	 * 	annotation_case_sensitive => BOOL Overall Case sensitive
+	 *    annotation_case_sensitive => BOOL Overall Case sensitive
 	 *
 	 *  order_by_annotation => null|ARR (array('name' => 'annotation_text1', 'direction' => ASC|DESC,
 	 *  'as' => text|integer),
@@ -327,30 +335,35 @@ class Annotations {
 	 */
 	function getEntities(array $options = []) {
 		$defaults = [
-			'annotation_names'                      => ELGG_ENTITIES_ANY_VALUE,
-			'annotation_values'                     => ELGG_ENTITIES_ANY_VALUE,
-			'annotation_name_value_pairs'           => ELGG_ENTITIES_ANY_VALUE,
+			'annotation_names' => ELGG_ENTITIES_ANY_VALUE,
+			'annotation_values' => ELGG_ENTITIES_ANY_VALUE,
+			'annotation_name_value_pairs' => ELGG_ENTITIES_ANY_VALUE,
 
-			'annotation_name_value_pairs_operator'  => 'AND',
-			'annotation_case_sensitive'             => true,
-			'order_by_annotation'                   => [],
+			'annotation_name_value_pairs_operator' => 'AND',
+			'annotation_case_sensitive' => true,
+			'order_by_annotation' => [],
 
-			'annotation_created_time_lower'         => ELGG_ENTITIES_ANY_VALUE,
-			'annotation_created_time_upper'         => ELGG_ENTITIES_ANY_VALUE,
-			'annotation_owner_guids'                => ELGG_ENTITIES_ANY_VALUE,
+			'annotation_created_time_lower' => ELGG_ENTITIES_ANY_VALUE,
+			'annotation_created_time_upper' => ELGG_ENTITIES_ANY_VALUE,
+			'annotation_owner_guids' => ELGG_ENTITIES_ANY_VALUE,
 		];
-	
+
 		$options = array_merge($defaults, $options);
-	
-		$singulars = ['annotation_name', 'annotation_value', 'annotation_name_value_pair', 'annotation_owner_guid'];
-	
+
+		$singulars = [
+			'annotation_name',
+			'annotation_value',
+			'annotation_name_value_pair',
+			'annotation_owner_guid'
+		];
+
 		$options = _elgg_normalize_plural_options_array($options, $singulars);
 		$options = _elgg_entities_get_metastrings_options('annotation', $options);
-	
+
 		if (!$options) {
 			return false;
 		}
-		
+
 		$time_wheres = _elgg_get_entity_time_where_sql('n_table', $options['annotation_created_time_upper'],
 			$options['annotation_created_time_lower']);
 
@@ -360,16 +373,16 @@ class Annotations {
 
 		return elgg_get_entities_from_metadata($options);
 	}
-	
+
 	/**
 	 * Get entities ordered by a mathematical calculation on annotation values
 	 *
-	 * @tip Note that this function uses { @link elgg_get_annotations() } to return a list of entities ordered by a mathematical
-	 * calculation on annotation values, and { @link elgg_get_entities_from_annotations() } to return a count of entities
-	 * if $options['count'] is set to a truthy value
+	 * @tip Note that this function uses { @link elgg_get_annotations() } to return a list of entities ordered by a
+	 *      mathematical calculation on annotation values, and { @link elgg_get_entities_from_annotations() } to return
+	 *      a count of entities if $options['count'] is set to a truthy value
 	 *
-	 * @param array $options An options array:
-	 * 	'calculation'            => The calculation to use. Must be a valid MySQL function.
+	 * @param array $options        An options array:
+	 *                              'calculation'            => The calculation to use. Must be a valid MySQL function.
 	 *                              Defaults to sum.  Result selected as 'annotation_calculation'.
 	 *                              Don't confuse this "calculation" option with the
 	 *                              "annotation_calculation" option to elgg_get_annotations().
@@ -377,17 +390,19 @@ class Annotations {
 	 *                              annotations and is selected as annotation_calculation for that row.
 	 *                              See the docs for elgg_get_annotations() for proper use of the
 	 *                              "annotation_calculation" option.
-	 *	'order_by'               => The order for the sorting. Defaults to 'annotation_calculation desc'.
-	 *	'annotation_names'       => The names of annotations on the entity.
-	 *	'annotation_values'	     => The values of annotations on the entity.
+	 *                              'order_by'               => The order for the sorting. Defaults to
+	 *                              'annotation_calculation desc'.
+	 *                              'annotation_names'       => The names of annotations on the entity.
+	 *                              'annotation_values'         => The values of annotations on the entity.
 	 *
-	 * 	'metadata_names'         => The name of metadata on the entity.
-	 * 	'metadata_values'        => The value of metadata on the entitiy.
-	 * 	'callback'               => Callback function to pass each row through.
-	 *                              @tip This function is different from other ege* functions,
+	 *    'metadata_names'         => The name of metadata on the entity.
+	 *    'metadata_values'        => The value of metadata on the entitiy.
+	 *    'callback'               => Callback function to pass each row through.
+	 *
+	 * @tip This function is different from other ege* functions,
 	 *                              as it uses a metastring-based getter function { @link elgg_get_annotations() },
-	 *                              therefore the callback function should be a derivative of { @link entity_row_to_elggstar() }
-	 *                              and not of { @link row_to_annotation() }
+	 *                              therefore the callback function should be a derivative of { @link
+	 *                              entity_row_to_elggstar() } and not of { @link row_to_annotation() }
 	 *
 	 * @return \ElggEntity[]|int An array or a count of entities
 	 * @see elgg_get_annotations()
@@ -403,15 +418,15 @@ class Annotations {
 			'calculation' => 'sum',
 			'order_by' => 'annotation_calculation desc, e.guid desc'
 		];
-	
+
 		$options = array_merge($defaults, $options);
-	
+
 		$function = sanitize_string(elgg_extract('calculation', $options, 'sum', false));
-	
+
 		// you must cast this as an int or it sorts wrong.
 		$options['selects'][] = 'e.*';
 		$options['selects'][] = "$function(CAST(n_table.value AS DECIMAL(10, 2))) AS annotation_calculation";
-	
+
 		// don't need access control because it's taken care of by elgg_get_annotations.
 		$options['group_by'] = 'e.guid';
 
@@ -422,7 +437,7 @@ class Annotations {
 
 		return elgg_get_annotations($options);
 	}
-	
+
 	/**
 	 * Check to see if a user has already created an annotation on an object
 	 *
@@ -433,11 +448,11 @@ class Annotations {
 	 * @return bool
 	 */
 	function exists($entity_guid, $annotation_type, $owner_guid = null) {
-	
-		if (!$owner_guid && !($owner_guid = $this->session->getLoggedInUserGuid())) {
+
+		if (!$owner_guid && !($owner_guid = elgg_get_session()->getLoggedInUserGuid())) {
 			return false;
 		}
-		
+
 		$sql = "SELECT id FROM {$this->db->prefix}annotations
 				WHERE owner_guid = :owner_guid
 				AND entity_guid = :entity_guid
@@ -448,7 +463,7 @@ class Annotations {
 			':entity_guid' => (int) $entity_guid,
 			':annotation_type' => $annotation_type,
 		]);
-	
+
 		return (bool) $result;
 	}
 }

--- a/engine/classes/Elgg/Database/Seeds/Groups.php
+++ b/engine/classes/Elgg/Database/Seeds/Groups.php
@@ -63,6 +63,15 @@ class Groups extends Seed {
 					'profile_fields' => (array) elgg_get_config('group'),
 					'group_tool_options' => (array) elgg_get_config('group_tool_options'),
 				]);
+
+				elgg_create_river_item([
+					'view' => 'river/group/create',
+					'action_type' => 'create',
+					'subject_guid' => $group->owner_guid,
+					'object_guid' => $group->guid,
+					'target_guid' => $group->container_guid,
+				]);
+
 				if (!$group) {
 					continue;
 				}

--- a/engine/classes/Elgg/Database/SubtypeTable.php
+++ b/engine/classes/Elgg/Database/SubtypeTable.php
@@ -272,7 +272,7 @@ class SubtypeTable {
 	protected function invalidateCache() {
 		$this->cache = null;
 		_elgg_services()->boot->invalidateCache();
-		_elgg_services()->entityCache->clear();
+		elgg_get_session()->entityCache->clear();
 	}
 
 	/**

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace Elgg\Di;
 
 use Elgg\Config;
 use Elgg\Cache\Pool;
 use Elgg\Printer\CliPrinter;
 use Elgg\Printer\HtmlPrinter;
-use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
-use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
 use Zend\Mail\Transport\TransportInterface as Mailer;
 
 /**
@@ -17,7 +16,6 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * the container generic.
  *
  * @property-read \Elgg\Database\AccessCollections         $accessCollections
- * @property-read \ElggStaticVariableCache                 $accessCache
  * @property-read \Elgg\ActionsService                     $actions
  * @property-read \Elgg\Database\AdminNotices              $adminNotices
  * @property-read \Elgg\Ajax\Service                       $ajax
@@ -38,10 +36,10 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\Database\DbConfig                  $dbConfig
  * @property-read \Elgg\DeprecationService                 $deprecation
  * @property-read \Elgg\EmailService                       $emails
- * @property-read \Elgg\Cache\EntityCache                  $entityCache
  * @property-read \Elgg\EntityPreloader                    $entityPreloader
  * @property-read \Elgg\Database\EntityTable               $entityTable
  * @property-read \Elgg\Assets\ExternalFiles               $externalFiles
+ * @property-read \Faker\Generator                         $faker
  * @property-read \ElggFileCache                           $fileCache
  * @property-read \ElggDiskFilestore                       $filestore
  * @property-read \Elgg\FormsService                       $forms
@@ -54,7 +52,6 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\Logger                             $logger
  * @property-read Mailer                                   $mailer
  * @property-read \Elgg\Menu\Service                       $menus
- * @property-read \Elgg\Cache\MetadataCache                $metadataCache
  * @property-read \Stash\Pool|null                         $memcacheStashPool
  * @property-read \Elgg\Database\MetadataTable             $metadataTable
  * @property-read \Elgg\Database\Mutex                     $mutex
@@ -106,93 +103,102 @@ class ServiceProvider extends DiContainer {
 	 */
 	public function __construct(Config $config) {
 
-		$this->setFactory('autoloadManager', function(ServiceProvider $c) {
+		$this->setFactory('autoloadManager', function (ServiceProvider $c) {
 			$manager = new \Elgg\AutoloadManager($c->classLoader);
 			if (!$c->config->AutoloaderManager_skip_storage) {
 				$manager->setStorage($c->fileCache);
 				$manager->loadCache();
 			}
+
 			return $manager;
 		});
 
-		$this->setFactory('accessCache', function(ServiceProvider $c) {
-			return new \ElggStaticVariableCache('access');
-		});
-
-		$this->setFactory('accessCollections', function(ServiceProvider $c) {
+		$this->setFactory('accessCollections', function (ServiceProvider $c) {
 			return new \Elgg\Database\AccessCollections(
-					$c->config, $c->db, $c->entityTable, $c->userCapabilities, $c->accessCache, $c->hooks, $c->session, $c->translator);
+				$c->config,
+				$c->db,
+				$c->entityTable,
+				$c->userCapabilities,
+				$c->hooks,
+				$c->translator
+			);
 		});
 
-		$this->setFactory('actions', function(ServiceProvider $c) {
-			return new \Elgg\ActionsService($c->config, $c->session, $c->crypto);
+		$this->setFactory('actions', function (ServiceProvider $c) {
+			return new \Elgg\ActionsService($c->config, $c->crypto);
 		});
 
 		$this->setClassName('adminNotices', \Elgg\Database\AdminNotices::class);
 
-		$this->setFactory('ajax', function(ServiceProvider $c) {
+		$this->setFactory('ajax', function (ServiceProvider $c) {
 			return new \Elgg\Ajax\Service($c->hooks, $c->systemMessages, $c->input, $c->amdConfig);
 		});
 
-		$this->setFactory('amdConfig', function(ServiceProvider $c) {
+		$this->setFactory('amdConfig', function (ServiceProvider $c) {
 			$obj = new \Elgg\Amd\Config($c->hooks);
 			$obj->setBaseUrl($c->simpleCache->getRoot());
+
 			return $obj;
 		});
 
-		$this->setFactory('annotations', function(ServiceProvider $c) {
-			return new \Elgg\Database\Annotations($c->db, $c->session, $c->hooks->getEvents());
+		$this->setFactory('annotations', function (ServiceProvider $c) {
+			return new \Elgg\Database\Annotations($c->db, $c->hooks);
 		});
 
 		$this->setClassName('autoP', \ElggAutoP::class);
 
-		$this->setFactory('boot', function(ServiceProvider $c) {
+		$this->setFactory('boot', function (ServiceProvider $c) {
 			$boot = new \Elgg\BootService();
 			if ($c->config->enable_profiling) {
 				$boot->setTimer($c->timer);
 			}
+
 			return $boot;
 		});
 
-		$this->setFactory('batchUpgrader', function(ServiceProvider $c) {
+		$this->setFactory('batchUpgrader', function (ServiceProvider $c) {
 			return new \Elgg\BatchUpgrader($c->config);
 		});
 
-		$this->setFactory('cacheHandler', function(ServiceProvider $c) {
+		$this->setFactory('cacheHandler', function (ServiceProvider $c) {
 			$simplecache_enabled = $c->config->simplecache_enabled;
 			if ($simplecache_enabled === null) {
 				$simplecache_enabled = $c->configTable->get('simplecache_enabled');
 			}
+
 			return new \Elgg\Application\CacheHandler($c->config, $c->request, $simplecache_enabled);
 		});
 
-		$this->setFactory('classLoader', function(ServiceProvider $c) {
+		$this->setFactory('classLoader', function (ServiceProvider $c) {
 			$loader = new \Elgg\ClassLoader(new \Elgg\ClassMap());
 			$loader->register();
+
 			return $loader;
 		});
 
-		$this->setFactory('cli', function(ServiceProvider $c) {
+		$this->setFactory('cli', function (ServiceProvider $c) {
 			$version = elgg_get_version(true);
 			$console = new \Symfony\Component\Console\Application('Elgg', $version);
+
 			return new \Elgg\Cli($console, $c->hooks);
 		});
 
 		$this->setValue('config', $config);
 
-		$this->setFactory('configTable', function(ServiceProvider $c) {
+		$this->setFactory('configTable', function (ServiceProvider $c) {
 			return new \Elgg\Database\ConfigTable($c->db, $c->boot, $c->logger);
 		});
 
-		$this->setFactory('context', function(ServiceProvider $c) {
+		$this->setFactory('context', function (ServiceProvider $c) {
 			$context = new \Elgg\Context();
 			$context->initialize($c->request);
+
 			return $context;
 		});
 
 		$this->setClassName('crypto', \ElggCrypto::class);
 
-		$this->setFactory('db', function(ServiceProvider $c) {
+		$this->setFactory('db', function (ServiceProvider $c) {
 			$db = new \Elgg\Database($c->dbConfig);
 			$db->setLogger($c->logger);
 
@@ -203,7 +209,7 @@ class ServiceProvider extends DiContainer {
 			return $db;
 		});
 
-		$this->setFactory('dbConfig', function(ServiceProvider $c) {
+		$this->setFactory('dbConfig', function (ServiceProvider $c) {
 			$config = $c->config;
 			$db_config = \Elgg\Database\DbConfig::fromElggConfig($config);
 
@@ -217,31 +223,24 @@ class ServiceProvider extends DiContainer {
 			return $db_config;
 		});
 
-		$this->setFactory('deprecation', function(ServiceProvider $c) {
+		$this->setFactory('deprecation', function (ServiceProvider $c) {
 			return new \Elgg\DeprecationService($c->logger);
 		});
 
-		$this->setFactory('emails', function(ServiceProvider $c) {
+		$this->setFactory('emails', function (ServiceProvider $c) {
 			return new \Elgg\EmailService($c->config, $c->hooks, $c->mailer, $c->logger);
 		});
 
-		$this->setFactory('entityCache', function(ServiceProvider $c) {
-			return new \Elgg\Cache\EntityCache($c->session, $c->metadataCache);
+		$this->setFactory('entityPreloader', function (ServiceProvider $c) {
+			return new \Elgg\EntityPreloader();
 		});
 
-		$this->setFactory('entityPreloader', function(ServiceProvider $c) {
-			return new \Elgg\EntityPreloader($c->entityCache, $c->entityTable);
-		});
-
-		$this->setFactory('entityTable', function(ServiceProvider $c) {
+		$this->setFactory('entityTable', function (ServiceProvider $c) {
 			return new \Elgg\Database\EntityTable(
 				$c->config,
 				$c->db,
-				$c->entityCache,
-				$c->metadataCache,
 				$c->subtypeTable,
-				$c->hooks->getEvents(),
-				$c->session,
+				$c->hooks,
 				$c->translator,
 				$c->logger
 			);
@@ -249,62 +248,64 @@ class ServiceProvider extends DiContainer {
 
 		$this->setClassName('externalFiles', \Elgg\Assets\ExternalFiles::class);
 
-		$this->setFactory('fileCache', function(ServiceProvider $c) {
+		$this->setFactory('faker', function (ServiceProvider $c) {
+			return \Faker\Factory::create();
+		});
+
+		$this->setFactory('fileCache', function (ServiceProvider $c) {
 			return new \ElggFileCache($c->config->cacheroot . 'system_cache/');
 		});
 
-		$this->setFactory('filestore', function(ServiceProvider $c) {
+		$this->setFactory('filestore', function (ServiceProvider $c) {
 			return new \ElggDiskFilestore($c->config->dataroot);
 		});
 
-		$this->setFactory('forms', function(ServiceProvider $c) {
+		$this->setFactory('forms', function (ServiceProvider $c) {
 			return new \Elgg\FormsService($c->views, $c->logger);
 		});
 
 		$this->setClassName('handlers', \Elgg\HandlersService::class);
 
-		$this->setFactory('hmac', function(ServiceProvider $c) {
+		$this->setFactory('hmac', function (ServiceProvider $c) {
 			return new \Elgg\Security\HmacFactory($c->siteSecret, $c->crypto);
 		});
 
-		$this->setFactory('hooks', function(ServiceProvider $c) {
+		$this->setFactory('hooks', function (ServiceProvider $c) {
 			$events = new \Elgg\EventsService($c->handlers);
 			if ($c->config->enable_profiling) {
 				$events->setTimer($c->timer);
 			}
+
 			return new \Elgg\PluginHooksService($events);
 		});
 
-		$this->setFactory('iconService', function(ServiceProvider $c) {
+		$this->setFactory('iconService', function (ServiceProvider $c) {
 			return new \Elgg\EntityIconService($c->config, $c->hooks, $c->request, $c->logger, $c->entityTable);
 		});
 
 		$this->setClassName('input', \Elgg\Http\Input::class);
 
-		$this->setFactory('imageService', function(ServiceProvider $c) {
+		$this->setFactory('imageService', function (ServiceProvider $c) {
 			$imagine = new \Imagine\Gd\Imagine();
+
 			return new \Elgg\ImageService($imagine, $c->config);
 		});
 
 		$this->setFactory('logger', function (ServiceProvider $c) {
 			$logger = new \Elgg\Logger($c->hooks, $c->context, $c->printer);
 			$logger->setLevel($c->config->debug);
+
 			return $logger;
 		});
 
 		// TODO(evan): Support configurable transports...
 		$this->setClassName('mailer', 'Zend\Mail\Transport\Sendmail');
 
-		$this->setFactory('menus', function(ServiceProvider $c) {
+		$this->setFactory('menus', function (ServiceProvider $c) {
 			return new \Elgg\Menu\Service($c->hooks, $c->config);
 		});
 
-		$this->setFactory('metadataCache', function (ServiceProvider $c) {
-			$cache = _elgg_get_memcache('metadata');
-			return new \Elgg\Cache\MetadataCache($cache);
-		});
-
-		$this->setFactory('memcacheStashPool', function(ServiceProvider $c) {
+		$this->setFactory('memcacheStashPool', function (ServiceProvider $c) {
 			if (!$c->config->memcache) {
 				return null;
 			}
@@ -316,55 +317,57 @@ class ServiceProvider extends DiContainer {
 			$driver = new \Stash\Driver\Memcache([
 				'servers' => $servers,
 			]);
+
 			return new \Stash\Pool($driver);
 		});
 
-		$this->setFactory('metadataTable', function(ServiceProvider $c) {
-			// TODO(ewinslow): Use Pool instead of MetadataCache for caching
-			return new \Elgg\Database\MetadataTable(
-				$c->metadataCache, $c->db, $c->entityTable, $c->hooks->getEvents(), $c->session);
+		$this->setFactory('metadataTable', function (ServiceProvider $c) {
+			return new \Elgg\Database\MetadataTable($c->db, $c->entityTable, $c->hooks);
 		});
 
-		$this->setFactory('mutex', function(ServiceProvider $c) {
+		$this->setFactory('mutex', function (ServiceProvider $c) {
 			return new \Elgg\Database\Mutex(
 				$c->db,
 				$c->logger
 			);
 		});
 
-		$this->setFactory('notifications', function(ServiceProvider $c) {
+		$this->setFactory('notifications', function (ServiceProvider $c) {
 			// @todo move queue in service provider
 			$queue_name = \Elgg\Notifications\NotificationsService::QUEUE_NAME;
 			$queue = new \Elgg\Queue\DatabaseQueue($queue_name, $c->db);
 			$sub = new \Elgg\Notifications\SubscriptionsService($c->db);
-			return new \Elgg\Notifications\NotificationsService($sub, $queue, $c->hooks, $c->session, $c->translator, $c->entityTable, $c->logger);
+
+			return new \Elgg\Notifications\NotificationsService($sub, $queue, $c->hooks, $c->translator, $c->entityTable, $c->logger);
 		});
 
 		$this->setClassName('nullCache', \Elgg\Cache\NullCache::class);
 
-		$this->setFactory('persistentLogin', function(ServiceProvider $c) {
+		$this->setFactory('persistentLogin', function (ServiceProvider $c) {
 			$global_cookies_config = $c->config->getCookieConfig();
 			$cookie_config = $global_cookies_config['remember_me'];
 			$cookie_name = $cookie_config['name'];
 			$cookie_token = $c->request->cookies->get($cookie_name, '');
+
 			return new \Elgg\PersistentLoginService(
-				$c->db, $c->session, $c->crypto, $cookie_config, $cookie_token);
+				$c->db, $c->crypto, $cookie_config, $cookie_token);
 		});
 
 		$this->setClassName('passwords', \Elgg\PasswordService::class);
 
-		$this->setFactory('plugins', function(ServiceProvider $c) {
+		$this->setFactory('plugins', function (ServiceProvider $c) {
 			$pool = new Pool\InMemory();
 			$plugins = new \Elgg\Database\Plugins($pool, $c->pluginSettingsCache);
 			if ($c->config->enable_profiling) {
 				$plugins->setTimer($c->timer);
 			}
+
 			return $plugins;
 		});
 
 		$this->setClassName('pluginSettingsCache', \Elgg\Cache\PluginSettingsCache::class);
 
-		$this->setFactory('printer', function(ServiceProvider $c) {
+		$this->setFactory('printer', function (ServiceProvider $c) {
 			if (php_sapi_name() === 'cli') {
 				return new CliPrinter();
 			} else {
@@ -372,63 +375,69 @@ class ServiceProvider extends DiContainer {
 			}
 		});
 
-		$this->setFactory('privateSettings', function(ServiceProvider $c) {
+		$this->setFactory('privateSettings', function (ServiceProvider $c) {
 			return new \Elgg\Database\PrivateSettingsTable($c->db, $c->entityTable, $c->pluginSettingsCache);
 		});
 
-		$this->setFactory('publicDb', function(ServiceProvider $c) {
+		$this->setFactory('publicDb', function (ServiceProvider $c) {
 			return new \Elgg\Application\Database($c->db);
 		});
 
-		$this->setFactory('queryCounter', function(ServiceProvider $c) {
+		$this->setFactory('queryCounter', function (ServiceProvider $c) {
 			return new \Elgg\Database\QueryCounter($c->db);
 		}, false);
 
-		$this->setFactory('redirects', function(ServiceProvider $c) {
+		$this->setFactory('redirects', function (ServiceProvider $c) {
 			$url = current_page_url();
 			$is_xhr = $c->request->isXmlHttpRequest();
-			return new \Elgg\RedirectService($c->session, $is_xhr, $c->config->wwwroot, $url);
+
+			return new \Elgg\RedirectService($is_xhr, $c->config->wwwroot, $url);
 		});
 
-		$this->setFactory('relationshipsTable', function(ServiceProvider $c) {
-			return new \Elgg\Database\RelationshipsTable($c->db, $c->entityTable, $c->metadataTable, $c->hooks->getEvents());
+		$this->setFactory('relationshipsTable', function (ServiceProvider $c) {
+			return new \Elgg\Database\RelationshipsTable($c->db, $c->entityTable, $c->metadataTable, $c->hooks);
 		});
 
-		$this->setFactory('request', [\Elgg\Http\Request::class, 'createFromGlobals']);
+		$this->setFactory('request', [
+			\Elgg\Http\Request::class,
+			'createFromGlobals'
+		]);
 
-		$this->setFactory('responseFactory', function(ServiceProvider $c) {
+		$this->setFactory('responseFactory', function (ServiceProvider $c) {
 			if (php_sapi_name() === 'cli') {
 				$transport = new \Elgg\Http\OutputBufferTransport();
 			} else {
 				$transport = new \Elgg\Http\HttpProtocolTransport();
 			}
+
 			return new \Elgg\Http\ResponseFactory($c->request, $c->hooks, $c->ajax, $transport);
 		});
 
-		$this->setFactory('router', function(ServiceProvider $c) {
+		$this->setFactory('router', function (ServiceProvider $c) {
 			// TODO(evan): Init routes from plugins or cache
 			$router = new \Elgg\Router($c->hooks);
 			if ($c->config->enable_profiling) {
 				$router->setTimer($c->timer);
 			}
+
 			return $router;
 		});
 
-		$this->setFactory('seeder', function(ServiceProvider $c) {
+		$this->setFactory('seeder', function (ServiceProvider $c) {
 			return new \Elgg\Database\Seeder($c->hooks);
 		});
 
-		$this->setFactory('serveFileHandler', function(ServiceProvider $c) {
+		$this->setFactory('serveFileHandler', function (ServiceProvider $c) {
 			return new \Elgg\Application\ServeFileHandler($c->hmac, $c->config);
 		});
 
-		$this->setFactory('session', function(ServiceProvider $c) {
+		$this->setFactory('session', function (ServiceProvider $c) {
 			return \ElggSession::fromDatabase($c->config, $c->db);
 		});
 
 		$this->setClassName('urlSigner', \Elgg\Security\UrlSigner::class);
 
-		$this->setFactory('simpleCache', function(ServiceProvider $c) {
+		$this->setFactory('simpleCache', function (ServiceProvider $c) {
 			return new \Elgg\Cache\SimpleCache($c->config);
 		});
 
@@ -437,13 +446,13 @@ class ServiceProvider extends DiContainer {
 		 *
 		 * @see \Elgg\Application::initConfig
 		 */
-		$this->setFactory('siteSecret', function(ServiceProvider $c) {
+		$this->setFactory('siteSecret', function (ServiceProvider $c) {
 			return \Elgg\Database\SiteSecret::fromDatabase($c->configTable);
 		});
 
 		$this->setClassName('stickyForms', \Elgg\Forms\StickyForms::class);
 
-		$this->setFactory('subtypeTable', function(ServiceProvider $c) {
+		$this->setFactory('subtypeTable', function (ServiceProvider $c) {
 			return new \Elgg\Database\SubtypeTable($c->db);
 		});
 
@@ -452,26 +461,27 @@ class ServiceProvider extends DiContainer {
 			if ($c->config->enable_profiling) {
 				$cache->setTimer($c->timer);
 			}
+
 			return $cache;
 		});
 
-		$this->setFactory('systemMessages', function(ServiceProvider $c) {
-			return new \Elgg\SystemMessagesService($c->session);
+		$this->setFactory('systemMessages', function (ServiceProvider $c) {
+			return new \Elgg\SystemMessagesService();
 		});
 
 		$this->setClassName('table_columns', \Elgg\Views\TableColumn\ColumnFactory::class);
 
 		$this->setClassName('timer', \Elgg\Timer::class);
 
-		$this->setFactory('translator', function(ServiceProvider $c) {
+		$this->setFactory('translator', function (ServiceProvider $c) {
 			return new \Elgg\I18n\Translator($c->config);
 		});
 
-		$this->setFactory('uploads', function(ServiceProvider $c) {
+		$this->setFactory('uploads', function (ServiceProvider $c) {
 			return new \Elgg\UploadService($c->request);
 		});
 
-		$this->setFactory('upgrades', function(ServiceProvider $c) {
+		$this->setFactory('upgrades', function (ServiceProvider $c) {
 			return new \Elgg\UpgradeService(
 				$c->translator,
 				$c->hooks,
@@ -481,21 +491,20 @@ class ServiceProvider extends DiContainer {
 			);
 		});
 
-		$this->setFactory('userCapabilities', function(ServiceProvider $c) {
+		$this->setFactory('userCapabilities', function (ServiceProvider $c) {
 			return new \Elgg\UserCapabilities($c->hooks, $c->entityTable, $c->session);
 		});
 
-		$this->setFactory('usersTable', function(ServiceProvider $c) {
+		$this->setFactory('usersTable', function (ServiceProvider $c) {
 			return new \Elgg\Database\UsersTable(
 				$c->config,
 				$c->db,
 				$c->entityTable,
-				$c->entityCache,
-				$c->hooks->getEvents()
+				$c->hooks
 			);
 		});
 
-		$this->setFactory('upgradeLocator', function(ServiceProvider $c) {
+		$this->setFactory('upgradeLocator', function (ServiceProvider $c) {
 			return new \Elgg\Upgrade\Locator(
 				$c->plugins,
 				$c->logger,
@@ -503,11 +512,11 @@ class ServiceProvider extends DiContainer {
 			);
 		});
 
-		$this->setFactory('views', function(ServiceProvider $c) {
+		$this->setFactory('views', function (ServiceProvider $c) {
 			return new \Elgg\ViewsService($c->hooks, $c->logger, $c->input);
 		});
 
-		$this->setFactory('viewCacher', function(ServiceProvider $c) {
+		$this->setFactory('viewCacher', function (ServiceProvider $c) {
 			return new \Elgg\Cache\ViewCacher($c->views, $c->config);
 		});
 

--- a/engine/classes/Elgg/EntityPreloader.php
+++ b/engine/classes/Elgg/EntityPreloader.php
@@ -26,16 +26,13 @@ class EntityPreloader {
 
 	/**
 	 * Constructor
-	 *
-	 * @param EntityCache $entity_cache Entity cache
-	 * @param EntityTable $entity_table Entity service
 	 */
-	public function __construct(EntityCache $entity_cache, EntityTable $entity_table) {
-		$this->_callable_cache_checker = function ($guid) use ($entity_cache) {
-			return $entity_cache->get($guid);
+	public function __construct() {
+		$this->_callable_cache_checker = function ($guid) {
+			return elgg_get_session()->entityCache->get($guid);
 		};
-		$this->_callable_entity_loader = function ($options) use ($entity_table) {
-			return $entity_table->getEntities($options);
+		$this->_callable_entity_loader = function ($options) {
+			return Application::getInstance()->_services->entityTable->getEntities($options);
 		};
 	}
 

--- a/engine/classes/Elgg/FileService/File.php
+++ b/engine/classes/Elgg/FileService/File.php
@@ -122,7 +122,7 @@ class File {
 		];
 
 		if ($this->use_cookie) {
-			$data['cookie'] = _elgg_services()->session->getId();
+			$data['cookie'] = elgg_get_session()->getId();
 			if (empty($data['cookie'])) {
 				return false;
 			}

--- a/engine/classes/Elgg/Forms/StickyForms.php
+++ b/engine/classes/Elgg/Forms/StickyForms.php
@@ -31,7 +31,7 @@ class StickyForms {
 			$banned_keys = ['password', 'password2'];
 		}
 
-		$session = _elgg_services()->session;
+		$session = elgg_get_session();
 		$data = $session->get('sticky_forms', []);
 		$req = _elgg_services()->request;
 	
@@ -57,7 +57,7 @@ class StickyForms {
 	 * @return void
 	 */
 	function clearStickyForm($form_name) {
-		$session = _elgg_services()->session;
+		$session = elgg_get_session();
 		$data = $session->get('sticky_forms', []);
 		unset($data[$form_name]);
 		$session->set('sticky_forms', $data);
@@ -71,7 +71,7 @@ class StickyForms {
 	 * @return boolean
 	 */
 	function isStickyForm($form_name) {
-		$session = _elgg_services()->session;
+		$session = elgg_get_session();
 		$data = $session->get('sticky_forms', []);
 		return isset($data[$form_name]);
 	}
@@ -89,7 +89,7 @@ class StickyForms {
 	 * @todo should this filter the default value?
 	 */
 	function getStickyValue($form_name, $variable = '', $default = null, $filter_result = true) {
-		$session = _elgg_services()->session;
+		$session = elgg_get_session();
 		$data = $session->get('sticky_forms', []);
 		if (isset($data[$form_name][$variable])) {
 			$value = $data[$form_name][$variable];
@@ -111,7 +111,7 @@ class StickyForms {
 	 * @return array
 	 */
 	function getStickyValues($form_name, $filter_result = true) {
-		$session = _elgg_services()->session;
+		$session = elgg_get_session();
 		$data = $session->get('sticky_forms', []);
 		if (!isset($data[$form_name])) {
 			return [];
@@ -136,7 +136,7 @@ class StickyForms {
 	 * @return void
 	 */
 	function clearStickyValue($form_name, $variable) {
-		$session = _elgg_services()->session;
+		$session = elgg_get_session();
 		$data = $session->get('sticky_forms', []);
 		unset($data[$form_name][$variable]);
 		$session->set('sticky_forms', $data);

--- a/engine/classes/Elgg/GroupItemVisibility.php
+++ b/engine/classes/Elgg/GroupItemVisibility.php
@@ -46,7 +46,7 @@ class GroupItemVisibility {
 			return new \Elgg\GroupItemVisibility();
 		}
 
-		$user = _elgg_services()->session->getLoggedInUser();
+		$user = elgg_get_session()->getLoggedInUser();
 		$user_guid = $user ? $user->guid : 0;
 
 		$container_guid = (int) $container_guid;

--- a/engine/classes/Elgg/I18n/Translator.php
+++ b/engine/classes/Elgg/I18n/Translator.php
@@ -215,7 +215,7 @@ class Translator {
 			return $url_lang;
 		}
 
-		$user = _elgg_services()->session->getLoggedInUser();
+		$user = elgg_get_session()->getLoggedInUser();
 		$language = false;
 
 		if (($user) && ($user->language)) {
@@ -462,7 +462,7 @@ class Translator {
 
 		$installed = [];
 
-		$admin_logged_in = _elgg_services()->session->isAdminLoggedIn();
+		$admin_logged_in = elgg_get_session()->isAdminLoggedIn();
 
 		foreach ($this->translations as $k => $v) {
 			if ($this->languageKeyExists($k, $k)) {

--- a/engine/classes/Elgg/Notifications/Event.php
+++ b/engine/classes/Elgg/Notifications/Event.php
@@ -51,7 +51,7 @@ class Event implements NotificationEvent {
 
 		$this->actor = $actor;
 		if (!isset($actor)) {
-			$this->actor = _elgg_services()->session->getLoggedInUser();
+			$this->actor = elgg_get_session()->getLoggedInUser();
 		}
 
 		$this->action = $action;

--- a/engine/classes/Elgg/Notifications/InstantNotificationEvent.php
+++ b/engine/classes/Elgg/Notifications/InstantNotificationEvent.php
@@ -40,7 +40,7 @@ class InstantNotificationEvent implements NotificationEvent {
 
 		$this->actor = $actor;
 		if (!isset($actor)) {
-			$this->actor = _elgg_services()->session->getLoggedInUser();
+			$this->actor = elgg_get_session()->getLoggedInUser();
 		}
 
 		$this->action = $action ? : self::DEFAULT_ACTION_NAME;

--- a/engine/classes/Elgg/Notifications/NotificationsService.php
+++ b/engine/classes/Elgg/Notifications/NotificationsService.php
@@ -36,9 +36,6 @@ class NotificationsService {
 	/** @var PluginHooksService */
 	protected $hooks;
 
-	/** @var ElggSession */
-	protected $session;
-
 	/** @var Translator */
 	protected $translator;
 
@@ -74,7 +71,6 @@ class NotificationsService {
 	public function __construct(
 			SubscriptionsService $subscriptions,
 			Queue $queue, PluginHooksService $hooks,
-			ElggSession $session,
 			Translator $translator,
 			EntityTable $entities,
 			Logger $logger) {
@@ -82,7 +78,6 @@ class NotificationsService {
 		$this->subscriptions = $subscriptions;
 		$this->queue = $queue;
 		$this->hooks = $hooks;
-		$this->session = $session;
 		$this->translator = $translator;
 		$this->entities = $entities;
 		$this->logger = $logger;
@@ -210,7 +205,7 @@ class NotificationsService {
 
 		// @todo grab mutex
 
-		$ia = $this->session->setIgnoreAccess(true);
+		$ia = elgg_get_session()->setIgnoreAccess(true);
 
 		while (time() < $stopTime) {
 			// dequeue notification event
@@ -248,7 +243,7 @@ class NotificationsService {
 
 		// release mutex
 
-		$this->session->setIgnoreAccess($ia);
+		elgg_get_session()->setIgnoreAccess($ia);
 
 		return $matrix ? $delivery_matrix : $count;
 	}

--- a/engine/classes/Elgg/RedirectService.php
+++ b/engine/classes/Elgg/RedirectService.php
@@ -1,17 +1,11 @@
 <?php
-namespace Elgg;
 
-use ElggSession;
+namespace Elgg;
 
 /**
  * Handles common tasks when redirecting a request
  */
 class RedirectService {
-
-	/**
-	 * @var ElggSession
-	 */
-	protected $session;
 
 	/**
 	 * @var bool
@@ -31,13 +25,11 @@ class RedirectService {
 	/**
 	 * Constructor
 	 *
-	 * @param ElggSession $session     Elgg session
-	 * @param bool        $is_xhr      Is the request from Ajax?
-	 * @param string      $site_url    Site URL
-	 * @param string      $current_url Current URL
+	 * @param bool   $is_xhr      Is the request from Ajax?
+	 * @param string $site_url    Site URL
+	 * @param string $current_url Current URL
 	 */
-	public function __construct(ElggSession $session, $is_xhr, $site_url, $current_url) {
-		$this->session = $session;
+	public function __construct($is_xhr, $site_url, $current_url) {
 		$this->is_xhr = $is_xhr;
 		$this->site_url = $site_url;
 		$this->current_url = $current_url;
@@ -69,6 +61,6 @@ class RedirectService {
 			}
 		}
 
-		$this->session->set('last_forward_from', $this->current_url);
+		elgg_get_session()->set('last_forward_from', $this->current_url);
 	}
 }

--- a/engine/classes/Elgg/Router.php
+++ b/engine/classes/Elgg/Router.php
@@ -54,12 +54,12 @@ class Router {
 		}
 
 		$is_walled_garden = _elgg_config()->walled_garden;
-		$is_logged_in = _elgg_services()->session->isLoggedIn();
+		$is_logged_in = elgg_get_session()->isLoggedIn();
 		$url = elgg_normalize_url($identifier . '/' . implode('/', $segments));
 		
 		if ($is_walled_garden && !$is_logged_in && !$this->isPublicPage($url)) {
 			if (!elgg_is_xhr()) {
-				_elgg_services()->session->set('last_forward_from', current_page_url());
+				elgg_get_session()->set('last_forward_from', current_page_url());
 			}
 			register_error(_elgg_services()->translator->translate('loggedinrequired'));
 			_elgg_services()->responseFactory->redirect('', 'walled_garden');

--- a/engine/classes/Elgg/SystemMessagesService.php
+++ b/engine/classes/Elgg/SystemMessagesService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elgg;
 
 use Elgg\SystemMessages\RegisterSet;
@@ -8,7 +9,7 @@ use Elgg\SystemMessages\RegisterSet;
  *
  * Use the elgg_* versions instead.
  *
- * @access private
+ * @access     private
  *
  * @package    Elgg.Core
  * @subpackage UX
@@ -19,20 +20,6 @@ class SystemMessagesService {
 	const SUCCESS = 'success';
 	const ERROR = 'error';
 	const SESSION_KEY = '_elgg_msgs';
-
-	/**
-	 * @var \ElggSession
-	 */
-	protected $session;
-
-	/**
-	 * Constructor
-	 *
-	 * @param \ElggSession $session The Elgg session
-	 */
-	public function __construct(\ElggSession $session) {
-		$this->session = $session;
-	}
 
 	/**
 	 * Empty and return the given register or all registers. In each case, the return value is
@@ -62,6 +49,7 @@ class SystemMessagesService {
 		}
 
 		$this->saveRegisters($set);
+
 		return $return;
 	}
 
@@ -121,11 +109,12 @@ class SystemMessagesService {
 	 * @return RegisterSet
 	 */
 	public function loadRegisters() {
-		$registers = $this->session->get(self::SESSION_KEY, []);
+		$registers = elgg_get_session()->get(self::SESSION_KEY, []);
 		$set = new RegisterSet();
 		foreach ($registers as $key => $register) {
 			$set->{$key} = $register;
 		}
+
 		return $set;
 	}
 
@@ -140,6 +129,7 @@ class SystemMessagesService {
 	 * Messages are stored as strings in the Elgg session as ['msg'][$register] array.
 	 *
 	 * @param RegisterSet $set The set of registers
+	 *
 	 * @return void
 	 */
 	public function saveRegisters(RegisterSet $set) {
@@ -158,6 +148,6 @@ class SystemMessagesService {
 			}
 		}
 
-		$this->session->set(self::SESSION_KEY, $data);
+		elgg_get_session()->set(self::SESSION_KEY, $data);
 	}
 }

--- a/engine/classes/ElggAccessCollection.php
+++ b/engine/classes/ElggAccessCollection.php
@@ -93,7 +93,7 @@ class ElggAccessCollection extends ElggData {
 			return _elgg_services()->hooks->trigger('access_collection:name', $this->getType(), $params, $name);
 		};
 
-		$user = _elgg_services()->session->getLoggedInUser();
+		$user = elgg_get_session()->getLoggedInUser();
 		$owner = $this->getOwnerEntity();
 		if (!$user || !$owner) {
 			// User is not logged in or does not access to the owner entity:

--- a/engine/classes/ElggDiskFilestore.php
+++ b/engine/classes/ElggDiskFilestore.php
@@ -209,7 +209,7 @@ class ElggDiskFilestore extends \ElggFilestore {
 	public function getFilenameOnFilestore(\ElggFile $file) {
 		$owner_guid = $file->getOwnerGuid();
 		if (!$owner_guid) {
-			$owner_guid = _elgg_services()->session->getLoggedInUserGuid();
+			$owner_guid = elgg_get_session()->getLoggedInUserGuid();
 		}
 
 		if (!$owner_guid) {

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -128,7 +128,7 @@ class ElggGroup extends \ElggEntity {
 	 */
 	public function isMember(\ElggUser $user = null) {
 		if ($user == null) {
-			$user = _elgg_services()->session->getLoggedInUser();
+			$user = elgg_get_session()->getLoggedInUser();
 		}
 		if (!$user) {
 			return false;

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -776,7 +776,7 @@ class ElggInstaller {
 		$use_elgg_session = ($index_step == $index_admin && $this->is_action) || ($index_step == $index_complete);
 		if (!$use_elgg_session) {
 			$session = ElggSession::fromFiles($app->_services->config);
-			$session->setName('Elgg_install');
+			//$session->setName('Elgg_install');
 			$app->_services->setValue('session', $session);
 		}
 

--- a/engine/classes/ElggMetadata.php
+++ b/engine/classes/ElggMetadata.php
@@ -95,7 +95,7 @@ class ElggMetadata extends \ElggExtender {
 	public function delete() {
 		$success = _elgg_delete_metastring_based_object_by_id($this->id, 'metadata');
 		if ($success) {
-			_elgg_services()->metadataCache->clear($this->entity_guid);
+			elgg_get_session()->metadataCache->clear($this->entity_guid);
 		}
 		return $success;
 	}
@@ -110,7 +110,7 @@ class ElggMetadata extends \ElggExtender {
 		$success = _elgg_set_metastring_based_object_enabled_by_id($this->id, 'no', 'metadata');
 		if ($success) {
 			$this->enabled = 'no';
-			_elgg_services()->metadataCache->clear($this->entity_guid);
+			elgg_get_session()->metadataCache->clear($this->entity_guid);
 		}
 		return $success;
 	}
@@ -125,7 +125,7 @@ class ElggMetadata extends \ElggExtender {
 		$success = _elgg_set_metastring_based_object_enabled_by_id($this->id, 'yes', 'metadata');
 		if ($success) {
 			$this->enabled = 'yes';
-			_elgg_services()->metadataCache->clear($this->entity_guid);
+			elgg_get_session()->metadataCache->clear($this->entity_guid);
 		}
 		return $success;
 	}

--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -53,7 +53,7 @@ class ElggObject extends \ElggEntity {
 		}
 
 		if ($user_guid == 0) {
-			$user_guid = _elgg_services()->session->getLoggedInUserGuid();
+			$user_guid = elgg_get_session()->getLoggedInUserGuid();
 		}
 
 		// must be logged in to comment

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -468,7 +468,7 @@ class ElggPlugin extends \ElggObject {
 		if ($user_guid) {
 			$user = get_entity($user_guid);
 		} else {
-			$user = _elgg_services()->session->getLoggedInUser();
+			$user = elgg_get_session()->getLoggedInUser();
 		}
 
 		if (!($user instanceof \ElggUser)) {
@@ -518,7 +518,7 @@ class ElggPlugin extends \ElggObject {
 		if ($user_guid) {
 			$user = get_entity($user_guid);
 		} else {
-			$user = _elgg_services()->session->getLoggedInUser();
+			$user = elgg_get_session()->getLoggedInUser();
 		}
 
 		if (!($user instanceof \ElggUser)) {
@@ -559,7 +559,7 @@ class ElggPlugin extends \ElggObject {
 		if ($user_guid) {
 			$user = get_entity($user_guid);
 		} else {
-			$user = _elgg_services()->session->getLoggedInUser();
+			$user = elgg_get_session()->getLoggedInUser();
 		}
 
 		if (!($user instanceof \ElggUser)) {

--- a/engine/classes/ElggUpgrade.php
+++ b/engine/classes/ElggUpgrade.php
@@ -49,6 +49,8 @@ class ElggUpgrade extends ElggObject {
 		$this->attributes['container_guid'] = 0;
 		$this->attributes['owner_guid'] = 0;
 
+		$this->attributes['access_id'] = ACCESS_PUBLIC;
+
 		$this->is_completed = 0;
 	}
 

--- a/engine/lib/access.php
+++ b/engine/lib/access.php
@@ -44,7 +44,7 @@ use Elgg\Project\Paths;
  * @see elgg_get_ignore_access()
  */
 function elgg_set_ignore_access($ignore = true) {
-	return _elgg_services()->session->setIgnoreAccess($ignore);
+	return elgg_get_session()->setIgnoreAccess($ignore);
 }
 
 /**
@@ -55,7 +55,7 @@ function elgg_set_ignore_access($ignore = true) {
  * @see elgg_set_ignore_access()
  */
 function elgg_get_ignore_access() {
-	return _elgg_services()->session->getIgnoreAccess();
+	return elgg_get_session()->getIgnoreAccess();
 }
 
 /**
@@ -124,7 +124,7 @@ function get_default_access(ElggUser $user = null, array $input_params = []) {
 
 	// user default access if enabled
 	if (_elgg_config()->allow_user_default_access) {
-		$user = $user ? $user : _elgg_services()->session->getLoggedInUser();
+		$user = $user ? $user : elgg_get_session()->getLoggedInUser();
 		if ($user) {
 			$user_access = $user->getPrivateSetting('elgg_default_access');
 			if ($user_access !== null) {

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -298,7 +298,7 @@ function _elgg_symlink_cache() {
  * @access private
  */
 function _elgg_invalidate_cache_for_entity($entity_guid) {
-	_elgg_services()->entityCache->remove($entity_guid);
+	elgg_get_session()->entityCache->remove($entity_guid);
 }
 
 /**

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -58,7 +58,11 @@ function elgg_get_data_path() {
  * @return string
  */
 function elgg_get_cache_path() {
-	return _elgg_config()->cacheroot;
+	$path = _elgg_config()->cacheroot;
+	if (!$path) {
+		$path = elgg_get_data_path();
+	}
+	return $path;
 }
 
 /**

--- a/engine/lib/metadata.php
+++ b/engine/lib/metadata.php
@@ -340,7 +340,7 @@ function get_metadata_url($id) {
  * @todo not used
  */
 function _elgg_invalidate_metadata_cache($action, array $options) {
-	_elgg_services()->metadataCache->invalidateByOptions($options);
+	elgg_get_session()->metadataCache->invalidateByOptions($options);
 }
 
 /**

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -408,13 +408,13 @@ function _elgg_prefetch_river_entities(array $river_items) {
 	// prefetch objects, subjects and targets
 	$guids = [];
 	foreach ($river_items as $item) {
-		if ($item->subject_guid && !_elgg_services()->entityCache->get($item->subject_guid)) {
+		if ($item->subject_guid && !elgg_get_session()->entityCache->get($item->subject_guid)) {
 			$guids[$item->subject_guid] = true;
 		}
-		if ($item->object_guid && !_elgg_services()->entityCache->get($item->object_guid)) {
+		if ($item->object_guid && !elgg_get_session()->entityCache->get($item->object_guid)) {
 			$guids[$item->object_guid] = true;
 		}
-		if ($item->target_guid && !_elgg_services()->entityCache->get($item->target_guid)) {
+		if ($item->target_guid && !elgg_get_session()->entityCache->get($item->target_guid)) {
 			$guids[$item->target_guid] = true;
 		}
 	}
@@ -433,7 +433,7 @@ function _elgg_prefetch_river_entities(array $river_items) {
 	$guids = [];
 	foreach ($river_items as $item) {
 		$object = $item->getObjectEntity();
-		if ($object->container_guid && !_elgg_services()->entityCache->get($object->container_guid)) {
+		if ($object->container_guid && !elgg_get_session()->entityCache->get($object->container_guid)) {
 			$guids[$object->container_guid] = true;
 		}
 	}

--- a/engine/lib/sessions.php
+++ b/engine/lib/sessions.php
@@ -27,7 +27,7 @@ function elgg_get_session() {
  * @return \ElggUser|null
  */
 function elgg_get_logged_in_user_entity() {
-	return _elgg_services()->session->getLoggedInUser();
+	return elgg_get_session()->getLoggedInUser();
 }
 
 /**
@@ -37,7 +37,7 @@ function elgg_get_logged_in_user_entity() {
  * @return int
  */
 function elgg_get_logged_in_user_guid() {
-	return _elgg_services()->session->getLoggedInUserGuid();
+	return elgg_get_session()->getLoggedInUserGuid();
 }
 
 /**
@@ -46,7 +46,7 @@ function elgg_get_logged_in_user_guid() {
  * @return bool
  */
 function elgg_is_logged_in() {
-	return _elgg_services()->session->isLoggedIn();
+	return elgg_get_session()->isLoggedIn();
 }
 
 /**
@@ -55,7 +55,7 @@ function elgg_is_logged_in() {
  * @return bool
  */
 function elgg_is_admin_logged_in() {
-	return _elgg_services()->session->isAdminLoggedIn();
+	return elgg_get_session()->isAdminLoggedIn();
 }
 
 /**
@@ -285,7 +285,7 @@ function login(\ElggUser $user, $persistent = false) {
 		throw new \LoginException(elgg_echo('LoginException:BannedUser'));
 	}
 
-	$session = _elgg_services()->session;
+	$session = elgg_get_session();
 
 	// give plugins a chance to reject the login of this user (no user in session!)
 	if (!elgg_trigger_before_event('login', 'user', $user)) {
@@ -318,7 +318,7 @@ function login(\ElggUser $user, $persistent = false) {
  * @return bool
  */
 function logout() {
-	$session = _elgg_services()->session;
+	$session = elgg_get_session();
 	$user = $session->getLoggedInUser();
 	if (!$user) {
 		return false;
@@ -371,7 +371,7 @@ function _elgg_session_boot(ServiceProvider $services) {
 
 	if ($user) {
 		$session->setLoggedInUser($user);
-		set_last_action($user);
+		$user->setLastLogin();
 
 		// logout a user with open session who has been banned
 		if ($user->isBanned()) {

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -21,51 +21,6 @@ function disable_user_entities($owner_guid) {
 }
 
 /**
- * Ban a user
- *
- * @param int    $user_guid The user guid
- * @param string $reason    A reason
- *
- * @return bool
- */
-function ban_user($user_guid, $reason = "") {
-	return _elgg_services()->usersTable->ban($user_guid, $reason);
-}
-
-/**
- * Unban a user.
- *
- * @param int $user_guid Unban a user.
- *
- * @return bool
- */
-function unban_user($user_guid) {
-	return _elgg_services()->usersTable->unban($user_guid);
-}
-
-/**
- * Makes user $guid an admin.
- *
- * @param int $user_guid User guid
- *
- * @return bool
- */
-function make_user_admin($user_guid) {
-	return _elgg_services()->usersTable->makeAdmin($user_guid);
-}
-
-/**
- * Removes user $guid's admin flag.
- *
- * @param int $user_guid User GUID
- *
- * @return bool
- */
-function remove_user_admin($user_guid) {
-	return _elgg_services()->usersTable->removeAdmin($user_guid);
-}
-
-/**
  * Get a user object from a GUID.
  *
  * This function returns an \ElggUser from a given GUID.
@@ -410,39 +365,6 @@ function elgg_get_login_url(array $query = [], $fragment = '') {
 	$url = elgg_normalize_url('login');
 	$url = elgg_http_add_url_query_elements($url, $query) . $fragment;
 	return elgg_trigger_plugin_hook('login_url', 'site', $query, $url);
-}
-
-/**
- * Sets the last action time of the given user to right now.
- *
- * @param ElggUser|int $user The user or GUID
- * @return void
- */
-function set_last_action($user) {
-	if (!$user) {
-		return;
-	}
-	if (!$user instanceof ElggUser) {
-		$user = get_user($user);
-	}
-	if (!$user) {
-		return;
-	}
-	_elgg_services()->usersTable->setLastAction($user);
-}
-
-/**
- * Sets the last logon time of the given user to right now.
- *
- * @param int $user_guid The user GUID
- * @return void
- */
-function set_last_login($user_guid) {
-	$user = get_user($user_guid);
-	if (!$user) {
-		return;
-	}
-	_elgg_services()->usersTable->setLastLogin($user);
 }
 
 /**

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1903,7 +1903,7 @@ function _elgg_get_js_page_data() {
 		],
 		'session' => [
 			'user' => null,
-			'token' => _elgg_services()->session->get('__elgg_session'),
+			'token' => elgg_get_session()->get('__elgg_session'),
 		],
 		'_data' => (object) $data,
 	];

--- a/engine/tests/classes/Elgg/BaseTestCase.php
+++ b/engine/tests/classes/Elgg/BaseTestCase.php
@@ -142,9 +142,6 @@ abstract class BaseTestCase extends PHPUnit_Framework_TestCase implements Seedab
 		$app->_services->annotations->setCurrentTime($dt);
 		$app->_services->usersTable->setCurrentTime($dt);
 
-		// Invalidate memcache
-		_elgg_get_memcache('new_entity_cache')->clear();
-
 		$app->_services->session->removeLoggedInUser();
 		$app->_services->session->setIgnoreAccess(false);
 		access_show_hidden_entities(false);

--- a/engine/tests/classes/Elgg/Mocks/Di/MockServiceProvider.php
+++ b/engine/tests/classes/Elgg/Mocks/Di/MockServiceProvider.php
@@ -43,26 +43,23 @@ class MockServiceProvider extends \Elgg\Di\ServiceProvider {
 			return new \Elgg\Mocks\Database\EntityTable(
 				$sp->config,
 				$sp->db,
-				$sp->entityCache,
-				$sp->metadataCache,
 				$sp->subtypeTable,
-				$sp->hooks->getEvents(),
-				$sp->session,
+				$sp->hooks,
 				$sp->translator,
 				$sp->logger
 			);
 		});
 
 		$this->setFactory('metadataTable', function (MockServiceProvider $sp) {
-			return new \Elgg\Mocks\Database\MetadataTable($sp->metadataCache, $sp->db, $sp->entityTable, $sp->hooks->getEvents(), $sp->session);
+			return new \Elgg\Mocks\Database\MetadataTable($sp->db, $sp->entityTable, $sp->hooks);
 		});
 
 		$this->setFactory('annotations', function (MockServiceProvider $sp) {
-			return new \Elgg\Mocks\Database\Annotations($sp->db, $sp->session, $sp->hooks->getEvents());
+			return new \Elgg\Mocks\Database\Annotations($sp->db, $sp->hooks);
 		});
 
 		$this->setFactory('relationshipsTable', function (MockServiceProvider $sp) {
-			return new \Elgg\Mocks\Database\RelationshipsTable($sp->db, $sp->entityTable, $sp->metadataTable, $sp->hooks->getEvents());
+			return new \Elgg\Mocks\Database\RelationshipsTable($sp->db, $sp->entityTable, $sp->metadataTable, $sp->hooks);
 		});
 
 		$this->setFactory('subtypeTable', function (MockServiceProvider $sp) {
@@ -75,9 +72,7 @@ class MockServiceProvider extends \Elgg\Di\ServiceProvider {
 				$sp->db,
 				$sp->entityTable,
 				$sp->userCapabilities,
-				$sp->accessCache,
 				$sp->hooks,
-				$sp->session,
 				$sp->translator
 			);
 		});

--- a/engine/tests/classes/Elgg/Testing.php
+++ b/engine/tests/classes/Elgg/Testing.php
@@ -57,7 +57,7 @@ trait Testing {
 		$request = Request::create($path, $method, $parameters);
 
 		$cookie_name = _elgg_config()->getCookieConfig()['session']['name'];
-		$session_id = _elgg_services()->session->getId();
+		$session_id = elgg_get_session()->getId();
 		$request->cookies->set($cookie_name, $session_id);
 
 		$request->headers->set('Referer', elgg_normalize_url('phpunit'));

--- a/engine/tests/classes/Elgg/UnitTestCase.php
+++ b/engine/tests/classes/Elgg/UnitTestCase.php
@@ -26,6 +26,8 @@ abstract class UnitTestCase extends BaseTestCase {
 		$sp->config->getCookieConfig();
 		$sp->config->boot_complete = false;
 
+		$sp->db->disableQueryCache();
+
 		$app = Application::factory([
 			'config' => $config,
 			'service_provider' => $sp,
@@ -69,6 +71,8 @@ abstract class UnitTestCase extends BaseTestCase {
 	 */
 	final protected function tearDown() {
 		$this->down();
+
+		_elgg_services()->entityTable->clearMocks();
 
 		parent::tearDown();
 	}

--- a/engine/tests/classes/ElggCoreUnitTest.php
+++ b/engine/tests/classes/ElggCoreUnitTest.php
@@ -31,8 +31,8 @@ abstract class ElggCoreUnitTest extends UnitTestCase implements Seedable, \Elgg\
 		$this->assertIsA(_elgg_services(), ServiceProvider::class);
 		$this->assertIsA(_elgg_services()->config, Config::class);
 
-		_elgg_services()->session->setLoggedInUser($this->getAdmin());
-		_elgg_services()->session->setIgnoreAccess(false);
+		elgg_get_session()->setLoggedInUser($this->getAdmin());
+		elgg_get_session()->setIgnoreAccess(false);
 		access_show_hidden_entities(false);
 
 		$this->up();
@@ -53,7 +53,7 @@ abstract class ElggCoreUnitTest extends UnitTestCase implements Seedable, \Elgg\
 		// Simpletest suite runs with an admin user logged in
 		$this->assertTrue(elgg_is_admin_logged_in());
 
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 
 	}
 

--- a/engine/tests/phpunit/ElggEntityUnitTest.php
+++ b/engine/tests/phpunit/ElggEntityUnitTest.php
@@ -13,7 +13,6 @@ class ElggEntityUnitTest extends \Elgg\UnitTestCase {
 	protected $obj;
 
 	public function up() {
-		_elgg_services()->setValue('session', \ElggSession::getMock());
 		$this->obj = $this->getMockForAbstractClass('\ElggObject');
 		$reflection = new ReflectionClass('\ElggObject');
 		$method = $reflection->getMethod('initializeAttributes');

--- a/engine/tests/phpunit/ElggFileUnitTest.php
+++ b/engine/tests/phpunit/ElggFileUnitTest.php
@@ -13,10 +13,6 @@ class ElggFileUnitTest extends \Elgg\UnitTestCase {
 	public function up() {
 		_elgg_filestore_init();
 
-		$session = \ElggSession::getMock();
-		_elgg_services()->setValue('session', $session);
-		_elgg_services()->session->start();
-
 		$file = new \ElggFile();
 		$file->owner_guid = 1;
 		$file->setFilename("foobar.txt");

--- a/engine/tests/phpunit/ElggMetadataUnitTest.php
+++ b/engine/tests/phpunit/ElggMetadataUnitTest.php
@@ -102,7 +102,7 @@ class ElggMetadataUnitTest extends UnitTestCase {
 	public function testCanSaveMetadata() {
 
 		$owner = $this->createUser();
-		_elgg_services()->session->setLoggedInUser($owner);
+		elgg_get_session()->setLoggedInUser($owner);
 
 		$object = $this->createObject([
 			'owner_guid' => $owner->guid,
@@ -138,13 +138,13 @@ class ElggMetadataUnitTest extends UnitTestCase {
 
 		$this->assertEquals($id, $metadata->save());
 		
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 	}
 
 	public function testCanDeleteMetadata() {
 
 		$owner = $this->createUser();
-		_elgg_services()->session->setLoggedInUser($owner);
+		elgg_get_session()->setLoggedInUser($owner);
 
 		$object = $this->createObject([
 			'owner_guid' => $owner->guid,
@@ -167,13 +167,13 @@ class ElggMetadataUnitTest extends UnitTestCase {
 
 		$this->assertTrue($metadata->delete());
 
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 	}
 
 	public function testCanDisableMetadata() {
 
 		$owner = $this->createUser();
-		_elgg_services()->session->setLoggedInUser($owner);
+		elgg_get_session()->setLoggedInUser($owner);
 
 		$object = $this->createObject([
 			'owner_guid' => $owner->guid,
@@ -192,7 +192,7 @@ class ElggMetadataUnitTest extends UnitTestCase {
 
 		$this->assertEquals('yes', $metadata->enabled);
 
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 	}
 
 }

--- a/engine/tests/phpunit/ElggObjectUnitTest.php
+++ b/engine/tests/phpunit/ElggObjectUnitTest.php
@@ -22,7 +22,7 @@ class ElggObjectUnitTest extends \Elgg\UnitTestCase {
 		$user = $this->createUser();
 		$user2 = $this->createUser();
 
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 
 		$group = $this->createGroup([
 			'owner_guid' => $user2->guid,
@@ -39,7 +39,7 @@ class ElggObjectUnitTest extends \Elgg\UnitTestCase {
 
 		$this->assertTrue($object->canComment());
 
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 	}
 
 	public function testCanConstructWithoutArguments() {
@@ -80,7 +80,7 @@ class ElggObjectUnitTest extends \Elgg\UnitTestCase {
 		$subtype_id = add_subtype('object', $subtype);
 
 		$user = $this->createUser();
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 		
 		$object = new \ElggObject();
 		$object->subtype = $subtype;
@@ -115,13 +115,13 @@ class ElggObjectUnitTest extends \Elgg\UnitTestCase {
 		$this->assertEquals($user, $object->getContainerEntity());
 		$this->assertEquals(ACCESS_LOGGED_IN, $object->access_id);
 
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 	}
 
 	public function testCanUpdateObject() {
 
 		$user = $this->createUser();
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 
 		$object = $this->createObject([
 			'owner_guid' => $user->guid,
@@ -157,7 +157,7 @@ class ElggObjectUnitTest extends \Elgg\UnitTestCase {
 		$object = get_entity($object->guid);
 		$this->assertEquals(ACCESS_PUBLIC, $object->access_id);
 
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 	}
 
 	public function testCanCloneObject() {
@@ -219,12 +219,12 @@ class ElggObjectUnitTest extends \Elgg\UnitTestCase {
 	public function testCanCommentWhenLoggedIn() {
 
 		$user = $this->createUser();
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 
 		$object = $this->createObject();
 		$this->assertTrue($object->canComment());
 
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 	}
 
 	public function testCanAddRelationship() {

--- a/engine/tests/phpunit/integration/Elgg/Database/SeedingTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Database/SeedingTest.php
@@ -2,13 +2,13 @@
 
 namespace Elgg\Database;
 
-use Elgg\LegacyIntegrationTestCase;
+use Elgg\IntegrationTestCase;
 
 /**
  * @group IntegrationTests
  * @group Seeding
  */
-class SeedingTest extends LegacyIntegrationTestCase {
+class SeedingTest extends IntegrationTestCase {
 
 	public function up() {
 
@@ -56,12 +56,61 @@ class SeedingTest extends LegacyIntegrationTestCase {
 	public function testCanCreateAdminUser() {
 
 		$user = $this->createUser([
-			'admin' => true,
+			'admin' => 'yes',
 		]);
 
 		$this->assertTrue($user->isAdmin());
+		$this->assertTrue(get_entity($user->guid)->isAdmin());
+
+		_elgg_invalidate_cache_for_entity($user->guid);
+		_elgg_invalidate_memcache_for_entity($user->guid);
+
+		$this->assertTrue(get_entity($user->guid)->isAdmin());
 
 		$user->delete();
+	}
+
+	public function testCanCreateBannedUser() {
+
+		$user = $this->createUser([
+			'banned' => 'yes',
+		]);
+
+		$this->assertTrue($user->isBanned());
+		$this->assertTrue(get_entity($user->guid)->isBanned());
+
+		_elgg_invalidate_cache_for_entity($user->guid);
+		_elgg_invalidate_memcache_for_entity($user->guid);
+
+		$this->assertTrue(get_entity($user->guid)->isBanned());
+
+		$user->delete();
+	}
+
+	public function testCanSetUserLanguage() {
+
+		$user = $this->createUser([
+			'language' => 'de',
+		]);
+
+		$this->assertEquals('de', $user->language);
+		$this->assertEquals('de', $user->getLanguage());
+		$this->assertEquals('de', get_entity($user->guid)->getLanguage());
+
+		$ia = elgg_set_ignore_access(true);
+		$user->language = 'af';
+		$this->assertTrue($user->save());
+		elgg_set_ignore_access($ia);
+
+		$this->assertEquals('af', $user->language);
+		$this->assertEquals('af', $user->getLanguage());
+		$this->assertEquals('af', get_entity($user->guid)->getLanguage());
+
+		_elgg_invalidate_cache_for_entity($user->guid);
+		_elgg_invalidate_memcache_for_entity($user->guid);
+
+		$this->assertEquals('af', get_entity($user->guid)->getLanguage());
+
 	}
 
 	public function testCanCreateGroup() {

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAccessCollectionsTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAccessCollectionsTest.php
@@ -126,8 +126,8 @@ class ElggCoreAccessCollectionsTest extends LegacyIntegrationTestCase {
 		$this->assertTrue($result);
 		elgg_set_ignore_access($ia);
 
-		$logged_in_user = _elgg_services()->session->getLoggedInUser();
-		_elgg_services()->session->removeLoggedInUser();
+		$logged_in_user = elgg_get_session()->getLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 
 		$ia = elgg_set_ignore_access(false);
 		$result = can_edit_access_collection($acl_id, $this->user->guid);
@@ -136,7 +136,7 @@ class ElggCoreAccessCollectionsTest extends LegacyIntegrationTestCase {
 		$this->assertFalse($result_no_user);
 		elgg_set_ignore_access($ia);
 
-		_elgg_services()->session->setLoggedInUser($logged_in_user);
+		elgg_get_session()->setLoggedInUser($logged_in_user);
 
 		delete_access_collection($acl_id);
 	}
@@ -248,7 +248,7 @@ class ElggCoreAccessCollectionsTest extends LegacyIntegrationTestCase {
 					 'get_access_list',
 					 'get_access_array'
 				 ] as $func) {
-			_elgg_services()->accessCache->clear();
+			elgg_get_session()->accessCache->clear();
 
 			// admin users run tests, so disable access
 			$ia = elgg_set_ignore_access(true);
@@ -283,14 +283,14 @@ class ElggCoreAccessCollectionsTest extends LegacyIntegrationTestCase {
 	}
 
 	public function testCanGetGuestReadAcccessArray() {
-		$logged_in_user = _elgg_services()->session->getLoggedInUser();
-		_elgg_services()->session->removeLoggedInUser();
+		$logged_in_user = elgg_get_session()->getLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 
 		$expected = [ACCESS_PUBLIC];
 		$actual = get_access_array();
 		$this->assertEqual($expected, $actual);
 
-		_elgg_services()->session->setLoggedInUser($logged_in_user);
+		elgg_get_session()->setLoggedInUser($logged_in_user);
 	}
 
 	public function testCanGetReadAccessArray() {

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAccessSQLTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAccessSQLTest.php
@@ -16,12 +16,12 @@ class ElggCoreAccessSQLTest extends LegacyIntegrationTestCase {
 
 	public function up() {
 		$this->user = $this->createOne('user');
-		_elgg_services()->session->setLoggedInUser($this->user);
+		elgg_get_session()->setLoggedInUser($this->user);
 		_elgg_services()->hooks->backup();
 	}
 
 	public function down() {
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 		$this->user->delete();
 		_elgg_services()->hooks->restore();
 	}
@@ -99,8 +99,8 @@ class ElggCoreAccessSQLTest extends LegacyIntegrationTestCase {
 
 	public function testCanBuildAccessSqlForLoggedOutUser() {
 
-		$user = _elgg_services()->session->getLoggedInUser();
-		_elgg_services()->session->removeLoggedInUser();
+		$user = elgg_get_session()->getLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 
 		$sql = _elgg_get_access_where_sql();
 		$access_clause = $this->getLoggedOutAccessListClause('e');
@@ -108,7 +108,7 @@ class ElggCoreAccessSQLTest extends LegacyIntegrationTestCase {
 
 		$this->assertSqlEqual($ans, $sql, "$sql does not match $ans");
 
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 	}
 
 	public function testAccessPluginHookRemoveEnabled() {

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAttributeLoaderTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAttributeLoaderTest.php
@@ -9,42 +9,58 @@ use Elgg\LegacyIntegrationTestCase;
  * Test attribute loader for entities
  *
  * @group IntegrationTests
+ * @group AttributeLoader
  */
 class ElggCoreAttributeLoaderTest extends LegacyIntegrationTestCase {
 
+	/**
+	 * @var array
+	 */
+	private $guids;
+
 	public function up() {
-		$this->createMany(Config::getEntityTypes(), 1);
+
 	}
 
 	public function down() {
 
 	}
 
+	public function entityTypeProvider() {
+		$provides = [];
+
+		foreach (Config::getEntityTypes() as $type) {
+			$provides[] = [$type];
+		}
+
+		return $provides;
+	}
+
 	/**
 	 * Checks if additional select columns are readable as volatile data
 	 *
 	 * https://github.com/Elgg/Elgg/issues/5543
+	 *
+	 * @dataProvider entityTypeProvider
 	 */
-	public function testSqlAdditionalSelectsAsVolatileData() {
+	public function testSqlAdditionalSelectsAsVolatileData($type) {
 
-		$types = Config::getEntityTypes();
-		
-		foreach ($types as $type) {
+		$this->createOne($type);
 
-			$entities = elgg_get_entities([
-				'type' => $type,
-				'selects' => ['42 as added_col2'],
-				'limit' => 1,
-			]);
+		$entities = elgg_get_entities([
+			'guids' => $this->guids,
+			'type' => $type,
+			'selects' => ['42 as added_col2'],
+			'limit' => 1,
+		]);
 
-			$this->assertFalse(empty($entities));
+		$this->assertFalse(empty($entities));
 
-			if ($entities) {
-				$entity = array_shift($entities);
-				$this->assertTrue($entity instanceof \ElggEntity);
-				$this->assertEqual($entity->added_col2, null, "Additional select columns are leaking to attributes for " . get_class($entity));
-				$this->assertEqual($entity->getVolatileData('select:added_col2'), 42);
-			}
+		if ($entities) {
+			$entity = array_shift($entities);
+			$this->assertTrue($entity instanceof \ElggEntity);
+			$this->assertEqual($entity->added_col2, null, "Additional select columns are leaking to attributes for " . get_class($entity));
+			$this->assertEqual($entity->getVolatileData('select:added_col2'), 42);
 		}
 
 	}
@@ -53,48 +69,47 @@ class ElggCoreAttributeLoaderTest extends LegacyIntegrationTestCase {
 	 * Checks if additional select columns are readable as volatile data even if we hit the cache while fetching entity.
 	 *
 	 * https://github.com/Elgg/Elgg/issues/5544
+	 *
+	 * @dataProvider entityTypeProvider
 	 */
-	public function testSqlAdditionalSelectsAsVolatileDataWithCache() {
+	public function testSqlAdditionalSelectsAsVolatileDataWithCache($type) {
 
-		$types = Config::getEntityTypes();
+		$this->createOne($type);
+		
+		$entities = elgg_get_entities([
+			'guids' => $this->guids,
+			'type' => $type,
+			'selects' => ['42 as added_col3'],
+			'limit' => 1,
+		]);
 
-		foreach ($types as $type) {
-			
-			$entities = elgg_get_entities([
-				'type' => $type,
-				'selects' => ['42 as added_col3'],
-				'limit' => 1,
-			]);
-			
-			$this->assertFalse(empty($entities));
-			
-			if ($entities) {
-				$entity = array_shift($entities);
-				$this->assertTrue($entity instanceof \ElggEntity);
-				$this->assertEqual($entity->added_col3, null, "Additional select columns are leaking to attributes for " . get_class($entity));
-				$this->assertEqual($entity->getVolatileData('select:added_col3'), 42);
+		$this->assertFalse(empty($entities));
 
-				// make sure we have cached the entity
-				$this->assertNotEqual(false, _elgg_services()->entityCache->get($entity->guid));
-			}
+		if ($entities) {
+			$entity = array_shift($entities);
+			$this->assertTrue($entity instanceof \ElggEntity);
+			$this->assertEqual($entity->added_col3, null, "Additional select columns are leaking to attributes for " . get_class($entity));
+			$this->assertEqual($entity->getVolatileData('select:added_col3'), 42);
+
+			// make sure we have cached the entity
+			$this->assertNotEqual(false, elgg_get_session()->entityCache->get($entity->guid));
 		}
 
 		// run these again but with different value to make sure cache does not interfere
-		foreach ($types as $type) {
-			$entities = elgg_get_entities([
-				'type' => $type,
-				'selects' => ['64 as added_col3'],
-				'limit' => 1,
-			]);
-			
-			$this->assertFalse(empty($entities));
-			
-			if ($entities) {
-				$entity = array_shift($entities);
-				$this->assertTrue($entity instanceof \ElggEntity);
-				$this->assertEqual($entity->added_col3, null, "Additional select columns are leaking to attributes for " . get_class($entity));
-				$this->assertEqual($entity->getVolatileData('select:added_col3'), 64, "Failed to overwrite volatile data in cached entity");
-			}
+		$entities = elgg_get_entities([
+			'guids' => $this->guids,
+			'type' => $type,
+			'selects' => ['64 as added_col3'],
+			'limit' => 1,
+		]);
+
+		$this->assertFalse(empty($entities));
+
+		if ($entities) {
+			$entity = array_shift($entities);
+			$this->assertTrue($entity instanceof \ElggEntity);
+			$this->assertEqual($entity->added_col3, null, "Additional select columns are leaking to attributes for " . get_class($entity));
+			$this->assertEqual($entity->getVolatileData('select:added_col3'), 64, "Failed to overwrite volatile data in cached entity");
 		}
 	}
 

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreCommentTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreCommentTest.php
@@ -47,8 +47,8 @@ class ElggCoreCommentTest extends LegacyIntegrationTestCase {
 
 		$this->assertTrue(_elgg_services()->hooks->getEvents()->hasHandler('update:after', 'all', '_elgg_comments_access_sync'));
 
-		_elgg_services()->entityCache->disableCachingForEntity($this->comment->guid);
-		_elgg_services()->entityCache->disableCachingForEntity($this->container->guid);
+		elgg_get_session()->entityCache->disableCachingForEntity($this->comment->guid);
+		elgg_get_session()->entityCache->disableCachingForEntity($this->container->guid);
 
 		$this->assertEqual($this->comment->access_id, $this->container->access_id);
 

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreEntityTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreEntityTest.php
@@ -45,7 +45,7 @@ class ElggCoreEntityTest extends \Elgg\LegacyIntegrationTestCase {
 		$this->assertIsA($subtype_prop, 'int');
 		$this->assertEqual($subtype_prop, get_subtype_id('object', 'elgg_entity_test_subtype'));
 
-		_elgg_services()->entityCache->remove($guid);
+		elgg_get_session()->entityCache->remove($guid);
 		$this->entity = null;
 		$this->entity = get_entity($guid);
 
@@ -137,7 +137,7 @@ class ElggCoreEntityTest extends \Elgg\LegacyIntegrationTestCase {
 
 		$this->assertEqual($this->entity->getSubtype(), 'elgg_entity_test_subtype');
 
-		_elgg_services()->entityCache->remove($guid);
+		elgg_get_session()->entityCache->remove($guid);
 		$this->entity = null;
 		$this->entity = get_entity($guid);
 
@@ -529,7 +529,7 @@ class ElggCoreEntityTest extends \Elgg\LegacyIntegrationTestCase {
 	public function testNewUserLoadedFromCacheDuringSaveOperations() {
 
 		$user = new ElggUser();
-		$user->username = $this->getRandomUsername();
+		$user->username = $this->generateUsername();
 
 		// Add temporary metadata, annotation and private settings
 		// to extend the scope of tests and catch issues with save operations

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGroupTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGroupTest.php
@@ -60,8 +60,8 @@ class ElggCoreGroupTest extends LegacyIntegrationTestCase {
 	}
 
 	public function testGroupItemVisibility() {
-		$original_user = _elgg_services()->session->getLoggedInUser();
-		_elgg_services()->session->setLoggedInUser($this->user);
+		$original_user = elgg_get_session()->getLoggedInUser();
+		elgg_get_session()->setLoggedInUser($this->user);
 		$group_guid = $this->group->guid;
 
 		// unrestricted: pass non-members
@@ -83,7 +83,7 @@ class ElggCoreGroupTest extends LegacyIntegrationTestCase {
 		$this->assertFalse($vis->shouldHideItems);
 
 		// non-member admins succeed - assumes admin logged in
-		_elgg_services()->session->setLoggedInUser($original_user);
+		elgg_get_session()->setLoggedInUser($original_user);
 		$vis = GroupItemVisibility::factory($group_guid, false);
 
 		$this->assertFalse($vis->shouldHideItems);

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreMetadataAPITest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreMetadataAPITest.php
@@ -227,12 +227,12 @@ class ElggCoreMetadataAPITest extends LegacyIntegrationTestCase {
 
 		// ignore access bypasses the MD cache, so we try it both ways
 		elgg_set_ignore_access(false);
-		_elgg_services()->metadataCache->clear($obj->guid);
+		elgg_get_session()->metadataCache->clear($obj->guid);
 		$md_values = $obj->test_md;
 		$this->assertEqual($md_values, [1, 2, 3]);
 
 		elgg_set_ignore_access(true);
-		_elgg_services()->metadataCache->clear($obj->guid);
+		elgg_get_session()->metadataCache->clear($obj->guid);
 		$md_values = $obj->test_md;
 		$this->assertEqual($md_values, [1, 2, 3]);
 

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreMetadataCacheTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreMetadataCacheTest.php
@@ -3,6 +3,7 @@
 namespace Elgg\Integration;
 
 use Elgg\Cache\MetadataCache;
+use Elgg\Cache\NullCache;
 use Elgg\LegacyIntegrationTestCase;
 
 /**
@@ -44,7 +45,7 @@ class ElggCoreMetadataCacheTest extends LegacyIntegrationTestCase {
 	public function up() {
 		$this->ignoreAccess = elgg_set_ignore_access(false);
 
-		$this->cache = _elgg_services()->metadataCache;
+		$this->cache = elgg_get_session()->metadataCache;
 
 		$this->obj1 = new \ElggObject();
 		$this->obj1->save();
@@ -63,7 +64,7 @@ class ElggCoreMetadataCacheTest extends LegacyIntegrationTestCase {
 	}
 
 	public function testHas() {
-		$cache = new MetadataCache();
+		$cache = new MetadataCache(new NullCache());
 
 		$cache->inject(1, ['foo1' => 'bar']);
 		$cache->inject(2, []);
@@ -73,7 +74,7 @@ class ElggCoreMetadataCacheTest extends LegacyIntegrationTestCase {
 	}
 
 	public function testLoad() {
-		$cache = new MetadataCache();
+		$cache = new MetadataCache(new NullCache());
 
 		$cache->inject(1, ['foo1' => 'bar']);
 		$cache->inject(2, []);
@@ -84,7 +85,7 @@ class ElggCoreMetadataCacheTest extends LegacyIntegrationTestCase {
 	}
 
 	public function testDirectInvalidation() {
-		$cache = new MetadataCache();
+		$cache = new MetadataCache(new NullCache());
 
 		$cache->inject(1, ['foo1' => 'bar']);
 		$cache->inject(2, []);

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreRegressionBugsTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreRegressionBugsTest.php
@@ -286,7 +286,7 @@ class ElggCoreRegressionBugsTest extends \Elgg\LegacyIntegrationTestCase {
 		$this->assertTrue($group->save() !== false);
 
 		// entity cache interferes with our test
-		_elgg_services()->entityCache->clear();
+		elgg_get_session()->entityCache->clear();
 
 		foreach ([
 					 'site',
@@ -397,7 +397,7 @@ class ElggCoreRegressionBugsTest extends \Elgg\LegacyIntegrationTestCase {
 			'handleUpdateForIssue6225test'
 		]);
 
-		_elgg_services()->entityCache->remove($guid);
+		elgg_get_session()->entityCache->remove($guid);
 
 		$object = get_entity($guid);
 		$this->assertEqual($object->access_id, ACCESS_PRIVATE);

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreRiverAPITest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreRiverAPITest.php
@@ -34,7 +34,7 @@ class ElggCoreRiverAPITest extends \Elgg\LegacyIntegrationTestCase {
 		$this->user = $user;
 		$this->entity = $entity;
 
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 
 		// By default, only admins are allowed to delete river items
 		// For the sake of this test case, we will allow the user to delete items
@@ -45,7 +45,7 @@ class ElggCoreRiverAPITest extends \Elgg\LegacyIntegrationTestCase {
 	}
 
 	public function down() {
-		_elgg_services()->session->setLoggedInUser($this->getAdmin());
+		elgg_get_session()->setLoggedInUser($this->getAdmin());
 
 		$this->user->delete();
 
@@ -245,8 +245,8 @@ class ElggCoreRiverAPITest extends \Elgg\LegacyIntegrationTestCase {
 		$id = elgg_create_river_item($params);
 
 		$owner = $this->entity->getOwnerEntity();
-		$old_user = _elgg_services()->session->getLoggedInUser();
-		_elgg_services()->session->setLoggedInUser($owner);
+		$old_user = elgg_get_session()->getLoggedInUser();
+		elgg_get_session()->setLoggedInUser($owner);
 
 		$events_fired = 0;
 		$handler = function () use (&$events_fired) {
@@ -265,7 +265,7 @@ class ElggCoreRiverAPITest extends \Elgg\LegacyIntegrationTestCase {
 
 		$this->assertEqual($events_fired, 3);
 
-		_elgg_services()->session->setLoggedInUser($old_user);
+		elgg_get_session()->setLoggedInUser($old_user);
 	}
 
 	public function testElggCreateRiverItemMissingRequiredParam() {

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreUserTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreUserTest.php
@@ -16,7 +16,7 @@ class ElggCoreUserTest extends \Elgg\LegacyIntegrationTestCase {
 
 	public function up() {
 		$this->user = new ElggUserWithExposableAttributes();
-		$this->user->username = $this->getRandomUsername();
+		$this->user->username = $this->generateUsername();
 	}
 
 	public function down() {
@@ -109,7 +109,7 @@ class ElggCoreUserTest extends \Elgg\LegacyIntegrationTestCase {
 
 	public function testGetUserByUsernameAcceptsUrlEncoded() {
 
-		$username = $this->getRandomUsername();
+		$username = $this->generateUsername();
 		$this->user->username = $username;
 		$guid = $this->user->save();
 

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggEntityPreloaderIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggEntityPreloaderIntegrationTest.php
@@ -17,8 +17,7 @@ class ElggEntityPreloaderIntegrationTest extends \Elgg\LegacyIntegrationTestCase
 	public function up() {
 		$this->realPreloader = _elgg_services()->entityPreloader;
 
-		$this->mockPreloader = new MockEntityPreloader20140623(
-			_elgg_services()->entityCache, _elgg_services()->entityTable);
+		$this->mockPreloader = new MockEntityPreloader20140623();
 
 		_elgg_services()->setValue('entityPreloader', $this->mockPreloader);
 	}

--- a/engine/tests/phpunit/integration/Elgg/IntegrationTestCaseIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/IntegrationTestCaseIntegrationTest.php
@@ -106,11 +106,11 @@ class IntegrationTestCaseIntegrationTest extends IntegrationTestCase {
 
 		$user = $this->createOne('user');
 
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 
 		$this->assertEquals(elgg_get_logged_in_user_entity(), $user);
 
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 
 	}
 }

--- a/engine/tests/phpunit/unit/Elgg/ActionsServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/ActionsServiceUnitTest.php
@@ -42,15 +42,15 @@ class ActionsServiceUnitTest extends \Elgg\UnitTestCase {
 	public function up() {
 		$this->actionsDir = $this->normalizeTestFilePath('actions');
 
-		$session = _elgg_services()->session;
-		_elgg_services()->session->start();
+		$session = elgg_get_session();
+		elgg_get_session()->start();
 
 		$config = _elgg_config();
 
 		$this->input = new Input();
 		_elgg_services()->setValue('input', $this->input);
 
-		$this->actions = new ActionsService($config, $session, _elgg_services()->crypto);
+		$this->actions = new ActionsService($config, _elgg_services()->crypto);
 		_elgg_services()->setValue('actions', $this->actions);
 
 		$this->request = $this->prepareHttpRequest();
@@ -260,8 +260,8 @@ class ActionsServiceUnitTest extends \Elgg\UnitTestCase {
 		$timeout = $this->actions->getActionTokenTimeout();
 		$timestamp = $dt->getTimestamp();
 		$token = $this->actions->generateActionToken($timestamp);
-		_elgg_services()->session->invalidate();
-		_elgg_services()->session->start();
+		elgg_get_session()->invalidate();
+		elgg_get_session()->start();
 		$this->assertFalse($this->actions->validateActionToken(false, $token, $timestamp));
 	}
 

--- a/engine/tests/phpunit/unit/Elgg/Application/ServeFileHandlerUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Application/ServeFileHandlerUnitTest.php
@@ -18,10 +18,6 @@ class ServeFileHandlerUnitTest extends \Elgg\UnitTestCase {
 	protected $file;
 
 	public function up() {
-		$session = \ElggSession::getMock();
-		_elgg_services()->setValue('session', $session);
-		_elgg_services()->session->start();
-
 		$this->handler = _elgg_services()->serveFileHandler;
 
 		$file = new \ElggFile();
@@ -49,7 +45,7 @@ class ServeFileHandlerUnitTest extends \Elgg\UnitTestCase {
 		$request = \Elgg\Http\Request::create("/$path");
 
 		$cookie_name = _elgg_config()->getCookieConfig()['session']['name'];
-		$session_id = _elgg_services()->session->getId();
+		$session_id = elgg_get_session()->getId();
 		$request->cookies->set($cookie_name, $session_id);
 
 		return $request;
@@ -118,9 +114,9 @@ class ServeFileHandlerUnitTest extends \Elgg\UnitTestCase {
 
 		$this->assertEquals(200, $response->getStatusCode());
 
-		_elgg_services()->session->invalidate();
+		elgg_get_session()->invalidate();
 		$cookie_name = _elgg_config()->getCookieConfig()['session']['name'];
-		$session_id = _elgg_services()->session->getId();
+		$session_id = elgg_get_session()->getId();
 		$request->cookies->set($cookie_name, $session_id);
 
 		$response = $this->handler->getResponse($request);

--- a/engine/tests/phpunit/unit/Elgg/Cache/EntityCacheUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Cache/EntityCacheUnitTest.php
@@ -18,47 +18,47 @@ class EntityCacheUnitTest extends \Elgg\UnitTestCase {
 
 	public function testCanGetEntityAfterDbQuery() {
 
-		$this->assertFalse(_elgg_services()->entityCache->get(0));
+		$this->assertFalse(elgg_get_session()->entityCache->get(0));
 
 		$object = $this->createObject();
 
-		_elgg_services()->entityCache->clear();
+		elgg_get_session()->entityCache->clear();
 
 		$object = get_entity($object->guid);
 
-		$this->assertEquals($object, _elgg_services()->entityCache->get($object->guid));
+		$this->assertEquals($object, elgg_get_session()->entityCache->get($object->guid));
 	}
 
 	public function testCanCacheElggObject() {
 
 		$object = $this->createObject();
 
-		_elgg_services()->entityCache->clear();
+		elgg_get_session()->entityCache->clear();
 
-		_elgg_services()->entityCache->set($object);
+		elgg_get_session()->entityCache->set($object);
 
-		$this->assertEquals($object, _elgg_services()->entityCache->get($object->guid));
+		$this->assertEquals($object, elgg_get_session()->entityCache->get($object->guid));
 
-		_elgg_services()->entityCache->remove($object->guid);
+		elgg_get_session()->entityCache->remove($object->guid);
 
-		$this->assertFalse(_elgg_services()->entityCache->get($object->guid));
+		$this->assertFalse(elgg_get_session()->entityCache->get($object->guid));
 	}
 	
 	public function testCanCacheElggUser() {
 
 		$user = $this->createUser();
 
-		_elgg_services()->entityCache->clear();
+		elgg_get_session()->entityCache->clear();
 
-		_elgg_services()->entityCache->set($user);
+		elgg_get_session()->entityCache->set($user);
 
-		$this->assertEquals($user, _elgg_services()->entityCache->get($user->guid));
-		$this->assertEquals($user, _elgg_services()->entityCache->getByUsername($user->username));
+		$this->assertEquals($user, elgg_get_session()->entityCache->get($user->guid));
+		$this->assertEquals($user, elgg_get_session()->entityCache->getByUsername($user->username));
 		
-		_elgg_services()->entityCache->remove($user->guid);
+		elgg_get_session()->entityCache->remove($user->guid);
 		
-		$this->assertFalse(_elgg_services()->entityCache->get($user->guid));
-		$this->assertFalse(_elgg_services()->entityCache->getByUsername($user->username));
+		$this->assertFalse(elgg_get_session()->entityCache->get($user->guid));
+		$this->assertFalse(elgg_get_session()->entityCache->getByUsername($user->username));
 
 	}
 
@@ -66,19 +66,19 @@ class EntityCacheUnitTest extends \Elgg\UnitTestCase {
 
 		$object = $this->createObject();
 
-		_elgg_services()->entityCache->clear();
+		elgg_get_session()->entityCache->clear();
 
-		_elgg_services()->entityCache->disableCachingForEntity($object->guid);
+		elgg_get_session()->entityCache->disableCachingForEntity($object->guid);
 
-		_elgg_services()->entityCache->set($object);
+		elgg_get_session()->entityCache->set($object);
 
-		$this->assertFalse(_elgg_services()->entityCache->get($object->guid));
+		$this->assertFalse(elgg_get_session()->entityCache->get($object->guid));
 
-		_elgg_services()->entityCache->enableCachingForEntity($object->guid);
+		elgg_get_session()->entityCache->enableCachingForEntity($object->guid);
 
-		_elgg_services()->entityCache->set($object);
+		elgg_get_session()->entityCache->set($object);
 
-		$this->assertEquals($object, _elgg_services()->entityCache->get($object->guid));
+		$this->assertEquals($object, elgg_get_session()->entityCache->get($object->guid));
 
 	}
 
@@ -86,60 +86,58 @@ class EntityCacheUnitTest extends \Elgg\UnitTestCase {
 
 		$user = $this->createUser();
 
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 
 		$object = $this->createObject([
 			'owner_guid' => $user->guid,
 		]);
 
-		$this->assertEquals($object, _elgg_services()->entityCache->get($object->guid));
+		$this->assertEquals($object, elgg_get_session()->entityCache->get($object->guid));
 
 		$this->assertTrue($object->delete());
 		
-		$this->assertFalse(_elgg_services()->entityCache->get($object->guid));
+		$this->assertFalse(elgg_get_session()->entityCache->get($object->guid));
 
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 	}
 
 	public function testRemovesDisabledEntityFromCache() {
 
 		$user = $this->createUser();
 
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 
 		$object = $this->createObject([
 			'owner_guid' => $user->guid,
 		]);
 
-		$this->assertEquals($object, _elgg_services()->entityCache->get($object->guid));
+		$this->assertEquals($object, elgg_get_session()->entityCache->get($object->guid));
 
 		$this->assertTrue($object->disable());
 
-		$this->assertFalse(_elgg_services()->entityCache->get($object->guid));
+		$this->assertFalse(elgg_get_session()->entityCache->get($object->guid));
 
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 	}
 
-	public function testBypassesCacheWithIgnoredAccess() {
+	public function testPopulatesCacheWithIgnoredAccess() {
 
 		$ia = elgg_set_ignore_access(true);
 
 		$user = $this->createUser();
 
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 
 		$object = $this->createObject([
 			'owner_guid' => $user->guid,
 			'access_id' => ACCESS_PRIVATE,
 		]);
 
-		$this->assertFalse(_elgg_services()->entityCache->get($object->guid));
+		$this->assertEquals($object, elgg_get_session()->entityCache->get($object->guid));
 
 		$this->assertEquals($object, get_entity($object->guid));
 
-		_elgg_services()->session->removeLoggedInUser();
-
-		$this->assertEquals($object, get_entity($object->guid));
+		elgg_get_session()->removeLoggedInUser();
 
 		elgg_set_ignore_access($ia);
 
@@ -151,20 +149,20 @@ class EntityCacheUnitTest extends \Elgg\UnitTestCase {
 
 		$user = $this->createUser();
 
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 
 		$object = $this->createObject([
 			'owner_guid' => $user->guid,
 			'access_id' => ACCESS_PRIVATE,
 		]);
 
-		$this->assertEquals($object, _elgg_services()->entityCache->get($object->guid));
+		$this->assertEquals($object, elgg_get_session()->entityCache->get($object->guid));
 
 		$this->assertEquals($object, get_entity($object->guid));
 
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 
-		$this->assertFalse(_elgg_services()->entityCache->get($object->guid));
+		$this->assertFalse(elgg_get_session()->entityCache->get($object->guid));
 
 		$this->assertFalse(get_entity($object->guid));
 	}
@@ -182,7 +180,7 @@ class EntityCacheUnitTest extends \Elgg\UnitTestCase {
 		]);
 		/** @var \ElggObject $object */
 		
-		$this->assertEquals($object, _elgg_services()->entityCache->get($object->guid));
+		$this->assertEquals($object, elgg_get_session()->entityCache->get($object->guid));
 
 		$posted = $object->updateLastAction();
 

--- a/engine/tests/phpunit/unit/Elgg/Database/EntityTableUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Database/EntityTableUnitTest.php
@@ -28,16 +28,16 @@ class EntityTableUnitTest extends \Elgg\UnitTestCase {
 
 	public function testCanGetUserForPermissionsCheckWhileLoggedIn() {
 		$user = $this->createUser();
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 
-		$this->assertEquals($user, _elgg_services()->session->getLoggedInUser());
+		$this->assertEquals($user, elgg_get_session()->getLoggedInUser());
 		
 		$this->assertEquals($user, _elgg_services()->entityTable->getUserForPermissionsCheck());
 
 		$user2 = $this->createUser();
 		$this->assertEquals($user2, _elgg_services()->entityTable->getUserForPermissionsCheck($user2->guid));
 
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 	}
 
 	/**

--- a/engine/tests/phpunit/unit/Elgg/EntityIconServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/EntityIconServiceUnitTest.php
@@ -77,7 +77,7 @@ class EntityIconServiceUnitTest extends \Elgg\UnitTestCase {
 		// Needed to test elgg_get_inline_url()
 		$session = \ElggSession::getMock();
 		_elgg_services()->setValue('session', $session);
-		_elgg_services()->session->start();
+		elgg_get_session()->start();
 	}
 
 	public function down() {

--- a/engine/tests/phpunit/unit/Elgg/EntityPreloaderTest.php
+++ b/engine/tests/phpunit/unit/Elgg/EntityPreloaderTest.php
@@ -18,7 +18,7 @@ class EntityPreloaderUnitTest extends \Elgg\UnitTestCase {
 	public $obj;
 
 	public function up() {
-		$this->obj = new EntityPreloader(\_elgg_services()->entityCache, \_elgg_services()->entityTable);
+		$this->obj = new EntityPreloader();
 		$dependency = new PreloaderMock_20140623();
 		$this->obj->_callable_cache_checker = array($dependency, 'isCached');
 		$this->obj->_callable_entity_loader = array($dependency, 'load');

--- a/engine/tests/phpunit/unit/Elgg/Http/ResponseFactoryUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Http/ResponseFactoryUnitTest.php
@@ -69,15 +69,13 @@ class ResponseFactoryUnitTest extends \Elgg\UnitTestCase {
 	private $response_factory;
 
 	public function up() {
-		$this->session = ElggSession::getMock();
-		$this->session->start();
-
+		$this->session = elgg_get_session();
 		$this->config = _elgg_config();
 		$this->hooks = new PluginHooksService();
 		$this->input = new Input();
 		$this->request = $this->createRequest('', 'GET');
 		$this->amd_config = new Config($this->hooks);
-		$this->system_messages = new SystemMessagesService($this->session);
+		$this->system_messages = new SystemMessagesService();
 		$this->ajax = new Service($this->hooks, $this->system_messages, $this->input, $this->amd_config);
 
 		_elgg_services()->logger->disable();

--- a/engine/tests/phpunit/unit/Elgg/I18n/TranslatorUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/I18n/TranslatorUnitTest.php
@@ -210,11 +210,11 @@ class TranslatorUnitTest extends \Elgg\UnitTestCase {
 
 		$this->assertEquals('en', $this->translator->getCurrentLanguage());
 
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 
 		$this->assertEquals($language, $this->translator->getCurrentLanguage());
 
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 
 		$user->delete();
 	}

--- a/engine/tests/phpunit/unit/Elgg/RouterUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/RouterUnitTest.php
@@ -61,7 +61,7 @@ class RouterUnitTest extends \Elgg\UnitTestCase {
 
 		$session = ElggSession::getMock();
 		_elgg_services()->setValue('session', $session);
-		_elgg_services()->session->start();
+		elgg_get_session()->start();
 
 		$config = _elgg_config();
 		_elgg_services()->setValue('config', $config);
@@ -1599,7 +1599,7 @@ class RouterUnitTest extends \Elgg\UnitTestCase {
 
 
 		$user = $this->createUser();
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 
 		$this->request = $this->prepareHttpRequest('bar/foo');
 		$this->createService();
@@ -1620,6 +1620,6 @@ class RouterUnitTest extends \Elgg\UnitTestCase {
 
 		$this->hooks->restore();
 
-		_elgg_services()->session->removeLoggedInUser($user);
+		elgg_get_session()->removeLoggedInUser($user);
 	}
 }

--- a/engine/tests/phpunit/unit/Elgg/Security/UrlSignerTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Security/UrlSignerTest.php
@@ -16,8 +16,6 @@ class SignedUrlTest extends \Elgg\UnitTestCase {
 	public function up() {
 		$this->service = new UrlSigner();
 		$this->url = '/foo?a=b&c[]=1&c[]=2&c[]=0,5&_d=@username&e=%20';
-
-		_elgg_services()->setValue('session', \ElggSession::getMock());
 	}
 
 	public function down() {
@@ -57,8 +55,8 @@ class SignedUrlTest extends \Elgg\UnitTestCase {
 		$signed_url = $this->service->sign($this->url, '+1 day');
 		$this->assertTrue($this->service->isValid($signed_url));
 
-		_elgg_services()->session->invalidate();
-		_elgg_services()->session->start();
+		elgg_get_session()->invalidate();
+		elgg_get_session()->start();
 		
 		$this->assertTrue($this->service->isValid($signed_url));
 	}

--- a/engine/tests/phpunit/unit/Elgg/SystemMessagesServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/SystemMessagesServiceUnitTest.php
@@ -18,8 +18,7 @@ class SystemMessagesServiceUnitTest extends \Elgg\UnitTestCase {
 	protected $session;
 
 	public function up() {
-		$this->session = \ElggSession::getMock();
-		$this->svc = new SystemMessagesService($this->session);
+		$this->svc = new SystemMessagesService();
 	}
 
 	public function down() {
@@ -44,7 +43,7 @@ class SystemMessagesServiceUnitTest extends \Elgg\UnitTestCase {
 	function testMessagesStoredInSession() {
 		$this->svc->addSuccessMessage('s1');
 
-		$this->assertEquals(['success' => ['s1']], $this->session->get(SystemMessagesService::SESSION_KEY));
+		$this->assertEquals(['success' => ['s1']], elgg_get_session()->get(SystemMessagesService::SESSION_KEY));
 	}
 
 	function testCanDumpOneRegister() {

--- a/engine/tests/phpunit/unit/Elgg/UploadServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/UploadServiceUnitTest.php
@@ -45,10 +45,6 @@ class UploadServiceUnitTest extends \Elgg\UnitTestCase {
 		$request = $this->prepareHttpRequest();
 		_elgg_services()->setValue('request', $request);
 		_elgg_services()->setValue('uploads', new UploadService($request));
-
-		$session = \ElggSession::getMock();
-		_elgg_services()->setValue('session', $session);
-		_elgg_services()->session->start();
 	}
 
 	public function down() {

--- a/engine/tests/phpunit/unit/Elgg/UserCapabilitiesUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/UserCapabilitiesUnitTest.php
@@ -2,12 +2,10 @@
 
 namespace Elgg;
 
-use Elgg\Database\EntityTable;
 use ElggAnnotation;
 use ElggEntity;
 use ElggMetadata;
 use ElggObject;
-use ElggSession;
 use ElggUser;
 use InvalidArgumentException;
 

--- a/engine/tests/phpunit/unit/Elgg/ViewsServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/ViewsServiceUnitTest.php
@@ -26,9 +26,6 @@ class ViewsServiceUnitTest extends \Elgg\UnitTestCase {
 
 		$this->views = new ViewsService($this->hooks, $logger);
 		$this->views->autoregisterViews('', "$this->viewsDir/default", 'default');
-
-		// supports deprecation wrapper for $vars['user']
-		_elgg_services()->setValue('session', \ElggSession::getMock());
 	}
 
 	public function down() {

--- a/engine/tests/simpletest/ElggBatchTest.php
+++ b/engine/tests/simpletest/ElggBatchTest.php
@@ -94,7 +94,7 @@ class ElggBatchTest extends \ElggCoreUnitTest {
 			$entity->access_id = ACCESS_PUBLIC;
 			$entity->save();
 			$guids[] = $entity->guid;
-			_elgg_services()->entityCache->remove($entity->guid);
+			elgg_get_session()->entityCache->remove($entity->guid);
 		}
 
 		// break entities such that the first fetch has one incomplete
@@ -149,7 +149,7 @@ class ElggBatchTest extends \ElggCoreUnitTest {
 			$entity->access_id = ACCESS_PUBLIC;
 			$entity->save();
 			$guids[] = $entity->guid;
-			_elgg_services()->entityCache->remove($entity->guid);
+			elgg_get_session()->entityCache->remove($entity->guid);
 		}
 
 		// break entities such that the first fetch has one incomplete

--- a/engine/tests/simpletest/ElggCoreAccessCollectionsTest.php
+++ b/engine/tests/simpletest/ElggCoreAccessCollectionsTest.php
@@ -123,8 +123,8 @@ class ElggCoreAccessCollectionsTest extends \ElggCoreUnitTest {
 		$this->assertTrue($result);
 		elgg_set_ignore_access($ia);
 
-		$logged_in_user = _elgg_services()->session->getLoggedInUser();
-		_elgg_services()->session->removeLoggedInUser();
+		$logged_in_user = elgg_get_session()->getLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 
 		$ia = elgg_set_ignore_access(false);
 		$result = can_edit_access_collection($acl_id, $this->user->guid);
@@ -133,7 +133,7 @@ class ElggCoreAccessCollectionsTest extends \ElggCoreUnitTest {
 		$this->assertFalse($result_no_user);
 		elgg_set_ignore_access($ia);
 
-		_elgg_services()->session->setLoggedInUser($logged_in_user);
+		elgg_get_session()->setLoggedInUser($logged_in_user);
 
 		delete_access_collection($acl_id);
 	}
@@ -245,7 +245,7 @@ class ElggCoreAccessCollectionsTest extends \ElggCoreUnitTest {
 					 'get_access_list',
 					 'get_access_array'
 				 ] as $func) {
-			_elgg_services()->accessCache->clear();
+			elgg_get_session()->accessCache->clear();
 
 			// admin users run tests, so disable access
 			$ia = elgg_set_ignore_access(true);
@@ -280,14 +280,14 @@ class ElggCoreAccessCollectionsTest extends \ElggCoreUnitTest {
 	}
 
 	public function testCanGetGuestReadAcccessArray() {
-		$logged_in_user = _elgg_services()->session->getLoggedInUser();
-		_elgg_services()->session->removeLoggedInUser();
+		$logged_in_user = elgg_get_session()->getLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 
 		$expected = [ACCESS_PUBLIC];
 		$actual = get_access_array();
 		$this->assertEqual($expected, $actual);
 
-		_elgg_services()->session->setLoggedInUser($logged_in_user);
+		elgg_get_session()->setLoggedInUser($logged_in_user);
 	}
 
 	public function testCanGetReadAccessArray() {

--- a/engine/tests/simpletest/ElggCoreAccessSQLTest.php
+++ b/engine/tests/simpletest/ElggCoreAccessSQLTest.php
@@ -13,12 +13,12 @@ class ElggCoreAccessSQLTest extends \ElggCoreUnitTest {
 
 	public function up() {
 		$this->user = $this->createUser();
-		_elgg_services()->session->setLoggedInUser($this->user);
+		elgg_get_session()->setLoggedInUser($this->user);
 		_elgg_services()->hooks->backup();
 	}
 
 	public function down() {
-		_elgg_services()->session->setLoggedInUser($this->getAdmin());
+		elgg_get_session()->setLoggedInUser($this->getAdmin());
 		$this->user->delete();
 		_elgg_services()->hooks->restore();
 	}
@@ -91,8 +91,8 @@ class ElggCoreAccessSQLTest extends \ElggCoreUnitTest {
 
 	public function testCanBuildAccessSqlForLoggedOutUser() {
 
-		$user = _elgg_services()->session->getLoggedInUser();
-		_elgg_services()->session->removeLoggedInUser();
+		$user = elgg_get_session()->getLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 
 		$sql = _elgg_get_access_where_sql();
 		$access_clause = $this->getLoggedOutAccessListClause('e');
@@ -100,7 +100,7 @@ class ElggCoreAccessSQLTest extends \ElggCoreUnitTest {
 
 		$this->assertTrue($this->assertSqlEqual($ans, $sql), "$sql does not match $ans");
 
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 	}
 
 	public function testAccessPluginHookRemoveEnabled() {

--- a/engine/tests/simpletest/ElggCoreCommentTest.php
+++ b/engine/tests/simpletest/ElggCoreCommentTest.php
@@ -36,8 +36,8 @@ class ElggCoreCommentTest extends \ElggCoreUnitTest {
 
 	public function testCommentAccessSync() {
 
-		_elgg_services()->entityCache->disableCachingForEntity($this->comment->guid);
-		_elgg_services()->entityCache->disableCachingForEntity($this->container->guid);
+		elgg_get_session()->entityCache->disableCachingForEntity($this->comment->guid);
+		elgg_get_session()->entityCache->disableCachingForEntity($this->container->guid);
 
 		$this->assertEqual($this->comment->access_id, $this->container->access_id);
 

--- a/engine/tests/simpletest/ElggCoreGroupTest.php
+++ b/engine/tests/simpletest/ElggCoreGroupTest.php
@@ -49,8 +49,8 @@ class ElggCoreGroupTest extends \ElggCoreUnitTest {
 	}
 
 	public function testGroupItemVisibility() {
-		$original_user = _elgg_services()->session->getLoggedInUser();
-		_elgg_services()->session->setLoggedInUser($this->user);
+		$original_user = elgg_get_session()->getLoggedInUser();
+		elgg_get_session()->setLoggedInUser($this->user);
 		$group_guid = $this->group->guid;
 
 		// unrestricted: pass non-members
@@ -72,7 +72,7 @@ class ElggCoreGroupTest extends \ElggCoreUnitTest {
 		$this->assertFalse($vis->shouldHideItems);
 
 		// non-member admins succeed - assumes admin logged in
-		_elgg_services()->session->setLoggedInUser($original_user);
+		elgg_get_session()->setLoggedInUser($original_user);
 		$vis = \Elgg\GroupItemVisibility::factory($group_guid, false);
 
 		$this->assertFalse($vis->shouldHideItems);

--- a/engine/tests/simpletest/ElggCoreMetadataAPITest.php
+++ b/engine/tests/simpletest/ElggCoreMetadataAPITest.php
@@ -221,12 +221,12 @@ class ElggCoreMetadataAPITest extends \ElggCoreUnitTest {
 
 		// ignore access bypasses the MD cache, so we try it both ways
 		elgg_set_ignore_access(false);
-		_elgg_services()->metadataCache->clear($obj->guid);
+		elgg_get_session()->metadataCache->clear($obj->guid);
 		$md_values = $obj->test_md;
 		$this->assertEqual($md_values, [1, 2, 3]);
 
 		elgg_set_ignore_access(true);
-		_elgg_services()->metadataCache->clear($obj->guid);
+		elgg_get_session()->metadataCache->clear($obj->guid);
 		$md_values = $obj->test_md;
 		$this->assertEqual($md_values, [1, 2, 3]);
 

--- a/engine/tests/simpletest/ElggCoreMetadataCacheTest.php
+++ b/engine/tests/simpletest/ElggCoreMetadataCacheTest.php
@@ -42,7 +42,7 @@ class ElggCoreMetadataCacheTest extends \ElggCoreUnitTest {
 	public function up() {
 		$this->ignoreAccess = elgg_set_ignore_access(false);
 
-		$this->cache = _elgg_services()->metadataCache;
+		$this->cache = elgg_get_session()->metadataCache;
 
 		$this->obj1 = new \ElggObject();
 		$this->obj1->save();
@@ -61,7 +61,7 @@ class ElggCoreMetadataCacheTest extends \ElggCoreUnitTest {
 	}
 
 	public function testHas() {
-		$cache = new MetadataCache();
+		$cache = new MetadataCache(new \Elgg\Cache\NullCache());
 
 		$cache->inject(1, ['foo1' => 'bar']);
 		$cache->inject(2, []);
@@ -71,7 +71,7 @@ class ElggCoreMetadataCacheTest extends \ElggCoreUnitTest {
 	}
 
 	public function testLoad() {
-		$cache = new MetadataCache();
+		$cache = new MetadataCache(new \Elgg\Cache\NullCache());
 
 		$cache->inject(1, ['foo1' => 'bar']);
 		$cache->inject(2, []);
@@ -82,7 +82,7 @@ class ElggCoreMetadataCacheTest extends \ElggCoreUnitTest {
 	}
 
 	public function testDirectInvalidation() {
-		$cache = new MetadataCache();
+		$cache = new MetadataCache(new \Elgg\Cache\NullCache());
 
 		$cache->inject(1, ['foo1' => 'bar']);
 		$cache->inject(2, []);

--- a/engine/tests/simpletest/ElggCoreRegressionBugsTest.php
+++ b/engine/tests/simpletest/ElggCoreRegressionBugsTest.php
@@ -114,9 +114,9 @@ class ElggCoreRegressionBugsTest extends \ElggCoreUnitTest {
 			'owner_guid' => $group_owner->guid,
 		]);
 
-		$logged_in = _elgg_services()->session->getLoggedInUser();
+		$logged_in = elgg_get_session()->getLoggedInUser();
 
-		_elgg_services()->session->removeLoggedInUser();
+		elgg_get_session()->removeLoggedInUser();
 
 		_elgg_services()->logger->disable();
 
@@ -139,7 +139,7 @@ class ElggCoreRegressionBugsTest extends \ElggCoreUnitTest {
 
 		_elgg_services()->logger->enable();
 
-		_elgg_services()->session->setLoggedInUser($logged_in);
+		elgg_get_session()->setLoggedInUser($logged_in);
 
 		$user->delete();
 		$owner->delete();
@@ -410,7 +410,7 @@ class ElggCoreRegressionBugsTest extends \ElggCoreUnitTest {
 			'handleUpdateForIssue6225test'
 		]);
 
-		_elgg_services()->entityCache->remove($guid);
+		elgg_get_session()->entityCache->remove($guid);
 		$object = get_entity($guid);
 		$this->assertEqual($object->access_id, ACCESS_PRIVATE);
 

--- a/engine/tests/simpletest/ElggCoreRiverAPITest.php
+++ b/engine/tests/simpletest/ElggCoreRiverAPITest.php
@@ -30,7 +30,7 @@ class ElggCoreRiverAPITest extends \ElggCoreUnitTest {
 		$this->user = $user;
 		$this->entity = $entity;
 
-		_elgg_services()->session->setLoggedInUser($user);
+		elgg_get_session()->setLoggedInUser($user);
 
 		// By default, only admins are allowed to delete river items
 		// For the sake of this test case, we will allow the user to delete items
@@ -41,7 +41,7 @@ class ElggCoreRiverAPITest extends \ElggCoreUnitTest {
 	}
 
 	public function down() {
-		_elgg_services()->session->setLoggedInUser($this->getAdmin());
+		elgg_get_session()->setLoggedInUser($this->getAdmin());
 
 		$this->user->delete();
 
@@ -241,8 +241,8 @@ class ElggCoreRiverAPITest extends \ElggCoreUnitTest {
 		$id = elgg_create_river_item($params);
 
 		$owner = $this->entity->getOwnerEntity();
-		$old_user = _elgg_services()->session->getLoggedInUser();
-		_elgg_services()->session->setLoggedInUser($owner);
+		$old_user = elgg_get_session()->getLoggedInUser();
+		elgg_get_session()->setLoggedInUser($owner);
 
 		$events_fired = 0;
 		$handler = function () use (&$events_fired) {
@@ -261,7 +261,7 @@ class ElggCoreRiverAPITest extends \ElggCoreUnitTest {
 
 		$this->assertEqual($events_fired, 3);
 
-		_elgg_services()->session->setLoggedInUser($old_user);
+		elgg_get_session()->setLoggedInUser($old_user);
 	}
 
 	public function testElggCreateRiverItemMissingRequiredParam() {

--- a/engine/tests/simpletest/ElggCoreUserTest.php
+++ b/engine/tests/simpletest/ElggCoreUserTest.php
@@ -9,7 +9,7 @@ class ElggCoreUserTest extends \ElggCoreUnitTest {
 
 	public function up() {
 		$this->user = new \ElggUserWithExposableAttributes();
-		$this->user->username = $this->getRandomUsername();
+		$this->user->username = $this->generateUsername();
 	}
 
 	public function down() {

--- a/engine/tests/simpletest/ElggEntityPreloaderIntegrationTest.php
+++ b/engine/tests/simpletest/ElggEntityPreloaderIntegrationTest.php
@@ -12,8 +12,7 @@ class ElggEntityPreloaderIntegrationTest extends ElggCoreUnitTest {
 	public function up() {
 		$this->realPreloader = _elgg_services()->entityPreloader;
 
-		$this->mockPreloader = new MockEntityPreloader20140623(
-			_elgg_services()->entityCache, _elgg_services()->entityTable);
+		$this->mockPreloader = new MockEntityPreloader20140623(_elgg_services()->entityTable);
 
 		_elgg_services()->setValue('entityPreloader', $this->mockPreloader);
 	}

--- a/engine/tests/simpletest/ElggEntityTest.php
+++ b/engine/tests/simpletest/ElggEntityTest.php
@@ -41,7 +41,7 @@ class ElggCoreEntityTest extends \ElggCoreUnitTest {
 		$this->assertIsA($subtype_prop, 'int');
 		$this->assertEqual($subtype_prop, get_subtype_id('object', 'elgg_entity_test_subtype'));
 
-		_elgg_services()->entityCache->remove($guid);
+		elgg_get_session()->entityCache->remove($guid);
 		$this->entity = null;
 		$this->entity = get_entity($guid);
 
@@ -133,7 +133,7 @@ class ElggCoreEntityTest extends \ElggCoreUnitTest {
 
 		$this->assertEqual($this->entity->getSubtype(), 'elgg_entity_test_subtype');
 
-		_elgg_services()->entityCache->remove($guid);
+		elgg_get_session()->entityCache->remove($guid);
 		$this->entity = null;
 		$this->entity = get_entity($guid);
 
@@ -519,7 +519,7 @@ class ElggCoreEntityTest extends \ElggCoreUnitTest {
 	public function testNewUserLoadedFromCacheDuringSaveOperations() {
 
 		$user = new \ElggUser();
-		$user->username = $this->getRandomUsername();
+		$user->username = $this->generateUsername();
 
 		// Add temporary metadata, annotation and private settings
 		// to extend the scope of tests and catch issues with save operations

--- a/engine/tests/test_files/.gitignore
+++ b/engine/tests/test_files/.gitignore
@@ -1,10 +1,6 @@
-/*
+/dataroot/
+/cacheroot/
 
-!.gitignore
-!/actions/
-!/autop/
-!/class_scanner/
-!/commit_messages
 !/dataroot/1/1/75x125.jpg
 !/dataroot/1/1/300x300.jpg
 !/dataroot/1/1/300x600.jpg
@@ -12,10 +8,3 @@
 !/dataroot/1/1/400x300.png
 !/dataroot/1/1/600x300.jpg
 !/dataroot/1/1/foobar.txt
-!/handlers/
-!/pages/
-!/plugin_18/
-!/sql/
-!/views/
-!/views2/
-!/xxe/

--- a/mod/likes/classes/Elgg/Likes/Preloader.php
+++ b/mod/likes/classes/Elgg/Likes/Preloader.php
@@ -151,7 +151,7 @@ class Preloader {
 		$fetch_guids = [];
 
 		foreach ($guids as $guid) {
-			$entity = _elgg_services()->entityCache->get($guid);
+			$entity = _elgg_services()->session->entityCache->get($guid);
 			if ($entity) {
 				$entities[] = $entity;
 			} else {


### PR DESCRIPTION
ElggSession is no longer injected into various services. Due to its
mutable state it led to various discrepancies and inconsistencies.
Services now use global session state.

Entity, metadata and access caches are now coupled with the session,
and are no longer used as stand alone services.

Caches are not populated more consistently.

Fixes #11202
Fixes #11199
Fixes #11197 