### PR TITLE
feat(routing): trigger an event when no route could be found

### DIFF
--- a/docs/guides/events-list.rst
+++ b/docs/guides/events-list.rst
@@ -223,7 +223,7 @@ System events
     might not be shown until after the process is completed. This means that any long-running
     processes will still delay the page load.
 
-.. note:: This event is prefered above using ``register_shutdown_function`` as you may not have access
+.. note:: This event is preferred above using ``register_shutdown_function`` as you may not have access
     to all the Elgg services (eg. database) in the shutdown function but you will in the event.
 
 .. note:: The Elgg session is already closed before this event. Manipulating session is not possible.
@@ -894,6 +894,18 @@ Routing
 **route:rewrite, <identifier>** |results|
 	Allows altering the site-relative URL path for an incoming request. See :doc:`routing` for details.
 	Please note that the handler for this event should be registered outside of the ``init`` event handler, as route rewrites take place after ``plugins_boot`` event has completed.
+
+**route:match, system** |results|
+	When no route is registered for a given URL path this event is triggered to allow developers to provide a routing 
+	configuration for the given path. This will allow more generic URLs to be handled without the need to register every
+	individual route.
+
+	``$params`` array includes:
+
+     * ``pathinfo`` - string with the URL path to be matched
+
+	The expected result is an array with a route definition. See :doc:`routing` for details. Also the result must contain
+	a key ``route`` with the name of the route.
 
 .. _guides/events-list#views:
 

--- a/engine/classes/Elgg/Router/UrlMatcher.php
+++ b/engine/classes/Elgg/Router/UrlMatcher.php
@@ -2,6 +2,9 @@
 
 namespace Elgg\Router;
 
+use Elgg\EventsService;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+
 /**
  * UrlMatcher Wrapper
  */
@@ -10,10 +13,62 @@ class UrlMatcher extends \Symfony\Component\Routing\Matcher\UrlMatcher {
 	/**
 	 * Create a new UrlMatcher
 	 *
-	 * @param RouteCollection $routes  route collection
-	 * @param RequestContext  $context request context
+	 * @param RouteCollection          $routes              route collection
+	 * @param RequestContext           $context             request context
+	 * @param EventsService            $events              Elgg events service
+	 * @param RouteRegistrationService $registrationService Elgg route registration service
 	 */
-	public function __construct(RouteCollection $routes, RequestContext $context) {
+	public function __construct(
+		RouteCollection $routes,
+		RequestContext $context,
+		protected EventsService $events,
+		protected RouteRegistrationService $registrationService
+	) {
 		parent::__construct($routes, $context);
+	}
+	
+	/**
+	 * {@inheritdoc}
+	 */
+	public function match(string $pathinfo): array {
+		try {
+			return parent::match($pathinfo);
+		} catch (ResourceNotFoundException $e) {
+			$result = $this->events->triggerResults('route:match', 'system', ['pathinfo' => $pathinfo]);
+			if (is_array($result) && isset($result['route'])) {
+				$name = $result['route'];
+				
+				// transform some keys inline with the route registration service
+				// @see RouteRegistrationService::register()
+				$transformed = $result;
+				$transform_keys = [
+					'controller',
+					'file',
+					'resource',
+					'handler',
+					'deprecated',
+					'middleware',
+					'detect_page_owner',
+					'use_logged_in',
+					'route',
+				];
+				foreach ($transform_keys as $key) {
+					if (!isset($transformed[$key])) {
+						continue;
+					}
+					
+					$transformed["_{$key}"] = $transformed[$key];
+					unset($transformed[$key]);
+				}
+				
+				if (!$this->routes->get($name)) {
+					$this->registrationService->register($name, $result);
+				}
+				
+				return $transformed;
+			}
+			
+			throw $e;
+		}
 	}
 }

--- a/engine/tests/phpunit/integration/Elgg/Router/UrlMatcherIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Router/UrlMatcherIntegrationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Elgg\Router;
+
+use Elgg\IntegrationTestCase;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+
+class UrlMatcherIntegrationTest extends IntegrationTestCase {
+	
+	public function up() {
+		$this->createApplication([
+			'isolate' => true,
+		]);
+	}
+	
+	public function testExisingRouteMatchDoesntTriggerEvent() {
+		elgg_register_route('foo', [
+			'path' => '/foo',
+			'handler' => function(\Elgg\Request $request) {
+				return elgg_ok_response('hello');
+			},
+		]);
+		
+		$event_handler = $this->registerTestingEvent('route:match', 'system', function(\Elgg\Event $event) {});
+		
+		$route = _elgg_services()->urlMatcher->match('/foo');
+		
+		$this->assertIsArray($route);
+		
+		$event_handler->assertNumberOfCalls(0);
+	}
+	
+	public function testNonExisingRouteMatchTriggersEventWithResults() {
+		$this->assertNull(elgg_get_route_for_url('/foo'));
+		
+		$event_handler = $this->registerTestingEvent('route:match', 'system', function(\Elgg\Event $event) {
+			return [
+				'route' => 'foo:match',
+				'path' => '/foo',
+				'file' => 'foo.php',
+			];
+		});
+		
+		$this->assertNotNull(elgg_get_route_for_url('/foo'));
+		$route = _elgg_services()->urlMatcher->match('/foo');
+		
+		$this->assertIsArray($route);
+		$event_handler->assertNumberOfCalls(1);
+		$event_handler->assertValueBefore(null);
+		$event_handler->assertParamBefore('pathinfo', '/foo');
+	}
+	
+	public function testNonExisingRouteMatchTriggersEventWithoutResults() {
+		$event_handler = $this->registerTestingEvent('route:match', 'system', function(\Elgg\Event $event) {});
+		
+		try {
+			$route = _elgg_services()->urlMatcher->match('/foo');
+		} catch (ResourceNotFoundException $e) {
+			$route = null;
+		}
+		
+		$this->assertEmpty($route);
+		
+		$event_handler->assertNumberOfCalls(1);
+		$event_handler->assertValueBefore(null);
+		$event_handler->assertParamBefore('pathinfo', '/foo');
+		$event_handler->assertValueAfter(null);
+		
+		$this->assertInstanceOf(ResourceNotFoundException::class, $e);
+	}
+}


### PR DESCRIPTION
This will allow developers to handle cases where registering a route is not practical.

fixes #14932