### PR TITLE
feat(navbar): properly handle second and third level child menus

### DIFF
--- a/mod/developers/views/default/theme_sandbox/navigation.php
+++ b/mod/developers/views/default/theme_sandbox/navigation.php
@@ -9,7 +9,7 @@ echo elgg_view_module('aside', "Tabs (.elgg-tabs)", elgg_view('theme_sandbox/nav
 
 echo elgg_view_module('aside', "Pagination (.elgg-pagination)", elgg_view('theme_sandbox/navigation/pagination'));
 
-echo elgg_view_module('aside', "Site Menu (.elgg-menu-site)", elgg_view('theme_sandbox/navigation/site'));
+echo elgg_view_module('aside', "Site Navbar", elgg_view('theme_sandbox/navigation/site'));
 
 echo elgg_view_module('aside', "Breadcrumbs (.elgg-breadcrumbs)", elgg_view('theme_sandbox/navigation/breadcrumbs'));
 

--- a/mod/developers/views/default/theme_sandbox/navigation/site.php
+++ b/mod/developers/views/default/theme_sandbox/navigation/site.php
@@ -1,16 +1,95 @@
 <?php
 
-$params = [];
-$params['menu'] = [];
-$params['menu']['default'] = [];
-for ($i=1; $i<=5; $i++) {
-	$params['menu']['default'][] = new ElggMenuItem($i, "Page $i", "#");
-}
-$params['menu']['default'][2]->setSelected(true);
+elgg_register_menu_item('site', [
+	'name' => 'parent',
+	'text' => 'Parent 1',
+	'href' => '#',
+]);
+
+elgg_register_menu_item('site', [
+	'name' => 'child1',
+	'parent_name' => 'parent',
+	'text' => 'Child 1',
+	'href' => '#',
+]);
+
+elgg_register_menu_item('site', [
+	'name' => 'child2',
+	'parent_name' => 'parent',
+	'text' => 'Child 2',
+	'href' => '#',
+]);
+
+elgg_register_menu_item('site', [
+	'name' => 'grandchild1',
+	'parent_name' => 'child1',
+	'text' => 'Grandchild 1',
+	'href' => '#',
+]);
+
+elgg_register_menu_item('site', [
+	'name' => 'grandchild2',
+	'parent_name' => 'child1',
+	'text' => 'Grandchild 2',
+	'href' => '#',
+]);
+
+elgg_register_menu_item('topbar', [
+	'name' => 'parent',
+	'parent_name' => 'account',
+	'text' => 'Parent 1',
+	'href' => '#',
+	'section' => 'alt',
+]);
+
+elgg_register_menu_item('topbar', [
+	'name' => 'child1',
+	'parent_name' => 'parent',
+	'text' => 'Child 1',
+	'href' => '#',
+	'section' => 'alt',
+]);
+
+elgg_register_menu_item('topbar', [
+	'name' => 'child2',
+	'parent_name' => 'parent',
+	'text' => 'Child 2',
+	'href' => '#',
+	'section' => 'alt',
+]);
+
+elgg_register_menu_item('topbar', [
+	'name' => 'grandchild1',
+	'parent_name' => 'child1',
+	'text' => 'Grandchild 1',
+	'href' => '#',
+	'section' => 'alt',
+]);
+
+elgg_register_menu_item('topbar', [
+	'name' => 'grandchild2',
+	'parent_name' => 'child1',
+	'text' => 'Grandchild 2',
+	'href' => '#',
+	'section' => 'alt',
+]);
 
 ?>
-<div class="elgg-page-header">
-	<div class="elgg-inner ptm">
-<?php echo elgg_view('navigation/menu/site', $params); ?>
+
+<div class="elgg-page-section elgg-page-topbar">
+	<div class="elgg-inner">
+		<div class="elgg-nav-button">
+			<span></span>
+			<span></span>
+			<span></span>
+		</div>
+
+		<div class="elgg-nav-collapse">
+			<?php
+			echo elgg_view_menu('site');
+			echo elgg_view_menu('topbar');
+			?>
+		</div>
 	</div>
 </div>
+

--- a/views/default/elements/layout/topbar.css
+++ b/views/default/elements/layout/topbar.css
@@ -217,9 +217,13 @@
 	order: 3;
 }
 
-.elgg-page-topbar .elgg-menu-site .elgg-menu-parent,
-.elgg-page-topbar .elgg-menu-topbar .elgg-menu-parent {
+.elgg-page-topbar .elgg-menu-site .elgg-menu-item-more > .elgg-menu-parent,
+.elgg-page-topbar .elgg-menu-topbar .elgg-menu-item-account > .elgg-menu-parent {
 	display: none;
+}
+
+.elgg-page-topbar .elgg-menu li .elgg-child-menu .elgg-child-menu {
+	margin-left: 1rem;
 }
 
 .elgg-page-topbar .elgg-menu > li > a .elgg-icon {
@@ -269,15 +273,17 @@
 	.elgg-page-topbar .elgg-menu li {
 		display: inline-block;
 		width: auto;
+		position: relative;
 	}
 
 	.elgg-page-topbar .elgg-menu li > a {
 		border: none;
 	}
 
-	.elgg-page-topbar .elgg-menu-site .elgg-menu-parent,
-	.elgg-page-topbar .elgg-menu-topbar .elgg-menu-parent {
+	.elgg-page-topbar .elgg-menu-site .elgg-menu-item-more > .elgg-menu-parent,
+	.elgg-page-topbar .elgg-menu-topbar .elgg-menu-item-account > .elgg-menu-parent {
 		display: inline-block;
+		width: 100%;
 	}
 
 	.elgg-page-topbar .elgg-menu li .elgg-child-menu {
@@ -293,11 +299,25 @@
 		box-shadow: 1px 2px 4px rgba(0, 0, 0, 0.2);
 	}
 
-	.elgg-page-topbar .elgg-menu li:hover .elgg-child-menu {
+	.elgg-page-topbar .elgg-menu-site li .elgg-child-menu .elgg-child-menu {
+		top: 0;
+		left: 100%;
+		right: auto;
+		margin: 0;
+	}
+
+	.elgg-page-topbar .elgg-menu-topbar li .elgg-child-menu .elgg-child-menu {
+		top: 0;
+		right: 100%;
+		left: auto;
+		margin: 0;
+	}
+
+	.elgg-page-topbar .elgg-menu li:hover > .elgg-child-menu {
 		display: flex;
 	}
 
-	.elgg-page-topbar .elgg-menu li:hover .elgg-child-menu:before {
+	.elgg-page-topbar .elgg-menu li:hover > .elgg-child-menu:before {
 		content: "\25b2";
 		color: $(topbar-background-color, $(background-color-highlight));
 		position: absolute;
@@ -309,6 +329,23 @@
 		margin-right: 1.5rem;
 		line-height: 1rem;
 		padding-top: 3px;
+	}
+
+	.elgg-page-topbar .elgg-menu-site li .elgg-child-menu li:hover > .elgg-child-menu:before {
+		content: "\25c0";
+		top: 0;
+		right: 100%;
+		margin: 13px -1px 0 0;
+		text-shadow: -2px 0 rgba(0, 0, 0, 0.05);
+		padding: 0;
+	}
+
+	.elgg-page-topbar .elgg-menu-topbar li .elgg-child-menu li:hover > .elgg-child-menu:before {
+		content: "\25b6";
+		top: 0;
+		left: 100%;
+		margin: 13px 0 0 -2px;
+		padding: 0;
 	}
 
 	.elgg-page-topbar .elgg-menu.elgg-child-menu > li > a {


### PR DESCRIPTION
Second and third level child menus can now be displayed without breaking the layout

![nav1](https://user-images.githubusercontent.com/1202761/37798863-4400dd16-2e1e-11e8-9780-277fd83e2ab3.JPG)
![nav2](https://user-images.githubusercontent.com/1202761/37798864-442250a4-2e1e-11e8-9d70-6077b67e90f3.png)
![nav3](https://user-images.githubusercontent.com/1202761/37798865-44404bfe-2e1e-11e8-86f4-735ffae635ec.png)
