### PR TITLE
feat(access): reduce boilerplate around magic access levels

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -258,6 +258,13 @@ Access hooks
 
 	 * ``access_collection`` - `ElggAccessCollection`
 
+**access_collection:icon, access_collection**
+	Can be used to filter the icon of the access collection.
+
+	The ``$params`` array will contain:
+
+	 * ``access_collection`` - `ElggAccessCollection`
+
 **access:collections:read, user**
 	Filters an array of access IDs that the user ``$params['user_id']`` can see.
 

--- a/engine/classes/Elgg/TempAccessCollection.php
+++ b/engine/classes/Elgg/TempAccessCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Elgg;
+
+use ElggAccessCollection;
+use stdClass;
+
+/**
+ * Magic access collection wrapper for ACCESS_PUBLIC, ACCESS_LOGGEDIN and ACCESS_PRIVATE
+ */
+class TempAccessCollection extends ElggAccessCollection {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function save() {
+		throw new \LogicException('Instances of ' . __CLASS__ . ' can not be saved');
+	}
+
+}

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1378,9 +1378,17 @@ abstract class ElggEntity extends \ElggData implements
 		if ($access_id == ACCESS_DEFAULT) {
 			throw new \InvalidParameterException('ACCESS_DEFAULT is not a valid access level. See its documentation in constants.php');
 		}
-		
+
 		if ($access_id == ACCESS_FRIENDS) {
-			throw new \InvalidParameterException('ACCESS_FRIENDS is not a valid access level. See its documentation in constants.php');
+			$owner = get_entity($owner_guid);
+			$acl = false;
+			if ($owner) {
+				$acl = $owner->getOwnedAccessCollection(ElggAccessCollection::FRIENDS);
+			}
+			if (!$acl) {
+				throw new \InvalidParameterException('ACCESS_FRIENDS is not a valid access level. See its documentation in constants.php');
+			}
+			$access_id = $acl->id;
 		}
 
 		$user_guid = _elgg_services()->session->getLoggedInUserGuid();
@@ -1513,9 +1521,17 @@ abstract class ElggEntity extends \ElggData implements
 		if ($access_id == ACCESS_DEFAULT) {
 			throw new \InvalidParameterException('ACCESS_DEFAULT is not a valid access level. See its documentation in constants.php');
 		}
-	
+
 		if ($access_id == ACCESS_FRIENDS) {
-			throw new \InvalidParameterException('ACCESS_FRIENDS is not a valid access level. See its documentation in constants.php');
+			$owner = get_entity($owner_guid);
+			$acl = false;
+			if ($owner) {
+				$acl = $owner->getOwnedAccessCollection(ElggAccessCollection::FRIENDS);
+			}
+			if (!$acl) {
+				throw new \InvalidParameterException('ACCESS_FRIENDS is not a valid access level. See its documentation in constants.php');
+			}
+			$access_id = $acl->id;
 		}
 
 		// Update primary table

--- a/engine/lib/access.php
+++ b/engine/lib/access.php
@@ -507,32 +507,6 @@ function access_friends_acl_remove_friend(\Elgg\Event $event) {
 }
 
 /**
- * Return the name of a friends ACL
- *
- * @elgg_event 'access_collection:name', 'access_collection'
- *
- * @param \Elgg\Hook $hook hook
- *
- * @return string|void
- *
- * @since 3.0.0
- *
- * @internal
- */
-function access_friends_acl_get_name(\Elgg\Hook $hook) {
-	$access_collection = $hook->getParam('access_collection');
-	if (!($access_collection instanceof ElggAccessCollection)) {
-		return;
-	}
-	
-	if ($access_collection->getSubtype() !== 'friends') {
-		return;
-	}
-	
-	return elgg_echo('access:label:friends');
-}
-
-/**
  * Runs unit tests for the access library
  *
  * @param string $hook   'unit_test'
@@ -562,7 +536,6 @@ return function(\Elgg\EventsService $events, \Elgg\HooksRegistrationService $hoo
 	$events->registerHandler('create', 'user', 'access_friends_acl_create');
 	$events->registerHandler('create', 'relationship', 'access_friends_acl_add_friend');
 	$events->registerHandler('delete', 'relationship', 'access_friends_acl_remove_friend');
-	$hooks->registerHandler('access_collection:name', 'access_collection', 'access_friends_acl_get_name');
 
 	$hooks->registerHandler('unit_test', 'system', 'access_test');
 };

--- a/engine/tests/phpunit/integration/ElggAccessCollectionUnitTest.php
+++ b/engine/tests/phpunit/integration/ElggAccessCollectionUnitTest.php
@@ -89,4 +89,47 @@ class ElggAccessCollectionUnitTest extends \Elgg\IntegrationTestCase {
 		$this->assertEquals($acl->id, $acl->getSystemLogID());
 		$this->assertEquals($acl, $acl->getObjectFromID($acl->id));
 	}
+
+	public function testCanResolvePublicAcl() {
+
+		$collection = get_access_collection(ACCESS_PUBLIC);
+
+		$this->assertEquals('globe', $collection->getIconName());
+		$this->assertEquals(elgg_echo('access:label:public'), $collection->getDisplayName());
+	}
+
+	public function testCanResolveLoggedInAcl() {
+
+		$collection = get_access_collection(ACCESS_LOGGED_IN);
+
+		$this->assertEquals('globe', $collection->getIconName());
+		$this->assertEquals(elgg_echo('access:label:logged_in'), $collection->getDisplayName());
+	}
+
+	public function testCanResolvePrivateAcl() {
+
+		$collection = get_access_collection(ACCESS_PRIVATE);
+
+		$this->assertEquals('lock', $collection->getIconName());
+		$this->assertEquals(elgg_echo('access:label:private'), $collection->getDisplayName());
+	}
+
+	public function testCanResolveFriendsCollection() {
+		$user = $this->createUser();
+
+		$id = create_access_collection('friends', $user->guid, ElggAccessCollection::FRIENDS);
+		$collection = get_access_collection($id);
+
+		$this->assertEquals('user', $collection->getIconName());
+		$this->assertEquals(elgg_echo('access:label:friends'), $collection->getDisplayName());
+	}
+
+	public function testCanResolveGroupCollectionIcon() {
+		$group = $this->createGroup();
+
+		$id = create_access_collection($group->getDisplayName(), $group->guid, ElggAccessCollection::GROUP_MEMBERS);
+		$collection = get_access_collection($id);
+
+		$this->assertEquals('users', $collection->getIconName());
+	}
 }

--- a/languages/en.php
+++ b/languages/en.php
@@ -197,6 +197,7 @@ return array(
 	'access:label:public' => "Public",
 	'access:label:logged_out' => "Logged out users",
 	'access:label:friends' => "Friends",
+	'access:label:owned' => '%s: %s',
 	'access' => "Who can see this",
 	'access:overridenotice' => "Note: Due to group policy, this content will be accessible only by group members.",
 	'access:limited:label' => "Limited",

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -562,18 +562,18 @@ function groups_write_acl_plugin_hook(\Elgg\Hook $hook) {
  * Return the write access for the current group if the user has write access to it
  *
  * @param \Elgg\Hook $hook 'access_collection:display_name' 'access_collection'
- * @return void|string
+ * @return string|null
  */
 function groups_set_access_collection_name(\Elgg\Hook $hook) {
 
 	$access_collection = $hook->getParam('access_collection');
 	if (!$access_collection instanceof ElggAccessCollection) {
-		return;
+		return null;
 	}
 
 	$owner = $access_collection->getOwnerEntity();
 	if (!$owner instanceof ElggGroup) {
-		return;
+		return null;
 	}
 	
 	$page_owner = elgg_get_page_owner_entity();
@@ -583,8 +583,15 @@ function groups_set_access_collection_name(\Elgg\Hook $hook) {
 	}
 
 	if ($owner->canWriteToContainer()) {
+		if ($owner->subtype !== 'group') {
+			$type_string = elgg_echo("item:$owner->type:$owner->subtype");
+			return elgg_echo('access:label:owned', [$type_string, $owner->getDisplayName()]);
+		}
+
 		return elgg_echo('groups:acl', [$owner->getDisplayName()]);
 	}
+
+	return elgg_echo('access:limited:label');
 }
 
 /**

--- a/views/default/object/elements/imprint/access.php
+++ b/views/default/object/elements/imprint/access.php
@@ -34,10 +34,11 @@ switch ($access) {
 		$icon_name = 'lock';
 		break;
 	default:
-		$icon_name = 'cog';
 		$collection = get_access_collection($access);
-		if ($collection && ($collection->getSubtype() == 'friends')) {
-			$icon_name = 'user';
+		if ($collection) {
+			$icon_name = $collection->getIconName();
+		} else {
+			$icon_name = 'cog';
 		}
 		break;
 }


### PR DESCRIPTION
Reduces boilerplate around magic access level by introducing intermediary objects.
Adds API to filter collection icons.