### PR TITLE
fix(likes): don't provide likes data in non default type ajax requests

### DIFF
--- a/mod/likes/classes/Elgg/Likes/AjaxResponseHandler.php
+++ b/mod/likes/classes/Elgg/Likes/AjaxResponseHandler.php
@@ -2,8 +2,6 @@
 
 namespace Elgg\Likes;
 
-use Elgg\Services\AjaxResponse;
-
 /**
  * Ajax response handler
  */
@@ -18,10 +16,11 @@ class AjaxResponseHandler {
 	 */
 	public function __invoke(\Elgg\Hook $hook) {
 		$entity = get_entity(get_input('guid'));
-		if (!$entity) {
+		if (!$entity || elgg_get_viewtype() !== 'default') {
 			return;
 		}
 		
+		/* @var $response \Elgg\Services\AjaxResponse */
 		$response = $hook->getValue();
 		
 		$response->getData()->likes_status = [


### PR DESCRIPTION
As not all views may be available during non default view type requests
(eg. json)