### PR TITLE
fix(perms): allow ownership if editing is allowed

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1396,7 +1396,7 @@ abstract class ElggEntity extends \ElggData implements
 
 			// If different owner than logged in, verify can write to container.
 
-			if ($user_guid != $owner_guid && !$owner->canWriteToContainer($user_guid, $type, $subtype)) {
+			if ($user_guid != $owner_guid && !$owner->canEdit() && !$owner->canWriteToContainer($user_guid, $type, $subtype)) {
 				_elgg_services()->logger->error("User $user_guid tried to create a ($type, $subtype) with owner"
 					. " $owner_guid, but the user wasn't permitted to write to the owner's container.");
 				return false;


### PR DESCRIPTION
ElggEntity::create() now check both canEdit and canWriteToContainer permissions
to verify if the user is allowed to create content owned by someone else.
Should user have edit permissions on the owner entity, entity save is no
longer prevented.

Situation may arise when container_logic_check permissions prevent users
from containing an entity of a given type, even with ignored access.
This change ensures that legacy permissions logic does not prevent
entities from being created.

Fixes #11213