### PR TITLE
Improve migration performance

### DIFF
--- a/engine/schema/migrations/20170728030000_denormalize_metastrings.php
+++ b/engine/schema/migrations/20170728030000_denormalize_metastrings.php
@@ -1,5 +1,6 @@
 <?php
 
+use Phinx\Db\Adapter\MysqlAdapter;
 use Phinx\Migration\AbstractMigration;
 
 class DenormalizeMetastrings extends AbstractMigration {
@@ -33,6 +34,7 @@ class DenormalizeMetastrings extends AbstractMigration {
 				$table->addColumn('value', 'text', [
 					'null' => false,
 					'after' => 'entity_guid',
+					'limit' => MysqlAdapter::TEXT_LONG,
 				]);
 			}
 

--- a/engine/schema/migrations/20170728040000_change_table_engine.php
+++ b/engine/schema/migrations/20170728040000_change_table_engine.php
@@ -1,6 +1,5 @@
 <?php
 
-use Phinx\Db\Adapter\MysqlAdapter;
 use Phinx\Migration\AbstractMigration;
 
 class ChangeTableEngine extends AbstractMigration {
@@ -14,47 +13,14 @@ class ChangeTableEngine extends AbstractMigration {
 		'entities',
 		'entity_relationships',
 		'entity_subtypes',
-		'groups_entity',
 		'metadata',
 		'metastrings',
-		'objects_entity',
 		'private_settings',
 		'queue',
 		'river',
-		'sites_entity',
 		'system_log',
-		'users_entity',
 		'users_remember_me_cookies',
 		'users_sessions',
-	];
-
-	private $full_text_indexes = [
-		'groups_entity' => [
-			'name_2' => [
-				'name',
-				'description'
-			],
-		],
-		'objects_entity' => [
-			'title' => [
-				'title',
-				'description'
-			],
-		],
-		'sites_entity' => [
-			'name' => [
-				'name',
-				'description',
-				'url'
-			],
-		],
-		'users_entity' => [
-			'name' => ['name'],
-			'name2' => [
-				'name',
-				'username'
-			],
-		],
 	];
 
 	/**
@@ -69,28 +35,10 @@ class ChangeTableEngine extends AbstractMigration {
 				continue;
 			}
 
-			$table = $this->table($table);
-
-			if (!empty($this->full_text_indexes[$table->getName()])) {
-				$indexes = $this->full_text_indexes[$table->getName()];
-				foreach ($indexes as $index => $columns) {
-					try {
-						$this->execute("
-							ALTER TABLE {$prefix}{$table->getName()}
-							DROP KEY `{$index}`
-						");
-					} catch (Exception $e) {
-						// though schema defines them, some of these keys do not seem to exist
-					}
-				}
-			}
-
-			$result = $this->execute("
-				ALTER TABLE {$prefix}{$table->getName()}
+			$this->execute("
+				ALTER TABLE {$prefix}{$table}
 				ENGINE=InnoDB
 			");
-
-			$table->save();
 		}
 	}
 
@@ -106,28 +54,10 @@ class ChangeTableEngine extends AbstractMigration {
 				continue;
 			}
 
-			$table = $this->table($table);
-
 			$this->execute("
-				ALTER TABLE {$prefix}{$table->getName()}
+				ALTER TABLE {$prefix}{$table}
 				ENGINE=MyISAM
 			");
-
-			if (!empty($this->full_text_indexes[$table->getName()])) {
-				$indexes = $this->full_text_indexes[$table->getName()];
-				foreach ($indexes as $index => $columns) {
-					$columns = implode(',', array_map(function ($e) {
-						return "'$e'";
-					}, $columns));
-
-					$this->execute("
-						ALTER TABLE {$prefix}{$table->getName()}
-						ADD FULLTEXT INDEX {$index} ($columns)
-					");
-				}
-			}
-
-			$table->save();
 		}
 
 	}

--- a/engine/schema/migrations/20170728050000_expand_text_columns_to_longtext.php
+++ b/engine/schema/migrations/20170728050000_expand_text_columns_to_longtext.php
@@ -7,13 +7,8 @@ class ExpandTextColumnsToLongtext extends AbstractMigration {
 
 	// Columns that change from text to longtext
 	private $text_to_longtext = [
-		'annotations' => ['value'],
 		'config' => ['value'],
-		'groups_entity' => ['description'],
-		'metadata' => ['value'],
-		'objects_entity' => ['description'],
 		'private_settings' => ['value'],
-		'sites_entity' => ['description'],
 	];
 
 	/**

--- a/engine/schema/migrations/20171006131622_drop_groups_entity_table.php
+++ b/engine/schema/migrations/20171006131622_drop_groups_entity_table.php
@@ -15,36 +15,55 @@ class DropGroupsEntityTable extends AbstractMigration
 
 		$prefix = $this->getAdapter()->getOption('table_prefix');
 		$cols = ['name', 'description'];
+		$col_names = "'" . implode("', '", $cols) . "'";
 		
-		$groups_query = "SELECT * FROM {$prefix}groups_entity LIMIT 25";
+		$groups_query = "SELECT * FROM {$prefix}groups_entity LIMIT 100";
 		while ($rows = $this->fetchAll($groups_query)) {
+			$guids = [];
+			foreach ($rows as $row) {
+				$guids[] = $row['guid'];
+			}
+			
+			$guids = implode(',', $guids);
+			
+			// remove existing metadata... attributes are more important
+			$this->execute("
+				DELETE FROM {$prefix}metadata
+				WHERE entity_guid IN ({$guids}) AND
+				name IN ({$col_names})
+			");
+			
+			$new_metadata_rows = [];
+			
 			foreach ($rows as $row) {
 				foreach ($cols as $col) {
-					// remove existing metadata... attributes are more important
-					$this->execute("
-						DELETE FROM {$prefix}metadata
-						WHERE entity_guid = {$row['guid']} AND
-						name = '{$col}'
-					");
+					$value = $row[$col];
+					if (is_null($value) || $value === '') {
+						continue;
+					}
 					
-					$this->insert('metadata', [
+					$new_metadata_rows[] = [
 						'entity_guid' => $row['guid'],
 						'name' => $col,
-						'value' => $row[$col],
+						'value' => $value,
 						'value_type' => 'text',
 						'owner_guid' => 0,
 						'access_id' => 2,
 						'time_created' => time(),
 						'enabled' => 'yes',
-					]);
+					];
 				}
-				
-				// remove from groups so it does not get processed again in the next while loop
-				$this->execute("
-					DELETE FROM {$prefix}groups_entity
-					WHERE guid = {$row['guid']}
-				");
 			}
+			
+			if (!empty($new_metadata_rows)) {
+				$this->insert('metadata', $new_metadata_rows);
+			}
+			
+			// remove from groups so it does not get processed again in the next while loop
+			$this->execute("
+				DELETE FROM {$prefix}groups_entity
+				WHERE guid IN ({$guids})
+			");
 		}
 		
 		// all data migrated, so drop the table

--- a/views/default/forms/user/changepassword.php
+++ b/views/default/forms/user/changepassword.php
@@ -25,7 +25,7 @@ $fields = [
 	],
 	[
 		'#type' => 'password',
-		'#label' => elgg_echo('user:password2'),
+		'#label' => elgg_echo('user:password2:label'),
 		'name' => 'password2',
 	],
 ];


### PR DESCRIPTION
- [x] fix double commits
- [x] finalize tests

Example data:
- column limit went from 50 minutes to 4 min
- objects subtable went from 240 minutes to 54 min
- total run from 6 hours to 2 hours

Noticed:
looks like objects subtable migration slowed down towards the end of its job... maybe a mysql issue (with memory size or something)