### PR TITLE
fix(routes): route url generation will always return a normalized url

### DIFF
--- a/engine/classes/Elgg/Router/RouteRegistrationService.php
+++ b/engine/classes/Elgg/Router/RouteRegistrationService.php
@@ -185,7 +185,7 @@ class RouteRegistrationService {
 	}
 
 	/**
-	 * Generate a relative URL for a named route
+	 * Generate a absolute URL for a named route
 	 *
 	 * @param string $name       Route name
 	 * @param array  $parameters Query parameters
@@ -194,7 +194,7 @@ class RouteRegistrationService {
 	 */
 	public function generateUrl($name, array $parameters = []) {
 		try {
-			return $this->generator->generate($name, $parameters, UrlGenerator::ABSOLUTE_URL);
+			return elgg_normalize_url($this->generator->generate($name, $parameters, UrlGenerator::ABSOLUTE_PATH));
 		} catch (Exception $exception) {
 			$this->logger->notice($exception->getMessage());
 		}

--- a/engine/tests/phpunit/unit/Elgg/RouteMatchingTest.php
+++ b/engine/tests/phpunit/unit/Elgg/RouteMatchingTest.php
@@ -164,8 +164,8 @@ class RouteMatchingTest extends \Elgg\UnitTestCase {
 			'handler' => function() {},
 		]);
 
-		$this->assertEquals('/hello/123?baz=x', elgg_generate_url('foo', ['guid' => '123', 'baz' => 'x']));
-		$this->assertEquals('/hello/123/x?baz=y', elgg_generate_url('foo', ['guid' => '123', 'bar' => 'x', 'baz' => 'y']));
+		$this->assertEquals(elgg_normalize_url('/hello/123?baz=x'), elgg_generate_url('foo', ['guid' => '123', 'baz' => 'x']));
+		$this->assertEquals(elgg_normalize_url('/hello/123/x?baz=y'), elgg_generate_url('foo', ['guid' => '123', 'bar' => 'x', 'baz' => 'y']));
 
 		elgg_unregister_route('foo');
 	}
@@ -262,7 +262,7 @@ class RouteMatchingTest extends \Elgg\UnitTestCase {
 			'foo2' => 'right',
 		]);
 
-		$this->assertEquals("/view/{$entity->guid}/my-object/bar/right?baz=bam", $url);
+		$this->assertEquals(elgg_normalize_url("/view/{$entity->guid}/my-object/bar/right?baz=bam"), $url);
 
 		// test view route with subview
 		$url = elgg_generate_entity_url($entity, 'view', 'sub', [
@@ -270,7 +270,7 @@ class RouteMatchingTest extends \Elgg\UnitTestCase {
 			'foo2' => 'right',
 		]);
 
-		$this->assertEquals("/view/sub/{$entity->guid}/my-object/bar/right?baz=bam", $url);
+		$this->assertEquals(elgg_normalize_url("/view/sub/{$entity->guid}/my-object/bar/right?baz=bam"), $url);
 
 		// test unknown route for entity
 		$url = elgg_generate_entity_url($entity, 'unknown', null, [

--- a/engine/tests/phpunit/unit/Elgg/Router/RouteRegistrationServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Router/RouteRegistrationServiceUnitTest.php
@@ -105,7 +105,7 @@ class RouteRegistrationServiceUnitTest extends UnitTestCase {
 		];
 		
 		$url = $this->service->generateUrl('view:object:blog', $params);
-		$this->assertEquals('/blog/view/123/dummy-title', $url);
+		$this->assertEquals(elgg_normalize_url('/blog/view/123/dummy-title'), $url);
 	}
 	
 	public function testGenerateUrlMissingRouteName() {


### PR DESCRIPTION
fixes #12290

fixes various issues as previously generateURL ignored $CONFIG->wwwroot. This caused issue with mixed https/http request vs config, but also subfolder installation, and route url generation in CLI (where REQUEST is missing)