### PR TITLE
chore(docs): updated RTD to use Python 3.x

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,6 +20,6 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 2.7
+  version: 3.7
   install:
     - requirements: docs/pip-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ matrix:
     - php: 7.3
       env: JOB_NAME=docs_build
       install:
-        - pip install --user "Sphinx==1.8.5"
+        - pyenv global 3.7.1
+        - pip install --user "Sphinx==2.3.1"
         - pip install --user "sphinx-intl"
         - pip install --user "sphinxcontrib.phpdomain"
         - export PATH=$PATH:$HOME/.local/bin

--- a/docs/contribute/docs.rst
+++ b/docs/contribute/docs.rst
@@ -22,6 +22,11 @@ seconds). You need `yarn`_ and `sphinx`_ installed to be able to use these scrip
 It's that easy! Grunt will continue running, watching the docs for changes and
 automatically rebuilding.
 
+.. note::
+	
+	You might need to install 'sphinxcontrib-phpdomain'. You can do this with the following command:
+	`pip install -U sphinxcontrib-phpdomain`
+
 .. _grunt: http://gruntjs.com/
 .. _yarn: https://yarnpkg.com/
 .. _sphinx: http://www.sphinx-doc.org/


### PR DESCRIPTION
Python 2.x will be End of Life in April 2020 https://www.python.org/psf/press-release/pr20191220/