### PR TITLE
feat(session): delay session boot until all plugins are loaded

### DIFF
--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -192,9 +192,13 @@ class Application {
 	 *
 	 * This method loads the full Elgg engine, checks the installation
 	 * state, and triggers a series of events to finish booting Elgg:
-	 *    - {@elgg_event boot system}
+	 *    - {@elgg_event plugins_load system}
+	 *    - {@elgg_event plugins_boot system}
 	 *    - {@elgg_event init system}
 	 *    - {@elgg_event ready system}
+	 *
+	 * Please note that the Elgg session is started after all plugins are loader, there will therefore
+	 * be no information about a logged user available until plugins_load,system event is complete.
 	 *
 	 * If Elgg is not fully installed, the browser will be redirected to an installation page.
 	 *

--- a/engine/classes/Elgg/Application/BootHandler.php
+++ b/engine/classes/Elgg/Application/BootHandler.php
@@ -116,14 +116,25 @@ class BootHandler {
 
 		$events = $this->app->_services->events;
 
+		$events->registerHandler('plugins_load:after', 'system', function() {
+			_elgg_session_boot($this->app->_services);
+		});
+
 		$events->registerHandler('plugins_boot:before', 'system', 'elgg_views_boot');
 		$events->registerHandler('plugins_boot', 'system', '_elgg_register_routes');
 		$events->registerHandler('plugins_boot', 'system', '_elgg_register_actions');
 
-		// Load the plugins that are active
-		$this->app->_services->plugins->load();
+		// Setup all boot sequence handlers for active plugins
+		$this->app->_services->plugins->build();
 
-		// Allows registering handlers strictly before all init, system handlers
+		// Register plugin classes, entities etc
+		// Call PluginBootstrap::load()
+		// After event completes, Elgg session is booted
+		$events->triggerSequence('plugins_load', 'system');
+
+		// Boot plugin, setup languages and views
+		// Include start.php
+		// Call PluginBootstrap::boot()
 		$events->triggerSequence('plugins_boot', 'system');
 
 		$config->_plugins_boot_complete = true;

--- a/engine/classes/Elgg/BootService.php
+++ b/engine/classes/Elgg/BootService.php
@@ -142,9 +142,6 @@ class BootService {
 		$debug = $config->hasInitialValue('debug') ? $config->getInitialValue('debug') : $config->debug;
 		$services->logger->setLevel($debug);
 
-		// finish boot sequence
-		_elgg_session_boot($services);
-
 		if ($config->system_cache_enabled) {
 			$config->system_cache_loaded = false;
 

--- a/engine/tests/classes/Elgg/Plugins/PluginTesting.php
+++ b/engine/tests/classes/Elgg/Plugins/PluginTesting.php
@@ -72,6 +72,7 @@ trait PluginTesting {
 
 		// @todo Resolve plugin dependencies and activate required plugins
 
+		$plugin->register();
 		$setup = $plugin->boot();
 		if ($setup instanceof \Closure) {
 			$setup();

--- a/engine/tests/phpunit/unit/Elgg/Application/BootHandlerUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Application/BootHandlerUnitTest.php
@@ -112,6 +112,9 @@ class BootHandlerUnitTest extends UnitTestCase {
 	public function testBootEventCalls() {
 
 		$calls = new \stdClass();
+		$calls->{'plugins_load:before'} = 0;
+		$calls->{'plugins_load'} = 0;
+		$calls->{'plugins_load:after'} = 0;
 		$calls->{'plugins_boot:before'} = 0;
 		$calls->{'plugins_boot'} = 0;
 		$calls->{'plugins_boot:after'} = 0;
@@ -139,6 +142,31 @@ class BootHandlerUnitTest extends UnitTestCase {
 		}
 	}
 
+	public function testCanSetCustomUserClassDuringBootSequence() {
 
+		$app = $this->createMockApplication();
+
+		$app->_services->events->registerHandler('plugins_load', 'system', function(Event $event) {
+			elgg_set_entity_class('user', 'custom_user', CustomUser::class);
+		});
+
+		$user = $this->createUser([
+			'subtype' => 'custom_user',
+		]);
+
+		$app->_services->session->set('guid', $user->guid);
+
+		$user->invalidateCache();
+
+		$app->bootCore();
+
+		$this->assertInstanceOf(CustomUser::class, $app->_services->session->getLoggedInUser());
+
+		$app->_services->session->removeLoggedInUser();
+	}
+
+}
+
+class CustomUser extends \ElggUser {
 
 }


### PR DESCRIPTION
In certain situations, we want plugins to have control over the session user,
e.g. by registered custom entity classes. This breaks down the plugin boot sequence
further to allow the system to perform operations, such as session boot,
after plugin files have been loaded, and the necessary plugin registrations took
place