### PR TITLE
feat(input): show default help text about upload limit on input/file

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -1015,6 +1015,7 @@ These changes will only affect new users on the site.',
 	'deleteconfirm' => "Are you sure you want to delete this item?",
 	'deleteconfirm:plural' => "Are you sure you want to delete these items?",
 	'fileexists' => "A file has already been uploaded. To replace it, select it below:",
+	'input:file:upload_limit' => 'Maximum allowed file size is %s',
 
 /**
  * User add

--- a/mod/file/languages/en.php
+++ b/mod/file/languages/en.php
@@ -57,8 +57,6 @@ return [
 
 	'file:delete:confirm' => "Are you sure you want to delete this file?",
 
-	'file:upload_limit' => 'Maximum allowed file size is %s',
-
 	'file:tagcloud' => "Tag cloud",
 
 	'file:display:number' => "Number of files to display",

--- a/mod/file/views/default/forms/file/upload.php
+++ b/mod/file/views/default/forms/file/upload.php
@@ -24,15 +24,6 @@ if ($guid) {
 	$submit_label = elgg_echo('upload');
 }
 
-// Get post_max_size and upload_max_filesize
-$post_max_size = elgg_get_ini_setting_in_bytes('post_max_size');
-$upload_max_filesize = elgg_get_ini_setting_in_bytes('upload_max_filesize');
-
-// Determine the correct value
-$max_upload = $upload_max_filesize > $post_max_size ? $post_max_size : $upload_max_filesize;
-
-$upload_limit = elgg_echo('file:upload_limit', [elgg_format_bytes($max_upload)]);
-
 $categories_field = $vars;
 $categories_field['#type'] = 'categories';
 
@@ -40,7 +31,6 @@ $fields = [
 	[
 		'#type' => 'file',
 		'#label' => $file_label,
-		'#help' => $upload_limit,
 		'name' => 'upload',
 		'value' => ($guid),
 		'required' => (!$guid),


### PR DESCRIPTION
When using elgg_view_field() of the type 'file' a default help text will
be appended about the upload limit of the server.

fixes: #11228