### PR TITLE
security(forward): prevent open redirect exploits

### DIFF
--- a/actions/admin/plugins/activate.php
+++ b/actions/admin/plugins/activate.php
@@ -63,5 +63,5 @@ if (count($activated_guids) === 1) {
 	if (strpos($url, '#')) {
 		$url = substr(0, strpos($url, '#'));
 	}
-	forward($url);
+	forward(elgg_normalize_site_url($url));
 }

--- a/engine/lib/output.php
+++ b/engine/lib/output.php
@@ -359,6 +359,28 @@ function elgg_normalize_url($url) {
 }
 
 /**
+ * From untrusted input, get a site URL safe for forwarding.
+ *
+ * @param string $unsafe_url URL from untrusted input
+ *
+ * @return bool|string Normalized URL or false if given URL was not a path.
+ *
+ * @since 1.12.18
+ */
+function elgg_normalize_site_url($unsafe_url) {
+	if (!is_string($unsafe_url)) {
+		return false;
+	}
+
+	$unsafe_url = elgg_normalize_url($unsafe_url);
+	if (0 === strpos($unsafe_url, elgg_get_site_url())) {
+		return $unsafe_url;
+	}
+
+	return false;
+}
+
+/**
  * When given a title, returns a version suitable for inclusion in a URL
  *
  * @param string $title The title

--- a/mod/blog/actions/blog/save.php
+++ b/mod/blog/actions/blog/save.php
@@ -31,7 +31,7 @@ if ($guid) {
 		$blog = $entity;
 	} else {
 		register_error(elgg_echo('blog:error:post_not_found'));
-		forward(get_input('forward', REFERER));
+		forward($error_forward_url);
 	}
 
 	// save some data for revisions once we save the new edit

--- a/mod/reportedcontent/actions/reportedcontent/add.php
+++ b/mod/reportedcontent/actions/reportedcontent/add.php
@@ -11,7 +11,7 @@ $access = ACCESS_PRIVATE; //this is private and only admins can see it
 
 $fail = function () use ($address) {
 	register_error(elgg_echo('reportedcontent:failed'));
-	forward($address);
+	forward(elgg_normalize_site_url($address));
 };
 
 if (!$title || !$address) {


### PR DESCRIPTION
Thanks to Jyoti Raval for reporting a potential exploit whereby
manipulating the Referer header could result in unwanted results.