### PR TITLE
fix(qb): set table alias when querying entities table

### DIFF
--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -189,7 +189,7 @@ class EntityTable {
 		$where->guids = (int) $guid;
 		$where->viewer_guid = $user_guid;
 
-		$select = Select::fromTable('entities');
+		$select = Select::fromTable('entities', 'e');
 		$select->select('*');
 		$select->addClause($where);
 

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -758,7 +758,7 @@ class ElggInstaller {
 			}
 
 			// check that the users entity table has an entry
-			$qb = \Elgg\Database\Select::fromTable('entities');
+			$qb = \Elgg\Database\Select::fromTable('entities', 'e');
 			$qb->select('COUNT(*) AS total')
 				->where($qb->compare('type', '=', 'user', ELGG_VALUE_STRING));
 

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -53,7 +53,7 @@ class ElggSite extends \ElggEntity {
 	 */
 	public function save() {
 		$db = $this->getDatabase();
-		$qb = \Elgg\Database\Select::fromTable('entities');
+		$qb = \Elgg\Database\Select::fromTable('entities', 'e');
 		$qb->select('*')
 			->where($qb->compare('type', '=', 'site', ELGG_VALUE_STRING));
 

--- a/engine/tests/classes/Elgg/Mocks/Database/EntityTable.php
+++ b/engine/tests/classes/Elgg/Mocks/Database/EntityTable.php
@@ -286,7 +286,7 @@ class EntityTable extends DbEntityTable {
 			$where->viewer_guid = $access_combination['user_guid'];
 			$where->guids = $row->guid;
 
-			$select = Select::fromTable('entities');
+			$select = Select::fromTable('entities', 'e');
 			$select->select('*');
 			$select->addClause($where);
 

--- a/engine/tests/phpunit/unit/Elgg/ApplicationUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/ApplicationUnitTest.php
@@ -48,7 +48,7 @@ class ApplicationUnitTest extends \Elgg\UnitTestCase {
 	}
 
 	function testCanCallService() {
-		$qb = Select::fromTable('entities');
+		$qb = Select::fromTable('entities', 'e');
 		$qb->select('1');
 
 		_elgg_services()->db->addQuerySpec([


### PR DESCRIPTION
e table alias is now always set when querying the database for entities