### PR TITLE
chore(events): restore the create event for entities

### DIFF
--- a/docs/appendix/upgrade-notes/4.x-to-5.0.rst
+++ b/docs/appendix/upgrade-notes/4.x-to-5.0.rst
@@ -23,6 +23,12 @@ Events and Hooks
 
 These two similar concepts have been merged and from now on we will only refer to events. The public service ``hooks`` no longer exists.
 
+Create event
+~~~~~~~~~~~~
+
+The ``create``, ``<object|group|user|site>`` events can no longer be used to prevent the creation of the entity.
+Use ``create:before`` if you wish to prevent the creation.
+
 Private Settings
 ----------------
 
@@ -31,7 +37,7 @@ The concept of private settings has been removed from the system. All private se
 Breadcrumbs integrated into menu system
 ---------------------------------------
 
-Helper functions for the breadcrumb menu have been changed to use `elgg_register_menu_item()` for adding items to the breadcrumb menu. 
+Helper functions for the breadcrumb menu have been changed to use ``elgg_register_menu_item()`` for adding items to the breadcrumb menu.
 Breadcrumb related events have been removed in favor of the regular menu events. 
 
 Upgrades
@@ -426,7 +432,6 @@ Removed events
 
 * ``access:collections:addcollection, collection`` use the ``create, access_collection`` sequence
 * ``access:collections:deletecollection, collection`` use the ``delete, access_collection`` sequence
-* ``create, <object|group|user|site>`` use the ``create:before, <type>`` or ``create:after, <type>`` event
 * ``prepare, breadcrumbs`` use ``register, menu:breadcrumbs``
 * ``widget_settings, <widget_handler>``
 

--- a/docs/guides/events-list.rst
+++ b/docs/guides/events-list.rst
@@ -361,9 +361,13 @@ Entity events
 **comments:count, <entity_type>** |results|
 	Return the number of comments on ``$params['entity']``.
 
+**create, <entity type>**
+    Triggered for user, group, object, and site entities after creation. Triggered just before the ``create:after`` event,
+    mostly for BC reasons. The use of the ``create:after`` event is preferred.
+
 **create:after, <entity type>**
     Triggered for user, group, object, and site entities after creation.
-	
+
 **create:before, <entity type>**
     Triggered for user, group, object, and site entities before creation. Return false to prevent creating the entity.
 

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1385,6 +1385,9 @@ abstract class ElggEntity extends \ElggData implements EntityIcon {
 			$container->updateLastAction();
 		}
 		
+		// for BC reasons this event is still needed (for example for notifications)
+		_elgg_services()->events->trigger('create', $this->type, $this);
+		
 		_elgg_services()->events->triggerAfter('create', $this->type, $this);
 
 		return $guid;


### PR DESCRIPTION
The event was mostly still used for notification handling.

ref #14216