### PR TITLE
fix(navigation): breadcrumbs set correct value for empty links

### DIFF
--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -289,7 +289,7 @@ function elgg_register_title_button($handler = null, $name = 'add', $entity_type
  * @since 1.8.0
  * @see elgg_get_breadcrumbs()
  */
-function elgg_push_breadcrumb($text, $href = null) {
+function elgg_push_breadcrumb($text, $href = false) {
 	$breadcrumbs = (array) _elgg_config()->breadcrumbs;
 	
 	$breadcrumbs[] = [
@@ -427,7 +427,7 @@ function elgg_push_entity_breadcrumbs(ElggEntity $entity, $link_self = true) {
 	$container = $entity->getContainerEntity() ? : null;
 	elgg_push_collection_breadcrumbs($entity->type, $entity->subtype, $container);
 
-	$entity_url = $link_self ? $entity->getURL() : null;
+	$entity_url = $link_self ? $entity->getURL() : false;
 	elgg_push_breadcrumb($entity->getDisplayName(), $entity_url);
 }
 

--- a/engine/tests/phpunit/unit/ElggBreadcrumbsUnitTest.php
+++ b/engine/tests/phpunit/unit/ElggBreadcrumbsUnitTest.php
@@ -20,7 +20,7 @@ class ElggBreadcrumbsUnitTest extends \Elgg\IntegratedUnitTestCase {
 		elgg_push_breadcrumb('title 2', 'path2');
 
 		$this->assertEquals([
-			['text' => 'title 1', 'href' => null, 'name' => 0],
+			['text' => 'title 1', 'href' => false, 'name' => 0],
 			['text' => 'title 2', 'href' => 'path2', 'name' => 1],
 		], elgg_get_breadcrumbs());
 	}
@@ -36,10 +36,10 @@ class ElggBreadcrumbsUnitTest extends \Elgg\IntegratedUnitTestCase {
 		$this->assertEquals(['text' => 'title 2', 'href' => 'path2'], elgg_pop_breadcrumb());
 
 		$this->assertEquals([
-			['text' => 'title 1', 'href' => null, 'name' => 0],
+			['text' => 'title 1', 'href' => false, 'name' => 0],
 		], elgg_get_breadcrumbs());
 
-		$this->assertEquals(['text' => 'title 1', 'href' => null], elgg_pop_breadcrumb());
+		$this->assertEquals(['text' => 'title 1', 'href' => false], elgg_pop_breadcrumb());
 
 		$this->assertEquals([], elgg_get_breadcrumbs());
 
@@ -54,7 +54,7 @@ class ElggBreadcrumbsUnitTest extends \Elgg\IntegratedUnitTestCase {
 		$this->assertEquals([
 			[
 				'text' => str_repeat('abcd ', 100),
-				'href' => null,
+				'href' => false,
 				'name' => 0,
 			],
 		], elgg_get_breadcrumbs());
@@ -66,7 +66,7 @@ class ElggBreadcrumbsUnitTest extends \Elgg\IntegratedUnitTestCase {
 		$this->assertEquals([
 			[
 				'text' => str_repeat('abcd ', 100),
-				'href' => null,
+				'href' => false,
 				'name' => 0,
 			]
 		], elgg_get_breadcrumbs());


### PR DESCRIPTION
Setting the href to an empty string results in a link to the current
page, not an empty link as expected.