### PR TITLE
feature(widgets): using input/number to select number of displayed items in widget edit views

### DIFF
--- a/docs/guides/upgrading.rst
+++ b/docs/guides/upgrading.rst
@@ -509,6 +509,7 @@ Miscellaneous API changes
  * If you override the view ``navigation/menu/user_hover/placeholder``, you must change the config key ``lazy_hover:menus`` to ``elgg_lazy_hover_menus``.
  * The config value ``entity_types`` is no longer present or used.
  * Uploaded images are autorotated based on their orientation metadata.
+ * The view ``object/widget/edit/num_display`` now uses an ``input/number`` field instead of ``input/select``; you might need to update your widget edit views accordingly.
 
 View extension behaviour changed
 --------------------------------

--- a/mod/activity/views/default/widgets/river_widget/content.php
+++ b/mod/activity/views/default/widgets/river_widget/content.php
@@ -5,11 +5,7 @@
 
 $widget = elgg_extract('entity', $vars);
 
-$num_display = sanitize_int($widget->num_display, false);
-// set default value for display number
-if (!$num_display) {
-	$num_display = 8;
-}
+$num_display = (int) $widget->num_display ?: 8;
 
 $options = [
 	'limit' => $num_display,

--- a/mod/blog/views/default/widgets/blog/edit.php
+++ b/mod/blog/views/default/widgets/blog/edit.php
@@ -7,7 +7,5 @@ $widget = elgg_extract('entity', $vars);
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
-	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 	'label' => elgg_echo('blog:numbertodisplay'),
-	'default' => 4,
 ]);

--- a/mod/bookmarks/views/default/widgets/bookmarks/edit.php
+++ b/mod/bookmarks/views/default/widgets/bookmarks/edit.php
@@ -7,7 +7,5 @@ $widget = elgg_extract('entity', $vars);
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
-	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 	'label' => elgg_echo('bookmarks:numbertodisplay'),
-	'default' => 4,
 ]);

--- a/mod/file/views/default/widgets/filerepo/edit.php
+++ b/mod/file/views/default/widgets/filerepo/edit.php
@@ -7,7 +7,5 @@ $widget = elgg_extract('entity', $vars);
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
-	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20],
 	'label' => elgg_echo('file:num_files'),
-	'default' => 4,
 ]);

--- a/mod/friends/views/default/widgets/friends/content.php
+++ b/mod/friends/views/default/widgets/friends/content.php
@@ -10,11 +10,7 @@ if (!($owner instanceof \ElggUser)) {
 	return;
 }
 
-$num_display = sanitize_int($widget->num_display, false);
-// set default value for display number
-if (!$num_display) {
-	$num_display = 12;
-}
+$num_display = (int) $widget->num_display ?: 12;
 
 echo elgg_list_entities_from_relationship([
 	'type' => 'user',

--- a/mod/friends/views/default/widgets/friends/edit.php
+++ b/mod/friends/views/default/widgets/friends/edit.php
@@ -7,9 +7,9 @@ $widget = elgg_extract('entity', $vars);
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
-	'default' => 12,
 	'label' => elgg_echo('friends:num_display'),
-	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 15, 20, 30, 50, 100],
+	'default' => 12,
+	'max' => 100,
 ]);
 
 echo elgg_view_field([

--- a/mod/groups/views/default/widgets/a_users_groups/edit.php
+++ b/mod/groups/views/default/widgets/a_users_groups/edit.php
@@ -7,7 +7,5 @@ $widget = elgg_extract('entity', $vars);
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
-	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20],
 	'label' => elgg_echo('groups:widget:num_display'),
-	'default' => 4,
 ]);

--- a/mod/messageboard/views/default/widgets/messageboard/content.php
+++ b/mod/messageboard/views/default/widgets/messageboard/content.php
@@ -10,7 +10,7 @@ if (elgg_is_logged_in()) {
 	echo elgg_view_form('messageboard/add', ['name' => 'elgg-messageboard']);
 }
 
-$num_display = (int) $widget->num_display ?: 5;
+$num_display = (int) $widget->num_display ?: 4;
 
 echo elgg_list_annotations([
 	'annotations_name' => 'messageboard',

--- a/mod/messageboard/views/default/widgets/messageboard/edit.php
+++ b/mod/messageboard/views/default/widgets/messageboard/edit.php
@@ -7,7 +7,5 @@ $widget = elgg_extract('entity', $vars);
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
-	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 	'label' => elgg_echo('messageboard:num_display'),
-	'default' => 5,
 ]);

--- a/mod/pages/views/default/widgets/pages/content.php
+++ b/mod/pages/views/default/widgets/pages/content.php
@@ -5,7 +5,7 @@
 
 $widget = elgg_extract('entity', $vars);
 
-$num_display = (int) $widget->pages_num ?: 5;
+$num_display = (int) $widget->pages_num ?: 4;
 
 $content = elgg_list_entities_from_metadata([
 	'type' => 'object',

--- a/mod/pages/views/default/widgets/pages/edit.php
+++ b/mod/pages/views/default/widgets/pages/edit.php
@@ -8,7 +8,5 @@ $widget = elgg_extract('entity', $vars);
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
 	'name' => 'pages_num',
-	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 	'label' => elgg_echo('pages:num'),
-	'default' => 5,
 ]);

--- a/mod/reportedcontent/views/default/widgets/reportedcontent/edit.php
+++ b/mod/reportedcontent/views/default/widgets/reportedcontent/edit.php
@@ -7,7 +7,5 @@ $widget = elgg_extract('entity', $vars);
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
-	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 	'label' => elgg_echo('reportedcontent:numbertodisplay'),
-	'default' => 4,
 ]);

--- a/mod/tagcloud/views/default/widgets/tagcloud/edit.php
+++ b/mod/tagcloud/views/default/widgets/tagcloud/edit.php
@@ -8,7 +8,7 @@ $widget = elgg_extract('entity', $vars);
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
 	'name' => 'num_items',
-	'options' => [10, 20, 30, 50, 100],
 	'label' => elgg_echo('tagcloud:widget:numtags'),
 	'default' => 30,
+	'max' => 100,
 ]);

--- a/mod/thewire/views/default/widgets/thewire/edit.php
+++ b/mod/thewire/views/default/widgets/thewire/edit.php
@@ -7,7 +7,5 @@ $widget = elgg_extract('entity', $vars);
 
 echo elgg_view('object/widget/edit/num_display', [
 	'entity' => $widget,
-	'options' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 	'label' => elgg_echo('thewire:num'),
-	'default' => 4,
 ]);

--- a/views/default/object/widget/edit/num_display.php
+++ b/views/default/object/widget/edit/num_display.php
@@ -4,7 +4,11 @@
  *
  * @uses $vars['entity']  ElggWidget
  * @uses $vars['name']    (optional) The name of the attribute, defaults to 'num_display'
- * @uses $vars['default'] (optional) The default value if no value is set, defaults to first option
+ * @uses $vars['default'] (optional) The default value if no value is set, defaults to 4
+ * @uses $vars['step']    (optional) The stepsize used in the number input, defaults to 1
+ * @uses $vars['min']     (optional) The smallest value allowed, defaults to 1
+ * @uses $vars['max']     (optional) The largest value allowed, defaults first to 'default_limit'
+ *                        and as last straw to max(min, 20)
  */
 
 $widget = elgg_extract('entity', $vars);
@@ -22,15 +26,26 @@ if (!isset($vars['label'])) {
 $vars['#label'] = $vars['label'];
 unset($vars['label']);
 
-if (!isset($vars['options'])) {
-	$vars['options'] = [5, 8, 10, 12, 15, 20];
-}
-
 $value = sanitize_int($widget->$name, false);
 if (!$value) {
-	$value = elgg_extract('default', $vars, $vars['options'][0]);
+	$value = (int) elgg_extract('default', $vars, 4);
 }
 $vars['value'] = $value;
-$vars['#type'] = 'select';
+
+$vars['step'] = (int) elgg_extract('step', $vars, 1);
+
+$min = (int) elgg_extract('min', $vars, 1);
+$vars['min'] = $min;
+
+$max = (int) elgg_extract('max', $vars, false);
+if (!$max) {
+	$max = (int) elgg_get_config('default_limit');
+}
+if (!$max) {
+	$max = max($min, 20);
+}
+$vars['max'] = $max;
+
+$vars['#type'] = 'number';
 
 echo elgg_view_field($vars);

--- a/views/default/widgets/banned_users/content.php
+++ b/views/default/widgets/banned_users/content.php
@@ -4,11 +4,7 @@
  */
 $widget = elgg_extract('entity', $vars);
 
-$num_display = sanitize_int($widget->num_display, false);
-// set default value for display number
-if (!$num_display) {
-	$num_display = 5;
-}
+$num_display = (int) $widget->num_display ?: 4;
 
 echo elgg_list_entities_from_metadata([
 	'type' => 'user',

--- a/views/default/widgets/new_users/content.php
+++ b/views/default/widgets/new_users/content.php
@@ -5,11 +5,7 @@
 
 $widget = elgg_extract('entity', $vars);
 
-$num_display = sanitize_int($widget->num_display, false);
-// set default value for display number
-if (!$num_display) {
-	$num_display = 5;
-}
+$num_display = (int) $widget->num_display ?: 4;
 
 echo elgg_list_entities([
 	'type' => 'user',

--- a/views/default/widgets/online_users/content.php
+++ b/views/default/widgets/online_users/content.php
@@ -5,11 +5,7 @@
 
 $widget = elgg_extract('entity', $vars);
 
-$num_display = sanitize_int($widget->num_display, false);
-// set default value for display number
-if (!$num_display) {
-	$num_display = 8;
-}
+$num_display = (int) $widget->num_display ?: 8;
 
 echo get_online_users([
 	'pagination' => false,


### PR DESCRIPTION
BREAKING CHANGE:
The view `object/widget/edit/num_display` now uses an `input/number` field instead of an `input/select` field to set the number of displayed items. Widget edit views might need to be updated if a custom max number (higher than default_limit or 20) is used or if a custom stepsize of selectable item numbers is wanted.