### PR TITLE
chore(cache): correctly validate APC availability

### DIFF
--- a/engine/classes/Elgg/Cache/CompositeCache.php
+++ b/engine/classes/Elgg/Cache/CompositeCache.php
@@ -220,7 +220,7 @@ class CompositeCache extends ElggCache {
 			return null;
 		}
 
-		if (!is_callable('apcu_fetch')) {
+		if (!extension_loaded('apc') || !ini_get('apc.enabled')) {
 			return null;
 		}
 


### PR DESCRIPTION
Make sure extension is loaded and enabled before attempting
to instantiate an APC cache.