### PR TITLE
feat(core): persistent login table records get removed after expiration

### DIFF
--- a/docs/design/security.rst
+++ b/docs/design/security.rst
@@ -66,6 +66,9 @@ the code in the cookies table, the corresponding user is automatically logged in
 
 When a user changes their password all existing permanent cookie codes are removed from the database.
 
+The lifetime of the persistent cookie can be controlled in the `/elgg-config/settings.php` file. The default lifetime is 30 days. The database records
+for the persistent cookies will be removed after the lifetime expired.
+
 Alternative authentication
 ==========================
 

--- a/engine/classes/Elgg/I18n/Translator.php
+++ b/engine/classes/Elgg/I18n/Translator.php
@@ -541,8 +541,6 @@ class Translator {
 		// Ensure that all possible translations are loaded
 		$this->reloadAllTranslations();
 
-		$language = sanitise_string($language);
-
 		$en = count($this->translations['en']);
 
 		$missing = $this->getMissingLanguageKeys($language);

--- a/engine/classes/ElggUser.php
+++ b/engine/classes/ElggUser.php
@@ -548,4 +548,17 @@ class ElggUser extends \ElggEntity
 
 		parent::invalidateCache();
 	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	public function delete($recursive = true) {
+		$result = parent::delete($recursive);
+		if ($result) {
+			// cleanup remember me cookie records
+			_elgg_services()->persistentLogin->removeAllHashes($this);
+		}
+		
+		return $result;
+	}
 }

--- a/engine/tests/phpunit/integration/Elgg/PersistentLoginServiceIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/PersistentLoginServiceIntegrationTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Elgg;
+
+use Elgg\Database\Update;
+
+class PersistentLoginServiceIntegrationTest extends IntegrationTestCase {
+	
+	/**
+	 * @var PersistentLoginService
+	 */
+	protected $service;
+	
+	/**
+	 * @var \ElggUser
+	 */
+	protected $user;
+	
+	/**
+	 * @var \ElggCookie
+	 */
+	protected $cookie;
+	
+	public function up() {
+		$this->service = _elgg_services()->persistentLogin;
+		$this->service->_callable_elgg_set_cookie = [$this, 'setCookie'];
+		
+		$this->user = $this->createUser();
+	}
+	
+	public function down() {
+		
+		$this->user->delete();
+		
+		unset($this->cookie);
+	}
+	
+	
+	public function testMakePersistentLogin() {
+		$user = $this->user;
+		$service = $this->service;
+		
+		$this->assertEmpty($this->cookie);
+		
+		$service->makeLoginPersistent($user);
+		
+		$this->assertInstanceOf(\ElggCookie::class, $this->cookie);
+		
+		$token = $this->cookie->value;
+		$this->assertNotEmpty($token);
+		
+		$hash = $this->hashToken($token);
+		$persistent_user = $service->getUserFromHash($hash);
+		
+		$this->assertEquals($user, $persistent_user);
+	}
+	
+	public function testRemovePersistentLogin() {
+		$user = $this->user;
+		$service = $this->service;
+		
+		$this->assertEmpty($this->cookie);
+		
+		$token = $this->makePersistentLoginToken($user);
+		
+		$new_service = $this->getServiceBasedOnCookie($token);
+		
+		$new_service->removePersistentLogin();
+		
+		$this->assertInstanceOf(\ElggCookie::class, $this->cookie);
+		$this->assertEmpty($this->cookie->value);
+		$this->assertLessThan(time(), $this->cookie->expire);
+		
+		$hash = $this->hashToken($token);
+		$this->assertNull($service->getUserFromHash($hash));
+	}
+	
+	public function testHandlePasswordChange() {
+		$user = $this->user;
+		$service = $this->service;
+		
+		$this->assertEmpty($this->cookie);
+		
+		$token = $this->makePersistentLoginToken($user);
+		
+		$service->handlePasswordChange($user);
+		
+		$hash = $this->hashToken($token);
+		$this->assertNull($service->getUserFromHash($hash));
+	}
+	
+	public function testUpdateTokenUsage() {
+		$user = $this->user;
+		$service = $this->service;
+		
+		$this->assertEmpty($this->cookie);
+		
+		$token = $this->makePersistentLoginToken($user);
+		
+		$new_service = $this->getServiceBasedOnCookie($token);
+		
+		$this->assertTrue($new_service->updateTokenUsage($user));
+	}
+	
+	public function testRemoveAllHashes() {
+		
+		$user = $this->user;
+		$service = $this->service;
+		
+		// generate mulitple tokens to test
+		$tokens = [];
+		for ($i = 0; $i <= 5; $i++) {
+			$tokens[] = $this->makePersistentLoginToken($user);
+		}
+		
+		$different_user = $this->createUser();
+		
+		$remaining_token = $this->makePersistentLoginToken($different_user);
+		
+		$service->removeAllHashes($user);
+		
+		foreach ($tokens as $token) {
+			$hash = $this->hashToken($token);
+			$this->assertNull($service->getUserFromHash($hash));
+		}
+		
+		$remaining_hash = $this->hashToken($remaining_token);
+		$this->assertEquals($different_user, $service->getUserFromHash($remaining_hash));
+		
+		$different_user->delete();
+	}
+	
+	public function testRemoveExpiredTokens() {
+		
+		$user = $this->user;
+		$service = $this->service;
+		
+		// generate mulitple tokens to test
+		$tokens = [];
+		$hashes = [];
+		for ($i = 0; $i <= 5; $i++) {
+			$token = $this->makePersistentLoginToken($user);
+			$tokens[] = $token;
+			$hashes[] = $this->hashToken($token);
+		}
+		
+		// manually setting timestamp to a lower value in order for cleanup to work correctly
+		// as there is no way to manipulate the timestamp during insertion
+		// and cleanup prevents using a future timestamp as offset
+		$qb = Update::table('users_remember_me_cookies');
+		$qb->set('timestamp', 12345)
+			->where($qb->compare('code', 'IN', '"' . implode('", "', $hashes) . '"'));
+		_elgg_services()->db->updateData($qb);
+			
+		$service->removeExpiredTokens(time());
+		
+		foreach ($tokens as $token) {
+			$hash = $this->hashToken($token);
+			$this->assertNull($service->getUserFromHash($hash));
+		}
+		
+		// again with different time offset
+		// generate mulitple tokens to test
+		$tokens = [];
+		for ($i = 0; $i <= 5; $i++) {
+			$tokens[] = $this->makePersistentLoginToken($user);
+		}
+		
+		$service->removeExpiredTokens(time());
+		
+		foreach ($tokens as $token) {
+			$hash = $this->hashToken($token);
+			$this->assertNotNull($service->getUserFromHash($hash));
+		}
+	}
+	
+	public function setCookie(\ElggCookie $cookie) {
+		$this->cookie = $cookie;
+	}
+	
+	/**
+	 * Create a service with a set cookie token in order to perform certain actions
+	 *
+	 * @param string $cookie_token a permanent cookie token (usualy comes from an actual cookie)
+	 *
+	 * @return \Elgg\PersistentLoginService
+	 */
+	protected function getServiceBasedOnCookie($cookie_token) {
+		
+		// create a service with correct cookie so we can remove it correctly
+		$global_cookies_config = _elgg_services()->config->getCookieConfig();
+		$cookie_config = $global_cookies_config['remember_me'];
+		
+		$service = new PersistentLoginService(
+			_elgg_services()->db,
+			_elgg_services()->session,
+			_elgg_services()->crypto,
+			$cookie_config,
+			$cookie_token
+		);
+		
+		$service->_callable_elgg_set_cookie = [$this, 'setCookie'];
+		
+		return $service;
+	}
+	
+	/**
+	 * Helper function to create a cookie token for testing
+	 *
+	 * @param \ElggUser $user user to create token for
+	 *
+	 * @return string
+	 */
+	protected function makePersistentLoginToken(\ElggUser $user) {
+		$service = $this->service;
+		
+		$service->makeLoginPersistent($user);
+		
+		$this->assertInstanceOf(\ElggCookie::class, $this->cookie);
+		
+		$token = $this->cookie->value;
+		$this->assertNotEmpty($token);
+		
+		return $token;
+	}
+	
+	/**
+	 * Hash a cookie token in order to be able to perform DB tasks
+	 *
+	 * @see \Elgg\PersistentLoginService::hashToken()
+	 *
+	 * @param string $token a cookie token to transform
+	 *
+	 * @return string
+	 */
+	protected function hashToken($token) {
+		return md5($token);
+	}
+}

--- a/engine/tests/phpunit/unit/Elgg/PersistentLoginUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/PersistentLoginUnitTest.php
@@ -319,6 +319,14 @@ class PersistentLoginUnitTest extends \Elgg\UnitTestCase {
 		
 		$this->assertTrue($this->svc->removeExpiredTokens(time()));
 	}
+	
+	function testRemoveAllHashes() {
+		$this->dbMock->expects($this->once())
+				->method('deleteData')
+				->will($this->returnCallback([$this, 'mock_deleteAll']));
+		
+		$this->svc->removeAllHashes($this->user123);
+	}
 
 	// mock \ElggUser which will return the GUID on ->guid reads
 	function getMockElggUser($guid) {

--- a/engine/tests/phpunit/unit/Elgg/PersistentLoginUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/PersistentLoginUnitTest.php
@@ -72,11 +72,7 @@ class PersistentLoginUnitTest extends \Elgg\UnitTestCase {
 		$this->dbMock = $this->getMockBuilder('\Elgg\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		// use addslashes as ->sanitizeString (my local CLI doesn't have MySQL)
-		$this->dbMock->expects($this->any())
-			->method('sanitizeString')
-			->will($this->returnCallback(array($this, 'mock_sanitizeString')));
-
+		
 		$this->cryptoMock = $this->getMockBuilder('\ElggCrypto')
 			->getMock();
 		$this->cryptoMock->expects($this->any())
@@ -287,6 +283,42 @@ class PersistentLoginUnitTest extends \Elgg\UnitTestCase {
 		$this->assertSame($this->mockToken, $this->lastCookieSet->value);
 		$this->assertSame($this->mockToken, $this->session->get('code'));
 	}
+	
+	function testUpdateTokenUsageWithoutCookie() {
+		$this->assertNull($this->svc->updateTokenUsage($this->user123));
+	}
+	
+	function testUpdateTokenUsageWithWrongUser() {
+		$this->svc = $this->getSvcWithCookie($this->mockToken);
+		
+		$wrong_user = $this->createUser();
+		
+		$this->dbMock->expects($this->once())
+				->method('updateData')
+				->will($this->returnCallback([$this, 'mock_updateWrongUser']));
+		
+		$this->assertFalse($this->svc->updateTokenUsage($wrong_user));
+	}
+	
+	function testUpdateTokenUsageWithCorrectUser() {
+		$this->svc = $this->getSvcWithCookie($this->mockToken);
+		
+		$this->dbMock->expects($this->once())
+				->method('updateData')
+				->will($this->returnCallback([$this, 'mock_updateCorrectUser']));
+		
+		$this->assertTrue($this->svc->updateTokenUsage($this->user123));
+		
+		$this->assertSame($this->mockToken, $this->lastCookieSet->value);
+	}
+	
+	function testRemoveExpiredTokens() {
+		$this->dbMock->expects($this->once())
+				->method('deleteData')
+				->will($this->returnCallback([$this, 'mock_deleteExpiredTokens']));
+		
+		$this->assertTrue($this->svc->removeExpiredTokens(time()));
+	}
 
 	// mock \ElggUser which will return the GUID on ->guid reads
 	function getMockElggUser($guid) {
@@ -315,11 +347,6 @@ class PersistentLoginUnitTest extends \Elgg\UnitTestCase {
 		$this->timeSlept = $seconds;
 	}
 
-	function mock_sanitizeString($string) {
-		// no need for dependence on MySQL here
-		return addslashes($string);
-	}
-
 	/**
 	 * @param string $cookie_token
 	 * @return \Elgg\PersistentLoginService
@@ -345,26 +372,68 @@ class PersistentLoginUnitTest extends \Elgg\UnitTestCase {
 		return $svc;
 	}
 
-	function mock_insertData($sql) {
-		$this->assertContains("INSERT INTO users_remember_me_cookies", $sql);
-		$this->assertContains("VALUES ('{$this->mockHash}', 123,", $sql);
+	function mock_insertData($sql, $params) {
+		$pattern = '~INSERT INTO users_remember_me_cookies \(code, guid, timestamp\)\\s+VALUES \(:hash, :guid, :time\)~';
+		$this->assertRegExp($pattern, $sql);
+		$this->assertArraySubset([
+			':guid' => 123,
+			':hash' => $this->mockHash,
+		], $params);
 	}
 
-	function mock_deleteData($sql) {
-		$pattern = "~DELETE FROM users_remember_me_cookies\\s+WHERE code = '{$this->mockHash}'~";
-		$this->assertSame(1, preg_match($pattern, $sql));
+	function mock_deleteData($sql, $params) {
+		$pattern = '~DELETE FROM users_remember_me_cookies\\s+WHERE code = :hash~';
+		$this->assertRegExp($pattern, $sql);
+		$this->assertEquals([
+			':hash' => $this->mockHash,
+		], $params);
 	}
 
-	function mock_getDataRow($sql) {
-		$pattern = "~SELECT guid FROM users_remember_me_cookies\\s+WHERE code = '{$this->mockHash}'~";
-		$this->assertSame(1, preg_match($pattern, $sql));
+	function mock_getDataRow($sql, $callback, $params) {
+		$pattern = '~SELECT guid\\s+FROM users_remember_me_cookies\\s+WHERE code = :hash~';
+		$this->assertRegExp($pattern, $sql);
+		$this->assertEquals([
+			':hash' => $this->mockHash,
+		], $params);
 
 		return (object) array('guid' => 123);
 	}
 
-	function mock_deleteAll($sql) {
-		$pattern = "~DELETE FROM users_remember_me_cookies\\s+WHERE guid = '123'+~";
-		$this->assertSame(1, preg_match($pattern, $sql));
+	function mock_deleteAll($sql, $params) {
+		$pattern = '~DELETE FROM users_remember_me_cookies\\s+WHERE guid = :guid~';
+		$this->assertRegExp($pattern, $sql);
+		$this->assertEquals([
+			':guid' => 123,
+		], $params);
 	}
 
+	function mock_updateWrongUser($sql, $get_num_rows, $params) {
+		$pattern = '~UPDATE users_remember_me_cookies\\s+SET timestamp = :time\\s+WHERE guid = :guid\\s+AND code = :hash~';
+		$this->assertRegExp($pattern, $sql);
+		$this->assertArraySubset([
+			':hash' => $this->mockHash,
+		], $params);
+		$this->assertNotContains($params, [
+			':guid' => 123,
+		]);
+	}
+	
+	function mock_updateCorrectUser($sql, $get_num_rows, $params) {
+		$pattern = '~UPDATE users_remember_me_cookies\\s+SET timestamp = :time\\s+WHERE guid = :guid\\s+AND code = :hash~';
+		$this->assertRegExp($pattern, $sql);
+		$this->assertArraySubset([
+			':guid' => 123,
+			':hash' => $this->mockHash,
+		], $params);
+		
+		return 1;
+	}
+	
+	function mock_deleteExpiredTokens($sql, $params) {
+		$pattern = '~DELETE FROM users_remember_me_cookies\\s+WHERE timestamp < :time~';
+		$this->assertRegExp($pattern, $sql);
+		$this->assertArrayHasKey(':time', $params);
+		
+		return 1;
+	}
 }


### PR DESCRIPTION
The persistent login codes get removed from the database after the
corresponding cookie has expired.

EDIT:
also added cleanup of the remember_me table when a user gets removed