### PR TITLE
chore(tests): test deleting admin notice with an empty string as id

### DIFF
--- a/engine/tests/phpunit/integration/Elgg/Actions/Admin/AdminNoticesTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Actions/Admin/AdminNoticesTest.php
@@ -40,6 +40,20 @@ class AdminNoticesTest extends ActionResponseTestCase {
 		$this->assertFalse(elgg_admin_notice_exists('zen'));
 	}
 
+	public function testDeletesSingleAdminNoticeWithEmptyID() {
+
+		$notice = elgg_add_admin_notice('will_be_removed', 'foo');
+		$this->assertInstanceOf(\ElggObject::class, $notice);
+		$this->assertEquals('will_be_removed', $notice->admin_notice_id);
+
+		$notice->admin_notice_id = '';
+		
+		$this->assertTrue(elgg_admin_notice_exists(''));
+
+		$this->assertTrue(elgg_delete_admin_notice(''));
+		$this->assertFalse(elgg_admin_notice_exists(''));
+	}
+
 	public function testIgnoresNonAdminNoticesDuringDeleteAction() {
 
 		$object = $this->createObject();


### PR DESCRIPTION
fixes #11528