### PR TITLE
feat(groups): group membership can be by invitation only

### DIFF
--- a/engine/classes/Elgg/Traits/Seeding/GroupHelpers.php
+++ b/engine/classes/Elgg/Traits/Seeding/GroupHelpers.php
@@ -10,27 +10,28 @@ namespace Elgg\Traits\Seeding;
  */
 trait GroupHelpers {
 	
-	private $visibility = [
+	private array $visibility = [
 		ACCESS_PUBLIC,
 		ACCESS_LOGGED_IN,
 		ACCESS_PRIVATE,
 	];
 	
-	private $content_access_modes = [
+	private array $content_access_modes = [
 		\ElggGroup::CONTENT_ACCESS_MODE_MEMBERS_ONLY,
 		\ElggGroup::CONTENT_ACCESS_MODE_UNRESTRICTED,
 	];
 	
-	private $membership = [
-		ACCESS_PUBLIC,
-		ACCESS_PRIVATE,
+	private array $membership = [
+		\ElggGroup::MEMBERSHIP_PUBLIC,
+		\ElggGroup::MEMBERSHIP_CLOSED,
+		\ElggGroup::MEMBERSHIP_INVITE_ONLY,
 	];
 	
 	/**
 	 * Returns random visibility value
 	 * @return int
 	 */
-	public function getRandomGroupVisibility() {
+	public function getRandomGroupVisibility(): int {
 		$key = array_rand($this->visibility, 1);
 		
 		return $this->visibility[$key];
@@ -40,7 +41,7 @@ trait GroupHelpers {
 	 * Returns random content access mode value
 	 * @return string
 	 */
-	public function getRandomGroupContentAccessMode() {
+	public function getRandomGroupContentAccessMode(): string {
 		$key = array_rand($this->content_access_modes, 1);
 		
 		return $this->content_access_modes[$key];
@@ -48,9 +49,9 @@ trait GroupHelpers {
 	
 	/**
 	 * Returns random membership mode
-	 * @return mixed
+	 * @return int
 	 */
-	public function getRandomGroupMembership() {
+	public function getRandomGroupMembership(): int {
 		$key = array_rand($this->membership, 1);
 		
 		return $this->membership[$key];

--- a/engine/classes/ElggGroup.php
+++ b/engine/classes/ElggGroup.php
@@ -16,6 +16,10 @@ class ElggGroup extends \ElggEntity {
 	const CONTENT_ACCESS_MODE_UNRESTRICTED = 'unrestricted';
 	const CONTENT_ACCESS_MODE_MEMBERS_ONLY = 'members_only';
 
+	const MEMBERSHIP_CLOSED = 0;
+	const MEMBERSHIP_INVITE_ONLY = 1;
+	const MEMBERSHIP_PUBLIC = 2;
+	
 	use PluginSettings;
 	
 	/**
@@ -26,6 +30,7 @@ class ElggGroup extends \ElggEntity {
 		
 		$this->attributes['type'] = 'group';
 		$this->attributes['subtype'] = 'group';
+		$this->attributes['access_id'] = ACCESS_PUBLIC;
 	}
 
 	/**
@@ -53,7 +58,17 @@ class ElggGroup extends \ElggEntity {
 	 * @return bool
 	 */
 	public function isPublicMembership(): bool {
-		return ($this->membership === ACCESS_PUBLIC);
+		return ($this->membership === self::MEMBERSHIP_PUBLIC);
+	}
+	
+	/**
+	 * Returns whether the current group has an invitation only membership
+	 *
+	 * @return bool
+	 * @since 7.1
+	 */
+	public function isInviteOnlyMembership(): bool {
+		return ($this->membership === self::MEMBERSHIP_INVITE_ONLY);
 	}
 
 	/**

--- a/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGroupTest.php
+++ b/engine/tests/phpunit/integration/Elgg/Integration/ElggCoreGroupTest.php
@@ -6,15 +6,9 @@ use Elgg\IntegrationTestCase;
 
 class ElggCoreGroupTest extends IntegrationTestCase {
 
-	/**
-	 * @var \ElggGroup
-	 */
-	protected $group;
+	protected ?\ElggGroup $group = null;
 
-	/**
-	 * @var \ElggUser
-	 */
-	protected $user;
+	protected ?\ElggUser $user = null;
 
 	public function up() {
 		$this->group = $this->createGroup();
@@ -30,7 +24,7 @@ class ElggCoreGroupTest extends IntegrationTestCase {
 
 		// if mode not set, closed groups are members only
 		unset($this->group->content_access_mode);
-		$this->group->membership = ACCESS_PRIVATE;
+		$this->group->membership = \ElggGroup::MEMBERSHIP_CLOSED;
 		$this->assertEquals($membersonly, $this->group->getContentAccessMode());
 
 		// test set

--- a/engine/tests/phpunit/unit/ElggGroupUnitTest.php
+++ b/engine/tests/phpunit/unit/ElggGroupUnitTest.php
@@ -66,10 +66,30 @@ class ElggGroupUnitTest extends \Elgg\UnitTestCase {
 	}
 	
 	public function testGetDisplaynameReturnsString() {
-		$group = new ElggGroup();
+		$group = new \ElggGroup();
 		$this->assertEquals('', $group->getDisplayName());
 		
 		$group->name = 'foo';
 		$this->assertEquals('foo', $group->getDisplayName());
+	}
+	
+	public function testIsPublicMembership() {
+		$group = new \ElggGroup();
+		$this->assertFalse($group->isInviteOnlyMembership());
+		$this->assertFalse($group->isPublicMembership());
+		
+		$group->membership = \ElggGroup::MEMBERSHIP_PUBLIC;
+		$this->assertTrue($group->isPublicMembership());
+		$this->assertFalse($group->isInviteOnlyMembership());
+	}
+	
+	public function testIsInviteOnlyMembership() {
+		$group = new \ElggGroup();
+		$this->assertFalse($group->isInviteOnlyMembership());
+		$this->assertFalse($group->isPublicMembership());
+		
+		$group->membership = \ElggGroup::MEMBERSHIP_INVITE_ONLY;
+		$this->assertTrue($group->isInviteOnlyMembership());
+		$this->assertFalse($group->isPublicMembership());
 	}
 }

--- a/mod/groups/actions/groups/edit.php
+++ b/mod/groups/actions/groups/edit.php
@@ -114,18 +114,10 @@ foreach ($tools as $tool) {
 	}
 }
 
-// Group membership - should these be treated with same constants as access permissions?
-$value = get_input('membership');
-if ($group->membership === null || $value !== null) {
-	$is_public_membership = ($value == ACCESS_PUBLIC);
-	$group->membership = $is_public_membership ? ACCESS_PUBLIC : ACCESS_PRIVATE;
-}
+// Group membership
+$group->membership = (int) get_input('membership');
 
 $group->setContentAccessMode((string) get_input('content_access_mode'));
-
-if ($is_new_group) {
-	$group->access_id = ACCESS_PUBLIC;
-}
 
 $old_owner_guid = $is_new_group ? 0 : $group->owner_guid;
 $new_owner_guid = (int) get_input('owner_guid', $old_owner_guid);

--- a/mod/groups/actions/groups/membership/join.php
+++ b/mod/groups/actions/groups/membership/join.php
@@ -27,18 +27,18 @@ if (!$user->canEdit() && !$group->canEdit()) {
 }
 
 // join or request
-$join = false;
+$can_join = false;
 if ($group->isPublicMembership() || $group->canEdit($user->guid)) {
 	// anyone can join public groups and admins can join any group
-	$join = true;
+	$can_join = true;
 } else {
 	if ($group->hasRelationship($user->guid, 'invited')) {
 		// user has invite to closed group
-		$join = true;
+		$can_join = true;
 	}
 }
 
-if ($join) {
+if ($can_join) {
 	if (!$group->join($user, [
 		'create_river_item' => true,
 		'notify_user_action' => 'join_membership',
@@ -47,6 +47,8 @@ if ($join) {
 	}
 	
 	return elgg_ok_response('', elgg_echo('groups:joined'), $group->getURL());
+} elseif ($group->isInviteOnlyMembership()) {
+	return elgg_error_response(elgg_echo('groups:join:invite_only'));
 }
 
 if ($user->hasRelationship($group->guid, 'membership_request')) {

--- a/mod/groups/classes/Elgg/Groups/Forms/PrepareFields.php
+++ b/mod/groups/classes/Elgg/Groups/Forms/PrepareFields.php
@@ -22,7 +22,7 @@ class PrepareFields {
 		// input names => defaults
 		$values = [
 			'name' => '',
-			'membership' => ACCESS_PUBLIC,
+			'membership' => \ElggGroup::MEMBERSHIP_PUBLIC,
 			'vis' => ACCESS_PUBLIC,
 			'guid' => null,
 			'owner_guid' => elgg_get_logged_in_user_guid(),

--- a/mod/groups/classes/Elgg/Groups/Menus/Page.php
+++ b/mod/groups/classes/Elgg/Groups/Menus/Page.php
@@ -33,7 +33,7 @@ class Page {
 		/* @var $return \Elgg\Menu\MenuItems */
 		$return = $event->getValue();
 		
-		if ($page_owner->isPublicMembership()) {
+		if ($page_owner->isPublicMembership() || $page_owner->isInviteOnlyMembership()) {
 			// show link to invited users
 			$return[] = \ElggMenuItem::factory([
 				'name' => 'membership_invites',

--- a/mod/groups/languages/en.php
+++ b/mod/groups/languages/en.php
@@ -100,7 +100,8 @@ return array(
 	/**
 	 * Access
 	 */
-	'groups:access:private' => 'Closed - Users must be invited',
+	'groups:access:invite_only' => 'Invite only - Users must be invited',
+	'groups:access:private' => 'Closed - Users must request membership',
 	'groups:access:public' => 'Open - Any user may join',
 	'groups:access:group' => 'Group members only',
 	'groups:closedgroup' => "This group's membership is closed.",
@@ -129,6 +130,7 @@ return array(
 	'groups:joinrequestnotmade' => 'Could not request to join group',
 	'groups:joinrequestmade' => 'Requested to join group',
 	'groups:joinrequest:exists' => 'You already requested membership for this group',
+	'groups:join:invite_only' => 'Membership for this group is by invitation only',
 	'groups:button:joined' => 'Joined',
 	'groups:button:owned' => 'Owned',
 	'groups:joined' => 'Successfully joined group!',

--- a/mod/groups/lib/functions.php
+++ b/mod/groups/lib/functions.php
@@ -77,6 +77,8 @@ function groups_get_group_join_menu_item(\ElggGroup $group, ?\ElggUser $user = n
 		// admins can always join
 		// non-admins can join if membership is public
 		$menu_name = 'groups:join';
+	} elseif ($group->isInviteOnlyMembership()) {
+		return false;
 	}
 	
 	return \ElggMenuItem::factory([

--- a/mod/groups/tests/phpunit/integration/Elgg/Groups/Actions/Membership/JoinTest.php
+++ b/mod/groups/tests/phpunit/integration/Elgg/Groups/Actions/Membership/JoinTest.php
@@ -8,15 +8,9 @@ class JoinTest extends ActionResponseTestCase {
 	
 	use \Elgg\MessageTesting;
 	
-	/**
-	 * @var \ElggGroup
-	 */
-	protected $group;
+	protected ?\ElggGroup $group = null;
 	
-	/**
-	 * @var \ElggUser
-	 */
-	protected $user;
+	protected ?\ElggUser $user = null;
 	
 	public function up() {
 		parent::up();
@@ -58,7 +52,7 @@ class JoinTest extends ActionResponseTestCase {
 	}
 	
 	public function testCanJoinPublicGroup() {
-		$this->group->membership = ACCESS_PUBLIC;
+		$this->group->membership = \ElggGroup::MEMBERSHIP_PUBLIC;
 		$this->assertTrue($this->group->isPublicMembership());
 		
 		$response = $this->executeAction('groups/join', [
@@ -74,7 +68,7 @@ class JoinTest extends ActionResponseTestCase {
 	}
 	
 	public function testGroupOwnerCanJoinUserOnPublicGroup() {
-		$this->group->membership = ACCESS_PUBLIC;
+		$this->group->membership = \ElggGroup::MEMBERSHIP_PUBLIC;
 		$this->assertTrue($this->group->isPublicMembership());
 		
 		_elgg_services()->session_manager->setLoggedInUser($this->group->getOwnerEntity());
@@ -92,7 +86,7 @@ class JoinTest extends ActionResponseTestCase {
 	}
 	
 	public function testCanJoinClosedGroupIfInvited() {
-		$this->group->membership = ACCESS_PRIVATE;
+		$this->group->membership = \ElggGroup::MEMBERSHIP_CLOSED;
 		$this->assertFalse($this->group->isPublicMembership());
 		
 		$this->assertTrue($this->group->addRelationship($this->user->guid, 'invited'));
@@ -110,7 +104,7 @@ class JoinTest extends ActionResponseTestCase {
 	}
 	
 	public function testCantHaveMultipleMembershipRequests() {
-		$this->group->membership = ACCESS_PRIVATE;
+		$this->group->membership = \ElggGroup::MEMBERSHIP_CLOSED;
 		$this->assertFalse($this->group->isPublicMembership());
 		
 		$this->assertTrue($this->user->addRelationship($this->group->guid, 'membership_request'));
@@ -124,7 +118,7 @@ class JoinTest extends ActionResponseTestCase {
 	}
 	
 	public function testCanRequestMembershipForClosedGroup() {
-		$this->group->membership = ACCESS_PRIVATE;
+		$this->group->membership = \ElggGroup::MEMBERSHIP_CLOSED;
 		$this->assertFalse($this->group->isPublicMembership());
 		
 		$response = $this->executeAction('groups/join', [
@@ -137,5 +131,35 @@ class JoinTest extends ActionResponseTestCase {
 		$this->assertSystemMessageEmitted(elgg_echo('groups:joinrequestmade'));
 		
 		$this->assertTrue($this->user->hasRelationship($this->group->guid, 'membership_request'));
+	}
+	
+	public function testCantJoinInviteOnlyGroupWithoutInvitation() {
+		$this->group->membership = \ElggGroup::MEMBERSHIP_INVITE_ONLY;
+		$this->assertTrue($this->group->isInviteOnlyMembership());
+		
+		$response = $this->executeAction('groups/join', [
+			'group_guid' => $this->group->guid,
+		]);
+		
+		$this->assertInstanceOf(\Elgg\Http\ErrorResponse::class, $response);
+		$this->assertEquals(elgg_echo('groups:join:invite_only'), $response->getContent());
+	}
+	
+	public function testCanJoinInviteOnlyGroupWithInvitation() {
+		$this->group->membership = \ElggGroup::MEMBERSHIP_INVITE_ONLY;
+		$this->assertTrue($this->group->isInviteOnlyMembership());
+		
+		$this->assertTrue($this->group->addRelationship($this->user->guid, 'invited'));
+		
+		$response = $this->executeAction('groups/join', [
+			'group_guid' => $this->group->guid,
+		]);
+		
+		$this->assertInstanceOf(\Elgg\Http\OkResponse::class, $response);
+		$this->assertEquals($this->group->getURL(), $response->getForwardURL());
+		
+		$this->assertSystemMessageEmitted(elgg_echo('groups:joined'));
+		
+		$this->assertTrue($this->group->isMember($this->user));
 	}
 }

--- a/mod/groups/views/default/groups/edit/access.php
+++ b/mod/groups/views/default/groups/edit/access.php
@@ -25,8 +25,9 @@ echo elgg_view_field([
 	'id' => 'groups-membership',
 	'value' => $membership,
 	'options_values' => [
-		ACCESS_PRIVATE => elgg_echo('groups:access:private'),
-		ACCESS_PUBLIC => elgg_echo('groups:access:public'),
+		\ElggGroup::MEMBERSHIP_PUBLIC => elgg_echo('groups:access:public'),
+		\ElggGroup::MEMBERSHIP_CLOSED => elgg_echo('groups:access:private'),
+		\ElggGroup::MEMBERSHIP_INVITE_ONLY => elgg_echo('groups:access:invite_only'),
 	],
 ]);
 


### PR DESCRIPTION
For groups with the invitation only membership option users can't request membership. They have to be invited by the group owner.