### PR TITLE
chore(cache): only invalidate bootcache when a plugin entity changes

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -2103,8 +2103,6 @@ abstract class ElggEntity extends \ElggData implements
 			return;
 		}
 
-		_elgg_services()->boot->invalidateCache();
-
 		_elgg_services()->entityCache->delete($this->guid);
 
 		$namespaces = [

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -1260,6 +1260,8 @@ class ElggPlugin extends ElggObject {
 	 * {@inheritdoc}
 	 */
 	public function invalidateCache() {
+		
+		_elgg_services()->boot->invalidateCache();
 		_elgg_services()->plugins->invalidateCache($this->getID());
 
 		return parent::invalidateCache();


### PR DESCRIPTION
This problem was introduce when behaviour of private settings has been merged into entities. Invalidating the bootcache is only needed when plugins change as they are included in the bootcache.

If we keep this in ElggEntity the bootcache will be invalidated every script run as at the end of a script run the last_login for the logged in user is updated, which is triggering the cache invalidation.