### PR TITLE
fix(css): display tabs horizontally on small screens

### DIFF
--- a/views/default/elements/components/tabs.css
+++ b/views/default/elements/components/tabs.css
@@ -1,12 +1,17 @@
 /* ***************************************
 	FILTER MENU AND TABS
 *************************************** */
+.elgg-layout-filter {
+	overflow: auto;
+	white-space: nowrap;
+}
+
 .elgg-menu-filter,
 .elgg-tabs {
 	margin-bottom: 0.5rem;
 	border-bottom: 1px solid $(border-color-soft);
 	display: flex;
-	flex-direction: column;
+	flex-direction: row;
 }
 
 .elgg-menu-filter > li,


### PR DESCRIPTION
Fix for https://github.com/Elgg/Elgg/issues/12173
The solution will create a horizontal scrolling tab menu.
Demo:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/2772844/55050972-5511b700-5079-11e9-83ca-c879494253ce.gif)