### PR TITLE
fix(i18n): update time format for German

### DIFF
--- a/languages/de.php
+++ b/languages/de.php
@@ -1177,7 +1177,7 @@ Nachdem Du Dich angemeldet hast, solltest Du Dein Passwort ändern.',
 
 	'input:date_format' => 'Y-m-d',
 	'input:date_format:datepicker' => 'yy-mm-dd', // jQuery UI datepicker format
-	'input:time_format' => 'g:ia',
+	'input:time_format' => 'G:i',
 	
 	'friendlytime:justnow' => "soeben",
 	'friendlytime:minutes' => "vor %s Minuten",


### PR DESCRIPTION
Updates the time format for the German translation as German doesn't use 12h am/pm format and rather 24 hours.