### PR TITLE
fix(routes): replace existing routes on repeat registration

### DIFF
--- a/engine/classes/Elgg/Router/RouteRegistrationService.php
+++ b/engine/classes/Elgg/Router/RouteRegistrationService.php
@@ -80,6 +80,8 @@ class RouteRegistrationService {
 	 */
 	public function register($name, array $params = []) {
 
+		$this->routes->remove($name);
+
 		$params = $this->hooks->trigger('route:config', $name, $params, $params);
 
 		$path = elgg_extract('path', $params);


### PR DESCRIPTION
Pushing routes to stack without unregistering them first, creates a situation
where first registered routes takes effect, which is not an expected behavior
in Elgg practices.