### PR TITLE
chore(widgets): use padding instead of margin for widget column spacing

### DIFF
--- a/views/default/elements/widgets.css
+++ b/views/default/elements/widgets.css
@@ -19,7 +19,7 @@
 	}
 
 	.elgg-widgets {
-		margin: 0 0.5rem;
+		padding: 0 0.5rem;
 	}
 }
 


### PR DESCRIPTION
the widget layout grid is a flex layout, if using flex-basis on the columns the width calculations are wrong if using margins. padding solves this problem