### PR TITLE
feat(simplecache): allow specifying custom simplecache path

### DIFF
--- a/docs/admin/duplicate-installation.rst
+++ b/docs/admin/duplicate-installation.rst
@@ -94,8 +94,7 @@ If you don't have shell access to your server and have to ftp the data, you may 
 
 .. note::
    
-   You also need to delete the views cache on the test server after the copy process. This is a directory called ``views_simplecache`` in your 
-   data directory and the directory called ``system_cache`` .
+   You also need to delete cache directories from your disk. These correspond to ``cacheroot`` and ``assetroot`` directories in your config.
 
 Edit settings.php
 =================

--- a/docs/admin/performance.rst
+++ b/docs/admin/performance.rst
@@ -84,13 +84,13 @@ This cache is automatically flushed when a plugin is enabled, disabled or reorde
 or when upgrade.php is executed.
 
 For best performance, you can also create a symlink from ``/cache/`` in your www
-root dir to the ``/views_simplecache/`` directory in the data directory you
-configured when you installed Elgg:
+root dir to the ``assetroot`` directory specified in your config (by default it's located under
+``/path/to/dataroot/caches/views_simplecache/``:
 
 .. code-block:: sh
 
     cd /path/to/wwwroot/
-    ln -s /path/to/dataroot/views_simplecache/ cache
+    ln -s /path/to/dataroot/caches/views_simplecache/ cache
 
 If your webserver supports following symlinks, this will serve files straight off
 disk without booting up PHP each time.

--- a/elgg-config/settings.example.php
+++ b/elgg-config/settings.example.php
@@ -188,6 +188,16 @@ $CONFIG->dbencoding = 'utf8mb4';
 //$CONFIG->cacheroot = "";
 
 /**
+ * Set views simplecache directory
+ *
+ * Elgg uses the asset directory to store cached asset files.
+ * By default, assets are stored in the cache root and site owners are
+ * advised to symlink project root /cache to asset root.
+ * Using this config value, you can change the default behavior
+ */
+//$CONFIG->assetroot = "";
+
+/**
  * Enable SendFile file serving
  *
  * After enabling X-Sendfile/X-Accel on your server, you can enable its support in Elgg. Set the

--- a/engine/classes/Elgg/Application/CacheHandler.php
+++ b/engine/classes/Elgg/Application/CacheHandler.php
@@ -132,7 +132,7 @@ class CacheHandler {
 		}
 
 		// trust the client but check for an existing cache file
-		$filename = $config->cacheroot . "views_simplecache/$ts/$viewtype/$view";
+		$filename = $config->assetroot . "$ts/$viewtype/$view";
 		if (file_exists($filename)) {
 			$this->sendCacheHeaders($etag, $response);
 			return BinaryFileResponse::create($filename, 200, $response->headers->all());
@@ -151,7 +151,7 @@ class CacheHandler {
 
 		$lastcache = (int) $config->lastcache;
 
-		$filename = $config->cacheroot . "views_simplecache/$lastcache/$viewtype/$view";
+		$filename = $config->assetroot . "$lastcache/$viewtype/$view";
 
 		if ($lastcache == $ts) {
 			$this->sendCacheHeaders($etag, $response);

--- a/engine/classes/Elgg/Cache/CompositeCache.php
+++ b/engine/classes/Elgg/Cache/CompositeCache.php
@@ -292,8 +292,8 @@ class CompositeCache extends ElggCache {
 			return null;
 		}
 
-		$path = $this->config->cacheroot ? : $this->config->dataroot;
-		if (!$path) {
+		$path = $this->config->cacheroot;
+		if (!$path || !is_writable($path)) {
 			return null;
 		}
 

--- a/engine/classes/Elgg/Cache/SimpleCache.php
+++ b/engine/classes/Elgg/Cache/SimpleCache.php
@@ -148,8 +148,7 @@ class SimpleCache {
 	 * @return string
 	 */
 	private function getPath() {
-		$realpath = realpath($this->config->cacheroot);
-		return rtrim($realpath, DIRECTORY_SEPARATOR) . "/views_simplecache";
+		return $this->config->assetroot;
 	}
 
 	/**

--- a/engine/classes/Elgg/Cache/SimpleCache.php
+++ b/engine/classes/Elgg/Cache/SimpleCache.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elgg\Cache;
 
 use Elgg\Application;
@@ -11,39 +12,32 @@ use Elgg\ViewsService;
  *
  * @access private
  *
- * @since 1.10.0
+ * @since  1.10.0
  */
 class SimpleCache {
 
-	/** @var Config */
-	private $config;
+	/**
+	 * @var Config
+	 */
+	protected $config;
+
+	/**
+	 * @var ViewsService
+	 */
+	protected $views;
 
 	/**
 	 * Constructor
 	 *
-	 * @param Config $config Elgg's global configuration
+	 * @param Config       $config Elgg's global configuration
+	 * @param ViewsService $views  Views service
 	 */
-	public function __construct(Config $config) {
+	public function __construct(
+		Config $config,
+		ViewsService $views
+	) {
 		$this->config = $config;
-	}
-
-	/**
-	 * Registers a view to simple cache.
-	 *
-	 * Simple cache is a caching mechanism that saves the output of
-	 * a view and its extensions into a file.
-	 *
-	 * @warning Simple cached views must take no parameters and return
-	 * the same content no matter who is logged in.
-	 *
-	 * @param string $view_name View name
-	 *
-	 * @return void
-	 * @see elgg_get_simplecache_url()
-	 */
-	function registerView($view_name) {
-		$view_name = ViewsService::canonicalizeViewName($view_name);
-		elgg_register_external_view($view_name, true);
+		$this->views = $views;
 	}
 
 	/**
@@ -85,7 +79,8 @@ class SimpleCache {
 		$view = ViewsService::canonicalizeViewName($view);
 
 		// should be normalized to canonical form by now: `getUrl('blog/save_draft.js')`
-		$this->registerView($view);
+		$this->views->registerCacheableView($view);
+
 		return $this->getRoot() . $view;
 	}
 
@@ -131,7 +126,7 @@ class SimpleCache {
 	 *
 	 * @warning Simplecache is also purged when disabled.
 	 *
-	 * @see elgg_register_simplecache_view()
+	 * @see     elgg_register_simplecache_view()
 	 * @return void
 	 */
 	function disable() {

--- a/engine/classes/Elgg/Cli/InstallCommand.php
+++ b/engine/classes/Elgg/Cli/InstallCommand.php
@@ -78,9 +78,10 @@ class InstallCommand extends BaseCommand {
 		$version = elgg_get_version(true);
 
 		$this->notice("Elgg $version install successful");
-		$this->notice("wwwroot: " . elgg_get_config('wwwroot'));
-		$this->notice("dataroot: " . elgg_get_config('dataroot'));
-		$this->notice("cacheroot: " . elgg_get_config('cacheroot'));
+		$this->notice("wwwroot: " . elgg_get_site_url());
+		$this->notice("dataroot: " . elgg_get_data_path());
+		$this->notice("cacheroot: " . elgg_get_cache_path());
+		$this->notice("assetroot: " . elgg_get_asset_path());
 
 		return 0;
 	}

--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -17,6 +17,7 @@ use Elgg\Project\Paths;
  * @property int           $action_token_timeout
  * @property bool          $allow_registration
  * @property string        $allow_user_default_access
+ * @property string        $assetroot            Path of asset (views) simplecache with trailing "/"
  * @property bool          $auto_disable_plugins
  * @property int           $batch_run_time_in_secs
  * @property bool          $boot_complete

--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -69,7 +69,7 @@ use Elgg\Project\Paths;
  * @property string[]      $pages
  * @property-read string   $path         Path of composer install with trailing "/"
  * @property-read string   $pluginspath  Alias of plugins_path
- * @property-read string   $plugins_path Path of project "mod/" directory
+ * @property string        $plugins_path Path of project "mod/" directory
  * @property array         $profile_custom_fields
  * @property array         $profile_fields
  * @property string        $profiling_minimum_percentage
@@ -449,6 +449,12 @@ class Config {
 	 * @internal
 	 */
 	public function lock($name) {
+		if ($this->elgg_config_locks === false) {
+			// the installer needs to build an application with defaults then update
+			// them after they're validated, so we don't want to lock them.
+			return;
+		}
+
 		$this->locked[$name] = true;
 	}
 
@@ -479,6 +485,22 @@ class Config {
 		if ($this->wasWarnedLocked($name)) {
 			return;
 		}
+
+		switch ($name) {
+			case 'dataroot' :
+			case 'cacheroot' :
+			case 'assetroot' :
+			case 'path' :
+			case 'pluginspath' :
+			case 'plugins_path' :
+				$value = $value ? Paths::sanitize($value) : null;
+				break;
+
+			case 'wwwroot' :
+				$value = $value ? rtrim($value, '/') . '/' : null;
+				break;
+		}
+
 		$this->values[$name] = $value;
 	}
 

--- a/engine/classes/Elgg/Database/Plugins.php
+++ b/engine/classes/Elgg/Database/Plugins.php
@@ -139,11 +139,7 @@ class Plugins {
 	 * @return string
 	 */
 	public function getPath() {
-		$path = $this->config->plugins_path;
-		if (!$path) {
-			$path = Paths::project() . 'mod/';
-		}
-		return $path;
+		return $this->config->plugins_path;
 	}
 
 	/**

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -742,7 +742,7 @@ class ServiceProvider extends DiContainer {
 		$sp->timer->begin([]);
 
 		if ($config->dataroot) {
-			$config->dataroot = rtrim($config->dataroot, '\\/') . DIRECTORY_SEPARATOR;
+			$config->dataroot = Paths::sanitize($config->dataroot);
 		} else {
 			if (!$config->installer_running) {
 				throw new ConfigurationException('Config value "dataroot" is required.');
@@ -751,12 +751,19 @@ class ServiceProvider extends DiContainer {
 		$lock('dataroot');
 
 		if ($config->cacheroot) {
-			$config->cacheroot = rtrim($config->cacheroot, '\\/') . DIRECTORY_SEPARATOR;
+			$config->cacheroot = Paths::sanitize($config->cacheroot);
 		} else {
-			$config->cacheroot = $config->dataroot . 'caches/';
+			$config->cacheroot = Paths::sanitize($config->dataroot . 'caches');
 		}
 		$lock('cacheroot');
 
+		if ($config->assetroot) {
+			$config->assetroot = Paths::sanitize($config->assetroot);
+		} else {
+			$config->assetroot = Paths::sanitize($config->cacheroot . 'views_simplecache');
+		}
+		$lock('assetroot');
+		
 		if ($config->wwwroot) {
 			$config->wwwroot = rtrim($config->wwwroot, '/') . '/';
 		} else {

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -604,7 +604,7 @@ class ServiceProvider extends DiContainer {
 		$this->initSiteSecret($config);
 
 		$this->setFactory('simpleCache', function(ServiceProvider $c) {
-			return new \Elgg\Cache\SimpleCache($c->config);
+			return new \Elgg\Cache\SimpleCache($c->config, $c->views);
 		});
 
 		$this->setClassName('stickyForms', \Elgg\Forms\StickyForms::class);

--- a/engine/classes/Elgg/Project/Paths.php
+++ b/engine/classes/Elgg/Project/Paths.php
@@ -33,7 +33,35 @@ class Paths {
 			}
 		}
 
-		return $path;
+		return self::sanitize($path);
+	}
+
+	/**
+	 * Get temporary directory location
+	 * @return string
+	 */
+	public static function temp() {
+		$is_valid = function($dir) {
+			if (!$dir) {
+				return false;
+			}
+
+			$dir = self::sanitize($dir);
+			return is_dir($dir) && is_writable($dir);
+		};
+
+		$temp = sys_get_temp_dir();
+		if ($is_valid($temp)) {
+			return self::sanitize($temp);
+		}
+
+		$temp = self::sanitize(self::project() . 'tmp/');
+		if ($is_valid($temp)) {
+			return $temp;
+		}
+
+		mkdir($temp);
+		return $temp;
 	}
 
 	/**
@@ -42,7 +70,7 @@ class Paths {
 	 * @return string
 	 */
 	public static function elgg() {
-		return dirname(dirname(dirname(dirname(__DIR__)))) . DIRECTORY_SEPARATOR;
+		return self::sanitize(dirname(dirname(dirname(dirname(__DIR__)))));
 	}
 
 	/**
@@ -51,7 +79,7 @@ class Paths {
 	 * @return string
 	 */
 	public static function projectConfig() {
-		return self::project() . self::PATH_TO_CONFIG . DIRECTORY_SEPARATOR;
+		return self::sanitize(self::project() . self::PATH_TO_CONFIG);
 	}
 
 	/**

--- a/engine/classes/Elgg/UploadService.php
+++ b/engine/classes/Elgg/UploadService.php
@@ -3,6 +3,7 @@
 namespace Elgg;
 
 use Elgg\Http\Request;
+use Elgg\Project\Paths;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Elgg\Filesystem\MimeTypeDetector;
 use Elgg\ImageService;
@@ -102,7 +103,7 @@ class UploadService {
 	 * @return void
 	 */
 	protected function fixImageOrientation(UploadedFile $file) {
-		$temp_location = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . uniqid() . $file->getClientOriginalName();
+		$temp_location = Paths::temp() . uniqid() . $file->getClientOriginalName();
 		copy($file->getPathname(), $temp_location);
 		
 		$rotated = $this->images->fixOrientation($temp_location);

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -118,7 +118,8 @@ class ElggInstaller {
 			$config->system_cache_enabled = false;
 			$config->simplecache_enabled = false;
 			$config->debug = \Psr\Log\LogLevel::WARNING;
-			$config->cacheroot = Paths::sanitize(sys_get_temp_dir()) . 'elgginstaller/';
+			$config->cacheroot = Paths::sanitize(sys_get_temp_dir()) . 'elgginstaller/caches/';
+			$config->assetroot = Paths::sanitize(sys_get_temp_dir()) . 'elgginstaller/assets/';
 
 			$services = new ServiceProvider($config);
 

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -118,9 +118,7 @@ class ElggInstaller {
 			$config->system_cache_enabled = false;
 			$config->simplecache_enabled = false;
 			$config->debug = \Psr\Log\LogLevel::WARNING;
-			$config->dataroot = sys_get_temp_dir() . 'elgginstaller/data/';
-			$config->cacheroot = sys_get_temp_dir() . 'elgginstaller/caches/';
-			$config->assetroot = sys_get_temp_dir() . 'elgginstaller/assets/';
+			$config->dataroot = Paths::temp() . 'elgginstaller/';
 
 			$services = new ServiceProvider($config);
 
@@ -637,7 +635,7 @@ class ElggInstaller {
 
 		$result = $this->render('complete');
 
-		_elgg_rmdir(Paths::sanitize(sys_get_temp_dir()) . 'elgginstaller/');
+		_elgg_rmdir(Paths::temp() . 'elgginstaller/');
 
 		return $result;
 	}

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -118,8 +118,9 @@ class ElggInstaller {
 			$config->system_cache_enabled = false;
 			$config->simplecache_enabled = false;
 			$config->debug = \Psr\Log\LogLevel::WARNING;
-			$config->cacheroot = Paths::sanitize(sys_get_temp_dir()) . 'elgginstaller/caches/';
-			$config->assetroot = Paths::sanitize(sys_get_temp_dir()) . 'elgginstaller/assets/';
+			$config->dataroot = sys_get_temp_dir() . 'elgginstaller/data/';
+			$config->cacheroot = sys_get_temp_dir() . 'elgginstaller/caches/';
+			$config->assetroot = sys_get_temp_dir() . 'elgginstaller/assets/';
 
 			$services = new ServiceProvider($config);
 

--- a/engine/classes/ElggTempDiskFilestore.php
+++ b/engine/classes/ElggTempDiskFilestore.php
@@ -24,7 +24,7 @@ class ElggTempDiskFilestore extends \ElggDiskFilestore {
 	public function __construct($directory_root = '') {
 		
 		if (!$directory_root) {
-			$directory_root = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . '/';
+			$directory_root = \Elgg\Project\Paths::temp();
 		}
 		
 		$this->unique_sub_dir = uniqid() . '/';

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -109,7 +109,7 @@ function elgg_disable_system_cache() {
  * @since 1.8.0
  */
 function elgg_register_simplecache_view($view_name) {
-	_elgg_services()->simpleCache->registerView($view_name);
+	_elgg_services()->views->registerCacheableView($view_name);
 }
 
 /**

--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -241,9 +241,8 @@ function elgg_flush_caches() {
  */
 function _elgg_is_cache_symlinked() {
 	$root_path = elgg_get_root_path();
-	$cache_path = elgg_get_cache_path();
 
-	$simplecache_path = "{$cache_path}views_simplecache";
+	$simplecache_path = elgg_get_asset_path();
 	$symlink_path = "{$root_path}cache";
 
 	if (!is_dir($simplecache_path)) {
@@ -266,9 +265,7 @@ function _elgg_symlink_cache() {
 	}
 
 	$root_path = elgg_get_root_path();
-	$cache_path = elgg_get_cache_path();
-
-	$simplecache_path = "{$cache_path}views_simplecache";
+	$simplecache_path = rtrim(elgg_get_asset_path(), '/');
 	$symlink_path = "{$root_path}cache";
 
 	if (is_dir($symlink_path)) {

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -59,6 +59,18 @@ function elgg_get_cache_path() {
 }
 
 /**
+ * Get the asset cache directory path for this installation, ending with slash.
+ *
+ * If not set in settings, the cache path will be returned.
+ *
+ * @return string
+ */
+function elgg_get_asset_path() {
+	$path = _elgg_config()->assetroot ? : elgg_get_cache_path() . 'views_simplecache/';
+	return Paths::sanitize($path);
+}
+
+/**
  * Get the project path (where composer is installed), ending with slash.
  *
  * Note: This is not the same as the Elgg root! In the Elgg 1.x series, Elgg

--- a/engine/lib/configuration.php
+++ b/engine/lib/configuration.php
@@ -33,7 +33,7 @@ function elgg_get_site_url() {
  * @since 1.8.0
  */
 function elgg_get_plugins_path() {
-	return _elgg_services()->plugins->getPath();
+	return _elgg_config()->plugins_path;
 }
 
 /**
@@ -54,8 +54,7 @@ function elgg_get_data_path() {
  * @return string
  */
 function elgg_get_cache_path() {
-	$path = _elgg_config()->cacheroot ? : elgg_get_data_path() . 'caches/';
-	return Paths::sanitize($path);
+	return _elgg_config()->cacheroot;
 }
 
 /**
@@ -66,8 +65,7 @@ function elgg_get_cache_path() {
  * @return string
  */
 function elgg_get_asset_path() {
-	$path = _elgg_config()->assetroot ? : elgg_get_cache_path() . 'views_simplecache/';
-	return Paths::sanitize($path);
+	return _elgg_config()->assetroot;
 }
 
 /**

--- a/engine/lib/deprecated-2.3.php
+++ b/engine/lib/deprecated-2.3.php
@@ -151,7 +151,7 @@ function get_resized_image_from_existing_file($input_name, $maxwidth, $maxheight
 
 	// we will write resized image to a temporary file and then delete it
 	// need to add a valid image extension otherwise resizing fails
-	$tmp_filename = tempnam(sys_get_temp_dir(), 'icon_resize');
+	$tmp_filename = tempnam(\Elgg\Project\Paths::temp(), 'icon_resize');
 	
 	$params = [
 		'w' => $maxwidth,

--- a/engine/tests/classes/Elgg/BaseTestCase.php
+++ b/engine/tests/classes/Elgg/BaseTestCase.php
@@ -78,9 +78,7 @@ abstract class BaseTestCase extends TestCase implements Seedable, Testable {
 
 			// These are fixed, because tests rely on specific location of the dataroot for source files
 			'wwwroot' => getenv('ELGG_WWWROOT') ? : 'http://localhost/',
-			'dataroot' => Paths::elgg() . 'engine/tests/test_files/dataroot/',
-			'cacheroot' => Paths::elgg() . 'engine/tests/test_files/cacheroot/',
-			'assetroot' => Paths::elgg() . 'engine/tests/test_files/assetroot/',
+			'dataroot' => Paths::sanitize(Paths::elgg() . 'engine/tests/test_files/dataroot/'),
 
 			'system_cache_enabled' => false,
 			'simplecache_enabled' => false,

--- a/engine/tests/classes/Elgg/BaseTestCase.php
+++ b/engine/tests/classes/Elgg/BaseTestCase.php
@@ -80,6 +80,7 @@ abstract class BaseTestCase extends TestCase implements Seedable, Testable {
 			'wwwroot' => getenv('ELGG_WWWROOT') ? : 'http://localhost/',
 			'dataroot' => Paths::elgg() . 'engine/tests/test_files/dataroot/',
 			'cacheroot' => Paths::elgg() . 'engine/tests/test_files/cacheroot/',
+			'assetroot' => Paths::elgg() . 'engine/tests/test_files/assetroot/',
 
 			'system_cache_enabled' => false,
 			'simplecache_enabled' => false,

--- a/engine/tests/elgg-config/simpletest.php
+++ b/engine/tests/elgg-config/simpletest.php
@@ -37,8 +37,6 @@ $settings = [
 	// These are fixed, because tests rely on specific location of the dataroot for source files
 	'wwwroot' => getenv('ELGG_WWWROOT') ? : 'http://localhost/',
 	'dataroot' => Paths::elgg() . 'engine/tests/test_files/dataroot/',
-	'cacheroot' => Paths::elgg() . 'engine/tests/test_files/cacheroot/',
-	'assetroot' => Paths::elgg() . 'engine/tests/test_files/assetroot/',
 	'plugins_path' => Paths::elgg() . 'mod/',
 
 	'system_cache_enabled' => false,

--- a/engine/tests/elgg-config/simpletest.php
+++ b/engine/tests/elgg-config/simpletest.php
@@ -38,6 +38,7 @@ $settings = [
 	'wwwroot' => getenv('ELGG_WWWROOT') ? : 'http://localhost/',
 	'dataroot' => Paths::elgg() . 'engine/tests/test_files/dataroot/',
 	'cacheroot' => Paths::elgg() . 'engine/tests/test_files/cacheroot/',
+	'assetroot' => Paths::elgg() . 'engine/tests/test_files/assetroot/',
 	'plugins_path' => Paths::elgg() . 'mod/',
 
 	'system_cache_enabled' => false,

--- a/engine/tests/phpunit/integration/Elgg/Actions/Admin/UpgradeTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Actions/Admin/UpgradeTest.php
@@ -35,7 +35,17 @@ class UpgradeTest extends ActionResponseTestCase {
 
 	public function testUpgradeSucceeds() {
 		elgg_delete_admin_notice('pending_upgrades');
+		$upgrades = elgg_get_entities([
+			'types' => 'object',
+			'subtypes' => 'elgg_upgrade',
+			'limit' => 0,
+			'batch' => true,
+		]);
 
+		foreach ($upgrades as $upgrade) {
+			$upgrade->delete();
+		}
+		
 		$batch = new UpgradeTestBatch();
 		$version = $batch->getVersion();
 

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggTempFileTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggTempFileTest.php
@@ -2,6 +2,7 @@
 
 namespace Elgg\Integration;
 
+use Elgg\Project\Paths;
 use ElggTempFile;
 use Elgg\IntegrationTestCase;
 
@@ -36,7 +37,7 @@ class ElggTempFileTest extends IntegrationTestCase {
 	
 	public function testFilenameInSystemTempFolder() {
 		
-		$this->assertStringStartsWith(sys_get_temp_dir(), $this->temp_file->getFilenameOnFilestore());
+		$this->assertStringStartsWith(Paths::temp(), $this->temp_file->getFilenameOnFilestore());
 	}
 	
 	public function testWriteContent() {

--- a/engine/tests/phpunit/unit/Elgg/Cache/SimpleCacheUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Cache/SimpleCacheUnitTest.php
@@ -5,6 +5,7 @@ namespace Elgg\Cache;
 /**
  * @group UnitTests
  * @group Cache
+ * @group SimpleCache
  */
 class SimpleCacheUnitTest extends \Elgg\UnitTestCase {
 
@@ -17,31 +18,26 @@ class SimpleCacheUnitTest extends \Elgg\UnitTestCase {
 	}
 
 	public function testGetUrlHandlesSingleArgument() {
-		$this->markTestIncomplete();
-		$simpleCache = new SimpleCache();
-
 		$view = 'view.js';
-		$url = $simpleCache->getUrl($view);
+		elgg_register_simplecache_view($view);
 
-		$this->assertTrue(preg_match("#default/view.js#", $url));
+		$url = _elgg_services()->simpleCache->getUrl($view);
+
+		$this->assertRegExp("#default/view.js#", $url);
 	}
 
 	public function testGetUrlHandlesTwoArguments() {
-		$this->markTestIncomplete();
-		$simpleCache = new SimpleCache();
+		elgg_register_simplecache_view('js/view.js');
+		$url = _elgg_services()->simpleCache->getUrl('js', 'view.js');
 
-		$url = $simpleCache->getUrl('js', 'view.js');
-
-		$this->assertTrue(preg_match("#default/view.js$#", $url));
+		$this->assertRegExp("#default/view.js$#", $url);
 	}
 
 	public function testGetUrlHandlesTwoArgumentsWhereSecondArgHasRedundantPrefix() {
-		$this->markTestIncomplete();
-		$simpleCache = new SimpleCache();
+		elgg_register_simplecache_view('js/view.js');
+		$url = _elgg_services()->simpleCache->getUrl('js', 'js/view.js');
 
-		$url = $simpleCache->getUrl('js', 'js/view.js');
-
-		$this->assertTrue(preg_match("#default/view.js$#", $url));
+		$this->assertRegExp("#default/view.js$#", $url);
 	}
 
 	public function testRespectsViewAliases() {

--- a/engine/tests/phpunit/unit/Elgg/ConfigUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/ConfigUnitTest.php
@@ -22,6 +22,7 @@ class ConfigUnitTest extends \Elgg\UnitTestCase {
 		$this->assertEquals(elgg_get_site_url(), $config->wwwroot);
 		$this->assertEquals(realpath(elgg_get_data_path()), realpath($config->dataroot));
 		$this->assertEquals(realpath(elgg_get_cache_path()), realpath($config->cacheroot));
+		$this->assertEquals(realpath(elgg_get_asset_path()), realpath($config->assetroot));
 		$this->assertEquals(realpath(elgg_get_site_url()), realpath($config->wwwroot));
 		$this->assertEquals(realpath(elgg_get_plugins_path()), realpath(Paths::project() . 'mod/'));
 

--- a/engine/tests/phpunit/unit/Elgg/ConfigUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/ConfigUnitTest.php
@@ -17,7 +17,15 @@ class ConfigUnitTest extends \Elgg\UnitTestCase {
 
 	public function testCanReadValuesFromConfig() {
 
-		$config = self::getTestingConfig();
+		$config = \Elgg\Application::$_instance->_services->config;
+
+		$wwwroot = getenv('ELGG_WWWROOT') ? : 'http://localhost/';
+		$dataroot = Paths::elgg() . 'engine/tests/test_files/dataroot/';
+
+		$this->assertEquals($wwwroot, $config->wwwroot);
+		$this->assertEquals(Paths::sanitize($dataroot), $config->dataroot);
+		$this->assertEquals(Paths::sanitize($dataroot . 'caches/'), $config->cacheroot);
+		$this->assertEquals(Paths::sanitize($dataroot . 'caches/views_simplecache/'), $config->assetroot);
 
 		$this->assertEquals(elgg_get_site_url(), $config->wwwroot);
 		$this->assertEquals(realpath(elgg_get_data_path()), realpath($config->dataroot));

--- a/engine/tests/phpunit/unit/Elgg/ImageServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/ImageServiceUnitTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Elgg;
+use Elgg\Project\Paths;
 
 /**
  * @group UnitTests
@@ -18,7 +19,7 @@ class ImageServiceUnitTest extends \Elgg\UnitTestCase {
 	public function up() {
 		$this->image_service = _elgg_services()->imageService;
 
-		$this->temp_dir = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+		$this->temp_dir = Paths::temp();
 
 		$this->temp_source_image_location = tempnam($this->temp_dir, 'imageservice');
 		$source_image = _elgg_config()->dataroot . '1/1/300x300.jpg';

--- a/engine/tests/phpunit/unit/Elgg/lib/elgglib/ElggCacheUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/lib/elgglib/ElggCacheUnitTest.php
@@ -19,9 +19,9 @@ class ElggCacheUnitTest extends \Elgg\UnitTestCase {
 	public function testCanSymlinkCache() {
 
 		$root_path = elgg_get_root_path();
-		$cache_path = elgg_get_cache_path();
+		$asset_path = elgg_get_asset_path();
 
-		$simplecache_path = "{$cache_path}views_simplecache";
+		$simplecache_path = $asset_path;
 		$symlink_path = "{$root_path}cache";
 
 		if (is_dir($simplecache_path)) {

--- a/engine/tests/phpunit/unit/ElggInstallerTest.php
+++ b/engine/tests/phpunit/unit/ElggInstallerTest.php
@@ -129,6 +129,7 @@ class ElggInstallerTest extends \Elgg\UnitTestCase {
 			'wwwroot' => getenv('ELGG_WWWROOT') ? : 'http://localhost/',
 			'timezone' => 'UTC',
 			'cacheroot' => \Elgg\Project\Paths::sanitize(Paths::elgg() . 'engine/tests/test_files/cacheroot/'),
+			'assetroot' => \Elgg\Project\Paths::sanitize(Paths::elgg() . 'engine/tests/test_files/assetroot/'),
 		];
 
 		foreach ($params as $k => $v) {

--- a/engine/tests/phpunit/unit/ElggInstallerTest.php
+++ b/engine/tests/phpunit/unit/ElggInstallerTest.php
@@ -74,6 +74,9 @@ class ElggInstallerTest extends \Elgg\UnitTestCase {
 
 		$config = new Config();
 		$config->elgg_config_locks = false;
+		$config->dataroot = Paths::sanitize(Paths::elgg() . 'engine/tests/test_files/dataroot/');
+		$config->cacheroot = Paths::sanitize(Paths::elgg() . 'engine/tests/test_files/cacheroot/');
+		$config->assetroot = Paths::sanitize(Paths::elgg() . 'engine/tests/test_files/assetroot/');
 		$config->installer_running = true;
 		$config->dbencoding = 'utf8mb4';
 		$config->boot_cache_ttl = 0;
@@ -125,11 +128,11 @@ class ElggInstallerTest extends \Elgg\UnitTestCase {
 			'dbpassword' => getenv('ELGG_DB_PASS') ? : '',
 			'dbhost' => getenv('ELGG_DB_HOST') ? : 'localhost',
 			'dbencoding' => getenv('ELGG_DB_ENCODING') ? : 'utf8mb4',
-			'dataroot' => \Elgg\Project\Paths::sanitize(Paths::elgg() . 'engine/tests/test_files/dataroot/'),
 			'wwwroot' => getenv('ELGG_WWWROOT') ? : 'http://localhost/',
 			'timezone' => 'UTC',
-			'cacheroot' => \Elgg\Project\Paths::sanitize(Paths::elgg() . 'engine/tests/test_files/cacheroot/'),
-			'assetroot' => \Elgg\Project\Paths::sanitize(Paths::elgg() . 'engine/tests/test_files/assetroot/'),
+			'dataroot' => Paths::sanitize(Paths::elgg() . 'engine/tests/test_files/dataroot/'),
+			'cacheroot' => Paths::sanitize(Paths::elgg() . 'engine/tests/test_files/cacheroot/'),
+			'assetroot' => Paths::sanitize(Paths::elgg() . 'engine/tests/test_files/assetroot/'),
 		];
 
 		foreach ($params as $k => $v) {

--- a/views/default/forms/admin/site/advanced/caching.php
+++ b/views/default/forms/admin/site/advanced/caching.php
@@ -43,7 +43,7 @@ if ($cache_symlinked) {
 
 $symlink_input = elgg_view('input/checkbox', $params);
 $symlink_source = elgg_get_root_path() . 'cache/';
-$symlink_target = elgg_get_cache_path() . 'views_simplecache/';
+$symlink_target = elgg_get_asset_path();
 $symlink_paths_help = elgg_echo('installation:cache_symlink:paths', [$symlink_source, $symlink_target]);
 $symlink_warning .= elgg_format_element('p', ['class' => 'elgg-text-help'], $symlink_paths_help);
 


### PR DESCRIPTION
Sites can now define a custom location to store cached views by providing
$CONFIG->assetroot value.