### PR TITLE
fix(js): remove parameters from url when determining fragment

### DIFF
--- a/js/lib/elgglib.js
+++ b/js/lib/elgglib.js
@@ -560,7 +560,7 @@ elgg.parse_str = function(string) {
  * @return {String} The selector
  */
 elgg.getSelectorFromUrlFragment = function(url) {
-	var fragment = url.split('#')[1];
+	var fragment = url.split('#')[1].split('?')[0];
 
 	if (fragment) {
 		// this is a .class or a tag.class


### PR DESCRIPTION
If you don't remove url part after '?' it will cause a jquery error because
it can't find an element with a name like #element?param=value