### PR TITLE
removed(core): support for the composer project as a 'plugin'

### DIFF
--- a/docs/appendix/upgrade-notes/3.x-to-4.0.rst
+++ b/docs/appendix/upgrade-notes/3.x-to-4.0.rst
@@ -5,6 +5,16 @@ From 3.x to 4.0
    :local:
    :depth: 1
 
+Composer project
+----------------
+
+The root of the composer project is no longer handled as a semi functional plugin. Languages from the ``languages`` directory are nog longer imported, the views from 
+the ``views`` directory are no longer registered, the PHP DI services from the ``elgg-services.php`` are no longer registered and the ``start.php`` file is no longer
+included.
+
+If you needed specific modification to your Elgg installation you need to make a :doc:`plugin</guides/plugins>` and ensure that the plugin is the latest in the plugin order to
+allow you to overrule everything you needed to change.
+
 PHP Requirements
 ----------------
 

--- a/docs/guides/dont-modify-core.rst
+++ b/docs/guides/dont-modify-core.rst
@@ -6,7 +6,7 @@ Don't Modify Core
     In general, you shouldn't modify non-config files that come with third-party software like Elgg.
    
 The best way to customize the behavior of Elgg is to :doc:`install Elgg as a composer dependency</intro/install>`
-and use the root directory to store modifications specific to your application,
+and use a :doc:`plugin<plugins>` to store modifications specific to your application,
 and alter behavior through the rich Elgg plugin API.
 
 If you'd like to share customizations between sites or even publish your changes

--- a/engine/classes/Elgg/Database/Plugins.php
+++ b/engine/classes/Elgg/Database/Plugins.php
@@ -572,8 +572,6 @@ class Plugins {
 			}
 		}
 
-		$this->registerRoot();
-
 		if ($this->timer) {
 			$this->timer->end([__METHOD__]);
 		}
@@ -603,58 +601,8 @@ class Plugins {
 			}
 		}
 
-		$this->bootRoot();
-
 		if ($this->timer) {
 			$this->timer->end([__METHOD__]);
-		}
-	}
-
-	/**
-	 * Register root level plugin views and translations
-	 * @return void
-	 */
-	protected function registerRoot() {
-		if (Paths::project() === Paths::elgg()) {
-			return;
-		}
-
-		// Elgg is installed as a composer dep, so try to treat the root directory
-		// as a custom plugin that is always loaded last and can't be disabled...
-		if (!$this->config->system_cache_loaded) {
-			// configure view locations for the custom plugin (not Elgg core)
-			$viewsFile = Paths::project() . 'views.php';
-			if (is_file($viewsFile)) {
-				$viewsSpec = Includer::includeFile($viewsFile);
-				if (is_array($viewsSpec)) {
-					$this->views->mergeViewsSpec($viewsSpec);
-				}
-			}
-
-			// find views for the custom plugin (not Elgg core)
-			$this->views->registerPluginViews(Paths::project());
-		}
-
-		if (!$this->config->i18n_loaded_from_cache) {
-			$this->translator->registerTranslations(Paths::project() . 'languages');
-		}
-	}
-	/**
-	 * Boot root level custom plugin for starter-project installation
-	 * @return void
-	 */
-	protected function bootRoot() {
-		if (Paths::project() === Paths::elgg()) {
-			return;
-		}
-
-		// This is root directory start.php
-		$root_start = Paths::project() . "start.php";
-		if (is_file($root_start)) {
-			$setup = Includer::requireFileOnce($root_start);
-			if ($setup instanceof \Closure) {
-				$setup();
-			}
 		}
 	}
 

--- a/engine/classes/Elgg/Di/DefinitionLoader.php
+++ b/engine/classes/Elgg/Di/DefinitionLoader.php
@@ -33,7 +33,6 @@ class DefinitionLoader {
 		// add core services
 		$sources = [
 			Paths::elgg() . 'engine/services.php',
-			Paths::project() . 'elgg-services.php',
 		];
 
 		$plugins = $this->plugins->find('active');


### PR DESCRIPTION
If modifications are needed for your installation you need to bundle
them in an actual plugin and no longer in the root of the composer
project.

fixes #11180