### PR TITLE
fix(menu): don't show 'invite friends' menu item on the group profile…

### DIFF
--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -893,13 +893,16 @@ function _groups_title_menu(\Elgg\Hook $hook) {
 			'text' => elgg_echo('groups:edit'),
 			'link_class' => 'elgg-button elgg-button-action',
 		]);
-		$result[] = \ElggMenuItem::factory([
-			'name' => 'groups:invite',
-			'icon' => 'user-plus',
-			'href' => elgg_generate_entity_url($group, 'invite'),
-			'text' => elgg_echo('groups:invite'),
-			'link_class' => 'elgg-button elgg-button-action',
-		]);
+		
+		if (elgg_is_active_plugin('friends')) {
+			$result[] = \ElggMenuItem::factory([
+				'name' => 'groups:invite',
+				'icon' => 'user-plus',
+				'href' => elgg_generate_entity_url($group, 'invite'),
+				'text' => elgg_echo('groups:invite'),
+				'link_class' => 'elgg-button elgg-button-action',
+			]);
+		}
 	}
 	
 	if ($group->isMember($user)) {


### PR DESCRIPTION
… when 'Friends' plugin is deactivated

Community discussion on https://elgg.org/discussion/view/3089391/group-menu-with-no-friends-plugin