### PR TITLE
chore(icons): allow for saving the unchanged uploaded image as 'original' entity icon image

### DIFF
--- a/docs/appendix/upgrade-notes/2.x-to-3.0.rst
+++ b/docs/appendix/upgrade-notes/2.x-to-3.0.rst
@@ -1046,6 +1046,8 @@ The generation of entity icons has ben changed. No longer will all the configure
 (``ElggEntity::saveIconFromUploadedFile``, ``ElggEntity::saveIconFromLocalFile`` or ``ElggEntity::saveIconFromElggFile``), but only the `master` size.
 The other configured sizes will be generated when requesting that size based of the `master` icon.
 
+The 'original' icon size is a special case. The 'original' icon size is the unchanged original image saved without resizing. The 'original' icon size is not configured by default though. If you need the original image to be saved for an entity type, use the ``entity:icon:sizes, <entity_type>`` plugin hook to add the 'original' key without size parameters to the icon_sizes array.
+
 Icon glyphs
 -----------
 

--- a/engine/classes/Elgg/EntityIconService.php
+++ b/engine/classes/Elgg/EntityIconService.php
@@ -225,9 +225,14 @@ class EntityIconService {
 		if ($created !== true) {
 			// remove existing icons
 			$this->deleteIcon($entity, $type, true);
-			
+
+			// save original image if 'original' icon_size is available for this type of entity
+			$store = $this->generateIcon($entity, $file, $type, $coords, 'original');
+
 			// save master image
-			$store = $this->generateIcon($entity, $file, $type, $coords, 'master');
+			if ($store) {
+				$store = $this->generateIcon($entity, $file, $type, $coords, 'master');
+			}
 			
 			if (!$store) {
 				$this->deleteIcon($entity, $type);


### PR DESCRIPTION
This is for https://github.com/Elgg/Elgg/issues/12165.

The original image is not saved by default, i.e. the 'original' icon_size is not registed for any entity. This can be done using the plugin hook if needed. But saving the 'original' image (if this size is available) must be dealt with in saveIcon()  at upload time as the original uploaded image is no longer available later on.