### PR TITLE
Transifex setup

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,247 +1,247 @@
 [main]
 host = https://www.transifex.com
 
-[elgg-core-2.engine]
+[elgg-core-3.engine]
 file_filter = languages/<lang>.php
 source_file = languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.install]
+[elgg-core-3.install]
 file_filter = install/languages/<lang>.php
 source_file = install/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.blog]
+[elgg-core-3.blog]
 file_filter = mod/blog/languages/<lang>.php
 source_file = mod/blog/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.bookmarks]
+[elgg-core-3.bookmarks]
 file_filter = mod/bookmarks/languages/<lang>.php
 source_file = mod/bookmarks/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.ckeditor]
+[elgg-core-3.ckeditor]
 file_filter = mod/ckeditor/languages/<lang>.php
 source_file = mod/ckeditor/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.custom_index]
+[elgg-core-3.custom_index]
 file_filter = mod/custom_index/languages/<lang>.php
 source_file = mod/custom_index/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.developers]
+[elgg-core-3.developers]
 file_filter = mod/developers/languages/<lang>.php
 source_file = mod/developers/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.diagnostics]
+[elgg-core-3.diagnostics]
 file_filter = mod/diagnostics/languages/<lang>.php
 source_file = mod/diagnostics/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.discussions]
+[elgg-core-3.discussions]
 file_filter = mod/discussions/languages/<lang>.php
 source_file = mod/discussions/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.embed]
+[elgg-core-3.embed]
 file_filter = mod/embed/languages/<lang>.php
 source_file = mod/embed/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.externalpages]
+[elgg-core-3.externalpages]
 file_filter = mod/externalpages/languages/<lang>.php
 source_file = mod/externalpages/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.friends_collections]
+[elgg-core-3.friends_collections]
 file_filter = mod/friends_collections/languages/<lang>.php
 source_file = mod/friends_collections/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.file]
+[elgg-core-3.file]
 file_filter = mod/file/languages/<lang>.php
 source_file = mod/file/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.garbagecollector]
+[elgg-core-3.garbagecollector]
 file_filter = mod/garbagecollector/languages/<lang>.php
 source_file = mod/garbagecollector/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.groups]
+[elgg-core-3.groups]
 file_filter = mod/groups/languages/<lang>.php
 source_file = mod/groups/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.invitefriends]
+[elgg-core-3.invitefriends]
 file_filter = mod/invitefriends/languages/<lang>.php
 source_file = mod/invitefriends/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.legacy_urls]
+[elgg-core-3.legacy_urls]
 file_filter = mod/legacy_urls/languages/<lang>.php
 source_file = mod/legacy_urls/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.likes]
+[elgg-core-3.likes]
 file_filter = mod/likes/languages/<lang>.php
 source_file = mod/likes/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.members]
+[elgg-core-3.members]
 file_filter = mod/members/languages/<lang>.php
 source_file = mod/members/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.messageboard]
+[elgg-core-3.messageboard]
 file_filter = mod/messageboard/languages/<lang>.php
 source_file = mod/messageboard/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.messages]
+[elgg-core-3.messages]
 file_filter = mod/messages/languages/<lang>.php
 source_file = mod/messages/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.notifications]
+[elgg-core-3.notifications]
 file_filter = mod/notifications/languages/<lang>.php
 source_file = mod/notifications/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.pages]
+[elgg-core-3.pages]
 file_filter = mod/pages/languages/<lang>.php
 source_file = mod/pages/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.profile]
+[elgg-core-3.profile]
 file_filter = mod/profile/languages/<lang>.php
 source_file = mod/profile/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.reportedcontent]
+[elgg-core-3.reportedcontent]
 file_filter = mod/reportedcontent/languages/<lang>.php
 source_file = mod/reportedcontent/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.search]
+[elgg-core-3.search]
 file_filter = mod/search/languages/<lang>.php
 source_file = mod/search/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.site_notifications]
+[elgg-core-3.site_notifications]
 file_filter = mod/site_notifications/languages/<lang>.php
 source_file = mod/site_notifications/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.system_log]
+[elgg-core-3.system_log]
 file_filter = mod/system_log/languages/<lang>.php
 source_file = mod/system_log/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.tagcloud]
+[elgg-core-3.tagcloud]
 file_filter = mod/tagcloud/languages/<lang>.php
 source_file = mod/tagcloud/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.thewire]
+[elgg-core-3.thewire]
 file_filter = mod/thewire/languages/<lang>.php
 source_file = mod/thewire/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.uservalidationbyemail]
+[elgg-core-3.uservalidationbyemail]
 file_filter = mod/uservalidationbyemail/languages/<lang>.php
 source_file = mod/uservalidationbyemail/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.web_services]
+[elgg-core-3.web_services]
 file_filter = mod/web_services/languages/<lang>.php
 source_file = mod/web_services/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
-[elgg-core-2.docs-design]
+[elgg-core-3.docs-design]
 file_filter = docs/locale/<lang>/LC_MESSAGES/design.po
 source_file = docs/locale/pot/design.pot
 source_lang = en
 type = PO
 
-[elgg-core-2.docs-tutorials]
+[elgg-core-3.docs-tutorials]
 file_filter = docs/locale/<lang>/LC_MESSAGES/tutorials.po
 source_file = docs/locale/pot/tutorials.pot
 source_lang = en
 type = PO
 
-[elgg-core-2.docs-about]
+[elgg-core-3.docs-about]
 file_filter = docs/locale/<lang>/LC_MESSAGES/about.po
 source_file = docs/locale/pot/about.pot
 source_lang = en
 type = PO
 
-[elgg-core-2.docs-index]
+[elgg-core-3.docs-index]
 file_filter = docs/locale/<lang>/LC_MESSAGES/index.po
 source_file = docs/locale/pot/index.pot
 source_lang = en
 type = PO
 
-[elgg-core-2.docs-admin]
+[elgg-core-3.docs-admin]
 file_filter = docs/locale/<lang>/LC_MESSAGES/admin.po
 source_file = docs/locale/pot/admin.pot
 source_lang = en
 type = PO
 
-[elgg-core-2.docs-contribute]
+[elgg-core-3.docs-contribute]
 file_filter = docs/locale/<lang>/LC_MESSAGES/contribute.po
 source_file = docs/locale/pot/contribute.pot
 source_lang = en
 type = PO
 
-[elgg-core-2.docs-appendix]
+[elgg-core-3.docs-appendix]
 file_filter = docs/locale/<lang>/LC_MESSAGES/appendix.po
 source_file = docs/locale/pot/appendix.pot
 source_lang = en
 type = PO
 
-[elgg-core-2.docs-intro]
+[elgg-core-3.docs-intro]
 file_filter = docs/locale/<lang>/LC_MESSAGES/intro.po
 source_file = docs/locale/pot/intro.pot
 source_lang = en
 type = PO
 
-[elgg-core-2.docs-guides]
+[elgg-core-3.docs-guides]
 file_filter = docs/locale/<lang>/LC_MESSAGES/guides.po
 source_file = docs/locale/pot/guides.pot
 source_lang = en

--- a/.tx/config
+++ b/.tx/config
@@ -13,6 +13,12 @@ source_file = install/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 
+[elgg-core-3.activity]
+file_filter = mod/activity/languages/<lang>.php
+source_file = mod/activity/languages/en.php
+source_lang = en
+type = PHP_ARRAY
+
 [elgg-core-3.blog]
 file_filter = mod/blog/languages/<lang>.php
 source_file = mod/blog/languages/en.php
@@ -64,6 +70,12 @@ type = PHP_ARRAY
 [elgg-core-3.externalpages]
 file_filter = mod/externalpages/languages/<lang>.php
 source_file = mod/externalpages/languages/en.php
+source_lang = en
+type = PHP_ARRAY
+
+[elgg-core-3.friends]
+file_filter = mod/friends/languages/<lang>.php
+source_file = mod/friends/languages/en.php
 source_lang = en
 type = PHP_ARRAY
 

--- a/docs/contribute/i18n.rst
+++ b/docs/contribute/i18n.rst
@@ -64,3 +64,44 @@ This file defines:
 Read the `Transifex documentation`_ for further details.
 
 .. _Transifex documentation: https://docs.transifex.com/
+
+New major Elgg version
+----------------------
+
+Every major version of Elgg must have its own project in Transifex. This way
+we can make sure that strings added and removed between versions do not conflict
+with each other. For example a translation key removed in Elgg 3 should not get
+removed from translations made for Elgg 2. Respectfully a new string added only
+to Elgg 3 should not be included in the translations meant for Elgg 2.
+
+The process of setting up a new major version is:
+
+ 1. Pull latest translations from Transifex to the previous major version
+ 2. Merge the git branch of the previous version to the new to make sure all the
+    latest translation keys are present
+ 3. Create a new Transifex project to https://www.transifex.com/elgg/
+ 4. Update ``.tx/config`` file in the development branch of the new major version
+
+    - Update the configuration to point to the new Transifex project
+    - Remove configuration of removed plugins
+    - Add configuration for new plugins
+
+ 5. Push the translation sources to the new Transifex project with the command:
+    ::
+
+      tx push -s
+
+ 6. Copy the new configuration file temporarily (do not commit) to the previous
+    major version, and push the existing translations from it to the new project:
+    ::
+
+      tx push -t -f --no-interactive
+
+Later, once the dedicated branch (e.g. ``3.x`` has been created for the major version,
+configure Transifex to fetch new translation keys from it automatically in
+https://www.transifex.com/elgg/elgg-core-3/content/. This way you don't have to
+repeat step 5 manually every time new translation keys are added.
+
+It is important to always have a ``n.x`` branch besides the branches meant for
+specific minor versions (``n.1``, ``n.2``, etc.). This way the URLs of the auto-update
+sources do not have to be updated every time a new minor branch is created.

--- a/docs/contribute/i18n.rst
+++ b/docs/contribute/i18n.rst
@@ -17,3 +17,50 @@ https://www.transifex.com/organization/elgg
 Plugin authors are encouraged to coordinate translations via Transifex as well
 so the whole community can be unified and make it really easy for translators
 to contribute to any plugin in the Elgg ecosystem.
+
+Pulling translations
+--------------------
+
+The translations made in Transifex need to be periodically pulled into the
+Elgg code repository. This can be done with the script ``.scripts/languages.php``
+bundled within Elgg's source code.
+
+Prerequisites for running the script are:
+ - Access to command line
+ - `Git`_
+ - `Transifex CLI tool`_
+
+.. _Git: https://git-scm.com/
+.. _Transifex CLI tool: https://docs.transifex.com/client/introduction
+
+The script will do the following steps:
+ 1. Create a new git branch named ``{branch}_i18n_{timestamp}``
+ 2. Pull translations for all languages that have 95% of the strings translated
+ 3. Remove possible invalid language codes
+ 4. Commit the changes to the branch
+
+After this you must push the branch to Github and make a new Pull request.
+
+For example if you want to pull the translations for the ``3.x`` branch,
+run the following commands:
+
+.. code-block:: sh
+
+    php .scripts/languages.php 3.x
+    git push -u your_fork 3.x_i18n_1515151617
+
+Run the command without parameters to get more detailed information of the usage.
+
+Transifex configuration
+-----------------------
+
+The configuration for Transifex can be found from Elgg's source code in the
+file ``.tx/config``.
+
+This file defines:
+ - The Transifex project associated with Elgg's major version
+ - The location of all the files that have translatable content
+
+Read the `Transifex documentation`_ for further details.
+
+.. _Transifex documentation: https://docs.transifex.com/


### PR DESCRIPTION
## The steps I've done so far:

1. I created the "Elgg Core 3" project to Transifex https://www.transifex.com/elgg/elgg-core-3/

2. I updated mappings in `.tx/config` file to point to the new project

3. I converted language files to use long array syntax instead of short, because Transifex does not yet support the short syntax.
   - https://github.com/thomasbachem/php-short-array-syntax-converter
   - `find mod/ -name en.php -exec php revert.php -w {} \;`

4. I added mappings for the following plugins:
   - `activity`
   - `friends`

5. I pushed new source files (translation keys) for the project:
   - `tx push -f`

6. I copied the configuration file `.tx/config` into a local Elgg 2 repo and force-pushed the existing translations from latest Elgg 2 source code:
   - `tx push -t -f --no-interactive`

7. The Elgg core 3 project should (I haven't checked yet) now:
   - Not contain any translation keys removed between Elgg 2 and 3
   - Have the old translations for keys that are identical with Elgg 2 and 3

Refs #11510