### PR TITLE
deprecate(groups): group_acl metadata has been deprecated

### DIFF
--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -28,6 +28,31 @@ class ElggGroup extends \ElggEntity {
 	public function getType() {
 		return 'group';
 	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @see ElggEntity::getMetadata()
+	 */
+	public function getMetadata($name) {
+		if ($name === 'group_acl') {
+			elgg_deprecated_notice("Getting 'group_acl' metadata has been deprecated, use ElggGroup::getOwnedAccessCollection('group_acl')", '3.0');
+		}
+		
+		return parent::getMetadata($name);
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @see ElggEntity::setMetadata()
+	 */
+	public function setMetadata($name, $value, $value_type = '', $multiple = false) {
+		if ($name === 'group_acl') {
+			elgg_deprecated_notice("Setting 'group_acl' metadata has been deprecated, use ElggGroup::getOwnedAccessCollection('group_acl')", '3.0');
+			return false;
+		}
+		
+		return parent::setMetadata($name, $value, $value_type, $multiple);
+	}
 
 	/**
 	 * Add an \ElggObject to this group.


### PR DESCRIPTION
Plugin developers should use ElggGroup::getOwnedAccessCollection('group_acl')

ref #11369