### PR TITLE
chore(core): filter out unsupported items in completed upgrades

### DIFF
--- a/engine/classes/Elgg/UpgradeService.php
+++ b/engine/classes/Elgg/UpgradeService.php
@@ -495,6 +495,7 @@ class UpgradeService {
 		$upgrades = elgg_get_entities([
 			'type' => 'object',
 			'subtype' => 'elgg_upgrade',
+			'private_setting_name' => 'class', // filters old upgrades
 			'private_setting_name_value_pairs' => [
 				'name' => 'is_completed',
 				'value' => true,


### PR DESCRIPTION
Fixes #12349 

This could happen with pre 3.0 upgrades. Those old upgrades miss the class data in the database