### PR TITLE
fix(walled_garden): register plugin hook during init

### DIFF
--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -461,32 +461,27 @@ class ElggSite extends \ElggEntity {
 	 * @since 1.8.0
 	 */
 	public function checkWalledGarden() {
-		global $CONFIG;
-
 		// command line calls should not invoke the walled garden check
 		if (PHP_SAPI === 'cli') {
 			return;
 		}
 
-		if ($CONFIG->walled_garden) {
-			if ($CONFIG->default_access == ACCESS_PUBLIC) {
-				$CONFIG->default_access = ACCESS_LOGGED_IN;
-			}
-			_elgg_services()->hooks->registerHandler(
-					'access:collections:write',
-					'all',
-					'_elgg_walled_garden_remove_public_access',
-					9999);
+		if (!elgg_get_config('walled_garden')) {
+			return;
+		}
+		
+		if (elgg_get_config('default_access') == ACCESS_PUBLIC) {
+			elgg_set_config('default_access', ACCESS_LOGGED_IN);
+		}
+		
+		if (!_elgg_services()->session->isLoggedIn()) {
+			// override the front page
+			elgg_register_page_handler('', '_elgg_walled_garden_index');
 
-			if (!_elgg_services()->session->isLoggedIn()) {
-				// override the front page
-				elgg_register_page_handler('', '_elgg_walled_garden_index');
-
-				if (!$this->isPublicPage()) {
-					_elgg_services()->redirects->setLastForwardFrom();
-					register_error(_elgg_services()->translator->translate('loggedinrequired'));
-					forward('', 'walled_garden');
-				}
+			if (!$this->isPublicPage()) {
+				_elgg_services()->redirects->setLastForwardFrom();
+				register_error(_elgg_services()->translator->translate('loggedinrequired'));
+				forward('', 'walled_garden');
 			}
 		}
 	}

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1983,16 +1983,23 @@ function _elgg_walled_garden_init() {
 /**
  * Remove public access for walled gardens
  *
- * @param string $hook
- * @param string $type
- * @param array $accesses
- * @return array
+ * @param string $hook     'access:collections:write'
+ * @param string $type     'all'
+ * @param array  $accesses current access list
+ *
+ * @return void|array
  * @access private
  */
 function _elgg_walled_garden_remove_public_access($hook, $type, $accesses) {
+	
+	if (!elgg_get_config('walled_garden')) {
+		return;
+	}
+	
 	if (isset($accesses[ACCESS_PUBLIC])) {
 		unset($accesses[ACCESS_PUBLIC]);
 	}
+	
 	return $accesses;
 }
 
@@ -2031,6 +2038,8 @@ function _elgg_init() {
 
 		return $result;
 	});
+	
+	elgg_register_plugin_hook_handler('access:collections:write', 'all', '_elgg_walled_garden_remove_public_access', 9999);
 
 	if (_elgg_services()->config->getVolatile('enable_profiling')) {
 		/**


### PR DESCRIPTION
This way others can unregister the hook easier

fixes #11811

Test:
- [x] walled garden has no public access
- [x] able to unregister hook from plugin