### PR TITLE
feat(core): added API for temporary ElggFile

### DIFF
--- a/docs/guides/file-system.rst
+++ b/docs/guides/file-system.rst
@@ -1,6 +1,10 @@
 File System
 ###########
 
+.. contents:: Contents
+   :local:
+   :depth: 1
+
 Filestore
 =========
 
@@ -178,3 +182,13 @@ If your file input supports multiple files, you can iterate through them in your
 .. note::
 
    If images are uploaded their is an automatic attempt to fix the orientation of the image.
+
+Temporary files
+===============
+
+If you ever need a temporary file you can use ``elgg_get_temp_file()``. You'll get an instance of an ``ElggTempFile`` which has all the 
+file functions of an ``ElggFile``, but writes it's data to the systems temp folder.
+
+.. warning::
+	
+	It's not possible to save the ``ElggTempFile`` to the database. You'll get an ``IOException`` if you try.

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -83,6 +83,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \Elgg\Cache\SystemCache                  $systemCache
  * @property-read \Elgg\SystemMessagesService              $systemMessages
  * @property-read \Elgg\Views\TableColumn\ColumnFactory    $table_columns
+ * @property-read \ElggTempDiskFilestore                   $temp_filestore
  * @property-read \Elgg\Timer                              $timer
  * @property-read \Elgg\I18n\Translator                    $translator
  * @property-read \Elgg\Security\UrlSigner                 $urlSigner
@@ -471,7 +472,9 @@ class ServiceProvider extends DiContainer {
 		});
 
 		$this->setClassName('table_columns', \Elgg\Views\TableColumn\ColumnFactory::class);
-
+		
+		$this->setClassName('temp_filestore',  \ElggTempDiskFilestore::class);
+		
 		$this->setClassName('timer', \Elgg\Timer::class);
 
 		$this->setFactory('translator', function(ServiceProvider $c) {

--- a/engine/classes/ElggDiskFilestore.php
+++ b/engine/classes/ElggDiskFilestore.php
@@ -12,7 +12,7 @@ class ElggDiskFilestore extends \ElggFilestore {
 	/**
 	 * Directory root.
 	 */
-	private $dir_root;
+	protected $dir_root;
 
 	/**
 	 * Number of entries per matrix dir.
@@ -96,7 +96,7 @@ class ElggDiskFilestore extends \ElggFilestore {
 	 * @param resource $f    File pointer resource
 	 * @param mixed    $data The data to write.
 	 *
-	 * @return bool
+	 * @return false|int
 	 */
 	public function write($f, $data) {
 		return fwrite($f, $data);

--- a/engine/classes/ElggFile.php
+++ b/engine/classes/ElggFile.php
@@ -216,7 +216,7 @@ class ElggFile extends ElggObject {
 	 *
 	 * @param string $data The data
 	 *
-	 * @return bool
+	 * @return false|int
 	 */
 	public function write($data) {
 		return $this->getFilestore()->write($this->handle, $data);

--- a/engine/classes/ElggTempDiskFilestore.php
+++ b/engine/classes/ElggTempDiskFilestore.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * A filestore that uses disk as storage.
+ *
+ * @warning This should be used by a wrapper class
+ * like {@link \ElggFile}.
+ *
+ * @package    Elgg.Core
+ * @subpackage FileStore.Disk
+ * @since 3.0
+ */
+class ElggTempDiskFilestore extends \ElggDiskFilestore {
+	
+	/**
+	 * @var string
+	 */
+	protected $unique_sub_dir;
+	
+	/**
+	 * Construct a temp disk filestore using the given directory root.
+	 *
+	 * @param string $directory_root Root directory, must end in "/"
+	 */
+	public function __construct($directory_root = '') {
+		
+		if (!$directory_root) {
+			$directory_root = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . '/';
+		}
+		
+		$this->unique_sub_dir = uniqid() . '/';
+		
+		parent::__construct($directory_root);
+	}
+
+	/**
+	 * Get the filename as saved on disk for an \ElggFile object
+	 *
+	 * Returns an empty string if no filename set
+	 *
+	 * @param \ElggFile $file File object
+	 *
+	 * @return string The full path of where the file is stored
+	 */
+	public function getFilenameOnFilestore(\ElggFile $file) {
+		
+		$filename = $file->getFilename();
+		if (!$filename) {
+			return '';
+		}
+
+		return $this->dir_root . $this->unique_sub_dir . $file->getFilename();
+	}
+	
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getParameters() {
+		$params = parent::getParameters();
+		$params['unique_sub_dir'] = $this->unique_sub_dir;
+		
+		return $params;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setParameters(array $parameters) {
+		
+		if (isset($parameters['unique_sub_dir'])) {
+			$this->unique_sub_dir = $parameters['unique_sub_dir'];
+		}
+
+		return parent::setParameters($parameters);
+	}
+}

--- a/engine/classes/ElggTempFile.php
+++ b/engine/classes/ElggTempFile.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This class represents a physical file (by default in the system temp directory).
+ *
+ * Create a new \ElggTempFile object and optionaly specify a filename
+ *
+ * Open the file using the appropriate mode, and you will be able to
+ * read and write to the file.
+ *
+ * Trying to save this entity to the database will fail
+ *
+ * @see \ElggFile
+ * @since 3.0
+ */
+class ElggTempFile extends ElggFile {
+
+	/**
+	 * Set subtype to 'temp_file'.
+	 *
+	 * @return void
+	 */
+	protected function initializeAttributes() {
+		parent::initializeAttributes();
+
+		$this->attributes['subtype'] = 'temp_file';
+		$this->setFilename(uniqid());
+	}
+
+	/**
+	 * Return the system temp filestore based on the system temp directory.
+	 *
+	 * @return \ElggTempDiskFilestore
+	 */
+	protected function getFilestore() {
+		return _elgg_services()->temp_filestore;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function transfer($owner_guid, $filename = null) {
+		return false;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function canDownload($user_guid = 0, $default = false) {
+		return false;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getDownloadURL($use_cookie = true, $expires = '+2 hours') {
+		return '';
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getInlineURL($use_cookie = false, $expires = '') {
+		return '';
+	}
+	
+	/**
+	 * {@inheritdoc}
+	 */
+	public function save() {
+		throw new \IOException("Temp files can't be saved to the database");
+	}
+
+}

--- a/engine/lib/filestore.php
+++ b/engine/lib/filestore.php
@@ -394,6 +394,16 @@ function elgg_get_uploaded_file($input_name, $check_for_validity = true) {
 }
 
 /**
+ * Returns a ElggTempFile which can handle writing/reading of data to a temporary file location
+ *
+ * @return ElggTempFile
+ * @since 3.0
+ */
+function elgg_get_temp_file() {
+	return new ElggTempFile();
+}
+
+/**
  * @see \Elgg\Application::loadCore Do not do work here. Just register for events.
  */
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggTempFileTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggTempFileTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Elgg\Integration;
+
+use ElggTempFile;
+use Elgg\IntegrationTestCase;
+
+/**
+ * Elgg Test Skeleton
+ *
+ * @group IntegrationTests
+ */
+class ElggTempFileTest extends IntegrationTestCase {
+
+	/**
+	 * @var \ElggTempFile
+	 */
+	protected $temp_file;
+	
+	public function up() {
+		$this->temp_file = new ElggTempFile();
+	}
+
+	public function down() {
+		
+		if (isset($this->temp_file)) {
+			$this->temp_file->delete();
+			unset($this->temp_file);
+		}
+	}
+
+	public function testInitialFilename() {
+		
+		$this->assertNotEmpty($this->temp_file->getFilename());
+	}
+	
+	public function testFilenameInSystemTempFolder() {
+		
+		$this->assertStringStartsWith(sys_get_temp_dir(), $this->temp_file->getFilenameOnFilestore());
+	}
+	
+	public function testWriteContent() {
+		
+		$temp_file = $this->temp_file;
+		
+		$this->assertTrue(is_resource($temp_file->open('write')));
+		$this->assertNotFalse($temp_file->write('1234'));
+		$this->assertTrue($temp_file->close());
+		
+		$this->assertEquals('1234', $temp_file->grabFile());
+	}
+	
+	public function testDeleteFile() {
+		
+		$temp_file = $this->temp_file;
+		
+		$this->assertTrue(is_resource($temp_file->open('write')));
+		$this->assertNotFalse($temp_file->write('1234'));
+		$this->assertTrue($temp_file->close());
+		
+		$this->assertTrue($temp_file->exists());
+		
+		$this->assertTrue($temp_file->delete());
+		
+		$this->assertFalse($temp_file->exists());
+	}
+	
+	public function testFilenameUniqueness() {
+		
+		$temp1 = new ElggTempFile();
+		$temp2 = new ElggTempFile();
+		
+		$this->assertNotEquals($temp1->getFilenameOnFilestore(), $temp2->getFilenameOnFilestore());
+	}
+	
+	public function testChangeFilename() {
+		
+		$temp_file = $this->temp_file;
+		
+		$initial_filename = $temp_file->getFilename();
+		
+		$temp_file->setFilename('testing');
+		
+		$this->assertEquals('testing', $temp_file->getFilename());
+		
+		$this->assertNotContains($initial_filename, $temp_file->getFilenameOnFilestore());
+		$this->assertContains('testing', $temp_file->getFilenameOnFilestore());
+		
+		$this->assertTrue(is_resource($temp_file->open('write')));
+		$this->assertNotFalse($temp_file->write('1234'));
+		$this->assertTrue($temp_file->close());
+		
+		$this->assertTrue($temp_file->exists());
+	}
+	
+	public function testUnsupportedFunctions() {
+		
+		$temp_file = $this->temp_file;
+		
+		$user = $this->createUser([
+			'admin' => 'yes',
+			'banned' => 'no',
+		]);
+		_elgg_services()->session->setLoggedInUser($user);
+		
+		$this->assertFalse($temp_file->canDownload());
+		$this->assertFalse($temp_file->transfer($user->guid));
+		$this->assertEquals('', $temp_file->getDownloadURL());
+		$this->assertEquals('', $temp_file->getInlineURL());
+		
+		_elgg_services()->session->removeLoggedInUser();
+		$user->delete();
+	}
+	
+	/**
+	 * @expectedException \IOException
+	 */
+	public function testSaveThrowsException() {
+		
+		$this->temp_file->save();
+	}
+	
+	public function testLibFunctionToGetTempFile() {
+		
+		$this->assertInstanceOf(ElggTempFile::class, elgg_get_temp_file());
+	}
+}


### PR DESCRIPTION
After this is merged I can check core for temp files usage (eg icon_service) and move it to the Elgg temp files.

todo:
- [x] docs