### PR TITLE
fix(comments): no longer disable save button after form submission

### DIFF
--- a/views/default/page/elements/comments.php
+++ b/views/default/page/elements/comments.php
@@ -64,7 +64,9 @@ $comments_list = elgg_list_entities($options);
 
 $content = $comments_list;
 if ($show_add_form && $entity->canComment()) {
-	$form_vars = [];
+	$form_vars = [
+		'prevent_double_submit' => false,
+	];
 	if ($latest_first && $comments_list && elgg_get_config('comment_box_collapses')) {
 		$form_vars['class'] = 'hidden';
 		


### PR DESCRIPTION
Since this is an ajax form, if an error occures the save button is
disabled and can't be re-enabled.