### PR TITLE
chore(sql): fix deprecation message about order_by strings

### DIFF
--- a/engine/classes/Elgg/Cache/MetadataCache.php
+++ b/engine/classes/Elgg/Cache/MetadataCache.php
@@ -1,8 +1,8 @@
 <?php
 namespace Elgg\Cache;
 
+use Elgg\Database\Clauses\OrderByClause;
 use ElggSharedMemoryCache;
-use Elgg\Cache\NullCache;
 
 /**
  * In memory cache of known metadata values stored by entity.
@@ -166,7 +166,11 @@ class MetadataCache {
 			'limit' => 0,
 			'callback' => false,
 			'distinct' => false,
-			'order_by' => 'n_table.entity_guid, n_table.time_created ASC, n_table.id ASC',
+			'order_by' => [
+				new OrderByClause('n_table.entity_guid'),
+				new OrderByClause('n_table.time_created'),
+				new OrderByClause('n_table.id'),
+			],
 		];
 		$data = _elgg_services()->metadataTable->getAll($options);
 

--- a/engine/classes/Elgg/Database/LegacyQueryOptionsAdapter.php
+++ b/engine/classes/Elgg/Database/LegacyQueryOptionsAdapter.php
@@ -937,8 +937,7 @@ trait LegacyQueryOptionsAdapter {
 			if (is_string($order_by)) {
 				elgg_deprecated_notice("
 					Using literal MySQL statements in 'order_by' options parameter is deprecated.
-					Instead use a closure that receives an instanceof of QueryBuilder
-					and returns a prepared clause.
+					Instead use an OrderByClause or array of them.
 					
 					{{ $order_by }}
 				", '3.0');


### PR DESCRIPTION
Also uses this strategy in the metadata cache.

Refs #11412