### PR TITLE
fix(qb): search_name_value_pairs now work as expected

### DIFF
--- a/engine/lib/entities.php
+++ b/engine/lib/entities.php
@@ -223,6 +223,10 @@ function elgg_get_site_entity() {
  *
  * In addition to metadata name value pairs, you can specify search pair, which will be merged using OR boolean
  * and will filter entities regardless of metadata name value pairs and their operator
+ * @warning During normalization, search name value pairs will ignore properties under metadata_ namespace, that is
+ *          you can not use metadata_ids, metadata_created_before, metadata_created_after, metadata_case_sensitive
+ *          to constrain search pairs. You will need to pass these properties for each individual search pair,
+ *          as seen in the example below
  *
  * @option array                $search_name_value_pairs
  *
@@ -253,10 +257,13 @@ function elgg_get_site_entity() {
  *       'case_sensitive' => false,
  *    ],
  *    [
+ *       // 'ids' => [55, 56, 57, 58, 59, 60], // only search these 5 metadata rows
  *       'name' => 'tags',
  *       'value' => '%world%',
  *       'operand' => 'LIKE',
  *       'case_sensitive' => false,
+ *       'created_after' => '-1 day',
+ *       'created_before' => 'now',
  *    ],
  * ];
  * </code>

--- a/engine/tests/phpunit/unit/Elgg/Database/QueryOptionsTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Database/QueryOptionsTest.php
@@ -92,6 +92,8 @@ class QueryOptionsTest extends UnitTestCase {
 		$this->assertEquals([0], $options['owner_guids']);
 	}
 
+	/* ACCESS */
+	
 	public function testNormalizesAccessOptions() {
 		$options = $this->options->normalizeOptions([
 			'access_id' => ['1', 2],
@@ -99,6 +101,8 @@ class QueryOptionsTest extends UnitTestCase {
 
 		$this->assertEquals([1, 2], $options['access_ids']);
 	}
+	
+	/* TYPE SUBTYPE PAIRS */
 
 	public function testNormalizesTypeSubtypeOptionsFromTypeSubtypeSingulars() {
 		$options = $this->options->normalizeOptions([
@@ -181,6 +185,8 @@ class QueryOptionsTest extends UnitTestCase {
 		$this->assertNotEmpty($messages);
 	}
 
+	/* METADATA PAIRS */
+	
 	public function testNormalizesMetadataOptionsFromSingulars() {
 
 		$options = $this->options->normalizeOptions([
@@ -492,6 +498,190 @@ class QueryOptionsTest extends UnitTestCase {
 		$this->assertEquals($options, $this->options->normalizeOptions($options));
 
 	}
+
+	/* METADATA SEARCH PAIRS */
+
+	public function testNormalizesSearchMetadataOptionsFromTimeOptionsWithNestedPair() {
+
+		$options = $this->options->normalizeOptions([
+			'search_name_value_pair' => [
+				['status' => 'draft']
+			],
+		]);
+
+		$this->assertEquals(1, count($options['search_name_value_pairs']));
+
+		$pair = array_shift($options['search_name_value_pairs']);
+
+		$this->assertInstanceOf(MetadataWhereClause::class, $pair);
+		$this->assertEquals(['status'], $pair->names);
+		$this->assertEquals(['draft'], $pair->values);
+	}
+
+	public function testNormalizesSearchMetadataOptionsFromTimeOptionsForMultiplePairs() {
+
+		$options = $this->options->normalizeOptions([
+			'search_name_value_pair' => [
+				'status' => 'draft',
+				'category' => ['foo', 'bar'],
+			],
+		]);
+
+		$this->assertEquals(2, count($options['search_name_value_pairs']));
+
+		$pair = array_shift($options['search_name_value_pairs']);
+
+		$this->assertInstanceOf(MetadataWhereClause::class, $pair);
+		$this->assertEquals(['status'], $pair->names);
+		$this->assertEquals(['draft'], $pair->values);;
+
+		$pair = array_shift($options['search_name_value_pairs']);
+
+		$this->assertInstanceOf(MetadataWhereClause::class, $pair);
+		$this->assertEquals(['category'], $pair->names);
+		$this->assertEquals(['foo', 'bar'], $pair->values);
+
+	}
+
+	public function testNormalizesSearchMetadataOptionsForMultiplePairs() {
+
+		$after = (new \DateTime())->modify('-1 day');
+		$before = (new \DateTime());
+
+		$options = $this->options->normalizeOptions([
+			'guid' => 1,
+			'search_name_value_pairs' => [
+				'status' => 'draft',
+				'category' => ['foo', 'bar'],
+				[
+					'name' => 'priority',
+					'value' => ['100', '200'],
+					'operand' => '!=',
+					'case_sensitive' => false,
+					'created_after' => $after,
+					'created_before' => $before,
+					'ids' => [5, 6, 7],
+				],
+				'tags' => "'tag1', 'tag2'",
+			],
+		]);
+
+		$this->assertEquals(4, count($options['search_name_value_pairs']));
+
+		$pair = array_shift($options['search_name_value_pairs']);
+
+		$this->assertInstanceOf(MetadataWhereClause::class, $pair);
+		$this->assertEquals(['status'], $pair->names);
+		$this->assertEquals(['draft'], $pair->values);
+		$this->assertEquals('=', $pair->comparison);
+		$this->assertTrue($pair->case_sensitive);
+		$this->assertEquals([1], $pair->entity_guids);
+
+		$pair = array_shift($options['search_name_value_pairs']);
+
+		$this->assertInstanceOf(MetadataWhereClause::class, $pair);
+		$this->assertEquals(['category'], $pair->names);
+		$this->assertEquals(['foo', 'bar'], $pair->values);
+		$this->assertEquals('=', $pair->comparison);
+		$this->assertTrue($pair->case_sensitive);
+		$this->assertEquals([1], $pair->entity_guids);
+
+		$pair = array_shift($options['search_name_value_pairs']);
+
+		$this->assertInstanceOf(MetadataWhereClause::class, $pair);
+		$this->assertEquals([5, 6, 7], $pair->ids);
+		$this->assertEquals(['priority'], $pair->names);
+		$this->assertEquals(['100', '200'], $pair->values);
+		$this->assertEquals($after, $pair->created_after);
+		$this->assertEquals($before, $pair->created_before);
+		$this->assertEquals('!=', $pair->comparison);
+		$this->assertFalse($pair->case_sensitive);
+		$this->assertEquals([1], $pair->entity_guids);
+
+		$pair = array_shift($options['search_name_value_pairs']);
+
+		$this->assertInstanceOf(MetadataWhereClause::class, $pair);
+		$this->assertEquals(['tags'], $pair->names);
+		$this->assertEquals(['tag1', 'tag2'], $pair->values);
+		$this->assertEquals('=', $pair->comparison);
+		$this->assertTrue($pair->case_sensitive);
+		$this->assertEquals([1], $pair->entity_guids);
+	}
+
+	public function testNormalizesSearchMetadataOptionsForMultipleMixedPairs() {
+		$options = $this->options->normalizeOptions([
+			'search_name_value_pairs' => [
+				'status' => 'draft',
+				new MetadataWhereClause(),
+				'owner_guid' => 1,
+			],
+		]);
+
+		$this->assertEquals(3, count($options['search_name_value_pairs']));
+
+		$pair = array_shift($options['search_name_value_pairs']);
+
+		$this->assertInstanceOf(MetadataWhereClause::class, $pair);
+		$this->assertEquals(['status'], $pair->names);
+		$this->assertEquals(['draft'], $pair->values);
+		$this->assertEquals('=', $pair->comparison);
+		$this->assertEquals(null, $pair->created_after);
+		$this->assertEquals(null, $pair->created_before);
+
+		$pair = array_shift($options['search_name_value_pairs']);
+
+		$this->assertInstanceOf(MetadataWhereClause::class, $pair);
+		$this->assertEquals(null, $pair->ids);
+		$this->assertEquals(null, $pair->names);
+		$this->assertEquals(null, $pair->values);
+		$this->assertEquals(null, $pair->created_after);
+		$this->assertEquals(null, $pair->created_before);
+
+		$pair = array_shift($options['search_name_value_pairs']);
+
+		$this->assertInstanceOf(AttributeWhereClause::class, $pair);
+		$this->assertEquals(['owner_guid'], $pair->names);
+		$this->assertEquals([1], $pair->values);
+	}
+
+	public function testNormalizesSearchMetadataOptionsForSinglePairInRoot() {
+
+		$options = $this->options->normalizeOptions([
+			'search_name_value_pairs' => [
+				'name' => 'status',
+				'value' => 'draft',
+			],
+		]);
+
+		$this->assertEquals(1, count($options['search_name_value_pairs']));
+
+		$pair = array_shift($options['search_name_value_pairs']);
+
+		$this->assertInstanceOf(MetadataWhereClause::class, $pair);
+		$this->assertEquals(['status'], $pair->names);
+		$this->assertEquals(['draft'], $pair->values);
+	}
+
+	public function testNormalizesSearchMetadataOptionsOnMultipleRuns() {
+
+		$after = (new \DateTime())->modify('-1 day');
+		$before = (new \DateTime());
+
+		$options = $this->options->normalizeOptions([
+			'metadata_id' => [5, 6, 7],
+			'search_name_value_pair' => [
+				'status' => 'draft',
+				'category' => ['foo', 'bar'],
+			],
+			'metadata_created_time_lower' => $after,
+			'metadata_created_time_upper' => $before,
+		]);
+
+		$this->assertEquals($options, $this->options->normalizeOptions($options));
+
+	}
+	
+	/* ANNOTATIONS */
 
 	public function testNormalizesAnnotationsOptionsFromSingulars() {
 


### PR DESCRIPTION
Fixes normalization of search_name_value_pairs to comply with the
original design of this feature.

Fixes #12068