### PR TITLE
feat(groups): consolidate API for joining groups

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -122,6 +122,7 @@ All the functions in ``engine/lib/deprecated-1.10.php`` were removed. See https:
  * ``get_user_entity_as_row``
  * ``garbagecollector_orphaned_metastrings``
  * ``groups_access_collection_override``
+ * ``groups_join_group``: Use ``ElggGroup::join``
  * ``groups_setup_sidebar_menus``
  * ``groups_set_icon_url``
  * ``groups_setup_sidebar_menus``

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -152,19 +152,30 @@ class ElggGroup extends \ElggEntity {
 	/**
 	 * Join a user to this group.
 	 *
-	 * @param \ElggUser $user User joining the group.
+	 * @param \ElggUser $user   User joining the group.
+	 * @param array     $params Additional params to pass to the 'join', 'group' event
 	 *
 	 * @return bool Whether joining was successful.
 	 */
-	public function join(\ElggUser $user) {
+	public function join(\ElggUser $user, $params = []) {
 		$result = add_entity_relationship($user->guid, 'member', $this->guid);
 	
-		if ($result) {
-			$params = ['group' => $this, 'user' => $user];
-			_elgg_services()->hooks->getEvents()->trigger('join', 'group', $params);
+		if (!$result) {
+			return false;
 		}
+		
+		$event_params = [
+			'group' => $this,
+			'user' => $user,
+		];
+		
+		if (is_array($params)) {
+			$event_params = array_merge($params, $event_params);
+		}
+		
+		_elgg_services()->hooks->getEvents()->trigger('join', 'group', $event_params);
 	
-		return $result;
+		return true;
 	}
 
 	/**

--- a/mod/groups/actions/groups/membership/add.php
+++ b/mod/groups/actions/groups/membership/add.php
@@ -41,7 +41,7 @@ foreach ($user_guid as $u_guid) {
 		continue;
 	}
 	
-	if (!groups_join_group($group, $user)) {
+	if (!$group->join($user, ['create_river_item' => true])) {
 		$errors[] = elgg_echo('groups:error:addedtogroup', [$user->getDisplayName()]);
 		
 		continue;

--- a/mod/groups/actions/groups/membership/join.php
+++ b/mod/groups/actions/groups/membership/join.php
@@ -37,7 +37,7 @@ if ($group->isPublicMembership() || $group->canEdit($user->guid)) {
 }
 
 if ($join) {
-	if (!groups_join_group($group, $user)) {
+	if (!$group->join($user, ['create_river_item' => true])) {
 		return elgg_error_response(elgg_echo('groups:cantjoin'));
 	}
 	

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -625,7 +625,6 @@ function groups_user_join_event_listener($event, $object_type, $params) {
 
 	if (elgg_extract('create_river_item', $params)) {
 		elgg_create_river_item([
-			'view' => 'river/relationship/member/create',
 			'action_type' => 'join',
 			'subject_guid' => $user->guid,
 			'object_guid' => $group->guid,


### PR DESCRIPTION
Removes groups_join_group() and moves additional groups plugin logic to
an event handler.

BREAKING CHANGE
groups_join_group() has been removed: use ElggGroup::join() instead.

Fixes #10659