### PR TITLE
fix(js): popup showing in wrong location in Opera

### DIFF
--- a/views/default/elgg/popup.js
+++ b/views/default/elgg/popup.js
@@ -129,7 +129,9 @@ define('elgg/popup', ['elgg', 'jquery', 'jquery-ui'], function (elgg, $) {
 				$target.appendTo('body');
 			}
 			
-			$target.fadeIn()
+			// need to do a double position because of positioning issues during fadeIn() in Opera 
+			// https://github.com/Elgg/Elgg/issues/6452
+			$target.position(position).fadeIn()
 				   .addClass('elgg-state-active elgg-state-popped')
 				   .position(position);
 


### PR DESCRIPTION
Fixes #6452 

Opera jumps to the element directly after fadeIn() (maybe related to the existence of the autofocus field) and then applies the repositioning with collision detection. It looks like the positioning is the problem, but that is not the case. The cause is things that happen during fadein.

Only changing the order of position and fadeIn is not helping (subsequent popups are positioned incorrectly). Doing a reposition before AND after fadeIn seems to do the trick.