### PR TITLE
chore(core): removed create_metadata_from_array function

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -93,6 +93,7 @@ All the functions in ``engine/lib/deprecated-1.9.php`` were removed. See https:/
 All the functions in ``engine/lib/deprecated-1.10.php`` were removed. See https://github.com/Elgg/Elgg/blob/2.0/engine/lib/deprecated-1.10.php for these functions. Each ``@deprecated`` declaration includes instructions on what to use instead.
 
  * ``can_write_to_container``: Use ``ElggEntity->canWriteToContainer()``
+ * ``create_metadata_from_array``
  * ``datalist_get``
  * ``datalist_set``
  * ``detect_extender_valuetype``

--- a/engine/classes/Elgg/Database/MetadataTable.php
+++ b/engine/classes/Elgg/Database/MetadataTable.php
@@ -251,31 +251,6 @@ class MetadataTable {
 	}
 
 	/**
-	 * This function creates metadata from an associative array of "key => value" pairs.
-	 *
-	 * To achieve an array for a single key, pass in the same key multiple times with
-	 * allow_multiple set to true. This creates an indexed array. It does not support
-	 * associative arrays and there is no guarantee on the ordering in the array.
-	 *
-	 * @param int    $entity_guid     The entity to attach the metadata to
-	 * @param array  $name_and_values Associative array - a value can be a string, number, bool
-	 * @param string $value_type      'text', 'integer', or '' for automatic detection
-	 * @param bool   $allow_multiple  Allow multiple values for one key. Default is false
-	 *
-	 * @return bool
-	 */
-	function createFromArray($entity_guid, array $name_and_values, $value_type, $allow_multiple = false) {
-
-		foreach ($name_and_values as $k => $v) {
-			$result = $this->create($entity_guid, $k, $v, $value_type, $allow_multiple);
-			if (!$result) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
 	 * Returns metadata.  Accepts all elgg_get_entities() options for entity
 	 * restraints.
 	 *

--- a/engine/lib/metadata.php
+++ b/engine/lib/metadata.php
@@ -83,29 +83,6 @@ function update_metadata($id, $name, $value, $value_type) {
 }
 
 /**
- * This function creates metadata from an associative array of "key => value" pairs.
- *
- * To achieve an array for a single key, pass in the same key multiple times with
- * allow_multiple set to true. This creates an indexed array. It does not support
- * associative arrays and there is no guarantee on the ordering in the array.
- *
- * @param int    $entity_guid     The entity to attach the metadata to
- * @param array  $name_and_values Associative array - a value can be a string, number, bool
- * @param string $value_type      'text', 'integer', or '' for automatic detection
- * @param int    $ignored1        GUID of entity that owns the metadata
- * @param null   $ignored2        This argument is not used
- * @param bool   $allow_multiple  Allow multiple values for one key. Default is false
- *
- * @return bool
- */
-function create_metadata_from_array($entity_guid, array $name_and_values, $value_type, $ignored1 = null,
-		$ignored2 = null, $allow_multiple = false) {
-
-	return _elgg_services()->metadataTable->createFromArray($entity_guid, $name_and_values,
-		$value_type, $allow_multiple);
-}
-
-/**
  * Returns metadata.  Accepts all elgg_get_entities() options for entity
  * restraints.
  *


### PR DESCRIPTION
BREAKING CHANGE:
The create_metadata_from_array function is no longer available. Use your
own foreach loop to create multiple metadata fields.