### PR TITLE
feat(events): align entity, extender and relationship events

### DIFF
--- a/docs/appendix/upgrade-notes/2.x-to-3.0.rst
+++ b/docs/appendix/upgrade-notes/2.x-to-3.0.rst
@@ -481,7 +481,7 @@ The user owned access collections are assumed to be used as Friends Collections 
 The groups access collection information was previously stored in the group_acl metadata. With the introduction of the ACL subtype
 this information has been moved to the ACL subtype attribute.
 
-The ``ACCESS_FRIENDS`` access_id has been migrated to an actual access collection (with the subtype ``friends``). All entities and annotations have been updated to use the new 
+The ``ACCESS_FRIENDS`` access_id has been migrated to an actual access collection (with the subtype ``friends``). All entities and annotations have been updated to use the new
 access collection id. The access collection is created when a user is created. When a relationship of the type ``friends`` is created, the related guid will
 also be added to the access collection. You can no longer save or update entities with the access id ``ACCESS_FRIENDS``.
 

--- a/docs/design/events.rst
+++ b/docs/design/events.rst
@@ -142,7 +142,7 @@ Example:
 
     // Register the function myPlugin_handle_create_object() to handle the
     // create object event with priority 400.
-    elgg_register_event_handler('create', 'object', 'myPlugin_handle_create_object', 400);
+    elgg_register_event_handler('create:after', 'object', 'myPlugin_handle_create_object', 400);
 
 .. warning::
 

--- a/docs/guides/events-list.rst
+++ b/docs/guides/events-list.rst
@@ -114,13 +114,19 @@ User events
 Relationship events
 ===================
 
-**create, relationship**
-    Triggered after a relationship has been created. Returning false deletes
-    the relationship that was just created.
+**create:before, relationship**
+    Triggered before a relationship is written to the database.
+	Return ``false`` to prevent the DB write.
 
-**delete, relationship**
-    Triggered before a relationship is deleted. Return false to prevent it
-    from being deleted.
+**create:after, relationship**
+    Triggered after a relationship is written to the database
+
+**delete:before, relationship**
+    Triggered before a relationship is deleted.
+    Return ``false`` to prevent it from being deleted.
+
+**delete:after, relationship**
+	Triggered after a relationship is deleted from the database.
 
 **join, group**
     Triggered after the user ``$params['user']`` has joined the group ``$params['group']``.
@@ -131,21 +137,31 @@ Relationship events
 Entity events
 =============
 
-**create, <entity type>**
-    Triggered for user, group, object, and site entities after creation. Return false to delete entity.
+**create:before, <entity type>**
+	Triggered before entity is written to the database and attributes are validated.
+	Handlers can use this hook to alter entity attributes.
+	Handlers can return ``false`` to stop an entity from being written to the database.
 
-**update, <entity type>**
-    Triggered before an update for the user, group, object, and site entities. Return false to prevent update.
-    The entity method ``getOriginalAttributes()`` can be used to identify which attributes have changed since
-    the entity was last saved.
+**create:after, <entity type>**
+	Triggered after an entity has been created.
+	Return from handlers is not honored.
+
+**update:before, <entity type>**
+	Triggered before updated entity properties have been written to the database.
+	Return ``false`` to prevent update.
+	The entity method ``getOriginalAttributes()`` can be used to identify which attributes have changed since
+	the entity was last saved.
 
 **update:after, <entity type>**
-    Triggered after an update for the user, group, object, and site entities.
-    The entity method ``getOriginalAttributes()`` can be used to identify which attributes have changed since
-    the entity was last saved.
+	Triggered after an update for the user, group, object, and site entities.
+	The entity method ``getOriginalAttributes()`` can be used to identify which attributes have changed since
+	the entity was last saved.
 
-**delete, <entity type>**
-    Triggered before entity deletion. Return false to prevent deletion.
+**delete:before, <entity type>**
+	Triggered before entity deletion. Return ``false`` to prevent deletion.
+
+**delete:after, <entity type>**
+	Triggered after the entity has been deleted.
 
 **disable, <entity type>**
     Triggered before the entity is disabled. Return false to prevent disabling.
@@ -162,15 +178,26 @@ Entity events
 Metadata events
 ===============
 
-**create, metadata**
-    Called after the metadata has been created. Return false to delete the
-    metadata that was just created.
+**create:before, metadata**
+    Called before metadata is written to the database.
+	Return ``false`` to prevent DB write.
 
-**update, metadata**
-    Called after the metadata has been updated. Return false to *delete the metadata.*
+**create:after, metadata**
+    Called after metadata is written to the database.
 
-**delete, metadata**
-    Called before metadata is deleted. Return false to prevent deletion.
+**update:before, metadata**
+    Called before updated metadata is written to the database.
+	Return ``false`` to prevent DB write.
+
+**update:after, metadata**
+	Called after metadata is written to the database.
+
+**delete:before, metadata**
+    Called before metadata is deleted from the database.
+    Return ``false`` to prevent deletion.
+
+**delete:after, metadata**
+	Called after metadata is deleted from the database.
 
 **enable, metadata**
 	Called when enabling metadata. Return false to prevent enabling.
@@ -181,19 +208,26 @@ Metadata events
 Annotation events
 =================
 
-**annotate, <entity type>**
-    Called before the annotation has been created. Return false to prevent
-    annotation of this entity.
+**create:before, annotation**
+    Called before annotation is written to the database.
+	Return ``false`` to prevent the DB write.
 
-**create, annotation**
-    Called after the annotation has been created. Return false to delete
-    the annotation.
+**create:after, annotation**
+    Called after annotation is written to the database.
 
-**update, annotation**
-    Called after the annotation has been updated. Return false to *delete the annotation.*
+**update:before, annotation**
+    Called before annotation is updated in the database.
+	Return ``false`` to prevent the DB write.
 
-**delete, annotation**
-    Called before annotation is deleted. Return false to prevent deletion.
+**update:after, annotation**
+	Called after annotation is updated in the database.
+
+**deleted:before, annotation**
+    Called before annotation is deleted the database.
+	Return ``false`` to prevent the deletion.
+
+**deleted:after, annotation**
+	Called after annotation is deleted from the database.
 
 **enable, annotation**
 	Called when enabling annotations. Return false to prevent enabling.

--- a/engine/classes/Elgg/Database/AnnotationsTable.php
+++ b/engine/classes/Elgg/Database/AnnotationsTable.php
@@ -75,7 +75,11 @@ class AnnotationsTable {
 			return false;
 		}
 
-		if (!$this->events->trigger('delete', 'annotation', $annotation)) {
+		if (!$this->events->triggerBefore('delete', 'annotation', $annotation)) {
+			return false;
+		}
+
+		if (!$this->events->triggerDeprecated('delete', 'annotation', $annotation)) {
 			return false;
 		}
 
@@ -88,6 +92,8 @@ class AnnotationsTable {
 				'annotation_id' => $annotation->id,
 				'limit' => false,
 			]);
+
+			$this->events->triggerAfter('delete', 'annotation', $annotation);
 		}
 
 		return $deleted !== false;
@@ -115,7 +121,7 @@ class AnnotationsTable {
 		//	return false;
 		//}
 
-		if (!$this->events->trigger('annotate', $entity->getType(), $entity)) {
+		if (!$this->events->triggerDeprecated('annotate', $entity->getType(), $entity)) {
 			return false;
 		}
 
@@ -144,7 +150,7 @@ class AnnotationsTable {
 		$annotation->id = $result;
 		$annotation->time_created = $time_created;
 
-		if (!$this->events->trigger('create', 'annotation', $annotation)) {
+		if (!$this->events->triggerDeprecated('create', 'annotation', $annotation)) {
 			elgg_delete_annotation_by_id($result);
 
 			return false;
@@ -189,7 +195,7 @@ class AnnotationsTable {
 			return false;
 		}
 
-		$this->events->trigger('update', 'annotation', $annotation);
+		$this->events->triggerDeprecated('update', 'annotation', $annotation);
 		$this->events->triggerAfter('update', 'annotation', $annotation);
 
 		return $result;

--- a/engine/classes/ElggAnnotation.php
+++ b/engine/classes/ElggAnnotation.php
@@ -46,6 +46,8 @@ class ElggAnnotation extends \ElggExtender {
 			$this->owner_guid = _elgg_services()->session->getLoggedInUserGuid();
 		}
 
+		$this->access_id = $this->normalizeAccessId($this->access_id, $this->owner_guid);
+
 		if ($this->id) {
 			return _elgg_services()->annotationsTable->update($this);
 		}

--- a/engine/classes/ElggData.php
+++ b/engine/classes/ElggData.php
@@ -16,6 +16,7 @@ abstract class ElggData implements CollectionItemInterface,
 								   ArrayAccess {
 
 	use \Elgg\TimeUsing;
+	use \Elgg\Loggable;
 
 	/**
 	 * The main attributes of an entity.
@@ -256,5 +257,41 @@ abstract class ElggData implements CollectionItemInterface,
 	 */
 	public function unserialize($serialized) {
 		$this->attributes = unserialize($serialized);
+	}
+
+	/**
+	 * Resolve a magic constant to an actual access level
+	 *
+	 * @param int  $access_id  Access ID
+	 * @param null $owner_guid Owner guid
+	 *
+	 * @return int
+	 * @throws InvalidParameterException
+	 *
+	 * @internal
+	 * @access private
+	 */
+	protected function normalizeAccessId($access_id, $owner_guid = null) {
+		switch ($access_id) {
+			case ACCESS_DEFAULT :
+				throw new InvalidParameterException('ACCESS_DEFAULT is not a valid access level. See its documentation in constants.php');
+
+			case ACCESS_FRIENDS :
+				$owner = get_entity($owner_guid);
+
+				$acl = false;
+				if ($owner instanceof ElggUser) {
+					$acl = $owner->getOwnedAccessCollection('friends');
+				}
+
+				if (!$acl) {
+					throw new InvalidParameterException('ACCESS_FRIENDS is not a valid access level. See its documentation in constants.php');
+				}
+
+				return $acl->getId();
+
+			default :
+				return $access_id;
+		}
 	}
 }

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1301,30 +1301,42 @@ abstract class ElggEntity extends \ElggData implements
 	}
 
 	/**
-	 * Save an entity.
+	 * Save an entity
 	 *
 	 * @return bool|int
+	 * @throws \Elgg\EntityPermissionsException
 	 */
 	public function save() {
-		$guid = $this->guid;
-		if ($guid > 0) {
-			$guid = $this->update();
-		} else {
-			$guid = $this->create();
-			if ($guid && !_elgg_services()->events->trigger('create', $this->type, $this)) {
-				// plugins that return false to event don't need to override the access system
-				elgg_call(ELGG_IGNORE_ACCESS, function() {
-					return $this->delete();
-				});
-				return false;
+		try {
+			$guid = $this->guid;
+
+			if ($guid > 0) {
+				$guid = $this->update();
+
+				if (!$guid) {
+					// Restore original attributes
+					foreach ($this->orig_attributes as $key => $value) {
+						$this->attributes[$key] = $value;
+					}
+
+					$this->orig_attributes = [];
+				}
+			} else {
+				$guid = $this->create();
 			}
-		}
 
-		if ($guid) {
-			$this->cache();
-		}
+			if ($guid) {
+				$this->cache();
+			}
 
-		return $guid;
+			return $guid;
+		} catch (Exception $ex) {
+			// All kinds of exceptions are thrown all over the place,
+			// so let's just log and give generic feedback to the user via router
+			$this->log(\Psr\Log\LogLevel::ERROR, $ex);
+
+			throw new \Elgg\EntityPermissionsException(elgg_echo('save:fail'));
+		}
 	}
 
 	/**
@@ -1337,20 +1349,30 @@ abstract class ElggEntity extends \ElggData implements
 	 * or they will throw an exception when loaded.
 	 *
 	 * @return int The new entity's GUID
-	 * @throws InvalidParameterException If the entity's type has not been set.
+	 * @throws DatabaseException
 	 * @throws IOException If the new row fails to write to the DB.
+	 * @throws InvalidParameterException If the entity's type has not been set.
+	 * @throws \Elgg\EntityPermissionsException
+	 * @throws \Elgg\HttpException
 	 */
 	protected function create() {
 
 		$type = $this->attributes['type'];
 		if (!in_array($type, \Elgg\Config::getEntityTypes())) {
-			throw new \InvalidParameterException('Entity type must be one of the allowed types: '
-					. implode(', ', \Elgg\Config::getEntityTypes()));
+			throw new InvalidParameterException(
+				'Entity type must be one of the allowed types: '
+					. implode(', ', \Elgg\Config::getEntityTypes())
+			);
 		}
 
 		$subtype = $this->attributes['subtype'];
 		if (!$subtype) {
-			throw new \InvalidParameterException("All entities must have a subtype");
+			throw new InvalidParameterException("All entities must have a subtype");
+		}
+
+		if (!_elgg_services()->events->triggerBefore('create', $this->type, $this)) {
+			// Allow hooks to alter attributes and/or prevent further save
+			return false;
 		}
 
 		$owner_guid = (int) $this->attributes['owner_guid'];
@@ -1365,13 +1387,7 @@ abstract class ElggEntity extends \ElggData implements
 		}
 		$container_guid = (int) $container_guid;
 
-		if ($access_id == ACCESS_DEFAULT) {
-			throw new \InvalidParameterException('ACCESS_DEFAULT is not a valid access level. See its documentation in constants.php');
-		}
-		
-		if ($access_id == ACCESS_FRIENDS) {
-			throw new \InvalidParameterException('ACCESS_FRIENDS is not a valid access level. See its documentation in constants.php');
-		}
+		$access_id = $this->normalizeAccessId($access_id, $owner_guid);
 
 		$user_guid = _elgg_services()->session->getLoggedInUserGuid();
 
@@ -1379,17 +1395,19 @@ abstract class ElggEntity extends \ElggData implements
 		if ($owner_guid) {
 			$owner = $this->getOwnerEntity();
 			if (!$owner) {
-				_elgg_services()->logger->error("User $user_guid tried to create a ($type, $subtype), but the given"
-					. " owner $owner_guid could not be loaded.");
-				return false;
+				throw new \Elgg\EntityPermissionsException(
+					"User $user_guid tried to create a ($type, $subtype), but the given"
+					. " owner $owner_guid could not be loaded."
+				);
 			}
 
 			// If different owner than logged in, verify can write to container.
 
 			if ($user_guid != $owner_guid && !$owner->canEdit() && !$owner->canWriteToContainer($user_guid, $type, $subtype)) {
-				_elgg_services()->logger->error("User $user_guid tried to create a ($type, $subtype) with owner"
-					. " $owner_guid, but the user wasn't permitted to write to the owner's container.");
-				return false;
+				throw new \Elgg\EntityPermissionsException(
+					"User $user_guid tried to create a ($type, $subtype) with owner"
+					. " $owner_guid, but the user wasn't permitted to write to the owner's container."
+				);
 			}
 		}
 
@@ -1397,15 +1415,17 @@ abstract class ElggEntity extends \ElggData implements
 		if ($container_guid) {
 			$container = $this->getContainerEntity();
 			if (!$container) {
-				_elgg_services()->logger->error("User $user_guid tried to create a ($type, $subtype), but the given"
-					. " container $container_guid could not be loaded.");
-				return false;
+				throw new \Elgg\EntityPermissionsException(
+					"User $user_guid tried to create a ($type, $subtype), but the given"
+					. " container $container_guid could not be loaded."
+				);
 			}
 
 			if (!$container->canWriteToContainer($user_guid, $type, $subtype)) {
-				_elgg_services()->logger->error("User $user_guid tried to create a ($type, $subtype), but was not"
-					. " permitted to write to container $container_guid.");
-				return false;
+				throw new \Elgg\EntityPermissionsException(
+					"User $user_guid tried to create a ($type, $subtype), but was not"
+					. " permitted to write to container $container_guid."
+				);
 			}
 		}
 
@@ -1469,6 +1489,16 @@ abstract class ElggEntity extends \ElggData implements
 			$this->temp_private_settings = [];
 		}
 
+		if (!_elgg_services()->events->triggerDeprecated('create', $this->type, $this)) {
+			elgg_call(ELGG_IGNORE_ACCESS | ELGG_SHOW_DISABLED_ENTITIES, function() {
+				$this->delete();
+			});
+
+			return false;
+		}
+
+		_elgg_services()->events->triggerAfter('create', $this->type, $this);
+
 		return $guid;
 	}
 
@@ -1480,13 +1510,23 @@ abstract class ElggEntity extends \ElggData implements
 	 * @throws InvalidParameterException
 	 */
 	protected function update() {
+		if ($this->owner_guid == $this->guid) {
+			throw new LogicException('An entity can not own itself');
+		}
+
+		if ($this->container_guid == $this->guid) {
+			throw new LogicException('An entity can not contain itself');
+		}
 
 		if (!$this->canEdit()) {
 			return false;
 		}
 
-		// give old update event a chance to stop the update
-		if (!_elgg_services()->events->trigger('update', $this->type, $this)) {
+		if (!_elgg_services()->events->triggerBefore('update', $this->type, $this)) {
+			return false;
+		}
+
+		if (!_elgg_services()->events->triggerDeprecated('update', $this->type, $this)) {
 			return false;
 		}
 
@@ -1500,13 +1540,7 @@ abstract class ElggEntity extends \ElggData implements
 		$time_created = (int) $this->time_created;
 		$time = $this->getCurrentTime()->getTimestamp();
 
-		if ($access_id == ACCESS_DEFAULT) {
-			throw new \InvalidParameterException('ACCESS_DEFAULT is not a valid access level. See its documentation in constants.php');
-		}
-	
-		if ($access_id == ACCESS_FRIENDS) {
-			throw new \InvalidParameterException('ACCESS_FRIENDS is not a valid access level. See its documentation in constants.php');
-		}
+		$access_id = $this->normalizeAccessId($access_id, $owner_guid);
 
 		// Update primary table
 		$ret = _elgg_services()->entityTable->updateRow($guid, (object) [

--- a/engine/classes/ElggRelationship.php
+++ b/engine/classes/ElggRelationship.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Relationship class.
  *
@@ -12,23 +13,29 @@
  * @property int    $time_created A UNIX timestamp of when the relationship was created (read-only, set on first save)
  */
 class ElggRelationship extends \ElggData {
-	// database column limit
+
+	/**
+	 * Database column length
+	 */
 	const RELATIONSHIP_LIMIT = 50;
 
 	/**
 	 * Create a relationship object
 	 *
-	 * @param \stdClass $row Database row
-	 * @throws InvalidArgumentException
+	 * @param stdClass $row Database row
 	 */
-	public function __construct(\stdClass $row) {
+	public function __construct(stdClass $row = null) {
 		$this->initializeAttributes();
 
-		foreach ((array) $row as $key => $value) {
-			$this->attributes[$key] = $value;
-		}
+		if ($row) {
+			foreach ((array) $row as $key => $value) {
+				if (in_array($key, ['id', 'guid_one', 'guid_two', 'time_created'])) {
+					$value = (int) $value;
+				}
 
-		$this->attributes['id'] = (int) $this->attributes['id'];
+				$this->attributes[$key] = $value;
+			}
+		}
 	}
 
 	/**
@@ -75,25 +82,10 @@ class ElggRelationship extends \ElggData {
 	/**
 	 * Save the relationship
 	 *
-	 * @return int the relationship ID
-	 * @throws IOException
+	 * @return int|false
 	 */
 	public function save() {
-		if ($this->id > 0) {
-			delete_relationship($this->id);
-		}
-
-		$this->id = _elgg_services()->relationshipsTable->add(
-			$this->guid_one,
-			$this->relationship,
-			$this->guid_two,
-			true
-		);
-		if (!$this->id) {
-			throw new \IOException("Unable to save new " . get_class());
-		}
-
-		return $this->id;
+		return _elgg_services()->relationshipsTable->add($this);
 	}
 
 	/**
@@ -102,7 +94,7 @@ class ElggRelationship extends \ElggData {
 	 * @return bool
 	 */
 	public function delete() {
-		return delete_relationship($this->id);
+		return _elgg_services()->relationshipsTable->delete($this);
 	}
 
 	/**

--- a/engine/lib/relationships.php
+++ b/engine/lib/relationships.php
@@ -25,7 +25,12 @@ function get_relationship($id) {
  * @return bool
  */
 function delete_relationship($id) {
-	return _elgg_services()->relationshipsTable->delete($id);
+	$relationship = _elgg_services()->relationshipsTable->get($id);
+	if (!$relationship) {
+		return false;
+	}
+
+	return $relationship->delete();
 
 }
 
@@ -43,7 +48,13 @@ function delete_relationship($id) {
  * @throws InvalidArgumentException
  */
 function add_entity_relationship($guid_one, $relationship, $guid_two) {
-	return _elgg_services()->relationshipsTable->add($guid_one, $relationship, $guid_two);
+	$rel = new ElggRelationship();
+
+	$rel->guid_one = $guid_one;
+	$rel->relationship = $relationship;
+	$rel->guid_two = $guid_two;
+
+	return $rel->save();
 }
 
 /**

--- a/engine/tests/phpunit/integration/Elgg/Database/DataEventsTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Database/DataEventsTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Elgg\Database;
+
+use Elgg\Event;
+use Elgg\IntegrationTestCase;
+
+/**
+ * @group Database
+ * @group Events
+ */
+class DataEventsTest extends IntegrationTestCase {
+
+	public function up() {
+
+	}
+
+	public function down() {
+
+	}
+
+	public function testEntityLifecycleEventsAreCalled() {
+		$calls = [
+			'create:before' => 0,
+			'create' => 0,
+			'create:after' => 0,
+			'update:before' => 0,
+			'update' => 0,
+			'update:after' => 0,
+			'delete:before' => 0,
+			'delete' => 0,
+			'delete:after' => 0,
+		];
+
+		elgg_register_event_handler('all', 'object', function(Event $event) use (&$calls) {
+			$name = $event->getName();
+			if (isset($calls[$name])) {
+				$calls[$name]++;
+			}
+		});
+
+		elgg_call(ELGG_IGNORE_ACCESS, function() {
+			$object = $this->createObject();
+
+			$object->access_id = 5;
+			$object->save();
+
+			$object->delete();
+		});
+
+		foreach ($calls as $event => $count) {
+			$fail = "$event was triggered $count times instead of expected 1";
+			$this->assertEquals(1, $count, $fail);
+		}
+	}
+
+	public function testMetadataLifecycleEventsAreCalled() {
+		$calls = [
+			'create:before' => 0,
+			'create' => 0,
+			'create:after' => 0,
+			'update:before' => 0,
+			'update' => 0,
+			'update:after' => 0,
+			'delete:before' => 0,
+			'delete' => 0,
+			'delete:after' => 0,
+		];
+
+		$object = $this->createObject();
+
+		elgg_register_event_handler('all', 'metadata', function(Event $event) use (&$calls) {
+			$name = $event->getName();
+			if (isset($calls[$name])) {
+				$calls[$name]++;
+			}
+		});
+
+		elgg_call(ELGG_IGNORE_ACCESS, function() use ($object) {
+			$metadata = new \ElggMetadata();
+			$metadata->name = 'foo';
+			$metadata->value = 'bar';
+			$metadata->entity_guid = $object->guid;
+
+			$metadata->save();
+
+			$metadata->value = 'bar1';
+			$metadata->save();
+
+			$metadata->delete();
+		});
+
+		foreach ($calls as $event => $count) {
+			$fail = "$event was triggered $count times instead of expected 1";
+			$this->assertEquals(1, $count, $fail);
+		}
+	}
+
+	public function testAnnotationLifecycleEventsAreCalled() {
+		$calls = [
+			'create:before' => 0,
+			'create' => 0,
+			'create:after' => 0,
+			'update:before' => 0,
+			'update' => 0,
+			'update:after' => 0,
+			'delete:before' => 0,
+			'delete' => 0,
+			'delete:after' => 0,
+		];
+
+		$object = $this->createObject();
+
+		elgg_register_event_handler('all', 'annotation', function(Event $event) use (&$calls) {
+			$name = $event->getName();
+			if (isset($calls[$name])) {
+				$calls[$name]++;
+			}
+		});
+
+		elgg_call(ELGG_IGNORE_ACCESS, function() use ($object) {
+			$ann = new \ElggAnnotation();
+			$ann->name = 'foo';
+			$ann->value = 'bar';
+			$ann->entity_guid = $object->guid;
+			$ann->access_id = ACCESS_PRIVATE;
+
+			$ann->save();
+
+			$ann->value = 'bar1';
+			$ann->access_id = ACCESS_PUBLIC;
+			$ann->save();
+
+			$ann->delete();
+		});
+
+		foreach ($calls as $event => $count) {
+			$fail = "$event was triggered $count times instead of expected 1";
+			$this->assertEquals(1, $count, $fail);
+		}
+	}
+
+	public function testRelationshipLifecycleEventsAreCalled() {
+		$calls = [
+			'create:before' => 0,
+			'create' => 0,
+			'create:after' => 0,
+			'delete:before' => 0,
+			'delete' => 0,
+			'delete:after' => 0,
+		];
+
+		$object = $this->createObject();
+		$subject = $object->getOwnerEntity();
+
+		elgg_register_event_handler('all', 'relationship', function(Event $event) use (&$calls) {
+			$name = $event->getName();
+			if (isset($calls[$name])) {
+				$calls[$name]++;
+			}
+		});
+
+		elgg_call(ELGG_IGNORE_ACCESS, function() use ($object, $subject) {
+			$rel = new \ElggRelationship();
+			$rel->guid_one = $object->guid;
+			$rel->relationship = 'belongs';
+			$rel->guid_two = $subject->guid;
+
+			$rel->save();
+
+			$rel->delete();
+		});
+
+		foreach ($calls as $event => $count) {
+			$fail = "$event was triggered $count times instead of expected 1";
+			$this->assertEquals(1, $count, $fail);
+		}
+	}
+
+}

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreObjectTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreObjectTest.php
@@ -234,12 +234,10 @@ class ElggCoreObjectTest extends \Elgg\LegacyIntegrationTestCase {
 		$obj = new \ElggObject();
 		$obj->subtype = $this->getRandomSubtype();
 		$obj->save();
-		$obj->owner_guid = $obj->guid;
-		$obj->save();
 
 		$q = "SELECT * FROM {$db_prefix}entities WHERE guid = $obj->guid";
 		$r = get_data_row($q);
-		$this->assertEqual($obj->guid, $r->owner_guid);
+		$this->assertEqual($obj->owner_guid, $r->owner_guid);
 
 		$this->assertTrue($obj->delete(true));
 

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggRelationshipTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggRelationshipTest.php
@@ -8,6 +8,7 @@ use ElggObject;
 
 /**
  * @group IntegrationTests
+ * @group EntityRelationships
  */
 class ElggRelationshipTest extends LegacyIntegrationTestCase {
 
@@ -114,22 +115,10 @@ class ElggRelationshipTest extends LegacyIntegrationTestCase {
 		$this->assertTrue(add_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
 		$r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid);
 		$this->assertInstanceOf(\ElggRelationship::class, $r);
-		$old_id = $r->id;
 
 		// note - string because that's how it's returned when getting a new object
 		$r->guid_two = (string) $this->entity3->guid;
-		$new_id = $r->save();
-		$this->assertInternalType('integer', $new_id);
-		$this->assertNotEqual($new_id, $old_id);
-
-		$test_r = check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity3->guid);
-		$this->assertInstanceOf(\ElggRelationship::class, $test_r);
-		$this->assertIdentical($r->guid_one, $test_r->guid_one);
-		$this->assertIdentical($r->guid_two, $test_r->guid_two);
-		$this->assertIdentical($r->relationship, $test_r->relationship);
-
-		// the original shouldn't exist anymore
-		$this->assertFalse(check_entity_relationship($this->entity1->guid, 'test_relationship', $this->entity2->guid));
+		$this->assertFalse($r->save());
 	}
 
 	public function testRelationshipDelete() {

--- a/engine/tests/simpletest/ElggCoreObjectTest.php
+++ b/engine/tests/simpletest/ElggCoreObjectTest.php
@@ -225,12 +225,10 @@ class ElggCoreObjectTest extends \ElggCoreUnitTest {
 		$obj = new \ElggObject();
 		$obj->subtype = $this->getRandomSubtype();
 		$obj->save();
-		$obj->owner_guid = $obj->guid;
-		$obj->save();
 
 		$q = "SELECT * FROM {$db_prefix}entities WHERE guid = $obj->guid";
 		$r = get_data_row($q);
-		$this->assertEqual($obj->guid, $r->owner_guid);
+		$this->assertEqual($obj->owner_guid, $r->owner_guid);
 
 		$this->assertTrue($obj->delete(true));
 


### PR DESCRIPTION
Entities, metadata, annotations and relationships are now consistent in their
lifecycle events. To avoid confusion, create, update and delete events have been
deprecated, instead plugins should use create:before, create:after, update:before
, update:after, delete:before and delete:after events.
This also eliminates the bad practice of deleting rows from database right after
they have been created, should a handler return false.

Also updates entity save operations to throw HttpExceptions when problems occur.
Failed entity update now resets entity attributes to their originals.

Fixes #11201
Fixes #9033
Fixes #7997

- [ ] Update core uses of lifecycle events
- [ ] Don't use create event for notification triggers, add `publish` event instead, which will allow plugins to implement publishing workflows, e.g. admin approval