### PR TITLE
Site menu ordering

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -742,9 +742,8 @@ function _elgg_normalize_content_layout_vars(array $vars = []) {
  *                              items => an array of unprepared menu items
  *                                       as ElggMenuItem or menu item factory options
  *                              sort_by => string or php callback
- *                                  string options: 'name', 'priority', 'title' (default),
- *                                  'register' (registration order) or a
- *                                  php callback (a compare function for usort)
+ *                                  string options: 'name', 'priority' (default), 'text'
+ *                                  or a php callback (a compare function for usort)
  *                              handler: string the page handler to build action URLs
  *                              entity: \ElggEntity to use to build action URLs
  *                              class: string the class for the entire menu.

--- a/views/default/page/elements/topbar.php
+++ b/views/default/page/elements/topbar.php
@@ -26,7 +26,9 @@ elgg_require_js('page/elements/topbar');
 		'class' => 'elgg-nav-search',
 	], elgg_view('search/search_box'));
 
-	echo elgg_view_menu('site');
+	echo elgg_view_menu('site', [
+		'sort_by' => 'text',
+	]);
 	echo elgg_view_menu('topbar');
 	?>
 </div>


### PR DESCRIPTION
We changed the default menu ordering to `priority`, this will make the site menu in the topbar more or less depended on plugin order which i think is weird.

Changed it back to `text` like in Elgg 2.3