### PR TITLE
feat(notifications): added option to exclude subscribers

### DIFF
--- a/engine/classes/Elgg/Notifications/CreateCommentEventHandler.php
+++ b/engine/classes/Elgg/Notifications/CreateCommentEventHandler.php
@@ -49,4 +49,20 @@ class CreateCommentEventHandler extends NotificationEventHandler {
 			$entity->getURL(),
 		], $recipient->getLanguage());
 	}
+	
+	/**
+	 * Is this event configurable by the user on the notification settings page
+	 *
+	 * @return bool
+	 */
+	public static function isConfigurableByUser(): bool {
+		return false;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function excludeOwnerSubscribers(): bool {
+		return true;
+	}
 }

--- a/engine/classes/Elgg/Notifications/NotificationEventHandler.php
+++ b/engine/classes/Elgg/Notifications/NotificationEventHandler.php
@@ -88,7 +88,64 @@ class NotificationEventHandler {
 	 * @return array
 	 */
 	public function getSubscriptions(): array {
-		return _elgg_services()->subscriptions->getNotificationEventSubscriptions($this->event, $this->getMethods());
+		return _elgg_services()->subscriptions->getNotificationEventSubscriptions($this->event, $this->getMethods(), $this->getNotificationSubsciptionExclusionGUIDs());
+	}
+	
+	/**
+	 * Get an array of GUIDs to not get the subscription records for
+	 *
+	 * @return int[]
+	 */
+	final protected function getNotificationSubsciptionExclusionGUIDs(): array {
+		$object = $this->event->getObject();
+		if (!$object instanceof \ElggEntity) {
+			return [];
+		}
+		
+		$exclude = [];
+		if ($this->excludeOwnerSubscribers()) {
+			$exclude[] = $object->owner_guid;
+		}
+		
+		if ($this->excludeContainerSubscribers()) {
+			$exclude[] = $object->container_guid;
+		}
+		
+		if ($this->excludeEntitySubscribers()) {
+			$exclude[] = $object->guid;
+		}
+		
+		return $exclude;
+	}
+	
+	/**
+	 * Exclude the NotificationEvent object owner_guid when fetching the subscription records for this notification
+	 *
+	 * @return bool
+	 * @see NotificationEventHandler::getSubscriptions();
+	 */
+	protected function excludeOwnerSubscribers(): bool {
+		return false;
+	}
+	
+	/**
+	 * Exclude the NotificationEvent object container_guid when fetching the subscription records for this notification
+	 *
+	 * @return bool
+	 * @see NotificationEventHandler::getSubscriptions();
+	 */
+	protected function excludeContainerSubscribers(): bool {
+		return false;
+	}
+	
+	/**
+	 * Exclude the NotificationEvent object guid when fetching the subscription records for this notification
+	 *
+	 * @return bool
+	 * @see NotificationEventHandler::getSubscriptions();
+	 */
+	protected function excludeEntitySubscribers(): bool {
+		return false;
 	}
 	
 	/**

--- a/engine/classes/Elgg/Notifications/SubscriptionsService.php
+++ b/engine/classes/Elgg/Notifications/SubscriptionsService.php
@@ -66,12 +66,13 @@ class SubscriptionsService {
 	 *     <user guid> => array('email', 'sms', 'ajax'),
 	 * );
 	 *
-	 * @param NotificationEvent $event   Notification event
-	 * @param array             $methods Notification methods
+	 * @param NotificationEvent $event                     Notification event
+	 * @param array             $methods                   Notification methods
+	 * @param array             $exclude_guids_for_records GUIDs to exclude from fetching subscription records
 	 *
 	 * @return array
 	 */
-	public function getNotificationEventSubscriptions(NotificationEvent $event, array $methods) {
+	public function getNotificationEventSubscriptions(NotificationEvent $event, array $methods, array $exclude_guids_for_records = []) {
 
 		if (empty($methods)) {
 			return [];
@@ -87,8 +88,6 @@ class SubscriptionsService {
 			return [];
 		}
 
-		$subscriptions = [];
-
 		$guids = [
 			$object->owner_guid,
 			$object->container_guid,
@@ -97,6 +96,12 @@ class SubscriptionsService {
 			$guids[] = $object->guid;
 		}
 		
+		$guids = array_diff($guids, $exclude_guids_for_records);
+		if (empty($guids)) {
+			return [];
+		}
+		
+		$subscriptions = [];
 		$records = $this->getSubscriptionRecords($guids, $methods, $object->type, $object->subtype, $event->getAction(), $event->getActorGUID());
 		foreach ($records as $record) {
 			if (empty($record->guid)) {

--- a/engine/tests/phpunit/integration/Elgg/Notifications/SubscriptionServiceIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Notifications/SubscriptionServiceIntegrationTest.php
@@ -439,6 +439,59 @@ class SubscriptionServiceIntegrationTest extends IntegrationTestCase {
 		$this->assertEmpty($this->service->filterSubscriptions($subscriptions, $event));
 	}
 	
+	public function testGetNotificationEventSubscriptionsWithExcludedOwnerGUID() {
+		$this->entities[] = $user = $this->createUser();
+		
+		$event = $this->getSubscriptionNotificationEvent();
+		
+		/* @var $object \ElggObject */
+		$object = $event->getObject();
+		$owner = $object->getOwnerEntity();
+		$this->assertTrue($owner->addSubscription($user->guid, 'apples'));
+		
+		$subscriptions = $this->service->getNotificationEventSubscriptions($event, ['apples', 'bananas']);
+		$this->assertNotEmpty($subscriptions);
+		
+		// exclude owner
+		$subscriptions = $this->service->getNotificationEventSubscriptions($event, ['apples', 'bananas'], [$owner->guid]);
+		$this->assertEmpty($subscriptions);
+	}
+	
+	public function testGetNotificationEventSubscriptionsWithExcludedContainerGUID() {
+		$this->entities[] = $user = $this->createUser();
+		
+		$event = $this->getSubscriptionNotificationEvent();
+		
+		/* @var $object \ElggObject */
+		$object = $event->getObject();
+		$container = $object->getContainerEntity();
+		$this->assertTrue($container->addSubscription($user->guid, 'apples'));
+		
+		$subscriptions = $this->service->getNotificationEventSubscriptions($event, ['apples', 'bananas']);
+		$this->assertNotEmpty($subscriptions);
+		
+		// exclude container
+		$subscriptions = $this->service->getNotificationEventSubscriptions($event, ['apples', 'bananas'], [$container->guid]);
+		$this->assertEmpty($subscriptions);
+	}
+	
+	public function testGetNotificationEventSubscriptionsWithExcludedEntityGUID() {
+		$this->entities[] = $user = $this->createUser();
+		
+		$event = $this->getSubscriptionNotificationEvent();
+		
+		/* @var $object \ElggObject */
+		$object = $event->getObject();
+		$this->assertTrue($object->addSubscription($user->guid, 'apples'));
+		
+		$subscriptions = $this->service->getNotificationEventSubscriptions($event, ['apples', 'bananas']);
+		$this->assertNotEmpty($subscriptions);
+		
+		// exclude entity
+		$subscriptions = $this->service->getNotificationEventSubscriptions($event, ['apples', 'bananas'], [$object->guid]);
+		$this->assertEmpty($subscriptions);
+	}
+	
 	public function testGetNotificationEventSubscriptionsWhereEventActorIsNotPresentInResult() {
 		$event = $this->getSubscriptionNotificationEvent();
 		


### PR DESCRIPTION
Offers the option in a NotificationEventHandler to exlude owner,
container and/or entity subscribers while fetching subscribers.