### PR TITLE
fix(webservices): correctly evaluate truthy values

### DIFF
--- a/docs/guides/web-services.rst
+++ b/docs/guides/web-services.rst
@@ -108,7 +108,7 @@ Values submitted with the API request for each parameter should match the declar
 Recognized parameter types are:	
 
  - ``integer`` (or ``int``)
- - ``boolean`` (or ``bool``)
+ - ``boolean`` (or ``bool``) ``'false'``, ``0`` and ``'0'`` will evaluate to ``false`` the rest will evaluate to ``true``
  - ``string``
  - ``float``
  - ``array``

--- a/mod/web_services/lib/web_services.php
+++ b/mod/web_services/lib/web_services.php
@@ -239,7 +239,7 @@ function _elgg_ws_get_parameter_names($method) {
  *
  * A leading comma needs to be removed from the output.
  *
- * @see \ElggCoreWebServicesApiTest::testSerialiseParametersCasting
+ * @see \Elgg\WebServices\ElggCoreWebServicesApiTest::testSerialiseParametersCasting
  *
  * @param string $method     API method name
  * @param array  $parameters Array of parameters
@@ -278,7 +278,7 @@ function serialise_parameters($method, $parameters) {
 				// change word false to boolean false
 				if (strcasecmp(trim($parameters[$key]), "false") == 0) {
 					$serialised_parameters .= ',false';
-				} else if ($parameters[$key] == 0) {
+				} elseif (empty(trim($parameters[$key]))) {
 					$serialised_parameters .= ',false';
 				} else {
 					$serialised_parameters .= ',true';


### PR DESCRIPTION
only 'false', 0 and '0' will evaluate to ``false``, the rest will result in ``true``

ref #13473