### PR TITLE
chore(developers): use less memory when printing exception backtrace

### DIFF
--- a/mod/developers/views/failsafe/messages/exceptions/admin_exception.php
+++ b/mod/developers/views/failsafe/messages/exceptions/admin_exception.php
@@ -29,5 +29,5 @@ if ($exception instanceof \DatabaseException) {
 ?>
 
 <p class="elgg-messages-exception">
-	<?= nl2br(htmlentities(print_r($exception, true), ENT_QUOTES, 'UTF-8')); ?>
+	<?= nl2br(htmlentities($exception->getTraceAsString(), ENT_QUOTES, 'UTF-8')); ?>
 </p>


### PR DESCRIPTION
Prevent OOM when printing exception backtrace