### PR TITLE
fix(access): user edit access flag for elgg_entity_gatekeeper

### DIFF
--- a/engine/classes/Elgg/Database/AccessCollections.php
+++ b/engine/classes/Elgg/Database/AccessCollections.php
@@ -277,6 +277,11 @@ class AccessCollections {
 			return true;
 		}
 
+		if ($user_guid && !$entity->canEdit($user_guid)) {
+			// Current logged in user (Owner/Admin) has edit access to the content
+			return false;
+		}
+
 		// See #7159. Must not allow ignore access to affect query
 		$ia = _elgg_services()->session->setIgnoreAccess(false);
 


### PR DESCRIPTION
Fix for https://github.com/Elgg/Elgg/issues/12402
`elgg_entity_gatekeeper` calls the function `assertAccessibleEntity `which calls the function `hasAccessToEntity`.
Now we know `hasAccessToEntity` throws an `EntityPermissionsException` if any of the checks is not fulfilled. Hence, added the `canEdit` check inside `hasAccessToEntity` function.