### PR TITLE
fix(actions): invokable classes can now be used as action controllers

### DIFF
--- a/engine/classes/Elgg/ActionsService.php
+++ b/engine/classes/Elgg/ActionsService.php
@@ -34,12 +34,24 @@ class ActionsService {
 	];
 
 	/**
+	 * @var RouteRegistrationService
+	 */
+	protected $routes;
+
+	/**
+	 * @var HandlersService
+	 */
+	protected $handlers;
+
+	/**
 	 * Constructor
 	 *
-	 * @param RouteRegistrationService $routes Routes
+	 * @param RouteRegistrationService $routes   Routes
+	 * @param HandlersService          $handlers Handlers service
 	 */
-	public function __construct(RouteRegistrationService $routes) {
+	public function __construct(RouteRegistrationService $routes, HandlersService $handlers) {
 		$this->routes = $routes;
+		$this->handlers = $handlers;
 	}
 
 	/**
@@ -156,7 +168,7 @@ class ActionsService {
 			return false;
 		}
 
-		if ($controller && !is_callable($controller)) {
+		if ($controller && !$this->handlers->isCallable($controller)) {
 			return false;
 		}
 

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -160,7 +160,7 @@ class ServiceProvider extends DiContainer {
 		});
 
 		$this->setFactory('actions', function(ServiceProvider $c) {
-			return new \Elgg\ActionsService($c->routes);
+			return new \Elgg\ActionsService($c->routes, $c->handlers);
 		});
 
 		$this->setClassName('adminNotices', \Elgg\Database\AdminNotices::class);

--- a/engine/classes/Elgg/HandlersService.php
+++ b/engine/classes/Elgg/HandlersService.php
@@ -71,6 +71,20 @@ class HandlersService {
 	}
 
 	/**
+	 * Test is callback is callable
+	 * Unlike is_callable(), this function also tests invokable classes
+	 *
+	 * @see is_callable()
+	 *
+	 * @param mixed $callback Callable
+	 * @return bool
+	 */
+	public function isCallable($callback) {
+		$callback = $this->resolveCallable($callback);
+		return $callback && is_callable($callback);
+	}
+
+	/**
 	 * Get the reflection interface for a callable
 	 *
 	 * @param callable $callable Callable


### PR DESCRIPTION
is_callable() was rejecting controllers that had __invoke() method.
This has now been fixed.