### PR TITLE
feat(web_services): allow different callbacks depending on HTTP request

### DIFF
--- a/docs/appendix/upgrade-notes/4.x-to-5.0.rst
+++ b/docs/appendix/upgrade-notes/4.x-to-5.0.rst
@@ -251,9 +251,9 @@ Lib functions function parameters
 * ``thewire_save_post()`` now requires a ``string`` for ``$text`` and ``$method`` and an ``int`` for ``$userid`` and ``$access_id`` and ``$parent_guid``
 * ``uservalidationbyemail_request_validation()`` now requires an ``int`` for ``$user_guid``
 * ``elgg_ws_expose_function()`` now requires a ``string`` for ``$method`` and ``$description`` and ``$call_method``, an ``array`` for ``$parameters`` and a ``bool`` for ``$require_api_auth`` and ``$require_user_auth`` and ``$assoc``	
-* ``elgg_ws_register_service_handler()`` now requires a ``string`` for ``$handler``	
-* ``elgg_ws_unexpose_function()`` now requires a ``string`` for ``$method``	
-* ``elgg_ws_unregister_service_handler()`` now requires a ``string`` for ``$handler``	
+* ``elgg_ws_register_service_handler()`` now requires a ``string`` for ``$handler``
+* ``elgg_ws_unexpose_function()`` now requires a ``string`` for ``$method`` and a ``string`` for ``$http_request_method``
+* ``elgg_ws_unregister_service_handler()`` now requires a ``string`` for ``$handler``
 
 Class function return types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mod/web_services/classes/Elgg/WebServices/ApiMethod.php
+++ b/mod/web_services/classes/Elgg/WebServices/ApiMethod.php
@@ -95,13 +95,13 @@ class ApiMethod implements CollectionItemInterface {
 				// catch common mistake of not setting up param array correctly
 				$first = current($value);
 				if (!is_array($first)) {
-					throw new InvalidParameterException(elgg_echo('InvalidParameterException:APIParametersArrayStructure', [$this->getID()]));
+					throw new InvalidParameterException(elgg_echo('InvalidParameterException:APIParametersArrayStructure', [$this->method]));
 				}
 				
 				// ensure the required flag is set correctly in default case for each parameter
 				foreach ($value as $key => $v) {
 					if (!isset($v['type'])) {
-						throw new InvalidParameterException(elgg_echo('APIException:InvalidParameter', [$key, $this->getID()]));
+						throw new InvalidParameterException(elgg_echo('APIException:InvalidParameter', [$key, $this->method]));
 					}
 					
 					// check if 'required' was specified - if not, make it true
@@ -119,7 +119,7 @@ class ApiMethod implements CollectionItemInterface {
 				if ($name === 'call_method') {
 					$value = strtoupper($value);
 					if (!in_array($value, ['GET', 'POST'])) {
-						throw new InvalidParameterException(elgg_echo('InvalidParameterException:UnrecognisedHttpMethod', [$value, $this->getID()]));
+						throw new InvalidParameterException(elgg_echo('InvalidParameterException:UnrecognisedHttpMethod', [$value, $this->method]));
 					}
 				}
 				break;
@@ -169,12 +169,12 @@ class ApiMethod implements CollectionItemInterface {
 		
 		// function must be callable
 		if (empty($callable)) {
-			throw new \APIException(elgg_echo('APIException:FunctionDoesNotExist', [$this->getID()]));
+			throw new \APIException(elgg_echo('APIException:FunctionDoesNotExist', [$this->method]));
 		}
 		
 		// check http call method
 		if ($this->call_method !== $request->getMethod()) {
-			throw new \APIException(elgg_echo('APIException:InvalidCallMethod', [$this->getID(), $this->call_method]));
+			throw new \APIException(elgg_echo('APIException:InvalidCallMethod', [$this->method, $this->call_method]));
 		}
 		
 		$parameters = $this->getParameters($request);
@@ -185,7 +185,7 @@ class ApiMethod implements CollectionItemInterface {
 			$result = call_user_func_array($callable, $parameters);
 		}
 		
-		$result = elgg_trigger_plugin_hook('rest:output', $this->getID(), $parameters, $result);
+		$result = elgg_trigger_plugin_hook('rest:output', $this->method, $parameters, $result);
 		
 		// Sanity check result
 		// If this function returns an api result itself, just return it
@@ -243,7 +243,7 @@ class ApiMethod implements CollectionItemInterface {
 			
 			// check required
 			if ((bool) elgg_extract('required', $settings) && elgg_is_empty($value)) {
-				throw new \APIException(elgg_echo('APIException:MissingParameterInMethod', [$key, $this->getID()]));
+				throw new \APIException(elgg_echo('APIException:MissingParameterInMethod', [$key, $this->method]));
 			}
 			
 			// type cast
@@ -300,7 +300,7 @@ class ApiMethod implements CollectionItemInterface {
 				return $value;
 				
 			default:
-				throw new \APIException(elgg_echo('APIException:UnrecognisedTypeCast', [$type, $key, $this->getID()]));
+				throw new \APIException(elgg_echo('APIException:UnrecognisedTypeCast', [$type, $key, $this->method]));
 		}
 		
 		return $value;
@@ -324,6 +324,6 @@ class ApiMethod implements CollectionItemInterface {
 	 * {@inheritDoc}
 	 */
 	public function getID() {
-		return $this->method;
+		return "{$this->call_method}:{$this->method}";
 	}
 }

--- a/mod/web_services/classes/Elgg/WebServices/Di/ApiRegistrationService.php
+++ b/mod/web_services/classes/Elgg/WebServices/Di/ApiRegistrationService.php
@@ -71,7 +71,7 @@ class ApiRegistrationService {
 			bool $require_api_auth = false,
 			bool $require_user_auth = false,
 			bool $assoc = false
-		) {
+		): void {
 		
 		$api = new ApiMethod($name, $function);
 		$api->params = $params;
@@ -87,23 +87,29 @@ class ApiRegistrationService {
 	/**
 	 * Unregister a API method
 	 *
-	 * @param string $name name of the API method
+	 * @param string $name                Name of the API method
+	 * @param string $http_request_method The HTTP call method (GET|POST|...)
 	 *
 	 * @return void
 	 */
-	public function unregisterApiMethod(string $name) {
-		$this->collection->remove($name);
+	public function unregisterApiMethod(string $name, string $http_request_method = 'GET'): void {
+		$http_request_method = strtoupper($http_request_method);
+		
+		$this->collection->remove("{$http_request_method}:{$name}");
 	}
 	
 	/**
 	 * Get an API method based on it's name
 	 *
-	 * @param string $name name of the API method
+	 * @param string $name                Name of the API method
+	 * @param string $http_request_method The HTTP call method (GET|POST|...)
 	 *
 	 * @return null|ApiMethod
 	 */
-	public function getApiMethod(string $name) {
-		return $this->collection->get($name);
+	public function getApiMethod(string $name, string $http_request_method = 'GET'): ?ApiMethod {
+		$http_request_method = strtoupper($http_request_method);
+		
+		return $this->collection->get("{$http_request_method}:{$name}");
 	}
 	
 	/**

--- a/mod/web_services/classes/Elgg/WebServices/RestServiceController.php
+++ b/mod/web_services/classes/Elgg/WebServices/RestServiceController.php
@@ -21,7 +21,7 @@ class RestServiceController {
 	 *
 	 * @return ResponseBuilder
 	 */
-	public function __invoke(Request $request) {
+	public function __invoke(Request $request): ResponseBuilder {
 		// plugins should return true to control what API and user authentication handlers are registered
 		if (elgg_trigger_plugin_hook('rest', 'init', null, false) === false) {
 			// user token can also be used for user authentication
@@ -38,10 +38,10 @@ class RestServiceController {
 		}
 		
 		// Get parameter variables
-		$method = $request->getParam('method');
+		$method = (string) $request->getParam('method');
 		
 		// this will throw an exception if authentication fails
-		$api = $this->authenticateMethod($method);
+		$api = $this->authenticateMethod($method, $request->getMethod());
 		
 		// execute the api method
 		$result = $api->execute($request);
@@ -57,13 +57,14 @@ class RestServiceController {
 	/**
 	 * Check that the method call has the proper API and user authentication
 	 *
-	 * @param string $method The api name that was exposed
+	 * @param string $method              The api name that was exposed
+	 * @param string $http_request_method The HTTP call method (GET|POST|...)
 	 *
 	 * @return ApiMethod
 	 * @throws \APIException
 	 */
-	protected function authenticateMethod($method) {
-		$api = ApiRegistrationService::instance()->getApiMethod($method);
+	protected function authenticateMethod(string $method, string $http_request_method): ApiMethod {
+		$api = ApiRegistrationService::instance()->getApiMethod($method, $http_request_method);
 		
 		// method must be exposed
 		if (!$api instanceof ApiMethod) {

--- a/mod/web_services/lib/functions.php
+++ b/mod/web_services/lib/functions.php
@@ -68,11 +68,13 @@ function elgg_ws_expose_function(
 /**
  * Unregister a web services method
  *
- * @param string $method The api name that was exposed
+ * @param string $method              The API name that was exposed
+ * @param string $http_request_method The HTTP call method (GET|POST|...)
+ *
  * @return void
  */
-function elgg_ws_unexpose_function(string $method): void {
-	ApiRegistrationService::instance()->unregisterApiMethod($method);
+function elgg_ws_unexpose_function(string $method, string $http_request_method = 'GET'): void {
+	ApiRegistrationService::instance()->unregisterApiMethod($method, $http_request_method);
 }
 
 /**

--- a/mod/web_services/tests/phpunit/integration/Elgg/WebServices/ApiMethodIntegrationTest.php
+++ b/mod/web_services/tests/phpunit/integration/Elgg/WebServices/ApiMethodIntegrationTest.php
@@ -27,18 +27,18 @@ class ApiMethodIntegrationTest extends IntegrationTestCase {
 	public function testConstructor() {
 		$api = new ApiMethod('foo', [$this, 'callbackTest']);
 		
-		$this->assertEquals('foo', $api->getID());
+		$this->assertEquals('GET:foo', $api->getID());
 		$this->assertEquals('(' . __CLASS__ . ')->callbackTest', $api->describeCallable());
 	}
 	
 	public function testSetterWithProtectedValues() {
 		$api = $this->getApiMethod();
 		
-		$this->assertEquals('foo', $api->getID());
+		$this->assertEquals('GET:foo', $api->getID());
 		$this->assertEquals('(' . __CLASS__ . ')->callbackTest', $api->describeCallable());
 		
 		$api->method = 'bar';
-		$this->assertEquals('foo', $api->getID());
+		$this->assertEquals('GET:foo', $api->getID());
 		
 		$api->callback = 'something';
 		$this->assertEquals('(' . __CLASS__ . ')->callbackTest', $api->describeCallable());
@@ -54,11 +54,10 @@ class ApiMethodIntegrationTest extends IntegrationTestCase {
 	public function testCollectionItemInterface() {
 		$api = $this->getApiMethod();
 		
-		$interfaces = class_implements($api);
-		$this->assertTrue(in_array(CollectionItemInterface::class, $interfaces));
+		$this->assertInstanceOf(CollectionItemInterface::class, $api);
 		
 		$this->assertEquals(1, $api->getPriority());
-		$this->assertEquals('foo', $api->getID());
+		$this->assertEquals('GET:foo', $api->getID());
 	}
 	
 	/**


### PR DESCRIPTION
When the same URL is called with a different HTTP request (GET or POST) a different callback can be registered

fixes #7951