### PR TITLE
fix(ajax): correctly report HTTP errors

### DIFF
--- a/engine/tests/js/ElggAjaxTest.js
+++ b/engine/tests/js/ElggAjaxTest.js
@@ -369,14 +369,40 @@ define(function(require) {
 			$.mockjax({
 				url: elgg.normalize_url("foo"),
 				status: 500,
-				responseText: {
-					error: 'not seen by user'
-				}
+				responseText: {}
 			});
 
 			ajax.path('foo').fail(function () {
 				expect(captured).toEqual({
 					error: elgg.echo('ajax:error')
+				});
+
+				elgg.register_error = tmp_register_error;
+
+				done();
+			});
+		});
+
+		it("outputs the error message of the non-200 response", function (done) {
+			var tmp_register_error = elgg.register_error;
+			var captured = {};
+
+			elgg.register_error = function (arg) {
+				captured.error = arg;
+			};
+
+			//$.mockjaxSettings.logging = true;
+			$.mockjax({
+				url: elgg.normalize_url("foo"),
+				status: 500,
+				responseText: {
+					error: 'Server throws'
+				}
+			});
+
+			ajax.path('foo').fail(function () {
+				expect(captured).toEqual({
+					error: 'Server throws'
 				});
 
 				elgg.register_error = tmp_register_error;

--- a/views/default/elgg/Ajax.js
+++ b/views/default/elgg/Ajax.js
@@ -52,17 +52,29 @@ define(function (require) {
 			 * Show messages and require dependencies
 			 *
 			 * @param {Object} data
+			 * @param {Number} status_code HTTP status code
 			 */
-			function extract_metadata(data) {
+			function extract_metadata(data, status_code) {
+
+				status_code = status_code || 200;
+
 				if (!metadata_extracted) {
 					var m = data._elgg_msgs;
 					if (m && m.error) {
-						elgg.register_error(m.error);
+						data.error = m.error;
+					}
+
+					if (data.error) {
+						elgg.register_error(data.error);
 						error_displayed = true;
+					}
+
+					if (data.error || status_code !== 200) {
 						data.status = -1;
 					} else {
 						data.status = 0;
 					}
+
 					m && m.success && elgg.system_message(m.success);
 					delete data._elgg_msgs;
 
@@ -154,7 +166,7 @@ define(function (require) {
 					try {
 						var data = $.parseJSON(jqXHR.responseText);
 						if ($.isPlainObject(data)) {
-							extract_metadata(data);
+							extract_metadata(data, jqXHR.status);
 						}
 					} catch (e) {
 						if (window.console) {
@@ -175,7 +187,7 @@ define(function (require) {
 
 				data = $.parseJSON(data);
 
-				extract_metadata(data);
+				extract_metadata(data, 200);
 
 				var params = {
 					options: orig_options


### PR DESCRIPTION
elgg/Ajax now correctly reports HTTP errors, e.g. server responses
constructed from HTTP exceptions as well as error responses with
non-200 codes.

Fixes #11911