### PR TITLE
feat(cache): boot cache is now enabled by default

### DIFF
--- a/docs/admin/performance.rst
+++ b/docs/admin/performance.rst
@@ -129,15 +129,15 @@ The system cache can be disabled via the administration menu, and it is
 recommended that you do this on your development platform if you are
 writing Elgg plugins.
 
-Boot cache (experimental)
--------------------------
+Boot cache
+----------
 
 Elgg has the ability to cache numerous resources created and fetched during
-the boot process. To enable this cache you must set a TTL in your ``settings.php``
-file: ``$CONFIG->boot_cache_ttl = 10;``
+the boot process. To configure how long this cache is valid you must set a TTL in your ``settings.php``
+file: ``$CONFIG->boot_cache_ttl = 3600;``
 
-A small TTL is recommended because it brings all the benefits of caching under load
-while reducing the harm if Elgg's cache invalidation strategy should miss something.
+Look at the `Stash <http://www.stashphp.com/index.html>`_ documentation for more info about the TTL. 
+
 
 Database query cache
 --------------------

--- a/elgg-config/settings.example.php
+++ b/elgg-config/settings.example.php
@@ -169,14 +169,13 @@ $CONFIG->dbencoding = 'utf8mb4';
 //$CONFIG->simplecache_enabled = true;
 
 /**
- * Enable the boot cache
+ * Configure the boot cache TTL
  *
  * Elgg can store most non-user-specific boot up data in a cache. If you want to
- * enable this, uncomment the next line to set it to 10. Although Elgg has a built-
- * in invalidation strategy for this cache, you should consider a small TTL to
- * minimize the damage if the cache should grow stale.
+ * configure how long Elgg takes before invalidating this cache, uncomment the next line
+ * and set it to a number of seconds. If not set Elgg will default to 3600 seconds.
  */
-//$CONFIG->boot_cache_ttl = 10;
+//$CONFIG->boot_cache_ttl = 3600;
 
 /**
  * Set cache directory

--- a/engine/classes/Elgg/BootService.php
+++ b/engine/classes/Elgg/BootService.php
@@ -18,12 +18,9 @@ class BootService {
 	use Profilable;
 
 	/**
-	 * Under load, a short TTL gives nearly all of the benefits of a longer TTL, but it also ensures
-	 * that, should cache invalidation fail for some reason, it'll be rebuilt quickly anyway.
-	 *
-	 * In 2.x we do not cache by default. This will likely change to 10 in 3.0.
+	 * The default TTL if not set in settings.php
 	 */
-	const DEFAULT_BOOT_CACHE_TTL = 0;
+	const DEFAULT_BOOT_CACHE_TTL = 3600;
 
 	/**
 	 * Has the cache already been invalidated this request? Avoids thrashing
@@ -198,7 +195,7 @@ class BootService {
 			$data = new BootData();
 			$data->populate($db, _elgg_services()->entityTable, _elgg_services()->plugins, $installed);
 			if ($config->boot_cache_ttl) {
-				$this->cache->save('boot_data', $data, $config->boot_cache_ttl, [Invalidation::NONE]);
+				$this->cache->save('boot_data', $data, $config->boot_cache_ttl);
 			}
 		} else {
 			$config->_boot_cache_hit = true;

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -124,6 +124,16 @@ class ElggSite extends \ElggEntity {
 	public function getURL() {
 		return _elgg_config()->wwwroot;
 	}
+	
+	/**
+	 * {@inheritdoc}
+	 */
+	public function invalidateCache() {
+		
+		_elgg_services()->boot->invalidateCache();
+
+		return parent::invalidateCache();
+	}
 
 	/**
 	 * {@inheritdoc}

--- a/engine/tests/classes/Elgg/IntegrationTestCase.php
+++ b/engine/tests/classes/Elgg/IntegrationTestCase.php
@@ -42,7 +42,7 @@ abstract class IntegrationTestCase extends BaseTestCase {
 		$config = self::getTestingConfig();
 		$sp = new ServiceProvider($config);
 		$config->system_cache_enabled = true;
-		$config->boot_cache_ttl = 10;
+		$config->boot_cache_ttl = 600;
 
 		// persistentLogin service needs this set to instantiate without calling DB
 		$sp->config->getCookieConfig();

--- a/mod/search/views/rss/search/list.php
+++ b/mod/search/views/rss/search/list.php
@@ -6,7 +6,8 @@
  * @uses $vars['params']
  */
 
-$entities = $vars['results']['entities'];
+$results = elgg_extract('results', $vars);
+$entities = elgg_extract('entities', $results);
 
 if (empty($entities)) {
 	return;
@@ -17,12 +18,10 @@ $service = new \Elgg\Search\Search($params);
 
 foreach ($entities as $entity) {
 	if ($view = $service->getSearchView()) {
-		$body .= elgg_view($view, [
+		echo elgg_view($view, [
 			'entity' => $entity,
 			'params' => $service->getParams(),
-			'results' => $vars['results']
+			'results' => $results,
 		]);
 	}
 }
-
-echo $body;

--- a/mod/system_log/views/default/core/settings/account/login_history.php
+++ b/mod/system_log/views/default/core/settings/account/login_history.php
@@ -1,6 +1,9 @@
 <?php
 
 $user = elgg_get_page_owner_entity();
+if (!$user instanceof ElggUser) {
+	return;
+}
 
 $log = system_log_get_log($user->guid, 'login', '', 'user', '', 20);
 if (empty($log)) {

--- a/mod/system_log/views/default/logbrowser/table.php
+++ b/mod/system_log/views/default/logbrowser/table.php
@@ -5,7 +5,13 @@
  * @package ElggLogBrowser
  */
 
-$log_entries = $vars['log_entries'];
+$log_entries = elgg_extract('log_entries', $vars);
+
+if (empty($log_entries)) {
+	echo elgg_echo('notfound');
+	return true;
+}
+
 ?>
 
 <table class="elgg-table">
@@ -84,7 +90,3 @@ $alt = $alt ? '' : 'class="alt"';
 ?>
 </table>
 <?php
-if (!$log_entries) {
-	echo elgg_echo('notfound');
-	return true;
-}

--- a/mod/system_log/views/default/plugins/system_log/settings.php
+++ b/mod/system_log/views/default/plugins/system_log/settings.php
@@ -6,6 +6,9 @@
  */
 
 $plugin = elgg_extract('entity', $vars);
+if (!$plugin instanceof ElggPlugin) {
+	return;
+}
 
 echo elgg_view_field([
 	'#type' => 'select',


### PR DESCRIPTION
the small default TTL we had was conflicting with the Invalidation Policy of stash, causing single processes to always invalidate the bootcache..

i trust in bootcache working correctly, so storing it for 1 hour and using default Precomute invalidation strategy