### PR TITLE
chore(docs): lock docutils so RTD builds succeed

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,8 +23,8 @@ jobs:
           docs-folder: 'docs/'
           build-command: 'sphinx-build -b latex -nW . _build/latex'
       
-      - name: Build custom (Spanish) language documentation
+      - name: Build custom (French) language documentation
         uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: 'docs/'
-          build-command: 'sphinx-build -b html -D language=es -n . _build/html_es'
+          build-command: 'sphinx-build -b html -D language=fr -n . _build/html_fr'

--- a/docs/pip-requirements.txt
+++ b/docs/pip-requirements.txt
@@ -1,1 +1,2 @@
+docutils<0.18
 sphinxcontrib.phpdomain

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+docutils<0.18
 sphinxcontrib.phpdomain
 sphinx-intl


### PR DESCRIPTION
ref https://github.com/readthedocs/readthedocs.org/issues/8616