### PR TITLE
feature(cli): Adds a --refresh option to the list command

### DIFF
--- a/engine/classes/Elgg/Cli/PluginsListCommand.php
+++ b/engine/classes/Elgg/Cli/PluginsListCommand.php
@@ -18,6 +18,9 @@ class PluginsListCommand extends Command {
 			->setDescription(elgg_echo('cli:plugins:list:description'))
 			->addOption('status', 's', InputOption::VALUE_OPTIONAL,
 				elgg_echo('cli:plugins:list:option:status', ['all | active | inactive'])
+			)
+			->addOption('refresh', 'r', InputOption::VALUE_NONE,
+				elgg_echo('cli:plugins:list:option:refresh')
 			);
 	}
 
@@ -30,6 +33,10 @@ class PluginsListCommand extends Command {
 		if (!in_array($status, ['all', 'active', 'inactive'])) {
 			$this->error(elgg_echo('cli:plugins:list:error:status', [$status, 'all | active | inactive']));
 			return 1;
+		}
+
+		if ($this->option('refresh') !== false) {
+			_elgg_generate_plugin_entities();
 		}
 
 		$table = new Table($this->output);

--- a/engine/tests/classes/Elgg/Mocks/Database/Plugins.php
+++ b/engine/tests/classes/Elgg/Mocks/Database/Plugins.php
@@ -73,13 +73,12 @@ class Plugins extends DbPlugins {
 		return $this->_plugins;
 	}
 
-    public function generateEntities()
-    {
-        $this->addTestingPlugin(ElggPlugin::fromId('test_plugin', ''));
-        return true;
-    }
+	public function generateEntities() {
+		$this->addTestingPlugin(ElggPlugin::fromId('test_plugin', ''));
+		return true;
+	}
 
-    public function addTestingPlugin(ElggPlugin $plugin) {
+	public function addTestingPlugin(ElggPlugin $plugin) {
 		$this->_plugins[$plugin->getID()] = $plugin;
 	}
 

--- a/engine/tests/classes/Elgg/Mocks/Database/Plugins.php
+++ b/engine/tests/classes/Elgg/Mocks/Database/Plugins.php
@@ -74,6 +74,7 @@ class Plugins extends DbPlugins {
 	}
 
 	public function generateEntities() {
+		parent::generateEntities();
 		$this->addTestingPlugin(ElggPlugin::fromId('test_plugin', ''));
 		return true;
 	}

--- a/engine/tests/classes/Elgg/Mocks/Database/Plugins.php
+++ b/engine/tests/classes/Elgg/Mocks/Database/Plugins.php
@@ -73,14 +73,20 @@ class Plugins extends DbPlugins {
 		return $this->_plugins;
 	}
 
-	public function addTestingPlugin(ElggPlugin $plugin) {
+    public function generateEntities()
+    {
+        $this->addTestingPlugin(ElggPlugin::fromId('test_plugin', ''));
+        return true;
+    }
+
+    public function addTestingPlugin(ElggPlugin $plugin) {
 		$this->_plugins[$plugin->getID()] = $plugin;
 	}
 
 	public function isActive($plugin_id) {
 		return array_key_exists($plugin_id, $this->_plugins);
 	}
-	
+
 	public function setPriority(ElggPlugin $plugin, $priority) {
 
 		$old_priority = $plugin->getPriority();

--- a/engine/tests/phpunit/unit/Elgg/Cli/PluginsListCommandTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Cli/PluginsListCommandTest.php
@@ -72,4 +72,27 @@ class PluginsListCommandTest extends UnitTestCase {
 		$this->assertRegExp('/active/im', $commandTester->getDisplay());
 	}
 
+	public function testRefreshOption() {
+		$application = new Application();
+
+		$command = new PluginsListCommand();
+		$application->add($command);
+
+		$command = $application->find('plugins:list');
+		$commandTester = new CommandTester($command);
+		$commandTester->execute([
+			'command' => $command->getName(),
+		]);
+
+		$this->assertNotRegExp('/test_plugin/im', $commandTester->getDisplay());
+
+		$commandTester = new CommandTester($command);
+		$commandTester->execute([
+			'command' => $command->getName(),
+			'--refresh' => true,
+		]);
+
+		$this->assertRegExp('/test_plugin/im', $commandTester->getDisplay());
+	}
+
 }

--- a/languages/en.php
+++ b/languages/en.php
@@ -1755,7 +1755,7 @@ To view %s's profile, click here:
 	
 	'cli:plugins:list:description' => "List all plugins installed on the site",
 	'cli:plugins:list:option:status' => "Plugin status ( %s )",
-	'cli:plugins:list:option:refresh' => "Refresh plugins from disk",
+	'cli:plugins:list:option:refresh' => "Refresh plugin list with recently installed plugins",
 	'cli:plugins:list:error:status' => "%s is not a valid status. Allowed options are: %s",
 	
 	'cli:simpletest:description' => "Run simpletest test suite (deprecated)",

--- a/languages/en.php
+++ b/languages/en.php
@@ -1755,6 +1755,7 @@ To view %s's profile, click here:
 	
 	'cli:plugins:list:description' => "List all plugins installed on the site",
 	'cli:plugins:list:option:status' => "Plugin status ( %s )",
+	'cli:plugins:list:option:refresh' => "Refresh plugins from disk",
 	'cli:plugins:list:error:status' => "%s is not a valid status. Allowed options are: %s",
 	
 	'cli:simpletest:description' => "Run simpletest test suite (deprecated)",


### PR DESCRIPTION
This option can be used to refresh plugins from disk before listing them. That way, plugins are completely manageable via cli

Fixes #13196