### PR TITLE
fix(css): member display name in hover menu

### DIFF
--- a/views/default/elements/components/menus.css
+++ b/views/default/elements/components/menus.css
@@ -252,7 +252,6 @@
 .elgg-menu-hover-card {
 	padding: 1rem;
 	max-width: 20rem;
-	flex: 2;
 }
 
 .elgg-menu-hover li:not(:last-child),


### PR DESCRIPTION
Fix https://github.com/Elgg/Elgg/issues/12511

Tested in both mobile and desktop view
Tested for worst case scenario when screen with is too small in desktop mode.

Old view:
![image](https://user-images.githubusercontent.com/2772844/55686351-ca389280-597d-11e9-8262-451cdb84f9c0.png)

New view:
![image](https://user-images.githubusercontent.com/2772844/55686356-dde3f900-597d-11e9-8e8f-7207b081ba30.png)
