### PR TITLE
fix(email): set default email attachment id

### DIFF
--- a/engine/classes/Elgg/Email/Attachment.php
+++ b/engine/classes/Elgg/Email/Attachment.php
@@ -26,6 +26,7 @@ class Attachment extends Part {
 		parent::__construct($content);
 		
 		$this->disposition = 'attachment';
+		$this->setId(uniqid('attachment'));
 	}
 	
 	/**

--- a/engine/classes/Elgg/EmailService.php
+++ b/engine/classes/Elgg/EmailService.php
@@ -10,6 +10,7 @@ use Zend\Mail\Transport\TransportInterface;
 use Zend\Mime\Mime;
 use Zend\Mime\Message as MimeMessage;
 use Zend\Mime\Part;
+use Zend\Mime\Exception\InvalidArgumentException;
 
 /**
  * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
@@ -121,7 +122,15 @@ class EmailService {
 		}
 		
 		// add the body to the message
-		$body = $this->buildMessageBody($email);
+		try {
+			$body = $this->buildMessageBody($email);
+		} catch (InvalidArgumentException $e) {
+			$this->logger->error($e->getMessage());
+			
+			return false;
+		}
+		
+		
 		$message->setBody($body);
 		
 		// set Subject
@@ -161,6 +170,7 @@ class EmailService {
 	 * @param Email $email Email
 	 *
 	 * @return \Zend\Mime\Message
+	 * @throws \Zend\Mime\Exception\InvalidArgumentException
 	 */
 	protected function buildMessageBody(Email $email) {
 		// create body

--- a/engine/tests/phpunit/unit/Elgg/Email/AttachmentUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Email/AttachmentUnitTest.php
@@ -52,6 +52,7 @@ class AttachmentUnitTest extends UnitTestCase {
 		$this->assertEquals($this->attachment['type'], $attachment->getType());
 		$this->assertEquals($this->attachment['filename'], $attachment->getFileName());
 		$this->assertEquals('attachment', $attachment->getDisposition());
+		$this->assertNotEmpty($attachment->getId());
 	}
 	
 	public function testFactoryFromInvalidArray() {
@@ -79,6 +80,7 @@ class AttachmentUnitTest extends UnitTestCase {
 		$this->assertEquals($this->file->getMimeType(), $attachment->getType());
 		$this->assertEquals($this->file->getFilename(), $attachment->getFileName());
 		$this->assertEquals('attachment', $attachment->getDisposition());
+		$this->assertNotEmpty($attachment->getId());
 	}
 	
 	public function testFromElggFile() {
@@ -92,6 +94,7 @@ class AttachmentUnitTest extends UnitTestCase {
 		$this->assertEquals($this->file->getMimeType(), $attachment->getType());
 		$this->assertEquals($this->file->getFilename(), $attachment->getFileName());
 		$this->assertEquals('attachment', $attachment->getDisposition());
+		$this->assertNotEmpty($attachment->getId());
 	}
 	
 	public function testFromInvalidElggFile() {
@@ -108,5 +111,32 @@ class AttachmentUnitTest extends UnitTestCase {
 		_elgg_services()->logger->enable();
 		
 		$this->assertFalse($attachment);
+	}
+	
+	public function testUniqueID() {
+		
+		$attachment = Attachment::factory($this->attachment);
+		$attachment2 = Attachment::factory($this->attachment);
+		
+		$this->assertNotFalse($attachment);
+		$this->assertNotFalse($attachment2);
+		
+		$this->assertNotEmpty($attachment->getId());
+		$this->assertNotEmpty($attachment2->getId());
+		
+		$this->assertNotEquals($attachment->getId(), $attachment2->getId());
+	}
+	
+	public function testSetID() {
+		
+		$options = $this->attachment;
+		$options['id'] = 'my_custom_id';
+		
+		$attachment = Attachment::factory($options);
+		
+		$this->assertNotFalse($attachment);
+		
+		$this->assertNotEmpty($attachment->getId());
+		$this->assertEquals($options['id'], $attachment->getId());
 	}
 }


### PR DESCRIPTION
This will prevent exceptions when the same attachment gets added to an
email message. Also improved handling if duplicate attachments are
added.