### PR TITLE
chore(tests): use fixed time in test

### DIFF
--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggDataFunctionsTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggDataFunctionsTest.php
@@ -129,6 +129,8 @@ class ElggDataFunctionsTest extends \Elgg\IntegrationTestCase {
 	}
 
 	public function testCanDelete() {
+		_elgg_services()->relationshipsTable->setCurrentTime();
+		
 		$relationship = new \ElggRelationship();
 		$relationship->guid_one = $this->user->guid;
 		$relationship->relationship = 'test_self1';


### PR DESCRIPTION
In order to reduce the change of a test failure due to time drift