### PR TITLE
docs(cli): added link to symfony

### DIFF
--- a/docs/intro/elgg-cli.rst
+++ b/docs/intro/elgg-cli.rst
@@ -92,3 +92,7 @@ Command class must extend ``\Elgg\CLI\Command``.
         return $return;
 
     });
+
+Custom commands are based on `Symfony Console Commands`_. Please refer to their documentation for more details.
+
+.. _Symfony Console Commands: https://symfony.com/doc/current/console.html


### PR DESCRIPTION
This PR clarifies the development of CLI commands by adding a link to the the symfony docs. I somewhat struggled with this when I wrote some CLI extensions.