### PR TITLE
fix(db): correctly invalidate query cache on insert/delete/update

### DIFF
--- a/engine/classes/Elgg/Database.php
+++ b/engine/classes/Elgg/Database.php
@@ -238,8 +238,6 @@ class Database {
 		
 		$this->getLogger()->info("DB insert query {$sql} (params: " . print_r($params, true) . ')');
 
-		$this->query_cache->clear();
-
 		$this->executeQuery($query);
 		
 		try {
@@ -269,8 +267,6 @@ class Database {
 	
 		$this->getLogger()->info("DB update query {$sql} (params: " . print_r($params, true) . ')');
 
-		$this->query_cache->clear();
-
 		$result = $this->executeQuery($query);
 		if (!$get_num_rows) {
 			return true;
@@ -293,8 +289,6 @@ class Database {
 		$sql = $query->getSQL();
 
 		$this->getLogger()->info("DB delete query {$sql} (params: " . print_r($params, true) . ')');
-
-		$this->query_cache->clear();
 
 		$result = $this->executeQuery($query);
 		return ($result instanceof Result) ? (int) $result->rowCount() : $result;

--- a/engine/classes/Elgg/Database/QueryBuilder.php
+++ b/engine/classes/Elgg/Database/QueryBuilder.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\DBAL\Query\QueryBuilder as DbalQueryBuilder;
+use Doctrine\DBAL\Result;
 use Elgg\Database\Clauses\Clause;
 use Elgg\Database\Clauses\ComparisonClause;
 use Elgg\Database\Clauses\JoinClause;
@@ -195,26 +196,37 @@ abstract class QueryBuilder extends DbalQueryBuilder {
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * Execute the database query for this QueryBuilder
 	 *
 	 * @param bool $track_query should the query be tracked by timers and loggers
+	 *
+	 * @return int|string|Result
 	 */
 	public function execute(bool $track_query = true) {
 		if (!$track_query) {
 			if ($this instanceof Select) {
-				return parent::executeQuery();
+				return $this->executeQuery();
 			} else {
-				return parent::executeStatement();
+				return $this->executeStatement();
 			}
 		}
 		
 		return _elgg_services()->db->trackQuery($this, function() {
 			if ($this instanceof Select) {
-				return parent::executeQuery();
+				return $this->executeQuery();
 			} else {
-				return parent::executeStatement();
+				return $this->executeStatement();
 			}
 		});
+	}
+	
+	/**
+	 * {@inheritdoc}
+	 */
+	public function executeStatement(): int|string {
+		_elgg_services()->queryCache->clear();
+		
+		return parent::executeStatement();
 	}
 	
 	/**


### PR DESCRIPTION
When using the QueryBuilder directly to execute a query, the query cache wasn't invalidated for insert/delete/update queries which could result in unexpected behavior.

fixes #15140