### PR TITLE
fix(admin): incorrect params

### DIFF
--- a/views/default/admin/server/redis.php
+++ b/views/default/admin/server/redis.php
@@ -12,7 +12,7 @@ if (!elgg_get_config('redis') || empty($servers) || !\Elgg\Cache\CompositeCache:
 $redis = new Redis();
 
 foreach ($servers as $server) {
-	$redis->connect($server[0], $server[1]);
+	$redis->connect($server['host'], $server['port']);
 }
 
 $password = elgg_extract('password', elgg_get_config('redis_options'));


### PR DESCRIPTION
Returns `php_network_getaddresses: getaddrinfo failed` error