### PR TITLE
fixed(rss): fatal error that occurred when enabling short_open_tag

### DIFF
--- a/views/rss/page/default.php
+++ b/views/rss/page/default.php
@@ -36,8 +36,8 @@ $extensions = elgg_view('extensions/channel');
 elgg_set_http_header('Pragma: public');
 elgg_set_http_header('Content-Type: text/xml; charset=utf-8');
 
+echo "<?xml version='1.0'?>";
 ?>
-<?xml version='1.0'?>
 <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:georss="http://www.georss.org/georss" xmlns:atom="http://www.w3.org/2005/Atom" <?= $namespaces; ?>>
 <channel>
 	<title><![CDATA[<?= $title; ?>}]]></title>


### PR DESCRIPTION
PHP throwing error on XML opening tag.

If `short_open_tag` option is enabled PHP sees `<?` part of `<?xml` as a PHP open tag and generates an error.