### PR TITLE
fix(annotations): no longer update entity last_action on annotate

### DIFF
--- a/engine/classes/Elgg/Database/AnnotationsTable.php
+++ b/engine/classes/Elgg/Database/AnnotationsTable.php
@@ -150,8 +150,6 @@ class AnnotationsTable {
 			return false;
 		}
 
-		$entity->updateLastAction($annotation->time_created);
-
 		$this->events->triggerAfter('create', 'annotation', $annotation);
 
 		return $result;

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -308,6 +308,30 @@ function _elgg_river_test($hook, $type, $value) {
 }
 
 /**
+ * Updates the last action of the object of an river item
+ *
+ * @param string         $event 'create'
+ * @param string         $type  'river'
+ * @param \ElggRiverItem $item  The entity being disabled
+ *
+ * @return void
+ *
+ * @access private
+ */
+function _elgg_river_update_object_last_action($event, $type, $item) {
+	if (!$item instanceof \ElggRiverItem) {
+		return;
+	}
+	
+	$object = $item->getObjectEntity();
+	if (!$object) {
+		return;
+	}
+	
+	$object->updateLastAction($item->getTimePosted());
+}
+
+/**
  * Disable river entries that reference a disabled entity as subject/object/target
  *
  * @param string     $event  'disable'
@@ -421,6 +445,8 @@ function _elgg_river_init() {
 	elgg_register_plugin_hook_handler('unit_test', 'system', '_elgg_river_test');
 
 	elgg_register_plugin_hook_handler('register', 'menu:river', '_elgg_river_menu_setup');
+	
+	elgg_register_event_handler('created', 'river', '_elgg_river_update_object_last_action');
 }
 
 /**

--- a/mod/discussions/views/default/object/discussion.php
+++ b/mod/discussions/views/default/object/discussion.php
@@ -49,7 +49,6 @@ if ($full_view) {
 		'show_summary' => true,
 		'body' => $body,
 		'responses' => $responses,
-		'show_navigation' => true,
 	];
 
 	$params = $params + $vars;

--- a/mod/discussions/views/default/resources/discussion/view.php
+++ b/mod/discussions/views/default/resources/discussion/view.php
@@ -18,6 +18,7 @@ $title = $topic->getDisplayName();
 $params = [
 	'content' => $content,
 	'title' => $title,
+	'entity' => $topic,
 	'sidebar' => elgg_view('discussion/sidebar'),
 	'filter' => '',
 ];


### PR DESCRIPTION
This was changed during https://github.com/Elgg/Elgg/commit/921dabc37c0259de5ba54285d5e80729563a8ea8#diff-7ef4165746f49d00047226a00e21bbc7L134

It has unwanted effects like discussions being reordered if liked. This PR restores the 2.x behaviour, but does it with an event, so if you want you can change the behaviour easily