### PR TITLE
Revert original libxml_use_internal_errors value after use

### DIFF
--- a/engine/classes/ElggAutoP.php
+++ b/engine/classes/ElggAutoP.php
@@ -90,7 +90,7 @@ class ElggAutoP {
 
 		// parse to DOM, suppressing loadHTML warnings
 		// http://www.php.net/manual/en/domdocument.loadhtml.php#95463
-		libxml_use_internal_errors(true);
+		$use_internal_errors = libxml_use_internal_errors(true);
 
 		// Do not load entities. May be unnecessary, better safe than sorry
 		$disable_load_entities = libxml_disable_entity_loader(true);
@@ -99,10 +99,12 @@ class ElggAutoP {
 				. "content='text/html; charset={$this->encoding}'><body>{$html}</body>"
 				. "</html>")) {
 
+			libxml_use_internal_errors($use_internal_errors);
 			libxml_disable_entity_loader($disable_load_entities);
 			return false;
 		}
 
+		libxml_use_internal_errors($use_internal_errors);
 		libxml_disable_entity_loader($disable_load_entities);
 
 		$this->_xpath = new DOMXPath($this->_doc);
@@ -124,14 +126,20 @@ class ElggAutoP {
 
 		// re-parse so we can handle new AUTOP elements
 
+		// parse to DOM, suppressing loadHTML warnings
+		// http://www.php.net/manual/en/domdocument.loadhtml.php#95463
+		$use_internal_errors = libxml_use_internal_errors(true);
+
 		// Do not load entities. May be unnecessary, better safe than sorry
 		$disable_load_entities = libxml_disable_entity_loader(true);
 
 		if (!$this->_doc->loadHTML($html)) {
+			libxml_use_internal_errors($use_internal_errors);
 			libxml_disable_entity_loader($disable_load_entities);
 			return false;
 		}
 
+		libxml_use_internal_errors($use_internal_errors);
 		libxml_disable_entity_loader($disable_load_entities);
 
 		// must re-create XPath object after DOM load


### PR DESCRIPTION
While using the `sabre/xml` librar I came across this hard to debug bug. It caused the error `Tag autop invalid` error while parsing a XML file that was not related to this ElggAutoP class in any way. After a lot of debugging and trial and error I came across this fix. Commenting out `libxml_use_internal_errors` in this class "fixed" the error and so I tried reverting the setting - which worked.

I'm not sure why, but it seems logical to do and it does the job, just like with the `libxml_disable_entity_loader` setting that is being reverted.

I targeted this bug against the branch that is described [here](http://learn.elgg.org/en/latest/contribute/code.html#pull-requests). This bug is present in all versions (V1.x, V2.x and V3.x).