### PR TITLE
chore(notifications): no longer deprecate Notification\Event

### DIFF
--- a/engine/classes/Elgg/Notifications/Event.php
+++ b/engine/classes/Elgg/Notifications/Event.php
@@ -11,7 +11,7 @@ use stdClass;
  *
  * @package    Elgg.Core
  * @subpackage Notifications
- * @deprecated 2.3
+ * @todo remove this class in Elgg 4.0 in favour of SubscriptionNotificationEvent (see https://github.com/Elgg/Elgg/issues/11241)
  */
 class Event implements NotificationEvent {
 


### PR DESCRIPTION
Needs to be cleaned up in Elgg 4

fixes #11241