### PR TITLE
feature(comments): comments are configurable per entity

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -734,7 +734,12 @@ Other
 =====
 
 **config, comments_per_page**
-	Filters the number of comments displayed per page. Default is 25.
+	Filters the number of comments displayed per page. Default is 25. ``$params['entity']`` will hold
+	the containing entity or null if not provided.
+
+**config, comments_latest_first**
+	Filters the order of comments. Default is ``true`` for latest first. ``$params['entity']`` will hold
+	the containing entity or null if not provided.
 
 **default, access**
 	In get_default_access(), this hook filters the return value, so it can be used to alter

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -27,7 +27,7 @@ use Elgg\EntityIcon;
  * @subpackage DataModel.Entities
  *
  * @property       string $type           object, user, group, or site (read-only after save)
- * @property       string $subtype        Further clarifies the nature of the entity (this should not be read)
+ * @property       string $subtype        Further clarifies the nature of the entity
  * @property-read  int    $guid           The unique identifier for this entity (read only)
  * @property       int    $owner_guid     The GUID of the owner of this entity (usually the creator)
  * @property       int    $container_guid The GUID of the entity containing this entity

--- a/views/default/page/elements/comments.php
+++ b/views/default/page/elements/comments.php
@@ -9,6 +9,9 @@
  * @uses $vars['limit']         Optional limit value (default is 25)
  */
 
+use Elgg\Database\QueryBuilder;
+use Elgg\Database\Clauses\OrderByClause;
+
 $entity = elgg_extract('entity', $vars);
 if (!$entity instanceof \ElggEntity) {
 	return;
@@ -16,9 +19,11 @@ if (!$entity instanceof \ElggEntity) {
 
 $show_add_form = elgg_extract('show_add_form', $vars, true);
 
+$latest_first = elgg_comments_are_latest_first($entity);
+
 $limit = elgg_extract('limit', $vars, get_input('limit', 0));
 if (!$limit) {
-	$limit = elgg_trigger_plugin_hook('config', 'comments_per_page', [], 25);
+	$limit = elgg_comments_per_page($entity);
 }
 
 $attr = [
@@ -31,7 +36,7 @@ if ($show_add_form && $entity->canComment()) {
 	$content .= elgg_view_form('comment/save', [], $vars);
 }
 
-$content .= elgg_list_entities([
+$options = [
 	'type' => 'object',
 	'subtype' => 'comment',
 	'container_guid' => $entity->guid,
@@ -40,7 +45,28 @@ $content .= elgg_list_entities([
 	'preload_owners' => true,
 	'distinct' => false,
 	'url_fragment' => $attr['id'],
-]);
+	'order_by' => [new OrderByClause('e.guid', $latest_first ? 'DESC' : 'ASC')],
+];
+
+$show_guid = (int) elgg_extract('show_guid', $vars);
+if ($show_guid && $limit) {
+	// show the offset that includes the comment
+	// this won't work with threaded comments, but core doesn't support that yet
+	$operator = $latest_first ? '>' : '<';
+	$condition = function(QueryBuilder $qb) use ($show_guid, $operator) {
+		return $qb->compare('e.guid', $operator, $show_guid, ELGG_VALUE_INTEGER);
+	};
+	$count = elgg_get_entities([
+		'type' => 'object',
+		'subtype' => 'comment',
+		'container_guid' => $entity->guid,
+		'count' => true,
+		'wheres' => [$condition],
+	]);
+	$options['offset'] = (int) floor($count / $limit) * $limit;
+}
+
+$content .= elgg_list_entities($options);
 
 if (empty($content)) {
 	return;


### PR DESCRIPTION
Using plugin hooks, sites determine the order of comments and how many appear per page, by entity type if desired.

The `comment/view/` URLs redirect correctly, and the comment streams always display the added comment when creating a comment.

This fixes several issues:
- Currently if you move to page 2 of comments, and leave a comment, the thread will change to the page 1 set of comments and the link to show page 2 won't work.
- If you alter the comments view to order comments latest-last (like Elgg 2.3), this makes the comment/view/ redirector work improperly, and leaving a comment loads the page 1 set of comments (not containing the comment you just left).