### PR TITLE
feat(notifications): split salutation and sign-off from message body

### DIFF
--- a/actions/admin/user/resetpassword.php
+++ b/actions/admin/user/resetpassword.php
@@ -27,7 +27,7 @@ if (!force_user_password_reset($user->guid, $password)) {
 notify_user($user->guid,
 	elgg_get_site_entity()->guid,
 	elgg_echo('email:resetpassword:subject', [], $user->language),
-	elgg_echo('email:resetpassword:body', [$user->username, $password], $user->language),
+	elgg_echo('email:resetpassword:body', [$password], $user->language),
 	[
 		'object' => $user,
 		'action' => 'resetpassword',

--- a/actions/useradd.php
+++ b/actions/useradd.php
@@ -59,7 +59,6 @@ try {
 
 	$subject = elgg_echo('useradd:subject', [], $new_user->language);
 	$body = elgg_echo('useradd:body', [
-		$name,
 		elgg_get_site_entity()->getDisplayName(),
 		elgg_get_site_entity()->getURL(),
 		$username,

--- a/docs/appendix/upgrade-notes/3.x-to-4.0.rst
+++ b/docs/appendix/upgrade-notes/3.x-to-4.0.rst
@@ -114,6 +114,13 @@ When requesting notification settings other than the default setting, if the use
 
 Management of the notification preferences for adding a new users to a friend collection has been removed.
 
+Notification Salutation & Sign-off
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To be able to have a more generic salutation and sign-off for outgoing mail notifications we have removed these texts from various translation strings and moved them to
+generic translations. This will mean you have to update your translations to reflect the new text and also check your code for uses of notifications where you provide your own
+salutation or sign-off text. You can find out more about this new behaviour in :doc:`/guides/notifications`.
+
 Diagnostics Plugin
 ------------------
 

--- a/docs/guides/notifications.rst
+++ b/docs/guides/notifications.rst
@@ -175,6 +175,15 @@ the contents of the notification when a new objects of subtype 'photo' is create
 
 	Make sure the notification will be in the correct language by passing
 	the reciepient's language into the ``elgg_echo()`` function.
+	
+Notification salutation and sign-off
+====================================
+
+Elgg will by default prepend a salutation to all outgoing notification body text. Also a sign-off will be appended.
+This means you will not need to add text like ``Hi Admin,`` or ``Kind regards, your friendly site administrator`` to your notifications body.
+If for some reason you do not need this magic to happen, you can prevent it by setting the notification parameter ``add_salutation`` to ``false``.
+You can do this as part of the parameters in ``notify_user()`` or in the ``prepare, notifications`` hook. 
+You can change the salutation and sign-off texts in the translations.
 
 Registering a new notification method
 ======================================

--- a/engine/classes/Elgg/Comments/CreateNotification.php
+++ b/engine/classes/Elgg/Comments/CreateNotification.php
@@ -90,8 +90,6 @@ class CreateNotification {
 			$commenter->getDisplayName(),
 			$comment->description,
 			$comment->getURL(),
-			$commenter->getDisplayName(),
-			$commenter->getURL(),
 		], $language);
 		
 		return $returnvalue;
@@ -132,8 +130,6 @@ class CreateNotification {
 			$commenter->getDisplayName(),
 			$comment->description,
 			$comment->getURL(),
-			$commenter->getDisplayName(),
-			$commenter->getURL(),
 		], $language);
 		
 		$returnvalue->url = $comment->getURL();

--- a/engine/classes/Elgg/Notifications/ChangeAdminNotification.php
+++ b/engine/classes/Elgg/Notifications/ChangeAdminNotification.php
@@ -91,12 +91,10 @@ class ChangeAdminNotification {
 		
 		$return_value->subject = elgg_echo('admin:notification:make_admin:admin:subject', [$site->getDisplayName()], $language);
 		$return_value->body = elgg_echo('admin:notification:make_admin:admin:body', [
-			$recipient->getDisplayName(),
 			$actor->getDisplayName(),
 			$object->getDisplayName(),
 			$site->getDisplayName(),
 			$object->getURL(),
-			$site->getURL(),
 		], $language);
 	
 		$return_value->url = elgg_normalize_url('admin/users/admins');
@@ -136,12 +134,10 @@ class ChangeAdminNotification {
 		
 		$return_value->subject = elgg_echo('admin:notification:remove_admin:admin:subject', [$site->getDisplayName()], $language);
 		$return_value->body = elgg_echo('admin:notification:remove_admin:admin:body', [
-			$recipient->getDisplayName(),
 			$actor->getDisplayName(),
 			$object->getDisplayName(),
 			$site->getDisplayName(),
 			$object->getURL(),
-			$site->getURL(),
 		], $language);
 	
 		$return_value->url = elgg_normalize_url('admin/users/admins');
@@ -215,7 +211,6 @@ class ChangeAdminNotification {
 		
 		$return_value->subject = elgg_echo('admin:notification:make_admin:user:subject', [$site->getDisplayName()], $language);
 		$return_value->body = elgg_echo('admin:notification:make_admin:user:body', [
-			$recipient->getDisplayName(),
 			$actor->getDisplayName(),
 			$site->getDisplayName(),
 			$site->getURL(),
@@ -258,7 +253,6 @@ class ChangeAdminNotification {
 		
 		$return_value->subject = elgg_echo('admin:notification:remove_admin:user:subject', [$site->getDisplayName()], $language);
 		$return_value->body = elgg_echo('admin:notification:remove_admin:user:body', [
-			$recipient->getDisplayName(),
 			$actor->getDisplayName(),
 			$site->getDisplayName(),
 			$site->getURL(),

--- a/engine/classes/Elgg/Notifications/NotificationsService.php
+++ b/engine/classes/Elgg/Notifications/NotificationsService.php
@@ -501,6 +501,7 @@ class NotificationsService {
 		$params['language'] = $language;
 		$params['object'] = $object;
 		$params['action'] = $event->getAction();
+		$params['add_salutation'] = elgg_extract('add_salutation', $params, true);
 
 		$notification = new Notification($actor, $recipient, $language, $subject, $body, $summary, $params);
 
@@ -515,6 +516,11 @@ class NotificationsService {
 			throw new RuntimeException("'prepare','$type' hook must return an instance of " . Notification::class);
 		}
 
+		if (elgg_extract('add_salutation', $notification->params) === true) {
+			$viewtype = elgg_view_exists('notifications/body') ? '' : 'default';
+			$notification->body = _elgg_view_under_viewtype('notifications/body', ['notification' => $notification], $viewtype);
+		}
+		
 		$notification = $this->hooks->trigger('format', "notification:$method", [], $notification);
 		if (!$notification instanceof Notification) {
 			throw new RuntimeException("'format','notification:$method' hook must return an instance of " . Notification::class);

--- a/engine/classes/Elgg/Notifications/UnbanUserNotification.php
+++ b/engine/classes/Elgg/Notifications/UnbanUserNotification.php
@@ -71,7 +71,6 @@ class UnbanUserNotification {
 	
 		$return_value->subject = elgg_echo('user:notification:unban:subject', [$site->getDisplayName()], $language);
 		$return_value->body = elgg_echo('user:notification:unban:body', [
-			$recipient->getDisplayName(),
 			$site->getDisplayName(),
 			$site->getURL(),
 		], $language);

--- a/engine/classes/Elgg/PasswordService.php
+++ b/engine/classes/Elgg/PasswordService.php
@@ -86,7 +86,6 @@ final class PasswordService {
 		// generate email
 		$ip_address = _elgg_services()->request->getClientIp();
 		$message = _elgg_services()->translator->translate('email:changereq:body', [
-			$user->name,
 			$ip_address,
 			$link,
 		], $user->language);

--- a/engine/classes/Elgg/Users/Accounts.php
+++ b/engine/classes/Elgg/Users/Accounts.php
@@ -414,7 +414,6 @@ class Accounts {
 			'to' => new Address($email, $user->getDisplayName()),
 			'subject' => $this->translator->translate('email:request:email:subject', [], $user->getLanguage()),
 			'body' => $this->translator->translate('email:request:email:body', [
-				$user->getDisplayName(),
 				$site->getDisplayName(),
 				$url,
 			], $user->getLanguage()),

--- a/engine/classes/Elgg/Users/BanUserNotificationHandler.php
+++ b/engine/classes/Elgg/Users/BanUserNotificationHandler.php
@@ -33,7 +33,6 @@ class BanUserNotificationHandler {
 	
 		$subject = elgg_echo('user:notification:ban:subject', [$site->getDisplayName()], $language);
 		$body = elgg_echo('user:notification:ban:body', [
-			$user->getDisplayName(),
 			$site->getDisplayName(),
 			$site->getURL(),
 		], $language);

--- a/engine/classes/Elgg/Users/EmailChangeController.php
+++ b/engine/classes/Elgg/Users/EmailChangeController.php
@@ -59,7 +59,6 @@ class EmailChangeController {
 			'to' => new Address($old_email, $user->getDisplayName()),
 			'subject' => $translator->translate('email:confirm:email:old:subject', [], $user->getLanguage()),
 			'body' => $translator->translate('email:confirm:email:old:body', [
-				$user->getDisplayName(),
 				$site->getDisplayName(),
 				$new_email,
 				$site->getURL(),
@@ -70,7 +69,6 @@ class EmailChangeController {
 		
 		$subject = $translator->translate('email:confirm:email:new:subject', [], $user->getLanguage());
 		$body = $translator->translate('email:confirm:email:new:body', [
-			$user->getDisplayName(),
 			$site->getDisplayName(),
 			$site->getURL(),
 		], $user->getLanguage());

--- a/engine/classes/Elgg/Users/Validation.php
+++ b/engine/classes/Elgg/Users/Validation.php
@@ -34,7 +34,6 @@ class Validation {
 		
 		$subject = elgg_echo('account:notification:validation:subject', [$site->getDisplayName()], $user->getLanguage());
 		$body = elgg_echo('account:notification:validation:body', [
-			$user->getDisplayName(),
 			$site->getDisplayName(),
 			$site->getURL(),
 		], $user->getLanguage());
@@ -128,7 +127,6 @@ class Validation {
 			
 			$subject = elgg_echo('admin:notification:unvalidated_users:subject', [$site->getDisplayName()], $admin->getLanguage());
 			$body = elgg_echo('admin:notification:unvalidated_users:body', [
-				$admin->getDisplayName(),
 				$unvalidated_count,
 				$site->getDisplayName(),
 				$url,

--- a/engine/tests/phpunit/unit/Elgg/Notifications/NotificationsServiceUnitTestCase.php
+++ b/engine/tests/phpunit/unit/Elgg/Notifications/NotificationsServiceUnitTestCase.php
@@ -504,7 +504,7 @@ abstract class NotificationsServiceUnitTestCase extends IntegratedUnitTestCase {
 			$call_count++;
 			$this->assertInstanceOf(Notification::class, $hook->getParam('notification'));
 			$this->assertEquals($this->translator->translate('notification:subject', [$event->getActor()->name], $recipient->language), $hook->getParam('notification')->subject);
-			$this->assertEquals($this->translator->translate('notification:body', [$event->getObject()->getURL()], $recipient->language), $hook->getParam('notification')->body);
+			$this->assertStringContainsString($this->translator->translate('notification:body', [$event->getObject()->getURL()], $recipient->language), $hook->getParam('notification')->body);
 			$this->assertEquals($event->toObject(), $hook->getParam('event')->toObject());
 
 			return true;
@@ -595,7 +595,7 @@ abstract class NotificationsServiceUnitTestCase extends IntegratedUnitTestCase {
 				$event->getActor()->name,
 				$display_name,
 			], $recipient->language), $hook->getParam('notification')->subject);
-			$this->assertEquals($this->translator->translate("notification:{$event->getDescription()}:body", [
+			$this->assertStringContainsString($this->translator->translate("notification:{$event->getDescription()}:body", [
 				$recipient->name,
 				$event->getActor()->name,
 				$display_name,
@@ -804,7 +804,7 @@ abstract class NotificationsServiceUnitTestCase extends IntegratedUnitTestCase {
 
 			$this->assertInstanceOf(Notification::class, $notification);
 			$this->assertEquals($notification->subject, $subject);
-			$this->assertEquals($notification->body, $body);
+			$this->assertStringContainsString($body, $notification->body);
 			$this->assertEquals($notification->summary, $subject);
 			$this->assertEquals($event->toObject(), $hook->getParam('event')->toObject());
 
@@ -894,7 +894,7 @@ abstract class NotificationsServiceUnitTestCase extends IntegratedUnitTestCase {
 
 			$this->assertInstanceOf(Notification::class, $notification);
 			$this->assertEquals($notification->subject, $subject);
-			$this->assertEquals($notification->body, $body);
+			$this->assertStringContainsString($body, $notification->body);
 			$this->assertEquals($event->toObject(), $hook->getParam('event')->toObject());
 
 			$this->assertTrue($notification->prepare_hook);

--- a/languages/en.php
+++ b/languages/en.php
@@ -342,6 +342,10 @@ return array(
 	'notifications:usersettings:save:ok' => "Notification settings were successfully saved.",
 	'notifications:usersettings:save:fail' => "There was a problem saving the notification settings.",
 
+	'notification:default:salutation' => 'Dear %s,',
+	'notification:default:sign-off' => 'Regards,
+
+%s',
 	'notification:subject' => 'Notification about %s',
 	'notification:body' => 'View the new activity at %s',
 	
@@ -745,61 +749,41 @@ Having icons session bound makes icon urls not shareable between sessions. The s
 	'admin:site:secret:prevented' => "The regeneration of the site secret was prevented",
 	
 	'admin:notification:make_admin:admin:subject' => 'A new site administrator was added to %s',
-	'admin:notification:make_admin:admin:body' => 'Hi %s,
-
-%s made %s a site administrator of %s.
+	'admin:notification:make_admin:admin:body' => '%s made %s a site administrator of %s.
 
 To view the profile of the new administrator, click here:
-%s
-
-To go to the site, click here:
 %s',
 	
 	'admin:notification:make_admin:user:subject' => 'You were added as a site administator of %s',
-	'admin:notification:make_admin:user:body' => 'Hi %s,
-
-%s made you a site administrator of %s.
+	'admin:notification:make_admin:user:body' => '%s made you a site administrator of %s.
 
 To go to the site, click here:
 %s',
 	'admin:notification:remove_admin:admin:subject' => 'A site administrator was removed from %s',
-	'admin:notification:remove_admin:admin:body' => 'Hi %s,
-
-%s removed %s as a site administrator of %s.
+	'admin:notification:remove_admin:admin:body' => '%s removed %s as a site administrator of %s.
 
 To view the profile of the old administrator, click here:
-%s
-
-To go to the site, click here:
 %s',
 	
 	'admin:notification:remove_admin:user:subject' => 'You were removed as a site administator from %s',
-	'admin:notification:remove_admin:user:body' => 'Hi %s,
-
-%s removed you as site administrator of %s.
+	'admin:notification:remove_admin:user:body' => '%s removed you as site administrator of %s.
 
 To go to the site, click here:
 %s',
 	'user:notification:ban:subject' => 'Your account on %s was banned',
-	'user:notification:ban:body' => 'Hi %s,
-
-Your account on %s was banned.
+	'user:notification:ban:body' => 'Your account on %s was banned.
 
 To go to the site, click here:
 %s',
 	
 	'user:notification:unban:subject' => 'Your account on %s is no longer banned',
-	'user:notification:unban:body' => 'Hi %s,
-
-Your account on %s is no longer banned. You can use the site again.
+	'user:notification:unban:body' => 'Your account on %s is no longer banned. You can use the site again.
 
 To go to the site, click here:
 %s',
 	
 	'user:notification:password_change:subject' => 'Your password has been changed!',
-	'user:notification:password_change:body' => "Hi %s,
-
-Your password on '%s' has been changed! If you made this change than you're all set.
+	'user:notification:password_change:body' => "Your password on '%s' has been changed! If you made this change than you're all set.
 
 If you didn't make this change, please reset your password here:
 %s
@@ -808,9 +792,7 @@ Or contact a site administrator:
 %s",
 	
 	'admin:notification:unvalidated_users:subject' => "Users awaiting approval on %s",
-	'admin:notification:unvalidated_users:body' => "Hi %s,
-
-%d users of '%s' are awaiting approval by an administrator.
+	'admin:notification:unvalidated_users:body' => "%d users of '%s' are awaiting approval by an administrator.
 
 See the full list of users here:
 %s",
@@ -1249,9 +1231,7 @@ These changes will only affect new users on the site.',
  */
 
 	'useradd:subject' => 'User account created',
-	'useradd:body' => '%s,
-
-A user account has been created for you at %s. To log in, visit:
+	'useradd:body' => 'A user account has been created for you at %s. To log in, visit:
 
 %s
 
@@ -1528,19 +1508,13 @@ To view their profile, click here:
 %s",
 
 	'email:changepassword:subject' => "Password changed!",
-	'email:changepassword:body' => "Hi %s,
-
-Your password has been changed.",
+	'email:changepassword:body' => "Your password has been changed.",
 
 	'email:resetpassword:subject' => "Password reset!",
-	'email:resetpassword:body' => "Hi %s,
-
-Your password has been reset to: %s",
+	'email:resetpassword:body' => "Your password has been reset to: %s",
 
 	'email:changereq:subject' => "Request for password change.",
-	'email:changereq:body' => "Hi %s,
-
-Somebody (from the IP address %s) has requested a password change for this account.
+	'email:changereq:body' => "Somebody (from the IP address %s) has requested a password change for this account.
 
 If you requested this, click on the link below. Otherwise ignore this email.
 
@@ -1548,9 +1522,7 @@ If you requested this, click on the link below. Otherwise ignore this email.
 	
 	'account:email:request:success' => "Your new e-mail address will be saved after confirmation, please check the inbox of '%s' for more instructions.",
 	'email:request:email:subject' => "Please confirm your e-mail address",
-	'email:request:email:body' => "Hi %s,
-
-You requested to change your e-mail address on '%s'.
+	'email:request:email:body' => "You requested to change your e-mail address on '%s'.
 If you didn't request this change, you can ignore this email.
 
 In order to confirm the e-mail address change, please click this link:
@@ -1561,18 +1533,14 @@ Please note this link is only valid for 1 hour.",
 	'account:email:request:error:no_new_email' => "No e-mail address change pending",
 	
 	'email:confirm:email:old:subject' => "You're e-mail address was changed",
-	'email:confirm:email:old:body' => "Hi %s,
-
-Your e-mail address on '%s' was changed.
+	'email:confirm:email:old:body' => "Your e-mail address on '%s' was changed.
 From now on you'll receive notifications on '%s'.
 
 If you didn't request this change, please contact a site administrator.
 %s",
 	
 	'email:confirm:email:new:subject' => "You're e-mail address was changed",
-	'email:confirm:email:new:body' => "Hi %s,
-
-Your e-mail address on '%s' was changed.
+	'email:confirm:email:new:body' => "Your e-mail address on '%s' was changed.
 From now on you'll receive notifications on this e-mail address.
 
 If you didn't request this change, please contact a site administrator.
@@ -1585,9 +1553,7 @@ If you didn't request this change, please contact a site administrator.
 	'account:validation:pending:content' => "Your account has been registered successfully! However before you can use you account a site administrator needs to validate you account. You'll receive an e-mail when you account is validated.",
 	
 	'account:notification:validation:subject' => "Your account on %s has been validated!",
-	'account:notification:validation:body' => "Hi %s,
-
-Your account on '%s' has been validated. You can now use your account.
+	'account:notification:validation:body' => "Your account on '%s' has been validated. You can now use your account.
 
 To go the the website, click here:
 %s",
@@ -1636,9 +1602,6 @@ To go the the website, click here:
 %s
 
 To reply or view the original item, click here:
-%s
-
-To view %s's profile, click here:
 %s",
 	
 	'generic_comment:notification:user:subject' => 'A new comment on: %s',
@@ -1648,9 +1611,6 @@ To view %s's profile, click here:
 %s
 
 To reply or view the original item, click here:
-%s
-
-To view %s's profile, click here:
 %s",
 
 /**

--- a/mod/developers/actions/developers/test_email.php
+++ b/mod/developers/actions/developers/test_email.php
@@ -7,7 +7,6 @@ $site = elgg_get_site_entity();
 
 $subject = elgg_echo('useradd:subject');
 $plain_message = elgg_echo('useradd:body', [
-	$user->getDisplayName(),
 	$site->getDisplayName(),
 	$site->getURL(),
 	$user->username,

--- a/mod/friends/classes/Elgg/Friends/Actions/AddFriendController.php
+++ b/mod/friends/classes/Elgg/Friends/Actions/AddFriendController.php
@@ -95,7 +95,6 @@ class AddFriendController {
 			
 			$subject = elgg_echo('friends:notification:request:subject', [$user->getDisplayName()], $friend->getLanguage());
 			$message = elgg_echo('friends:notification:request:message', [
-				$friend->getDisplayName(),
 				$user->getDisplayName(),
 				$site->getDisplayName(),
 				elgg_generate_url('collection:relationship:friendrequest:pending', [

--- a/mod/friends/classes/Elgg/Friends/Actions/DeclineFriendRequestController.php
+++ b/mod/friends/classes/Elgg/Friends/Actions/DeclineFriendRequestController.php
@@ -44,7 +44,6 @@ class DeclineFriendRequestController {
 		if ($requesting_user instanceof \ElggUser) {
 			$subject = elgg_echo('friends:notification:request:decline:subject', [$receiving_user->getDisplayName()], $requesting_user->getLanguage());
 			$message = elgg_echo('friends:notification:request:decline:message', [
-				$requesting_user->getDisplayName(),
 				$receiving_user->getDisplayName(),
 			], $requesting_user->getLanguage());
 			

--- a/mod/friends/classes/Elgg/Friends/Notifications.php
+++ b/mod/friends/classes/Elgg/Friends/Notifications.php
@@ -22,7 +22,6 @@ class Notifications {
 		
 		$subject = elgg_echo('friends:notification:request:accept:subject', [$sender->getDisplayName()], $recipient->getLanguage());
 		$message = elgg_echo('friends:notification:request:accept:message', [
-			$recipient->getDisplayName(),
 			$sender->getDisplayName(),
 		], $recipient->getLanguage());
 		

--- a/mod/friends/languages/en.php
+++ b/mod/friends/languages/en.php
@@ -48,22 +48,16 @@ After enabling friendship requests when user A wants to be friends with user B, 
 	'widgets:friends:description' => "Displays some of your friends.",
 	
 	'friends:notification:request:subject' => "%s wants to be your friend!",
-	'friends:notification:request:message' => "Hi %s,
-
-%s has requested to be your friend on %s.
+	'friends:notification:request:message' => "%s has requested to be your friend on %s.
 
 To view the friendship request, click here:
 %s",
 	
 	'friends:notification:request:decline:subject' => "%s has declined your friendship request",
-	'friends:notification:request:decline:message' => "Hi %s,
-
-%s has declined your friendship request.",
+	'friends:notification:request:decline:message' => "%s has declined your friendship request.",
 	
 	'friends:notification:request:accept:subject' => "%s has accepted your friendship request",
-	'friends:notification:request:accept:message' => "Hi %s,
-
-%s has accepted your friendship request.",
+	'friends:notification:request:accept:message' => "%s has accepted your friendship request.",
 	
 	'friends:action:friendrequest:revoke:fail' => "An error occured while revoking the friendship request, please try again",
 	'friends:action:friendrequest:revoke:success' => "The friendship request has been revoked",

--- a/mod/groups/actions/groups/membership/add.php
+++ b/mod/groups/actions/groups/membership/add.php
@@ -47,7 +47,6 @@ foreach ($user_guid as $u_guid) {
 	$subject = elgg_echo('groups:welcome:subject', [$group->getDisplayName()], $user->language);
 
 	$body = elgg_echo('groups:welcome:body', [
-		$user->getDisplayName(),
 		$group->getDisplayName(),
 		$group->getURL(),
 	], $user->language);

--- a/mod/groups/actions/groups/membership/invite.php
+++ b/mod/groups/actions/groups/membership/invite.php
@@ -57,7 +57,6 @@ foreach ($user_guids as $guid) {
 	], $user->getLanguage());
 
 	$body = elgg_echo('groups:invite:body', [
-		$user->getDisplayName(),
 		$logged_in_user->getDisplayName(),
 		$group->getDisplayName(),
 		$url,

--- a/mod/groups/actions/groups/membership/join.php
+++ b/mod/groups/actions/groups/membership/join.php
@@ -61,7 +61,6 @@ $subject = elgg_echo('groups:request:subject', [
 ], $owner->language);
 
 $body = elgg_echo('groups:request:body', [
-	$group->getOwnerEntity()->getDisplayName(),
 	$user->getDisplayName(),
 	$group->getDisplayName(),
 	$user->getURL(),

--- a/mod/groups/languages/en.php
+++ b/mod/groups/languages/en.php
@@ -139,25 +139,19 @@ return array(
 	'groups:invite:subject' => "%s you have been invited to join %s!",
 	'groups:joinrequest:remove:check' => 'Are you sure you want to remove this join request?',
 	'groups:invite:remove:check' => 'Are you sure you want to remove this invitation?',
-	'groups:invite:body' => "Hi %s,
-
-%s invited you to join the '%s' group.
+	'groups:invite:body' => "%s invited you to join the '%s' group.
 
 Click below to view your invitations:
 %s",
 
 	'groups:welcome:subject' => "Welcome to the %s group!",
-	'groups:welcome:body' => "Hi %s!
-
-You are now a member of the '%s' group.
+	'groups:welcome:body' => "You are now a member of the '%s' group.
 
 Click below to begin posting!
 %s",
 
 	'groups:request:subject' => "%s has requested to join %s",
-	'groups:request:body' => "Hi %s,
-
-%s has requested to join the '%s' group.
+	'groups:request:body' => "%s has requested to join the '%s' group.
 
 Click below to view their profile:
 %s

--- a/mod/likes/actions/likes/add.php
+++ b/mod/likes/actions/likes/add.php
@@ -66,7 +66,6 @@ $subject = elgg_echo('likes:notifications:subject', [
 );
 
 $body = elgg_echo('likes:notifications:body', [
-		$owner->getDisplayName(),
 		$user->getDisplayName(),
 		$title_str,
 		$site->getDisplayName(),

--- a/mod/likes/languages/en.php
+++ b/mod/likes/languages/en.php
@@ -29,18 +29,13 @@ return array(
 	// notifications. yikes.
 	'likes:notifications:subject' => '%s likes your post "%s"',
 	'likes:notifications:body' =>
-'Hi %1$s,
-
-%2$s likes your post "%3$s" on %4$s
+'%1$s likes your post "%2$s" on %3$s
 
 See your original post here:
 
-%5$s
+%4$s
 
-or view %2$s\'s profile here:
+or view %1$s\'s profile here:
 
-%6$s
-
-Thanks,
-%4$s',
+%5$s',
 );

--- a/mod/messages/tests/phpunit/integration/Elgg/Messages/MessagesPluginTest.php
+++ b/mod/messages/tests/phpunit/integration/Elgg/Messages/MessagesPluginTest.php
@@ -91,7 +91,7 @@ class MessagesPluginTest extends IntegrationTestCase {
 		$this->assertNotEmpty($plain_text_part);
 
 		$this->assertEquals($expected_subject, $notification->getSubject());
-		$this->assertEquals($expected_body, $plain_text_part->getRawContent());
+		$this->assertStringContainsString($expected_body, $plain_text_part->getRawContent());
 
 	}
 }

--- a/mod/messages/tests/phpunit/integration/Elgg/Messages/SendActionTest.php
+++ b/mod/messages/tests/phpunit/integration/Elgg/Messages/SendActionTest.php
@@ -199,7 +199,7 @@ class SendActionTest extends ActionResponseTestCase {
 		$this->assertNotEmpty($plain_text_part);
 
 		$this->assertEquals($expected_subject, $notification->getSubject());
-		$this->assertEquals(preg_replace('/\\n/m', ' ', $expected_body), preg_replace('/\\n/m', ' ', $plain_text_part->getRawContent()));
+		$this->assertStringContainsString(preg_replace('/\\n/m', ' ', $expected_body), preg_replace('/\\n/m', ' ', $plain_text_part->getRawContent()));
 
 		_elgg_services()->session->removeLoggedInUser();
 	}

--- a/mod/uservalidationbyemail/languages/en.php
+++ b/mod/uservalidationbyemail/languages/en.php
@@ -7,18 +7,13 @@
 
 return array(
 	'email:validate:subject' => "%s please confirm your email address for %s!",
-	'email:validate:body' => "Hi %s,
-
-Before you can start using %s, you must confirm your email address.
+	'email:validate:body' => "Before you can start using %s, you must confirm your email address.
 
 Please confirm your email address by clicking on the link below:
 
 %s
 
-If you can't click on the link, copy and paste it to your browser manually.
-
-%s
-%s",
+If you can't click on the link, copy and paste it to your browser manually.",
 	'email:confirm:success' => "You have confirmed your email address!",
 	'email:confirm:fail' => "Your email address could not be verified...",
 

--- a/mod/uservalidationbyemail/lib/functions.php
+++ b/mod/uservalidationbyemail/lib/functions.php
@@ -42,11 +42,8 @@ function uservalidationbyemail_request_validation($user_guid) {
 	);
 
 	$body = elgg_echo('email:validate:body', [
-			$user->getDisplayName(),
 			$site->getDisplayName(),
 			$link,
-			$site->getDisplayName(),
-			$site->getURL(),
 		], $user->language
 	);
 

--- a/views/default/notifications/body.php
+++ b/views/default/notifications/body.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * View to wrap notification body with a generic salutation and sign-off
+ *
+ * @uses $vars['notification'] Notification to return new body for
+ */
+
+use Elgg\Notifications\Notification;
+
+$notification = elgg_extract('notification', $vars);
+if (!$notification instanceof Notification) {
+	return;
+}
+
+$salutation = elgg_view('notifications/elements/salutation', $vars);
+$body = $notification->body;
+$signoff = elgg_view('notifications/elements/sign-off', $vars);
+
+echo implode(PHP_EOL . PHP_EOL, array_filter([$salutation, $body, $signoff]));

--- a/views/default/notifications/elements/salutation.php
+++ b/views/default/notifications/elements/salutation.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Output the salutation for a notification
+ *
+ * @uses $vars['notification'] Notification to return salutation for
+ */
+
+use Elgg\Notifications\Notification;
+
+$notification = elgg_extract('notification', $vars);
+if (!$notification instanceof Notification) {
+	return;
+}
+
+$recipient = $notification->getRecipient();
+
+echo elgg_echo('notification:default:salutation', [$recipient->getDisplayName()], $notification->language);

--- a/views/default/notifications/elements/sign-off.php
+++ b/views/default/notifications/elements/sign-off.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Output the sign-off for a notification
+ */
+
+use Elgg\Notifications\Notification;
+
+$notification = elgg_extract('notification', $vars);
+if (!$notification instanceof Notification) {
+	return;
+}
+
+echo elgg_echo('notification:default:sign-off', [elgg_get_site_entity()->getDisplayName()], $notification->language);


### PR DESCRIPTION
fixes #10485

- [x] migrate docs
- [x] notifications docs