### PR TITLE
WebServices param type bool not working

### DIFF
--- a/mod/web_services/lib/web_services.php
+++ b/mod/web_services/lib/web_services.php
@@ -276,7 +276,8 @@ function serialise_parameters($method, $parameters) {
 			case 'bool':
 			case 'boolean':
 				// change word 'true' or '1' to boolean true, everything else is false
-				if ($parameters[$key] === 'true' OR $parameters[$key] === '1' ) {
+				if (strcasecmp(trim($parameters[$key]), "true") == 0
+                                        OR strcasecmp(trim($parameters[$key]), "1") == 0 ) {
                                     $serialised_parameters .= ',true';
                                 }else {
                                     $serialised_parameters .= ',false';

--- a/mod/web_services/lib/web_services.php
+++ b/mod/web_services/lib/web_services.php
@@ -275,15 +275,12 @@ function serialise_parameters($method, $parameters) {
 				break;
 			case 'bool':
 			case 'boolean':
-				// change word false to boolean false
-				if (strcasecmp(trim($parameters[$key]), "false") == 0) {
-					$serialised_parameters .= ',false';
-				} else if ($parameters[$key] == 0) {
-					$serialised_parameters .= ',false';
-				} else {
-					$serialised_parameters .= ',true';
+				// change word 'true' or '1' to boolean true, everything else is false
+				if ($parameters[$key] === 'true' OR $parameters[$key] === '1' ) {
+                                    $serialised_parameters .= ',true';
+                                }else {
+                                    $serialised_parameters .= ',false';
 				}
-
 				break;
 			case 'string':
 				$serialised_parameters .= ',' . var_export(trim($parameters[$key]), true);


### PR DESCRIPTION
The input params of type 'bool' or 'boolean' are not treated properly.
Just as example, configuring a input param as 'bool' and setting it's value with the string 'true', will be translated as false.
I think should be easier to identify the value 'true' or '1', while anything else it's just 'false'.