### PR TITLE
fix(discussion): comment actor on group discussion no longer notified

### DIFF
--- a/docs/plugins/discussions.rst
+++ b/docs/plugins/discussions.rst
@@ -1,0 +1,14 @@
+Discussions
+===========
+
+Add a forum like place to start a discussion. This feature is mainly meant to used in groups. The group owners can enable/disable this feature 
+for their group.
+
+There is a plugin setting to enable global discussions (so outside of a group). This setting is disabled by default but can be enabled by 
+a site administrator.
+
+Notifications
+-------------
+
+In order to encourage discussion in a group all group members will receive notifications about comments on a discussion topic. This will follow the 
+notification preferences of the group member based on the global group preference or the specific group preference for new discussions.

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -8,6 +8,7 @@ Elgg comes with a set of plugins. These provide the basic functionality for your
    
    blog
    dashboard
+   discussions
    file
    friends
    groups
@@ -26,7 +27,6 @@ The following plugins are also bundled with Elgg, but are not (yet) documented
 - ckeditor
 - custom_index
 - developers
-- discussions
 - embed
 - externalpages
 - friends_collections

--- a/engine/classes/Elgg/Notifications/SubscriptionsService.php
+++ b/engine/classes/Elgg/Notifications/SubscriptionsService.php
@@ -133,12 +133,16 @@ class SubscriptionsService {
 	 *     <user guid> => array('email', 'sms', 'ajax'),
 	 * );
 	 *
-	 * @param int   $container_guid GUID of the entity acting as a container
-	 * @param array $methods        Notification methods
+	 * @param int    $container_guid GUID of the entity acting as a container
+	 * @param array  $methods        Notification methods
+	 * @param string $type           (optional) entity type
+	 * @param string $subtype        (optional) entity subtype
+	 * @param string $action         (optional) notification action (eg. 'create')
+	 * @param int    $actor_guid     (optional) Notification event actor to exclude from the database subscriptions
 	 *
 	 * @return array User GUIDs (keys) and their subscription types (values).
 	 */
-	public function getSubscriptionsForContainer(int $container_guid, array $methods) {
+	public function getSubscriptionsForContainer(int $container_guid, array $methods, string $type = null, string $subtype = null, string $action = null, int $actor_guid = 0) {
 
 		if (empty($methods)) {
 			return [];
@@ -146,7 +150,7 @@ class SubscriptionsService {
 
 		$subscriptions = [];
 
-		$records = $this->getSubscriptionRecords([$container_guid], $methods);
+		$records = $this->getSubscriptionRecords([$container_guid], $methods, $type, $subtype, $action, $actor_guid);
 		foreach ($records as $record) {
 			if (empty($record->guid)) {
 				// happens when no records are found

--- a/mod/discussions/classes/Elgg/Discussions/Notifications.php
+++ b/mod/discussions/classes/Elgg/Discussions/Notifications.php
@@ -87,7 +87,10 @@ class Notifications {
 		}
 		
 		$subscriptions = $hook->getValue();
-		$group_subscriptions = elgg_get_subscriptions_for_container($container->guid);
+		
+		// get subscribers on the group (using the discussion create preference for detailed subscriptions)
+		$methods = elgg_get_notification_methods();
+		$group_subscriptions = _elgg_services()->subscriptions->getSubscriptionsForContainer($container->guid, $methods, 'object', 'discussion', 'create', $event->getActorGUID());
 		
 		return ($subscriptions + $group_subscriptions);
 	}


### PR DESCRIPTION
The comment creator will no longer be notified when the comment was made
on a group discussion topic. Also the preference for discussion create
will be used to get the subscribers (along the group subscribers).