### PR TITLE
chore(docs): documents the `usersettings/save` action better

### DIFF
--- a/actions/usersettings/save.php
+++ b/actions/usersettings/save.php
@@ -1,6 +1,16 @@
 <?php
 /**
  * Aggregate action for saving settings
+ *
+ * To see the individual action methods, enable the developers plugin, visit Admin > Inspect > Plugin Hooks
+ * and search for "usersettings:save". The default methods are listed below:
+ *
+ * @see _elgg_set_user_language
+ * @see _elgg_set_user_password
+ * @see _elgg_set_user_default_access
+ * @see _elgg_set_user_name
+ * @see _elgg_set_user_username
+ * @see _elgg_set_user_email
  */
 
 elgg_make_sticky_form('usersettings');


### PR DESCRIPTION
Also documents the `usersettings/save` action better.

<hr>

This is an incremental nudge that allows plugins to easily make a one-at-a-time Ajax UI if they wish, whereas individual forms/actions could not be re-combined so easily.

IMO this form is totally usable as is, and I don't see the implementation as an abomination.