### PR TITLE
Email attachments encoding

### DIFF
--- a/engine/classes/Elgg/Email/Attachment.php
+++ b/engine/classes/Elgg/Email/Attachment.php
@@ -4,6 +4,7 @@ namespace Elgg\Email;
 
 use Elgg\Filesystem\MimeTypeDetector;
 use Zend\Mime\Part;
+use Zend\Mime\Mime;
 
 /**
  * Email attachment
@@ -70,6 +71,8 @@ class Attachment extends Part {
 			
 			$content = file_get_contents($filepath);
 			
+			$options['encoding'] = Mime::ENCODING_BASE64;
+			
 			if (!isset($options['filename'])) {
 				$options['filename'] = basename($filepath);
 			}
@@ -107,6 +110,7 @@ class Attachment extends Part {
 			'content' => $file->grabFile(),
 			'type' => $file->getMimeType(),
 			'filename' => basename($file->getFilename()),
+			'encoding' => Mime::ENCODING_BASE64,
 		];
 		
 		return self::factory($options);

--- a/engine/classes/Elgg/EmailService.php
+++ b/engine/classes/Elgg/EmailService.php
@@ -171,9 +171,9 @@ class EmailService {
 		
 		$body->addPart($plain_text_part);
 		
-		// process attachements
-		$attachements = $email->getAttachments();
-		foreach ($attachements as $attachement) {
+		// process attachments
+		$attachments = $email->getAttachments();
+		foreach ($attachments as $attachement) {
 			$body->addPart($attachement);
 		}
 		

--- a/engine/tests/phpunit/unit/Elgg/Email/AttachmentUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Email/AttachmentUnitTest.php
@@ -3,6 +3,7 @@
 namespace Elgg\Email;
 
 use Elgg\UnitTestCase;
+use Zend\Mime\Mime;
 
 /**
  * @group EmailService
@@ -73,7 +74,8 @@ class AttachmentUnitTest extends UnitTestCase {
 		
 		$this->assertNotFalse($attachment);
 		
-		$this->assertEquals($this->file->grabFile(), $attachment->getContent());
+		$this->assertEquals(Mime::ENCODING_BASE64, $attachment->getEncoding());
+		$this->assertEquals($this->file->grabFile(), base64_decode($attachment->getContent()));
 		$this->assertEquals($this->file->getMimeType(), $attachment->getType());
 		$this->assertEquals($this->file->getFilename(), $attachment->getFileName());
 		$this->assertEquals('attachment', $attachment->getDisposition());
@@ -85,7 +87,8 @@ class AttachmentUnitTest extends UnitTestCase {
 		
 		$this->assertNotFalse($attachment);
 		
-		$this->assertEquals($this->file->grabFile(), $attachment->getContent());
+		$this->assertEquals(Mime::ENCODING_BASE64, $attachment->getEncoding());
+		$this->assertEquals($this->file->grabFile(), base64_decode($attachment->getContent()));
 		$this->assertEquals($this->file->getMimeType(), $attachment->getType());
 		$this->assertEquals($this->file->getFilename(), $attachment->getFileName());
 		$this->assertEquals('attachment', $attachment->getDisposition());

--- a/engine/tests/phpunit/unit/Elgg/EmailUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/EmailUnitTest.php
@@ -3,6 +3,7 @@
 namespace Elgg;
 
 use Elgg\Email\Address;
+use Zend\Mime\Mime;
 
 /**
  * @group EmailService
@@ -237,7 +238,8 @@ class EmailUnitTest extends UnitTestCase {
 		$email_parts = $email->getAttachments();
 		$email_part = $email_parts[0];
 		
-		$this->assertEquals($file->grabFile(), $email_part->getContent());
+		$this->assertEquals(Mime::ENCODING_BASE64, $email_part->getEncoding());
+		$this->assertEquals($file->grabFile(), base64_decode($email_part->getContent()));
 		$this->assertEquals($file->getMimeType(), $email_part->getType());
 		$this->assertEquals($file->getFilename(), $email_part->getFileName());
 	}


### PR DESCRIPTION
Base64 encode e-mail attachments for better support in different e-mail
clients