### PR TITLE
fix(notifications): fix faulty subscription list mutations

### DIFF
--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -350,6 +350,9 @@ Note that not all hooks apply to instant notifications.
 	In case of a subscription event, by default, the subscribers list consists of the users subscribed to the container entity of the event object.
 	In case of an instant notification event, the subscribers list consists of the users passed as recipients to ``notify_user()``
 
+   **IMPORTANT** Always validate the notification event, object and/or action types before adding any new recipients to ensure that you do not accidentally dispatch notifications to unintended recipients.
+   Consider a situation, where a mentions plugin sends out an instant notification to a mentioned user - any hook acting on a subject or an object without validating an event or action type (e.g. including an owner of the original wire thread) might end up sending notifications to wrong users.
+
 	``$params`` array includes:
 
 	 * ``event`` - ``\Elgg\Notifications\NotificationEvent`` instance that describes the notification event

--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -383,10 +383,16 @@ function discussion_prepare_reply_notification($hook, $type, $notification, $par
  * @return array
  */
 function discussion_get_subscriptions($hook, $type, $subscriptions, $params) {
-	$reply = $params['event']->getObject();
+	$event = elgg_extract('event', $params);
+
+	if (!$event instanceof \Elgg\Notifications\SubscriptionNotificationEvent) {
+		return;
+	}
+
+	$reply = $event->getObject();
 
 	if (!elgg_instanceof($reply, 'object', 'discussion_reply')) {
-		return $subscriptions;
+		return;
 	}
 
 	$container_guid = $reply->getContainerEntity()->container_guid;

--- a/mod/thewire/start.php
+++ b/mod/thewire/start.php
@@ -331,6 +331,11 @@ function thewire_save_post($text, $userid, $access_id, $parent_guid = 0, $method
  */
 function thewire_add_original_poster($hook, $type, $subscriptions, $params) {
 	$event = $params['event'];
+
+	if (!$event instanceof \Elgg\Notifications\SubscriptionNotificationEvent) {
+		return;
+	}
+
 	$entity = $event->getObject();
 	if (!$entity || !elgg_instanceof($entity, 'object', 'thewire')) {
 		return;


### PR DESCRIPTION
Plugins must validate the nature of the notification event before altering
the list of recipients