### PR TITLE
perf(site_notifications): cron cleanup uses direct database queries

### DIFF
--- a/docs/plugins/site_notifications.rst
+++ b/docs/plugins/site_notifications.rst
@@ -11,3 +11,10 @@ Features
 - Unread notifications will automatically be marked as read when you view the content it relates to
 - Notifications will automatically be removed if the content it relates to is removed
 - Plugin settings are available to automatically cleanup unread/read notifications
+
+Note for developers
+-------------------
+
+The cron based cleanup of (un)read site notifications removes the entities directly from the database.
+It isn't using ``$entity->delete()`` to help with performance. This means that no events are triggered for 
+the entities which are removed during the cleanup.

--- a/mod/site_notifications/README.md
+++ b/mod/site_notifications/README.md
@@ -1,8 +1,10 @@
-Site Notifications
-====================
-In Elgg 1.5-1.8, site notifications were provided by the message plugin. In Elgg
+# Site Notifications
+
+In Elgg 1.5-1.8, site notifications were provided by the Messages plugin. In Elgg
 1.9 they were moved to a separate plugin.
 
-Because site notifications can result in a lot of writes to the database to create
-a notification per recipient (as opposed to email notifications), they may not
-scale well for large sites or sites that have large groups.
+## Note for developers
+
+The cron based cleanup of (un)read site notifications removes the entities directly from the database.
+It isn't using ``$entity->delete()`` to help with performance. This means that no events are triggered for 
+the entities which are removed during the cleanup.

--- a/mod/site_notifications/classes/Elgg/SiteNotifications/Seeder.php
+++ b/mod/site_notifications/classes/Elgg/SiteNotifications/Seeder.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Elgg\SiteNotifications;
+
+use Elgg\Database\Clauses\OrderByClause;
+use Elgg\Database\QueryBuilder;
+use Elgg\Database\Seeds\Seed;
+
+/**
+ * Add site notification seed
+ *
+ * @internal
+ */
+class Seeder extends Seed {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function seed() {
+		$this->advance($this->getCount());
+		
+		$attributes = [
+			'subtype' => 'site_notification',
+			'access_id' => ACCESS_PRIVATE,
+		];
+		
+		while ($this->getCount() < $this->limit) {
+			$metadata = [
+				'read' => $this->faker()->boolean(),
+				'summary' => $this->faker()->sentence(),
+			];
+			
+			$notification = $this->createObject($attributes, $metadata);
+			if (!$notification instanceof \SiteNotification) {
+				continue;
+			}
+			
+			// link to entity on site
+			$linked_entity = $this->getRandomLinkedEntity();
+			if ($linked_entity instanceof \ElggEntity) {
+				$notification->setLinkedEntity($linked_entity);
+			}
+			
+			// set notification actor
+			$actor = $this->getRandomUser([$notification->owner_guid]);
+			if ($actor instanceof \ElggUser) {
+				$notification->setActor($actor);
+			}
+			
+			$notification->save();
+			
+			$this->advance();
+		}
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function unseed() {
+		
+		/* @var $notifications \ElggBatch */
+		$notifications = elgg_get_entities([
+			'type' => 'object',
+			'subtype' => 'site_notification',
+			'metadata_name' => '__faker',
+			'limit' => false,
+			'batch' => true,
+			'batch_inc_offset' => false,
+		]);
+		
+		/* @var $notification \SiteNotification */
+		foreach ($notifications as $notification) {
+			if ($notification->delete()) {
+				$this->log("Deleted site notification {$notification->guid}");
+			} else {
+				$this->log("Failed to delete site notification {$notification->guid}");
+			}
+			
+			$this->advance();
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function getType() : string {
+		return 'site_notification';
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function getCountOptions() : array {
+		return [
+			'type' => 'object',
+			'subtype' => 'site_notification',
+		];
+	}
+	
+	/**
+	 * Get a rondom seeded entity to link the notification to
+	 *
+	 * @param array $exclude      GUIDs to exclude in the search
+	 * @param bool  $allow_create allow creation of new entities
+	 *
+	 * @return \ElggEntity|false
+	 */
+	protected function getRandomLinkedEntity(array $exclude = [], bool $allow_create = true) {
+		$exclude[] = 0;
+		
+		$entities = elgg_get_entities([
+			'types' => ['object', 'group'],
+			'metadata_names' => ['__faker'],
+			'limit' => 1,
+			'wheres' => [
+				function(QueryBuilder $qb, $main_alias) use ($exclude) {
+					return $qb->compare("{$main_alias}.guid", 'NOT IN', $exclude, ELGG_VALUE_INTEGER);
+				}
+			],
+			'order_by' => new OrderByClause('RAND()', null),
+		]);
+		
+		if (!empty($entities)) {
+			return $entities[0];
+		}
+		
+		if ($allow_create) {
+			return $this->createObject();
+		}
+		
+		return false;
+	}
+}

--- a/mod/site_notifications/elgg-plugin.php
+++ b/mod/site_notifications/elgg-plugin.php
@@ -63,6 +63,11 @@ return [
 				'Elgg\SiteNotifications\Menus\Topbar::register' => [],
 			],
 		],
+		'seeds' => [
+			'database' => [
+				'Elgg\SiteNotifications\Seeder::register' => [],
+			],
+		],
 		'send' => [
 			'notification:site' => [
 				'Elgg\SiteNotifications\Notifications::createSiteNotifications' => [],


### PR DESCRIPTION
To increase the amount of site notifications which can be cleaned the
Elgg event system isn't used anymore.

fixes #13780