### PR TITLE
fix(plugins): correctly fetch plugins that miss priority private setting

### DIFF
--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -11,6 +11,9 @@ use Elgg\Includer;
  */
 class ElggPlugin extends ElggObject {
 
+	const STATUS_ACTIVE = 'active';
+	const STATUS_INACTIVE = 'inactive';
+
 	/**
 	 * @var ElggPluginPackage
 	 */
@@ -68,7 +71,6 @@ class ElggPlugin extends ElggObject {
 		}
 
 		$plugin = elgg_get_plugin_from_id($plugin_id);
-
 		if (!$plugin) {
 			$ia = _elgg_services()->session->setIgnoreAccess(true);
 			$plugin = new ElggPlugin();

--- a/engine/tests/phpunit/unit/Elgg/Database/PluginsUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Database/PluginsUnitTest.php
@@ -60,7 +60,7 @@ class PluginsUnitTest extends \Elgg\UnitTestCase {
 		$priority_name = $plugins->namespacePrivateSetting('internal', 'priority');
 		// because of mocking issues don't use ->setPriority()
 		$plugin_high_priority->setPrivateSetting($priority_name, 100);
-		
+
 		/* @var $plugin_low_priority \ElggPlugin */
 		$plugin_low_priority = $this->createObject([
 			'subtype' => 'plugin',
@@ -77,7 +77,7 @@ class PluginsUnitTest extends \Elgg\UnitTestCase {
 			$plugin_high_priority,
 			$plugin_low_priority,
 		];
-		
+
 		$plugins->setBootPlugins($bootplugins);
 		
 		$active_plugins = $plugins->find('active');


### PR DESCRIPTION
All plugins are now fetched regardless of their priority. This helps avoid a situation
where broken plugin (missing priority) exists as plugin entity, but is never disabled
by _elgg_generate_plugin_entities().

Fixes #12140