### PR TITLE
chore(sql): removes reverse_order_by query option

### DIFF
--- a/docs/appendix/upgrade-notes/2.x-to-3.0.rst
+++ b/docs/appendix/upgrade-notes/2.x-to-3.0.rst
@@ -338,6 +338,8 @@ or a closure that returns an instance of ``\Doctrine\DBAL\Query\Expression\Compo
 ``joins``, ``order_by``, ``group_by``, ``selects`` clauses should not use raw SQL strings. Use closures that receive
 an instance of ``\Elgg\Database\QueryBuilder`` and return a prepared statement.
 
+The ``reverse_order_by`` option has been removed.
+
 Plugins should not rely on joined and selected table aliases. Closures passed to the options array will receive a second argument
 that corresponds to the selected table alias. Plugins must perform their own joins and use joined aliases accordingly.
 

--- a/engine/classes/Elgg/Database/LegacyQueryOptionsAdapter.php
+++ b/engine/classes/Elgg/Database/LegacyQueryOptionsAdapter.php
@@ -96,7 +96,6 @@ trait LegacyQueryOptionsAdapter {
 			'last_action_before' => null,
 
 			'sort_by' => [],
-			'reverse_order_by' => null,
 			'order_by' => null,
 			'count' => false,
 			'limit' => elgg_get_config('default_limit'),
@@ -260,7 +259,6 @@ trait LegacyQueryOptionsAdapter {
 			}
 
 			$options['order_by'] = null;
-			$options['reverse_order_by'] = null;
 			$options['order_by_metadata'] = null;
 		}
 
@@ -378,7 +376,6 @@ trait LegacyQueryOptionsAdapter {
 			}
 
 			$options['order_by'] = null;
-			$options['reverse_order_by'] = null;
 			$options['order_by_annotation'] = null;
 		}
 
@@ -933,10 +930,7 @@ trait LegacyQueryOptionsAdapter {
 	protected function normalizeOrderByClauses(array $options = []) {
 
 		$order_by = $options['order_by'];
-		$reverse_order_by = $options['reverse_order_by'];
-
 		$options['order_by'] = [];
-		unset($options['reverse_order_by']);
 
 		if (!empty($order_by)) {
 			if (is_string($order_by)) {
@@ -973,9 +967,6 @@ trait LegacyQueryOptionsAdapter {
 					'ASC',
 					'DESC'
 				]) ? strtoupper($direction) : 'ASC';
-				if ($reverse_order_by) {
-					$direction = $direction == 'ASC' ? 'DESC' : 'ASC';
-				}
 
 				$options['order_by'][] = new OrderByClause($column, $direction);
 			}

--- a/engine/lib/annotations.php
+++ b/engine/lib/annotations.php
@@ -38,6 +38,8 @@ function elgg_delete_annotation_by_id($id) {
  *
  * Accepts all options supported by {@link elgg_get_entities()}
  *
+ * The default 'order_by' is 'n_table.time_created, n_table.id',
+ *
  * @see   elgg_get_entities()
  *
  * @param array $options Options

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1543,32 +1543,6 @@ function _elgg_favicon_page_handler($segments) {
 }
 
 /**
- * Reverses the ordering in an ORDER BY clause.  This is achived by replacing
- * asc with desc, or appending desc to the end of the clause.
- *
- * This is used mostly for elgg_get_entities() and other similar functions.
- *
- * @param string $order_by An order by clause
- * @access private
- * @return string
- * @access private
- */
-function _elgg_sql_reverse_order_by_clause($order_by) {
-	$order_by = strtolower($order_by);
-
-	if (strpos($order_by, ' asc') !== false) {
-		$return = str_replace(' asc', ' desc', $order_by);
-	} elseif (strpos($order_by, ' desc') !== false) {
-		$return = str_replace(' desc', ' asc', $order_by);
-	} else {
-		// no order specified, so default to desc since mysql defaults to asc
-		$return = $order_by . ' desc';
-	}
-
-	return $return;
-}
-
-/**
  * Enable objects with an enable() method.
  *
  * Used as a callback for \ElggBatch.

--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -380,10 +380,8 @@ function elgg_get_site_entity() {
  * Order by value of a speicifc metadata/attribute
  * @option array $order_by_metadata
  *
- * Order by arbitrary clauses, if $reverse_order_by is true, then all asc|desc statements in order by clauses will be
- * replaced with their opposites
+ * Order by arbitrary clauses
  * @option array $order_by
- * @option bool $reverse_order by
  *
  * <code>
  * $options['order_by_metadata'] = [

--- a/engine/tests/phpunit/unit/Elgg/Database/QueryOptionsTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Database/QueryOptionsTest.php
@@ -1038,7 +1038,6 @@ class QueryOptionsTest extends UnitTestCase {
 
 		$options = $this->options->normalizeOptions([
 			'order_by' => 'foo.bar, foo.baz ASC,  sum(x) desc',
-			'reverse_order_by' => true,
 		]);
 
 		$this->assertEquals(3, count($options['order_by']));
@@ -1048,19 +1047,19 @@ class QueryOptionsTest extends UnitTestCase {
 
 		$this->assertInstanceOf(OrderByClause::class, $clause);
 		$this->assertEquals('foo.bar', $clause->expr);
-		$this->assertEquals('DESC', $clause->direction);
+		$this->assertEquals('ASC', $clause->direction);
 
 		$clause = array_shift($options['order_by']);
 
 		$this->assertInstanceOf(OrderByClause::class, $clause);
 		$this->assertEquals('foo.baz', $clause->expr);
-		$this->assertEquals('DESC', $clause->direction);
+		$this->assertEquals('ASC', $clause->direction);
 
 		$clause = array_shift($options['order_by']);
 
 		$this->assertInstanceOf(OrderByClause::class, $clause);
 		$this->assertEquals('sum(x)', $clause->expr);
-		$this->assertEquals('ASC', $clause->direction);
+		$this->assertEquals('DESC', $clause->direction);
 
 	}
 

--- a/mod/blog/views/default/blog/sidebar/revisions.php
+++ b/mod/blog/views/default/blog/sidebar/revisions.php
@@ -29,7 +29,7 @@ if ($auto_save_annotations) {
 
 $saved_revisions = $blog->getAnnotations([
 	'annotation_name' => 'blog_revision',
-	'reverse_order_by' => true,
+	'order_by' => 'n_table.time_created desc, n_table.id desc',
 	'limit' => false
 ]);
 

--- a/mod/messageboard/actions/messageboard/add.php
+++ b/mod/messageboard/actions/messageboard/add.php
@@ -23,7 +23,7 @@ $output = elgg_list_annotations([
 	'annotations_name' => 'messageboard',
 	'guid' => $owner->guid,
 	'pagination' => false,
-	'reverse_order_by' => true,
+	'order_by' => 'n_table.time_created desc, n_table.id desc',
 	'limit' => 1,
 ]);
 

--- a/mod/messageboard/views/default/resources/messageboard/owner.php
+++ b/mod/messageboard/views/default/resources/messageboard/owner.php
@@ -18,7 +18,7 @@ elgg_push_breadcrumb($page_owner->name, $page_owner->getURL());
 $options = [
 	'annotations_name' => 'messageboard',
 	'guid' => $page_owner_guid,
-	'reverse_order_by' => true,
+	'order_by' => 'n_table.time_created desc, n_table.id desc',
 	'preload_owners' => true,
 ];
 
@@ -52,7 +52,6 @@ $vars = [
 	'filter' => false,
 	'content' => $content,
 	'title' => $title,
-	'reverse_order_by' => true
 ];
 
 $body = elgg_view_layout('content', $vars);

--- a/mod/messageboard/views/default/widgets/messageboard/content.php
+++ b/mod/messageboard/views/default/widgets/messageboard/content.php
@@ -17,7 +17,7 @@ echo elgg_list_annotations([
 	'guid' => $owner->guid,
 	'limit' => $num_display,
 	'pagination' => false,
-	'reverse_order_by' => true,
+	'order_by' => 'n_table.time_created desc, n_table.id desc',
 ]);
 
 if ($owner instanceof ElggGroup) {

--- a/mod/pages/views/default/object/page.php
+++ b/mod/pages/views/default/object/page.php
@@ -27,7 +27,7 @@ if ($revision) {
 	$annotation = $page->getAnnotations([
 		'annotation_name' => 'page',
 		'limit' => 1,
-		'reverse_order_by' => true,
+		'order_by' => 'n_table.time_created desc, n_table.id desc',
 	]);
 	if ($annotation) {
 		$annotation = $annotation[0];

--- a/mod/pages/views/default/pages/sidebar/history.php
+++ b/mod/pages/views/default/pages/sidebar/history.php
@@ -16,7 +16,7 @@ if ($page instanceof ElggPage) {
 		'guid' => $page->guid,
 		'annotation_name' => 'page',
 		'limit' => max(20, elgg_get_config('default_limit')),
-		'reverse_order_by' => true,
+		'order_by' => 'n_table.time_created desc, n_table.id desc',
 	]);
 	
 	elgg_pop_context();


### PR DESCRIPTION
All usages have been replaced by explicit `order_by` values.

Fixes #11460

BREAKING CHANGE:
`reverse_order_by` in $options is ignored.