### PR TITLE
fix(cache): prevent timeout during cache flush

### DIFF
--- a/engine/lib/cache.php
+++ b/engine/lib/cache.php
@@ -232,6 +232,9 @@ function elgg_invalidate_simplecache() {
  * @since 1.11
  */
 function elgg_flush_caches() {
+	// this event sequence could take while, make sure there is no timeout
+	set_time_limit(0);
+	
 	_elgg_services()->events->triggerSequence('cache:flush', 'system');
 }
 


### PR DESCRIPTION
The cache flush sequence can take some time depending on how plugins
implement event handlers. This makes sure no timeout occures