### PR TITLE
feat(admin): added a site setting to require admin approval of accounts

### DIFF
--- a/actions/admin/site/settings.php
+++ b/actions/admin/site/settings.php
@@ -30,6 +30,18 @@ if (!$site->save()) {
 $allow_registration = ('on' === get_input('allow_registration', false));
 elgg_save_config('allow_registration', $allow_registration);
 
+// require admin validation for new users?
+$require_admin_validation = ('on' === get_input('require_admin_validation', false));
+elgg_save_config('require_admin_validation', $require_admin_validation);
+
+// notify admins about pending validation
+$admin_validation_notification = get_input('admin_validation_notification');
+if (empty($admin_validation_notification)) {
+	elgg_remove_config('admin_validation_notification');
+} else {
+	elgg_save_config('admin_validation_notification', $admin_validation_notification);
+}
+
 // setup walled garden
 $walled_garden = ('on' === get_input('walled_garden', false));
 elgg_save_config('walled_garden', $walled_garden);

--- a/docs/admin/uservalidation.rst
+++ b/docs/admin/uservalidation.rst
@@ -11,7 +11,7 @@ Listing of unvalidated users
 ============================
 
 In the Admin section of the website is a list of all unvalidated users. Some actions can be taken on the users, like delete them from the system
-or validate them.
+or validate them. 
 
 Plugins have the option to add additional features to this list.
 
@@ -19,3 +19,13 @@ Plugins have the option to add additional features to this list.
 
 	An example of this is the :doc:`/plugins/uservalidationbyemail` plugin which doesn't allow users onto the website until their e-mail address 
 	is validated.
+
+Require admin validation
+========================
+
+In the Site settings under the Users section there is a setting which can be enabled to require admin validation of a new user account before
+the user can use their account. After registration the user gets notified that their account is awaiting validation by an administrator.
+
+Site administrators can receive an e-mail notification that there are users awaiting validation.
+
+After validation the user is notified that they can use their account.

--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -83,6 +83,7 @@ use Elgg\Project\Paths;
  * @property array         $redis_servers
  * @property string[]      $registered_entities
  * @property bool          $remove_branding Is Elgg branding disabled
+ * @property bool          $require_admin_validation
  * @property bool          $security_disable_password_autocomplete
  * @property bool          $security_email_require_password
  * @property bool          $security_notify_admins

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -1458,6 +1458,7 @@ class ElggInstaller {
 			'language' => 'en',
 			'default_access' => $submissionVars['siteaccess'],
 			'allow_registration' => false,
+			'require_admin_validation' => false,
 			'walled_garden' => false,
 			'allow_user_default_access' => '',
 			'default_limit' => 10,

--- a/engine/routes.php
+++ b/engine/routes.php
@@ -64,6 +64,14 @@ return [
 			\Elgg\Router\Middleware\SignedRequestGatekeeper::class,
 		],
 	],
+	'account:validation:pending' => [
+		'path' => '/validation_pending',
+		'resource' => 'account/validation_pending',
+		'walled' => false,
+		'middleware' => [
+			\Elgg\Router\Middleware\LoggedOutGatekeeper::class,
+		],
+	],
 	'ajax' => [
 		'path' => '/ajax/{segments}',
 		'handler' => '_elgg_ajax_page_handler',

--- a/engine/tests/classes/Elgg/Mocks/Database/ConfigTable.php
+++ b/engine/tests/classes/Elgg/Mocks/Database/ConfigTable.php
@@ -8,6 +8,7 @@ class ConfigTable extends \Elgg\Database\ConfigTable {
 		'__site_secret__' => "z1234567890123456789012345678901",
 		'admin_registered' => 1,
 		'allow_registration' => 1,
+		'require_admin_validation' => 0,
 		'allow_user_default_access' => 1,
 		'default_access' => 2,
 		'default_limit' => 10,

--- a/engine/tests/phpunit/integration/Elgg/Actions/LoginIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Actions/LoginIntegrationTest.php
@@ -121,6 +121,37 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 		$this->assertInstanceOf(ErrorResponse::class, $response);
 		$this->assertEquals(elgg_echo('LoginException:UsernameFailure'), $response->getContent());
 	}
+	
+	public function testLoginFailsWithDisabledUser() {
+
+		$username = $this->getRandomUsername();
+		$user = $this->user = $this->createUser([], [
+			'username' => $username,
+			'password' => 123456,
+		]);
+
+		elgg_call(ELGG_IGNORE_ACCESS, function () use ($user) {
+			$user->setValidationStatus(true, 'login_test');
+			$user->disable('', false);
+			$user->save();
+		});
+		
+		/* @var $user \ElggUser */
+		$user = elgg_call(ELGG_SHOW_DISABLED_ENTITIES, function() use ($username) {
+			return get_user_by_username($username);
+		});
+		
+		$this->assertFalse($user->isEnabled());
+		$user->invalidateCache();
+		
+		$response = $this->executeAction('login', [
+			'username' => $user->username,
+			'password' => 123456,
+		]);
+
+		$this->assertInstanceOf(ErrorResponse::class, $response);
+		$this->assertEquals(elgg_echo('LoginException:UsernameFailure'), $response->getContent());
+	}
 
 	public function testLoginFailsWithNonExistentUser() {
 

--- a/languages/en.php
+++ b/languages/en.php
@@ -114,6 +114,7 @@ return array(
 	'LoginException:AccountLocked' => 'Your account has been locked for too many log in failures.',
 	'LoginException:ChangePasswordFailure' => 'Failed current password check.',
 	'LoginException:Unknown' => 'We could not log you in due to an unknown error.',
+	'LoginException:AdminValidationPending' => "Your account needs to be validated by a site administrator before you can use it. You'll be notified when your account is validated.",
 
 	'UserFetchFailureException' => 'Cannot check permission for user_guid [%s] as the user does not exist.',
 
@@ -754,6 +755,14 @@ If you didn't make this change, please reset your password here:
 Or contact a site administrator:
 %s",
 	
+	'admin:notification:unvalidated_users:subject' => "Users awaiting approval on %s",
+	'admin:notification:unvalidated_users:body' => "Hi %s,
+
+%d users of '%s' are awaiting approval by an administrator.
+
+See the full list of users here:
+%s",
+
 /**
  * Plugins
  */
@@ -1325,6 +1334,11 @@ Once you have logged in, we highly recommend that you change your password.',
 	// Walled Garden support
 	'installation:registration:description' => 'If enabled, visitors can create their own user accounts.',
 	'installation:registration:label' => 'Allow visitors to register',
+	'installation:adminvalidation:description' => 'If enabled, newly registered users require manual validation by an administrator before they can use the site.',
+	'installation:adminvalidation:label' => 'New users require manual validation by an administrator',
+	'installation:adminvalidation:notification:description' => 'When enabled, site administrators will get a notification that there are pending user validations. An administrator can disable the notification on their personal settings page.',
+	'installation:adminvalidation:notification:label' => 'Notify administrators of pending user validations',
+	'installation:adminvalidation:notification:direct' => 'Direct',
 	'installation:walled_garden:description' => 'If enabled, logged-out visitors can see only pages marked public (such as login and registration).',
 	'installation:walled_garden:label' => 'Restrict pages to logged-in users',
 
@@ -1497,6 +1511,20 @@ Your e-mail address on '%s' was changed.
 From now on you'll receive notifications on this e-mail address.
 
 If you didn't request this change, please contact a site administrator.
+%s",
+
+	'account:email:admin:validation_notification' => "Notify me when there are users requiring validation by an administrator",
+	'account:email:admin:validation_notification:help' => "Because of the site settings, newly registered users require manual validation by an administrator. With this setting you can disable notifications about pending validation requests.",
+	
+	'account:validation:pending:title' => "Account validation pending",
+	'account:validation:pending:content' => "Your account has been registered successfully! However before you can use you account a site administrator needs to validate you account. You'll receive an e-mail when you account is validated.",
+	
+	'account:notification:validation:subject' => "Your account on %s has been validated!",
+	'account:notification:validation:body' => "Hi %s,
+
+Your account on '%s' has been validated. You can now use your account.
+
+To go the the website, click here:
 %s",
 
 /**

--- a/mod/uservalidationbyemail/classes/Elgg/UserValidationByEmail/Upgrades/TrackValidationStatus.php
+++ b/mod/uservalidationbyemail/classes/Elgg/UserValidationByEmail/Upgrades/TrackValidationStatus.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Elgg\UserValidationByEmail\Upgrades;
+
+use Elgg\Upgrade\AsynchronousUpgrade;
+use Elgg\Upgrade\Result;
+use Elgg\Database\QueryBuilder;
+
+/**
+ * Track the email validation status of users
+ *
+ * @since 3.2
+ */
+class TrackValidationStatus implements AsynchronousUpgrade {
+	
+	/**
+	 * {@inheritDoc}
+	 * @see \Elgg\Upgrade\Batch::getVersion()
+	 */
+	public function getVersion() {
+		return 2019090600;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @see \Elgg\Upgrade\Batch::shouldBeSkipped()
+	 */
+	public function shouldBeSkipped() {
+		return empty($this->countItems());
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @see \Elgg\Upgrade\Batch::countItems()
+	 */
+	public function countItems() {
+		return elgg_call(ELGG_SHOW_DISABLED_ENTITIES, function () {
+			return elgg_count_entities($this->getOptions());
+		});
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @see \Elgg\Upgrade\Batch::needsIncrementOffset()
+	 */
+	public function needsIncrementOffset() {
+		return true;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @see \Elgg\Upgrade\Batch::run()
+	 */
+	public function run(Result $result, $offset) {
+		
+		$options = $this->getOptions([
+			'offset' => $offset,
+			'batch' => true,
+		]);
+		
+		elgg_call(ELGG_SHOW_DISABLED_ENTITIES, function() use (&$result, $options) {
+			$users = elgg_get_entities($options);
+			
+			/* @var $user \ElggUser */
+			foreach ($users as $user) {
+				if (elgg_set_plugin_user_setting('email_validated', false, $user->guid, 'uservalidationbyemail')) {
+					$result->addSuccesses();
+					continue;
+				}
+				
+				$result->addFailures();
+			}
+		});
+		
+		return $result;
+	}
+	
+	/**
+	 * Get options for use in elgg_get_entities()
+	 *
+	 * @param array $options additional options
+	 *
+	 * @return array
+	 */
+	protected function getOptions(array $options = []) {
+		$defaults = [
+			'type' => 'user',
+			'metadata_name_value_pairs' => [
+				'name' => 'disable_reason',
+				'value' => 'uservalidationbyemail_new_user',
+			],
+			'plugin_user_setting_name_value_pairs_operator' => 'or',
+			'wheres' => [
+				function (QueryBuilder $qb, $main_alias) {
+					return $qb->compare("{$main_alias}.enabled", '=', 'no', ELGG_VALUE_STRING);
+				}
+			],
+		];
+		
+		return array_merge($defaults, $options);
+	}
+}

--- a/mod/uservalidationbyemail/elgg-plugin.php
+++ b/mod/uservalidationbyemail/elgg-plugin.php
@@ -1,5 +1,7 @@
 <?php
 
+use Elgg\UserValidationByEmail\Upgrades\TrackValidationStatus;
+
 return [
 	'actions' => [
 		'uservalidationbyemail/resend_validation' => [
@@ -23,5 +25,8 @@ return [
 				\Elgg\Router\Middleware\LoggedOutGatekeeper::class,
 			],
 		],
+	],
+	'upgrades' => [
+		TrackValidationStatus::class,
 	],
 ];

--- a/mod/uservalidationbyemail/languages/en.php
+++ b/mod/uservalidationbyemail/languages/en.php
@@ -29,5 +29,8 @@ If you can't click on the link, copy and paste it to your browser manually.
 	'uservalidationbyemail:errors:could_not_resend_validations' => 'Could not resend all validation requests to checked users.',
 
 	'uservalidationbyemail:messages:resent_validation' => 'Validation request resent.',
-	'uservalidationbyemail:messages:resent_validations' => 'Validation requests resent to all checked users.'
+	'uservalidationbyemail:messages:resent_validations' => 'Validation requests resent to all checked users.',
+	
+	'uservalidationbyemail:upgrade:2019090600:title' => 'Track user e-mail validation status',
+	'uservalidationbyemail:upgrade:2019090600:description' => 'The e-mail validation status is tracked in a new way. Make sure all pending users are updated to the new tracking in order to still require e-mail validation.',
 );

--- a/mod/uservalidationbyemail/lib/functions.php
+++ b/mod/uservalidationbyemail/lib/functions.php
@@ -21,6 +21,12 @@ function uservalidationbyemail_request_validation($user_guid) {
 		return false;
 	}
 	
+	$validated = elgg_get_plugin_user_setting('email_validated', $user->guid, 'uservalidationbyemail');
+	if (!isset($validated) || (bool) $validated) {
+		// email address already validated, or not required by this plugin
+		return true;
+	}
+	
 	$site = elgg_get_site_entity();
 	
 	// Work out validate link

--- a/mod/uservalidationbyemail/start.php
+++ b/mod/uservalidationbyemail/start.php
@@ -31,9 +31,6 @@ function uservalidationbyemail_init() {
 
 	// prevent the engine from logging in users via login()
 	elgg_register_event_handler('login:before', 'user', 'uservalidationbyemail_check_manual_login');
-
-	// make admin users always validated
-	elgg_register_event_handler('make_admin', 'user', 'uservalidationbyemail_validate_new_admin_user');
 }
 
 /**
@@ -115,20 +112,6 @@ function uservalidationbyemail_allow_new_user_can_edit(\Elgg\Hook $hook) {
 	$context = elgg_get_context();
 	if ($context == 'uservalidationbyemail_new_user' || $context == 'uservalidationbyemail_validate_user') {
 		return true;
-	}
-}
-
-/**
- * Make sure any admin users are automatically validated
- *
- * @param \Elgg\Event $event 'make_admin', 'user'
- *
- * @return void
- */
-function uservalidationbyemail_validate_new_admin_user(\Elgg\Event $event) {
-	$user = $event->getObject();
-	if ($user instanceof ElggUser && $user->isValidated() !== true) {
-		$user->setValidationStatus(true, 'admin_user');
 	}
 }
 

--- a/mod/uservalidationbyemail/tests/phpunit/unit/integration/Elgg/UserValidationByEmail/RegistrationIntegrationTest.php
+++ b/mod/uservalidationbyemail/tests/phpunit/unit/integration/Elgg/UserValidationByEmail/RegistrationIntegrationTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Elgg\UserValidationByEmail;
+
+use Elgg\ActionResponseTestCase;
+use Elgg\Http\OkResponse;
+
+/**
+ * Test the registration and follow up procedures
+ *
+ * @since 3.2
+ */
+class RegistrationIntegrationTest extends ActionResponseTestCase {
+	
+	public function up() {
+		parent::up();
+		
+		self::createApplication(['isolate' => true]);
+		_elgg_config()->min_password_length = 3;
+		_elgg_config()->minusername = 4;
+		_elgg_config()->allow_registration = true;
+	}
+	
+	public function down() {
+		parent::down();
+	}
+	
+	public function testRegistrationWithoutAdminValidation() {
+		
+		_elgg_config()->require_admin_validation = false;
+		
+		// Register new user
+		$username = $this->getRandomUsername();
+		
+		$response = $this->executeAction('register', [
+			'username' => $username,
+			'password' => '1111111111111',
+			'password2' => '1111111111111',
+			'email' => $this->getRandomEmail(),
+			'name' => 'Test User',
+		]);
+		
+		$this->assertInstanceOf(OkResponse::class, $response);
+		
+		/* @var $user \ElggUser */
+		$user = elgg_call(ELGG_SHOW_DISABLED_ENTITIES, function () use ($username) {
+			return get_user_by_username($username);
+		});
+		$this->assertInstanceOf(\ElggUser::class, $user);
+		$this->assertFalse($user->isValidated());
+		$this->assertFalse($user->isEnabled());
+		
+		$this->assertEmpty(elgg_get_logged_in_user_entity());
+		
+		$plugin_tracking = elgg_get_plugin_user_setting('email_validated', $user->guid, 'uservalidationbyemail');
+		$this->assertNotNull($plugin_tracking);
+		$this->assertEmpty($plugin_tracking);
+		
+		// confirm email
+		$link = elgg_generate_url('account:validation:email:confirm', [
+			'u' => $user->guid,
+		]);
+		$link = elgg_http_get_signed_url($link);
+		
+		$request = $this->prepareHttpRequest($link);
+		_elgg_services()->setValue('request', $request);
+		
+		$response = _elgg_services()->router->getResponse($request);
+		
+		$user = elgg_call(ELGG_SHOW_DISABLED_ENTITIES, function () use ($username) {
+			return get_user_by_username($username);
+		});
+		
+		$this->assertTrue($user->isEnabled());
+		$this->assertTrue($user->isValidated());
+		
+		$this->assertEquals($user->guid, elgg_get_logged_in_user_guid());
+		
+		$plugin_tracking = elgg_get_plugin_user_setting('email_validated', $user->guid, 'uservalidationbyemail');
+		$this->assertNotEmpty($plugin_tracking);
+		
+		elgg_get_session()->removeLoggedInUser();
+	}
+	
+	public function testRegistrationWithAdminValidation() {
+		
+		_elgg_config()->require_admin_validation = true;
+		
+		// Register new user
+		$username = $this->getRandomUsername();
+		
+		$response = $this->executeAction('register', [
+			'username' => $username,
+			'password' => '1111111111111',
+			'password2' => '1111111111111',
+			'email' => $this->getRandomEmail(),
+			'name' => 'Test User',
+		]);
+		
+		$this->assertInstanceOf(OkResponse::class, $response);
+		
+		/* @var $user \ElggUser */
+		$user = elgg_call(ELGG_SHOW_DISABLED_ENTITIES, function () use ($username) {
+			return get_user_by_username($username);
+		});
+		$this->assertInstanceOf(\ElggUser::class, $user);
+		$this->assertFalse($user->isValidated());
+		$this->assertFalse($user->isEnabled());
+		
+		$this->assertEmpty(elgg_get_logged_in_user_entity());
+		
+		$plugin_tracking = elgg_get_plugin_user_setting('email_validated', $user->guid, 'uservalidationbyemail');
+		$this->assertNotNull($plugin_tracking);
+		$this->assertEmpty($plugin_tracking);
+		
+		// confirm email
+		$link = elgg_generate_url('account:validation:email:confirm', [
+			'u' => $user->guid,
+		]);
+		$link = elgg_http_get_signed_url($link);
+		
+		$request = $this->prepareHttpRequest($link);
+		_elgg_services()->setValue('request', $request);
+		
+		$response = _elgg_services()->router->getResponse($request);
+		
+		$user = elgg_call(ELGG_SHOW_DISABLED_ENTITIES, function () use ($username) {
+			return get_user_by_username($username);
+		});
+		
+		$this->assertFalse($user->isEnabled());
+		$this->assertFalse($user->isValidated());
+		
+		$this->assertEmpty(elgg_get_logged_in_user_guid());
+		
+		$plugin_tracking = elgg_get_plugin_user_setting('email_validated', $user->guid, 'uservalidationbyemail');
+		$this->assertNotEmpty($plugin_tracking);
+	}
+}

--- a/mod/uservalidationbyemail/views/default/resources/uservalidationbyemail/confirm.php
+++ b/mod/uservalidationbyemail/views/default/resources/uservalidationbyemail/confirm.php
@@ -9,11 +9,15 @@ return elgg_call(ELGG_SHOW_DISABLED_ENTITIES, function() {
 		return elgg_error_response(elgg_echo('email:confirm:fail'));
 	}
 	
-	$user->setValidationStatus(true, 'email');
-	
-	elgg_push_context('uservalidationbyemail_validate_user');
-	$user->enable();
-	elgg_pop_context();
+	elgg_call(ELGG_IGNORE_ACCESS, function() use (&$user) {
+		// set validation flag
+		elgg_set_plugin_user_setting('email_validated', true, $user->guid, 'uservalidationbyemail');
+		
+		if (!(bool) elgg_get_config('require_admin_validation')) {
+			// user doesn't have to be validated by admin after this
+			$user->setValidationStatus(true, 'email');
+		}
+	});
 	
 	try {
 		login($user);

--- a/views/default/core/settings/account/email.php
+++ b/views/default/core/settings/account/email.php
@@ -39,4 +39,21 @@ $content .= elgg_view_field([
 	'value' => $user->email,
 ]);
 
+if ($user->isAdmin()) {
+	// check is unvalidated e-mail notifications are sent
+	if ((bool) elgg_get_config('require_admin_validation') && !empty(elgg_get_config('admin_validation_notification'))) {
+		$user_setting = $user->getPrivateSetting('admin_validation_notification');
+		
+		$content .= elgg_view_field([
+			'#type' => 'checkbox',
+			'#label' => elgg_echo('account:email:admin:validation_notification'),
+			'#help' => elgg_echo('account:email:admin:validation_notification:help'),
+			'name' => 'admin_validation_notification',
+			'value' => 1,
+			'checked' => isset($user_setting) ? (bool) $user_setting : true,
+			'switch' => true,
+		]);
+	}
+}
+
 echo elgg_view_module('info', $title, $content);

--- a/views/default/elgg/admin.js
+++ b/views/default/elgg/admin.js
@@ -13,6 +13,7 @@ define(function(require) {
 		});
 
 		// disable simple cache compress settings if simple cache is off
+		$('[name=require_admin_validation]').click(adminValidationToggle);
 		$('[name=simplecache_enabled]').click(simplecacheToggle);
 	}
 
@@ -31,6 +32,14 @@ define(function(require) {
 					$input.parent().toggleClass('elgg-state-disabled');
 				}
 			}
+		}
+	}
+	
+	function adminValidationToggle() {
+		if ($(this).prop('checked')) {
+			$('.elgg-admin-users-admin-validation-notification').show();
+		} else {
+			$('.elgg-admin-users-admin-validation-notification').hide();
 		}
 	}
 

--- a/views/default/forms/admin/site/settings/users.php
+++ b/views/default/forms/admin/site/settings/users.php
@@ -2,7 +2,7 @@
 
 $result = elgg_view_field([
 	'#type' => 'checkbox',
-	'label' => elgg_echo('installation:registration:label'),
+	'#label' => elgg_echo('installation:registration:label'),
 	'#help' => elgg_echo('installation:registration:description'),
 	'name' => 'allow_registration',
 	'checked' => (bool) elgg_get_config('allow_registration'),
@@ -11,7 +11,36 @@ $result = elgg_view_field([
 
 $result .= elgg_view_field([
 	'#type' => 'checkbox',
-	'label' => elgg_echo('config:users:can_change_username'),
+	'#label' => elgg_echo('installation:adminvalidation:label'),
+	'#help' => elgg_echo('installation:adminvalidation:description'),
+	'name' => 'require_admin_validation',
+	'checked' => (bool) elgg_get_config('require_admin_validation'),
+	'switch' => true,
+]);
+
+$classes = ['elgg-divide-left', 'plm', 'elgg-admin-users-admin-validation-notification'];
+if (!(bool) elgg_get_config('require_admin_validation')) {
+	$classes[] = 'hidden';
+}
+
+$result .= elgg_view_field([
+	'#type' => 'select',
+	'#label' => elgg_echo('installation:adminvalidation:notification:label'),
+	'#help' => elgg_echo('installation:adminvalidation:notification:description'),
+	'#class' => $classes,
+	'name' => 'admin_validation_notification',
+	'value' => elgg_get_config('admin_validation_notification'),
+	'options_values' => [
+		'' => elgg_echo('option:no'),
+		'direct' => elgg_echo('installation:adminvalidation:notification:direct'),
+		'daily' => elgg_echo('interval:daily'),
+		'weekly' => elgg_echo('interval:weekly'),
+	],
+]);
+
+$result .= elgg_view_field([
+	'#type' => 'checkbox',
+	'#label' => elgg_echo('config:users:can_change_username'),
 	'#help' => elgg_echo('config:users:can_change_username:help'),
 	'name' => 'can_change_username',
 	'checked' => (bool) elgg_get_config('can_change_username'),

--- a/views/default/resources/account/validation_pending.php
+++ b/views/default/resources/account/validation_pending.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Show a page after registration that account validation is pending
+ */
+
+use Elgg\ValidationException;
+
+$session = elgg_get_session();
+if (!$session->get('admin_validation')) {
+	throw new ValidationException();
+}
+
+$session->remove('admin_validation');
+
+$shell = elgg_get_config('walled_garden') ? 'walled_garden' : 'default';
+
+// build page elements
+$title = elgg_echo('account:validation:pending:title');
+
+$content = elgg_view('output/longtext', [
+	'value' => elgg_echo('account:validation:pending:content')
+]);
+
+// build page
+$body = elgg_view_layout('default', [
+	'title' => $title,
+	'content' => $content,
+	'sidebar' => false,
+]);
+
+// draw page
+echo elgg_view_page($title, $body, $shell);


### PR DESCRIPTION
After registering an account a site administrator needs to approve the
account.

ref #8725

ToDo
- [x] uservalidationbyemail adjusted to support dual validation
- [x] tests
- [x] docs