### PR TITLE
fix(qb): preserve 0 guid when normalizing query options

### DIFF
--- a/engine/classes/Elgg/Database/LegacyQueryOptionsAdapter.php
+++ b/engine/classes/Elgg/Database/LegacyQueryOptionsAdapter.php
@@ -729,7 +729,20 @@ trait LegacyQueryOptionsAdapter {
 		];
 
 		foreach ($names as $name) {
-			$options[$name] = !empty($options[$name]) ? $options[$name] : null;
+			if (!isset($options[$name])) {
+				continue;
+			}
+
+			if (!is_array($options[$name])) {
+				$options[$name] = [$options[$name]];
+			}
+
+			foreach ($options[$name] as $key => $value) {
+				if ($value === false || $value === '') {
+					unset($options[$name][$key]);
+					continue;
+				}
+			}
 		}
 
 		return $options;

--- a/engine/tests/phpunit/unit/Elgg/Database/QueryOptionsTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Database/QueryOptionsTest.php
@@ -45,6 +45,54 @@ class QueryOptionsTest extends UnitTestCase {
 		$this->assertNotEmpty($options);
 	}
 
+	public function testNormalizesEmptyGuidOptionsFromSingulars() {
+		$options = $this->options->normalizeOptions([
+			'guid' => '',
+			'container_guid' => false,
+			'owner_guid' => null,
+		]);
+
+		$this->assertEquals([], $options['guids']);
+		$this->assertEquals([], $options['container_guids']);
+		$this->assertEquals(null, $options['owner_guids']);
+	}
+
+	public function testNormalizesZeroGuidOptionsFromSingulars() {
+		$options = $this->options->normalizeOptions([
+			'guid' => 0,
+			'container_guid' => 0,
+			'owner_guid' => 0,
+		]);
+
+		$this->assertEquals([0], $options['guids']);
+		$this->assertEquals([0], $options['container_guids']);
+		$this->assertEquals([0], $options['owner_guids']);
+	}
+
+	public function testNormalizesEmptyGuidOptions() {
+		$options = $this->options->normalizeOptions([
+			'guids' => '',
+			'container_guids' => false,
+			'owner_guids' => null,
+		]);
+
+		$this->assertEquals([], $options['guids']);
+		$this->assertEquals([], $options['container_guids']);
+		$this->assertEquals(null, $options['owner_guids']);
+	}
+
+	public function testNormalizesZeroGuidOptions() {
+		$options = $this->options->normalizeOptions([
+			'guids' => 0,
+			'container_guids' => 0,
+			'owner_guids' => 0,
+		]);
+
+		$this->assertEquals([0], $options['guids']);
+		$this->assertEquals([0], $options['container_guids']);
+		$this->assertEquals([0], $options['owner_guids']);
+	}
+
 	public function testNormalizesAccessOptions() {
 		$options = $this->options->normalizeOptions([
 			'access_id' => ['1', 2],


### PR DESCRIPTION
0 is now treated as a valid guid and not stripped during normalization.

Fixes #11992