### PR TITLE
fix(security): tokenize outgoing no-reply email address

### DIFF
--- a/engine/lib/notification.php
+++ b/engine/lib/notification.php
@@ -245,7 +245,8 @@ function _elgg_send_email_notification($hook, $type, $result, $params) {
 		$from = $site->email;
 	} else {
 		// If all else fails, use the domain of the site.
-		$from = 'noreply@' . $site->getDomain();
+		$token = _elgg_services()->crypto->getRandomBytes(24);
+		$from = "noreply-{$token}@{$site->getDomain()}";
 	}
 
 	return elgg_send_email($from, $to, $message->subject, $message->body, $params);

--- a/languages/en.php
+++ b/languages/en.php
@@ -1147,6 +1147,7 @@ Once you have logged in, we highly recommend that you change your password.
 	'installation:view' => "Enter the view which will be used as the default for your site or leave this blank for the default view (if in doubt, leave as default):",
 
 	'installation:siteemail' => "Site email address (used when sending system emails):",
+	'installation:siteemail:help' => "Warning: Do no use an email address that you may have associated with other third-party services, such as ticketing systems, that perform inbound email parsing, as it may expose you and your users to unintentional leakage of private data and security tokens. Ideally, create a new dedicated email address that will serve only this website.",
 	'installation:default_limit' => "Default number of items per page",
 
 	'admin:site:access:warning' => "This is the privacy setting suggested to users when they create new content. Changing it does not change access to content.",

--- a/views/default/forms/admin/site/update_basic.php
+++ b/views/default/forms/admin/site/update_basic.php
@@ -18,6 +18,7 @@ echo elgg_view_field([
 	'#type' => 'email',
 	'name' => 'siteemail',
 	'#label' => elgg_echo('installation:siteemail'),
+	'#help' => elgg_echo('installation:siteemail:help'),
 	'value' => elgg_get_site_entity()->email,
 	'class' => 'elgg-input-text',
 ]);


### PR DESCRIPTION
Help site owners protect themselves from hacking attacks, in case
their ticketing or other systems perform inbound email parsing from
no-reply email address.