### PR TITLE
fix(site_notifications): prevent input limit reached in bulk actions

### DIFF
--- a/mod/site_notifications/views/default/resources/site_notifications/owner.php
+++ b/mod/site_notifications/views/default/resources/site_notifications/owner.php
@@ -13,6 +13,7 @@ $list = elgg_list_entities([
 	'metadata_name_value_pairs' => [
 		'read' => false,
 	],
+	'pagination_behaviour' => 'ajax-replace',
 ]);
 
 if (empty($list)) {

--- a/mod/site_notifications/views/default/resources/site_notifications/read.php
+++ b/mod/site_notifications/views/default/resources/site_notifications/read.php
@@ -13,6 +13,7 @@ $list = elgg_list_entities([
 	'metadata_name_value_pairs' => [
 		'read' => true,
 	],
+	'pagination_behaviour' => 'ajax-replace',
 ]);
 
 if (empty($list)) {


### PR DESCRIPTION
Prevent the list from growing too large which could potentialy hit the
input limit when sumbitting the form to delete/mark as read