### PR TITLE
security(input): prevent more html elements during input filtering

### DIFF
--- a/mod/htmlawed/start.php
+++ b/mod/htmlawed/start.php
@@ -50,6 +50,7 @@ function htmlawed_filter_tags($hook, $type, $result, $params = null) {
 		'comment' => 1,
 		'cdata' => 1,
 
+		'elements' => '*-applet-button-form-input-textarea-iframe-script-style-embed-object',
 		'deny_attribute' => 'class, on*',
 		'hook_tag' => 'htmlawed_tag_post_processor',
 
@@ -84,7 +85,7 @@ function htmLawedArray(&$v, $k, $htmlawed_config) {
 
 /**
  * Post processor for tags in htmlawed
- * 
+ *
  * This runs after htmlawed has filtered. It runs for each tag and filters out
  * style attributes we don't want.
  *

--- a/mod/htmlawed/tests/tags.php
+++ b/mod/htmlawed/tests/tags.php
@@ -173,7 +173,12 @@ class HtmLawedTest extends ElggCoreUnitTest {
 
 			// 'deny_attribute' => 'class, on*',
 			'<span class="elgg-inner">Test</span>' => '<span>Test</span>',
-			'<button onclick="javascript:alert(\'test\')">Test</button>' => '<button>Test</button>',
+			'<a onclick="javascript:alert(\'test\')">Test</a>' => '<a>Test</a>',
+			
+			// some of the prevented 'elements'
+			'<button>Test</button>' => 'Test',
+			'<form>Test</form>' => 'Test',
+			'<textarea>Test</textarea>' => 'Test',
 		);
 
 		// test elements filtered by "safe" option
@@ -190,5 +195,4 @@ class HtmLawedTest extends ElggCoreUnitTest {
 			$this->assertEqual($expected, $result);
 		}
 	}
-
 }


### PR DESCRIPTION
The 'safe' option of htmlAwed still allows certain html elements which
could be considered dangerous.