### PR TITLE
feat(groups): improve usability of group tools

### DIFF
--- a/docs/appendix/upgrade-notes/2.x-to-3.0.rst
+++ b/docs/appendix/upgrade-notes/2.x-to-3.0.rst
@@ -157,7 +157,7 @@ All the functions in ``engine/lib/deprecated-1.10.php`` were removed. See https:
  * ``update_river_access_by_object``
  * ``garbagecollector_orphaned_metastrings``
  * ``groups_access_collection_override``
- * ``groups_get_group_tool_options``: Use ``elgg_get_group_tool_options``
+ * ``groups_get_group_tool_options``: Use ``elgg()->group_tools->all()``
  * ``groups_join_group``: Use ``ElggGroup::join``
  * ``groups_prepare_profile_buttons``: Use ``register, menu:title`` hook
  * ``groups_register_profile_buttons``: Use ``register, menu:title`` hook

--- a/docs/guides/group-tools.rst
+++ b/docs/guides/group-tools.rst
@@ -1,12 +1,32 @@
 Group Tools
 ===========
 
-In Elgg groups have a feature where you can enable or disable different tools for a group. These tools are provided by other plugins like blog or file.
+Elgg groups allow group administrators to enable/disable various tools available within a group.
+These tools are provided by other plugins like blog or file.
 
-Plugins need to tell Elgg that these tools exist. This can be done by using the ``add_group_tool_option`` function.
-If an existing tool option needs to be removed you can use ``remove_group_tool_option``.
+Plugins can access group tool register via ``elgg()->group_tools``.
 
-On a group edit form you can turn the tools on or off for the specific group. You can also do so programmatically as shown in the code example below. 
+.. code-block:: php
+
+	elgg()->group_tools->register('my-tool', [
+		'default_on' => false, // default is true
+		'label' => elgg_echo('my-tool:checkbox:label'),
+		'priority' => 300, // display this earlier than other modules/tools
+	]);
+
+A registered tool will have an option to be toggled on the group edit form, and can have a profile view module associated with it.
+To add a profile module, simply add a corresponding view as ``groups/profile/module/<tool_name>``.
+
+.. code-block:: php
+
+	// file: groups/profile/module/my-tool.php
+
+	echo elgg_view('groups/profile/module', [
+		'title' => elgg_echo('my-tool'),
+		'content' => 'Hello, world!',
+	]);
+
+You can programmically enable and disable tools for a given group:
 
 .. code-block:: php
 	
@@ -30,4 +50,4 @@ It is also a possibility to use a gatekeeper function to prevent access to a gro
 
 	Read more about gatekeepers here: :ref:`authentication-gatekeepers`
 
-If you need the configured group tool options for a specific group you can use the ``elgg_get_group_tool_options($group)`` function.
+If you need the configured group tool options for a specific group you can use the ``elgg()->group_tools->group($group)`` function.

--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -1108,7 +1108,13 @@ Groups
 	Filters buttons (``ElggMenuItem`` instances) to be registered in the title menu of the group profile page
 
 **tool_options, group**
-	Use this hook to influence the available group tool options
+	Filters a collection of tools available within a specific group:
+
+	The ``$return`` is ``\Elgg\Collections\Collection<\Elgg\Groups\Tool>``, a collection of group tools.
+
+	The ``$params`` array contains:
+
+	 * ``entity`` - ``\ElggGroup``
 
 HTMLawed
 --------

--- a/docs/info/config.php
+++ b/docs/info/config.php
@@ -228,13 +228,6 @@ $CONFIG->registers;
 $CONFIG->register_objects;
 
 /**
- * Holds available group tools options.  Added with {@link add_group_tool_option()}
- *
- * @global array $CONFIG->group_tool_options
- */
-$CONFIG->group_tool_options;
-
-/**
  * The last cache time for the current viewtype.  Used in the generation of CSS and JS links.
  *
  * @global string $CONFIG->lastcache

--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elgg;
 
+use Elgg\Collections\Collection;
 use Elgg\Config\DatarootSettingMigrator;
 use Elgg\Config\WwwrootSettingMigrator;
 use Elgg\Database\ConfigTable;
@@ -50,7 +51,6 @@ use Elgg\Project\Paths;
  * @property mixed         $embed_tab
  * @property string        $exception_include
  * @property string[]      $group
- * @property array         $group_tool_options
  * @property bool          $i18n_loaded_from_cache
  * @property array         $icon_sizes
  * @property string        $image_processor
@@ -384,6 +384,12 @@ class Config {
 	 * @return mixed null if does not exist
 	 */
 	public function __get($name) {
+		switch ($name) {
+			case 'group_tool_options':
+				elgg_deprecated_notice("'$name' config option is no longer in use. Use elgg()->group_tools->all()", '3.0');
+				return elgg()->group_tools->all();
+		}
+
 		if (isset($this->values[$name])) {
 			return $this->values[$name];
 		}

--- a/engine/classes/Elgg/Database/Seeds/Groups.php
+++ b/engine/classes/Elgg/Database/Seeds/Groups.php
@@ -63,7 +63,7 @@ class Groups extends Seed {
 					'membership' => $this->getRandomMembership(),
 				], [
 					'profile_fields' => (array) elgg_get_config('group'),
-					'group_tool_options' => (array) elgg_get_config('group_tool_options'),
+					'group_tool_options' => elgg()->group_tools->all(),
 				]);
 				if (!$group) {
 					continue;

--- a/engine/classes/Elgg/Database/Seeds/Seeding.php
+++ b/engine/classes/Elgg/Database/Seeds/Seeding.php
@@ -2,8 +2,10 @@
 
 namespace Elgg\Database\Seeds;
 
+use Elgg\Collections\Collection;
 use Elgg\Database\Clauses\OrderByClause;
 use Elgg\Database\QueryBuilder;
+use Elgg\Groups\Tool;
 use ElggEntity;
 use ElggGroup;
 use ElggObject;
@@ -254,12 +256,12 @@ trait Seeding {
 			}
 
 			$tool_options = elgg_extract('group_tools_options', $options, []);
-			if ($tool_options) {
-				foreach ($tool_options as $group_option) {
-					$option_toggle_name = $group_option->name . "_enable";
-					$option_default = $group_option->default_on ? 'yes' : 'no';
-					$properties[$option_toggle_name] = $option_default;
-				}
+			/* @var $tool_options Collection|Tool[] */
+
+			foreach ($tool_options as $group_option) {
+				$prop_name = $group_option->mapMetadataName();
+				$prop_value = $group_option->mapMetadataValue();
+				$properties[$prop_name] = $prop_value;
 			}
 
 			if ($this->faker()->boolean(20)) {

--- a/engine/classes/Elgg/Di/PublicContainer.php
+++ b/engine/classes/Elgg/Di/PublicContainer.php
@@ -7,6 +7,7 @@ use Elgg\Application\Database;
 use Elgg\Config;
 use Elgg\EventsService;
 use Elgg\Gatekeeper;
+use Elgg\Groups\Tools;
 use Elgg\I18n\Translator;
 use Elgg\Logger;
 use Elgg\Menu\Service;
@@ -27,6 +28,7 @@ use ElggSession;
  * @property-read Database              $db              Public database
  * @property-read EventsService         $events          Event service
  * @property-read Gatekeeper            $gatekeeper      Gatekeeper
+ * @property-read Tools                 $group_tools     Group Tools
  * @property-read HtmlFormatter         $html_formatter  HTML formatter
  * @property-read PluginHooksService    $hooks           Hooks service
  * @property-read Logger                $logger          Logger

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -14,6 +14,7 @@ use Elgg\Config;
 use Elgg\Cron;
 use Elgg\Database\DbConfig;
 use Elgg\Database\SiteSecret;
+use Elgg\Groups\Tools;
 use Elgg\Invoker;
 use Elgg\Logger;
 use Elgg\Project\Paths;
@@ -69,6 +70,7 @@ use Zend\Mail\Transport\TransportInterface as Mailer;
  * @property-read \ElggDiskFilestore                              $filestore
  * @property-read \Elgg\FormsService                              $forms
  * @property-read \Elgg\Gatekeeper                                $gatekeeper
+ * @property-read \Elgg\Groups\Tools                              $group_tools
  * @property-read \Elgg\HandlersService                           $handlers
  * @property-read \Elgg\Security\HmacFactory                      $hmac
  * @property-read \Elgg\Views\HtmlFormatter                       $html_formatter
@@ -394,6 +396,10 @@ class ServiceProvider extends DiContainer {
 			);
 		});
 
+		$this->setFactory('group_tools', function(ServiceProvider $c) {
+			return new Tools($c->hooks);
+		});
+		
 		$this->setClassName('handlers', \Elgg\HandlersService::class);
 
 		$this->setFactory('hmac', function(ServiceProvider $c) {

--- a/engine/classes/Elgg/Groups/Tool.php
+++ b/engine/classes/Elgg/Groups/Tool.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Elgg\Groups;
+
+use Elgg\Collections\CollectionItemInterface;
+
+/**
+ * Represents a registered group tool option
+ *
+ * @property string      $name          Module name
+ * @property string      $label         Module title
+ * @property bool        $default_on    Enabled by default
+ * @property int         $priority      Priority
+ */
+class Tool implements CollectionItemInterface {
+
+	/**
+	 * @var string
+	 */
+	public $name;
+
+	/**
+	 * @var array
+	 */
+	protected $options;
+
+	/**
+	 * Constructor
+	 *
+	 * @param string $name    Tool name
+	 * @param array  $options Tool options
+	 */
+	public function __construct($name, array $options = []) {
+		$this->name = $name;
+
+		$defaults = [
+			'label' => null,
+			'default_on' => true,
+			'priority' => 500,
+		];
+
+		$this->options = array_merge($defaults, $options);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function __get($name) {
+		switch ($name) {
+			case 'label' :
+				return $this->getLabel();
+
+			case 'default_on' :
+				return $this->isEnabledByDefault();
+		}
+
+		return elgg_extract($name, $this->options);
+	}
+
+	/**
+	 *
+	 */
+	public function __set($name, $value) {
+		$this->options[$name] = $value;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getId() {
+		return $this->name;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getPriority() {
+		return $this->priority;
+	}
+
+	/**
+	 * Get module title
+	 * @return string
+	 */
+	public function getLabel() {
+		$label = elgg_extract('label', $this->options);
+		if (isset($label)) {
+			return $label;
+		}
+
+		return elgg_echo("groups:tool:{$this->name}");
+	}
+
+	/**
+	 * Is the tool enabled by default?
+	 * @return bool
+	 */
+	public function isEnabledByDefault() {
+		$default_on = elgg_extract('default_on', $this->options, true);
+
+		if ($default_on === true || $default_on === 'yes') {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get metadata name for DB storage
+	 * @return string
+	 */
+	public function mapMetadataName() {
+		return "{$this->name}_enable";
+	}
+
+	/**
+	 * Get metadata value for DB storage
+	 *
+	 * @param mixed $value Input value
+	 *                     Defaults to 'default_on' property
+	 *
+	 * @return string
+	 */
+	public function mapMetadataValue($value = null) {
+		if (!isset($value)) {
+			$value = $this->default_on;
+		}
+
+		if ($value === 'yes' || $value === true) {
+			return 'yes';
+		}
+
+		return 'no';
+	}
+
+}

--- a/engine/classes/Elgg/Groups/Tools.php
+++ b/engine/classes/Elgg/Groups/Tools.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Elgg\Groups;
+
+use Elgg\Collections\Collection;
+use Elgg\PluginHooksService;
+use ElggGroup;
+
+/**
+ * Group tools service
+ *
+ * @access private
+ * @internal
+ */
+class Tools {
+
+	/**
+	 * @var Collection
+	 */
+	protected $tools;
+
+	/**
+	 * @var PluginHooksService
+	 */
+	protected $hooks;
+
+	/**
+	 * Constructor
+	 *
+	 * @param PluginHooksService $hooks Hooks
+	 */
+	public function __construct(PluginHooksService $hooks) {
+		$this->tools = new Collection([], Tool::class);
+		$this->hooks = $hooks;
+	}
+
+	/**
+	 * Adds a group tool option
+	 *
+	 * @param string $name    Tool ID
+	 * @param array  $options Tool config options
+	 *
+	 * @option string   $label      Label to appear on the group edit form
+	 * @option string   $title      Tool name
+	 * @option bool     $default_on Is the tool enabled by default?
+	 * @option int      $priority   Module priority
+	 *
+	 * @return void
+	 */
+	public function register($name, array $options = []) {
+		$tool = new Tool($name, $options);
+
+		$this->tools->add($tool);
+	}
+
+	/**
+	 * Removes a group tool
+	 *
+	 * @param string $name Tool name
+	 *
+	 * @return void
+	 */
+	public function unregister($name) {
+		$this->tools->remove($name);
+	}
+
+	/**
+	 * Get a registered tool by its name
+	 *
+	 * @param string $name Tool name
+	 * @return Tool|null
+	 */
+	public function get($name) {
+		return $this->tools->get($name);
+	}
+
+	/**
+	 * Returns registered tools
+	 *
+	 * @return Collection|Tool[]
+	 */
+	public function all() {
+		return $this->tools;
+	}
+
+	/**
+	 * Returns group specific tools
+	 *
+	 * @param ElggGroup $group Group
+	 *
+	 * @return Collection|Tool[]
+	 */
+	public function group(ElggGroup $group) {
+
+		$tool_options = clone $this->tools;
+
+		$params = [
+			'entity' => $group,
+		];
+
+		return $this->hooks->trigger('tool_options', 'group', $params, $tool_options);
+	}
+}

--- a/engine/lib/deprecated-3.0.php
+++ b/engine/lib/deprecated-3.0.php
@@ -1709,3 +1709,69 @@ function get_entity_dates($type = '', $subtype = '', $container_guid = 0, $ignor
 
 	return elgg_get_entity_dates($options);
 }
+
+/**
+ * Adds a group tool option
+ *
+ * @see        remove_group_tool_option()
+ *
+ * @param string $name    Tool ID
+ * @param array  $options Tool config options
+ *
+ * @option string   $label      Label to appear on the group edit form
+ * @option bool     $default_on Is the tool enabled by default?
+ * @option int      $priority   Module priority
+ * @return void
+ *
+ * @since 1.5.0
+ * @deprecated 3.0 Use elgg()->group_tools
+ */
+function add_group_tool_option($name, $options = []) {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use elgg()->group_tools service', '3.0');
+
+	if (!is_array($options)) {
+		$arguments = func_get_args();
+		$options = [
+			'label' => elgg_extract(1, $arguments),
+			'default_on' => elgg_extract(2, $arguments),
+			'priority' => null,
+		];
+	}
+
+	elgg()->group_tools->register($name, $options);
+}
+
+/**
+ * Removes a group tool option based on name
+ *
+ * @see add_group_tool_option()
+ *
+ * @param string $name Name of the group tool option
+ *
+ * @return void
+ * @since 1.7.5
+ * @deprecated 3.0 Use elgg()->group_tools
+ */
+function remove_group_tool_option($name) {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use elgg()->group_tools service', '3.0');
+
+	elgg()->group_tools->unregister($name);
+}
+
+/**
+ * Function to return available group tool options
+ *
+ * @param \ElggGroup $group optional group
+ *
+ * @return Collection|Tool[]
+ * @deprecated 3.0
+ */
+function elgg_get_group_tool_options(\ElggGroup $group = null) {
+	elgg_deprecated_notice(__FUNCTION__ . ' is deprecated. Use elgg()->group_tools service', '3.0');
+
+	if ($group) {
+		return elgg()->group_tools->group($group);
+	}
+
+	return elgg()->group_tools->all();
+}

--- a/engine/services.php
+++ b/engine/services.php
@@ -25,6 +25,7 @@ return [
 	'db' => new PhpDiResolver(Database::class, 'publicDb'),
 	'events' => new PhpDiResolver(EventsService::class, 'events'),
 	'gatekeeper' => new PhpDiResolver(Gatekeeper::class, 'gatekeeper'),
+	'group_tools' => new PhpDiResolver(\Elgg\Groups\Tools::class, 'group_tools'),
 	'html_formatter' => new PhpDiResolver(HtmlFormatter::class, 'html_formatter'),
 	'hooks' => new PhpDiResolver(PluginHooksService::class, 'hooks'),
 	'logger' => new PhpDiResolver(Logger::class, 'logger'),

--- a/engine/tests/classes/Elgg/BaseTestCase.php
+++ b/engine/tests/classes/Elgg/BaseTestCase.php
@@ -87,7 +87,6 @@ abstract class BaseTestCase extends TestCase implements Seedable, Testable {
 
 			'profile_files' => [],
 			'group' => [],
-			'group_tool_options' => [],
 
 			'minusername' => 10,
 			'profile_custom_fields' => [],

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGroupToolTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGroupToolTest.php
@@ -7,6 +7,7 @@ use Elgg\IntegrationTestCase;
 
 /**
  * @group Groups
+ * @group GroupTools
  */
 class ElggCoreGroupToolTest extends IntegrationTestCase {
 	/**

--- a/engine/tests/phpunit/unit/Elgg/Groups/ToolsUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Groups/ToolsUnitTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Elgg\Groups;
+
+use Elgg\UnitTestCase;
+
+/**
+ * @group Groups
+ * @group GroupTools
+ */
+class ToolsUnitTest extends UnitTestCase {
+
+	public function up() {
+		elgg()->group_tools->all()->fill([]);
+	}
+
+	public function down() {
+
+	}
+
+	public function testCanRegisterTools() {
+
+		elgg()->group_tools->register('my-tool', [
+			'default_on' => false,
+			'priority' => 300,
+		]);
+
+		$tool = elgg()->group_tools->get('my-tool');
+
+		$this->assertInstanceOf(Tool::class, $tool);
+		$this->assertEquals(elgg_echo("groups:tool:my-tool"), $tool->label);
+		$this->assertEquals($tool->label, $tool->getLabel());
+		$this->assertEquals('my-tool', $tool->name);
+		$this->assertEquals($tool->name, $tool->getId());
+		$this->assertFalse($tool->default_on);
+		$this->assertFalse($tool->isEnabledByDefault());
+		$this->assertEquals('my-tool_enable', $tool->mapMetadataName());
+		$this->assertEquals('no', $tool->mapMetadataValue());
+		$this->assertEquals('yes', $tool->mapMetadataValue('yes'));
+		$this->assertEquals('yes', $tool->mapMetadataValue(true));
+		$this->assertEquals('no', $tool->mapMetadataValue(false));
+		$this->assertEquals(300, $tool->priority);
+
+		elgg()->group_tools->unregister('my-tool');
+
+		$tool = elgg()->group_tools->get('my-tool');
+		$this->assertNull($tool);
+	}
+
+	public function testCanMutateToolAtRuntime() {
+		elgg()->group_tools->register('my-tool');
+
+		$tool = elgg()->group_tools->get('my-tool');
+
+		$this->assertEquals(elgg_echo("groups:tool:my-tool"), $tool->label);
+		$this->assertTrue($tool->isEnabledByDefault());
+		$this->assertEquals(500, $tool->priority);
+
+		elgg()->group_tools->get('my-tool')->label = 'edited';
+		elgg()->group_tools->get('my-tool')->default_on = false;
+		elgg()->group_tools->get('my-tool')->priority = 300;
+
+		$this->assertEquals('edited', $tool->label);
+		$this->assertFalse($tool->isEnabledByDefault());
+		$this->assertEquals(300, $tool->priority);
+	}
+}

--- a/mod/activity/start.php
+++ b/mod/activity/start.php
@@ -51,8 +51,7 @@ function elgg_activity_init() {
 		'href' => elgg_generate_url('default:river'),
 	]);
 	
-	add_group_tool_option('activity', null, true);
-	elgg_extend_view('groups/tool_latest', 'activity/group_module');
+	elgg()->group_tools->register('activity');
 	
 	elgg_register_plugin_hook_handler('register', 'menu:owner_block', '_elgg_activity_owner_block_menu');
 }

--- a/mod/activity/views/default/groups/profile/module/activity.php
+++ b/mod/activity/views/default/groups/profile/module/activity.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Groups latest activity
+ *
+ * @todo add people joining group to activity
+ */
+
+echo elgg_view('activity/group_module', $vars);

--- a/mod/blog/start.php
+++ b/mod/blog/start.php
@@ -30,8 +30,7 @@ function blog_init() {
 	elgg_register_plugin_hook_handler('register', 'menu:owner_block', 'blog_owner_block_menu');
 
 	// Add group option
-	add_group_tool_option('blog', null, true);
-	elgg_extend_view('groups/tool_latest', 'blog/group_module');
+	elgg()->group_tools->register('blog');
 
 	// archive menu
 	elgg_register_plugin_hook_handler('register', 'menu:blog_archive', 'blog_archive_menu_setup');

--- a/mod/blog/views/default/groups/profile/module/blog.php
+++ b/mod/blog/views/default/groups/profile/module/blog.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Group blog module
+ */
+
+echo elgg_view('blog/group_module', $vars);

--- a/mod/bookmarks/start.php
+++ b/mod/bookmarks/start.php
@@ -33,8 +33,7 @@ function bookmarks_init() {
 	elgg_register_plugin_hook_handler('get_views', 'ecml', 'bookmarks_ecml_views_hook');
 
 	// Groups
-	add_group_tool_option('bookmarks', null, true);
-	elgg_extend_view('groups/tool_latest', 'bookmarks/group_module');
+	elgg()->group_tools->register('bookmarks');
 
 	// allow to be liked
 	elgg_register_plugin_hook_handler('likes:is_likable', 'object:bookmarks', 'Elgg\Values::getTrue');

--- a/mod/bookmarks/views/default/groups/profile/module/bookmarks.php
+++ b/mod/bookmarks/views/default/groups/profile/module/bookmarks.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * List most recent bookmarks on group profile page
+ *
+ * @package Bookmarks
+ */
+
+echo elgg_view('bookmarks/group_module', $vars);

--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -19,8 +19,7 @@ function discussion_init() {
 	elgg_extend_view('object/elements/imprint/contents', 'discussion/imprint/status');
 
 	// add the forum tool option
-	add_group_tool_option('forum', null, true);
-	elgg_extend_view('groups/tool_latest', 'discussion/group_module');
+	elgg()->group_tools->register('forum');
 
 	// notifications
 	elgg_register_plugin_hook_handler('get', 'subscriptions', 'discussion_get_subscriptions');

--- a/mod/discussions/views/default/groups/profile/module/forum.php
+++ b/mod/discussions/views/default/groups/profile/module/forum.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Latest forum posts
+ *
+ * @uses $vars['entity']
+ */
+
+echo elgg_view('discussion/group_module', $vars);

--- a/mod/file/start.php
+++ b/mod/file/start.php
@@ -37,7 +37,7 @@ function file_init() {
 	elgg_register_plugin_hook_handler('prepare', 'notification:create:object:file', 'file_prepare_notification');
 
 	// add the group files tool option
-	add_group_tool_option('file', null, true);
+	elgg()->group_tools->register('file');
 
 	// add a file link to owner blocks
 	elgg_register_plugin_hook_handler('register', 'menu:owner_block', 'file_owner_block_menu');

--- a/mod/file/views/default/groups/profile/module/file.php
+++ b/mod/file/views/default/groups/profile/module/file.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Group file module
+ */
+
+echo elgg_view('file/group_module', $vars);

--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -91,21 +91,26 @@ if (!$group->name) {
 }
 
 // Set group tool options (only pass along saved entities)
-$tool_entity = !$is_new_group ? $group : null;
-$tool_options = elgg_get_group_tool_options($tool_entity);
-if ($tool_options) {
-	foreach ($tool_options as $group_option) {
-		$option_toggle_name = $group_option->name . "_enable";
-		$value = get_input($option_toggle_name);
-		if ($value === null) {
-			continue;
-		}
-		
-		if ($value === 'yes') {
-			$group->enableTool($group_option->name);
-		} else {
-			$group->disableTool($group_option->name);
-		}
+// @todo: move this to an event handler to make sure groups created outside of the action
+// get their tools configured
+if ($is_new_group) {
+	$tools = elgg()->group_tools->all();
+} else {
+	$tools = elgg()->group_tools->group($group);
+}
+
+foreach ($tools as $tool) {
+	$prop_name = $tool->mapMetadataName();
+	$value = get_input($prop_name);
+
+	if (!isset($value)) {
+		continue;
+	}
+
+	if ($value === 'yes') {
+		$group->enableTool($tool->name);
+	} else {
+		$group->disableTool($tool->name);
 	}
 }
 

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -1168,15 +1168,17 @@ function groups_prepare_form_vars($group = null) {
 
 	// handle tool options
 	$entity = ($group instanceof \ElggGroup) ? $group : null;
-	$tools = elgg_get_group_tool_options($entity);
-	foreach ($tools as $group_option) {
-		$option_name = $group_option->name . "_enable";
+	$tools = elgg()->group_tools->group($entity);
 
-		$enabled = $group_option->default_on;
+	foreach ($tools as $tool) {
 		if ($entity) {
-			$enabled = $entity->isToolEnabled($group_option->name);
+			$enabled = $entity->isToolEnabled($tool->name);
+		} else {
+			$enabled = $tool->isEnabledByDefault();
 		}
-		$values[$option_name] = $enabled ? 'yes' : 'no';
+
+		$prop_name = $tool->mapMetadataName();
+		$values[$prop_name] = $enabled ? 'yes' : 'no';
 	}
 
 	// get any sticky form settings

--- a/mod/groups/views/default/groups/edit/tools.php
+++ b/mod/groups/views/default/groups/edit/tools.php
@@ -8,23 +8,29 @@
  * @package ElggGroups
  */
 
-$tools = elgg_get_group_tool_options(elgg_extract('entity', $vars));
+$entity = elgg_extract('entity', $vars);
+
+if ($entity instanceof ElggGroup) {
+	$tools = elgg()->group_tools->group($entity);
+} else {
+	$tools = elgg()->group_tools->all();
+}
+
+$tools = $tools->sort()->all();
+/* @var $tools \Elgg\Groups\Tool[] */
+
 if (empty($tools)) {
 	return;
 }
 
-usort($tools, function($a, $b) {
-	return strcmp($a->label, $b->label);
-});
-
-foreach ($tools as $group_option) {
-	$group_option_toggle_name = $group_option->name . "_enable";
-	$value = elgg_extract($group_option_toggle_name, $vars);
+foreach ($tools as $tool) {
+	$prop_name = $tool->mapMetadataName();
+	$value = elgg_extract($prop_name, $vars);
 
 	echo elgg_view_field([
 		'#type' => 'checkbox',
-		'#label' => $group_option->label,
-		'name' => $group_option_toggle_name,
+		'#label' => $tool->label,
+		'name' => $prop_name,
 		'value' => 'yes',
 		'default' => 'no',
 		'switch' => true,

--- a/mod/groups/views/default/groups/profile/module.php
+++ b/mod/groups/views/default/groups/profile/module.php
@@ -26,10 +26,8 @@ if ($group->canWriteToContainer() && isset($vars['add_link'])) {
 	], elgg_extract('add_link', $vars));
 }
 
-echo '<li>';
 echo elgg_view_module('info', $title, $vars['content'], [
 	'menu' => $menu,
 	'class' => 'elgg-module-group',
 	'footer' => $footer,
 ]);
-echo '</li>';

--- a/mod/groups/views/default/groups/profile/modules.php
+++ b/mod/groups/views/default/groups/profile/modules.php
@@ -1,0 +1,30 @@
+<?php
+
+$entity = elgg_extract('entity', $vars);
+if (!$entity instanceof ElggGroup) {
+	return;
+}
+
+$tools = elgg()->group_tools->group($entity)
+	->filter(function (\Elgg\Groups\Tool $tool) use ($entity) {
+		return $entity->isToolEnabled($tool->name);
+	})
+	->sort();
+
+foreach ($tools as $tool) {
+	if (elgg_view_exists("groups/profile/module/{$tool->name}")) {
+		$params = $vars;
+		$params['tool'] = $tool;
+
+		echo elgg_view("groups/profile/module/{$tool->name}", $params);
+	}
+}
+
+$legacy = elgg_view("groups/tool_latest", $vars);
+if ($legacy) {
+	elgg_deprecated_notice(
+		"Extending 'groups/tool_latest' to render group profile modules is deprecated. " .
+		"Instead add a view corresponding to your group tool name in 'groups/profile/module/<tool_name>'",
+		'3.0'
+	);
+}

--- a/mod/groups/views/default/groups/profile/widgets.php
+++ b/mod/groups/views/default/groups/profile/widgets.php
@@ -4,12 +4,9 @@
 *
 * @package ElggGroups
 */
-	
-// tools widget area
-echo '<ul id="groups-tools">';
 
-// enable tools to extend this area
-echo elgg_view("groups/tool_latest", $vars);
+$modules = elgg_view('groups/profile/modules', $vars);
 
-echo "</ul>";
-
+echo elgg_format_element('div', [
+	'id' => 'groups-tools',
+], $modules);

--- a/mod/pages/start.php
+++ b/mod/pages/start.php
@@ -33,8 +33,7 @@ function pages_init() {
 	elgg_register_plugin_hook_handler('prepare', 'notification:create:object:page', 'pages_prepare_notification');
 
 	// add to groups
-	add_group_tool_option('pages', null, true);
-	elgg_extend_view('groups/tool_latest', 'pages/group_module');
+	elgg()->group_tools->register('pages');
 	
 	// Language short codes must be of the form "pages:key"
 	// where key is the array key below

--- a/mod/pages/views/default/groups/profile/module/pages.php
+++ b/mod/pages/views/default/groups/profile/module/pages.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Group pages
+ */
+
+echo elgg_view('pages/group_module', $vars);


### PR DESCRIPTION
Improves usability of group tools and reduces all the boilerplate around
their registration and formatting.
Add support for priority.
Deprecates support for extending views to add profile modules,
instead uses predictable view locations to render tool related modules