### PR TITLE
chore(input): prefer config to translations for date and time formats

### DIFF
--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -25,6 +25,8 @@ use Elgg\Project\Paths;
  * @property array         $css_compiler_options Options passed to CssCrush during CSS compilation
  * @property string        $dataroot             Path of data storage with trailing "/"
  * @property bool          $data_dir_override
+ * @property string        $date_format          Preferred PHP date format
+ * @property string        $date_format_datepicker Preferred jQuery datepicker date format
  * @property array         $db
  * @property string        $dbencoding
  * @property string        $dbname
@@ -95,6 +97,7 @@ use Elgg\Project\Paths;
  * @property-read int      $site_guid
  * @property bool          $system_cache_enabled
  * @property bool          $system_cache_loaded
+ * @property string        $time_format  Preferred PHP time format
  * @property string        $url          Alias of "wwwroot"
  * @property int           $version
  * @property string        $view         Default viewtype (usually not set)

--- a/views/default/input/date.php
+++ b/views/default/input/date.php
@@ -24,7 +24,7 @@ $defaults = [
 	'disabled' => false,
 	'timestamp' => false,
 	'type' => 'text',
-	'format' => elgg_echo('input:date_format'),
+	'format' => elgg_get_config('date_format', elgg_echo('input:date_format')),
 ];
 
 $vars = array_merge($defaults, $vars);
@@ -70,7 +70,7 @@ $datepicker_options = (array) elgg_extract('datepicker_options', $vars, []);
 unset($vars['datepicker_options']);
 
 if (empty($datepicker_options['dateFormat'])) {
-	$datepicker_options['dateFormat'] = elgg_echo('input:date_format:datepicker');
+	$datepicker_options['dateFormat'] = elgg_get_config('date_format_datepicker', elgg_echo('input:date_format:datepicker'));
 }
 
 $vars['data-datepicker-opts'] = $datepicker_options ? json_encode($datepicker_options) : '';

--- a/views/default/input/time.php
+++ b/views/default/input/time.php
@@ -19,7 +19,7 @@ $defaults = [
 	'value' => '',
 	'timestamp' => false,
 	'type' => 'select',
-	'format' => elgg_echo('input:time_format'),
+	'format' => elgg_get_config('time_format', elgg_echo('input:time_format')),
 ];
 
 $vars = array_merge($defaults, $vars);

--- a/views/default/output/date.php
+++ b/views/default/output/date.php
@@ -6,7 +6,7 @@
  * @uses $vars['format'] Date format
  */
 
-$format = elgg_extract('format', $vars, elgg_echo('input:date_format'), false);
+$format = elgg_extract('format', $vars, elgg_get_config('date_format', elgg_echo('input:date_format')), false);
 
 $value = elgg_extract('value', $vars);
 if (!$value) {

--- a/views/default/output/time.php
+++ b/views/default/output/time.php
@@ -6,7 +6,7 @@
  * @uses $vars['format'] Date format
  */
 
-$format = elgg_extract('format', $vars, elgg_echo('input:time_format'), false);
+$format = elgg_extract('format', $vars, elgg_get_config('time_format', elgg_echo('input:time_format')), false);
 $vars['format'] = $format;
 
 echo elgg_view('output/date', $vars);


### PR DESCRIPTION
Make it easier to adjust date and time formats at runtime by
preferring config values to those stored in translation strings