### PR TITLE
fix(account): user settings form is no longer ajax based

### DIFF
--- a/views/default/core/settings/account.php
+++ b/views/default/core/settings/account.php
@@ -7,5 +7,4 @@
 
 echo elgg_view_form('usersettings/save', [
 	'class' => 'elgg-form-alt',
-	'ajax' => true,
 ], $vars);


### PR DESCRIPTION
In order to preserve system/error messages as the ajax form would
present the messages and then reload the page.