### PR TITLE
chore(admin): show that registration is disabled in the welcome widget

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -590,6 +590,7 @@ file access this will negatively impact performance. Also PHPs opcache can no lo
 	'admin:widget:admin_welcome:intro' =>
 'Welcome to Elgg! Right now you are looking at the administration dashboard. It\'s useful for tracking what\'s happening on the site.',
 
+	'admin:widget:admin_welcome:registration' => "Registration for new users is currently disabled! You can enabled this on the %s page.",
 	'admin:widget:admin_welcome:admin_overview' =>
 "Navigation for the administration area is provided by the menu to the right. It is organized into
 three sections:

--- a/views/default/widgets/admin_welcome/content.php
+++ b/views/default/widgets/admin_welcome/content.php
@@ -6,6 +6,15 @@
 // section => string replacements.
 $sections = [
 	'intro' => [],
+	'registration' => [
+		elgg_view('output/url', [
+			'text' => elgg_echo('admin:site_settings'),
+			'href' => elgg_generate_url('admin', [
+				'segments' => 'site_settings',
+			]),
+			'is_trusted' => true,
+		]),
+	],
 	'admin_overview' => [],
 	'outro' => [],
 ];
@@ -14,6 +23,15 @@ $sections = [
 // that's annoying.
 echo '<div class="elgg-output">';
 foreach ($sections as $section => $strings) {
-	echo '<p>' . elgg_echo("admin:widget:admin_welcome:$section", $strings) . '</p>';
+	if ($section === 'registration') {
+		if (!elgg_get_config('allow_registration')) {
+			// registration is disabled, tell the admin
+			echo elgg_view_message('warning', elgg_echo("admin:widget:admin_welcome:{$section}", $strings));
+		}
+		
+		continue;
+	}
+	
+	echo '<p>' . elgg_echo("admin:widget:admin_welcome:{$section}", $strings) . '</p>';
 }
 echo '</div>';


### PR DESCRIPTION
Show admins that registration is currently disabled in the admin welcome
widget. This is very usefull after installation and maybe even later on.

fixes #12083

![afbeelding](https://user-images.githubusercontent.com/881958/67372019-886be400-f57d-11e9-964d-11321510779f.png)
