### PR TITLE
chore(blogs): set correct page title in archive

### DIFF
--- a/mod/blog/views/default/blog/sidebar/archives.php
+++ b/mod/blog/views/default/blog/sidebar/archives.php
@@ -6,6 +6,11 @@
 $entity = elgg_extract('entity', $vars, elgg_get_page_owner_entity());
 $page = elgg_extract('page', $vars);
 
+if ($page === 'friends') {
+	// don't show archive links on friends' blogs page
+	return;
+}
+
 $content = elgg_view_menu('blog_archive', [
 	'page' => $page,
 	'entity' => $entity,

--- a/mod/blog/views/default/resources/blog/all.php
+++ b/mod/blog/views/default/resources/blog/all.php
@@ -7,10 +7,9 @@ elgg_register_title_button('blog', 'add', 'object', 'blog');
 
 elgg_push_collection_breadcrumbs('object', 'blog');
 
+$title = elgg_echo('collection:object:blog:all');
 if ($lower) {
-	$title = elgg_echo('date:month:' . date('m', $lower), [date('Y', $lower)]);
-} else {
-	$title = elgg_echo('collection:object:blog:all');
+	$title .= ': ' . elgg_echo('date:month:' . date('m', $lower), [date('Y', $lower)]);
 }
 
 $content = elgg_view('blog/listing/all', [

--- a/mod/blog/views/default/resources/blog/friends.php
+++ b/mod/blog/views/default/resources/blog/friends.php
@@ -9,19 +9,13 @@ if (!$user) {
 	throw new \Elgg\EntityNotFoundException();
 }
 
-$params = [
-	'filter_context' => 'friends',
-	'title' => elgg_echo('blog:title:friends'),
-];
-
 elgg_push_collection_breadcrumbs('object', 'blog', $user, true);
 
 elgg_register_title_button('blog', 'add', 'object', 'blog');
 
+$title = elgg_echo('collection:friends', [elgg_echo('collection:object:blog')]);
 if ($lower) {
-	$title = elgg_echo('date:month:' . date('m', $lower), [date('Y', $lower)]);
-} else {
-	$title = elgg_echo('collection:friends', [elgg_echo('collection:object:blog')]);
+	$title = ': ' . elgg_echo('date:month:' . date('m', $lower), [date('Y', $lower)]);
 }
 
 $content = elgg_view('blog/listing/friends', [

--- a/mod/blog/views/default/resources/blog/group.php
+++ b/mod/blog/views/default/resources/blog/group.php
@@ -11,10 +11,9 @@ elgg_register_title_button('blog', 'add', 'object', 'blog');
 
 elgg_push_collection_breadcrumbs('object', 'blog', $group);
 
+$title = elgg_echo('collection:object:blog:group');
 if ($lower) {
-	$title = elgg_echo('date:month:' . date('m', $lower), [date('Y', $lower)]);
-} else {
-	$title = elgg_echo('collection:object:blog');
+	$title .= ': ' . elgg_echo('date:month:' . date('m', $lower), [date('Y', $lower)]);
 }
 
 $content = elgg_view('blog/listing/group', [

--- a/mod/blog/views/default/resources/blog/owner.php
+++ b/mod/blog/views/default/resources/blog/owner.php
@@ -13,10 +13,14 @@ elgg_register_title_button('blog', 'add', 'object', 'blog');
 
 elgg_push_collection_breadcrumbs('object', 'blog', $user);
 
-if ($lower) {
-	$title = elgg_echo('date:month:' . date('m', $lower), [date('Y', $lower)]);
-} else {
+if ($user->guid === elgg_get_logged_in_user_guid()) {
 	$title = elgg_echo('collection:object:blog');
+} else {
+	$title = elgg_echo('collection:object:blog:owner', [$user->getDisplayName()]);
+}
+
+if ($lower) {
+	$title .= ': ' . elgg_echo('date:month:' . date('m', $lower), [date('Y', $lower)]);
 }
 
 $content = elgg_view('blog/listing/owner', [


### PR DESCRIPTION
Keep the normal page title, but add the month/year to the title. Instead
of just a month/year title.

Before: 
![image](https://user-images.githubusercontent.com/881958/40614286-a74f2984-6282-11e8-99f8-178eedec9357.png)

After:
![image](https://user-images.githubusercontent.com/881958/40614293-b5d64f6e-6282-11e8-967f-9fb3fa6e2893.png)

