### PR TITLE
fix(http): allow access to client IP behind proxy server

### DIFF
--- a/docs/appendix/faqs/general.rst
+++ b/docs/appendix/faqs/general.rst
@@ -393,3 +393,15 @@ Javascript not working
 If the user hover menu stops working or you cannot dismiss system messages, that means JavaScript is broken on your site. This usually due to a plugin having bad JavaScript code. You should find the plugin causing the problem and disable it. You can do this be disabling non-bundled plugins one at a time until the problem goes away. Another approach is disabling all non-bundled plugins and then enabling them one by one until the problem occurs again.
 
 Most web browsers will give you a hint as to what is breaking the JavaScript code. They often have a console for JavaScript errors or an advanced mode for displaying errors. Once you see the error message, you may have an easier time locating the problem.
+
+IP addresses in the logs are wrong
+----------------------------------
+
+When your Elgg installation is behind a proxy server or loadbalancer the IP addresses logged in the System Log plugin can be wrong. It could show only
+the IP addresses for the proxy server.
+
+In order to solve this you can configure the IP addresses of the proxy server as a trusted IP address and with that allow the system access to the 
+correct IP address of your users.
+
+In the ``settings.php`` file you can configure settings for ``$CONFIG->http_request_trusted_proxy_ips`` and ``$CONFIG->http_request_trusted_proxy_headers``
+check the ``settings.php`` file for more information. 

--- a/elgg-config/settings.example.php
+++ b/elgg-config/settings.example.php
@@ -432,3 +432,24 @@ $CONFIG->allow_phpinfo = false;
  * @see https://secure.php.net/manual/en/function.setlocale.php
  */
 //$CONFIG->language_to_locale_mapping = [];
+
+/**
+ * When your webserver is behind a loadbalancer or reverse proxy server some client information (IP, protocol, etc) is
+ * stored in different headers. For Elgg to be able to access these headers you need to configure the IP addresses of
+ * the loadbalancer/reverse proxy.
+ *
+ * @see https://symfony.com/doc/3.3/deployment/proxies.html
+ */
+//$CONFIG->http_request_trusted_proxy_ips = [
+//	'ip-address-1',
+//	'ip-address-2',
+//];
+
+/**
+ * When your webserver is behind a loadbalancer or reverse proxy server some client information (IP, protocol, etc) is
+ * stored in different headers. For Elgg to be able to access these headers you need to configure the headers it's allowed to read.
+ * This is a bitwise flag of the allowed headers, if nothing is configured all commonly used headers are allowed.
+ *
+ * @see https://symfony.com/doc/3.3/deployment/proxies.html
+ */
+//$CONFIG->http_request_trusted_proxy_headers = '';

--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -305,6 +305,7 @@ class Application {
 
 		if ($spec['request']) {
 			if ($spec['request'] instanceof HttpRequest) {
+				$spec['request']->initializeTrustedProxyConfiguration($spec['service_provider']->config);
 				$spec['service_provider']->setValue('request', $spec['request']);
 			} else {
 				throw new InvalidArgumentException("Given request is not a " . HttpRequest::class);

--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -59,6 +59,8 @@ use Elgg\Project\Paths;
  * @property mixed         $embed_tab
  * @property string        $exception_include						This is an optional script used to override Elgg's default handling of uncaught exceptions.
  * @property string[]      $group
+ * @property string[]      $http_request_trusted_proxy_ips			When Elgg is behind a loadbalancer/proxy this can contain IP adresses to allow access to better client information
+ * @property int           $http_request_trusted_proxy_headers		When Elgg is behind a loadbalancer/proxy this can contain a bitwise string of allowed headers for better client information
  * @property bool          $i18n_loaded_from_cache
  * @property array         $icon_sizes
  * @property string        $image_processor

--- a/engine/classes/Elgg/Database/MetadataTable.php
+++ b/engine/classes/Elgg/Database/MetadataTable.php
@@ -411,8 +411,8 @@ class MetadataTable {
 		$qb->select('*')
 			->where($qb->compare('entity_guid', 'IN', $guids, ELGG_VALUE_GUID))
 			->orderBy('entity_guid', 'asc')
-			->orderBy('time_created', 'asc')
-			->orderBy('id', 'asc');
+			->addOrderBy('time_created', 'asc')
+			->addOrderBy('id', 'asc');
 		
 		return $qb->execute()->fetchAll();
 	}

--- a/engine/classes/Elgg/Di/ServiceProvider.php
+++ b/engine/classes/Elgg/Di/ServiceProvider.php
@@ -614,7 +614,15 @@ class ServiceProvider extends DiContainer {
 			return new \Elgg\Database\RelationshipsTable($c->db, $c->entityTable, $c->metadataTable, $c->events);
 		});
 
-		$this->setFactory('request', [\Elgg\Http\Request::class, 'createFromGlobals']);
+		$this->setFactory('request', function(ServiceProvider $c) use ($config) {
+			$request = \Elgg\Http\Request::createFromGlobals();
+			
+			// not using ServiceProvider->config because of deadloop issues
+			// using (the same) $config as the ServiceProvider was constructed with)
+			$request->initializeTrustedProxyConfiguration($config);
+			
+			return $request;
+		});
 
 		$this->setFactory('requestContext', function(ServiceProvider $c) {
 			$context = new \Elgg\Router\RequestContext();

--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -8,6 +8,7 @@ use Elgg\HttpException;
 use Elgg\Router\Route;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Elgg\Config;
 
 /**
  * Elgg HTTP request.
@@ -49,8 +50,27 @@ class Request extends SymfonyRequest {
 		parent::__construct($query, $request, $attributes, $cookies, $files, $server, $content);
 
 		$this->initializeContext();
-
+		
 		$this->request_overrides = [];
+	}
+	
+	/**
+	 * Configure trusted proxy servers to allow access to more client information
+	 *
+	 * @return void
+	 */
+	public function initializeTrustedProxyConfiguration(Config $config) {
+		$trusted_proxies = $config->http_request_trusted_proxy_ips;
+		if (empty($trusted_proxies)) {
+			return;
+		}
+		
+		$allowed_headers = $config->http_request_trusted_proxy_headers;
+		if (empty($allowed_headers)) {
+			$allowed_headers = self::HEADER_X_FORWARDED_ALL;
+		}
+		
+		$this->setTrustedProxies($trusted_proxies, $allowed_headers);
 	}
 
 	/**


### PR DESCRIPTION
When behind a proxy server or loadbalancer the real client IP adres can
only be found in special headers. It's now possible to configure the
proxy server address in order to allow access to the correct headers.