### PR TITLE
chore(tests): use fixed time in test

### DIFF
--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggDataFunctionsTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggDataFunctionsTest.php
@@ -19,6 +19,10 @@ class ElggDataFunctionsTest extends \Elgg\IntegrationTestCase {
 	public function up() {
 		$this->user = $this->createUser();
 	}
+	
+	public function down() {
+		_elgg_services()->relationshipsTable->resetCurrentTime();
+	}
 
 	public function testCanGetData() {
 		
@@ -89,6 +93,8 @@ class ElggDataFunctionsTest extends \Elgg\IntegrationTestCase {
 	}
 
 	public function testCanUpdate() {
+		_elgg_services()->relationshipsTable->setCurrentTime();
+		
 		$relationship = new \ElggRelationship();
 		$relationship->guid_one = $this->user->guid;
 		$relationship->relationship = 'test_self1';


### PR DESCRIPTION
In order to reduce the change of a test failure due to time drift