### PR TITLE
chore(composer): lock htmlawed version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "symfony/mime": "~5.3",
         "symfony/routing": "~5.3",
         "symfony/var-dumper": "~5.3",
-        "vanilla/htmlawed": "~2.2.0"
+        "vanilla/htmlawed": "2.2.5"
     },
     "config": {
         "process-timeout": 0,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d23b5378a159382534da12503d5cd4c4",
+    "content-hash": "480ee308beaf57a3c8453aa2a9d1da2d",
     "packages": [
         {
             "name": "cakephp/core",
@@ -8708,5 +8708,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
latest version of htmlawed breaks our tests. locking it until we fix it in 5.x

https://github.com/vanilla/htmlawed/releases/tag/v2.2.15