### PR TITLE
fix(css): reset fieldset min-width

### DIFF
--- a/views/default/elements/reset.css.php
+++ b/views/default/elements/reset.css.php
@@ -263,4 +263,5 @@ input::-moz-focus-inner {
 
 fieldset {
 	border: none;
+	min-width: 0; /* override -webkit-min-content */
 }


### PR DESCRIPTION
webkit browsers set fieldset min-width which happens to overflow
viewport on most occasions