### PR TITLE
feat(menus): added menu param to set a selected menu item 

### DIFF
--- a/docs/guides/menus.rst
+++ b/docs/guides/menus.rst
@@ -16,13 +16,10 @@ Basic usage
 
 Basic functionalities can be achieved through these two functions:
 
- - `elgg_register_menu_item()`__ to add an item to a menu
- - `elgg_unregister_menu_item()`__ to remove an item from a menu
+ - ``elgg_register_menu_item()`` to add an item to a menu
+ - ``elgg_unregister_menu_item()`` to remove an item from a menu
 
 You normally want to call them from your plugin's init function.
-
-__ http://reference.elgg.org/engine_2lib_2navigation_8php.html#a344445364078d03607904c44bad36c1c
-__ http://reference.elgg.org/engine_2lib_2navigation_8php.html#ae26ee09e330a130984c9a6f9e19f6546
 
 Examples
 --------
@@ -44,21 +41,22 @@ Examples
 Admin menu
 ==========
 
-You can also register `page` menu items to the admin backend menu. When registering for the admin menu you can set the context of
-the menu items to `admin` so the menu items only show in the `admin` context. There are 3 default sections to add your menu items to.
+You can also register ``page`` menu items to the admin backend menu. When registering for the admin menu you can set the context of
+the menu items to ``admin`` so the menu items only show in the ``admin`` context. There are 3 default sections to add your menu items to.
  
- - `administer` for daily tasks, usermanagement and other actionable tasks
- - `configure` for settings, configuration and utilities that configure stuff
- - `information` for statistics, overview of information or status
+ - ``administer`` for daily tasks, usermanagement and other actionable tasks
+ - ``configure`` for settings, configuration and utilities that configure stuff
+ - ``information`` for statistics, overview of information or status
 
 
 Advanced usage
 ==============
 
 You can get more control over menus by using :doc:`plugin hooks </design/events>`
-and the public methods provided by the ElggMenuItem__ class.
+and the public methods provided by the ``ElggMenuItem`` class.
 
-There are two hooks that can be used to modify a menu:
+There are three hooks that can be used to modify a menu:
+ - ``'parameters', 'menu:<menu name>'`` to add or modify parameters use for the menu building (eg. sorting)
  - ``'register', 'menu:<menu name>'`` to add or modify items (especially in dynamic menus)
  - ``'prepare', 'menu:<menu name>'`` to modify the structure of the menu before it is displayed
 
@@ -69,8 +67,6 @@ The third parameter passed into a menu handler contains all the menu items that
 have been registered so far by Elgg core and other enabled plugins. In the
 handler we can loop through the menu items and use the class methods to
 interact with the properties of the menu item.
-
-__ http://reference.elgg.org/classElggMenuItem.html
 
 Examples
 --------
@@ -154,10 +150,8 @@ Creating a new menu
 Elgg provides multiple different menus by default. Sometimes you may however
 need some menu items that don't fit in any of the existing menus.
 If this is the case, you can create your very own menu with the
-`elgg_view_menu()`__ function. You must call the function from the view,
+``elgg_view_menu()`` function. You must call the function from the view,
 where you want to menu to be displayed.
-
-__ http://reference.elgg.org/views_8php.html#ac2d475d3efbbec30603537013ac34e22
 
 **Example:** Display a menu called "my_menu" that displays it's menu items 
 in alphapetical order:

--- a/engine/classes/Elgg/Menu/Service.php
+++ b/engine/classes/Elgg/Menu/Service.php
@@ -2,7 +2,6 @@
 
 namespace Elgg\Menu;
 
-use Elgg\Collections\Collection;
 use Elgg\PluginHooksService;
 use Elgg\Config;
 use ElggMenuBuilder;
@@ -89,8 +88,11 @@ class Service {
 		$name = $menu->getName();
 		$params = $menu->getParams();
 		$sort_by = $menu->getSortBy();
-
+		$selected_menu_item_name = elgg_extract('selected_item_name', $params, '');
+		
 		$builder = new ElggMenuBuilder($menu->getItems());
+		$builder->setSelected($selected_menu_item_name);
+		
 		$params['menu'] = $builder->getMenu($sort_by);
 		$params['selected_item'] = $builder->getSelected();
 

--- a/engine/classes/ElggMenuBuilder.php
+++ b/engine/classes/ElggMenuBuilder.php
@@ -56,6 +56,24 @@ class ElggMenuBuilder {
 	}
 
 	/**
+	 * Set a menu item as selected
+	 *
+	 * @param string $item_name the menu item name to select
+	 *
+	 * @return bool
+	 */
+	public function setSelected(string $item_name) {
+		$menu_item = $this->items->get($item_name);
+		if (!$menu_item instanceof ElggMenuItem) {
+			return false;
+		}
+		
+		$menu_item->setSelected();
+		
+		return true;
+	}
+	
+	/**
 	 * Get the selected menu item
 	 *
 	 * @return ElggMenuItem|null

--- a/engine/lib/admin.php
+++ b/engine/lib/admin.php
@@ -1057,14 +1057,11 @@ function _elgg_admin_upgrades_menu(\Elgg\Hook $hook) {
 	
 	$result = $hook->getValue();
 	
-	$selected = $hook->getParam('filter_value');
-	
 	$result[] = ElggMenuItem::factory([
 		'name' => 'pending',
 		'text' => elgg_echo('admin:upgrades:menu:pending'),
 		'href' => 'admin/upgrades',
 		'priority' => 100,
-		'selected' => $selected === 'pending',
 	]);
 	
 	$result[] = ElggMenuItem::factory([
@@ -1072,7 +1069,6 @@ function _elgg_admin_upgrades_menu(\Elgg\Hook $hook) {
 		'text' => elgg_echo('admin:upgrades:menu:completed'),
 		'href' => 'admin/upgrades/finished',
 		'priority' => 200,
-		'selected' => $selected === 'completed',
 	]);
 	
 	$result[] = ElggMenuItem::factory([
@@ -1080,7 +1076,6 @@ function _elgg_admin_upgrades_menu(\Elgg\Hook $hook) {
 		'text' => elgg_echo('admin:upgrades:menu:db'),
 		'href' => 'admin/upgrades/db',
 		'priority' => 300,
-		'selected' => $selected === 'db',
 	]);
 	
 	return $result;

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -737,17 +737,16 @@ function _elgg_normalize_content_layout_vars(array $vars = []) {
  * @param string|Menu|UnpreparedMenu $menu Menu name (or object)
  * @param array                      $vars An associative array of display options for the menu.
  *
- *                          Options include:
- *                              items => an array of unprepared menu items
- *                                       as ElggMenuItem or menu item factory options
- *                              sort_by => string or php callback
- *                                  string options: 'name', 'priority' (default), 'text'
- *                                  or a php callback (a compare function for usort)
- *                              handler: string the page handler to build action URLs
- *                              entity: \ElggEntity to use to build action URLs
- *                              class: string the class for the entire menu.
- *                              menu_view: name of the view to be used to render the menu
- *                              show_section_headers: bool show headers before menu sections.
+ *  Options include:
+ *    items                => (array) an array of unprepared menu items as ElggMenuItem or menu item factory options
+ *    sort_by              => (string) or php callback string options: 'name', 'priority' (default), 'text'
+ *                            or a php callback (a compare function for usort)
+ *    handler              => (string) the page handler to build action URLs
+ *    entity               => (\ElggEntity) entity to use to build action URLs
+ *    class                => (string) the class for the entire menu
+ *    menu_view            => (string) name of the view to be used to render the menu
+ *    show_section_headers => (bool) show headers before menu sections
+ *    selected_item_name   => (string) the menu item name to be selected
  *
  * @return string
  * @since 1.8.0

--- a/engine/tests/phpunit/unit/Elgg/Menu/MenuServiceTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Menu/MenuServiceTest.php
@@ -188,6 +188,24 @@ class MenuServiceTest extends UnitTestCase {
 		$this->assertEquals(["t:100", "t:200", "t:300", "t:400"], $sorts);
 
 	}
+	
+	public function testSetSelectedMenuItem() {
+		$items = $this->buildMenu();
+		
+		foreach ($items as $item) {
+			elgg_register_menu_item('test', $item);
+		}
+		
+		$menu = elgg()->menus->getMenu('test', [
+			'selected_item_name' => 'n:200',
+		]);
+		
+		$params = $menu->getParams();
+		$selected_item = elgg_extract('selected_item', $params);
+		
+		$this->assertInstanceOf(\ElggMenuItem::class, $selected_item);
+		$this->assertEquals('n:200', $selected_item->getName());
+	}
 
 	public function buildMenu() {
 		$items = [

--- a/mod/discussions/start.php
+++ b/mod/discussions/start.php
@@ -256,8 +256,6 @@ function discussion_prepare_form_vars($topic = null) {
  */
 function discussion_setup_groups_filter_tabs($hook, $type, $return, $params) {
 
-	$filter_value = elgg_extract('filter_value', $params);
-
 	$return[] = ElggMenuItem::factory([
 		'name' => 'discussion',
 		'text' => elgg_echo('discussion:latest'),
@@ -265,7 +263,6 @@ function discussion_setup_groups_filter_tabs($hook, $type, $return, $params) {
 			'filter' => 'discussion',
 		]),
 		'priority' => 500,
-		'selected' => $filter_value == 'discussion',
 	]);
 
 	return $return;

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -1051,8 +1051,6 @@ function groups_default_page_owner_handler($hook, $type, $return, $params) {
  */
 function groups_setup_filter_tabs($hook, $type, $return, $params) {
 
-	$filter_value = elgg_extract('filter_value', $params);
-
 	$return[] = ElggMenuItem::factory([
 		'name' => 'newest',
 		'text' => elgg_echo('sort:newest'),
@@ -1060,7 +1058,6 @@ function groups_setup_filter_tabs($hook, $type, $return, $params) {
 			'filter' => 'newest',
 		]),
 		'priority' => 200,
-		'selected' => $filter_value == 'newest',
 	]);
 
 	$return[] = ElggMenuItem::factory([
@@ -1070,7 +1067,6 @@ function groups_setup_filter_tabs($hook, $type, $return, $params) {
 			'filter' => 'alpha',
 		]),
 		'priority' => 250,
-		'selected' => $filter_value == 'alpha',
 	]);
 
 	$return[] = ElggMenuItem::factory([
@@ -1080,7 +1076,6 @@ function groups_setup_filter_tabs($hook, $type, $return, $params) {
 			'filter' => 'popular',
 		]),
 		'priority' => 300,
-		'selected' => $filter_value == 'popular',
 	]);
 
 	$return[] = ElggMenuItem::factory([
@@ -1090,7 +1085,6 @@ function groups_setup_filter_tabs($hook, $type, $return, $params) {
 			'filter' => 'featured',
 		]),
 		'priority' => 400,
-		'selected' => $filter_value == 'featured',
 	]);
 	
 	return $return;

--- a/mod/members/start.php
+++ b/mod/members/start.php
@@ -42,31 +42,26 @@ function members_init() {
  */
 function members_register_filter_menu(\Elgg\Hook $hook) {
 	$result = $hook->getValue();
-	$filter_value = $hook->getParam('filter_value');
 	
 	$result['newest'] = \ElggMenuItem::factory([
 		'name' => 'newest',
 		'text' => elgg_echo('sort:newest'),
 		'href' => elgg_generate_url('collection:user:user:newest'),
-		'selected' => $filter_value === 'newest',
 	]);
 	$result['alpha'] =\ElggMenuItem::factory([
 		'name' => 'alpha',
 		'text' => elgg_echo('sort:alpha'),
 		'href' => elgg_generate_url('collection:user:user:alpha'),
-		'selected' => $filter_value === 'alpha',
 	]);
 	$result['popular'] = \ElggMenuItem::factory([
 		'name' => 'popular',
 		'text' => elgg_echo('sort:popular'),
 		'href' => elgg_generate_url('collection:user:user:popular'),
-		'selected' => $filter_value === 'popular',
 	]);
 	$result['online'] = \ElggMenuItem::factory([
 		'name' => 'online',
 		'text' => elgg_echo('members:label:online'),
 		'href' => elgg_generate_url('collection:user:user:online'),
-		'selected' => $filter_value === 'online',
 	]);
 	
 	return $result;

--- a/views/default/navigation/filter.php
+++ b/views/default/navigation/filter.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Renders a filter menu
  *
@@ -13,7 +12,6 @@
  *                             If not provided, will be determined by current page's URL
  */
 
-$filter_value = elgg_extract('filter_value', $vars);
 $filter_tabs = (array) elgg_extract('filter', $vars, []);
 foreach ($filter_tabs as $name => $tab) {
 	if (!is_array($tab)) {
@@ -21,9 +19,6 @@ foreach ($filter_tabs as $name => $tab) {
 	}
 	if (!isset($tab['name'])) {
 		$tab['name'] = $name;
-	}
-	if (!isset($tab['selected']) && $filter_value) {
-		$tab['selected'] = $tab['name'] == $filter_value;
 	}
 	$filter_tabs[$name] = ElggMenuItem::factory($tab);
 }
@@ -35,5 +30,6 @@ $menu_params = $vars;
 $menu_params['items'] = $filter_tabs;
 $menu_params['sort_by'] = 'priority';
 $menu_params['class'] = 'elgg-menu-filter';
+$menu_params['selected_item_name'] = elgg_extract('selected_item_name', $vars, elgg_extract('filter_value', $vars)); // for BC
 
 echo elgg_view_menu($menu_name, $menu_params);


### PR DESCRIPTION
By default the menu items would be selected based on matching URL, but
if you now provide 'selected_item_name' in the params the menu item with
a matching name will be selected.

The filter menu is the best use case for this.

fixes #12308