### PR TITLE
fix(core): report correct duration for non sequential timers

### DIFF
--- a/engine/classes/Elgg/Profiler.php
+++ b/engine/classes/Elgg/Profiler.php
@@ -27,8 +27,8 @@ class Profiler {
 	public function buildTree(Timer $timer) {
 		$times = $timer->getTimes();
 
-		if (!isset($times[':end'])) {
-			$times[':end'] = microtime();
+		if (!isset($times[Timer::MARKER_END])) {
+			$times[Timer::MARKER_END] = microtime(true);
 		}
 
 		$begin = $this->findBeginTime($times);
@@ -137,7 +137,8 @@ class Profiler {
 		if ($begin === false || $end === false) {
 			return false;
 		}
-		unset($times[':begin'], $times[':end']);
+		$has_own_markers = isset($times[Timer::MARKER_BEGIN]) && isset($times[Timer::MARKER_BEGIN]);
+		unset($times[Timer::MARKER_BEGIN], $times[Timer::MARKER_END]);
 
 		$total = $this->diffMicrotime($begin, $end);
 		$ret = [
@@ -159,6 +160,15 @@ class Profiler {
 		}
 
 		if (isset($ret['periods'])) {
+			if (!$has_own_markers) {
+				// this is an aggregation of different non sequential timers (eg. SQL queries)
+				$ret['duration'] = 0;
+				foreach ($ret['periods'] as $period) {
+					$ret['duration'] += $period['duration'];
+				}
+				$ret['percentage'] = 100 * $ret['duration'] / $this->total;
+			}
+			
 			usort($ret['periods'], function ($a, $b) {
 				if ($a['duration'] == $b['duration']) {
 					return 0;
@@ -177,10 +187,10 @@ class Profiler {
 	 * @return string|false
 	 */
 	private function findBeginTime(array $times) {
-		if (isset($times[':begin'])) {
-			return $times[':begin'];
+		if (isset($times[Timer::MARKER_BEGIN])) {
+			return $times[Timer::MARKER_BEGIN];
 		}
-		unset($times[':begin'], $times[':end']);
+		unset($times[Timer::MARKER_BEGIN], $times[Timer::MARKER_END]);
 		$first = reset($times);
 		if (is_array($first)) {
 			return $this->findBeginTime($first);
@@ -195,10 +205,10 @@ class Profiler {
 	 * @return string|false
 	 */
 	private function findEndTime(array $times) {
-		if (isset($times[':end'])) {
-			return $times[':end'];
+		if (isset($times[Timer::MARKER_END])) {
+			return $times[Timer::MARKER_END];
 		}
-		unset($times[':begin'], $times[':end']);
+		unset($times[Timer::MARKER_BEGIN], $times[Timer::MARKER_END]);
 		$last = end($times);
 		if (is_array($last)) {
 			return $this->findEndTime($last);
@@ -209,16 +219,12 @@ class Profiler {
 	/**
 	 * Calculate a precise time difference.
 	 *
-	 * @param string $start result of microtime()
-	 * @param string $end   result of microtime()
+	 * @param float $start result of microtime(true)
+	 * @param float $end   result of microtime(true)
 	 *
 	 * @return float difference in seconds, calculated with minimum precision loss
 	 */
 	private function diffMicrotime($start, $end) {
-		list($start_usec, $start_sec) = explode(" ", $start);
-		list($end_usec, $end_sec) = explode(" ", $end);
-		$diff_sec = (int) $end_sec - (int) $start_sec;
-		$diff_usec = (float) $end_usec - (float) $start_usec;
-		return (float) $diff_sec + $diff_usec;
+		return (float) $end - $start;
 	}
 }

--- a/engine/classes/Elgg/Timer.php
+++ b/engine/classes/Elgg/Timer.php
@@ -19,7 +19,7 @@ class Timer {
 	 * @return void
 	 */
 	public function begin(array $keys) {
-		$this->getTreeNode($keys)[self::MARKER_BEGIN] = microtime();
+		$this->getTreeNode($keys)[self::MARKER_BEGIN] = microtime(true);
 	}
 
 	/**
@@ -29,7 +29,7 @@ class Timer {
 	 * @return void
 	 */
 	public function end(array $keys) {
-		$this->getTreeNode($keys)[self::MARKER_END] = microtime();
+		$this->getTreeNode($keys)[self::MARKER_END] = microtime(true);
 	}
 
 	/**

--- a/engine/tests/phpunit/unit/Elgg/TimerUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/TimerUnitTest.php
@@ -43,8 +43,7 @@ class TimerUnitTest extends \Elgg\UnitTestCase {
 	}
 
 	public function assertIsATime($val) {
-		list($one, $two) = explode(' ', $val);
-		$this->assertTrue(is_numeric($one) && is_numeric($two));
+		$this->assertInternalType('float', $val);
 	}
 
 	public function testCanDetectEnd() {


### PR DESCRIPTION
For example the SQL query time isn't the time between the first and last
query, but the duration of the individual queries.