### PR TITLE
fix(plugins): load elgg-plugin.php after classes and translations

### DIFF
--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -851,9 +851,6 @@ class ElggPlugin extends \ElggObject {
 			throw new Exception($this->getError());
 		}
 
-		// Preload static config file
-		$this->getStaticConfig('');
-
 		// include classes
 		if ($flags & ELGG_PLUGIN_REGISTER_CLASSES) {
 			$this->registerClasses();
@@ -870,6 +867,9 @@ class ElggPlugin extends \ElggObject {
 			// so translations can be used... for example in registering widgets
 			$this->registerLanguages();
 		}
+		
+		// Preload static config file
+		$this->getStaticConfig('');
 		
 		// include start file if it exists
 		if ($flags & ELGG_PLUGIN_INCLUDE_START) {


### PR DESCRIPTION
As the elgg-plugin.php file can use translations (eg. to register
widgets) the translations need to be available before including the
file.

I was getting notices about missing translation keys because of widget registration in de elgg-plugin.php file.