### PR TITLE
fix(db): improved handling of duplicate relationship creation

### DIFF
--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -444,8 +444,10 @@ class Database {
 			}
 		} catch (\Exception $e) {
 			throw new \DatabaseException($e->getMessage() . "\n\n"
-			. "QUERY: $query \n\n"
-			. "PARAMS: " . print_r($params, true));
+					. "QUERY: $query \n\n"
+					. "PARAMS: " . print_r($params, true),
+				null,
+				$e);
 		}
 
 		if ($this->timer) {
@@ -581,9 +583,9 @@ class Database {
 
 	/**
 	 * Enable the query cache
-	 * 
+	 *
 	 * This does not take precedence over the \Elgg\Database\Config setting.
-	 * 
+	 *
 	 * @return void
 	 * @access private
 	 */
@@ -596,10 +598,10 @@ class Database {
 
 	/**
 	 * Disable the query cache
-	 * 
+	 *
 	 * This is useful for special scripts that pull large amounts of data back
 	 * in single queries.
-	 * 
+	 *
 	 * @return void
 	 * @access private
 	 */

--- a/engine/classes/Elgg/Database/RelationshipsTable.php
+++ b/engine/classes/Elgg/Database/RelationshipsTable.php
@@ -3,6 +3,7 @@ namespace Elgg\Database;
 
 use Elgg\Database;
 use Elgg\EventsService;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -41,7 +42,7 @@ class RelationshipsTable {
 	 * Constructor
 	 *
 	 * @param Database      $db       Elgg Database
-	 * @param EntityTable   $entities Entity table 
+	 * @param EntityTable   $entities Entity table
 	 * @param MetadataTable $metadata Metadata table
 	 * @param EventsService $events   Events service
 	 */
@@ -138,7 +139,6 @@ class RelationshipsTable {
 			INSERT INTO {$this->db->prefix}entity_relationships
 			       (guid_one, relationship, guid_two, time_created)
 			VALUES (:guid1, :relationship, :guid2, :time)
-				ON DUPLICATE KEY UPDATE time_created = :time
 		";
 		$params = [
 			':guid1' => (int)$guid_one,
@@ -147,9 +147,18 @@ class RelationshipsTable {
 			':time' => $this->getCurrentTime()->getTimestamp(),
 		];
 
-		$id = $this->db->insertData($sql, $params);
-		if (!$id) {
-			return false;
+		try {
+			$id = $this->db->insertData($sql, $params);
+			if (!$id) {
+				return false;
+			}
+		} catch (\DatabaseException $e) {
+			$prev = $e->getPrevious();
+			if ($prev instanceof UniqueConstraintViolationException) {
+				// duplicate key error see https://github.com/Elgg/Elgg/issues/9179
+				return false;
+			}
+			throw $e;
 		}
 
 		$obj = $this->get($id);

--- a/engine/tests/phpunit/Elgg/Mocks/Database/RelationshipsTable.php
+++ b/engine/tests/phpunit/Elgg/Mocks/Database/RelationshipsTable.php
@@ -90,7 +90,6 @@ class RelationshipsTable extends DbRelationshipsTable {
 			INSERT INTO {$dbprefix}entity_relationships
 			       (guid_one, relationship, guid_two, time_created)
 			VALUES (:guid1, :relationship, :guid2, :time)
-				ON DUPLICATE KEY UPDATE time_created = :time
 		";
 
 		$this->query_specs[$row->id][] = $this->db->addQuerySpec([


### PR DESCRIPTION
ref #9179, #11975

Racing conditions exist where the check for an existing relationship
passes but the following insertion fails because of a duplicate key. The
result of the function was incorrect.

On duplicate it reported ok but it should report a failure