### PR TITLE
fix(caches): metadata is now accessible with data cache disabled

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -108,6 +108,18 @@ abstract class ElggEntity extends \ElggData implements
 	protected $_is_cacheable = true;
 
 	/**
+	 * Holds metadata key/value pairs acquired from the metadata cache
+	 * Entity metadata may have mutated since last call to __get,
+	 * do not rely on this value for any business logic
+	 * This storage is intended to help with debugging objects during dump,
+	 * because otherwise it's hard to tell what the object is from it's attributes
+	 *
+	 * @var array
+	 * @internal
+	 */
+	protected $_cached_metadata;
+
+	/**
 	 * Create a new entity.
 	 *
 	 * Plugin developers should only use the constructor to create a new entity.
@@ -319,35 +331,25 @@ abstract class ElggEntity extends \ElggData implements
 	 * @return mixed The value, or null if not found.
 	 */
 	public function getMetadata($name) {
-		$guid = $this->guid;
+		$metadata = $this->getAllMetadata();
+		return elgg_extract($name, $metadata);
+	}
 
-		if (!$guid) {
-			if (isset($this->temp_metadata[$name])) {
-				// md is returned as an array only if more than 1 entry
-				if (count($this->temp_metadata[$name]) == 1) {
-					return $this->temp_metadata[$name][0];
-				} else {
-					return $this->temp_metadata[$name];
-				}
-			} else {
-				return null;
-			}
+	/**
+	 * Get all entity metadata
+	 *
+	 * @return array
+	 */
+	public function getAllMetadata() {
+		if (!$this->guid) {
+			return array_map(function($values) {
+				return count($values) > 1 ? $values : $values[0];
+			}, $this->temp_metadata);
 		}
 
-		// upon first cache miss, just load/cache all the metadata and retry.
-		// if this works, the rest of this function may not be needed!
-		$cache = _elgg_services()->metadataCache;
-		if ($cache->isLoaded($guid)) {
-			return $cache->getSingle($guid, $name);
-		} else {
-			$cache->populateFromEntities([$guid]);
-			// in case ignore_access was on, we have to check again...
-			if ($cache->isLoaded($guid)) {
-				return $cache->getSingle($guid, $name);
-			}
+		$this->_cached_metadata = _elgg_services()->metadataCache->getAll($this->guid);
 
-			return null;
-		}
+		return $this->_cached_metadata;
 	}
 
 	/**

--- a/engine/tests/classes/Elgg/BaseTestCase.php
+++ b/engine/tests/classes/Elgg/BaseTestCase.php
@@ -298,4 +298,19 @@ abstract class BaseTestCase extends TestCase implements Seedable, Testable {
 		);
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
+	public static function assertEquals($expected, $actual, $message = '', $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false) {
+		if ($expected instanceof \ElggData) {
+			$expected = $expected->toObject();
+		}
+
+		if ($actual instanceof \ElggData) {
+			$actual = $actual->toObject();
+		}
+
+		parent::assertEquals($expected, $actual, $message, $delta, $maxDepth, $canonicalize, $ignoreCase);
+	}
+
 }

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreMetadataCacheTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreMetadataCacheTest.php
@@ -55,6 +55,19 @@ class ElggCoreMetadataCacheTest extends IntegrationTestCase {
 		$this->assertNull($this->cache->getSingle(2, 'foo1'));
 	}
 
+	public function testLoadAll() {
+
+		$this->cache->inject(1, ['foo1' => 'bar', 'foo2' => ['bar1', 'bar2']]);
+		$this->cache->inject(2, []);
+
+		$this->assertEquals($this->cache->getAll(1), [
+			'foo1' => 'bar',
+			'foo2' => ['bar1', 'bar2'],
+		]);
+
+		$this->assertEmpty($this->cache->getAll(2));
+	}
+
 	public function testDirectInvalidation() {
 
 		$this->cache->inject(1, ['foo1' => 'bar']);
@@ -169,5 +182,26 @@ class ElggCoreMetadataCacheTest extends IntegrationTestCase {
 
 		$object1->delete();
 		$object2->delete();
+	}
+
+	public function testMetadataCanBeLoadedWithCacheDisabled() {
+		$object1 = $this->createObject();
+		$object1->foo = 'bar';
+
+		_elgg_disable_caches();
+
+		$object = get_entity($object1->guid);
+		$this->assertInstanceOf(\ElggObject::class, $object);
+		$this->assertEquals($object->guid, $object1->guid);
+
+		$this->assertEquals('bar', $object->foo);
+
+		_elgg_enable_caches();
+
+		$object = get_entity($object1->guid);
+		$this->assertInstanceOf(\ElggObject::class, $object);
+		$this->assertEquals($object->guid, $object1->guid);
+
+		$this->assertEquals('bar', $object->foo);
 	}
 }

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggEntityMetadataTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggEntityMetadataTest.php
@@ -331,4 +331,21 @@ class ElggEntityMetadataTest extends \Elgg\IntegrationTestCase {
 			], $entity->foo);
 		}
 	}
+	
+	public function testCanGetAllEntityMetadata() {
+		foreach ($this->entities as $entity) {
+
+			$entity->foo1 = 'bar1';
+			$entity->foo2 = ['bar2', 'bar3', 'bar4', 5];
+			$entity->foo3 = false;
+
+			$metadata = $entity->getAllMetadata();
+
+			$this->assertEquals($metadata['foo1'], $entity->foo1);
+			$this->assertEquals($metadata['foo2'], $entity->foo2);
+			$this->assertEquals($metadata['foo3'], $entity->foo3);
+		}
+	}
+
+
 }

--- a/engine/tests/phpunit/unit/Elgg/Notifications/NotificationsServiceUnitTestCase.php
+++ b/engine/tests/phpunit/unit/Elgg/Notifications/NotificationsServiceUnitTestCase.php
@@ -480,7 +480,7 @@ abstract class NotificationsServiceUnitTestCase extends IntegratedUnitTestCase {
 			$this->assertInstanceOf(Notification::class, $params['notification']);
 			$this->assertEquals($this->translator->translate('notification:subject', [$event->getActor()->name], $recipient->language), $params['notification']->subject);
 			$this->assertEquals($this->translator->translate('notification:body', [$event->getObject()->getURL()], $recipient->language), $params['notification']->body);
-			$this->assertEquals($event, $params['event']);
+			$this->assertEquals($event->toObject(), $params['event']->toObject());
 
 			return true;
 		});
@@ -775,7 +775,7 @@ abstract class NotificationsServiceUnitTestCase extends IntegratedUnitTestCase {
 			$this->assertEquals($notification->subject, $subject);
 			$this->assertEquals($notification->body, $body);
 			$this->assertEquals($notification->summary, $subject);
-			$this->assertEquals($event, $params['event']);
+			$this->assertEquals($event->toObject(), $params['event']->toObject());
 
 			$this->assertTrue($notification->prepare_hook);
 			$this->assertTrue($notification->granular_prepare_hook);
@@ -860,7 +860,7 @@ abstract class NotificationsServiceUnitTestCase extends IntegratedUnitTestCase {
 			$this->assertInstanceOf(Notification::class, $notification);
 			$this->assertEquals($notification->subject, $subject);
 			$this->assertEquals($notification->body, $body);
-			$this->assertEquals($event, $params['event']);
+			$this->assertEquals($event->toObject(), $params['event']->toObject());
 
 			$this->assertTrue($notification->prepare_hook);
 			$this->assertTrue($notification->granular_prepare_hook);
@@ -920,7 +920,7 @@ abstract class NotificationsServiceUnitTestCase extends IntegratedUnitTestCase {
 
 		$this->hooks->registerHandler('send:before', 'notifications', function ($hook, $type, $return, $params) use (&$before_call_count, $event, $subscribers) {
 			$before_call_count++;
-			$this->assertEquals($event, $params['event']);
+			$this->assertEquals($event->toObject(), $params['event']->toObject());
 			$this->assertEquals($subscribers, $params['subscriptions']);
 
 			return false;

--- a/engine/tests/phpunit/unit/ElggSessionUnitTest.php
+++ b/engine/tests/phpunit/unit/ElggSessionUnitTest.php
@@ -47,25 +47,14 @@ class ElggSessionUnitTest extends \Elgg\UnitTestCase {
 
 	public function testCanSetLoggedInUser() {
 
-		$user = $this->getMockBuilder(\ElggUser::class)
-		->setMethods(['__get'])
-		->disableOriginalConstructor()
-		->getMock();
-
-		$user->expects($this->any())
-		->method('__get')
-		->will($this->returnCallback(function($name) {
-			if ($name == 'guid') {
-				return 123;
-			}
-		}));
+		$user = $this->createUser();
 
 		$session = \ElggSession::getMock();
 
 		$session->setLoggedInUser($user);
 
 		$this->assertEquals($user, $session->getLoggedInUser());
-		$this->assertEquals(123, $session->getLoggedInUserGuid());
+		$this->assertEquals($user->guid, $session->getLoggedInUserGuid());
 
 		$session->removeLoggedInUser();
 


### PR DESCRIPTION
Entity metadata is now loaded and accessible regardless if the data cache
has been disabled.
Adds method to retrieve all entity metadata.

Fixes #12014