### PR TITLE
fix(menu): don't show 'invite friends' menu item on the group profile…

### DIFF
--- a/mod/groups/classes/Elgg/Groups/Menus/Title.php
+++ b/mod/groups/classes/Elgg/Groups/Menus/Title.php
@@ -39,7 +39,7 @@ class Title {
 				'link_class' => 'elgg-button elgg-button-action',
 			]);
 			
-			if (elgg_is_active_plugin('invitefriends')) {
+			if (elgg_is_active_plugin('friends')) {
 				$result[] = \ElggMenuItem::factory([
 					'name' => 'groups:invite',
 					'icon' => 'user-plus',

--- a/mod/groups/classes/Elgg/Groups/Menus/Title.php
+++ b/mod/groups/classes/Elgg/Groups/Menus/Title.php
@@ -38,13 +38,16 @@ class Title {
 				'text' => elgg_echo('groups:edit'),
 				'link_class' => 'elgg-button elgg-button-action',
 			]);
-			$result[] = \ElggMenuItem::factory([
-				'name' => 'groups:invite',
-				'icon' => 'user-plus',
-				'href' => elgg_generate_entity_url($group, 'invite'),
-				'text' => elgg_echo('groups:invite'),
-				'link_class' => 'elgg-button elgg-button-action',
-			]);
+			
+			if (elgg_is_active_plugin('invitefriends')) {
+				$result[] = \ElggMenuItem::factory([
+					'name' => 'groups:invite',
+					'icon' => 'user-plus',
+					'href' => elgg_generate_entity_url($group, 'invite'),
+					'text' => elgg_echo('groups:invite'),
+					'link_class' => 'elgg-button elgg-button-action',
+				]);
+			}
 		}
 		
 		if ($group->isMember($user)) {


### PR DESCRIPTION
… when 'Friends' plugin is deactivated

Community discussion on https://elgg.org/discussion/view/3089391/group-menu-with-no-friends-plugin