### PR TITLE
feat(cache): boost metadata cache

### DIFF
--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -648,6 +648,8 @@ class EntityTable {
 
 		_elgg_services()->events->triggerAfter('delete', $entity->type, $entity);
 
+		$entity->invalidateCache();
+
 		return true;
 	}
 

--- a/engine/classes/ElggMetadata.php
+++ b/engine/classes/ElggMetadata.php
@@ -73,7 +73,12 @@ class ElggMetadata extends ElggExtender {
 	 * @return bool
 	 */
 	public function delete() {
-		return _elgg_services()->metadataTable->delete($this);
+		if (_elgg_services()->metadataTable->delete($this)) {
+			_elgg_services()->metadataCache->clear($this->entity_guid);
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/engine/lib/metadata.php
+++ b/engine/lib/metadata.php
@@ -31,6 +31,7 @@ function elgg_delete_metadata_by_id($id) {
 	if (!$metadata) {
 		return false;
 	}
+
 	return $metadata->delete();
 }
 

--- a/engine/tests/classes/Elgg/BaseTestCase.php
+++ b/engine/tests/classes/Elgg/BaseTestCase.php
@@ -11,6 +11,7 @@ use Elgg\Plugins\PluginTesting;
 use Elgg\Project\Paths;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
+use Stash\Driver\FileSystem\NativeEncoder;
 
 /**
  * Base test case abstraction
@@ -301,12 +302,12 @@ abstract class BaseTestCase extends TestCase implements Seedable, Testable {
 	 * {@inheritdoc}
 	 */
 	public static function assertEquals($expected, $actual, $message = '', $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false) {
-		if ($expected instanceof \ElggData) {
-			$expected = $expected->toObject();
+		if ($expected instanceof \Serializable) {
+			$expected = serialize($expected);
 		}
 
-		if ($actual instanceof \ElggData) {
-			$actual = $actual->toObject();
+		if ($actual instanceof \Serializable) {
+			$actual = serialize($actual);
 		}
 
 		parent::assertEquals($expected, $actual, $message, $delta, $maxDepth, $canonicalize, $ignoreCase);

--- a/engine/tests/classes/Elgg/Mocks/Database/MetadataTable.php
+++ b/engine/tests/classes/Elgg/Mocks/Database/MetadataTable.php
@@ -89,7 +89,7 @@ class MetadataTable extends DbMetadataTabe {
 	 */
 	public function getAll(array $options = array()) {
 		$guids = elgg_extract('guids', $options, (array) elgg_extract('guid', $options));
-		
+
 		$rows = [];
 		foreach ($this->rows as $id => $row) {
 			if (empty($guids) || in_array($row->entity_guid, $guids)) {


### PR DESCRIPTION
Metadata cache is no longer wiped whenever entity metadata is
create, updated or deleted. Instead updated values are added to
cache, hence no new DB query needed to load all metadata again