### PR TITLE
fix(request): return expected return type

### DIFF
--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -368,7 +368,11 @@ class Request extends SymfonyRequest {
 	 * @return UploadedFile[]
 	 */
 	public function getFiles($input_name) {
-		$files = $this->files->get($input_name, []);
+		$files = $this->files->get($input_name);
+		if (empty($files)) {
+			return [];
+		}
+
 		if (!is_array($files)) {
 			$files = [$files];
 		}

--- a/engine/classes/Elgg/UploadService.php
+++ b/engine/classes/Elgg/UploadService.php
@@ -48,9 +48,7 @@ class UploadService {
 		$files = $this->request->getFiles($input_name);
 
 		foreach ($files as $file) {
-			if ($file instanceof UploadedFile) {
-				$this->prepareFile($file);
-			}
+			$this->prepareFile($file);
 		}
 		
 		return $files;

--- a/engine/lib/filestore.php
+++ b/engine/lib/filestore.php
@@ -375,7 +375,7 @@ function _elgg_filestore_move_icons($event, $type, $entity) {
  * Returns an array of uploaded file objects regardless of upload status/errors
  *
  * @param string $input_name Form input name
- * @return UploadedFile[]|false
+ * @return UploadedFile[]
  */
 function elgg_get_uploaded_files($input_name) {
 	return _elgg_services()->uploads->getFiles($input_name);


### PR DESCRIPTION
It was possible to have a return array with a null value when no file
was posted in a request. This would fail empty checks and potentialy
break pages