### PR TITLE
fix(blog): excerpt no longer limited during save

### DIFF
--- a/mod/blog/actions/blog/auto_save_revision.php
+++ b/mod/blog/actions/blog/auto_save_revision.php
@@ -36,7 +36,7 @@ if ($guid) {
 	$blog->access_id = ACCESS_PRIVATE;
 	$blog->title = $title;
 	$blog->description = $description;
-	$blog->excerpt = $excerpt ? elgg_get_excerpt($excerpt) : null;
+	$blog->excerpt = $excerpt;
 
 	// mark this as a brand new post so we can work out the
 	// river / revision logic in the real save action.

--- a/mod/blog/actions/blog/save.php
+++ b/mod/blog/actions/blog/save.php
@@ -73,12 +73,6 @@ foreach ($values as $name => $default) {
 			$values[$name] = string_to_tag_array($value);
 			break;
 
-		case 'excerpt':
-			if ($value) {
-				$values[$name] = elgg_get_excerpt($value);
-			}
-			break;
-
 		case 'container_guid':
 			// this can't be empty or saving the base entity fails
 			if (!empty($value)) {

--- a/mod/blog/classes/ElggBlog.php
+++ b/mod/blog/classes/ElggBlog.php
@@ -51,11 +51,9 @@ class ElggBlog extends ElggObject {
 	 * @since 1.9.0
 	 */
 	public function getExcerpt($length = 250) {
-		if ($this->excerpt) {
-			return $this->excerpt;
-		} else {
-			return elgg_get_excerpt($this->description, $length);
-		}
+		$excerpt = $this->excerpt ?: $this->description;
+		
+		return elgg_get_excerpt($excerpt, $length);
 	}
 
 }


### PR DESCRIPTION
The excerpt of the blog was limited during save, if however a blog was
created any other way the excerpt wasn't limited. Now it's always
limited during presentation.