### PR TITLE
Group invites

### DIFF
--- a/mod/groups/elgg-plugin.php
+++ b/mod/groups/elgg-plugin.php
@@ -64,6 +64,7 @@ return [
 			'resource' => 'groups/invitations',
 			'middleware' => [
 				\Elgg\Router\Middleware\Gatekeeper::class,
+				\Elgg\Router\Middleware\UserPageOwnerCanEditGatekeeper::class,
 			],
 		],
 		'collection:group:group:search' => [

--- a/mod/groups/elgg-plugin.php
+++ b/mod/groups/elgg-plugin.php
@@ -77,6 +77,14 @@ return [
 				'sort' => 'alpha',
 			],
 		],
+		'collection:user:user:group_invites' => [
+			'path' => '/groups/invites/{guid}',
+			'resource' => 'groups/invites',
+			'middleware' => [
+				\Elgg\Router\Middleware\Gatekeeper::class,
+				\Elgg\Router\Middleware\GroupPageOwnerCanEditGatekeeper::class,
+			],
+		],
 		'add:group:group' => [
 			'path' => '/groups/add/{container_guid}',
 			'resource' => 'groups/add',

--- a/mod/groups/elgg-plugin.php
+++ b/mod/groups/elgg-plugin.php
@@ -107,6 +107,7 @@ return [
 			'resource' => 'groups/requests',
 			'middleware' => [
 				\Elgg\Router\Middleware\Gatekeeper::class,
+				\Elgg\Router\Middleware\GroupPageOwnerCanEditGatekeeper::class,
 			],
 		],
 	],

--- a/mod/groups/languages/en.php
+++ b/mod/groups/languages/en.php
@@ -61,6 +61,8 @@ return array(
 	'groups:invite:title' => 'Invite friends to this group',
 	'groups:invite:friends:help' => 'Search for a friend by name or username and select the friend from the list',
 	'groups:invite:resend' => 'Resend the invitations to already invited users',
+	'groups:invite:member' => 'Already a member of this group',
+	'groups:invite:invited' => 'Already invited to this group',
 
 	'groups:nofriendsatall' => 'You have no friends to invite!',
 	'groups:group' => "Group",

--- a/mod/groups/languages/en.php
+++ b/mod/groups/languages/en.php
@@ -20,6 +20,7 @@ return array(
 	'groups:invitations:pending' => 'Group invitations (%s)',
 	
 	'relationship:invited' => '%2$s was invited to join %1$s',
+	'relationship:membership_request' => '%s requested to join %s',
 
 	'groups:icon' => 'Group icon (leave blank to leave unchanged)',
 	'groups:name' => 'Group name',

--- a/mod/groups/languages/en.php
+++ b/mod/groups/languages/en.php
@@ -15,8 +15,11 @@ return array(
 	'groups:delete' => 'Delete group',
 	'groups:membershiprequests' => 'Manage join requests',
 	'groups:membershiprequests:pending' => 'Manage join requests (%s)',
+	'groups:invitedmembers' => "Manage invitations",
 	'groups:invitations' => 'Group invitations',
 	'groups:invitations:pending' => 'Group invitations (%s)',
+	
+	'relationship:invited' => '%2$s was invited to join %1$s',
 
 	'groups:icon' => 'Group icon (leave blank to leave unchanged)',
 	'groups:name' => 'Group name',

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -832,6 +832,15 @@ function groups_members_menu_setup(\Elgg\Hook $hook) {
 		]),
 		'priority' => 200
 	]);
+	
+	if ($entity->canEdit()) {
+		$menu[] = ElggMenuItem::factory([
+			'name' => 'membership_requests',
+			'text' => elgg_echo('groups:membershiprequests'),
+			'href' => elgg_generate_entity_url($entity, 'requests'),
+			'priority' => 300
+		]);
+	}
 
 	return $menu;
 }

--- a/mod/groups/views/default/forms/groups/invite.php
+++ b/mod/groups/views/default/forms/groups/invite.php
@@ -6,7 +6,7 @@
  */
 
 $group = elgg_extract('entity', $vars);
-if (!($group instanceof \ElggGroup)) {
+if (!$group instanceof \ElggGroup) {
 	return;
 }
 
@@ -32,6 +32,10 @@ echo elgg_view_field([
 	'#type' => 'friendspicker',
 	'#help' => elgg_echo('groups:invite:friends:help'),
 	'name' => 'user_guid',
+	'options' => [
+		'item_view' => 'livesearch/user/group_invite',
+		'group_guid' => $group->guid,
+	],
 ]);
 
 echo elgg_view_field([

--- a/mod/groups/views/default/group/format/invitationrequest.php
+++ b/mod/groups/views/default/group/format/invitationrequest.php
@@ -5,6 +5,8 @@
  * @uses $vars['entity'] Group entity
  */
 
+elgg_deprecated_notice("The view 'group/format/invitationrequest' has been deprecated, use the 'relationship/invited' view", '3.2');
+
 $user = elgg_get_page_owner_entity();
 if (!$user instanceof \ElggUser || !$user->canEdit()) {
 	return;

--- a/mod/groups/views/default/groups/invitationrequests.php
+++ b/mod/groups/views/default/groups/invitationrequests.php
@@ -5,6 +5,8 @@
  * @uses $vars['invitations'] Optional. Array of ElggGroups
  */
 
+elgg_deprecated_notice("The view 'groups/invitationrequests' has been deprecated use elgg_list_relationships()", '3.2');
+
 if (isset($vars['invitations'])) {
 	$invitations = $vars['invitations'];
 	unset($vars['invitations']);

--- a/mod/groups/views/default/groups/invite/user_html.php
+++ b/mod/groups/views/default/groups/invite/user_html.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Group invite user HTML view for autocomplete items
+ *
+ * @uses $vars['entity']     the selected entity
+ * @uses $vars['input_name'] name of the returned data array
+ * @uses $vars['group_guid'] when present will show if the user is already a member of the group
+ */
+
+$entity = elgg_extract('entity', $vars);
+if (!$entity instanceof ElggUser) {
+	return;
+}
+
+$input_name = elgg_extract('input_name', $vars);
+if (empty($input_name)) {
+	return;
+}
+
+$icon = elgg_view_entity_icon($entity, 'tiny', ['use_hover' => false]);
+$delete_icon = elgg_view_icon('delete', ['class' => 'elgg-autocomplete-item-remove']);
+
+$title = $entity->getDisplayName();
+
+$group = get_entity(elgg_extract('group_guid', $vars));
+if ($group instanceof ElggGroup) {
+	if ($group->isMember($entity)) {
+		$title .= elgg_format_element('span', ['class' => ['mls', 'elgg-subtext']], elgg_echo('groups:invite:member'));
+	} elseif (check_entity_relationship($group->guid, 'invited', $entity->guid)) {
+		$title .= elgg_format_element('span', ['class' => ['mls', 'elgg-subtext']], elgg_echo('groups:invite:invited'));
+	}
+}
+
+$body = elgg_view_image_block($icon, $title, ['image_alt' => $delete_icon]);
+$body .= elgg_view('input/hidden', [
+	'name' => "{$input_name}[]",
+	'value' => $entity->guid,
+]);
+
+echo elgg_format_element('li', [
+	'class' => 'elgg-item',
+	'data-guid' => $entity->guid,
+], $body);

--- a/mod/groups/views/default/groups/membershiprequests.php
+++ b/mod/groups/views/default/groups/membershiprequests.php
@@ -6,6 +6,8 @@
  * @uses $vars['requests'] Array of ElggUsers
  */
 
+elgg_deprecated_notice("The view 'groups/membershiprequests' has been deprecated, elgg_list_relationships()", '3.2');
+
 $entity = elgg_extract('entity', $vars);
 $requests = elgg_extract('requests', $vars);
 if (empty($requests) || !is_array($requests)) {

--- a/mod/groups/views/default/relationship/invited.php
+++ b/mod/groups/views/default/relationship/invited.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Relationship view of a group membership invitation
+ *
+ * @note To add or remove from the relationship menu, register handlers for the menu:relationship hook.
+ *
+ * @uses $vars['relationship'] the group invitation
+ */
+
+$relationship = elgg_extract('relationship', $vars);
+if (!$relationship instanceof ElggRelationship) {
+	return;
+}
+
+$group = get_entity($relationship->guid_one);
+$user = get_entity($relationship->guid_two);
+if (!$group instanceof ElggGroup || !$user instanceof ElggUser) {
+	return;
+}
+
+$page_owner = elgg_get_page_owner_entity();
+if ($page_owner->guid === $group->guid) {
+	$vars['icon_entity'] = $user;
+	$vars['title'] = elgg_view('output/url', [
+		'text' => $user->getDisplayName(),
+		'href' => $user->getURL(),
+		'is_trusted' => true,
+	]);
+} elseif ($page_owner->guid === $user->guid) {
+	$vars['icon_entity'] = $group;
+	$vars['title'] = elgg_view('output/url', [
+		'text' => $group->getDisplayName(),
+		'href' => $group->getURL(),
+		'is_trusted' => true,
+	]);
+}
+
+echo elgg_view('relationship/elements/summary', $vars);

--- a/mod/groups/views/default/relationship/membership_request.php
+++ b/mod/groups/views/default/relationship/membership_request.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Relationship view of a group membership invitation
+ * Relationship view of a group membership request
  *
  * @note To add or remove from the relationship menu, register handlers for the menu:relationship hook.
  *
@@ -12,8 +12,8 @@ if (!$relationship instanceof ElggRelationship) {
 	return;
 }
 
-$group = get_entity($relationship->guid_one);
-$user = get_entity($relationship->guid_two);
+$user = get_entity($relationship->guid_one);
+$group = get_entity($relationship->guid_two);
 if (!$group instanceof ElggGroup || !$user instanceof ElggUser) {
 	return;
 }
@@ -26,14 +26,6 @@ if ($page_owner->guid === $group->guid) {
 		'href' => $user->getURL(),
 		'is_trusted' => true,
 	]);
-} elseif ($page_owner->guid === $user->guid) {
-	$vars['icon_entity'] = $group;
-	$vars['title'] = elgg_view('output/url', [
-		'text' => $group->getDisplayName(),
-		'href' => $group->getURL(),
-		'is_trusted' => true,
-	]);
-	$vars['subtitle'] = $group->briefdescription;
 }
 
 echo elgg_view('relationship/elements/summary', $vars);

--- a/mod/groups/views/default/resources/groups/invitations.php
+++ b/mod/groups/views/default/resources/groups/invitations.php
@@ -1,29 +1,27 @@
 <?php
 
-$username = elgg_extract('username', $vars);
-if ($username) {
-	$user = get_user_by_username($username);
-} else {
-	$user = elgg_get_logged_in_user_entity();
-}
-
-if (!$user || !$user->canEdit()) {
-	throw new \Elgg\EntityPermissionsException();
-}
+$user = elgg_get_page_owner_entity();
 
 elgg_push_breadcrumb(elgg_echo('groups'), "groups/all");
 
-elgg_set_page_owner_guid($user->guid);
-
+// build page elements
 $title = elgg_echo('groups:invitations');
 
-$content = elgg_view('groups/invitationrequests');
+$content = elgg_call(ELGG_IGNORE_ACCESS, function() use ($user) {
+	return elgg_list_relationships([
+		'relationship' => 'invited',
+		'relationship_guid' => $user->guid,
+		'inverse_relationship' => true,
+		'no_results' => elgg_echo('groups:invitations:none'),
+	]);
+});
 
-$params = [
-	'content' => $content,
+// build page
+$body = elgg_view_layout('content', [
 	'title' => $title,
+	'content' => $content,
 	'filter' => '',
-];
-$body = elgg_view_layout('content', $params);
+]);
 
+// draw page
 echo elgg_view_page($title, $body);

--- a/mod/groups/views/default/resources/groups/invites.php
+++ b/mod/groups/views/default/resources/groups/invites.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Show a listing of all users who are invited to join this group
+ */
+
+$group = elgg_get_page_owner_entity();
+
+elgg_push_breadcrumb(elgg_echo('groups'), "groups/all");
+elgg_push_breadcrumb($group->getDisplayName(), $group->getURL());
+
+elgg_register_menu_item('title', [
+	'name' => 'groups:invite',
+	'icon' => 'user-plus',
+	'href' => elgg_generate_entity_url($group, 'invite'),
+	'text' => elgg_echo('groups:invite'),
+	'link_class' => 'elgg-button elgg-button-action',
+]);
+
+// build page elements
+$title = elgg_echo('groups:invitedmembers');
+
+$content = elgg_list_relationships([
+	'relationship' => 'invited',
+	'relationship_guid' => $group->guid,
+	'no_results' => true,
+]);
+
+$tabs = elgg_view_menu('groups_members', [
+	'entity' => $group,
+	'class' => 'elgg-tabs'
+]);
+
+// build page
+$body = elgg_view_layout('default', [
+	'title' => $title,
+	'content' => $content,
+	'filter' => $tabs,
+]);
+
+// draw page
+echo elgg_view_page($title, $body);

--- a/mod/groups/views/default/resources/groups/members.php
+++ b/mod/groups/views/default/resources/groups/members.php
@@ -15,6 +15,17 @@ elgg_set_page_owner_guid($guid);
 elgg_push_breadcrumb(elgg_echo('groups'), "groups/all");
 elgg_push_breadcrumb($group->getDisplayName(), $group->getURL());
 
+if ($group->canEdit()) {
+	elgg_register_menu_item('title', [
+		'name' => 'groups:invite',
+		'icon' => 'user-plus',
+		'href' => elgg_generate_entity_url($group, 'invite'),
+		'text' => elgg_echo('groups:invite'),
+		'link_class' => 'elgg-button elgg-button-action',
+	]);
+}
+
+// build page elements
 $options = [
 	'relationship' => 'member',
 	'relationship_guid' => $group->guid,
@@ -53,11 +64,12 @@ $tabs = elgg_view_menu('groups_members', [
 
 $content = elgg_list_relationships($options);
 
-$params = [
+// build page
+$body = elgg_view_layout('content', [
 	'content' => $content,
 	'title' => $title,
 	'filter' => $tabs,
-];
-$body = elgg_view_layout('content', $params);
+]);
 
+// draw page
 echo elgg_view_page($title, $body);

--- a/mod/groups/views/default/resources/groups/requests.php
+++ b/mod/groups/views/default/resources/groups/requests.php
@@ -1,19 +1,14 @@
 <?php
 
 $guid = elgg_extract('guid', $vars);
-elgg_set_page_owner_guid($guid);
 
-$group = get_entity($guid);
-if (!$group instanceof ElggGroup || !$group->canEdit()) {
-	register_error(elgg_echo('groups:noaccess'));
-	forward(REFERER);
-}
-
-$title = elgg_echo('groups:membershiprequests');
+$group = elgg_get_page_owner_entity();
 
 elgg_push_breadcrumb(elgg_echo('groups'), "groups/all");
 elgg_push_breadcrumb($group->getDisplayName(), $group->getURL());
-elgg_push_breadcrumb($title);
+
+// build page elements
+$title = elgg_echo('groups:membershiprequests');
 
 $requests = elgg_get_entities([
 	'type' => 'user',
@@ -27,11 +22,17 @@ $content = elgg_view('groups/membershiprequests', [
 	'entity' => $group,
 ]);
 
-$params = [
-	'content' => $content,
-	'title' => $title,
-	'filter' => '',
-];
-$body = elgg_view_layout('content', $params);
+$tabs = elgg_view_menu('groups_members', [
+	'entity' => $group,
+	'class' => 'elgg-tabs'
+]);
 
+// build page
+$body = elgg_view_layout('content', [
+	'title' => $title,
+	'content' => $content,
+	'filter' => $tabs,
+]);
+
+// draw page
 echo elgg_view_page($title, $body);

--- a/mod/groups/views/default/resources/groups/requests.php
+++ b/mod/groups/views/default/resources/groups/requests.php
@@ -1,6 +1,6 @@
 <?php
 
-$guid = elgg_extract('guid', $vars);
+use Elgg\Database\Clauses\OrderByClause;
 
 $group = elgg_get_page_owner_entity();
 
@@ -10,16 +10,11 @@ elgg_push_breadcrumb($group->getDisplayName(), $group->getURL());
 // build page elements
 $title = elgg_echo('groups:membershiprequests');
 
-$requests = elgg_get_entities([
-	'type' => 'user',
+$content = elgg_list_relationships([
 	'relationship' => 'membership_request',
-	'relationship_guid' => $guid,
+	'relationship_guid' => $group->guid,
 	'inverse_relationship' => true,
-	'limit' => 0,
-]);
-$content = elgg_view('groups/membershiprequests', [
-	'requests' => $requests,
-	'entity' => $group,
+	'order_by' => new OrderByClause('er.time_created', 'ASC'),
 ]);
 
 $tabs = elgg_view_menu('groups_members', [

--- a/mod/groups/views/json/livesearch/user/group_invite.php
+++ b/mod/groups/views/json/livesearch/user/group_invite.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * User view of a livesearch result when inviting a user for a group
+ *
+ * @uses $vars['entity']     the matched user for the search query
+ * @uses $vars['group_guid'] when present will show if the user is already a member of the group
+ */
+
+$entity = elgg_extract('entity', $vars);
+if (!$entity instanceof ElggUser) {
+	return;
+}
+
+// group guid can isn't passed through the original livesearch endpoint resource
+$vars['group_guid'] = (int) elgg_extract('group_guid', $vars, (int) get_input('group_guid'));
+
+// reset the viewtype so we can render html views
+$viewtype = elgg_get_viewtype();
+elgg_set_viewtype('default');
+
+$icon = elgg_view_entity_icon($entity, 'tiny', [
+	'use_link' => false,
+	'href' => false,
+	'use_hover' => false,
+]);
+
+$title_text = $entity->getDisplayName();
+
+$group = get_entity($vars['group_guid']);
+if ($group instanceof ElggGroup) {
+	if ($group->isMember($entity)) {
+		$title_text .= elgg_format_element('span', ['class' => ['mls', 'elgg-subtext']], elgg_echo('groups:invite:member'));
+	} elseif (check_entity_relationship($group->guid, 'invited', $entity->guid)) {
+		$title_text .= elgg_format_element('span', ['class' => ['mls', 'elgg-subtext']], elgg_echo('groups:invite:invited'));
+	}
+}
+
+$title = elgg_format_element('h3', [], $title_text);
+
+$label = elgg_view_image_block($icon, $title, [
+	'class' => 'elgg-autocomplete-item',
+]);
+
+$data = $entity->toObject();
+$data->label = $label;
+$data->value = $entity->username;
+$data->icon = $icon;
+
+if (elgg_extract('input_name', $vars)) {
+	$data->html = elgg_view('groups/invite/user_html', $vars);
+}
+
+echo json_encode($data);
+
+// restore viewtype
+elgg_set_viewtype($viewtype);

--- a/views/default/elements/components/menus.css
+++ b/views/default/elements/components/menus.css
@@ -116,7 +116,7 @@
 	}
 }
 
-.elgg-menu.elgg-menu-hz .elgg-menu-item-has-dropdown,
+.elgg-menu.elgg-menu-hz:not(.elgg-menu-relationship) .elgg-menu-item-has-dropdown,
 .elgg-menu.elgg-menu-filter .elgg-menu-item-has-dropdown {
 	.elgg-menu-closed:after,
 	.elgg-menu-opened:after {

--- a/views/json/resources/livesearch/groups.php
+++ b/views/json/resources/livesearch/groups.php
@@ -13,7 +13,7 @@ $options = [
 	'sort' => 'name',
 	'order' => 'ASC',
 	'fields' => ['metadata' => ['name']],
-	'item_view' => 'search/entity',
+	'item_view' => elgg_extract('item_view', $vars, 'search/entity'),
 	'input_name' => $input_name,
 ];
 

--- a/views/json/resources/livesearch/objects.php
+++ b/views/json/resources/livesearch/objects.php
@@ -14,7 +14,7 @@ $options = [
 	'sort' => 'title',
 	'order' => 'ASC',
 	'fields' => ['metadata' => ['title']],
-	'item_view' => 'search/entity',
+	'item_view' => elgg_extract('item_view', $vars, 'search/entity'),
 	'input_name' => $input_name,
 ];
 

--- a/views/json/resources/livesearch/users.php
+++ b/views/json/resources/livesearch/users.php
@@ -13,7 +13,7 @@ $options = [
 	'sort' => 'name',
 	'order' => 'ASC',
 	'fields' => ['metadata' => ['name', 'username']],
-	'item_view' => 'search/entity',
+	'item_view' => elgg_extract('item_view', $vars, 'search/entity'),
 	'input_name' => $input_name,
 ];
 


### PR DESCRIPTION
Reworked pages related to group membership, membership requests and invites

- Inviting friends to groups now shows if the user is already a member or was already invited
![afbeelding](https://user-images.githubusercontent.com/881958/67288153-b9e0a300-f4dc-11e9-8100-3efd3c061dcb.png)

- group members page has button to invite friends
- a page was added for group admins to see a list of invited users
- group members page has tabs for membership requests and invitations (same tabs on those pages)
