### PR TITLE
fix(view) : fixing show_owner_block

### DIFF
--- a/views/default/page/elements/sidebar.php
+++ b/views/default/page/elements/sidebar.php
@@ -9,7 +9,10 @@
  * @uses $vars['sidebar'] Optional content that is displayed at the bottom of sidebar
  */
 
+elgg_extract('show_owner_block', $vars, true){
 echo elgg_view('page/elements/owner_block', $vars);
+}
+
 echo elgg_view('page/elements/page_menu', $vars);
 
 // optional 'sidebar' parameter


### PR DESCRIPTION
  `$vars['show_owner_block'] = false` had no effect on sidebar  `$vars['show_owner_block_menu'] = false;` worked perfectly but the menu disappeared leaving the owner block still in view without menu