### PR TITLE
fix(routes): defer route and action registration until plugins are loaded

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -543,9 +543,11 @@ Routing
 **route:config, <route_name>**
 	Allows altering the route configuration before it is registered.
 	This hook can be used to alter the path, default values, requirements, as well as to set/remove middleware.
+	Please note that the handler for this hook should be registered outside of the ``init`` event handler, as core routes are registered during ``plugins_boot`` event.
 
 **route:rewrite, <identifier>**
 	Allows altering the site-relative URL path for an incoming request. See :doc:`routing` for details.
+	Please note that the handler for this hook should be registered outside of the ``init`` event handler, as route rewrites take place after ``plugins_boot`` event has completed.
 
 **response, path:<path>**
     Filter an instance of ``\Elgg\Http\ResponseBuilder`` before it is sent to the client.

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -224,6 +224,8 @@ class Application {
 		$this->_services->boot->boot($this->_services);
 
 		$events->registerHandler('plugins_boot:before', 'system', 'elgg_views_boot');
+		$events->registerHandler('plugins_boot', 'system', '_elgg_register_routes');
+		$events->registerHandler('plugins_boot', 'system', '_elgg_register_actions');
 
 		// Load the plugins that are active
 		$this->_services->plugins->load();

--- a/engine/lib/elgglib.php
+++ b/engine/lib/elgglib.php
@@ -1725,9 +1725,6 @@ function _elgg_api_test($hook, $type, $value, $params) {
  */
 return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hooks) {
 
-	_elgg_register_routes();
-	_elgg_register_actions();
-
 	elgg_set_entity_class('user', 'user', \ElggUser::class);
 	elgg_set_entity_class('group', 'group', \ElggGroup::class);
 	elgg_set_entity_class('site', 'site', \ElggSite::class);


### PR DESCRIPTION
Core routes and actions are now registered after plugins are loaded (during
plugins_boot event) thus giving plugins an opportunity to register handlers
to alter route configuration

Fixes 11824