### PR TITLE
fix(http): non-multipart requests should not fail validation

### DIFF
--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -415,16 +415,19 @@ class Request extends SymfonyRequest {
 	public function validate() {
 
 		$reported_bytes = $this->server->get('CONTENT_LENGTH');
+		// Requests with multipart content type
 		$post_data_count = count($this->request->all());
+		// Requests with other content types
+		$post_body_length = is_string($this->content) ? strlen($this->content) : 0;
 		$file_count = count($this->files->all());
 		
-		$is_valid = function() use ($reported_bytes, $post_data_count, $file_count) {
+		$is_valid = function() use ($reported_bytes, $post_data_count, $post_body_length, $file_count) {
 			if (empty($reported_bytes)) {
 				// Content length is set for POST requests only
 				return true;
 			}
 
-			if (empty($post_data_count) && empty($file_count)) {
+			if (empty($post_data_count) && empty($post_body_length) && empty($file_count)) {
 				// The size of $_POST or uploaded files has exceed the size limit
 				// and the request body/query has been truncated
 				// thus the request reported bytes is set, but no postdata is found


### PR DESCRIPTION
Request::validate() was only looking at count of $_POST parameters, which in
case of non-multipart requests was empty. This also looks at the length of the posted
content body.

Fixes #12654