### PR TITLE
chore(core): no longer use secondaryAttributeLoader for getDisplayName

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -277,8 +277,7 @@ abstract class ElggEntity extends \ElggData implements
 	 * @return string The title or name of this entity.
 	 */
 	public function getDisplayName() {
-		$attr = $this->getSecondaryTableColumns()[0];
-		return $this->$attr;
+		return $this->name;
 	}
 
 	/**
@@ -288,8 +287,7 @@ abstract class ElggEntity extends \ElggData implements
 	 * @return void
 	 */
 	public function setDisplayName($display_name) {
-		$attr = $this->getSecondaryTableColumns()[0];
-		$this->$attr = $display_name;
+		$this->name = $display_name;
 	}
 
 	/**

--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -35,6 +35,20 @@ class ElggObject extends \ElggEntity {
 		$object->tags = $this->tags ? $this->tags : [];
 		return $object;
 	}
+	
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getDisplayName() {
+		return $this->title;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setDisplayName($display_name) {
+		$this->title = $display_name;
+	}
 
 	/**
 	 * Can a user comment on this object?


### PR DESCRIPTION
get rid of using secondaryattributeloader to prepare for dropping secondary tables