### PR TITLE
fix(css): popped out dropdown always showing

### DIFF
--- a/views/default/elements/z-index.css
+++ b/views/default/elements/z-index.css
@@ -59,3 +59,8 @@
 .elgg-spinner {
 	z-index: 2000;
 }
+
+
+.elgg-menu.elgg-state-popped {
+	z-index: 3000;
+}


### PR DESCRIPTION
popped out menus like the entity dropdown were not showing in lightboxes... this fixes the behaviour so that popped menus are always on top