### PR TITLE
fix(profile): handle null ban_reason in profile/wrapper view

### DIFF
--- a/mod/profile/views/default/profile/wrapper.php
+++ b/mod/profile/views/default/profile/wrapper.php
@@ -7,7 +7,7 @@
 
 $user = elgg_extract('entity', $vars);
 if ($user->isBanned()) {
-	$reason = (empty($user->ban_reason) || $user->ban_reason === 'banned') ? '' : (string) $user->ban_reason;
+	$reason = ($user->ban_reason === 'banned') ? '' : (string) $user->ban_reason;
 	
 	echo elgg_view_message('warning', $reason, [
 		'title' => elgg_echo('banned'),

--- a/mod/profile/views/default/profile/wrapper.php
+++ b/mod/profile/views/default/profile/wrapper.php
@@ -7,7 +7,7 @@
 
 $user = elgg_extract('entity', $vars);
 if ($user->isBanned()) {
-	$reason = ($user->ban_reason === 'banned') ? '' : $user->ban_reason;
+	$reason = (empty($user->ban_reason) || $user->ban_reason === 'banned') ? '' : (string) $user->ban_reason;
 	
 	echo elgg_view_message('warning', $reason, [
 		'title' => elgg_echo('banned'),


### PR DESCRIPTION
When a user is banned without a reason, ban_reason is null rather than the string 'banned'. The strict equality check did not catch this case, passing null to elgg_view_message() which expects a string body argument.

Use empty() to guard against both null and empty string before falling back to an explicit (string) cast.

Fixes: TypeError: elgg_view_message(): Argument #2 () must be of type string, null given