### PR TITLE
feat(plugins): separate plugin repository from caching concerns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ matrix:
         - php -f ./.scripts/is_memcached_enabled.php
       script:
         - curl -s http://localhost:8888/ | tac | tac | grep -q "<title>Elgg Travis Site</title>"
-        - ./vendor/bin/phpunit
+        - ./vendor/bin/phpunit --verbose
 
     # Redis enabled
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ matrix:
         - php -f ./.scripts/is_memcached_enabled.php
       script:
         - curl -s http://localhost:8888/ | tac | tac | grep -q "<title>Elgg Travis Site</title>"
-        - ./vendor/bin/phpunit --verbose
+        - ./vendor/bin/phpunit --verbose --debug
 
     # Redis enabled
     - php: 7.0

--- a/engine/classes/Elgg/BootService.php
+++ b/engine/classes/Elgg/BootService.php
@@ -136,8 +136,26 @@ class BootService {
 			$services->dataCache->metadata->save($guid, $metadata);
 		}
 
-		$services->plugins->setBootPlugins($data->getActivePlugins());
+		$plugins = $data->getActivePlugins();
 
+		if (!empty($plugins)) {
+			foreach ($plugins as $plugin) {
+				if (!$plugin instanceof \ElggPlugin) {
+					continue;
+				}
+
+				$plugin_id = $plugin->getID();
+				if (!$plugin_id) {
+					continue;
+				}
+
+				$plugin->setAsActivated();
+				$plugin->cache();
+			}
+		}
+
+		$config->_active_plugins_set = true;
+		
 		// use value in settings.php if available
 		$debug = $config->hasInitialValue('debug') ? $config->getInitialValue('debug') : $config->debug;
 		$services->logger->setLevel($debug);
@@ -171,7 +189,7 @@ class BootService {
 	 */
 	public function invalidateCache() {
 		$this->cache->clear();
-		_elgg_services()->plugins->setBootPlugins(null);
+
 		_elgg_config()->system_cache_loaded = false;
 		_elgg_config()->_boot_cache_hit = false;
 	}

--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -105,6 +105,7 @@ use Elgg\Project\Paths;
  * @property string        $wwwroot      Site URL
  * @property string        $x_sendfile_type
  * @property string        $x_accel_mapping
+ * @property string        $_active_plugins_set
  * @property bool          $_boot_cache_hit
  * @property bool          $_elgg_autofeed
  *

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -138,7 +138,6 @@ class ElggInstaller {
 			$this->app = $app;
 
 			$app->_services->boot->getCache()->disable();
-			$app->_services->plugins->getCache()->disable();
 			$app->_services->sessionCache->disable();
 			$app->_services->dic_cache->getCache()->disable();
 			$app->_services->dataCache->disable();

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -316,7 +316,6 @@ function _elgg_cache_init() {
  */
 function _elgg_disable_caches() {
 	_elgg_services()->boot->getCache()->disable();
-	_elgg_services()->plugins->getCache()->disable();
 	_elgg_services()->sessionCache->disable();
 	_elgg_services()->dataCache->disable();
 	_elgg_services()->dic_cache->getCache()->disable();
@@ -333,7 +332,7 @@ function _elgg_disable_caches() {
  */
 function _elgg_clear_caches() {
 	_elgg_services()->boot->invalidateCache();
-	_elgg_services()->plugins->clear();
+	_elgg_services()->plugins->invalidateProvidesCache();
 	_elgg_services()->sessionCache->clear();
 	_elgg_services()->dataCache->clear();
 	_elgg_services()->dic_cache->flushAll();
@@ -351,7 +350,6 @@ function _elgg_clear_caches() {
  */
 function _elgg_enable_caches() {
 	_elgg_services()->boot->getCache()->enable();
-	_elgg_services()->plugins->getCache()->enable();
 	_elgg_services()->sessionCache->enable();
 	_elgg_services()->dataCache->enable();
 	_elgg_services()->dic_cache->getCache()->enable();

--- a/engine/tests/classes/Elgg/Mocks/Database/Plugins.php
+++ b/engine/tests/classes/Elgg/Mocks/Database/Plugins.php
@@ -11,11 +11,6 @@ use ElggPlugin;
  */
 class Plugins extends DbPlugins {
 
-	/**
-	 * @var ElggPlugin[]
-	 */
-	protected $_plugins = [];
-
 	public static $managed_plugins = [
 		'activity',
 		'blog',
@@ -67,14 +62,6 @@ class Plugins extends DbPlugins {
 		]);
 
 		return $plugin;
-	}
-
-	public function find($status = 'active') {
-		return $this->_plugins;
-	}
-
-	public function addTestingPlugin(ElggPlugin $plugin) {
-		$this->_plugins[] = $plugin;
 	}
 
 	public function setPriority(ElggPlugin $plugin, $priority) {

--- a/engine/tests/classes/Elgg/Mocks/Di/MockServiceProvider.php
+++ b/engine/tests/classes/Elgg/Mocks/Di/MockServiceProvider.php
@@ -99,10 +99,9 @@ class MockServiceProvider extends \Elgg\Di\ServiceProvider {
 		});
 
 		$this->setFactory('plugins', function (MockServiceProvider $sp) {
-			$cache = $sp->dataCache->plugins;
-
 			return new \Elgg\Mocks\Database\Plugins(
-				$cache,
+				$sp->knownPlugins,
+				$sp->runtimePlugins,
 				$sp->db,
 				$sp->session,
 				$sp->events,

--- a/engine/tests/phpunit/integration/ElggPluginIntegrationTest.php
+++ b/engine/tests/phpunit/integration/ElggPluginIntegrationTest.php
@@ -102,7 +102,12 @@ class ElggPluginIntegrationTest extends \Elgg\IntegrationTestCase {
 
 		$site = elgg_get_site_entity();
 		$this->assertEquals('test_plugin', $plugin->getID());
+
+		// This tries to read the manifest and logs an error
+		_elgg_services()->logger->disable();
 		$this->assertEquals('test_plugin', $plugin->getDisplayName());
+		_elgg_services()->logger->enable();
+
 		$this->assertEquals($site->guid, $plugin->owner_guid);
 		$this->assertEquals($site->guid, $plugin->container_guid);
 		$this->assertEquals(ACCESS_PUBLIC, $plugin->access_id);

--- a/engine/tests/phpunit/unit/Elgg/I18n/TranslatorUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/I18n/TranslatorUnitTest.php
@@ -219,7 +219,7 @@ class TranslatorUnitTest extends \Elgg\UnitTestCase {
 		$plugin = \ElggPlugin::fromId('languages_plugin', $this->normalizeTestFilePath('mod/'));
 
 		$app->_services->config->boot_cache_ttl = 0;
-		$app->_services->plugins->addTestingPlugin($plugin);
+		$app->_services->runtimePlugins->add($plugin);
 
 		$plugin->activate();
 
@@ -237,7 +237,7 @@ class TranslatorUnitTest extends \Elgg\UnitTestCase {
 		$plugin = \ElggPlugin::fromId('languages_plugin', $this->normalizeTestFilePath('mod/'));
 
 		$app->_services->config->boot_cache_ttl = 0;
-		$app->_services->plugins->addTestingPlugin($plugin);
+		$app->_services->runtimePlugins->add($plugin);
 
 		$plugin->activate();
 

--- a/engine/tests/phpunit/unit/ElggPluginUnitTest.php
+++ b/engine/tests/phpunit/unit/ElggPluginUnitTest.php
@@ -174,8 +174,10 @@ class ElggPluginUnitTest extends \Elgg\UnitTestCase {
 
 		$plugin = ElggPlugin::fromId('bootstrap_plugin', $this->normalizeTestFilePath('mod/'));
 
+		$plugin->setAsActivated();
+		$plugin->cache();
+
 		$app->_services->config->boot_cache_ttl = 0;
-		$app->_services->plugins->addTestingPlugin($plugin);
 
 		$app->bootCore();
 
@@ -232,10 +234,8 @@ class ElggPluginUnitTest extends \Elgg\UnitTestCase {
 			'sql' => "SHOW TABLE STATUS FROM `{$config['database']}`",
 		]);
 
-		_elgg_services()->plugins->addTestingPlugin($plugin);
-
 		$assertions = 0;
-		$assert = function() use ($plugin, &$assertions) {
+		$assert = function () use ($plugin, &$assertions) {
 			$methods = [
 				'upgrade',
 			];
@@ -248,7 +248,7 @@ class ElggPluginUnitTest extends \Elgg\UnitTestCase {
 			$assertions++;
 		};
 
-		$fail = function($error) {
+		$fail = function ($error) {
 			if ($error instanceof Throwable) {
 				$error = $error->getMessage();
 			} else if (is_array($error)) {
@@ -265,8 +265,23 @@ class ElggPluginUnitTest extends \Elgg\UnitTestCase {
 	}
 
 	public function testUsesBootstrapOnShutdown() {
-		/* @todo Test that bootstrap handlers are called during the shutdown event */
 
-		$this->markTestIncomplete();
+		$app = $this->createApplication();
+		$app->bootCore();
+
+		$plugin = ElggPlugin::fromId('bootstrap_plugin', $this->normalizeTestFilePath('mod/'));
+		$plugin->activate();
+
+		$shutdown = new \Elgg\Application\ShutdownHandler($app);
+		$shutdown->shutdownApplication();
+
+		$methods = [
+			'shutdown',
+		];
+
+		foreach ($methods as $method) {
+			$prop = BootstrapPluginTestBootstrap::class . '::' . $method . '_calls';
+			$this->assertEquals(1, $plugin->$prop, "Method $method was called {$plugin->$prop} instead of expected 1 times");
+		}
 	}
 }


### PR DESCRIPTION
To simplify testing, plugins DB/repository service no longer manages plugin caching.
Because during testing, upgrades and installation, DB might not be available or plugins
and caches might be in a volatile state, this makes it easier to inject plugins
into related services without having to instantiate the DB and the
plugin repository.

Fixes #12004