### PR TITLE
fix(discussions): river items get correctly updated to comments view

### DIFF
--- a/mod/discussions/classes/Elgg/Discussions/Upgrades/MigrateDiscussionReplyRiver.php
+++ b/mod/discussions/classes/Elgg/Discussions/Upgrades/MigrateDiscussionReplyRiver.php
@@ -31,18 +31,12 @@ class MigrateDiscussionReplyRiver implements AsynchronousUpgrade {
 	 * {@inheritDoc}
 	 */
 	public function countItems() {
-		
-		$hidden = access_show_hidden_entities(true);
-		
-		$count = elgg_get_river([
-			'type' => 'object',
-			'subtype' => 'discussion_reply',
+				
+		return elgg_get_river([
+			'action_type' => 'reply',
+			'view' => 'river/object/discussion_reply/create',
 			'count' => true,
 		]);
-		
-		access_show_hidden_entities($hidden);
-		
-		return $count;
 	}
 	
 	/**
@@ -58,10 +52,8 @@ class MigrateDiscussionReplyRiver implements AsynchronousUpgrade {
 	public function run(Result $result, $offset) {
 		
 		$qb = Update::table('river', 'r')
-			->set('r.subtype', '"comment"')
 			->set('r.action_type', '"comment"')
 			->set('r.view', '"river/object/comment/create"')
-			->andWhere('r.subtype = "discussion_reply"')
 			->andWhere('r.action_type = "reply"')
 			->andWhere('r.view = "river/object/discussion_reply/create"');
 		


### PR DESCRIPTION
Fixes #12313

**reasons for change**

- subtype column does not exist in river
- reply entities are changed to comments before this upgrade runs, so selection based on subtype is not possible