### PR TITLE
fix(qb): use correct aliases in query predicates

### DIFF
--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -190,7 +190,7 @@ class EntityTable {
 		$where->viewer_guid = $user_guid;
 
 		$select = Select::fromTable('entities', 'e');
-		$select->select('*');
+		$select->select('e.*');
 		$select->addClause($where);
 
 		return $this->db->getDataRow($select);

--- a/engine/classes/ElggSite.php
+++ b/engine/classes/ElggSite.php
@@ -54,8 +54,8 @@ class ElggSite extends \ElggEntity {
 	public function save() {
 		$db = $this->getDatabase();
 		$qb = \Elgg\Database\Select::fromTable('entities', 'e');
-		$qb->select('*')
-			->where($qb->compare('type', '=', 'site', ELGG_VALUE_STRING));
+		$qb->select('e.*')
+			->where($qb->compare('e.type', '=', 'site', ELGG_VALUE_STRING));
 
 		$row = $db->getDataRow($qb);
 

--- a/engine/tests/classes/Elgg/Mocks/Database/EntityTable.php
+++ b/engine/tests/classes/Elgg/Mocks/Database/EntityTable.php
@@ -287,7 +287,7 @@ class EntityTable extends DbEntityTable {
 			$where->guids = $row->guid;
 
 			$select = Select::fromTable('entities', 'e');
-			$select->select('*');
+			$select->select('e.*');
 			$select->addClause($where);
 
 			$this->query_specs[$row->guid][] = $this->db->addQuerySpec([

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreUserTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreUserTest.php
@@ -242,9 +242,9 @@ class ElggCoreUserTest extends \Elgg\IntegrationTestCase {
 	}
 
 	protected function fetchUser($guid) {
-		$qb = Select::fromTable('entities');
-		$qb->select('*');
-		$qb->where($qb->compare('guid', '=', $guid, ELGG_VALUE_INTEGER));
+		$qb = Select::fromTable('entities', 'e');
+		$qb->select('e.*');
+		$qb->where($qb->compare('e.guid', '=', $guid, ELGG_VALUE_INTEGER));
 
 		return _elgg_services()->db->getDataRow($qb);
 	}


### PR DESCRIPTION
Missing aliases resulted in the database row being polluted by the
properties of the joined table in cases where access SQL hook was used.