### PR TITLE
fix(icons): increased the default resolution of master icon to 10240px

### DIFF
--- a/docs/guides/database.rst
+++ b/docs/guides/database.rst
@@ -165,7 +165,7 @@ objects. These methods save the `master` size of the icon defined in the system.
 	$object->save();
 
 The following sizes exist by default: 
- * ``master`` - 2048px at longer edge (not upscaled)
+ * ``master`` - 10240px at longer edge (not upscaled)
  * ``large`` - 200px at longer edge (not upscaled)
  * ``medium`` - 100px square
  * ``small`` - 40px square

--- a/engine/classes/Elgg/EntityIconService.php
+++ b/engine/classes/Elgg/EntityIconService.php
@@ -603,8 +603,8 @@ class EntityIconService {
 		// lazy generation of icons requires a 'master' size
 		// this ensures a default config for 'master' size
 		$sizes['master'] = elgg_extract('master', $sizes, [
-			'w' => 2048,
-			'h' => 2048,
+			'w' => 10240,
+			'h' => 10240,
 			'square' => false,
 			'upscale' => false,
 			'crop' => false,

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -1836,7 +1836,7 @@ function elgg_views_boot() {
 			'small' => ['w' => 40, 'h' => 40, 'square' => true, 'upscale' => true],
 			'medium' => ['w' => 100, 'h' => 100, 'square' => true, 'upscale' => true],
 			'large' => ['w' => 200, 'h' => 200, 'square' => true, 'upscale' => true],
-			'master' => ['w' => 2048, 'h' => 2048, 'square' => false, 'upscale' => false, 'crop' => false],
+			'master' => ['w' => 10240, 'h' => 10240, 'square' => false, 'upscale' => false, 'crop' => false],
 		];
 		elgg_set_config('icon_sizes', $icon_sizes);
 	}

--- a/engine/tests/classes/Elgg/BaseTestCase.php
+++ b/engine/tests/classes/Elgg/BaseTestCase.php
@@ -126,8 +126,8 @@ abstract class BaseTestCase extends TestCase implements Seedable, Testable {
 					'upscale' => true
 				],
 				'master' => [
-					'w' => 2048,
-					'h' => 2048,
+					'w' => 10240,
+					'h' => 10240,
 					'square' => false,
 					'upscale' => false,
 					'crop' => false,

--- a/engine/tests/elgg-config/simpletest.php
+++ b/engine/tests/elgg-config/simpletest.php
@@ -77,8 +77,8 @@ $settings = [
 			'upscale' => true
 		],
 		'master' => [
-			'w' => 2048,
-			'h' => 2048,
+			'w' => 10240,
+			'h' => 10240,
 			'square' => false,
 			'upscale' => false
 		],

--- a/engine/tests/phpunit/unit/Elgg/EntityIconServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/EntityIconServiceUnitTest.php
@@ -113,8 +113,8 @@ class EntityIconServiceUnitTest extends \Elgg\UnitTestCase {
 	public static function getDefaultIconSizes() {
 		return [
 			'master' => [
-				'w' => 2048,
-				'h' => 2048,
+				'w' => 10240,
+				'h' => 10240,
 				'square' => false,
 				'upscale' => false,
 				'crop' => false,


### PR DESCRIPTION
The old value (2048) resulted in a pictue less than 3MP. This will also
help to prevents cropping issues.

The new resolution is above 8K UHD