### PR TITLE
feat(routes): adds gatekeeper service

### DIFF
--- a/docs/appendix/upgrade-notes/2.x-to-3.0.rst
+++ b/docs/appendix/upgrade-notes/2.x-to-3.0.rst
@@ -314,6 +314,7 @@ Deprecated APIs
  * ``elgg_list_entities_from_access_id``: Use ``elgg_list_entities()``
  * ``elgg_batch_delete_callback``
  * ``\Elgg\Project\Paths::sanitize``: Use ``\Elgg\Project\Paths::sanitize()``
+ * ``elgg_group_gatekeeper``: Use ``elgg_entity_gatekeeper()``
 
 Removed global vars
 -------------------
@@ -760,6 +761,10 @@ within these page handlers has been moved to respective resource views.
 routes that depend on entity type and subtype.
 
 Use of ``handler`` parameter in entity menus has been deprecated in favour of named entity routes.
+
+Gatekeeper function have been refactored to serve as middleware in the routing process, and as such they no longer
+return values. These functions throw HTTP exceptions that are then routed to error pages and can be redirected
+to other pages via hooks.
 
 Labelling
 ---------

--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -374,7 +374,16 @@ Permission hooks
 	Triggered by ``api_auth_key()``. Returning false prevents the key from being authenticated.
 
 **gatekeeper, <entity_type>:<entity_subtype>**
-    Filters the result of ``elgg_entity_gatekeeper()`` to prevent access to an entity that user would otherwise have access to. A handler should return false to deny access to an entity.
+    Filters the result of ``elgg_entity_gatekeeper()`` to prevent or allow access to an entity that user would otherwise have or not have access to.
+    A handler can return ``false`` or an instance of ``HttpException`` to prevent access to an entity.
+    A handler can return ``true`` to override the result of the gatekeeper.
+    **Important** that the entity received by this hook is fetched with ignored access and including disabled entities,
+    so you have to be careful to not bypass the access system.
+
+    ``$params`` array includes:
+
+	 * ``entity`` - Entity that is being accessed
+	 * ``user`` - User accessing the entity (``null`` implies logged in user)
 
 
 Notifications

--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -358,15 +358,19 @@ class EntityTable {
 	/**
 	 * Loads and returns an entity object from a guid.
 	 *
-	 * @param int    $guid The GUID of the entity
-	 * @param string $type The type of the entity. If given, even an existing entity with the given GUID
-	 *                     will not be returned unless its type matches.
+	 * @param int    $guid    The GUID of the entity
+	 * @param string $type    The type of the entity
+	 *                        If given, even an existing entity with the given GUID
+	 *                        will not be returned unless its type matches
+	 * @param string $subtype The subtype of the entity
+	 *                        If given, even an existing entity with the given GUID
+	 *                        will not be returned unless its subtype matches
 	 *
 	 * @return ElggEntity|false The correct Elgg or custom object based upon entity type and subtype
 	 * @throws ClassException
 	 * @throws InvalidParameterException
 	 */
-	public function get($guid, $type = '') {
+	public function get($guid, $type = null, $subtype = null) {
 		// We could also use: if (!(int) $guid) { return false },
 		// but that evaluates to a false positive for $guid = true.
 		// This is a bit slower, but more thorough.
@@ -377,7 +381,7 @@ class EntityTable {
 		$guid = (int) $guid;
 
 		$entity = $this->getFromCache($guid);
-		if ($entity && (!$type || elgg_instanceof($entity, $type))) {
+		if ($entity && elgg_instanceof($entity, $type, $subtype)) {
 			return $entity;
 		}
 
@@ -387,6 +391,10 @@ class EntityTable {
 		}
 
 		if ($type && $row->type != $type) {
+			return false;
+		}
+
+		if ($subtype && $row->subtype !== $subtype) {
 			return false;
 		}
 

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -56,6 +56,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \ElggCache                               $fileCache
  * @property-read \ElggDiskFilestore                       $filestore
  * @property-read \Elgg\FormsService                       $forms
+ * @property-read \Elgg\Gatekeeper                         $gatekeeper
  * @property-read \Elgg\HandlersService                    $handlers
  * @property-read \Elgg\Security\HmacFactory               $hmac
  * @property-read \Elgg\PluginHooksService                 $hooks
@@ -300,6 +301,17 @@ class ServiceProvider extends DiContainer {
 
 		$this->setFactory('forms', function(ServiceProvider $c) {
 			return new \Elgg\FormsService($c->views, $c->logger);
+		});
+
+		$this->setFactory('gatekeeper', function(ServiceProvider $c) {
+			return new \Elgg\Gatekeeper(
+				$c->session,
+				$c->request,
+				$c->redirects,
+				$c->entityTable,
+				$c->accessCollections,
+				$c->translator
+			);
 		});
 
 		$this->setClassName('handlers', \Elgg\HandlersService::class);

--- a/engine/classes/Elgg/Gatekeeper.php
+++ b/engine/classes/Elgg/Gatekeeper.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Elgg;
+
+use Elgg\Database\AccessCollections;
+use Elgg\Database\EntityTable;
+use Elgg\Http\Request;
+use Elgg\I18n\Translator;
+use ElggEntity;
+use ElggGroup;
+use ElggSession;
+use ElggUser;
+use Exception;
+
+/**
+ * Gatekeeper
+ *
+ * API in flux. Use elgg_* functions intead
+ *
+ * @access private
+ */
+class Gatekeeper {
+
+	/**
+	 * @var ElggSession
+	 */
+	protected $session;
+
+	/**
+	 * @var Request
+	 */
+	protected $request;
+
+	/**
+	 * @var RedirectService
+	 */
+	protected $redirects;
+
+	/**
+	 * @var EntityTable
+	 */
+	protected $entities;
+
+	/**
+	 * @var AccessCollections
+	 */
+	protected $access;
+
+	/**
+	 * @var Translator
+	 */
+	protected $translator;
+
+	/**
+	 * Constructor
+	 *
+	 * @param ElggSession       $session    Session
+	 * @param Request           $request    HTTP Request
+	 * @param RedirectService   $redirects  Redirects Service
+	 * @param EntityTable       $entities   Entity table
+	 * @param AccessCollections $access     Access collection table
+	 * @param Translator        $translator Translator
+	 */
+	public function __construct(
+		ElggSession $session,
+		Request $request,
+		RedirectService $redirects,
+		EntityTable $entities,
+		AccessCollections $access,
+		Translator $translator
+	) {
+		$this->session = $session;
+		$this->request = $request;
+		$this->redirects = $redirects;
+		$this->entities = $entities;
+		$this->access = $access;
+		$this->translator = $translator;
+	}
+
+	/**
+	 * Require a user to be authenticated to with code execution
+	 * @return void
+	 * @throws GatekeeperException
+	 */
+	public function assertAuthenticatedUser() {
+		if ($this->session->isLoggedIn()) {
+			return;
+		}
+
+		$this->redirects->setLastForwardFrom();
+
+		$msg = $this->translator->translate('loggedinrequired');
+		throw new GatekeeperException($msg);
+	}
+
+	/**
+	 * Require an admin user to be authenticated to proceed with code execution
+	 * @return void
+	 * @throws GatekeeperException
+	 */
+	public function assertAuthenticatedAdmin() {
+		$this->assertAuthenticatedUser();
+
+		$user = $this->session->getLoggedInUser();
+		if ($user->isAdmin()) {
+			return;
+		}
+
+		$this->redirects->setLastForwardFrom();
+
+		$msg = $this->translator->translate('adminrequired');
+		throw new GatekeeperException($msg);
+	}
+
+	/**
+	 * Require an entity with a given guid, type and subtype to proceed with code execution
+	 *
+	 * @warning Returned entity has been retrieved with ignored access, as well including disabled entities.
+	 *          You must validate entity access on the return of this method.
+	 *
+	 * @param int  $guid    GUID of the entity
+	 * @param null $type    Entity type
+	 * @param null $subtype Entity subtype
+	 *
+	 * @return ElggEntity
+	 * @throws EntityNotFoundException
+	 * @throws Exception
+	 */
+	public function assertExists($guid, $type = null, $subtype = null) {
+		$entity = elgg_call(ELGG_IGNORE_ACCESS | ELGG_SHOW_DISABLED_ENTITIES, function () use ($guid, $type, $subtype) {
+			return $this->entities->get($guid, $type, $subtype);
+		});
+
+		if (!$entity) {
+			throw new EntityNotFoundException();
+		}
+
+		return $entity;
+	}
+
+	/**
+	 * Require that authenticated user has access to entity
+	 *
+	 * @param ElggEntity $entity Entity
+	 * @param ElggUser   $user   User
+	 *
+	 * @return void
+	 * @throws HttpException
+	 */
+	public function assertAccessibleEntity(ElggEntity $entity, ElggUser $user = null) {
+
+		$result = true;
+
+		try {
+			if (!$this->session->getIgnoreAccess() && !$this->access->hasAccessToEntity($entity, $user)) {
+				// user is logged in but still does not have access to it
+				$msg = $this->translator->translate('limited_access');
+				throw new EntityNotFoundException($msg);
+			}
+
+			if (!$entity->isEnabled() && !access_get_show_hidden_status()) {
+				throw new EntityNotFoundException();
+			}
+
+			if ($entity instanceof ElggUser) {
+				$this->assertAccessibleUser($entity, $user);
+			}
+
+			if ($entity instanceof ElggGroup) {
+				$this->assertAccessibleGroup($entity, $user);
+			}
+
+			foreach (['owner_guid', 'container_guid'] as $prop) {
+				if (!$entity->$prop) {
+					continue;
+				}
+
+				$parent = $this->assertExists($entity->$prop);
+				$this->assertAccessibleEntity($parent);
+			}
+		} catch (HttpException $ex) {
+			$result = $ex;
+		}
+
+		$hook_params = [
+			'entity' => $entity,
+			'user' => $user,
+		];
+
+		$result = elgg_trigger_plugin_hook('gatekeeper', "{$entity->type}:{$entity->subtype}", $hook_params, $result);
+
+		if ($result instanceof HttpException) {
+			throw $result;
+		} else if ($result === false) {
+			throw new HttpException();
+		}
+	}
+
+	/**
+	 * Validate active user account
+	 *
+	 * @param ElggUser $user   User
+	 * @param ElggUser $viewer Viewing user
+	 *
+	 * @return void
+	 * @throws EntityNotFoundException
+	 */
+	public function assertAccessibleUser(ElggUser $user, ElggUser $viewer = null) {
+		if ($user->isBanned()) {
+			if (!isset($viewer)) {
+				$viewer = $this->session->getLoggedInUser();
+			}
+
+			if (!$viewer || !$viewer->isAdmin()) {
+				throw new EntityNotFoundException();
+			}
+		}
+	}
+
+	/**
+	 * Validate group content visibility
+	 *
+	 * @param ElggGroup $group Group entity
+	 * @param ElggUser  $user  User entity
+	 *
+	 * @return void
+	 * @throws GroupGatekeeperException
+	 * @throws GatekeeperException
+	 */
+	public function assertAccessibleGroup(ElggGroup $group, ElggUser $user = null) {
+		if (!$group->canAccessContent($user)) {
+			$this->assertAuthenticatedUser();
+
+			$this->redirects->setLastForwardFrom();
+
+			throw new GroupGatekeeperException();
+		}
+	}
+
+	/**
+	 * Require XmlHttpRequest
+	 *
+	 * @return void
+	 * @throws BadRequestException
+	 */
+	public function assertXmlHttpRequest() {
+		if ($this->request->isXmlHttpRequest()) {
+			return;
+		}
+
+		$msg = $this->translator->translate('ajax:not_is_xhr');
+		throw new BadRequestException($msg);
+	}
+
+}

--- a/engine/classes/Elgg/GroupGatekeeperException.php
+++ b/engine/classes/Elgg/GroupGatekeeperException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Elgg;
+
+use Throwable;
+
+/**
+ * Thrown when one of the gatekeepers prevents access
+ */
+class GroupGatekeeperException extends HttpException {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function __construct(string $message = "", int $code = 0, Throwable $previous = null) {
+		if (!$message) {
+			$message = elgg_echo('membershiprequired');
+		}
+		if (!$code) {
+			$code = ELGG_HTTP_FORBIDDEN;
+		}
+		parent::__construct($message, $code, $previous);
+	}
+}

--- a/engine/classes/Elgg/GroupItemVisibility.php
+++ b/engine/classes/Elgg/GroupItemVisibility.php
@@ -9,6 +9,8 @@ namespace Elgg;
  * @subpackage Groups
  *
  * @access private
+ * @deprecated 3.0 Use ElggGroup::canAccessContent or Gatekeeper::assertAccessibleGroup
+ *
  */
 class GroupItemVisibility {
 
@@ -34,7 +36,7 @@ class GroupItemVisibility {
 	 *
 	 * @return \Elgg\GroupItemVisibility
 	 *
-	 * @todo Make this faster, considering it must run for every river item.
+	 * @deprecated 3.0 Use ElggGroup::canAccessContent
 	 */
 	static public function factory($container_guid, $use_cache = true) {
 		// cache because this may be called repeatedly during river display, and

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -302,4 +302,27 @@ class ElggGroup extends \ElggEntity {
 		
 		return false;
 	}
+
+	/**
+	 * Check if current user can access group content based on his/her membership status
+	 * and group's content access policy
+	 *
+	 * @param ElggUser|null $user User
+	 * @return bool
+	 */
+	public function canAccessContent(ElggUser $user = null) {
+		if (!isset($user)) {
+			$user = elgg_get_logged_in_user_entity();
+		}
+
+		if ($this->getContentAccessMode() == self::CONTENT_ACCESS_MODE_MEMBERS_ONLY) {
+			if (!$user) {
+				return false;
+			}
+
+			return $this->isMember($user) || $user->isAdmin();
+		}
+
+		return true;
+	}
 }

--- a/engine/lib/deprecated-3.0.php
+++ b/engine/lib/deprecated-3.0.php
@@ -1369,3 +1369,41 @@ function group_gatekeeper($forward = true, $page_owner_guid = null) {
 	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use elgg_group_gatekeeper()', '3.0');
 	return elgg_group_gatekeeper($forward, $page_owner_guid);
 }
+
+
+/**
+ * May the current user access item(s) on this page? If the page owner is a group,
+ * membership, visibility, and logged in status are taken into account.
+ *
+ * @param bool $forward    If set to true (default), will forward the page;
+ *                         if set to false, will return true or false.
+ *
+ * @param int  $group_guid The group that owns the page. If not set, this
+ *                         will be pulled from elgg_get_page_owner_guid().
+ *
+ * @return bool Will return if $forward is set to false.
+ * @throws InvalidParameterException
+ * @throws SecurityException
+ * @since 1.9.0
+ * @deprecated 3.0 Use elgg_entity_gatekeeper()
+ */
+function elgg_group_gatekeeper($forward = true, $group_guid = null) {
+	elgg_deprecated_notice(__FUNCTION__ . ' has been deprecated. Use elgg_entity_gatekeeper()', '3.0');
+	if (null === $group_guid) {
+		$group_guid = elgg_get_page_owner_guid();
+	}
+
+	if (!$group_guid) {
+		return true;
+	}
+
+	try {
+		return elgg_entity_gatekeeper($group_guid);
+	} catch (Exception $ex) {
+		if ($forward) {
+			throw $ex;
+		} else {
+			return false;
+		}
+	}
+}

--- a/engine/tests/phpunit/integration/Elgg/Actions/LoginIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Actions/LoginIntegrationTest.php
@@ -171,9 +171,6 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 		$this->markTestIncomplete();
 	}
 
-	/**
-	 * @group Current
-	 */
 	public function testRespectsLastForwardFrom() {
 
 		$user = $this->createOne('user', [], [

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAnnotationAPITest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreAnnotationAPITest.php
@@ -200,9 +200,6 @@ class ElggCoreAnnotationAPITest extends IntegrationTestCase {
 		];
 	}
 
-	/**
-	 * @group Current
-	 */
 	public function testCanDeleteAnnotationById() {
 
 		$entity = $this->createObject();

--- a/engine/tests/phpunit/unit/Elgg/GatekeeperTest.php
+++ b/engine/tests/phpunit/unit/Elgg/GatekeeperTest.php
@@ -1,0 +1,436 @@
+<?php
+
+namespace Elgg;
+
+/**
+ * @group Gatekeeper
+ */
+class GatekeeperTest extends UnitTestCase {
+
+	/**
+	 * @var Gatekeeper
+	 */
+	protected $gatekeeper;
+
+	/**
+	 * @var \ElggSession
+	 */
+	protected $session;
+
+	public function up() {
+		$this->session = _elgg_services()->session;
+		$this->gatekeeper = _elgg_services()->gatekeeper;
+	}
+
+	public function down() {
+		$this->session->removeLoggedInUser();
+	}
+
+	/**
+	 * @expectedException \Elgg\GatekeeperException
+	 */
+	public function testGatekeeperPreventsAccessByGuestUser() {
+		$this->gatekeeper->assertAuthenticatedUser();
+	}
+
+	public function testGatekeeperAllowsAccessToLoggedInUser() {
+
+		$user = $this->createUser();
+		$this->session->setLoggedInUser($user);
+
+		$this->assertNull($this->gatekeeper->assertAuthenticatedUser());
+	}
+
+	/**
+	 * @expectedException \Elgg\GatekeeperException
+	 */
+	public function testAdminGatekeeperPreventsAccessByGuestUser() {
+		$this->gatekeeper->assertAuthenticatedAdmin();
+	}
+
+	/**
+	 * @expectedException \Elgg\GatekeeperException
+	 */
+	public function testAdminGatekeeperPreventsAccessByNonAdminUser() {
+		$user = $this->createUser();
+		$this->session->setLoggedInUser($user);
+
+		$this->gatekeeper->assertAuthenticatedAdmin();
+	}
+
+	public function testAdminGatekeeperAllowsAccessToLoggedInAdmin() {
+
+		$user = $this->createUser([
+			'admin' => 'yes',
+		]);
+		$this->session->setLoggedInUser($user);
+
+		$this->assertNull($this->gatekeeper->assertAuthenticatedAdmin());
+	}
+
+	public function testEntityGatekeeperAllowsAccessToPublicEntity() {
+
+		$user = $this->createUser();
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_PUBLIC,
+			'owner_guid' => $user->guid,
+		]);
+
+		$this->assertNull($this->gatekeeper->assertAccessibleEntity($object));
+	}
+
+	/**
+	 * @expectedException \Elgg\EntityNotFoundException
+	 */
+	public function testEntityGatekeeperPreventsAccessToNonPublicEntity() {
+		$user = $this->createUser();
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_LOGGED_IN,
+			'owner_guid' => $user->guid,
+		]);
+
+		$this->gatekeeper->assertAccessibleEntity($object);
+	}
+
+	public function testEntityGatekeeperAllowsAccessToNonPublicEntityWithIgnoredAccess() {
+		$user = $this->createUser();
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_LOGGED_IN,
+			'owner_guid' => $user->guid,
+		]);
+
+		$this->session->setIgnoreAccess();
+		$this->assertNull($this->gatekeeper->assertAccessibleEntity($object));
+		$this->session->setIgnoreAccess(false);
+	}
+
+	public function testEntityGatekeeperAllowsAccessToAccessControlledEntityByAuthenticatedUser() {
+
+		$user = $this->createUser();
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_LOGGED_IN,
+			'owner_guid' => $user->guid,
+		]);
+
+		$viewer = $this->createUser();
+
+		$this->session->setLoggedInUser($viewer);
+
+		$this->assertNull($this->gatekeeper->assertAccessibleEntity($object));
+
+	}
+
+	/**
+	 * @expectedException \Elgg\EntityNotFoundException
+	 */
+	public function testEntityGatekeeperPreventsAccessByType() {
+		$user = $this->createUser();
+
+		$object = $this->createObject([
+			'type' => 'object',
+			'subtype' => 'foo1',
+			'access_id' => ACCESS_PUBLIC,
+			'owner_guid' => $user->guid,
+		]);
+
+		elgg_entity_gatekeeper($object->guid, 'object', 'foo2');
+	}
+
+	/**
+	 * @expectedException \Elgg\EntityNotFoundException
+	 */
+	public function testEntityGatekeeperPreventsAccessBannedUser() {
+		$user = $this->createUser([
+			'banned' => 'yes'
+		]);
+
+		$this->gatekeeper->assertAccessibleEntity($user);
+
+	}
+
+	/**
+	 * @expectedException \Elgg\EntityNotFoundException
+	 */
+	public function testEntityGatekeeperPreventsAccessToContentOwnedByBannedUser() {
+		$user = $this->createUser([
+			'banned' => 'yes'
+		]);
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_PUBLIC,
+			'owner_guid' => $user->guid,
+		]);
+
+		$this->gatekeeper->assertAccessibleEntity($object);
+
+	}
+
+	/**
+	 * @expectedException \Elgg\EntityNotFoundException
+	 */
+	public function testEntityGatekeeperPreventsAccessToContainedByBannedUser() {
+		$user = $this->createUser([
+			'banned' => 'yes'
+		]);
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_PUBLIC,
+			'container_guid' => $user->guid,
+		]);
+
+		$this->gatekeeper->assertAccessibleEntity($object);
+
+	}
+
+	/**
+	 * @expectedException \Elgg\EntityNotFoundException
+	 */
+	public function testEntityGatekeeperPreventsAccessToDisabledEntity() {
+
+		$user = $this->createUser();
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_PUBLIC,
+			'owner_guid' => $user->guid,
+			'enabled' => 'no',
+		]);
+
+		$this->gatekeeper->assertAccessibleEntity($object);
+
+	}
+
+	/**
+	 * @expectedException \Elgg\EntityNotFoundException
+	 */
+	public function testEntityGatekeeperPreventsAccessToPublicEntityWithNonPublicParent() {
+
+		$container = $this->createObject([
+			'access_id' => ACCESS_LOGGED_IN,
+		]);
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_PUBLIC,
+			'container_guid' => $container->guid,
+		]);
+
+		$this->gatekeeper->assertAccessibleEntity($object);
+
+	}
+
+	public function testEntityGatekeeperAllowsAccessToDisabledEntityWithShownHiddenEntities() {
+
+		$user = $this->createUser();
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_PUBLIC,
+			'owner_guid' => $user->guid,
+			'enabled' => 'no',
+		]);
+
+		access_show_hidden_entities(true);
+		$this->assertNull($this->gatekeeper->assertAccessibleEntity($object));
+		access_show_hidden_entities(false);
+
+	}
+
+	public function testEntityGatekeeperAllowsAccessToPublicGroupContent() {
+
+		$group = $this->createGroup([
+			'membership' => ACCESS_PUBLIC,
+			'access_id' => ACCESS_PUBLIC,
+			'content_access_mode' => \ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED,
+		]);
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_PUBLIC,
+			'container_guid' => $group->guid,
+		]);
+
+		$this->assertNull($this->gatekeeper->assertAccessibleEntity($object));
+	}
+
+	public function testEntityGatekeeperAllowsAccessToNonPublicGroupContent() {
+
+		$group = $this->createGroup([
+			'membership' => ACCESS_PUBLIC,
+			'access_id' => ACCESS_PUBLIC,
+			'content_access_mode' => \ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED,
+		]);
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_LOGGED_IN,
+			'container_guid' => $group->guid,
+		]);
+
+		$viewer = $this->createUser();
+		$this->session->setLoggedInUser($viewer);
+
+		$this->assertNull($this->gatekeeper->assertAccessibleEntity($object));
+	}
+
+	/**
+	 * @expectedException \Elgg\GroupGatekeeperException
+	 */
+	public function testEntityGatekeeperPreventsAccessToPublicGroupContentWithRestrictedContentPolicy() {
+
+		$group = $this->createGroup([
+			'membership' => ACCESS_PUBLIC,
+			'access_id' => ACCESS_PUBLIC,
+			'content_access_mode' => \ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY,
+		]);
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_PUBLIC,
+			'container_guid' => $group->guid,
+		]);
+
+		$viewer = $this->createUser();
+		$this->session->setLoggedInUser($viewer);
+
+		$this->gatekeeper->assertAccessibleEntity($object);
+
+	}
+
+	/**
+	 * @expectedException \Elgg\GroupGatekeeperException
+	 */
+	public function testEntityGatekeeperPreventsAccessToAGroupWithRestrictedContentPolicy() {
+
+		$group = $this->createGroup([
+			'membership' => ACCESS_PUBLIC,
+			'access_id' => ACCESS_PUBLIC,
+			'content_access_mode' => \ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY,
+		]);
+
+		$viewer = $this->createUser();
+		$this->session->setLoggedInUser($viewer);
+
+		$this->gatekeeper->assertAccessibleEntity($group);
+
+	}
+
+	public function testEntityGatekeeperAllowsAccessToPublicGroupContentWithRestrictedContentPolicyToGroupMembers() {
+
+		$group = $this->createGroup([
+			'membership' => ACCESS_PUBLIC,
+			'access_id' => ACCESS_PUBLIC,
+			'content_access_mode' => \ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY,
+		]);
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_PUBLIC,
+			'container_guid' => $group->guid,
+		]);
+
+		$viewer = $this->createUser();
+
+		$group->join($viewer);
+
+		$this->session->setLoggedInUser($viewer);
+
+		$this->assertNull($this->gatekeeper->assertAccessibleEntity($object));
+
+	}
+
+	public function testEntityGatekeeperCanPreventAccessToEntityWithAHook() {
+
+		$user = $this->createUser();
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_PUBLIC,
+			'owner_guid' => $user->guid,
+		]);
+
+		$handler = function (Hook $hook) {
+			$this->assertTrue($hook->getValue());
+
+			return new HttpException('Override', ELGG_HTTP_I_AM_A_TEAPOT);
+		};
+
+		$hook = $this->registerTestingHook('gatekeeper', "object:$object->subtype", $handler);
+
+		try {
+			$this->gatekeeper->assertAccessibleEntity($object);
+
+		} catch (HttpException $ex) {
+			$this->assertEquals('Override', $ex->getMessage());
+			$this->assertEquals(ELGG_HTTP_I_AM_A_TEAPOT, $ex->getCode());
+		}
+
+		$this->assertInstanceOf(HttpException::class, $hook->getResult());
+
+		$hook->unregister();
+
+	}
+
+	/**
+	 * @expectedException \Elgg\HttpException
+	 */
+	public function testEntityGatekeeperCanPreventAccessToEntityWithAHookWithFalseReturn() {
+
+		$user = $this->createUser();
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_PUBLIC,
+			'owner_guid' => $user->guid,
+		]);
+
+		$handler = function (Hook $hook) {
+			$this->assertTrue($hook->getValue());
+
+			return false;
+		};
+
+		$hook = $this->registerTestingHook('gatekeeper', "object:$object->subtype", $handler);
+
+		$ex = null;
+		try {
+			$this->gatekeeper->assertAccessibleEntity($object);
+		} catch (HttpException $ex) {
+
+		}
+
+		$this->assertFalse($hook->getResult());
+
+		$hook->unregister();
+
+		if ($ex instanceof \Exception) {
+			throw $ex;
+		}
+
+	}
+
+	public function testEntityGatekeeperCanAllowAccessToNonAccessibleEntityWithAHook() {
+		$user = $this->createUser();
+
+		$object = $this->createObject([
+			'access_id' => ACCESS_PRIVATE,
+			'owner_guid' => $user->guid,
+		]);
+
+		$handler = function (Hook $hook) {
+			$this->assertInstanceOf(EntityNotFoundException::class, $hook->getValue());
+
+			return true;
+		};
+
+		$hook = $this->registerTestingHook('gatekeeper', "object:$object->subtype", $handler);
+
+		$this->assertNull($this->gatekeeper->assertAccessibleEntity($object));
+
+		$this->assertTrue($hook->getResult());
+
+		$hook->unregister();
+	}
+
+	/**
+	 * @expectedException \Elgg\BadRequestException
+	 */
+	public function testXhrGatekeeperPreventsAccess() {
+		$this->gatekeeper->assertXmlHttpRequest();
+	}
+}

--- a/mod/activity/views/default/resources/activity/group.php
+++ b/mod/activity/views/default/resources/activity/group.php
@@ -1,12 +1,8 @@
 <?php
 
-elgg_group_gatekeeper();
-
 $group = elgg_get_page_owner_entity();
 
-if (!$group instanceof \ElggGroup) {
-	throw new \Elgg\EntityNotFoundException();
-}
+elgg_entity_gatekeeper($group->guid, 'group');
 
 elgg_group_tool_gatekeeper('activity');
 

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -69,6 +69,8 @@ function groups_init() {
 	elgg_register_plugin_hook_handler('register', 'menu:page', '_groups_page_menu_group_profile');
 	elgg_register_plugin_hook_handler('register', 'menu:page', '_groups_page_menu');
 	elgg_register_plugin_hook_handler('register', 'menu:title', '_groups_title_menu');
+
+	elgg_register_plugin_hook_handler('forward', '403', '_groups_gatekeeper_redirect');
 }
 
 /**
@@ -1176,6 +1178,23 @@ function groups_prepare_form_vars($group = null) {
 	elgg_clear_sticky_form('groups');
 
 	return $values;
+}
+
+/**
+ * Redirect unsuccessful attempts to view group content to group's profile
+ *
+ * @param \Elgg\Hook $hook Hook
+ * @return string|void
+ */
+function _groups_gatekeeper_redirect(\Elgg\Hook $hook) {
+
+	$exception = $hook->getParam('exception');
+	if ($exception instanceof \Elgg\GroupGatekeeperException) {
+		$page_owner = elgg_get_page_owner_entity();
+		if ($page_owner instanceof ElggGroup) {
+			return $page_owner->getURL();
+		}
+	}
 }
 
 return function() {

--- a/mod/groups/views/default/groups/profile/layout.php
+++ b/mod/groups/views/default/groups/profile/layout.php
@@ -5,12 +5,15 @@
  * @uses $vars['entity']
  */
 
-/* @var ElggGroup $group */
 $group = elgg_extract('entity', $vars);
+
+if (!$group instanceof ElggGroup) {
+	return;
+}
 
 echo elgg_view('groups/profile/summary', $vars);
 
-if (elgg_group_gatekeeper(false)) {
+if ($group->canAccessContent()) {
 	if (!$group->isPublicMembership() && !$group->isMember()) {
 		echo elgg_view('groups/profile/closed_membership');
 	}

--- a/mod/groups/views/default/resources/groups/members.php
+++ b/mod/groups/views/default/resources/groups/members.php
@@ -8,8 +8,6 @@ $group = get_entity($guid);
 
 elgg_set_page_owner_guid($guid);
 
-elgg_group_gatekeeper();
-
 elgg_push_breadcrumb(elgg_echo('groups'), "groups/all");
 elgg_push_breadcrumb($group->getDisplayName(), $group->getURL());
 

--- a/mod/groups/views/default/resources/groups/profile.php
+++ b/mod/groups/views/default/resources/groups/profile.php
@@ -7,6 +7,7 @@ elgg_register_rss_link();
 elgg_entity_gatekeeper($guid, 'group');
 
 $group = get_entity($guid);
+/* @var $group ElggGroup */
 
 elgg_push_context('group_profile');
 
@@ -16,7 +17,7 @@ elgg_push_breadcrumb($group->getDisplayName());
 $content = elgg_view('groups/profile/layout', ['entity' => $group]);
 
 $sidebar = '';
-if (elgg_group_gatekeeper(false)) {
+if ($group->canAccessContent()) {
 	$sidebar .= elgg_view('groups/sidebar/search', ['entity' => $group]);
 	$sidebar .= elgg_view('groups/sidebar/owner', ['entity' => $group]);
 	$sidebar .= elgg_view('groups/sidebar/members', ['entity' => $group]);

--- a/mod/pages/views/default/resources/pages/revision.php
+++ b/mod/pages/views/default/resources/pages/revision.php
@@ -14,14 +14,9 @@ if (!$page instanceof ElggPage) {
 	throw new \Elgg\EntityNotFoundException();
 }
 
+elgg_entity_gatekeeper($page->container_guid);
+
 elgg_set_page_owner_guid($page->getContainerGUID());
-
-elgg_group_gatekeeper();
-
-$container = elgg_get_page_owner_entity();
-if (!$container) {
-	throw new \Elgg\EntityNotFoundException();
-}
 
 $title = "{$page->getDisplayName()}: " . elgg_echo('pages:revision');
 

--- a/mod/search/views/default/resources/search/index.php
+++ b/mod/search/views/default/resources/search/index.php
@@ -16,8 +16,9 @@ $params = $service->getParams();
 
 $container_guid = elgg_extract('container_guid', $params);
 if ($container_guid && !is_array($container_guid)) {
+	elgg_entity_gatekeeper($container_guid);
+	
 	elgg_set_page_owner_guid($container_guid);
-	elgg_group_gatekeeper(true);
 }
 
 $query = elgg_extract('query', $params);


### PR DESCRIPTION
Adds a gatekeeper service integrated with the routing system.
Deprecates some gatekeeper functions in favor of OOP alternatives.

BREAKING CHANGE
Gatekeeper functions no longer have a return value, instead they
throw an HttpException.