### PR TITLE
chore(tests): prevent random test failure

### DIFF
--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -445,7 +445,7 @@ class Database {
 				}
 			});
 		} catch (\Exception $e) {
-			$ex = new \DatabaseException($e->getMessage());
+			$ex = new \DatabaseException($e->getMessage(), null, $e);
 			$ex->setParameters($params);
 			$ex->setQuery($sql);
 

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreRegressionBugsTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreRegressionBugsTest.php
@@ -100,7 +100,9 @@ class ElggCoreRegressionBugsTest extends \Elgg\IntegrationTestCase {
 		$object = $this->createObject([
 			'owner_guid' => $owner->guid, // make sure this is a different user
 		]);
-		$group = $this->createGroup();
+		$group = $this->createGroup([
+			'owner_guid' => $owner->guid, // make sure this is a different user
+		]);
 
 		// disable access overrides because we're admin.
 		elgg_call(ELGG_ENFORCE_ACCESS, function() use ($user, $object, $group) {


### PR DESCRIPTION
Because no group owner was given it could happen that the test user
would become the owner, thus failing the test.