### PR TITLE
fix(css): wordbreaking is now allow everywhere

### DIFF
--- a/views/default/elements/components/table.css
+++ b/views/default/elements/components/table.css
@@ -15,7 +15,6 @@
 		padding: 0.5em 0.75em;
 		vertical-align: top;
 		background-color: white;
-		word-break: break-word;
 	}
 
 	tr.elgg-state-selected td,
@@ -39,4 +38,16 @@
 .elgg-table-alt th:first-child,
 .elgg-table-alt td:first-child {
 	width: 15rem;
+}
+
+@media $(media-tablet-up) {
+	.elgg-table,
+	.elgg-table-alt {
+		thead,
+		tfoot {
+			th {
+				word-break: normal;
+			}
+		}
+	}
 }

--- a/views/default/elements/components/typography.css
+++ b/views/default/elements/components/typography.css
@@ -3,6 +3,11 @@
 *************************************** */
 body {
 	font-family: $(font-family);
+	
+	/* Break everywhere as a fallback */
+	word-break: break-all;
+	/* Instead use this non-standard one as it is better */
+	word-break: break-word;
 }
 
 a {


### PR DESCRIPTION
This allows better default behaviour of long string in a responsive website

fixes #12177

related #12178