### PR TITLE
fix(qb): make sure selected table always has an alias

### DIFF
--- a/engine/classes/Elgg/Database/Select.php
+++ b/engine/classes/Elgg/Database/Select.php
@@ -11,6 +11,10 @@ class Select extends QueryBuilder {
 	 * {@inheritdoc}
 	 */
 	public static function fromTable($table, $alias = null) {
+		if (!$alias) {
+			$alias = 'master';
+		}
+		
 		$connection = _elgg_services()->db->getConnection('read');
 
 		$qb = new static($connection);


### PR DESCRIPTION
To ensure consistency in access SQL queries, the selected table
alias is now defaulted to "master", if none set.