### PR TITLE
chore(livesearch): no longer search on an unsupported group field

### DIFF
--- a/views/json/resources/livesearch/groups.php
+++ b/views/json/resources/livesearch/groups.php
@@ -14,7 +14,7 @@ $options = [
 	'limit' => $limit,
 	'sort' => 'name',
 	'order' => 'ASC',
-	'fields' => ['metadata' => ['name', 'username']],
+	'fields' => ['metadata' => ['name']],
 	'item_view' => 'search/entity',
 	'input_name' => $input_name,
 ];


### PR DESCRIPTION
Since groups don't have a username there is no need to try to search on
it.