### PR TITLE
updated Support documentation

### DIFF
--- a/docs/admin/performance.rst
+++ b/docs/admin/performance.rst
@@ -169,16 +169,19 @@ If the static assets aren't being cached:
 
 __ https://addons.mozilla.org/en-us/firefox/addon/yslow/
 
-Memcache
---------
+Memcached
+---------
 
-Memcache is a generic caching technology developed by Brad Fitzpatrick for LiveJournal.
+Libmemcached was created by Brian Aker and was designed from day one to give the best performance available to users of Memcached. 
 
-.. warning:: SUPPORT FOR MEMCACHE IS EXPERIMENTAL AND MAY BE CHANGED.
+.. seealso::
+
+	http://libmemcached.org/About.html and https://secure.php.net/manual/en/book.memcached.php
 
 Installation requirements:
 
-- php5-memcache
+- php-memcached
+- libmemcached
 - memcached
 
 Configuration:

--- a/docs/appendix/support.rst
+++ b/docs/appendix/support.rst
@@ -1,43 +1,68 @@
 Support policy
-==============
+##############
 
 As of Elgg 2.0, each minor release receives bug and security fixes only until the next minor release.
 
+.. contents:: Contents
+   :depth: 2
+   :local:
+
 Long Term Support Releases
---------------------------
+==========================
 
 Within each major version, the last minor release is designated for long term support ("LTS") and will
-receive bug fixes until the 2nd following major version release, and security fixes until the 3rd
+receive bug fixes until 1 year after the release of the next major version and security fixes until the 2nd
 following major version release.
 
-E.g. 1.12 is the last minor release within 1.x. It will receive bug fixes until 3.0 is released and
+E.g. 2.3 is the last minor release within 2.x. It will receive bug fixes until 1 year aftr 3.0 is released and
 security fixes until 4.0 is released.
-
-When bugs are found, a good faith effort will be made to patch the LTS release, but **not all fixes
-will be back-ported.** E.g. some fixes may depend on new APIs, break backwards compatibility, or require
-significant refactoring. If a fix risks stability of the LTS branch, it will not be included.
-
 
 .. seealso::
 
-   :doc:`releases`
+   - :doc:`releases`
+   - :doc:`/contribute/issues`
+
+Bugs
+----
+
+When bugs are found, a good faith effort will be made to patch the LTS release, but **not all fixes
+will be back-ported.** E.g. some fixes may depend on new APIs, break backwards compatibility, or require
+significant refactoring.
+
+.. important::
+
+	 If a fix risks stability of the LTS branch, it will not be included.
+
+Security issues
+---------------
+
+When a security issue is found every effort will be made to patch the LTS release.
+
+.. attention::
+
+	Please report any security issue to **security @ elgg . org**
+
+Timeline
+========
 
 Below is a table outlining the specifics for each release (future dates are tentative):
 
-+----------+----------------------+-------------------+------------------------+
-| Version  | First stable release | Bug fixes through | Security fixes through |
-+==========+======================+===================+========================+
-| 1.12 LTS | July 2015            | **Until 3.0**     | **Until 4.0**          |
-+----------+----------------------+-------------------+------------------------+
-| 2.0      | December 2015        | March 2016        |                        |
-+----------+----------------------+-------------------+------------------------+
-| 2.1      | March 2016           | June 2016         |                        |
-+----------+----------------------+-------------------+------------------------+
-| 2.2      | June 2016            | November 2016     |                        |
-+----------+----------------------+-------------------+------------------------+
-| 2.3 LTS  | November 2016        | **Until 4.0**     | **Until 5.0**          |
-+----------+----------------------+-------------------+------------------------+
-| 3.0      | December 2016        |                   |                        |
-+----------+----------------------+-------------------+------------------------+
-| 4.0      | December 2017        |                   |                        |
-+----------+----------------------+-------------------+------------------------+
++----------+----------------------+--------------------+------------------------+
+| Version  | First stable release | Bug fixes through  | Security fixes through |
++==========+======================+====================+========================+
+| 1.12 LTS | July 2015            | August 2018 [#f1]_ | August 2018 [#f1]_     |
++----------+----------------------+--------------------+------------------------+
+| 2.0      | December 2015        | March 2016         |                        |
++----------+----------------------+--------------------+------------------------+
+| 2.1      | March 2016           | June 2016          |                        |
++----------+----------------------+--------------------+------------------------+
+| 2.2      | June 2016            | November 2016      |                        |
++----------+----------------------+--------------------+------------------------+
+| 2.3 LTS  | November 2016        | August 2019 [#f1]_ | **Until 4.0**          |
++----------+----------------------+--------------------+------------------------+
+| 3.0      | August 2018 [#f1]_   |                    |                        |
++----------+----------------------+--------------------+------------------------+
+| 4.0      | TBD                  |                    |                        |
++----------+----------------------+--------------------+------------------------+
+
+.. [#f1] Will be updated when 3.0 becomes stable

--- a/docs/contribute/issues.rst
+++ b/docs/contribute/issues.rst
@@ -7,11 +7,17 @@ See below for guidelines.
 DISCLAIMERS
 -----------
 
--  **SECURITY ISSUES SHOULD BE REPORTED TO security @ elgg . org!**
-   Please do not post any security issues on github!!
--  Support requests belong on the `community site`_.
-   Tickets with support requests will be closed.
--  We cannot make any guarantees as to when your ticket will be resolved.
+.. attention::
+
+	Security issues should be reported to **security @ elgg . org**! Please do not post any security issues on github!!
+
+.. note:: 
+
+	Support requests belong on the `community site`_. Tickets with support requests will be closed.
+
+.. important::
+	
+	We cannot make any guarantees as to when your ticket will be resolved.
 
 Bug reports
 -----------


### PR DESCRIPTION
The biggest change is the timeline for the LTS version support.

Due to the fact we're only a small development team (which completely relies on the spare time of volunteers) it's impossible to keep supporting old versions.

New LTS support policy
- bug fixes until 1 year after next major
- security fixes until 2nd next major

cc @Elgg/core any different opinions?

fixes #11138 