### PR TITLE
feat(forms): add time input, support DateTime values

### DIFF
--- a/engine/classes/Elgg/Values.php
+++ b/engine/classes/Elgg/Values.php
@@ -2,6 +2,12 @@
 
 namespace Elgg;
 
+use DataFormatException;
+use DateTime;
+use DateTimeZone;
+use Exception;
+
+
 /**
  * Functions for use as plugin hook/event handlers or other situations where you need a
  * globally accessible callable.
@@ -53,22 +59,35 @@ class Values {
 	 * @param DateTime|string|int $time Time
 	 *
 	 * @return int
-	 * @throws \DataFormatException
+	 * @throws DataFormatException
 	 */
 	public static function normalizeTimestamp($time) {
-		try {
-			if ($time instanceof \DateTime) {
-				return $time->getTimestamp();
-			} else if (is_string($time)) {
-				$dt = new \DateTime($time);
+		return self::normalizeTime($time)->getTimestamp();
+	}
 
-				return $dt->getTimestamp();
+	/**
+	 * Returns DateTime object based on time representation
+	 *
+	 * @param DateTime|string|int $time Time
+	 *
+	 * @return DateTime
+	 * @throws DataFormatException
+	 */
+	public static function normalizeTime($time) {
+		try {
+			if ($time instanceof DateTime) {
+				$dt = $time;
+			} else if (is_numeric($time)) {
+				$dt = new DateTime(null, new DateTimeZone('UTC'));
+				$dt->setTimestamp((int) $time);
+			} else {
+				$dt = new DateTime($time);
 			}
-		} catch (\Exception $e) {
-			throw new \DataFormatException($e->getMessage());
+		} catch (Exception $e) {
+			throw new DataFormatException($e->getMessage());
 		}
 
-		return (int) $time;
+		return $dt;
 	}
 
 	/**
@@ -77,7 +96,7 @@ class Values {
 	 * @param array ...$args IDs
 	 *
 	 * @return int[]
-	 * @throws \DataFormatException
+	 * @throws DataFormatException
 	 */
 	public static function normalizeIds(...$args) {
 		if (empty($args)) {
@@ -100,7 +119,7 @@ class Values {
 				$ids[] = (int) $arg;
 			} else {
 				$arg = print_r($arg, true);
-				throw new \DataFormatException("Parameter '$arg' can not be resolved to a valid ID'");
+				throw new DataFormatException("Parameter '$arg' can not be resolved to a valid ID'");
 			}
 		}
 
@@ -113,7 +132,7 @@ class Values {
 	 * @param mixed ...$args Elements to normalize
 	 *
 	 * @return int[]|null
-	 * @throws \DataFormatException
+	 * @throws DataFormatException
 	 */
 	public static function normalizeGuids(...$args) {
 		if (empty($args)) {
@@ -136,7 +155,7 @@ class Values {
 				$guids[] = (int) $arg;
 			} else {
 				$arg = print_r($arg, true);
-				throw new \DataFormatException("Parameter '$arg' can not be resolved to a valid GUID'");
+				throw new DataFormatException("Parameter '$arg' can not be resolved to a valid GUID'");
 			}
 		}
 

--- a/engine/tests/phpunit/unit/Elgg/ValuesUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/ValuesUnitTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Elgg;
+
+use DateTime;
+
+/**
+ * @group Values
+ */
+class ValuesUnitTest extends UnitTestCase {
+
+	public function up() {
+
+	}
+
+	public function down() {
+
+	}
+
+	/**
+	 * @dataProvider timeProvider
+	 */
+	public function testCanNormalizeTime($time) {
+
+		$dt = Values::normalizeTime($time);
+
+		$this->assertInstanceOf(\DateTime::class, $dt);
+		$this->assertEquals($dt->getTimestamp(), Values::normalizeTimestamp($time));
+
+	}
+
+	public function timeProvider() {
+		return [
+			['January 9, 2018 12:00'],
+			[1515496794],
+			[new DateTime('+2 days')],
+		];
+	}
+}

--- a/engine/tests/phpunit/unit/Elgg/Views/DateOutputTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Views/DateOutputTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Elgg\Views;
+
+/**
+ * @group ViewRendering
+ * @group ViewsService
+ */
+class DateOutputTest extends ViewRenderingTestCase {
+
+	public function up() {
+		parent::up();
+
+		$this->date = new \DateTime();
+		$this->format = 'Y-m-d H:i';
+	}
+
+
+	public function getViewNames() {
+		return [
+			'output/date',
+			'output/time',
+		];
+	}
+
+	public function getDefaultViewVars() {
+		return [
+			'value' => $this->date,
+			'format' => $this->format,
+		];
+	}
+
+	public function testCanRenderDate() {
+
+		$output = $this->date->format($this->format);
+
+		$this->assertEquals($output, elgg_view('output/date', [
+			'value' => $this->date,
+			'format' => $this->format,
+		]));
+	}
+
+	public function testCanRenderTime() {
+
+		$format = 'g:ia';
+		$output = $this->date->format($format);
+
+		$this->assertEquals($output, elgg_view('output/time', [
+			'value' => $this->date,
+			'format' => $format,
+		]));
+	}
+
+
+}

--- a/languages/en.php
+++ b/languages/en.php
@@ -1073,6 +1073,10 @@ Once you have logged in, we highly recommend that you change your password.
  * Time
  */
 
+	'input:date_format' => 'Y-m-d',
+	'input:date_format:datepicker' => 'yy-mm-dd', // jQuery UI datepicker format
+	'input:time_format' => 'g:ia',
+
 	'friendlytime:justnow' => "just now",
 	'friendlytime:minutes' => "%s minutes ago",
 	'friendlytime:minutes:singular' => "a minute ago",

--- a/mod/developers/views/default/theme_sandbox/forms.php
+++ b/mod/developers/views/default/theme_sandbox/forms.php
@@ -1,6 +1,7 @@
 <?php
 $ipsum = elgg_view('developers/ipsum');
-?><form action="#">
+?>
+<form action="#">
 	<fieldset>
 		<legend>Fieldset Legend</legend>
 		<?php
@@ -95,7 +96,7 @@ $ipsum = elgg_view('developers/ipsum');
 			'label' => 'a (.elgg-input-checkbox) - Input label',
 			'#help' => 'Single checkbox .elgg-input-checkbox wrapped in .elgg-input-single-checkbox (label and #label)',
 		]);
-		
+
 		echo elgg_view_input('checkbox', [
 			'name' => 'f4s3',
 			'id' => 'f4s3',
@@ -105,7 +106,7 @@ $ipsum = elgg_view('developers/ipsum');
 			'label' => 'a (.elgg-input-checkbox)',
 			'help' => 'Single checkbox .elgg-input-checkbox wrapped in .elgg-input-single-checkbox using elgg_view_input',
 		]);
-		
+
 		echo elgg_view_field([
 			'#type' => 'checkboxes',
 			'name' => 'f4',
@@ -346,6 +347,26 @@ $ipsum = elgg_view('developers/ipsum');
 		]);
 
 		echo elgg_view_field([
+			'#type' => 'time',
+			'name' => 'f121-time',
+			'id' => 'f121-time',
+			'#label' => 'Time input (.elgg-input-time):',
+		]);
+
+		echo elgg_view_field([
+			'#type' => 'time',
+			'name' => 'f122-time',
+			'id' => 'f122-time',
+			'value' => new DateTime(),
+			'min' => 8 * 60 * 60,
+			'max' => 20 * 60 * 60,
+			'step' => 30 * 60,
+			'#label' => 'Time input (.elgg-input-time) with custom options:',
+			'#help' => 'Select time between 8:00 and 20:00',
+			'timestamp' => true,
+		]);
+
+		echo elgg_view_field([
 			'#type' => 'userpicker',
 			'name' => 'f13',
 			'id' => 'f13',
@@ -426,30 +447,30 @@ $ipsum = elgg_view('developers/ipsum');
 			'name' => 'f16',
 			'legend' => 'Fieldset with a legend',
 			'fields' => [
-					[
+				[
 					'#type' => 'text',
 					'#label' => 'Text field',
 					'required' => true,
-					],
-					[
+				],
+				[
 					'#type' => 'fieldset',
 					'#label' => 'Date and time fieldset',
 					'align' => 'horizontal',
 					'fields' => [
-							[
+						[
 							'#type' => 'date',
 							'value' => time(),
 							'timestamp' => true,
 							'#label' => 'Date',
-							],
-							[
+						],
+						[
 							'#type' => 'select',
 							'#label' => 'Time',
 							'options' => $hour_options,
-							],
+						],
 					],
-					],
-					[
+				],
+				[
 					'#type' => 'fieldset',
 					'#label' => 'Nested fieldset',
 					'#help' => 'Fieldset with horizontal alignment of fields',
@@ -461,20 +482,20 @@ $ipsum = elgg_view('developers/ipsum');
 							'text' => 'Save',
 							'icon' => 'save',
 						],
-							[
+						[
 							'#type' => 'button',
 							'text' => 'Download',
 							'icon' => 'download',
 							'class' => 'elgg-button-action',
-							],
-							[
+						],
+						[
 							'#type' => 'button',
 							'type' => 'reset',
 							'text' => 'Cancel',
 							'icon' => 'remove',
-							],
+						],
 					],
-					],
+				],
 			]
 		]);
 		?>

--- a/views/default/input/date.php
+++ b/views/default/input/date.php
@@ -15,6 +15,7 @@
  * @uses $vars['class']     Additional CSS class
  * @uses $vars['timestamp'] Store as a Unix timestamp in seconds. Default = false
  * @uses $vars['datepicker_options'] An array of options to pass to the jQuery UI datepicker
+ * @uses $vars['format']    Date format, default Y-m-d (2018-01-30)
  */
 $vars['class'] = elgg_extract_class($vars, 'elgg-input-date');
 
@@ -22,7 +23,8 @@ $defaults = [
 	'value' => '',
 	'disabled' => false,
 	'timestamp' => false,
-	'type' => 'text'
+	'type' => 'text',
+	'format' => elgg_echo('input:date_format'),
 ];
 
 $vars = array_merge($defaults, $vars);
@@ -30,27 +32,47 @@ $vars = array_merge($defaults, $vars);
 $timestamp = $vars['timestamp'];
 unset($vars['timestamp']);
 
+$format = elgg_extract('format', $vars, $defaults['format'], false);
+unset($vars['format']);
+
+$value = elgg_extract('value', $vars);
+
+$value_date = '';
+$value_timestamp = '';
+
+if ($value) {
+	try {
+		$value = \Elgg\Values::normalizeTime($value);
+
+		$value_date = $dt->format($format);
+		$value_timestamp = $dt->getTimestamp();
+	} catch (DataFormatException $ex) {
+	}
+}
+
 if ($timestamp) {
 	if (!isset($vars['id'])) {
 		$vars['id'] = $vars['name'];
 	}
 	echo elgg_view('input/hidden', [
 		'name' => $vars['name'],
-		'value' => $vars['value'],
+		'value' => $value_timestamp,
 		'rel' => $vars['id'],
 	]);
 	$vars['class'][] = 'elgg-input-timestamp';
 	unset($vars['name']);
 }
 
-// convert timestamps to text for display
-if (is_numeric($vars['value'])) {
-	$vars['value'] = gmdate('Y-m-d', $vars['value']);
+$vars['value'] = $value_date;
+
+$datepicker_options = (array) elgg_extract('datepicker_options', $vars, []);
+unset($vars['datepicker_options']);
+
+if (empty($datepicker_options['dateFormat'])) {
+	$datepicker_options['dateFormat'] = elgg_echo('input:date_format:datepicker');
 }
 
-$datepicker_options = elgg_extract('datepicker_options', $vars);
 $vars['data-datepicker-opts'] = $datepicker_options ? json_encode($datepicker_options) : '';
-unset($vars['datepicker_options']);
 
 echo elgg_format_element('input', $vars);
 

--- a/views/default/input/time.php
+++ b/views/default/input/time.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Elgg time input
+ * Displays a select field with time options.
+ *
+ * Unix timestamps are supported by setting the 'timestamp' parameter to true.
+ *
+ * @uses $vars['value']     The current value, if any (as a unix timestamp)
+ * @uses $vars['class']     Additional CSS class
+ * @uses $vars['timestamp'] Store as a Unix timestamp in seconds. Default = false
+ * @uses $vars['format']    Date format, default g:ia (4:44pm)
+ * @uses $vars['step']      Interval/step (in seconds) between available time options (e.g. 15*60 for 15min)
+ * @uses $vars['min']       Min available time in seconds (e.g. 2*60*60 for 2am)
+ * @uses $vars['max']       Max available time in seconds (e.g. 23*60*60 for 11pm)
+ */
+$vars['class'] = elgg_extract_class($vars, 'elgg-input-time');
+
+$defaults = [
+	'value' => '',
+	'timestamp' => false,
+	'type' => 'select',
+	'format' => elgg_echo('input:time_format'),
+];
+
+$vars = array_merge($defaults, $vars);
+
+$timestamp = $vars['timestamp'];
+unset($vars['timestamp']);
+
+$format = elgg_extract('format', $vars, $defaults['format'], false);
+unset($vars['format']);
+
+$min = (int) elgg_extract('min', $vars, 0);
+unset($vars['min']);
+
+$max = (int) elgg_extract('max', $vars, 24 * 60 * 60);
+unset($vars['max']);
+
+$step = (int) elgg_extract('step', $vars, 15 * 60);
+unset($vars['step']);
+
+$value = elgg_extract('value', $vars);
+$value_time = '';
+$value_timestamp = '';
+if ($value) {
+	try {
+		$dt = \Elgg\Values::normalizeTime($value);
+
+		// round value to the closest divisible of a step
+		$next_step_ts = (int) ceil($dt->getTimestamp() / $step) * $step;
+		$dt->setTimestamp($next_step_ts);
+
+		$value_timestamp = $dt->format('H') * 60 * 60 + $dt->format('i') * 60;
+		$value_time = $dt->format($format);
+	} catch (DataFormatException $ex) {
+	}
+}
+
+if ($timestamp) {
+	$vars['value'] = $value_timestamp;
+} else {
+	$vars['value'] = $value_time;
+}
+
+$hour_options = [];
+$hour_options_ts = range($min, $max, $step);
+
+$dt = new DateTime(null, new DateTimeZone('UTC'));
+
+foreach ($hour_options_ts as $ts) {
+	$dt->setTimestamp($ts);
+	$key = ($timestamp) ? $dt->getTimestamp() : $dt->format($format);
+	$hour_options[$key] = $dt->format($format);
+}
+
+$vars['options_values'] = $hour_options;
+
+echo elgg_view('input/select', $vars);

--- a/views/default/output/date.php
+++ b/views/default/output/date.php
@@ -1,17 +1,20 @@
 <?php
 /**
- * Date
- * Displays a properly formatted date
+ * Displays a formatted date
  *
- * @package Elgg
- * @subpackage Core
- *
- * @uses $vars['value'] Date as text or a Unix timestamp in seconds
+ * @uses $vars['value'] Date as DateTime, text or a Unix timestamp
+ * @uses $vars['format'] Date format
  */
 
-// convert timestamps to text for display
-if (is_numeric($vars['value'])) {
-	$vars['value'] = gmdate('Y-m-d', $vars['value']);
+$format = elgg_extract('format', $vars, elgg_echo('input:date_format'), false);
+
+$value = elgg_extract('value', $vars);
+if (!$value) {
+	return;
 }
 
-echo $vars['value'];
+try {
+	$dt = \Elgg\Values::normalizeTime($value);
+	echo $dt->format($format);
+} catch (DataFormatException $ex) {
+}

--- a/views/default/output/time.php
+++ b/views/default/output/time.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Displays a formatted time
+ *
+ * @uses $vars['value'] Date as DateTime, text or a Unix timestamp
+ * @uses $vars['format'] Date format
+ */
+
+$format = elgg_extract('format', $vars, elgg_echo('input:time_format'), false);
+$vars['format'] = $format;
+
+echo elgg_view('output/date', $vars);


### PR DESCRIPTION
Date input now supports DateTime object.
Date and time format can now be set using translation strings.
Adds time input.
  
![time](https://user-images.githubusercontent.com/1202761/34678926-cc2fa58c-f494-11e7-9a02-884ecc49d7c2.JPG)


- [x] Add support for `DateTime` in `output/date`
- [x] Add `output/time` view