### PR TITLE
fix(search): make sure entity_subtype is a string during search options

### DIFF
--- a/engine/classes/Elgg/Search/SearchService.php
+++ b/engine/classes/Elgg/Search/SearchService.php
@@ -99,8 +99,8 @@ class SearchService {
 		}
 
 		$options = $this->hooks->trigger('search:options', $entity_type, $options, $options);
-		if ($entity_subtype) {
-			$options = $this->hooks->trigger('search:options', "$entity_type:$entity_subtype", $options, $options);
+		if (!empty($entity_subtype) && is_string($entity_subtype)) {
+			$options = $this->hooks->trigger('search:options', "{$entity_type}:{$entity_subtype}", $options, $options);
 		}
 
 		$options = $this->hooks->trigger('search:options', $search_type, $options, $options);


### PR DESCRIPTION
Prevent a PHP notice when providing an array of subtypes