### PR TITLE
chore(core): removed warning text from class descriptions

### DIFF
--- a/engine/classes/Elgg/ActionsService.php
+++ b/engine/classes/Elgg/ActionsService.php
@@ -11,9 +11,7 @@ use Elgg\Router\RouteRegistrationService;
 use Elgg\Traits\Loggable;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
- * Use the elgg_* versions instead.
+ * Actions service
  *
  * @internal
  * @since 1.9.0

--- a/engine/classes/Elgg/Amd/ViewFilter.php
+++ b/engine/classes/Elgg/Amd/ViewFilter.php
@@ -3,12 +3,9 @@
 namespace Elgg\Amd;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * This filter adds AMD names to anonymous AMD modules defined in views.
  *
  * @since 1.9
- *
  * @internal
  */
 class ViewFilter {

--- a/engine/classes/Elgg/Assets/ExternalFiles.php
+++ b/engine/classes/Elgg/Assets/ExternalFiles.php
@@ -3,10 +3,10 @@
 namespace Elgg\Assets;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * External files service
  *
  * @internal
- * @since  1.10.0
+ * @since 1.10.0
  */
 class ExternalFiles {
 

--- a/engine/classes/Elgg/Cache/SimpleCache.php
+++ b/engine/classes/Elgg/Cache/SimpleCache.php
@@ -6,10 +6,10 @@ use Elgg\Config;
 use Elgg\ViewsService;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * Simple cache service
  *
  * @internal
- * @since  1.10.0
+ * @since 1.10.0
  */
 class SimpleCache {
 

--- a/engine/classes/Elgg/Database/AccessCollections.php
+++ b/engine/classes/Elgg/Database/AccessCollections.php
@@ -13,10 +13,9 @@ use Elgg\UserCapabilities;
 use Elgg\Traits\Loggable;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * Access collections database service
  *
  * @internal
- *
  * @since 1.10.0
  */
 class AccessCollections {

--- a/engine/classes/Elgg/Database/AdminNotices.php
+++ b/engine/classes/Elgg/Database/AdminNotices.php
@@ -3,12 +3,9 @@
 namespace Elgg\Database;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * Controls all admin notices in the system.
  *
  * @internal
- *
  * @since 1.10.0
  */
 class AdminNotices {

--- a/engine/classes/Elgg/Database/Annotations.php
+++ b/engine/classes/Elgg/Database/Annotations.php
@@ -18,8 +18,6 @@ use ElggEntity;
  * Annotation repository contains methods for fetching annotations from database or performing
  * calculations on entity properties.
  *
- * API IN FLUX Do not access the methods directly, use elgg_get_annotations() instead
- *
  * @internal
  */
 class Annotations extends Repository {

--- a/engine/classes/Elgg/Database/AnnotationsTable.php
+++ b/engine/classes/Elgg/Database/AnnotationsTable.php
@@ -11,8 +11,6 @@ use Elgg\Traits\TimeUsing;
 /**
  * Interfaces with the database to perform CRUD operations on annotations
  *
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * @internal
  */
 class AnnotationsTable {

--- a/engine/classes/Elgg/Database/ConfigTable.php
+++ b/engine/classes/Elgg/Database/ConfigTable.php
@@ -10,8 +10,6 @@ use Elgg\Traits\Loggable;
 /**
  * Manipulates values in the dbprefix_config table. Do not use to read/write $CONFIG.
  *
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * @internal
  * @since 1.10.0
  */

--- a/engine/classes/Elgg/Database/DbConfig.php
+++ b/engine/classes/Elgg/Database/DbConfig.php
@@ -5,7 +5,7 @@ namespace Elgg\Database;
 use Elgg\Config;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * Database configuration service
  *
  * @internal
  * @since 1.9.0

--- a/engine/classes/Elgg/Database/Entities.php
+++ b/engine/classes/Elgg/Database/Entities.php
@@ -17,8 +17,6 @@ use ElggEntity;
  * Entities repository contains methods for fetching entities from database or performing
  * calculations on entity properties.
  *
- * API IN FLUX Do not access the methods directly, use elgg_get_entities() instead
- *
  * @todo   Resolve table alias collissions when querying for both annotationa and metadata name value pairs
  *         Currently, n_table is expected across core and plugins, we need to refactor that code
  *         and remove n_table joins here

--- a/engine/classes/Elgg/Database/EntityTable.php
+++ b/engine/classes/Elgg/Database/EntityTable.php
@@ -18,10 +18,9 @@ use Elgg\Traits\Loggable;
 use Elgg\Traits\TimeUsing;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * Entity table database service
  *
  * @internal
- *
  * @since 1.10.0
  */
 class EntityTable {

--- a/engine/classes/Elgg/Database/Metadata.php
+++ b/engine/classes/Elgg/Database/Metadata.php
@@ -20,8 +20,6 @@ use LogicException;
  * Metadata repository contains methods for fetching metadata from database or performing
  * calculations on entity properties.
  *
- * API IN FLUX Do not access the methods directly, use elgg_get_metadata() instead
- *
  * @internal
  */
 class Metadata extends Repository {

--- a/engine/classes/Elgg/Database/MetadataTable.php
+++ b/engine/classes/Elgg/Database/MetadataTable.php
@@ -13,8 +13,6 @@ use Elgg\Traits\TimeUsing;
 /**
  * This class interfaces with the database to perform CRUD operations on metadata
  *
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * @internal
  */
 class MetadataTable {

--- a/engine/classes/Elgg/Database/Mutex.php
+++ b/engine/classes/Elgg/Database/Mutex.php
@@ -7,8 +7,6 @@ use Elgg\Exceptions\InvalidParameterException;
 use Elgg\Traits\Loggable;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * Provides database mutex that can be used to prevent race conditions
  * between two processes that affect the same data.
  *

--- a/engine/classes/Elgg/Database/Plugins.php
+++ b/engine/classes/Elgg/Database/Plugins.php
@@ -21,10 +21,8 @@ use Psr\Log\LogLevel;
 /**
  * Persistent, installation-wide key-value storage.
  *
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * @internal
- * @since  1.10.0
+ * @since 1.10.0
  */
 class Plugins {
 

--- a/engine/classes/Elgg/Database/PrivateSettingsTable.php
+++ b/engine/classes/Elgg/Database/PrivateSettingsTable.php
@@ -10,13 +10,10 @@ use Elgg\Values;
 /**
  * Private settings for entities
  *
- * Private settings provide metadata like storage of settings for plugins
- * and users.
- *
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * Private settings provide metadata like storage of settings for plugins and users.
  *
  * @internal
- * @since  2.0.0
+ * @since 2.0.0
  */
 class PrivateSettingsTable {
 

--- a/engine/classes/Elgg/Database/RelationshipsTable.php
+++ b/engine/classes/Elgg/Database/RelationshipsTable.php
@@ -13,10 +13,9 @@ use Elgg\Exceptions\InvalidArgumentException;
 use Elgg\Traits\TimeUsing;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * Relationships table database service
  *
  * @internal
- *
  * @since 1.10.0
  */
 class RelationshipsTable {

--- a/engine/classes/Elgg/Database/River.php
+++ b/engine/classes/Elgg/Database/River.php
@@ -13,8 +13,6 @@ use Elgg\Traits\Database\LegacyQueryOptionsAdapter;
 /**
  * River repository contains methods for fetching/counting river items
  *
- * API IN FLUX Do not access the methods directly, use elgg_get_river() instead
- *
  * @internal
  */
 class River extends Repository {

--- a/engine/classes/Elgg/Database/UsersTable.php
+++ b/engine/classes/Elgg/Database/UsersTable.php
@@ -8,10 +8,9 @@ use Elgg\Database\Clauses\OrderByClause;
 use Elgg\Traits\TimeUsing;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * Users helper service
  *
  * @internal
- *
  * @since 1.10.0
  */
 class UsersTable {

--- a/engine/classes/Elgg/Debug/Inspector.php
+++ b/engine/classes/Elgg/Debug/Inspector.php
@@ -7,10 +7,9 @@ use Elgg\Project\Paths;
 use Elgg\Menu\MenuItems;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * Debug inspector
  *
  * @internal
- *
  * @since 1.11
  */
 class Inspector {

--- a/engine/classes/Elgg/Debug/Inspector/ViewComponent.php
+++ b/engine/classes/Elgg/Debug/Inspector/ViewComponent.php
@@ -3,10 +3,9 @@
 namespace Elgg\Debug\Inspector;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * View inspector
  *
  * @internal
- *
  * @since 1.11
  */
 class ViewComponent {

--- a/engine/classes/Elgg/EmailService.php
+++ b/engine/classes/Elgg/EmailService.php
@@ -19,9 +19,7 @@ use Laminas\Mime\Mime;
 use RuntimeException;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
- * Use the elgg_* versions instead.
+ * Email service
  *
  * @internal
  * @since 3.0

--- a/engine/classes/Elgg/EntityIconService.php
+++ b/engine/classes/Elgg/EntityIconService.php
@@ -9,9 +9,7 @@ use Elgg\Traits\Loggable;
 use Elgg\Traits\TimeUsing;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
- * Use the elgg_* versions instead.
+ * Entity icon service
  *
  * @internal
  * @since 2.2

--- a/engine/classes/Elgg/Forms/StickyForms.php
+++ b/engine/classes/Elgg/Forms/StickyForms.php
@@ -3,10 +3,9 @@
 namespace Elgg\Forms;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * Stick forms service
  *
  * @since 1.10.0
- *
  * @internal
  */
 class StickyForms {

--- a/engine/classes/Elgg/FormsService.php
+++ b/engine/classes/Elgg/FormsService.php
@@ -5,9 +5,7 @@ namespace Elgg;
 use Elgg\Traits\Loggable;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
- * Use the elgg_* versions instead.
+ * Forms service
  *
  * @internal
  * @since 2.3

--- a/engine/classes/Elgg/Http/Input.php
+++ b/engine/classes/Elgg/Http/Input.php
@@ -3,8 +3,6 @@
 namespace Elgg\Http;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * Provides unified access to the $_GET and $_POST inputs.
  *
  * @since 1.10.0

--- a/engine/classes/Elgg/Http/ResponseFactory.php
+++ b/engine/classes/Elgg/Http/ResponseFactory.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * HTTP response service
  *
  * @since 2.3
  * @internal

--- a/engine/classes/Elgg/I18n/Locale.php
+++ b/engine/classes/Elgg/I18n/Locale.php
@@ -5,8 +5,6 @@ namespace Elgg\I18n;
 use Elgg\Exceptions\I18n\InvalidLocaleException;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * Language class to ensure only valid languages are used.
  *
  * @since 1.11

--- a/engine/classes/Elgg/I18n/NullTranslator.php
+++ b/engine/classes/Elgg/I18n/NullTranslator.php
@@ -3,8 +3,6 @@
 namespace Elgg\I18n;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * A translator that does nothing except return the key that was requested.
  *
  * This translator is useful during development if you want to be able to

--- a/engine/classes/Elgg/I18n/TranslatorInterface.php
+++ b/engine/classes/Elgg/I18n/TranslatorInterface.php
@@ -3,12 +3,9 @@
 namespace Elgg\I18n;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * Can "translate" language keys into various human-readable, localized strings.
  *
  * @since 1.11
- *
  * @internal
  */
 interface TranslatorInterface {

--- a/engine/classes/Elgg/Notifications/NotificationsService.php
+++ b/engine/classes/Elgg/Notifications/NotificationsService.php
@@ -7,10 +7,9 @@ use Elgg\PluginHooksService;
 use Elgg\Queue\Queue;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * Notifications service
  *
  * @internal
- *
  * @since 1.9.0
  */
 class NotificationsService {

--- a/engine/classes/Elgg/Notifications/SubscriptionsService.php
+++ b/engine/classes/Elgg/Notifications/SubscriptionsService.php
@@ -12,7 +12,7 @@ use Elgg\Database\Entities;
 use Elgg\Exceptions\InvalidArgumentException;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
+ * Subscription service
  *
  * @internal
  * @since 1.9.0

--- a/engine/classes/Elgg/PasswordService.php
+++ b/engine/classes/Elgg/PasswordService.php
@@ -3,7 +3,7 @@
 namespace Elgg;
 
 /**
- * PRIVATE CLASS. API IN FLUX. DO NOT USE DIRECTLY.
+ * Password service
  *
  * @internal
  * @since 1.10.0

--- a/engine/classes/Elgg/Queue/DatabaseQueue.php
+++ b/engine/classes/Elgg/Queue/DatabaseQueue.php
@@ -11,10 +11,7 @@ use Elgg\Traits\TimeUsing;
 /**
  * FIFO queue that uses the database for persistence
  *
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * @internal
- *
  * @since 1.9.0
  */
 class DatabaseQueue implements \Elgg\Queue\Queue {

--- a/engine/classes/Elgg/Queue/MemoryQueue.php
+++ b/engine/classes/Elgg/Queue/MemoryQueue.php
@@ -5,10 +5,7 @@ namespace Elgg\Queue;
 /**
  * FIFO queue that is memory based (not persistent)
  *
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * @internal
- *
  * @since 1.9.0
  */
 class MemoryQueue implements \Elgg\Queue\Queue {

--- a/engine/classes/Elgg/Queue/Queue.php
+++ b/engine/classes/Elgg/Queue/Queue.php
@@ -5,10 +5,7 @@ namespace Elgg\Queue;
 /**
  * Queue interface
  *
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * @internal
- *
  * @since 1.9.0
  */
 interface Queue {

--- a/engine/classes/Elgg/Search/SearchService.php
+++ b/engine/classes/Elgg/Search/SearchService.php
@@ -15,12 +15,10 @@ use Elgg\PluginHooksService;
 use Elgg\Traits\Database\LegacyQueryOptionsAdapter;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
- * Use elgg_search() instead.
+ * Search service
  *
  * @internal
- * @since  3.0
+ * @since 3.0
  */
 class SearchService {
 

--- a/engine/classes/Elgg/Upgrade/Locator.php
+++ b/engine/classes/Elgg/Upgrade/Locator.php
@@ -10,9 +10,7 @@ use Elgg\Project\Paths;
 /**
  * Locates and registers both core and plugin upgrades
  *
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
- * @since  3.0.0
+ * @since 3.0.0
  * @internal
  */
 class Locator {

--- a/engine/classes/Elgg/UploadService.php
+++ b/engine/classes/Elgg/UploadService.php
@@ -6,9 +6,7 @@ use Elgg\Http\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
- * Use the elgg_* versions instead.
+ * File upload handling service
  *
  * @internal
  * @since 2.3

--- a/engine/classes/Elgg/UserCapabilities.php
+++ b/engine/classes/Elgg/UserCapabilities.php
@@ -12,9 +12,7 @@ use ElggRiverItem;
 use ElggSession;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
- * Use the elgg_* versions instead.
+ * User capabilities service
  *
  * @internal
  * @since 2.2

--- a/engine/classes/Elgg/ViewsService.php
+++ b/engine/classes/Elgg/ViewsService.php
@@ -10,12 +10,10 @@ use Elgg\Project\Paths;
 use Elgg\Traits\Loggable;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
- * Use the elgg_* versions instead.
+ * Views service
  *
  * @internal
- * @since  1.9.0
+ * @since 1.9.0
  */
 class ViewsService {
 

--- a/engine/classes/Elgg/WidgetsService.php
+++ b/engine/classes/Elgg/WidgetsService.php
@@ -5,12 +5,9 @@ namespace Elgg;
 use Elgg\Exceptions\Database\UserFetchFailureException;
 
 /**
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
- * Use the elgg_* versions instead.
+ * Widgets service
  *
  * @internal
- *
  * @since 1.9.0
  */
 class WidgetsService {

--- a/views/default/core/js/upgrader.js
+++ b/views/default/core/js/upgrader.js
@@ -1,10 +1,7 @@
 /**
  * Javascript that takes care of running batch upgrades
  *
- * WARNING: API IN FLUX. DO NOT USE DIRECTLY.
- *
  * @internal
- *
  * @since 3.0.0
  */
 define(['jquery', 'elgg', 'elgg/Ajax', 'elgg/spinner', 'elgg/popup', 'jquery-ui/widgets/progressbar'], function($, elgg, Ajax, spinner, popup) {


### PR DESCRIPTION
The fact that a class shouldn't be used directly is better handled by
documenting it `@internal`