### PR TITLE
fix(core): generate correct URLs in special request cases

### DIFF
--- a/engine/classes/Elgg/Application.php
+++ b/engine/classes/Elgg/Application.php
@@ -259,6 +259,7 @@ class Application {
 		if ($spec['request']) {
 			if ($spec['request'] instanceof HttpRequest) {
 				$spec['request']->initializeTrustedProxyConfiguration($spec['internal_services']->config);
+				$spec['request']->correctBaseURL($spec['internal_services']->config);
 				$spec['internal_services']->set('request', $spec['request']);
 			} else {
 				throw new InvalidArgumentException("Given request is not a " . HttpRequest::class);

--- a/engine/classes/Elgg/Http/Request.php
+++ b/engine/classes/Elgg/Http/Request.php
@@ -484,4 +484,23 @@ class Request extends SymfonyRequest {
 			throw new BadRequestException($error_msg);
 		}
 	}
+	
+	/**
+	 * Correct the base URL of the request
+	 *
+	 * @param \Elgg\Config $config the Elgg config
+	 *
+	 * @return void
+	 * @see https://github.com/Elgg/Elgg/issues/13667
+	 * @since 4.3
+	 */
+	public function correctBaseURL(\Elgg\Config $config): void {
+		if (\Elgg\Application::isCli()) {
+			return;
+		}
+		
+		$path = parse_url($config->wwwroot, PHP_URL_PATH);
+		
+		$this->baseUrl = rtrim($path, '/');
+	}
 }

--- a/engine/internal_services.php
+++ b/engine/internal_services.php
@@ -141,6 +141,7 @@ return [
 		// global $CONFIG is not set during installer
 		if ($CONFIG instanceof \Elgg\Config) {
 			$request->initializeTrustedProxyConfiguration($CONFIG);
+			$request->correctBaseURL($CONFIG);
 		}
 		
 		return $request;


### PR DESCRIPTION
When the request script isn't Elggs base index.php the generation of the
URLs could result in a wrong URL.

fixes #13667