### PR TITLE
chore(languages): change mixed line endings

### DIFF
--- a/languages/nl.php
+++ b/languages/nl.php
@@ -39,7 +39,7 @@ return array(
 	'actionnotfound' => "Het actiebestand voor %s kon niet worden gevonden.",
 	'actionloggedout' => "Sorry, je kunt deze actie niet uitvoeren als je bent afgemeld.",
 	'actionunauthorized' => 'Je bent niet geautoriseerd om deze actie uit te voeren',
-	
+
 	'ajax:error' => 'Onverwacht probleem opgetreden tijdens de uitvoer van een AJAX call. Mogelijk is de verbinding met de server verloren.',
 	'ajax:not_is_xhr' => 'Je kan AJAX views niet rechtstreeks aanroepen',
 
@@ -85,7 +85,7 @@ Ongeldig %s afhankelijkheid "%s" in plugin %s. Let op: plugins kunnen niet confl
 	'ElggPlugin:Dependencies:Priority:Before' => 'Voor %s',
 	'ElggPlugin:Dependencies:Priority:Uninstalled' => '%s is niet geïnstalleerd',
 	'ElggPlugin:Dependencies:Suggests:Unsatisfied' => 'Ontbreekt',
-	
+
 	'ElggPlugin:Dependencies:ActiveDependent' => 'Er zijn plugins die afhankelijk zijn van %s. Je moet eerst de volgende plugins uitschakelen voordat je deze kunt uitschakelen: %s',
 
 	'ElggMenuBuilder:Trees:NoParents' => 'Menu items gevonden zonder bovenliggende menu items om ze aan te linken',
@@ -409,7 +409,7 @@ Je kunt op elk moment terugkeren naar het standaardprofiel, maar dan gaat alle i
 	'registration:usernametoolong' => 'Je gebruikersnaam is te lang. Je kunt maximaal %u karakters gebruiken.',
 	'registration:passwordtooshort' => 'Het wachtwoord moet minimaal %u karakters lang zijn.',
 	'registration:dupeemail' => 'Dit e-mailadres is al geregistreerd.',
-	'registration:invalidchars' => 'Sorry, je gebruikersnaam bevat het volgende ongeldige karakter: %s 
+	'registration:invalidchars' => 'Sorry, je gebruikersnaam bevat het volgende ongeldige karakter: %s
 De volgende karakters zijn niet toegestaan: %s',
 	'registration:emailnotvalid' => 'Sorry, het opgegeven e-mailadres is ongeldig op dit systeem',
 	'registration:passwordnotvalid' => 'Sorry, het opgegeven wachtwoord is ongeldig op dit systeem',
@@ -724,7 +724,7 @@ De volgende karakters zijn niet toegestaan: %s',
 	'admin:robots.txt:physical' => "De robots.txt tool zal niet werken omdat er een fysiek robots.txt bestand aanwezig is.",
 
 	'admin:maintenance_mode:default_message' => 'De site is offline in verband met onderhoud.',
-	'admin:maintenance_mode:instructions' => 'Je kunt de onderhoudsmodus het beste alléén gebruiken als er sprake is van een upgrade, of als je grote veranderingen aan de site wilt aanbrengen. 
+	'admin:maintenance_mode:instructions' => 'Je kunt de onderhoudsmodus het beste alléén gebruiken als er sprake is van een upgrade, of als je grote veranderingen aan de site wilt aanbrengen.
 Wanneer de site in onderhoudsmodus is kunnen alleen sitebeheerders inloggen en de site bekijken!',
 	'admin:maintenance_mode:mode_label' => 'Onderhoudsmodus',
 	'admin:maintenance_mode:message_label' => 'Bericht dat gebruikers zien als de site in onderhoudsmodus is',
@@ -735,7 +735,7 @@ Wanneer de site in onderhoudsmodus is kunnen alleen sitebeheerders inloggen en d
 /**
  * User settings
  */
-		
+
 	'usersettings:description' => "Het paneel voor gebruikersinstellingen geeft je controle over al je persoonlijke instellingen: van gebruikersmanagement tot hoe plugins zijn geconfigureerd. Kies een optie om te beginnen.",
 
 	'usersettings:statistics' => "Jouw statistieken",
@@ -762,7 +762,7 @@ Wanneer de site in onderhoudsmodus is kunnen alleen sitebeheerders inloggen en d
 /**
  * Activity river
  */
-		
+
 	'river:all' => 'Alle site-activiteit',
 	'river:mine' => 'Mijn activiteit',
 	'river:owner' => 'Activiteit van %s',
@@ -789,7 +789,7 @@ Wanneer de site in onderhoudsmodus is kunnen alleen sitebeheerders inloggen en d
 	'icon:size:medium' => "Normaal",
 	'icon:size:large' => "Groot",
 	'icon:size:master' => "Extra groot",
-		
+
 /**
  * Generic action words
  */
@@ -874,11 +874,11 @@ Wanneer de site in onderhoudsmodus is kunnen alleen sitebeheerders inloggen en d
 
 	'active' => 'Actief',
 	'total' => 'Totaal',
-	
+
 	'ok' => 'OK',
 	'any' => 'Welke dan ook',
 	'error' => 'Fout',
-	
+
 	'other' => 'Andere',
 	'options' => 'Opties',
 	'advanced' => 'Geavanceerd',
@@ -891,7 +891,7 @@ Wanneer de site in onderhoudsmodus is kunnen alleen sitebeheerders inloggen en d
 	'content:latest:blurb' => 'Of klik hier om de laatste inhoud van de hele site te bekijken',
 
 	'link:text' => 'bekijk link',
-	
+
 /**
  * Generic questions
  */
@@ -919,7 +919,7 @@ Wanneer de site in onderhoudsmodus is kunnen alleen sitebeheerders inloggen en d
 	'sort:popular' => 'Populair',
 	'sort:alpha' => 'Alfabetisch',
 	'sort:priority' => 'Prioriteit',
-		
+
 /**
  * Generic data words
  */
@@ -944,7 +944,7 @@ Wanneer de site in onderhoudsmodus is kunnen alleen sitebeheerders inloggen en d
 /**
  * Entity actions
  */
-		
+
 	'edit:this' => 'Bewerk dit',
 	'delete:this' => 'Verwijder dit',
 	'comment:this' => 'Reageer hierop',
@@ -985,7 +985,7 @@ Als je bent aangemeld raden we je aan om je wachtwoord direct te wijzigen.',
 /**
  * Import / export
  */
-		
+
 	'importsuccess' => "Importeren van data was succesvol",
 	'importfail' => "OpenDD data importeren is mislukt.",
 
@@ -1001,7 +1001,7 @@ Als je bent aangemeld raden we je aan om je wachtwoord direct te wijzigen.',
 	'friendlytime:days' => "%s dagen geleden",
 	'friendlytime:days:singular' => "gisteren",
 	'friendlytime:date_format' => 'j F Y @ G:i',
-	
+
 	'friendlytime:future:minutes' => "over %s minuten",
 	'friendlytime:future:minutes:singular' => "zometeen",
 	'friendlytime:future:hours' => "over %s uur",
@@ -1029,7 +1029,7 @@ Als je bent aangemeld raden we je aan om je wachtwoord direct te wijzigen.',
 	'date:weekday:4' => 'donderdag',
 	'date:weekday:5' => 'vrijdag',
 	'date:weekday:6' => 'zaterdag',
-	
+
 	'interval:minute' => 'Elke minuut',
 	'interval:fiveminute' => 'Elke vijf minuten',
 	'interval:fifteenmin' => 'Elke vijftien minuten',
@@ -1087,7 +1087,7 @@ Als je bent aangemeld raden we je aan om je wachtwoord direct te wijzigen.',
 
 	'installation:htaccess:needs_upgrade' => "Je moet het bestand .htaccess zodanig wijzigen dat het pad geïnjecteerd wordt in de GET-parameter __elgg_uri (je kunt install/config/htaccess.dist als voorbeeld gebruiken).",
 	'installation:htaccess:localhost:connectionfailed' => "Elgg kan niet zelf de rewrite-rules testen. Controleer dat curl werkt en dat er geen IP-restricties zijn die localhost connecties blokkeren.",
-	
+
 	'installation:systemcache:description' => "De systeemcache verlaagt de laadtijd van de Elgg-engine door data te cachen naar bestanden.",
 	'installation:systemcache:label' => "Gebruik systeemcache (aanbevolen)",
 
@@ -1153,12 +1153,12 @@ Als je meer gedetailleerde instructie wilt, ga je naar de <a href="http://learn.
 /**
  * Emails
  */
-		
+
 	'email:from' => 'Van',
 	'email:to' => 'Aan',
 	'email:subject' => 'Titel',
 	'email:body' => 'Bericht',
-	
+
 	'email:settings' => "E-mailinstellingen",
 	'email:address:label' => "Jouw e-mailadres",
 
@@ -1254,14 +1254,14 @@ Dit is een automatisch aangemaakt bericht. Je kunt hier niet op reageren.",
 /**
  * Entities
  */
-	
+
 	'byline' => 'Door %s',
 	'entity:default:strapline' => 'Aangemaakt op %s door %s',
 	'entity:default:missingsupport:popup' => 'Deze entity kan niet correct worden weergegeven. Dit kan komen doordat er ondersteuning nodig is van een plugin die niet meer is geïnstalleerd.',
 
 	'entity:delete:success' => 'Entity %s is verwijderd',
 	'entity:delete:fail' => 'Entity %s kon niet worden verwijderd',
-	
+
 	'entity:can_delete:invaliduser' => 'Kan canDelete voor user_guid [%s] niet nakijken omdat de gebruiker niet bestaat.',
 
 /**

--- a/languages/pt_br.php
+++ b/languages/pt_br.php
@@ -39,7 +39,7 @@ return array(
 	'actionnotfound' => "A arquivo de ação <i>(action file)</i> para %s não foi encontrado.",
 	'actionloggedout' => "Desculpe, você não pode executar esta ação enquando desconectado.",
 	'actionunauthorized' => 'Você não está autorizado a executar esta ação',
-	
+
 	'ajax:error' => 'Erro inesperado durante a execução de um procedimento AJAX. Talvez a conexão com o servidor foi perdida.',
 	'ajax:not_is_xhr' => 'You cannot access AJAX views directly',
 
@@ -84,7 +84,7 @@ return array(
 	'ElggPlugin:Dependencies:Priority:Before' => 'Antes %s',
 	'ElggPlugin:Dependencies:Priority:Uninstalled' => '%s não está instalado',
 	'ElggPlugin:Dependencies:Suggests:Unsatisfied' => 'Perdido',
-	
+
 	'ElggPlugin:Dependencies:ActiveDependent' => 'Existem outros plugins que listam %s como dependencia. Você deve desabilitar os seguintes plugins antes de desabilitar o atual: %s',
 
 	'ElggMenuBuilder:Trees:NoParents' => 'Menu items found without parents to link them to',
@@ -627,7 +627,7 @@ return array(
 
 	'admin:plugins:warning:elgg_version_unknown' => 'Este plugin usa um arquivo de manifesto antigo e não define uma versão compatível do Elgg.  Ele provavelmente não funcionará!
 ',
-	'admin:plugins:warning:unmet_dependencies' => 'Este plugin usa dependências desencontradas e não foi possível ativaá-lo.  Verifique as dependências lendo sobre mais informações. 
+	'admin:plugins:warning:unmet_dependencies' => 'Este plugin usa dependências desencontradas e não foi possível ativaá-lo.  Verifique as dependências lendo sobre mais informações.
 ',
 	'admin:plugins:warning:invalid' => ' Este plugin não é válido: %s.',
 	'admin:plugins:warning:invalid:check_docs' => 'Verifiqye  <a href="http://docs.elgg.org/Invalid_Plugin">a documentacao do Elgg</a> para dicas de solu��o de problemas.',
@@ -733,7 +733,7 @@ return array(
 /**
  * User settings
  */
-		
+
 	'usersettings:description' => "O Painel de configurações do usuário permite a você controlar suas informações pessoais, desde configurar o usuário até como os plugins se comportam. Escolha uma opção abaixo para iniciar.",
 
 	'usersettings:statistics' => "Suas estatísticas.",
@@ -760,7 +760,7 @@ return array(
 /**
  * Activity river
  */
-		
+
 	'river:all' => 'Toda atividade do site',
 	'river:mine' => 'Minhas atividades',
 	'river:owner' => 'Atividade de %s',
@@ -787,7 +787,7 @@ return array(
 	'icon:size:medium' => "Medio",
 	'icon:size:large' => "Grande",
 	'icon:size:master' => "Extra Grande",
-		
+
 /**
  * Generic action words
  */
@@ -872,11 +872,11 @@ return array(
 
 	'active' => 'Ativo',
 	'total' => 'Total ',
-	
+
 	'ok' => 'OK',
 	'any' => 'Qualquer',
 	'error' => 'Erro',
-	
+
 	'other' => 'Outro',
 	'options' => 'Opcoes',
 	'advanced' => 'Avancado',
@@ -889,7 +889,7 @@ return array(
 	'content:latest:blurb' => 'Alternativamente, clique aqui para exibir os últimos conteúdos do site.',
 
 	'link:text' => 'ver link',
-	
+
 /**
  * Generic questions
  */
@@ -917,7 +917,7 @@ return array(
 	'sort:popular' => 'Popular',
 	'sort:alpha' => 'Alfabetica',
 	'sort:priority' => 'Prioridade',
-		
+
 /**
  * Generic data words
  */
@@ -942,7 +942,7 @@ return array(
 /**
  * Entity actions
  */
-		
+
 	'edit:this' => 'Editar',
 	'delete:this' => 'Apagar',
 	'comment:this' => 'Comentar',
@@ -985,7 +985,7 @@ Assim que você se conectar, nós recomendamos fortemente que você altere sua s
 /**
  * Import / export
  */
-		
+
 	'importsuccess' => "Importação de dados realizada com sucesso",
 	'importfail' => "OpenDD falhou ao importar dados.",
 
@@ -1001,7 +1001,7 @@ Assim que você se conectar, nós recomendamos fortemente que você altere sua s
 	'friendlytime:days' => "%s dias atrás",
 	'friendlytime:days:singular' => "ontem",
 	'friendlytime:date_format' => 'j F Y  @ g:ia',
-	
+
 	'friendlytime:future:minutes' => "em %s minutos",
 	'friendlytime:future:minutes:singular' => "em um minute",
 	'friendlytime:future:hours' => "em %s horas",
@@ -1029,7 +1029,7 @@ Assim que você se conectar, nós recomendamos fortemente que você altere sua s
 	'date:weekday:4' => 'Quinta',
 	'date:weekday:5' => 'Sexta',
 	'date:weekday:6' => 'Sabado',
-	
+
 	'interval:minute' => 'A cada minuto',
 	'interval:fiveminute' => 'A cada 5 minutos',
 	'interval:fifteenmin' => 'A cada 15 minutos',
@@ -1087,7 +1087,7 @@ Assim que você se conectar, nós recomendamos fortemente que você altere sua s
 
 	'installation:htaccess:needs_upgrade' => "Voce deve atualizar seu arquivo .htaccess para que o caminho seja injetado no parametro GET __elgg_uri (voce pode usar o arquivo htaccess_dist como guia).",
 	'installation:htaccess:localhost:connectionfailed' => "Elgg nao pode se conectar para o autoteste das regras de escrita. Verifique se o curl esta funcionando e se nao existe nenhuma restricao de acesso local ao seu IP.",
-	
+
 	'installation:systemcache:description' => "O sistema de armazenamento (cache) diminui o tempo de carregamento do Elgg por guardar na memória os arquivos.",
 	'installation:systemcache:label' => "Utilizar o sistema de armazenamento (cache) - RECOMENDÁVEL",
 
@@ -1153,12 +1153,12 @@ Assim que você se conectar, nós recomendamos fortemente que você altere sua s
 /**
  * Emails
  */
-		
+
 	'email:from' => 'De',
 	'email:to' => 'Para',
 	'email:subject' => 'Assunto',
 	'email:body' => 'Corpo',
-	
+
 	'email:settings' => "Configurações de Email",
 	'email:address:label' => "Endereco de email",
 
@@ -1192,7 +1192,7 @@ Alguém (do endereço de IP %s) solicitou uma nova senha para esta conta.
 Se você fez esta solicitação, clique no link abaixo, caso contrário por favor ignore este email.
 
 %s
- 
+
 ",
 
 /**
@@ -1251,14 +1251,14 @@ Não responda a este email.",
 /**
  * Entities
  */
-	
+
 	'byline' => 'Por %s',
 	'entity:default:strapline' => 'Criado %s por %s',
 	'entity:default:missingsupport:popup' => 'Esta entidade não pôde ser exibida corretamente. Isto deve ter ocorrido pois requer o suporte de um plugin que não está mais instalado.',
 
 	'entity:delete:success' => 'Entidade %s foi apagada',
 	'entity:delete:fail' => 'Entidade %s não pode ser apagada',
-	
+
 	'entity:can_delete:invaliduser' => 'Can not check canDelete for user_guid [%s] as the user does not exist.',
 
 /**


### PR DESCRIPTION
The translations had some mixed CRLF line ends. Other whitespace was trimmed automatically by the editor.
