### PR TITLE
fix(groups): respect subtype specific permissions in group modules

### DIFF
--- a/mod/blog/views/default/blog/group_module.php
+++ b/mod/blog/views/default/blog/group_module.php
@@ -35,13 +35,16 @@ $options = [
 $content = elgg_list_entities($options);
 elgg_pop_context();
 
-$new_link = elgg_view('output/url', [
-	'href' => elgg_generate_url('add:object:blog', [
-		'guid' => $group->guid,
-	]),
-	'text' => elgg_echo('blog:write'),
-	'is_trusted' => true,
-]);
+$new_link = null;
+if ($group->canWriteToContainer(0, 'object', 'blog')) {
+	$new_link = elgg_view('output/url', [
+		'href' => elgg_generate_url('add:object:blog', [
+			'guid' => $group->guid,
+		]),
+		'text' => elgg_echo('blog:write'),
+		'is_trusted' => true,
+	]);
+}
 
 echo elgg_view('groups/profile/module', [
 	'title' => elgg_echo('collection:object:blog:group'),

--- a/mod/bookmarks/views/default/bookmarks/group_module.php
+++ b/mod/bookmarks/views/default/bookmarks/group_module.php
@@ -34,11 +34,14 @@ $options = [
 $content = elgg_list_entities($options);
 elgg_pop_context();
 
-$new_link = elgg_view('output/url', [
-	'href' => elgg_generate_url('add:object:bookmarks', ['guid' => $group->guid]),
-	'text' => elgg_echo('add:object:bookmarks'),
-	'is_trusted' => true,
-]);
+$new_link = null;
+if ($group->canWriteToContainer(0, 'object', 'bookmarks')) {
+	$new_link = elgg_view('output/url', [
+		'href' => elgg_generate_url('add:object:bookmarks', ['guid' => $group->guid]),
+		'text' => elgg_echo('add:object:bookmarks'),
+		'is_trusted' => true,
+	]);
+}
 
 echo elgg_view('groups/profile/module', [
 	'title' => elgg_echo('collection:object:bookmarks:group'),

--- a/mod/discussions/views/default/discussion/group_module.php
+++ b/mod/discussions/views/default/discussion/group_module.php
@@ -33,11 +33,14 @@ $options = [
 $content = elgg_list_entities($options);
 elgg_pop_context();
 
-$new_link = elgg_view('output/url', [
-	'href' => elgg_generate_url('add:object:discussion', ['guid' => $group->guid]),
-	'text' => elgg_echo('add:object:discussion'),
-	'is_trusted' => true,
-]);
+$new_link = null;
+if ($group->canWriteToContainer(0, 'object', 'discussion')) {
+	$new_link = elgg_view('output/url', [
+		'href' => elgg_generate_url('add:object:discussion', ['guid' => $group->guid]),
+		'text' => elgg_echo('add:object:discussion'),
+		'is_trusted' => true,
+	]);
+}
 
 echo elgg_view('groups/profile/module', [
 	'title' => elgg_echo('collection:object:discussion:group'),

--- a/mod/file/views/default/file/group_module.php
+++ b/mod/file/views/default/file/group_module.php
@@ -31,11 +31,14 @@ $content = elgg_list_entities([
 ]);
 elgg_pop_context();
 
-$new_link = elgg_view('output/url', [
-	'href' => elgg_generate_url('add:object:file', ['guid' => $group->guid]),
-	'text' => elgg_echo('add:object:file'),
-	'is_trusted' => true,
-]);
+$new_link = null;
+if ($group->canWriteToContainer(0, 'object', 'file')) {
+	$new_link = elgg_view('output/url', [
+		'href' => elgg_generate_url('add:object:file', ['guid' => $group->guid]),
+		'text' => elgg_echo('add:object:file'),
+		'is_trusted' => true,
+	]);
+}
 
 echo elgg_view('groups/profile/module', [
 	'title' => elgg_echo('collection:object:file:group'),

--- a/mod/pages/views/default/pages/group_module.php
+++ b/mod/pages/views/default/pages/group_module.php
@@ -35,11 +35,14 @@ $content = elgg_list_entities([
 
 elgg_pop_context();
 
-$new_link = elgg_view('output/url', [
-	'href' => elgg_generate_url('add:object:page', ['guid' => $group->guid]),
-	'text' => elgg_echo('add:object:page'),
-	'is_trusted' => true,
-]);
+$new_link = null;
+if ($group->canWriteToContainer(0, 'object', 'page')) {
+	$new_link = elgg_view('output/url', [
+		'href' => elgg_generate_url('add:object:page', ['guid' => $group->guid]),
+		'text' => elgg_echo('add:object:page'),
+		'is_trusted' => true,
+	]);
+}
 
 echo elgg_view('groups/profile/module', [
 	'title' => elgg_echo('collection:object:page:group'),


### PR DESCRIPTION
Groups modules now respect subtype specific container permissions within the
group. Previously, only a generic canWriteToContainer() was called from the
wrapper module view, which creates an odd situation with links shown, while
permissions not being granted in a custom group environment