### PR TITLE
fix(mail): improved handling of email recipients name formatting

### DIFF
--- a/engine/classes/Elgg/Email/Address.php
+++ b/engine/classes/Elgg/Email/Address.php
@@ -15,6 +15,17 @@ use Zend\Validator\Hostname;
 class Address extends ZendAddress {
 	
 	/**
+	 * {@inheritdoc}
+	 */
+	public function __construct($email, $name = null, $comment = null) {
+		if (isset($name) && is_string($name)) {
+			$name = html_entity_decode($name, ENT_QUOTES | ENT_XHTML, 'UTF-8');
+		}
+		
+		parent::__construct($email, $name, $comment);
+	}
+	
+	/**
 	 * Set the email address
 	 *
 	 * @param string $email the new email address
@@ -61,7 +72,7 @@ class Address extends ZendAddress {
 			throw new InvalidArgumentException('CRLF injection detected');
 		}
 		
-		$this->name = $name;
+		$this->name = html_entity_decode($name, ENT_QUOTES | ENT_XHTML, 'UTF-8');
 	}
 	
 	/**

--- a/engine/tests/phpunit/unit/Elgg/Email/AddressUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Email/AddressUnitTest.php
@@ -157,4 +157,35 @@ class AddressUnitTest extends \Elgg\UnitTestCase {
 		$this->expectException(InvalidArgumentException::class);
 		Address::getFormattedEmailAddress('example@elgg.org', []);
 	}
+	
+	/**
+	 * @dataProvider nameHtmlDecodingProvider
+	 */
+	public function testConstructorNameHtmlDecoding($input_name, $expected_output) {
+		$address = new Address('john.doe@example.com', $input_name);
+		
+		$this->assertEquals($expected_output, $address->getName());
+	}
+	
+	/**
+	 * @dataProvider nameHtmlDecodingProvider
+	 */
+	public function testSetNameHtmlDecoding($input_name, $expected_output) {
+		$address = new Address('john.doe@example.com');
+		$address->setName($input_name);
+		
+		$this->assertEquals($expected_output, $address->getName());
+	}
+	
+	public function nameHtmlDecodingProvider() {
+		return [
+			['Doe, John', 'Doe, John'],
+			['John Doe', 'John Doe'],
+			['John & Jane Doe', 'John & Jane Doe'],
+			['John &amp; Jane Doe', 'John & Jane Doe'],
+			['J&ocirc;hn &amp; Jane Doe', 'Jôhn & Jane Doe'],
+			['John &quot;Doe&quot;', 'John "Doe"'],
+			['John O&apos;Doe', 'John O\'Doe'],
+		];
+	}
 }


### PR DESCRIPTION
Certain characters could cause e-mail clients to have problems
interpreting recipients or senders.