### PR TITLE
fix(access): flag to check user edit access

### DIFF
--- a/engine/lib/pagehandler.php
+++ b/engine/lib/pagehandler.php
@@ -161,9 +161,10 @@ function elgg_admin_gatekeeper() {
  * if it does. If the viewer cannot view this entity, it forwards to an
  * appropriate page.
  *
- * @param int    $guid    Entity GUID
- * @param string $type    Optional required entity type
- * @param string $subtype Optional required entity subtype
+ * @param int    $guid         Entity GUID
+ * @param string $type         Optional required entity type
+ * @param string $subtype      Optional required entity subtype
+ * @param bool   $canEditCheck flag to check canEdit access
  *
  * @return void
  *
@@ -173,9 +174,9 @@ function elgg_admin_gatekeeper() {
  * @throws \Elgg\HttpException
  * @since 1.9.0
  */
-function elgg_entity_gatekeeper($guid, $type = null, $subtype = null) {
+function elgg_entity_gatekeeper($guid, $type = null, $subtype = null, $canEditCheck = false) {
 	$entity = _elgg_services()->gatekeeper->assertExists($guid, $type, $subtype);
-	_elgg_services()->gatekeeper->assertAccessibleEntity($entity);
+	_elgg_services()->gatekeeper->assertAccessibleEntity($entity, null, $canEditCheck);
 }
 
 /**

--- a/mod/blog/views/default/resources/blog/edit.php
+++ b/mod/blog/views/default/resources/blog/edit.php
@@ -1,7 +1,7 @@
 <?php
 
 $guid = elgg_extract('guid', $vars);
-elgg_entity_gatekeeper($guid, 'object', 'blog');
+elgg_entity_gatekeeper($guid, 'object', 'blog', true);
 
 $blog = get_entity($guid);
 if (!$blog->canEdit()) {

--- a/mod/bookmarks/views/default/resources/bookmarks/edit.php
+++ b/mod/bookmarks/views/default/resources/bookmarks/edit.php
@@ -6,7 +6,7 @@
  */
 
 $bookmark_guid = elgg_extract('guid', $vars);
-elgg_entity_gatekeeper($bookmark_guid, 'object', 'bookmarks');
+elgg_entity_gatekeeper($bookmark_guid, 'object', 'bookmarks', true);
 
 $bookmark = get_entity($bookmark_guid);
 

--- a/mod/discussions/views/default/resources/discussion/edit.php
+++ b/mod/discussions/views/default/resources/discussion/edit.php
@@ -2,7 +2,7 @@
 
 $guid = elgg_extract('guid', $vars);
 
-elgg_entity_gatekeeper($guid, 'object', 'discussion');
+elgg_entity_gatekeeper($guid, 'object', 'discussion', true);
 
 $topic = get_entity($guid);
 

--- a/mod/pages/views/default/resources/pages/edit.php
+++ b/mod/pages/views/default/resources/pages/edit.php
@@ -5,7 +5,7 @@
 
 $page_guid = (int) elgg_extract('guid', $vars);
 
-elgg_entity_gatekeeper($page_guid, 'object', 'page');
+elgg_entity_gatekeeper($page_guid, 'object', 'page', true);
 
 $page = get_entity($page_guid);
 if (!$page->canEdit()) {


### PR DESCRIPTION
Fix for https://github.com/Elgg/Elgg/issues/12402

- function `assertAccessibleEntity` now has a new parameter `canEditCheck` (default set as false) to check if user has edit access to the ElggEntity. If true, `assertAccessibleEntity` will check user edit access.
- `elgg_entity_gatekeeper` also has the same new parameter `canEditCheck` (default set as false) which is pass as parameter to `assertAccessibleEntity` function.
- Updated edit files for blog, bookmarks, discussion, page to call `elgg_entity_gatekeeper` with `canEditCheck` as true.