### PR TITLE
chore(comments): only update comments access if entity access changed

### DIFF
--- a/engine/classes/Elgg/Comments/SyncContainerAccessHandler.php
+++ b/engine/classes/Elgg/Comments/SyncContainerAccessHandler.php
@@ -19,7 +19,12 @@ class SyncContainerAccessHandler {
 	public function __invoke(\Elgg\Event $event) {
 		$entity = $event->getObject();
 		if (!$entity instanceof \ElggEntity) {
-			return true;
+			return;
+		}
+		
+		// only need update query if access_id of entity has been changed
+		if (!array_key_exists('access_id', $entity->getOriginalAttributes())) {
+			return;
 		}
 		
 		// need to override access in case comments ended up with ACCESS_PRIVATE
@@ -45,7 +50,5 @@ class SyncContainerAccessHandler {
 				$comment->save();
 			}
 		});
-			
-		return true;
 	}
 }

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreCommentTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreCommentTest.php
@@ -3,8 +3,6 @@
 namespace Elgg\Integration;
 
 use Elgg\IntegrationTestCase;
-use ElggComment;
-use ElggObject;
 
 /**
  * Elgg Test \ElggComment
@@ -13,12 +11,12 @@ use ElggObject;
  */
 class ElggCoreCommentTest extends IntegrationTestCase {
 	/**
-	 * @var ElggComment
+	 * @var \ElggComment
 	 */
 	protected $comment;
 
 	/**
-	 * @var ElggObject
+	 * @var \ElggObject
 	 */
 	protected $container;
 
@@ -49,13 +47,16 @@ class ElggCoreCommentTest extends IntegrationTestCase {
 		$this->assertEquals($this->container->access_id, $this->comment->access_id);
 
 		// now change the access of the container
-		$this->container->access_id = ACCESS_LOGGED_IN;
-		$this->container->save();
-
-		$updated_container = get_entity($this->container->guid);
-		$updated_comment = get_entity($this->comment->guid);
-
-		$this->assertEquals($updated_container->access_id, $updated_comment->access_id);
+		$this->container->access_id = 123456;
+		
+		elgg_call(ELGG_IGNORE_ACCESS, function() {
+			$this->assertTrue($this->container->save());
+			
+			$updated_container = get_entity($this->container->guid);
+			$updated_comment = get_entity($this->comment->guid);
+	
+			$this->assertEquals(123456, $updated_container->access_id);
+			$this->assertEquals(123456, $updated_comment->access_id);
+		});
 	}
-
 }


### PR DESCRIPTION
fixes #13858