### PR TITLE
fix(plugins): avoid multiple executions of runtime logic in plugin files

### DIFF
--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -871,7 +871,7 @@ class ElggPlugin extends ElggObject {
 		}
 
 		try {
-			$ret = Includer::includeFile($filepath);
+			$ret = Application::requireSetupFileOnce($filepath);
 		} catch (Exception $e) {
 			$msg = elgg_echo(
 				'ElggPlugin:Exception:IncludeFileThrew',

--- a/engine/tests/phpunit/unit/ElggPluginUnitTest.php
+++ b/engine/tests/phpunit/unit/ElggPluginUnitTest.php
@@ -146,6 +146,10 @@ class ElggPluginUnitTest extends \Elgg\UnitTestCase {
 			$prop = BootstrapPluginTestBootstrap::class . '::' . $method . '_calls';
 			$this->assertEquals(1, $plugin->$prop, "Method $method was called {$plugin->$prop} instead of expected 1 times");
 		}
+
+		// elgg-plugin.php should only be included once
+		global $BOOTSTRAP_PLUGIN_TEST;
+		$this->assertEquals(1, $BOOTSTRAP_PLUGIN_TEST);
 	}
 
 	public function testUsesBootstrapOnDeactivate() {
@@ -164,6 +168,10 @@ class ElggPluginUnitTest extends \Elgg\UnitTestCase {
 			$prop = BootstrapPluginTestBootstrap::class . '::' . $method . '_calls';
 			$this->assertEquals(1, $plugin->$prop, "Method $method was called {$plugin->$prop} instead of expected 1 times");
 		}
+
+		// elgg-plugin.php should only be included once
+		global $BOOTSTRAP_PLUGIN_TEST;
+		$this->assertEquals(1, $BOOTSTRAP_PLUGIN_TEST);
 	}
 
 	public function testUsesBootstrapOnBoot() {
@@ -190,6 +198,10 @@ class ElggPluginUnitTest extends \Elgg\UnitTestCase {
 			$prop = BootstrapPluginTestBootstrap::class . '::' . $method . '_calls';
 			$this->assertEquals(1, $plugin->$prop, "Method $method was called {$plugin->$prop} instead of expected 1 times");
 		}
+
+		// elgg-plugin.php should only be included once
+		global $BOOTSTRAP_PLUGIN_TEST;
+		$this->assertEquals(1, $BOOTSTRAP_PLUGIN_TEST);
 	}
 
 	/**
@@ -244,6 +256,10 @@ class ElggPluginUnitTest extends \Elgg\UnitTestCase {
 				$prop = BootstrapPluginTestBootstrap::class . '::' . $method . '_calls';
 				$this->assertEquals(1, $plugin->$prop, "Method $method was called {$plugin->$prop} instead of expected 1 times");
 			}
+
+			// elgg-plugin.php should only be included once
+			global $BOOTSTRAP_PLUGIN_TEST;
+			$this->assertEquals(1, $BOOTSTRAP_PLUGIN_TEST);
 
 			$assertions++;
 		};

--- a/engine/tests/test_files/mod/bootstrap_plugin/elgg-plugin.php
+++ b/engine/tests/test_files/mod/bootstrap_plugin/elgg-plugin.php
@@ -1,5 +1,8 @@
 <?php
 
+global $BOOTSTRAP_PLUGIN_TEST;
+$BOOTSTRAP_PLUGIN_TEST++;
+
 return [
 	'bootstrap' => BootstrapPluginTestBootstrap::class,
 ];


### PR DESCRIPTION
Instead of including plugin files, require them once and cache the output,
in case the file is needed again. This avoid executing runtime logic on
multiple file includes, as well as eliminates potential problems with
multiple function/variable declaralations.

Fixes #11946