### PR TITLE
feat(actions): deprecate action hook in favor of action:validate hook

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -242,7 +242,18 @@ Action hooks
 ============
 
 **action, <action>**
+	Deprecated. Use ``'action:validate', <action>`` hook instead.
 	Triggered before executing action scripts. Return false to abort action.
+
+**action:validate, <action>**
+	Trigger before action script/controller is executed.
+	This hook should be used to validate/alter user input, before proceeding with the action.
+	The hook handler can throw an instance of ``\Elgg\ValidationException`` or return ``false``
+	to terminate further execution.
+
+    ``$params`` array includes:
+
+     * ``request`` - instance of ``\Elgg\Request``
 
 **action_gatekeeper:permissions:check, all**
 	Triggered after a CSRF token is validated. Return false to prevent validation.

--- a/engine/classes/Elgg/Router/Middleware/ActionMiddleware.php
+++ b/engine/classes/Elgg/Router/Middleware/ActionMiddleware.php
@@ -3,6 +3,7 @@
 namespace Elgg\Router\Middleware;
 
 use Elgg\Http\ResponseBuilder;
+use Elgg\ValidationException;
 
 /**
  * Some logic implemented before action is executed
@@ -13,24 +14,40 @@ class ActionMiddleware {
 	 * Pre-action logic
 	 *
 	 * @param \Elgg\Request $request Request
+	 *
 	 * @return ResponseBuilder|null
+	 * @throws ValidationException
 	 */
 	public function __invoke(\Elgg\Request $request) {
 		$route = $request->getRoute();
 		list($prefix, $action) = explode(':', $route, 2);
 
-		ob_start();
-		$result = $request->elgg()->hooks->trigger('action', $action, null, true);
-		$output = ob_get_clean();
+		if ($request->elgg()->hooks->hasHandler('action', $action)) {
+			elgg_deprecated_notice(
+				"'action', '$action' hook has been deprecated. 
+				Please use route middleware or 'action:validate','$action' hook",
+				'3.0'
+			);
 
-		//  this allows you to return a ok or error response in the hook
-		if ($result instanceof ResponseBuilder) {
-			return $result;
+			ob_start();
+			$result = $request->elgg()->hooks->trigger('action', $action, null, true);
+			$output = ob_get_clean();
+
+			//  this allows you to return a ok or error response in the hook
+			if ($result instanceof ResponseBuilder) {
+				return $result;
+			}
+
+			// To quietly cancel the file, return a falsey value in the "action" hook.
+			if (!$result) {
+				return elgg_ok_response($output);
+			}
 		}
-		
-		// To quietly cancel the file, return a falsey value in the "action" hook.
-		if (!$result) {
-			return elgg_ok_response($output);
+
+		$hook_params = ['request' => $request];
+		$result = $request->elgg()->hooks->trigger('action:validate', $action, $hook_params, true);
+		if ($result === false) {
+			throw new ValidationException(elgg_echo('ValidationException'));
 		}
 
 		// set the maximum execution time for actions

--- a/engine/classes/Elgg/ValidationException.php
+++ b/engine/classes/Elgg/ValidationException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Elgg;
+
+/**
+ * Action validation exception
+ */
+class ValidationException extends HttpException {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function __construct(string $message = "", int $code = 0, Throwable $previous = null) {
+		if (!$code) {
+			$code = ELGG_HTTP_BAD_REQUEST;
+		}
+		parent::__construct($message, $code, $previous);
+	}
+}

--- a/engine/tests/phpunit/unit/Elgg/ActionsServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/ActionsServiceUnitTest.php
@@ -402,6 +402,23 @@ class ActionsServiceUnitTest extends \Elgg\UnitTestCase {
 	}
 
 	/**
+	 * @expectedException \Elgg\ValidationException
+	 */
+	public function testValidateHookIsTriggered() {
+		$request = $this->prepareHttpRequest('action/output3', 'POST', [], false);
+		$this->createService($request);
+		$this->addCsrfTokens($request);
+
+		_elgg_services()->hooks->registerHandler('action:validate', 'output3', function ($hook, $type, $return, $params) {
+			throw new ValidationException('Invalid');
+		});
+
+		$this->assertTrue(_elgg_services()->actions->register('output3', "$this->actionsDir/output3.php", 'public'));
+
+		_elgg_services()->router->route($request);
+	}
+
+	/**
 	 * @expectedException \Elgg\PageNotFoundException
 	 */
 	public function testCanNotExecuteActionWithoutActionFile() {

--- a/languages/en.php
+++ b/languages/en.php
@@ -115,6 +115,7 @@ return array(
 	'EntityPermissionsException' => 'You do not have sufficient permissions for this action.',
 	'GatekeeperException' => 'You do not have permissions to view the page you are trying to access',
 	'BadRequestException' => 'Bad request',
+	'ValidationException' => 'Submitted data did not meet the requirements, please check your input.',
 
 	'deprecatedfunction' => 'Warning: This code uses the deprecated function \'%s\' and is not compatible with this version of Elgg',
 


### PR DESCRIPTION
Adds action:validate hook that receives an instance of the request and
can throw an HttpException. Unlike the old hook, this new hook does not
allow arbitrary buffer output.