### PR TITLE
Group write options

### DIFF
--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -536,9 +536,16 @@ function groups_write_acl_plugin_hook(\Elgg\Hook $hook) {
 	}
 
 	if ($page_owner->getContentAccessMode() !== ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY) {
-		$allowed_access[] = ACCESS_LOGGED_IN;
-		if (!elgg_get_config('walled_garden')) {
-			$allowed_access[] = ACCESS_PUBLIC;
+		// don't allow content sharing with higher levels than group access level
+		// see https://github.com/Elgg/Elgg/issues/10285
+		if (in_array($page_owner->access_id, [ACCESS_PUBLIC, ACCESS_LOGGED_IN])) {
+			// at least logged in is allowed
+			$allowed_access[] = ACCESS_LOGGED_IN;
+			
+			if ($page_owner->access_id === ACCESS_PUBLIC && !elgg_get_config('walled_garden')) {
+				// public access is allowed
+				$allowed_access[] = ACCESS_PUBLIC;
+			}
 		}
 	}
 
@@ -549,6 +556,7 @@ function groups_write_acl_plugin_hook(\Elgg\Hook $hook) {
 		$write_acls[$acl->id] = $acl->getDisplayName();
 	}
 
+	// remove all but the allowed access levels
 	foreach (array_keys($write_acls) as $access_id) {
 		if (!in_array($access_id, $allowed_access)) {
 			unset($write_acls[$access_id]);
@@ -1107,7 +1115,7 @@ function _groups_get_group_acl(\ElggGroup $group) {
 		return false;
 	}
 	
-	return elgg_extract(0, $group->getOwnedAccessCollections(['subtype' => 'group_acl']), false);
+	return $group->getOwnedAccessCollection('group_acl');
 }
 
 /**

--- a/views/default/input/access.php
+++ b/views/default/input/access.php
@@ -88,9 +88,7 @@ if (!isset($vars['disabled'])) {
 
 // if access is set to a value not present in the available options, add the option
 if (!isset($vars['options_values'][$vars['value']])) {
-	$acl = get_access_collection($vars['value']);
-	$display = $acl ? $acl->name : elgg_echo('access:missing_name');
-	$vars['options_values'][$vars['value']] = $display;
+	$vars['options_values'][$vars['value']] = get_readable_access_level($vars['value']);
 }
 
 echo elgg_view('input/select', $vars);


### PR DESCRIPTION
If a group is only visible to logged in users or group members, don't
allow sharing of content outside the group (eg public)

fixes #10285