### PR TITLE
feat(config): default minimal password length now is 16

### DIFF
--- a/docs/appendix/upgrade-notes/6.x-to-7.0.rst
+++ b/docs/appendix/upgrade-notes/6.x-to-7.0.rst
@@ -44,6 +44,7 @@ Default config changes
 ~~~~~~~~~~~~~~~~~~~~~~
 
 * The trash is now enabled by default
+* The config option ``min_password_length`` has been changed to 16
 * The config option ``css_compiler_options`` has been removed
 * The config option ``memcache`` has been removed
 * The config option ``memcache_namespace_prefix`` has been removed

--- a/engine/classes/Elgg/Config.php
+++ b/engine/classes/Elgg/Config.php
@@ -199,7 +199,7 @@ class Config {
 		'lastcache' => 0,
 		'mentions_display_format' => 'display_name',
 		'message_delay' => 6,
-		'min_password_length' => 6,
+		'min_password_length' => 16,
 		'minusername' => 4,
 		'notifications_max_runtime' => 45,
 		'notifications_queue_delay' => 0,

--- a/engine/classes/Elgg/Security/PasswordGeneratorService.php
+++ b/engine/classes/Elgg/Security/PasswordGeneratorService.php
@@ -42,7 +42,7 @@ class PasswordGeneratorService {
 	 *
 	 * @return string
 	 */
-	public function generatePassword(int $length = 12): string {
+	public function generatePassword(int $length = 16): string {
 		
 		$length = $this->getValidLength($length);
 		

--- a/engine/classes/ElggInstaller.php
+++ b/engine/classes/ElggInstaller.php
@@ -571,7 +571,7 @@ class ElggInstaller {
 				'type' => 'password',
 				'value' => '',
 				'required' => true,
-				'pattern' => '.{6,}',
+				'pattern' => '.{16,}',
 			],
 			'password2' => [
 				'type' => 'password',

--- a/engine/lib/users.php
+++ b/engine/lib/users.php
@@ -125,7 +125,7 @@ function elgg_save_new_password(\ElggUser $user, string $conf_code, ?string $pas
 }
 
 /**
- * Generate a random 12 character clear text password.
+ * Generate a random 16 character clear text password.
  *
  * @return string
  *

--- a/engine/tests/classes/Elgg/Mocks/Database/ConfigTable.php
+++ b/engine/tests/classes/Elgg/Mocks/Database/ConfigTable.php
@@ -16,7 +16,7 @@ class ConfigTable extends \Elgg\Database\ConfigTable {
 		'language' => 'en',
 		'simplecache_enabled' => 0,
 		'system_cache_enabled' => 0,
-		'min_password_length' => 6,
+		'min_password_length' => 16,
 	];
 
 	/**

--- a/engine/tests/phpunit/integration/Elgg/Actions/LoginIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Actions/LoginIntegrationTest.php
@@ -28,7 +28,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 	public function testLoginWithUsernameAndPassword() {
 
 		$user = $this->user = $this->createUser([
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 			'language' => 'de',
 		]);
 
@@ -38,7 +38,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 
 		$response = $this->executeAction('login', [
 			'username' => $user->username,
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 			'persistent' => false,
 		]);
 
@@ -57,7 +57,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 	public function testLoginWithEmailAndPassword() {
 
 		$user = $this->user = $this->createUser([
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 		]);
 
 		$user->setValidationStatus(true, 'login_test');
@@ -66,7 +66,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 
 		$response = $this->executeAction('login', [
 			'username' => $user->email,
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 			'persistent' => false,
 		]);
 
@@ -81,7 +81,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 	public function testLoginFailsWithEmptyPassword() {
 
 		$user = $this->user = $this->createUser([
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 		]);
 
 		$user->setValidationStatus(true, 'login_test');
@@ -97,7 +97,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 	public function testLoginFailsWithIncorrectPassword() {
 
 		$user = $this->user = $this->createUser([
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 		]);
 
 		$user->setValidationStatus(true, 'login_test');
@@ -118,7 +118,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 		$username = $this->getRandomUsername();
 		$user = $this->user = $this->createUser([
 			'username' => $username,
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 		]);
 
 		elgg()->events->restore();
@@ -139,7 +139,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 		
 		$response = $this->executeAction('login', [
 			'username' => $user->username,
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 		]);
 
 		$this->assertInstanceOf(ErrorResponse::class, $response);
@@ -150,7 +150,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 
 		$response = $this->executeAction('login', [
 			'username' => $this->getRandomUsername(),
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 		]);
 
 		$this->assertInstanceOf(ErrorResponse::class, $response);
@@ -160,7 +160,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 	public function testLoginFailsWithBannedUser() {
 
 		$user = $this->user = $this->createUser([
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 			'banned' => true,
 		]);
 
@@ -168,7 +168,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 
 		$response = $this->executeAction('login', [
 			'username' => $user->username,
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 			'persistent' => false,
 		]);
 
@@ -185,7 +185,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 		_elgg_services()->events->registerHandler('login:before', 'user', $handler);
 
 		$user = $this->user = $this->createUser([
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 			'language' => 'de',
 		]);
 
@@ -193,7 +193,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 
 		$response = $this->executeAction('login', [
 			'username' => $user->username,
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 			'persistent' => false,
 		]);
 
@@ -248,7 +248,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 	public function testCanPersistLogin() {
 
 		$user = $this->user = $this->createUser([
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 			'language' => 'de',
 		]);
 		
@@ -256,7 +256,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 		
 		$action_response = $this->executeAction('login', [
 			'username' => $user->username,
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 			'persistent' => true,
 		]);
 		
@@ -299,7 +299,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 	public function testRespectsLastForwardFrom() {
 
 		$user = $this->user = $this->createUser([
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 		]);
 
 		$user->setValidationStatus(true, 'login_test');
@@ -323,7 +323,7 @@ class LoginIntegrationTest extends ActionResponseTestCase {
 
 		$response = $this->executeAction('login', [
 			'username' => $user->username,
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 			'persistent' => false,
 		]);
 

--- a/engine/tests/phpunit/integration/Elgg/Actions/LogoutIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Actions/LogoutIntegrationTest.php
@@ -24,7 +24,7 @@ class LogoutIntegrationTest extends ActionResponseTestCase {
 	public function testLogout() {
 
 		$user = $this->createUser([
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 			'language' => 'de',
 		]);
 
@@ -43,7 +43,7 @@ class LogoutIntegrationTest extends ActionResponseTestCase {
 
 	public function testCanUseLogoutActionWithoutTokens() {
 		$user = $this->createUser([
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 			'language' => 'de',
 		]);
 
@@ -63,7 +63,7 @@ class LogoutIntegrationTest extends ActionResponseTestCase {
 	public function testCanPreventLogoutWithEvent() {
 
 		$user = $this->createUser([
-			'password' => 123456,
+			'password' => '123456789abcdefgh',
 			'language' => 'de',
 		]);
 

--- a/engine/tests/phpunit/integration/Elgg/Actions/RegisterIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Actions/RegisterIntegrationTest.php
@@ -104,8 +104,8 @@ class RegisterIntegrationTest extends ActionResponseTestCase {
 
 		$response = $this->executeAction('register', [
 			'username' => $username,
-			'password' => '1111111111111',
-			'password2' => '1111111111111 ',
+			'password' => 'longenoughpassword',
+			'password2' => 'longenoughpassword ',
 			'email' => $email,
 			'name' => 'Test User',
 		]);
@@ -122,8 +122,8 @@ class RegisterIntegrationTest extends ActionResponseTestCase {
 
 		$response = $this->executeAction('register', [
 			'username' => 'username\r\n',
-			'password' => '1111111111111',
-			'password2' => '1111111111111',
+			'password' => 'longenoughpassword',
+			'password2' => 'longenoughpassword',
 			'email' => $email,
 			'name' => 'Test User',
 		]);
@@ -140,8 +140,8 @@ class RegisterIntegrationTest extends ActionResponseTestCase {
 
 		$response = $this->executeAction('register', [
 			'username' => 'username?#',
-			'password' => '1111111111111',
-			'password2' => '1111111111111',
+			'password' => '123456789abcdefgh',
+			'password2' => '123456789abcdefgh',
 			'email' => $email,
 			'name' => 'Test User',
 		]);
@@ -158,8 +158,8 @@ class RegisterIntegrationTest extends ActionResponseTestCase {
 
 		$response = $this->executeAction('register', [
 			'username' => 'abc',
-			'password' => '1111111111111',
-			'password2' => '1111111111111',
+			'password' => '123456789abcdefgh',
+			'password2' => '123456789abcdefgh',
 			'email' => $email,
 			'name' => 'Test User',
 		]);
@@ -177,8 +177,8 @@ class RegisterIntegrationTest extends ActionResponseTestCase {
 		$username = str_repeat('a', 150);
 		$response = $this->executeAction('register', [
 			'username' => $username,
-			'password' => '1111111111111',
-			'password2' => '1111111111111',
+			'password' => '123456789abcdefgh',
+			'password2' => '123456789abcdefgh',
 			'email' => $email,
 			'name' => 'Test User',
 		]);
@@ -195,8 +195,8 @@ class RegisterIntegrationTest extends ActionResponseTestCase {
 
 		$response = $this->executeAction('register', [
 			'username' => $username,
-			'password' => '1111111111111',
-			'password2' => '1111111111111',
+			'password' => '123456789abcdefgh',
+			'password2' => '123456789abcdefgh',
 			'email' => "$username@",
 			'name' => 'Test User',
 		]);
@@ -217,8 +217,8 @@ class RegisterIntegrationTest extends ActionResponseTestCase {
 		$username2 = $this->getRandomUsername();
 		$response = $this->executeAction('register', [
 			'username' => $username2,
-			'password' => '1111111111111',
-			'password2' => '1111111111111',
+			'password' => '123456789abcdefgh',
+			'password2' => '123456789abcdefgh',
 			'email' => "$username@example.com",
 			'name' => 'Test User',
 		]);
@@ -236,8 +236,8 @@ class RegisterIntegrationTest extends ActionResponseTestCase {
 
 		$response = $this->executeAction('register', [
 			'username' => $username,
-			'password' => '1111111111111',
-			'password2' => '1111111111111',
+			'password' => '123456789abcdefgh',
+			'password2' => '123456789abcdefgh',
 			'email' => $this->getRandomEmail(),
 			'name' => 'Test User',
 		]);
@@ -252,8 +252,8 @@ class RegisterIntegrationTest extends ActionResponseTestCase {
 
 		$response = $this->executeAction('register', [
 			'username' => $username,
-			'password' => '1111111111111',
-			'password2' => '1111111111111',
+			'password' => '123456789abcdefgh',
+			'password2' => '123456789abcdefgh',
 			'email' => $this->getRandomEmail(),
 			'name' => 'Test User',
 		]);
@@ -276,8 +276,8 @@ class RegisterIntegrationTest extends ActionResponseTestCase {
 
 		$response = $this->executeAction('register', [
 			'username' => $username,
-			'password' => '1111111111111',
-			'password2' => '1111111111111',
+			'password' => '123456789abcdefgh',
+			'password2' => '123456789abcdefgh',
 			'email' => $this->getRandomEmail(),
 			'name' => 'Test User',
 		]);
@@ -303,8 +303,8 @@ class RegisterIntegrationTest extends ActionResponseTestCase {
 		
 		$response = $this->executeAction('register', [
 			'username' => $username,
-			'password' => '1111111111111',
-			'password2' => '1111111111111',
+			'password' => '123456789abcdefgh',
+			'password2' => '123456789abcdefgh',
 			'email' => $this->getRandomEmail(),
 			'name' => 'Test User',
 		]);
@@ -331,8 +331,8 @@ class RegisterIntegrationTest extends ActionResponseTestCase {
 		
 		$response = $this->executeAction('register', [
 			'username' => $username,
-			'password' => '1111111111111',
-			'password2' => '1111111111111',
+			'password' => '123456789abcdefgh',
+			'password2' => '123456789abcdefgh',
 			'email' => $this->getRandomEmail(),
 			'name' => 'Test User',
 		]);

--- a/engine/tests/phpunit/integration/Elgg/Security/PasswordGeneratorServiceIntegrationTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Security/PasswordGeneratorServiceIntegrationTest.php
@@ -167,7 +167,7 @@ class PasswordGeneratorServiceIntegrationTest extends IntegrationTestCase {
 			}
 		}
 		
-		$expected .= '.{6,}';
+		$expected .= '.{16,}';
 		
 		$regex = _elgg_services()->passwordGenerator->getInputRegEx();
 		

--- a/engine/tests/phpunit/unit/Elgg/Security/PasswordGeneratorServiceUnitTest.php
+++ b/engine/tests/phpunit/unit/Elgg/Security/PasswordGeneratorServiceUnitTest.php
@@ -7,10 +7,10 @@ use Elgg\UnitTestCase;
 class PasswordGeneratorServiceUnitTest extends UnitTestCase {
 	
 	public function testGeneratePasswordWithSufficientLength() {
-		$password = _elgg_services()->passwordGenerator->generatePassword(12);
+		$password = _elgg_services()->passwordGenerator->generatePassword(22);
 		
 		$this->assertIsString($password);
-		$this->assertEquals(12, strlen($password));
+		$this->assertEquals(22, strlen($password));
 	}
 	
 	public function testGeneratePasswordWithInsufficientLength() {

--- a/engine/tests/phpunit/unit/ElggInstallerUnitTest.php
+++ b/engine/tests/phpunit/unit/ElggInstallerUnitTest.php
@@ -509,7 +509,7 @@ class ElggInstallerUnitTest extends \Elgg\UnitTestCase {
 					'type' => 'password',
 					'value' => '',
 					'required' => true,
-					'pattern' => '.{6,}',
+					'pattern' => '.{16,}',
 				],
 				'password2' => [
 					'type' => 'password',
@@ -565,8 +565,8 @@ class ElggInstallerUnitTest extends \Elgg\UnitTestCase {
 			'displayname' => 'admin user',
 			'email' => 'admin@example.com',
 			'username' => 'admin',
-			'password1' => '12345678',
-			'password2' => '12345678',
+			'password1' => '12345678abcdefgh',
+			'password2' => '12345678abcdefgh',
 		]);
 
 		$this->getApp()->internal_services->set('request', $request);
@@ -614,7 +614,7 @@ class ElggInstallerUnitTest extends \Elgg\UnitTestCase {
 			'displayname' => 'Administrator',
 			'email' => 'admin@ci.elgg.org',
 			'username' => 'admin',
-			'password' => 'fancypassword',
+			'password' => 'longenoughpassword',
 
 			// timezone
 			'timezone' => 'UTC',

--- a/install/cli/testing_app.php
+++ b/install/cli/testing_app.php
@@ -24,7 +24,7 @@ return [
 	'displayname' => 'Administrator',
 	'email' => 'admin@ci.elgg.org',
 	'username' => 'admin',
-	'password' => 'fancypassword',
+	'password' => 'longenoughpassword',
 
 	// timezone
 	'timezone' => 'UTC'


### PR DESCRIPTION
fixes #14999

Following recommendations from:
https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
https://www.nist.gov/cybersecurity/how-do-i-create-good-password