### PR TITLE
fix(embed): make embed route pattern greedy

### DIFF
--- a/mod/embed/elgg-plugin.php
+++ b/mod/embed/elgg-plugin.php
@@ -5,6 +5,9 @@ return [
 		'default:embed' => [
 			'path' => '/embed/{tab?}',
 			'resource' => 'embed/embed',
+			'requirements' => [
+				'tab' => '\w+',
+			],
 		],
 	],
 ];


### PR DESCRIPTION
Makes embed route regex pattern greedy to allow other plugins
register routes within /embed path