### PR TITLE
chore(cache): set cache drivers in order of fastest access

### DIFF
--- a/engine/classes/Elgg/Cache/CompositeCache.php
+++ b/engine/classes/Elgg/Cache/CompositeCache.php
@@ -200,11 +200,11 @@ class CompositeCache extends ElggCache {
 	 */
 	protected function createPool() {
 		$drivers = [];
+		$drivers[] = $this->buildEphemeralDriver();
 		$drivers[] = $this->buildApcDriver();
 		$drivers[] = $this->buildRedisDriver();
 		$drivers[] = $this->buildMemcachedDriver();
 		$drivers[] = $this->buildFileSystemDriver();
-		$drivers[] = $this->buildEphemeralDriver();
 		$drivers[] = $this->buildBlackHoleDriver();
 		$drivers = array_filter($drivers);
 
@@ -304,7 +304,7 @@ class CompositeCache extends ElggCache {
 
 	/**
 	 * Builds in-memory driver
-	 * @return Ephemeral
+	 * @return null|Ephemeral
 	 */
 	protected function buildEphemeralDriver() {
 		if (!($this->flags & ELGG_CACHE_RUNTIME)) {
@@ -316,7 +316,7 @@ class CompositeCache extends ElggCache {
 
 	/**
 	 * Builds null cache driver
-	 * @return BlackHole
+	 * @return null|BlackHole
 	 */
 	protected function buildBlackHoleDriver() {
 		if (!($this->flags & ELGG_CACHE_BLACK_HOLE)) {


### PR DESCRIPTION
See https://www.stashphp.com/Drivers.html#composite for explanation.

When reading data from cache the fastest driver should be first in order to have benifits when reading mulitple times