### PR TITLE
chore(css): maintain grid columns on tablet viewports

### DIFF
--- a/views/default/elements/grid.css
+++ b/views/default/elements/grid.css
@@ -52,7 +52,7 @@
 	margin: 0 -0.5rem;
 }
 
-@media $(media-desktop-down) {
+@media $(media-mobile-only) {
 	.elgg-grid > * {
 		width: 100%;
 	}


### PR DESCRIPTION
.elgg-grid columns are now wrapped on mobile devices only.

Fixes #11708