### PR TITLE
fix(developers): prevent 'view not found' deadloops

### DIFF
--- a/mod/developers/classes/Elgg/DevelopersPlugin/ErrorLogHtmlFormatter.php
+++ b/mod/developers/classes/Elgg/DevelopersPlugin/ErrorLogHtmlFormatter.php
@@ -36,7 +36,12 @@ class ErrorLogHtmlFormatter extends HtmlFormatter {
 	 * @return mixed The formatted record
 	 */
 	public function format(array $record) {
-
+		
+		if (elgg_get_viewtype() !== 'default') {
+			// prevent 'view not found' deadloops in other viewtypes (eg failsafe)
+			return parent::format($record);
+		}
+		
 		$context = elgg_extract('context', $record, []);
 		$exception = elgg_extract('exception', $context);
 		


### PR DESCRIPTION
When the viewtype isn't 'default' some of the error reporting views are
missing, which cause an error to be logged, etc.