### PR TITLE
fix(system_log): prevent fatal exception when constructing objects

### DIFF
--- a/mod/system_log/classes/Elgg/SystemLog/SystemLogEntry.php
+++ b/mod/system_log/classes/Elgg/SystemLog/SystemLogEntry.php
@@ -55,7 +55,7 @@ class SystemLogEntry {
 
 		if (isset($getters[$class]) && is_callable($getters[$class])) {
 			$object = call_user_func($getters[$class], $id);
-		} else if (preg_match('~^Elgg[A-Z]~', $class)) {
+		} elseif (is_subclass_of($class, \ElggEntity::class)) {
 			$object = get_entity($id);
 		} else {
 			// surround with try/catch because object could be disabled
@@ -64,6 +64,9 @@ class SystemLogEntry {
 
 				return $object;
 			} catch (\Exception $e) {
+				return false;
+			} catch (\Error $e) {
+				elgg_log("SystemLogEntry is unable to construct '{$class}' with ID: '{$this->object_id}': {$e->getMessage()}", 'ERROR');
 				return false;
 			}
 		}


### PR DESCRIPTION
The SystemLogEntry tries to construct the log row class. Improved
fetching of ElggEntity class and catch errors when constructing other
classes.