### PR TITLE
fix(comments): popup menu will close itself when inline editing comments

### DIFF
--- a/views/default/elgg/comments.js
+++ b/views/default/elgg/comments.js
@@ -97,6 +97,10 @@ define(['jquery', 'elgg'], function ($, elgg) {
 			$(this).data('Comment', dc);
 		}
 		dc.toggleEdit();
+		
+		// trick the popup menu to close itself
+		$(document).trigger('scroll');
+		
 		return false;
 	});
 	


### PR DESCRIPTION
fixes #12197