### PR TITLE
Legacy plugin hook / event callback parameters

### DIFF
--- a/docs/design/events.rst
+++ b/docs/design/events.rst
@@ -140,7 +140,8 @@ Example:
 Invokable classes as handlers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You may use a class with an ``__invoke()`` method as a handler. Just register the class name and it will be instantiated (with no arguments) for the lifetime of the event (or hook).
+You may use a class with an ``__invoke()`` method as a handler. Just register the class name and it will be instantiated (with no arguments) 
+for the lifetime of the event (or hook).
 
 .. code-block:: php
 
@@ -240,7 +241,7 @@ trigger.
 Plugin Hook Handlers
 --------------------
 
-Hook handlers are callables with one of the following prototypes:
+Hook handlers are callables with the following prototype:
 
 .. code-block:: php
 
@@ -251,28 +252,16 @@ Hook handlers are callables with one of the following prototypes:
      *
      * @return mixed if not null, this will be the new value of the plugin hook
      */
-    function plugin_hook_handler1(\Elgg\Hook $hook) {
+    function plugin_hook_handler(\Elgg\Hook $hook) {
         ...
     }
 
-    /**
-     * @param string $hook    The name of the plugin hook
-     * @param string $type    The type of the plugin hook
-     * @param mixed  $value   The current value of the plugin hook
-     * @param mixed  $params  Data passed from the trigger
-     *
-     * @return mixed if not null, this will be the new value of the plugin hook
-     */
-    function plugin_hook_handler2($hook, $type, $value, $params) {
-        ...
-    }
-
-In ``plugin_hook_handler1``, the ``Hook`` object has various methods for getting the name, type, value,
+In ``plugin_hook_handler``, the ``Hook`` object has various methods for getting the name, type, value,
 and parameters of the hook. See the ``Elgg\Hook`` interface for details.
 
-In both cases, if the handler returns no value (or ``null`` explicitly), the plugin hook value
+If the handler returns no value (or ``null`` explicitly), the plugin hook value
 is not altered. Otherwise the returned value becomes the new value of the plugin hook, and it
-will then be available as ``$hook->getValue()`` (or ``$value``) in the next handler.
+will then be available as ``$hook->getValue()`` in the next handler.
 
 Register to handle a Plugin Hook
 --------------------------------

--- a/docs/guides/ajax.rst
+++ b/docs/guides/ajax.rst
@@ -309,8 +309,11 @@ Let's say when the view ``foo`` is fetched, we want to also send the client some
 
     use Elgg\Services\AjaxResponse;
 
-    function myplugin_append_ajax($hook, $type, AjaxResponse $response, $params) {
+    function myplugin_append_ajax(\Elgg\Hook $hook) {
 
+        /* @var $response AjaxResponse */
+        $response = $hook->getValue();
+        
         // alter the value being returned
         $response->getData()->value .= " hello";
 

--- a/docs/guides/hooks-list.rst
+++ b/docs/guides/hooks-list.rst
@@ -909,22 +909,28 @@ Other
 
 	/**
 	 * Default to icon from gravatar for users without avatar.
+	 *
+	 * @param \Elgg\Hook $hook 'entity:icon:url', 'user'
+	 *
+	 * @return string
 	 */
-	function gravatar_icon_handler($hook, $type, $url, $params) {
+	function gravatar_icon_handler(\Elgg\Hook $hook) {
+		$entity = $hook->getEntityParam();
+		
 		// Allow users to upload avatars
-		if ($params['entity']->icontime) {
+		if ($entity->icontime) {
 			return $url;
 		}
 
 		// Generate gravatar hash for user email
-		$hash = md5(strtolower(trim($params['entity']->email)));
+		$hash = md5(strtolower(trim($entity->email)));
 
 		// Default icon size
 		$size = '150x150';
 
 		// Use configured size if possible
 		$config = elgg_get_icon_sizes('user');
-		$key = $params['size'];
+		$key = $hook->getParam('size');
 		if (isset($config[$key])) {
 			$size = $config[$key]['w'] . 'x' . $config[$key]['h'];
 		}

--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -96,19 +96,27 @@ Let's pass some data to a module:
 
     <?php
 
-    function myplugin_config_site($hook, $type, $value, $params) {
+    function myplugin_config_site(\Elgg\Hook $hook) {
+        $value = $hook->getValue();
+    	
         // this will be cached client-side
         $value['myplugin']['api'] = elgg_get_site_url() . 'myplugin-api';
         $value['myplugin']['key'] = 'none';
+        
         return $value;
     }
 
-    function myplugin_config_page($hook, $type, $value, $params) {
+    function myplugin_config_page(\Elgg\Hook $hook) {
         $user = elgg_get_logged_in_user_entity();
-        if ($user) {
-            $value['myplugin']['key'] = $user->myplugin_api_key;
-            return $value;
+        if (!$user) {
+        	return;
         }
+        
+        $value = $hook->getValue();
+        
+        $value['myplugin']['key'] = $user->myplugin_api_key;
+        
+        return $value;
     }
 
     elgg_register_plugin_hook_handler('elgg.data', 'site', 'myplugin_config_site');

--- a/docs/guides/menus.rst
+++ b/docs/guides/menus.rst
@@ -86,8 +86,8 @@ Examples
 	/**
 	 * Change the URL of the "Albums" menu item in the owner_block menu
 	 */
-	function my_owner_block_menu_handler($hook, $type, $items, $params) {
-		$owner = $params['entity'];
+	function my_owner_block_menu_handler(\Elgg\Hook $hook) {
+		$owner = $hook->getEntityParam();
 
 		// Owner can be either user or a group, so we
 		// need to take both URLs into consideration:
@@ -100,6 +100,7 @@ Examples
 				break;
 		}
 
+		$items = $hook->getValue();
 		if ($items->has('albums')) {
 			$items->get('albums')->setURL($url);
 		}
@@ -124,16 +125,18 @@ Examples
 	/**
 	 * Customize the entity menu for ElggBlog objects
 	 */
-	function my_entity_menu_handler($hook, $type, $items, $params) {
+	function my_entity_menu_handler(\Elgg\Hook $hook) {
 		// The entity can be found from the $params parameter
-		$entity = $params['entity'];
+		$entity = $hook->getEntityParam();
 
 		// We want to modify only the ElggBlog objects, so we
 		// return immediately if the entity is something else
 		if (!$entity instanceof ElggBlog) {
-			return $menu;
+			return;
 		}
 
+		$items = $hook->getValue();
+		
 		$items->remove('likes');
 
 		if ($items->has('edit')) {

--- a/docs/guides/notifications.rst
+++ b/docs/guides/notifications.rst
@@ -138,19 +138,22 @@ the contents of the notification when a new objects of subtype 'photo' is create
 	/**
 	 * Prepare a notification message about a new photo
 	 *
-	 * @param string                          $hook         Hook name
-	 * @param string                          $type         Hook type
-	 * @param Elgg_Notifications_Notification $notification The notification to prepare
-	 * @param array                           $params       Hook parameters
-	 * @return Elgg_Notifications_Notification
+	 * @param \Elgg\Hook $hook 'prepare', 'notification:create:object:photo'
+	 
+	 * @return \Elgg\Notification\Notification
 	 */
-	function photos_prepare_notification($hook, $type, $notification, $params) {
-	    $entity = $params['event']->getObject();
-	    $owner = $params['event']->getActor();
-	    $recipient = $params['recipient'];
-	    $language = $params['language'];
-	    $method = $params['method'];
+	function photos_prepare_notification(\Elgg\Hook $hook) {
+	    $event = $hook->getParam('event');
+	    
+	    $entity = $event->getObject();
+	    $owner = $event->getActor();
+	    $recipient = $hook->getParam('recipient');
+	    $language = $hook->getParam('language');
+	    $method = $hook->getParam('method');
 
+	    /* @var $notification \Elgg\Notification\Notification */
+	    $notification = $hook->getValue();
+	    
 	    // Title for the notification
 	    $notification->subject = elgg_echo('photos:notify:subject', [$entity->getDisplayName()], $language);
 
@@ -222,16 +225,14 @@ Example:
 	/**
 	 * Send an SMS notification
 	 * 
-	 * @param string $hook   Hook name
-	 * @param string $type   Hook type
-	 * @param bool   $result Has anyone sent a message yet?
-	 * @param array  $params Hook parameters
+	 * @param \Elgg\Hook $hook 'send', 'notification:sms'
+	 *
 	 * @return bool
 	 * @internal
 	 */
-	function sms_notifications_send($hook, $type, $result, $params) {
-		/* @var Elgg_Notifications_Notification $message */
-		$message = $params['notification'];
+	function sms_notifications_send(\Elgg\Hook $hook) {
+		/* @var \Elgg\Notifications\Notification $message */
+		$message = $hook->getParam('notification');
 
 		$recipient = $message->getRecipient();
 
@@ -276,20 +277,19 @@ Example:
 	/**
 	 * Get subscriptions for group notifications
 	 *
-	 * @param string $hook          'get'
-	 * @param string $type          'subscriptions'
-	 * @param array  $subscriptions Array containing subscriptions in the form
-	 *                       <user guid> => array('email', 'site', etc.)
-	 * @param array  $params        Hook parameters
-	 * @return array
+	 * @param \Elgg\Hook $hook 'get', 'subscriptions'
+	 *
+	 * @return void|array
 	 */
-	function discussion_get_subscriptions($hook, $type, $subscriptions, $params) {
-		$reply = $params['event']->getObject();
+	function discussion_get_subscriptions(\Elgg\Hook $hook) {
+		$reply = $hook->getParam('event')->getObject();
 
 		if (!$reply instanceof \ElggDiscussionReply) {
-			return $subscriptions;
+			return;
 		}
 
+		$subscriptions = $hook->getValue();
+		
 		$group_guid = $reply->getContainerEntity()->container_guid;
 		$group_subscribers = elgg_get_subscriptions_for_container($group_guid);
 

--- a/docs/guides/permissions-check.rst
+++ b/docs/guides/permissions-check.rst
@@ -24,7 +24,7 @@ Note that this function can return 3 values: true if the entity has write access
 
 .. code-block:: php
 
-   function myplugin_permissions_check($hook_name, $entity_type, $return_value, $parameters) {
+   function myplugin_permissions_check(\Elgg\Hook $hook) {
       $has_access = determine_access_somehow();
 
       if ($has_access === true) {
@@ -60,7 +60,7 @@ This is a full example using the context to determine if the entity has write ac
    /**
     * Hook for cron event. 
     */
-   function myaccess_cron($event, $object_type, $object) {
+   function myaccess_cron(\Elgg\Hook $hook) {
 
       elgg_push_context('myaccess_cron');
 
@@ -74,7 +74,7 @@ This is a full example using the context to determine if the entity has write ac
    /**
     * Overrides default permissions for the myaccess context
     */
-   function myaccess_permissions_check($hook_name, $entity_type, $return_value, $parameters) {	
+   function myaccess_permissions_check(\Elgg\Hook $hook) {	
       if (elgg_in_context('myaccess_cron')) {
          return true;
       }
@@ -84,4 +84,3 @@ This is a full example using the context to determine if the entity has write ac
 
    // Initialise plugin
    register_elgg_event_handler('init', 'system', 'myaccess_init');
-   ?>

--- a/docs/guides/routing.rst
+++ b/docs/guides/routing.rst
@@ -320,8 +320,11 @@ Here we rewrite requests for ``news/*`` to ``blog/*``:
 
 .. code-block:: php
 
-    function myplugin_rewrite_handler($hook, $type, $value, $params) {
+    function myplugin_rewrite_handler(\Elgg\Hook $hook) {
+        $value = $hook->getValue();
+        
         $value['identifier'] = 'blog';
+        
         return $value;
     }
 

--- a/docs/guides/search.rst
+++ b/docs/guides/search.rst
@@ -86,12 +86,9 @@ To combine search results or filter how search results are presented in the sear
     elgg_register_plugin_hook_handler('search:config', 'type_subtype_pairs', 'my_plugin_place_search_config');
 
     // Add place review to search options as a subtype
-    function my_plugin_place_search_options($hook, $type, $value, $params) {
+    function my_plugin_place_search_options(\Elgg\Hook $hook) {
 
-        if (empty($params) || !is_array($params)) {
-            return;
-        }
-
+        $params = $hook->getParams();
         if (isset($params['subtypes'])) {
             $subtypes = (array) $params['subtypes'];
         } else {

--- a/docs/guides/views.rst
+++ b/docs/guides/views.rst
@@ -357,9 +357,12 @@ Here we'll alter the default pagination limit for the comments view:
 
 	elgg_register_plugin_hook_handler('view_vars', 'page/elements/comments', 'myplugin_alter_comments_limit');
 
-	function myplugin_alter_comments_limit($hook, $type, $vars, $params) {
+	function myplugin_alter_comments_limit(\Elgg\Hook $hook) {
+	    $vars = $hook->getValue();
+	    
 	    // only 10 comments per page
 	    $vars['limit'] = elgg_extract('limit', $vars, 10);
+	    
 	    return $vars;
 	}
 
@@ -416,7 +419,7 @@ string. View extensions will not be used and the ``view`` hook will not be trigg
 
     elgg_register_plugin_hook_handler('view_vars', 'navigation/breadcrumbs', 'myplugin_no_page_breadcrumbs');
 
-    function myplugin_no_page_breadcrumbs($hook, $type, $vars, $params) {
+    function myplugin_no_page_breadcrumbs(\Elgg\Hook $hook) {
         if (elgg_in_context('pages')) {
             return ['__view_output' => ""];
         }

--- a/docs/guides/walled-garden.rst
+++ b/docs/guides/walled-garden.rst
@@ -38,7 +38,10 @@ This assumes the plugin has registered a :doc:`route </guides/routing>` for ``my
    // Legacy approach
    elgg_register_plugin_hook_handler('public_pages', 'walled_garden', 'my_plugin_walled_garden_public_pages');
    
-   function my_plugin_walled_garden_public_pages($hook, $type, $pages) {
+   function my_plugin_walled_garden_public_pages(\Elgg\Hook $hook) {
+      $pages = $hook->getValue();
+      
       $pages[] = 'my_plugin/public_page';
+      
       return $pages;
    }

--- a/docs/guides/widgets.rst
+++ b/docs/guides/widgets.rst
@@ -148,11 +148,13 @@ If, for example, you wish to conditionally register widgets you can also use a h
         elgg_register_plugin_hook_handler('handlers', 'widgets', 'my_plugin_conditional_widgets_hook');
     }
 
-    function my_plugin_conditional_widgets_hook($hook, $type, $return, $params) {
+    function my_plugin_conditional_widgets_hook(\Elgg\Hook $hook) {
         if (!elgg_is_active_plugin('file')) {
             return;
         }
 
+        $return = $hook->getValue();
+		
         $return[] = \Elgg\WidgetDefinition::factory([
             'id' => 'filerepo',
         ]);
@@ -170,7 +172,9 @@ If, for example, you wish to change the allowed contexts of an already registere
         elgg_register_plugin_hook_handler('handlers', 'widgets', 'my_plugin_change_widget_definition_hook');
     }
 
-    function my_plugin_change_widget_definition_hook($hook, $type, $return, $params) {
+    function my_plugin_change_widget_definition_hook(\Elgg\Hook $hook) {
+        $return = $hook->getValue();
+    	
         foreach ($return as $key => $widget) {
             if ($widget->id === 'filerepo') {
                 $return[$key]->multiple = false;
@@ -191,7 +195,9 @@ To announce default widget support in your plugin, register for the ``get_list, 
 
     elgg_register_plugin_hook_handler('get_list', 'default_widgets', 'my_plugin_default_widgets_hook');
     
-    function my_plugin_default_widgets_hook($hook, $type, $return, $params) {
+    function my_plugin_default_widgets_hook(\Elgg\Hook $hook) {
+    	$return = $hook->getValue();
+    	
         $return[] = [
             'name' => elgg_echo('my_plugin'),
             'widget_context' => 'my_plugin',

--- a/docs/intro/elgg-cli.rst
+++ b/docs/intro/elgg-cli.rst
@@ -102,7 +102,8 @@ Command class must extend ``\Elgg\CLI\Command``.
 
     }
 
-    elgg_register_plugin_hook_handler('commands', 'cli', function($hook, $type, $return) {
+    elgg_register_plugin_hook_handler('commands', 'cli', function(\Elgg\Hook $hook) {
+        $return = $hook->getValue();
 
         $return[] = MyCommand::class;
 

--- a/engine/classes/Elgg/HandlersService.php
+++ b/engine/classes/Elgg/HandlersService.php
@@ -49,42 +49,25 @@ class HandlersService {
 			return [false, null, $object];
 		}
 
-		$use_object = $this->acceptsObject($callable);
-		if ($use_object) {
-			if (is_string($object)) {
-				switch ($object) {
-					case 'hook' :
-						$object = new HrsHook(elgg(), $args[0], $args[1], $args[2], $args[3]);
-						break;
+		if (is_string($object)) {
+			switch ($object) {
+				case 'hook' :
+					$object = new HrsHook(elgg(), $args[0], $args[1], $args[2], $args[3]);
+					break;
 
-					case 'event' :
-						$object = new HrsEvent(elgg(), $args[0], $args[1], $args[2]);
-						break;
+				case 'event' :
+					$object = new HrsEvent(elgg(), $args[0], $args[1], $args[2]);
+					break;
 
-					case 'middleware' :
-					case 'controller' :
-					case 'action' :
-						$object = new Request(elgg(), $args[0]);
-						break;
-				}
+				case 'middleware' :
+				case 'controller' :
+				case 'action' :
+					$object = new Request(elgg(), $args[0]);
+					break;
 			}
-
-			$result = call_user_func($callable, $object);
-		} else {
-			// legacy arguments
-			if ($this->getParamTypeForCallable($callable) !== null) {
-				$described_callback = $this->describeCallable($callable);
-				$msg = "Using legacy style hook and event callback arguments is deprecated. Used by: {$described_callback} for [{$args[0]}, {$args[1]}].";
-				
-				$msg_hash = md5($msg);
-				if (!in_array($msg_hash, $this->deprecated_args_msgs)) {
-					elgg_deprecated_notice($msg, "3.1");
-					$this->deprecated_args_msgs[] = $msg_hash;
-				}
-			}
-			
-			$result = call_user_func_array($callable, $args);
 		}
+
+		$result = call_user_func($callable, $object);
 
 		return [true, $result, $object];
 	}
@@ -152,24 +135,6 @@ class HandlersService {
 		}
 
 		return is_callable($callable) ? $callable : null;
-	}
-
-	/**
-	 * Should we pass this callable a Hook/Event object instead of the 2.0 arguments?
-	 *
-	 * @param callable $callable Callable
-	 *
-	 * @return bool
-	 */
-	private function acceptsObject($callable) {
-		// note: caching string callables didn't help any
-		$type = (string) $this->getParamTypeForCallable($callable);
-		if (0 === strpos($type, 'Elgg\\')) {
-			// probably right. We can just assume and let PHP handle it
-			return true;
-		}
-
-		return false;
 	}
 
 	/**

--- a/engine/tests/phpunit/integration/Elgg/Actions/LoginIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Actions/LoginIntegrationTest.php
@@ -185,7 +185,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 
 	public function testCanPreventLoginWithHook() {
 
-		$handler = function() {
+		$handler = function(\Elgg\Event $hook) {
 			return false;
 		};
 

--- a/engine/tests/phpunit/integration/ElggAccessCollectionUnitTest.php
+++ b/engine/tests/phpunit/integration/ElggAccessCollectionUnitTest.php
@@ -34,9 +34,10 @@ class ElggAccessCollectionUnitTest extends \Elgg\IntegrationTestCase {
 
 		_elgg_services()->hooks->backup();
 
-		_elgg_services()->hooks->registerHandler('access_collection:url', 'access_collection', function ($hook, $type, $return, $params) use ($acl) {
-			$this->assertEquals($acl, $params['access_collection']);
-			if ($params['access_collection']->getSubtype() == 'foo') {
+		_elgg_services()->hooks->registerHandler('access_collection:url', 'access_collection', function (\Elgg\Hook $hook) use ($acl) {
+			$hook_acl = $hook->getParam('access_collection');
+			$this->assertEquals($acl, $hook_acl);
+			if ($hook_acl->getSubtype() === 'foo') {
 				return 'bar';
 			}
 		});

--- a/engine/tests/phpunit/unit/Elgg/ActionsServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/ActionsServiceUnitTest.php
@@ -377,7 +377,7 @@ class ActionsServiceUnitTest extends \Elgg\UnitTestCase {
 		$this->createService($request);
 		$this->addCsrfTokens($request);
 
-		_elgg_services()->hooks->registerHandler('action:validate', 'output3', function ($hook, $type, $return, $params) {
+		_elgg_services()->hooks->registerHandler('action:validate', 'output3', function (\Elgg\Hook $hook) {
 			throw new ValidationException('Invalid');
 		});
 
@@ -518,8 +518,10 @@ class ActionsServiceUnitTest extends \Elgg\UnitTestCase {
 		$this->createService($request);
 		$this->addCsrfTokens($request);
 
-		_elgg_services()->hooks->registerHandler(Services\AjaxResponse::RESPONSE_HOOK, 'action:output3', function ($hook, $type, $api_response) {
+		_elgg_services()->hooks->registerHandler(Services\AjaxResponse::RESPONSE_HOOK, 'action:output3', function (\Elgg\Hook $hook) {
 			/* @var $api_response Services\AjaxResponse */
+			$api_response = $hook->getValue();
+			
 			$api_response->setTtl(1000);
 			$api_response->setData((object) ['value' => 'output3_modified']);
 
@@ -568,8 +570,10 @@ class ActionsServiceUnitTest extends \Elgg\UnitTestCase {
 		$this->createService($request);
 		$this->addCsrfTokens($request);
 
-		_elgg_services()->hooks->registerHandler(Services\AjaxResponse::RESPONSE_HOOK, 'action:output3', function ($hook, $type, $api_response) {
+		_elgg_services()->hooks->registerHandler(Services\AjaxResponse::RESPONSE_HOOK, 'action:output3', function (\Elgg\Hook $hook) {
 			/* @var $api_response Services\AjaxResponse */
+			$api_response = $hook->getValue();
+			
 			return $api_response->cancel();
 		});
 
@@ -1090,10 +1094,12 @@ class ActionsServiceUnitTest extends \Elgg\UnitTestCase {
 		$this->createService($request);
 		$this->addCsrfTokens($request);
 
-		_elgg_services()->hooks->registerHandler('response', 'action:output4', function ($hook, $type, $response, $params) {
-			$this->assertEquals('response', $hook);
-			$this->assertEquals('action:output4', $type);
-			$this->assertEquals($response, $params);
+		_elgg_services()->hooks->registerHandler('response', 'action:output4', function (\Elgg\Hook $hook) {
+			$response = $hook->getValue();
+			
+			$this->assertEquals('response', $hook->getName());
+			$this->assertEquals('action:output4', $hook->getType());
+			$this->assertEquals($response, $hook->getParams());
 			$this->assertInstanceOf(OkResponse::class, $response);
 
 			$response->setContent('good bye');

--- a/engine/tests/phpunit/unit/Elgg/Amd/ConfigUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Amd/ConfigUnitTest.php
@@ -145,7 +145,7 @@ class ConfigUnitTest extends \Elgg\UnitTestCase {
 
 		$test_input = ['test' => 'test_' . time()];
 
-		$this->hooks->registerHandler('config', 'amd', function() use ($test_input) {
+		$this->hooks->registerHandler('config', 'amd', function(\Elgg\Hook $hook) use ($test_input) {
 			return $test_input;
 		});
 

--- a/engine/tests/phpunit/unit/Elgg/EmailServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/EmailServiceUnitTest.php
@@ -52,10 +52,13 @@ class EmailServiceUnitTest extends \Elgg\UnitTestCase {
 
 		$calls = 0;
 		$original_email = null;
-		$handler = function ($hook, $type, $email, $params) use (&$original_email, &$calls) {
+		$handler = function (\Elgg\Hook $hook) use (&$original_email, &$calls) {
+			$email = $hook->getValue();
+			
 			$calls++;
 			$original_email = clone $email;
 			$email->setBody("<p>&lt;Hello&gt;</p>");
+			
 			return $email;
 		};
 

--- a/engine/tests/phpunit/unit/Elgg/EntityIconServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/EntityIconServiceUnitTest.php
@@ -149,10 +149,10 @@ class EntityIconServiceUnitTest extends \Elgg\UnitTestCase {
 		return array_merge($cover_sizes, self::getDefaultIconSizes());
 	}
 
-	public static function getIconSizesForSubtype($hook, $type, $sizes, $params) {
-		$subtype = elgg_extract('entity_subtype', $params);
-		$icon_type = elgg_extract('type', $params);
-		if ($type == 'object' && $subtype == 'foo' && $icon_type == 'icon') {
+	public static function getIconSizesForSubtype(\Elgg\Hook $hook) {
+		$subtype = $hook->getParam('entity_subtype');
+		$icon_type = $hook->getParam('type');
+		if ($hook->getType() == 'object' && $subtype == 'foo' && $icon_type == 'icon') {
 			return self::getTestSizes();
 		}
 	}
@@ -219,10 +219,12 @@ class EntityIconServiceUnitTest extends \Elgg\UnitTestCase {
 	}
 
 	public function testCanReplaceIconFile() {
-		$callback = function($hook, $type, $icon, $params) {
-			$size = elgg_extract('size', $params);
-			$type = elgg_extract('type', $params);
-			$entity = elgg_extract('entity', $params);
+		$callback = function(\Elgg\Hook $hook) {
+			$size = $hook->getParam('size');
+			$type = $hook->getParam('type');
+			$icon = $hook->getValue();
+			
+			$entity = $hook->getEntityParam();
 			if ($entity->getSubtype() == 'foo') {
 				$icon->owner_guid = $entity->owner_guid;
 				$icon->setFilename("foo/bar/$type/$size.jpg");
@@ -242,7 +244,7 @@ class EntityIconServiceUnitTest extends \Elgg\UnitTestCase {
 	}
 
 	public function testThrowsExceptionOnInvalidHookHandlerReturnForIconFile() {
-		$callback = function($hook, $type, $icon, $params) {
+		$callback = function(\Elgg\Hook $hook) {
 			return '/path/to/foo.jpg';
 		};
 
@@ -390,7 +392,7 @@ class EntityIconServiceUnitTest extends \Elgg\UnitTestCase {
 
 	public function testCanReplaceDefaultIconURL() {
 
-		$this->hooks->registerHandler('entity:icon:url', 'object', function() {
+		$this->hooks->registerHandler('entity:icon:url', 'object', function(\Elgg\Hook $hook) {
 			return '/path/to/icon.png';
 		});
 
@@ -530,9 +532,10 @@ class EntityIconServiceUnitTest extends \Elgg\UnitTestCase {
 		// make sure we have a wide master
 		$this->assertTrue($size[0] > $size[1]);
 
-		$this->hooks->registerHandler('entity:icon:prepare', 'object', function($hook, $type, $file, $params) {
+		$this->hooks->registerHandler('entity:icon:prepare', 'object', function(\Elgg\Hook $hook) {
 			// make sure we passed in documented params
-			if (!$params['entity'] instanceof \ElggEntity || !$params['file'] instanceof \ElggFile || !$file instanceof \ElggFile) {
+			$file = $hook->getValue();
+			if (!$hook->getEntityParam() instanceof \ElggEntity || !$hook->getParam('file') instanceof \ElggFile || !$file instanceof \ElggFile) {
 				return;
 			}
 			$new_source = new \ElggFile();
@@ -540,7 +543,7 @@ class EntityIconServiceUnitTest extends \Elgg\UnitTestCase {
 			$new_source->setFilename('300x600.jpg');
 
 			// replace with tall image
-			$file->owner_guid = $params['entity']->guid;
+			$file->owner_guid = $hook->getEntityParam()->guid;
 			$file->setFilename('tmp/tmp.jpg');
 			$file->open('write');
 			$file->close();
@@ -577,17 +580,21 @@ class EntityIconServiceUnitTest extends \Elgg\UnitTestCase {
 		$file->owner_guid = 1;
 		$file->setFilename('600x300.jpg');
 
-		$this->hooks->registerHandler('entity:icon:save', 'object', function($hook, $type, $return, $params) {
-			if ($return) {
+		$this->hooks->registerHandler('entity:icon:save', 'object', function(\Elgg\Hook $hook) {
+			if ($hook->getValue()) {
 				return;
 			}
 
 			// make sure we passed in documented params
-			if (!$params['entity'] instanceof \ElggEntity || !$params['file'] instanceof \ElggFile) {
+			if (!$hook->getEntityParam() instanceof \ElggEntity || !$hook->getParam('file') instanceof \ElggFile) {
 				return;
 			}
 
-			if (!isset($params['x1']) || !isset($params['y1']) || !isset($params['x2']) || !isset($params['y2'])) {
+			$x1 = $hook->getParam('x1');
+			$x2 = $hook->getParam('x2');
+			$y1 = $hook->getParam('y1');
+			$y2 = $hook->getParam('y2');
+			if (!isset($x1) || !isset($x2) || !isset($y1) || !isset($y2)) {
 				return;
 			}
 
@@ -621,13 +628,13 @@ class EntityIconServiceUnitTest extends \Elgg\UnitTestCase {
 		$file->owner_guid = 1;
 		$file->setFilename('600x300.jpg');
 
-		$this->hooks->registerHandler('entity:icon:delete', 'object', function($hook, $type, $return, $params) {
-			if ($return === false) {
+		$this->hooks->registerHandler('entity:icon:delete', 'object', function(\Elgg\Hook $hook) {
+			if ($hook->getValue() === false) {
 				return;
 			}
 
 			// make sure we passed in documented params
-			if (!$params['entity'] instanceof \ElggEntity) {
+			if (!$hook->getEntityParam() instanceof \ElggEntity) {
 				return;
 			}
 
@@ -661,18 +668,22 @@ class EntityIconServiceUnitTest extends \Elgg\UnitTestCase {
 		$file->owner_guid = 1;
 		$file->setFilename('600x300.jpg');
 
-		$this->hooks->registerHandler('entity:icon:saved', 'object', function($hook, $type, $return, $params) {
+		$this->hooks->registerHandler('entity:icon:saved', 'object', function(\Elgg\Hook $hook) {
 
 			// make sure we passed in documented params
-			if (!$params['entity'] instanceof \ElggEntity) {
+			if (!$hook->getEntityParam() instanceof \ElggEntity) {
 				return;
 			}
 
-			if (!isset($params['x1']) || !isset($params['y1']) || !isset($params['x2']) || !isset($params['y2'])) {
+			$x1 = $hook->getParam('x1');
+			$x2 = $hook->getParam('x2');
+			$y1 = $hook->getParam('y1');
+			$y2 = $hook->getParam('y2');
+			if (!isset($x1) || !isset($x2) || !isset($y1) || !isset($y2)) {
 				return;
 			}
 
-			_elgg_services()->iconService->deleteIcon($params['entity']);
+			_elgg_services()->iconService->deleteIcon($hook->getEntityParam());
 		});
 
 		$this->assertTrue($this->hooks->hasHandler('entity:icon:saved', 'object'));

--- a/engine/tests/phpunit/unit/Elgg/LoggerUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/LoggerUnitTest.php
@@ -43,7 +43,7 @@ class LoggerUnitTest extends \Elgg\UnitTestCase {
 		$hooks->backup();
 
 		$num_processed = 0;
-		$hooks->registerHandler('debug', 'log', function () use (&$num_processed) {
+		$hooks->registerHandler('debug', 'log', function (\Elgg\Hook $hook) use (&$num_processed) {
 			$num_processed++;
 			return false;
 		});

--- a/engine/tests/phpunit/unit/Elgg/PluginHooksServiceTest.php
+++ b/engine/tests/phpunit/unit/Elgg/PluginHooksServiceTest.php
@@ -134,11 +134,11 @@ class PluginHooksServiceUnitTest extends \Elgg\UnitTestCase {
 		return 2;
 	}
 
-	public static function changeReturn($foo, $bar, $returnval, $params) {
-		$testCase = $params['testCase'];
+	public static function changeReturn(\Elgg\Hook $hook) {
+		$testCase = $hook->getParam('testCase');
 		/* @var PluginHooksServiceUnitTest $testCase */
 
-		$testCase->assertEquals(1, $returnval);
+		$testCase->assertEquals(1, $hook->getValue());
 
 		return 2;
 	}

--- a/engine/tests/phpunit/unit/Elgg/RouterUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/RouterUnitTest.php
@@ -126,10 +126,12 @@ class RouterUnitTest extends \Elgg\UnitTestCase {
 		$request = $this->prepareHttpRequest('foo/bar/baz');
 		$this->createService($request);
 
-		_elgg_services()->hooks->registerHandler('route:rewrite', 'foo', function ($hook, $type, $return, $params) {
-			$this->assertEquals('route:rewrite', $hook);
-			$this->assertEquals('foo', $type);
-			$this->assertEquals($return, $params);
+		_elgg_services()->hooks->registerHandler('route:rewrite', 'foo', function (\Elgg\Hook $hook) {
+			$this->assertEquals('route:rewrite', $hook->getName());
+			$this->assertEquals('foo', $hook->getType());
+			
+			$return = $hook->getValue();
+			$this->assertEquals($return, $hook->getParams());
 
 			$this->assertEquals('foo', $return['identifier']);
 			$this->assertEquals(['bar', 'baz'], $return['segments']);
@@ -157,10 +159,12 @@ class RouterUnitTest extends \Elgg\UnitTestCase {
 		$request = $this->prepareHttpRequest('foo/bar', 'GET');
 		$this->createService($request);
 
-		_elgg_services()->hooks->registerHandler('response', 'path:foo/bar', function ($hook, $type, $response, $params) {
-			$this->assertEquals('response', $hook);
-			$this->assertEquals('path:foo/bar', $type);
-			$this->assertEquals($response, $params);
+		_elgg_services()->hooks->registerHandler('response', 'path:foo/bar', function (\Elgg\Hook $hook) {
+			$this->assertEquals('response', $hook->getName());
+			$this->assertEquals('path:foo/bar', $hook->getType());
+			
+			$response = $hook->getValue();
+			$this->assertEquals($response, $hook->getParams());
 			$this->assertInstanceOf(OkResponse::class, $response);
 
 			return elgg_error_response('', REFERRER, ELGG_HTTP_BAD_REQUEST);
@@ -882,10 +886,12 @@ class RouterUnitTest extends \Elgg\UnitTestCase {
 		$request = $this->prepareHttpRequest('ajax/view/query_view', 'GET', $vars, 1);
 		$this->createService($request);
 
-		_elgg_services()->hooks->registerHandler('response', 'view:query_view', function ($hook, $type, $response, $params) {
-			$this->assertEquals('response', $hook);
-			$this->assertEquals('view:query_view', $type);
-			$this->assertEquals($response, $params);
+		_elgg_services()->hooks->registerHandler('response', 'view:query_view', function (\Elgg\Hook $hook) {
+			$this->assertEquals('response', $hook->getName());
+			$this->assertEquals('view:query_view', $hook->getType());
+			
+			$response = $hook->getValue();
+			$this->assertEquals($response, $hook->getParams());
 			$this->assertInstanceOf(OkResponse::class, $response);
 
 			return elgg_error_response('good bye', REFERRER, ELGG_HTTP_BAD_REQUEST);
@@ -1094,10 +1100,12 @@ class RouterUnitTest extends \Elgg\UnitTestCase {
 		$request = $this->prepareHttpRequest('ajax/view/query_view', 'GET', $vars, 2);
 		$this->createService($request);
 
-		_elgg_services()->hooks->registerHandler('response', 'view:query_view', function ($hook, $type, $response, $params) {
-			$this->assertEquals('response', $hook);
-			$this->assertEquals('view:query_view', $type);
-			$this->assertEquals($response, $params);
+		_elgg_services()->hooks->registerHandler('response', 'view:query_view', function (\Elgg\Hook $hook) {
+			$this->assertEquals('response', $hook->getName());
+			$this->assertEquals('view:query_view', $hook->getType());
+			
+			$response = $hook->getValue();
+			$this->assertEquals($response, $hook->getParams());
 			$this->assertInstanceOf(OkResponse::class, $response);
 
 			return elgg_error_response('good bye', REFERRER, ELGG_HTTP_BAD_REQUEST);

--- a/engine/tests/phpunit/unit/Elgg/UploadServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/UploadServiceUnitTest.php
@@ -192,19 +192,19 @@ class UploadServiceUnitTest extends \Elgg\UnitTestCase {
 		$upload_event_calls = 0;
 		$upload_hook_calls = 0;
 
-		_elgg_services()->events->registerHandler('upload:after', 'file', function($event, $type, $object) use (&$upload_event_calls) {
-			$this->assertEquals('upload:after', $event);
-			$this->assertEquals('file', $type);
-			$this->assertInstanceOf(\ElggFile::class, $object);
+		_elgg_services()->events->registerHandler('upload:after', 'file', function(\Elgg\Event $event) use (&$upload_event_calls) {
+			$this->assertEquals('upload:after', $event->getName());
+			$this->assertEquals('file', $event->getType());
+			$this->assertInstanceOf(\ElggFile::class, $event->getObject());
 			$upload_event_calls++;
 		});
 
-		_elgg_services()->hooks->registerHandler('upload', 'file', function($hook, $type, $return, $params) use (&$upload_hook_calls) {
-			$this->assertNull($return);
-			$this->assertEquals('upload', $hook);
-			$this->assertEquals('file', $type);
-			$this->assertInstanceOf(\ElggFile::class, $params['file']);
-			$this->assertInstanceOf(UploadedFile::class, $params['upload']);
+		_elgg_services()->hooks->registerHandler('upload', 'file', function(\Elgg\Hook $hook) use (&$upload_hook_calls) {
+			$this->assertNull($hook->getValue());
+			$this->assertEquals('upload', $hook->getName());
+			$this->assertEquals('file', $hook->getType());
+			$this->assertInstanceOf(\ElggFile::class, $hook->getParam('file'));
+			$this->assertInstanceOf(UploadedFile::class, $hook->getParam('upload'));
 			$upload_hook_calls++;
 			return false;
 		});

--- a/engine/tests/phpunit/unit/Elgg/UserCapabilitiesUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/UserCapabilitiesUnitTest.php
@@ -90,12 +90,12 @@ class UserCapabilitiesUnitTest extends UnitTestCase {
 
 		$this->assertTrue($entity->canEdit($user->guid));
 
-		$this->hooks->registerHandler('permissions_check', 'object', function($hook, $type, $return, $params) use ($entity, $user) {
-			$this->assertInstanceOf(ElggEntity::class, $params['entity']);
-			$this->assertInstanceOf(ElggUser::class, $params['user']);
-			$this->assertEquals($entity, $params['entity']);
-			$this->assertEquals($user, $params['user']);
-			$this->assertTrue($return);
+		$this->hooks->registerHandler('permissions_check', 'object', function(\Elgg\Hook $hook) use ($entity, $user) {
+			$this->assertInstanceOf(ElggEntity::class, $hook->getEntityParam());
+			$this->assertInstanceOf(ElggUser::class, $hook->getUserParam());
+			$this->assertEquals($entity, $hook->getEntityParam());
+			$this->assertEquals($user, $hook->getUserParam());
+			$this->assertTrue($hook->getValue());
 			return false;
 		});
 		$this->assertFalse($entity->canEdit($user->guid));
@@ -137,12 +137,12 @@ class UserCapabilitiesUnitTest extends UnitTestCase {
 		]);
 		$this->assertTrue($entity->canDelete($owner->guid));
 
-		$this->hooks->registerHandler('permissions_check:delete', 'object', function($hook, $type, $return, $params) use ($entity, $owner) {
-			$this->assertInstanceOf(ElggEntity::class, $params['entity']);
-			$this->assertInstanceOf(ElggUser::class, $params['user']);
-			$this->assertEquals($entity, $params['entity']);
-			$this->assertEquals($owner, $params['user']);
-			$this->assertTrue($return);
+		$this->hooks->registerHandler('permissions_check:delete', 'object', function(\Elgg\Hook $hook) use ($entity, $owner) {
+			$this->assertInstanceOf(ElggEntity::class, $hook->getEntityParam());
+			$this->assertInstanceOf(ElggUser::class, $hook->getUserParam());
+			$this->assertEquals($entity, $hook->getEntityParam());
+			$this->assertEquals($owner, $hook->getUserParam());
+			$this->assertTrue($hook->getValue());
 			return false;
 		});
 
@@ -186,13 +186,13 @@ class UserCapabilitiesUnitTest extends UnitTestCase {
 
 		$this->assertTrue($entity->canWriteToContainer($owner->guid, 'object', 'bar'));
 
-		$this->hooks->registerHandler('container_permissions_check', 'object', function($hook, $type, $return, $params) use ($entity, $owner) {
-			$this->assertInstanceOf(ElggEntity::class, $params['container']);
-			$this->assertInstanceOf(ElggUser::class, $params['user']);
-			$this->assertEquals($entity, $params['container']);
-			$this->assertEquals($owner, $params['user']);
-			$this->assertEquals('bar', $params['subtype']);
-			$this->assertTrue($return);
+		$this->hooks->registerHandler('container_permissions_check', 'object', function(\Elgg\Hook $hook) use ($entity, $owner) {
+			$this->assertInstanceOf(ElggEntity::class, $hook->getParam('container'));
+			$this->assertInstanceOf(ElggUser::class, $hook->getUserParam());
+			$this->assertEquals($entity, $hook->getParam('container'));
+			$this->assertEquals($owner, $hook->getUserParam());
+			$this->assertEquals('bar', $hook->getParam('subtype'));
+			$this->assertTrue($hook->getValue());
 			return false;
 		});
 
@@ -298,14 +298,14 @@ class UserCapabilitiesUnitTest extends UnitTestCase {
 		]);
 		$this->assertTrue($annotation->canEdit($owner->guid));
 
-		$this->hooks->registerHandler('permissions_check', 'annotation', function($hook, $type, $return, $params) use ($entity, $owner, $annotation) {
-			$this->assertInstanceOf(ElggEntity::class, $params['entity']);
-			$this->assertInstanceOf(ElggUser::class, $params['user']);
-			$this->assertInstanceOf(ElggAnnotation::class, $params['annotation']);
-			$this->assertEquals($entity, $params['entity']);
-			$this->assertEquals($owner, $params['user']);
-			$this->assertEquals($annotation, $params['annotation']);
-			$this->assertTrue($return);
+		$this->hooks->registerHandler('permissions_check', 'annotation', function(\Elgg\Hook $hook) use ($entity, $owner, $annotation) {
+			$this->assertInstanceOf(ElggEntity::class, $hook->getEntityParam());
+			$this->assertInstanceOf(ElggUser::class, $hook->getUserParam());
+			$this->assertInstanceOf(ElggAnnotation::class, $hook->getParam('annotation'));
+			$this->assertEquals($entity, $hook->getEntityParam());
+			$this->assertEquals($owner, $hook->getUserParam());
+			$this->assertEquals($annotation, $hook->getParam('annotation'));
+			$this->assertTrue($hook->getValue());
 			return false;
 		});
 
@@ -384,13 +384,13 @@ class UserCapabilitiesUnitTest extends UnitTestCase {
 		
 		$this->assertTrue($entity->canComment($owner->guid));
 
-		$this->hooks->registerHandler('permissions_check:comment', 'object', function($hook, $type, $return, $params) use ($entity, $owner) {
-			$this->assertInstanceOf(ElggEntity::class, $params['entity']);
-			$this->assertInstanceOf(ElggUser::class, $params['user']);
-			$this->assertEquals($entity, $params['entity']);
-			$this->assertEquals($owner, $params['user']);
-			$this->assertEquals('object', $type);
-			$this->assertNull($return); // called from ElggObject, no default value
+		$this->hooks->registerHandler('permissions_check:comment', 'object', function(\Elgg\Hook $hook) use ($entity, $owner) {
+			$this->assertInstanceOf(ElggEntity::class, $hook->getEntityParam());
+			$this->assertInstanceOf(ElggUser::class, $hook->getUserParam());
+			$this->assertEquals($entity, $hook->getEntityParam());
+			$this->assertEquals($owner, $hook->getUserParam());
+			$this->assertEquals('object', $hook->getType());
+			$this->assertNull($hook->getValue()); // called from ElggObject, no default value
 			return false;
 		});
 
@@ -477,14 +477,14 @@ class UserCapabilitiesUnitTest extends UnitTestCase {
 		]);
 		$this->assertTrue($entity->canAnnotate($owner->guid, 'baz'));
 
-		$this->hooks->registerHandler('permissions_check:annotate:baz', 'object', function($hook, $type, $return, $params) use ($entity, $owner) {
-			$this->assertInstanceOf(ElggEntity::class, $params['entity']);
-			$this->assertInstanceOf(ElggUser::class, $params['user']);
-			$this->assertEquals($entity, $params['entity']);
-			$this->assertEquals($owner, $params['user']);
-			$this->assertEquals('baz', $params['annotation_name']);
-			$this->assertEquals('object', $type);
-			$this->assertTrue($return);
+		$this->hooks->registerHandler('permissions_check:annotate:baz', 'object', function(\Elgg\Hook $hook) use ($entity, $owner) {
+			$this->assertInstanceOf(ElggEntity::class, $hook->getEntityParam());
+			$this->assertInstanceOf(ElggUser::class, $hook->getUserParam());
+			$this->assertEquals($entity, $hook->getEntityParam());
+			$this->assertEquals($owner, $hook->getUserParam());
+			$this->assertEquals('baz', $hook->getParam('annotation_name'));
+			$this->assertEquals('object', $hook->getType());
+			$this->assertTrue($hook->getValue());
 			return false;
 		});
 
@@ -507,14 +507,14 @@ class UserCapabilitiesUnitTest extends UnitTestCase {
 		]);
 		$this->assertTrue($entity->canAnnotate($owner->guid, 'baz'));
 
-		$this->hooks->registerHandler('permissions_check:annotate', 'object', function($hook, $type, $return, $params) use ($entity, $owner) {
-			$this->assertInstanceOf(ElggEntity::class, $params['entity']);
-			$this->assertInstanceOf(ElggUser::class, $params['user']);
-			$this->assertEquals($entity, $params['entity']);
-			$this->assertEquals($owner, $params['user']);
-			$this->assertEquals('baz', $params['annotation_name']);
-			$this->assertEquals('object', $type);
-			$this->assertTrue($return);
+		$this->hooks->registerHandler('permissions_check:annotate', 'object', function(\Elgg\Hook $hook) use ($entity, $owner) {
+			$this->assertInstanceOf(ElggEntity::class, $hook->getEntityParam());
+			$this->assertInstanceOf(ElggUser::class, $hook->getUserParam());
+			$this->assertEquals($entity, $hook->getEntityParam());
+			$this->assertEquals($owner, $hook->getUserParam());
+			$this->assertEquals('baz', $hook->getParam('annotation_name'));
+			$this->assertEquals('object', $hook->getType());
+			$this->assertTrue($hook->getValue());
 			return false;
 		});
 
@@ -537,27 +537,26 @@ class UserCapabilitiesUnitTest extends UnitTestCase {
 		]);
 		$this->assertTrue($entity->canAnnotate($owner->guid, 'baz'));
 
-		$this->hooks->registerHandler('permissions_check:annotate:baz', 'object', function($hook, $type, $return, $params) use ($entity, $owner) {
-			$this->assertInstanceOf(ElggEntity::class, $params['entity']);
-			$this->assertInstanceOf(ElggUser::class, $params['user']);
-			$this->assertEquals($entity, $params['entity']);
-			$this->assertEquals($owner, $params['user']);
-			$this->assertEquals('baz', $params['annotation_name']);
-			$this->assertEquals('object', $type);
-			$this->assertTrue($return);
+		$this->hooks->registerHandler('permissions_check:annotate:baz', 'object', function(\Elgg\Hook $hook) use ($entity, $owner) {
+			$this->assertInstanceOf(ElggEntity::class, $hook->getEntityParam());
+			$this->assertInstanceOf(ElggUser::class, $hook->getUserParam());
+			$this->assertEquals($entity, $hook->getEntityParam());
+			$this->assertEquals($owner, $hook->getUserParam());
+			$this->assertEquals('baz', $hook->getParam('annotation_name'));
+			$this->assertEquals('object', $hook->getType());
+			$this->assertTrue($hook->getValue());
 			return false;
 		});
 
 		$this->assertFalse($entity->canAnnotate($owner->guid, 'baz'));
 
-		$this->hooks->registerHandler('permissions_check:annotate', 'object', function($hook, $type, $return, $params) use ($entity, $owner) {
-			$this->assertInstanceOf(ElggEntity::class, $params['entity']);
-			$this->assertInstanceOf(ElggUser::class, $params['user']);
-			$this->assertEquals($entity, $params['entity']);
-			$this->assertEquals($owner, $params['user']);
-			$this->assertEquals('baz', $params['annotation_name']);
-			$this->assertEquals('object', $type);
-			$this->assertFalse($return); // return from named hook
+		$this->hooks->registerHandler('permissions_check:annotate', 'object', function(\Elgg\Hook $hook) use ($entity, $owner) {
+			$this->assertInstanceOf(ElggEntity::class, $hook->getEntityParam());
+			$this->assertInstanceOf(ElggUser::class, $hook->getUserParam());
+			$this->assertEquals($entity, $hook->getEntityParam());
+			$this->assertEquals($owner, $hook->getUserParam());
+			$this->assertEquals('baz', $hook->getParam('annotation_name'));
+			$this->assertEquals('object', $hook->getType());// return from named hook
 			return true;
 		});
 
@@ -573,14 +572,14 @@ class UserCapabilitiesUnitTest extends UnitTestCase {
 
 		$this->assertTrue($entity->canWriteToContainer($owner->guid, 'object', 'bar'));
 
-		$this->hooks->registerHandler('container_logic_check', 'object', function($hook, $type, $return, $params) use ($entity, $owner) {
-			$this->assertInstanceOf(ElggEntity::class, $params['container']);
-			$this->assertInstanceOf(ElggUser::class, $params['user']);
-			$this->assertEquals($entity, $params['container']);
-			$this->assertEquals($owner, $params['user']);
-			$this->assertEquals('object', $type);
-			$this->assertEquals('bar', $params['subtype']);
-			$this->assertNull($return);
+		$this->hooks->registerHandler('container_logic_check', 'object', function(\Elgg\Hook $hook) use ($entity, $owner) {
+			$this->assertInstanceOf(ElggEntity::class, $hook->getParam('container'));
+			$this->assertInstanceOf(ElggUser::class, $hook->getUserParam());
+			$this->assertEquals($entity, $hook->getParam('container'));
+			$this->assertEquals($owner, $hook->getUserParam());
+			$this->assertEquals('object', $hook->getType());
+			$this->assertEquals('bar', $hook->getParam('subtype'));
+			$this->assertNull($hook->getValue());
 			return false;
 		});
 

--- a/engine/tests/phpunit/unit/Elgg/ViewsServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/ViewsServiceUnitTest.php
@@ -151,16 +151,17 @@ class ViewsServiceUnitTest extends \Elgg\UnitTestCase {
 	}
 
 	public function testCanAlterViewInput() {
-		$this->hooks->registerHandler('view_vars', 'js/interpreted.js', function ($h, $t, $v, $p) {
-			$v['in'] = 'out';
-			return $v;
+		$this->hooks->registerHandler('view_vars', 'js/interpreted.js', function (\Elgg\Hook $hook) {
+			$vars = $hook->getValue();
+			$vars['in'] = 'out';
+			return $vars;
 		});
 
 		$this->assertEquals("// PHPout", $this->views->renderView('js/interpreted.js'));
 	}
 
 	public function testCanAlterViewOutput() {
-		$this->hooks->registerHandler('view', 'js/interpreted.js', function ($h, $t, $v, $p) {
+		$this->hooks->registerHandler('view', 'js/interpreted.js', function (\Elgg\Hook $hook) {
 			return '// Hello';
 		});
 
@@ -168,11 +169,11 @@ class ViewsServiceUnitTest extends \Elgg\UnitTestCase {
 	}
 
 	public function testCanReplaceViews() {
-		$this->hooks->registerHandler('view_vars', 'js/interpreted.js', function ($h, $t, $v, $p) {
+		$this->hooks->registerHandler('view_vars', 'js/interpreted.js', function (\Elgg\Hook $hook) {
 			return ['__view_output' => 123];
 		});
 
-		$this->hooks->registerHandler('view', 'js/interpreted.js', function ($h, $t, $v, $p) {
+		$this->hooks->registerHandler('view', 'js/interpreted.js', function (\Elgg\Hook $hook) {
 			$this->fail('view hook was called though __view_output was set.');
 		});
 

--- a/engine/tests/phpunit/unit/Elgg/WidgetsServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/WidgetsServiceUnitTest.php
@@ -112,19 +112,18 @@ class WidgetsServiceUnitTest extends \Elgg\UnitTestCase {
 	/**
 	 * Register a widget
 	 *
-	 * @param string $hook
-	 * @param string $type
-	 * @param array  $value
-	 * @param array $params
+	 * @param \Elgg\Hook $hook 'handlers', 'widgets'
 	 *
 	 * @return \Elgg\WidgetDefinition[]
 	 */
-	public function registerWidgetsHookHandler($hook, $type, $value, $params) {
+	public function registerWidgetsHookHandler(\Elgg\Hook $hook) {
+		$value = $hook->getValue();
+		
 		$value[] = \Elgg\WidgetDefinition::factory([
-					'id' => 'hook_widget',
-					'name' => 'hook_widget name',
-					'description' => 'hook_widget description',
-					'context' => 'from_hook',
+			'id' => 'hook_widget',
+			'name' => 'hook_widget name',
+			'description' => 'hook_widget description',
+			'context' => 'from_hook',
 		]);
 
 		return $value;
@@ -133,14 +132,13 @@ class WidgetsServiceUnitTest extends \Elgg\UnitTestCase {
 	/**
 	 * Unregister a widget
 	 *
-	 * @param string $hook
-	 * @param string $type
-	 * @param array  $value
-	 * @param array $params
+	 * @param \Elgg\Hook $hook 'handlers', 'widgets'
 	 *
 	 * @return \Elgg\WidgetDefinition[]
 	 */
-	public function unregisterWidgetsHookHandler($hook, $type, $value, $params) {
+	public function unregisterWidgetsHookHandler(\Elgg\Hook $hook) {
+		$value = $hook->getValue();
+		
 		foreach ($value as $key => $widget_definition) {
 			if ($widget_definition->id === 'hook_widget') {
 				unset($value[$key]);

--- a/engine/tests/phpunit/unit/ElggMetadataUnitTest.php
+++ b/engine/tests/phpunit/unit/ElggMetadataUnitTest.php
@@ -78,9 +78,10 @@ class ElggMetadataUnitTest extends UnitTestCase {
 		
 		_elgg_services()->hooks->backup();
 
-		_elgg_services()->hooks->registerHandler('extender:url', 'metadata', function($hook, $type, $return, $params) use ($metadata, $name) {
-			$this->assertEquals($metadata, $params['extender']);
-			if ($params['extender']->getSubtype() == $name) {
+		_elgg_services()->hooks->registerHandler('extender:url', 'metadata', function(\Elgg\Hook $hook) use ($metadata, $name) {
+			$extender = $hook->getParam('extender');
+			$this->assertEquals($metadata, $extender);
+			if ($extender->getSubtype() == $name) {
 				return 'foo';
 			}
 		});


### PR DESCRIPTION
The legacy callback parameters (`$hook, $type, $return, $params` and `$event, $type, $object`) have been removed.