### PR TITLE
fix(account): improved valid username detection

### DIFF
--- a/engine/classes/Elgg/Users/Accounts.php
+++ b/engine/classes/Elgg/Users/Accounts.php
@@ -255,9 +255,10 @@ class Accounts {
 		// Whitelist all supported route characters
 		// @see Elgg\Router\RouteRegistrationService::register()
 		// @link https://github.com/Elgg/Elgg/issues/12518
-		$whitelist = '/[\p{L}\p{M}\p{Nd}._-]+/';
-		if (!preg_match_all($whitelist, $username)) {
-			throw new RegistrationException($this->translator->translate('registration:invalidchars'));
+		// @link https://github.com/Elgg/Elgg/issues/14239
+		$invalid_chars = [];
+		if (preg_match_all('/[^\p{L}\p{M}\p{Nd}._-]+/iu', $username, $invalid_chars)) {
+			throw new RegistrationException($this->translator->translate('registration:invalidchars:route', [implode(',', $invalid_chars[0])]));
 		}
 
 		// Belts and braces

--- a/engine/tests/phpunit/unit/Elgg/Router/RouteRegistrationServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Router/RouteRegistrationServiceUnitTest.php
@@ -12,18 +12,10 @@ class RouteRegistrationServiceUnitTest extends UnitTestCase {
 	 */
 	protected $service;
 	
-	/**
-	 * {@inheritDoc}
-	 * @see \Elgg\BaseTestCase::up()
-	 */
 	public function up() {
 		$this->service = _elgg_services()->routes;
 	}
 	
-	/**
-	 * {@inheritDoc}
-	 * @see \Elgg\BaseTestCase::down()
-	 */
 	public function down() {
 		unset($this->service);
 	}
@@ -171,5 +163,66 @@ class RouteRegistrationServiceUnitTest extends UnitTestCase {
 		$message_details = $logged[0];
 		
 		$this->assertStringContainsString('The route "view:foo:bar" has been deprecated.', $message_details['message']);
+	}
+	
+	/**
+	 * @dataProvider validUsernameProvider
+	 */
+	public function testGenerateUrlWithValidUsername($username) {
+		$this->service->register('valid:username', [
+			'path' => '/valid/{username}',
+			'resource' => 'dummy',
+		]);
+		
+		$url = $this->service->generateUrl('valid:username', [
+			'username' => $username,
+		]);
+		$this->assertIsString($url);
+	}
+	
+	/**
+	 * @see \Elgg\Users\AccountsServiceUnitTest::validUsernameProvider()
+	 *
+	 * @return array
+	 */
+	public function validUsernameProvider() {
+		return [
+			['username'],
+			['úsernâmé'],
+			['user1234'],
+			['123456789'],
+			['user-name'],
+			['user.name'],
+			['user_name'],
+			['देवनागरी'], // https://github.com/Elgg/Elgg/issues/12518 and https://github.com/Elgg/Elgg/issues/13067
+		];
+	}
+	
+	/**
+	 * @dataProvider invalidUsernameProvider
+	 */
+	public function testGenerateUrlWithInvalidUsername($username) {
+		$this->service->register('invalid:username', [
+			'path' => '/invalid/{username}',
+			'resource' => 'dummy',
+		]);
+		
+		$url = $this->service->generateUrl('invalid:username', [
+			'username' => $username,
+		]);
+		$this->assertFalse($url);
+	}
+	
+	/**
+	 * @see \Elgg\Users\AccountsServiceUnitTest::invalidUsernameProvider()
+	 *
+	 * @return array
+	 */
+	public function invalidUsernameProvider() {
+		return [
+			['username#'],
+			['username@'],
+			['Username™'],
+		];
 	}
 }

--- a/engine/tests/phpunit/unit/Elgg/Users/AccountsServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Users/AccountsServiceUnitTest.php
@@ -40,12 +40,18 @@ class AccountsServiceUnitTest extends UnitTestCase {
 		elgg()->accounts->assertValidUsername($username);
 	}
 	
+	/**
+	 * @see \Elgg\Router\RouteRegistrationServiceUnitTest::invalidUsernameProvider()
+	 *
+	 * @return array
+	 */
 	public function invalidUsernameProvider() {
 		return [
 			[str_repeat('a', $this->minusername - 1)], // too short
 			[str_repeat('a', 129)], // too long, this is hard coded
 			['username#'],
 			['username@'],
+			['Username™'], // https://github.com/Elgg/Elgg/issues/14239
 		];
 	}
 
@@ -61,6 +67,11 @@ class AccountsServiceUnitTest extends UnitTestCase {
 		elgg()->accounts->assertValidUsername($username);
 	}
 	
+	/**
+	 * @see \Elgg\Router\RouteRegistrationServiceUnitTest::validUsernameProvider()
+	 *
+	 * @return array
+	 */
 	public function validUsernameProvider() {
 		return [
 			['username'],

--- a/languages/en.php
+++ b/languages/en.php
@@ -422,6 +422,7 @@ return array(
 	'registration:usernametoolong' => 'Your username is too long. It can have a maximum of %u characters.',
 	'registration:dupeemail' => 'This email address has already been registered.',
 	'registration:invalidchars' => 'Sorry, your username contains the character %s which is invalid. The following characters are invalid: %s',
+	'registration:invalidchars:route' => 'Sorry, your username contains the character %s which is invalid.',
 	'registration:emailnotvalid' => 'Sorry, the email address you entered is invalid on this system',
 	'registration:passwordnotvalid' => 'Sorry, the password you entered is invalid on this system',
 	'registration:usernamenotvalid' => 'Sorry, the username you entered is invalid on this system',


### PR DESCRIPTION
The username needs to be valid for use in the route generation. This fixes a misalignment bewteen the Account service and the Router.

fixes #14239