### PR TITLE
fix(cache): correctly load simplecache from database

### DIFF
--- a/engine/classes/Elgg/Upgrades/RemoveOrphanedThreadedComments.php
+++ b/engine/classes/Elgg/Upgrades/RemoveOrphanedThreadedComments.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Elgg\Upgrades;
+
+use Elgg\Database\QueryBuilder;
+use Elgg\Upgrade\AsynchronousUpgrade;
+use Elgg\Upgrade\Result;
+
+class RemoveOrphanedThreadedComments implements AsynchronousUpgrade {
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getVersion(): int {
+		return 2023011701;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	public function shouldBeSkipped(): bool {
+		return empty($this->countItems());
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	public function needsIncrementOffset(): bool {
+		return false;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	public function countItems(): int {
+		return elgg_count_entities($this->getOptions());
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	public function run(Result $result, $offset): Result {
+		/* @var $batch \ElggBatch */
+		$batch = elgg_get_entities($this->getOptions([
+			'offset' => $offset,
+		]));
+		/* @var $comment \ElggComment */
+		foreach ($batch as $comment) {
+			if ($comment->delete()) {
+				$result->addSuccesses();
+				continue;
+			}
+			
+			$result->addError();
+		}
+		
+		return $result;
+	}
+	
+	/**
+	 * Get the options to fetch orphaned comments
+	 *
+	 * @param array $options additional options
+	 *
+	 * @return array
+	 * @see elgg_get_entities()
+	 */
+	protected function getOptions(array $options = []): array {
+		$defaults = [
+			'type' => 'object',
+			'subtype' => 'comment',
+			'limit' => 100,
+			'batch' => true,
+			'batch_inc_offset' => $this->needsIncrementOffset(),
+			'batch_size' => 50,
+			'metadata_name_value_pairs' => [
+				'name' => 'parent_guid',
+				'value' => 0,
+				'operand' => '>'
+			],
+			'wheres' => [
+				function (QueryBuilder $qb, $main_alias) {
+					$sub = $qb->subquery('entities');
+					$sub->select('guid')
+						->where($qb->compare('type', '=', 'object', ELGG_VALUE_STRING))
+						->andWhere($qb->compare('subtype', '=', 'comment', ELGG_VALUE_STRING));
+					
+					$md = $qb->joinMetadataTable($main_alias, 'guid', 'parent_guid');
+					return $qb->compare("{$md}.value", 'NOT IN', $sub->getSQL());
+				}
+			],
+		];
+		
+		return array_merge($defaults, $options);
+	}
+}

--- a/engine/classes/ElggComment.php
+++ b/engine/classes/ElggComment.php
@@ -31,7 +31,7 @@ class ElggComment extends \ElggObject {
 		
 		if ($result) {
 			// remove the threaded comments directly below this comment
-			elgg_call(ELGG_IGNORE_ACCESS & ELGG_SHOW_DISABLED_ENTITIES, function() use ($recursive) {
+			elgg_call(ELGG_IGNORE_ACCESS | ELGG_SHOW_DISABLED_ENTITIES, function() use ($recursive) {
 				$children = elgg_get_entities([
 					'type' => 'object',
 					'subtype' => 'comment',

--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -893,6 +893,12 @@ function elgg_view_comments($entity, $add_comment = true, array $vars = []) {
 	$vars['entity'] = $entity;
 	$vars['show_add_form'] = $add_comment;
 	$vars['class'] = elgg_extract('class', $vars, "{$entity->getSubtype()}-comments");
+	
+	$default_id = 'comments';
+	if ($entity instanceof \ElggComment) {
+		$default_id .= "-{$entity->guid}";
+	}
+	$vars['id'] = elgg_extract('id', $vars, $default_id);
 
 	$output = elgg_trigger_plugin_hook('comments', $entity->getType(), $vars, false);
 	if ($output !== false) {

--- a/engine/tests/phpunit/unit/Elgg/Application/CacheHandlerUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Application/CacheHandlerUnitTest.php
@@ -13,7 +13,12 @@ class CacheHandlerUnitTest extends \Elgg\UnitTestCase {
 	protected $handler;
 
 	public function up() {
-		$this->handler = new CacheHandler(_elgg_services()->config, _elgg_services()->request, _elgg_services()->simpleCache);
+		$this->handler = new CacheHandler(
+			_elgg_services()->config,
+			_elgg_services()->request,
+			_elgg_services()->simpleCache,
+			_elgg_services()->configTable,
+		);
 	}
 
 	protected function _testParseFail($input) {

--- a/engine/upgrades.php
+++ b/engine/upgrades.php
@@ -14,4 +14,5 @@ return [
 	\Elgg\Upgrades\DeleteNotificationsPlugin::class,
 	\Elgg\Upgrades\MigrateACLNotificationPreferences::class,
 	\Elgg\Upgrades\NotificationsPrefix::class,
+	\Elgg\Upgrades\RemoveOrphanedThreadedComments::class,
 ];

--- a/languages/en.php
+++ b/languages/en.php
@@ -2014,4 +2014,7 @@ Global variables:
 	
 	'core:upgrade:2021060401:title' => "Add content owners to the subscribers",
 	'core:upgrade:2021060401:description' => "Content owners should be subscribed on their own content, this upgrade migrates all old content.",
+	
+	'core:upgrade:2023011701:title' => "Remove orphaned threaded comments",
+	'core:upgrade:2023011701:description' => "Due to an error in how threaded comments were removed, there was a chance to create orphaned comments, this upgrade will remove those orphans.",
 );

--- a/mod/discussions/views/default/object/discussion.php
+++ b/mod/discussions/views/default/object/discussion.php
@@ -68,19 +68,20 @@ if ($full_view) {
 			'metadata_name_value_pairs' => ['level' => 1],
 		]);
 		
-		/* @var ElggComment $last_comment */
-		$last_comment = $comments[0];
+		$last_comment = elgg_extract(0, $comments);
 		
-		$poster = $last_comment->getOwnerEntity();
-		
-		$comment_text = elgg_echo('discussion:updated', [$poster->getDisplayName(), elgg_view_friendly_time($last_comment->time_created)]);
-		$comment_text = elgg_format_element('span', ['class' => 'float-alt'], elgg_view_url($last_comment->getURL(), $comment_text));
+		if ($last_comment instanceof \ElggComment) {
+			$poster = $last_comment->getOwnerEntity();
+			
+			$comment_text = elgg_echo('discussion:updated', [$poster->getDisplayName(), elgg_view_friendly_time($last_comment->time_created)]);
+			$comment_text = elgg_format_element('span', ['class' => 'float-alt'], elgg_view_url($last_comment->getURL(), $comment_text));
+		}
 	}
 	
 	// brief view
 	$by_line = elgg_view('object/elements/imprint', $vars);
 	
-	$subtitle = "$by_line $comment_text";
+	$subtitle = "{$by_line} {$comment_text}";
 
 	$params = [
 		'subtitle' => $subtitle,


### PR DESCRIPTION
If the settings for 'simplecache_enabled' isn't set in the elgg-config/settings.php the system wouldn't correctly load the value from the database.