### PR TITLE
fix(views): boot core views before plugins are loaded

### DIFF
--- a/engine/classes/Elgg/Application/BootHandler.php
+++ b/engine/classes/Elgg/Application/BootHandler.php
@@ -116,11 +116,11 @@ class BootHandler {
 
 		$events = $this->app->_services->events;
 
+		$events->registerHandler('plugins_load:before', 'system', 'elgg_views_boot');
 		$events->registerHandler('plugins_load:after', 'system', function() {
 			_elgg_session_boot($this->app->_services);
 		});
 
-		$events->registerHandler('plugins_boot:before', 'system', 'elgg_views_boot');
 		$events->registerHandler('plugins_boot', 'system', '_elgg_register_routes');
 		$events->registerHandler('plugins_boot', 'system', '_elgg_register_actions');
 


### PR DESCRIPTION
Recent changes to boot sequence overlooked the fact that core views
need to be loaded before plugin views are registered