### PR TITLE
chore(tests): make sure Ajax Controller test is run in non walled garden

### DIFF
--- a/engine/tests/phpunit/integration/Elgg/Ajax/ControllerIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Ajax/ControllerIntegrationTest.php
@@ -31,6 +31,10 @@ class ControllerIntegrationTest extends IntegrationTestCase {
 			'request' => $request,
 		]);
 		
+		// make sure the tests run in a non walled garden environment
+		elgg_set_config('walled_garden', false);
+		$this->assertFalse(elgg_get_config('walled_garden'));
+		
 		$this->registerViews();
 	}
 	


### PR DESCRIPTION
As the walled garden prevents access to the ajax controller for logged
out users (which happens in the tests)