### PR TITLE
fix(ajax): reponseFactory prepares reponse

### DIFF
--- a/engine/classes/Elgg/Ajax/Service.php
+++ b/engine/classes/Elgg/Ajax/Service.php
@@ -201,7 +201,7 @@ class Service {
 			return new JsonResponse(['error' => "The response was cancelled"], 400);
 		}
 
-		$response = new JsonResponse($api_response->getData());
+		$response = _elgg_services()->responseFactory->prepareJsonResponse($api_response->getData());
 
 		$ttl = $api_response->getTtl();
 		if ($ttl > 0) {

--- a/engine/classes/Elgg/Http/ResponseFactory.php
+++ b/engine/classes/Elgg/Http/ResponseFactory.php
@@ -12,6 +12,7 @@ use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -145,14 +146,17 @@ class ResponseFactory {
 	 * @param string  $content The response content
 	 * @param integer $status  The response status code
 	 * @param array   $headers An array of response headers
+	 *
 	 * @return Response
+	 * @throws InvalidArgumentException
 	 */
 	public function prepareResponse($content = '', $status = 200, array $headers = []) {
 		$header_bag = $this->getHeaders();
 		$header_bag->add($headers);
+		
 		$response = new Response($content, $status, $header_bag->all());
-		$response->prepare($this->request);
-		return $response;
+		
+		return $this->finalizeResponsePreparation($response, $header_bag);
 	}
 
 	/**
@@ -161,14 +165,63 @@ class ResponseFactory {
 	 * @param string  $url     URL to redirect to
 	 * @param integer $status  The status code (302 by default)
 	 * @param array   $headers An array of response headers (Location is always set to the given URL)
+	 *
 	 * @return SymfonyRedirectResponse
 	 * @throws InvalidArgumentException
 	 */
 	public function prepareRedirectResponse($url, $status = 302, array $headers = []) {
 		$header_bag = $this->getHeaders();
 		$header_bag->add($headers);
+		
 		$response = new SymfonyRedirectResponse($url, $status, $header_bag->all());
+		
+		return $this->finalizeResponsePreparation($response, $header_bag);
+	}
+	
+	/**
+	 * Creates an JSON response
+	 *
+	 * @param string  $content The response content
+	 * @param integer $status  The response status code
+	 * @param array   $headers An array of response headers
+	 *
+	 * @return JsonResponse
+	 * @throws InvalidArgumentException
+	 */
+	public function prepareJsonResponse($content = '', $status = 200, array $headers = []) {
+		$header_bag = $this->getHeaders();
+		$header_bag->add($headers);
+		
+		/**
+		 * Removing Content-Type header because in some cases content-type headers were already set
+		 * This is a problem when serving a cachable view (for example a .css) in ajax/view
+		 *
+		 * @see https://github.com/Elgg/Elgg/issues/9794
+		 */
+		$header_bag->remove('Content-Type');
+		
+		$response = new JsonResponse($content, $status, $header_bag->all());
+		
+		return $this->finalizeResponsePreparation($response, $header_bag);
+	}
+	
+	/**
+	 * Last preparations on a response
+	 *
+	 * @param Response          $response The response to prepare
+	 * @param ResponseHeaderBag $headers  Header container with additional content
+	 *
+	 * @return Response
+	 * @todo revisit this when upgrading to Symfony/HttpFoundation v3.3+
+	 */
+	private function finalizeResponsePreparation(Response $response, ResponseHeaderBag $headers) {
+		// Cookies aren't part of the headers, need to copy manualy
+		foreach ($headers->getCookies() as $cookie) {
+			$response->headers->setCookie($cookie);
+		}
+		
 		$response->prepare($this->request);
+		
 		return $response;
 	}
 

--- a/engine/tests/phpunit/integration/Elgg/Http/ResponseFactoryIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Http/ResponseFactoryIntegrationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Elgg\Http;
+
+use Elgg\IntegrationTestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class ResponseFactoryIntegrationTest extends IntegrationTestCase {
+	
+	/**
+	 * @var ResponseFactory
+	 */
+	private $service;
+	
+	/**
+	 * {@inheritDoc}
+	 * @see \Elgg\BaseTestCase::up()
+	 */
+	public function up() {
+		self::createApplication(['isolate'=> true]);
+		
+		$this->service = _elgg_services()->responseFactory;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @see \Elgg\BaseTestCase::down()
+	 */
+	public function down() {
+		if (isset($this->service)) {
+			unset($this->service);
+		}
+	}
+	
+	public function testCanSetCookie() {
+		$cookie = new \ElggCookie('foo');
+		$cookie->value = 'bar';
+		
+		$this->assertTrue($this->service->setCookie($cookie));
+		
+		$headers = $this->service->getHeaders();
+		$this->assertNotEmpty($headers);
+		
+		$header_cookies = $headers->getCookies();
+		$this->assertInternalType('array', $header_cookies);
+		$this->assertCount(1, $header_cookies);
+		
+		$this->assertEquals($cookie->name, $header_cookies[0]->getName());
+		$this->assertEquals($cookie->value, $header_cookies[0]->getValue());
+	}
+	
+	public function testPrepareResponseContainsFactoryCookies() {
+		$cookie = new \ElggCookie('foo');
+		$cookie->value = 'bar';
+		
+		$this->assertTrue($this->service->setCookie($cookie));
+		
+		$factory_cookies = $this->service->getHeaders()->getCookies();
+		
+		$response = $this->service->prepareResponse();
+		$this->assertInstanceOf(Response::class, $response);
+		
+		$response_cookies = $response->headers->getCookies();
+		
+		$this->assertEquals($factory_cookies, $response_cookies);
+	}
+	
+	public function testPrepareRedirectResponseContainsFactoryCookies() {
+		$cookie = new \ElggCookie('foo');
+		$cookie->value = 'bar';
+		
+		$this->assertTrue($this->service->setCookie($cookie));
+		
+		$factory_cookies = $this->service->getHeaders()->getCookies();
+		
+		$response = $this->service->prepareRedirectResponse('foo/bar');
+		$this->assertInstanceOf(RedirectResponse::class, $response);
+		
+		$response_cookies = $response->headers->getCookies();
+		
+		$this->assertEquals($factory_cookies, $response_cookies);
+	}
+	
+	public function testPrepareJsonResponseContainsFactoryCookies() {
+		$cookie = new \ElggCookie('foo');
+		$cookie->value = 'bar';
+		
+		$this->assertTrue($this->service->setCookie($cookie));
+		
+		$factory_cookies = $this->service->getHeaders()->getCookies();
+		
+		$response = $this->service->prepareJsonResponse();
+		$this->assertInstanceOf(JsonResponse::class, $response);
+		
+		$response_cookies = $response->headers->getCookies();
+		
+		$this->assertEquals($factory_cookies, $response_cookies);
+	}
+}


### PR DESCRIPTION
This way headers (and cookies) will be prepared in the response

fixes #12592