### PR TITLE
doc(intro/install): mention necessary SELinux changes

### DIFF
--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -38,6 +38,14 @@ By "official support", we mean that:
 -  Priority on bug reports is given to Apache and Nginx users if the bug is web server specific
    (but those are rare).
 
+.. note::
+
+   If using RHEL, CentOS, or any other distribution with SELinux enabled, you
+   will need to make sure that the appropriate contexts and permissions are configured:
+
+   - Give your project root, your data directory, and all of their children the ``httpd_sys_rw_content_t`` context
+   - Enable the ``httpd_can_network_connect`` and ``httpd_can_network_connect_db`` booleans
+
 .. _Multibyte String support: http://www.php.net/mbstring
 .. _rewrite module: https://httpd.apache.org/docs/2.0/mod/mod_rewrite.html
 

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -326,7 +326,7 @@ I get the following messages after the requirements check step (step 2) of the i
     A less likely cause is Apache is configured with an alias for your Elgg directory and you need to set the RewriteBase in
     your .htaccess. There are further instructions in the .htaccess file in your Elgg directory.
     
-After this error, everinteraction with the web interface results in a error 500 (Internal Server Error)
+After this error, every interaction with the web interface results in a error 500 (Internal Server Error)
 
 This is likely caused by not loading the "filter module by un-commenting the
 


### PR DESCRIPTION
I noticed that a topic that poster Nikolai Shcherbin seems to address frequently
are questions regarding installing Elgg on CentOS. A lot of people seem to be
getting stuck at various points in the installation procedure, and the common
link appears to be SELinux-related permissions issues. It therefore seems
prescient to document what needs to be done in the official documentation to cut
down on the help requests.

-----

Please let me know if there are any silly errors this patch; I followed `CONTRIBUTING` to the best of my ability, but I'm ultimately unfamiliar with this toolchain.