### PR TITLE
fix(ajax): display error messages when allowed

### DIFF
--- a/views/default/elgg/Ajax.js
+++ b/views/default/elgg/Ajax.js
@@ -180,7 +180,7 @@ define(function (require) {
 						}
 					}
 
-					if (!error_displayed && options.showErrorMessages) {
+					if (error_displayed) {
 						elgg.register_error(elgg.echo('ajax:error'));
 					}
 				};


### PR DESCRIPTION
Users with bad internet bandwidth often see this message. 

This isn't a critical error message, so we can define it in the JS script options:

> if (data.error && options.showErrorMessages)